### PR TITLE
Add tested and icons passthrough to WC Helper update transient

### DIFF
--- a/plugins/woocommerce/changelog/63986-fix-wccom-ext-tested-up-to
+++ b/plugins/woocommerce/changelog/63986-fix-wccom-ext-tested-up-to
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Pass `tested` and `icons` fields from WooCommerce.com update-check API response into the `update_plugins` site transient, allowing WordPress to display compatibility info and extension icons on the Updates page.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -108,6 +108,14 @@ class WC_Helper_Updater {
 				$item['requires_php'] = $data['requires_php'];
 			}
 
+			if ( isset( $data['tested'] ) ) {
+				$item['tested'] = $data['tested'];
+			}
+
+			if ( isset( $data['icons'] ) ) {
+				$item['icons'] = $data['icons'];
+			}
+
 			if ( $transient instanceof stdClass ) {
 				if ( version_compare( $plugin['Version'], $data['version'], '<' ) ) {
 					$transient->response[ $filename ] = (object) $item;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The WC Helper Updater builds the update_plugins transient item from the WCCOM API response but only forwards a subset of fields. The API now returns `tested` (WP compatibility) and `icons` (extension thumbnails), but they are silently dropped.

Forward both fields from the API response data to the transient item, following the same conditional pattern as the existing `requires_php` passthrough. This allows WordPress core to display compatibility info and extension icons on the Updates page for WCCOM-hosted extensions.

Closes WCCOM-2235.


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="783" height="367" alt="Screenshot 2026-04-02 at 13 00 59" src="https://github.com/user-attachments/assets/91a81ec9-d660-4109-bb54-e3daaf263ee0" /> |  <img width="794" height="308" alt="Screenshot 2026-04-02 at 13 00 26" src="https://github.com/user-attachments/assets/5bc1053a-df1f-44ed-9e6d-ff7be7a99353" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Checkout this branch
2. `cd plugins/woocommerce && pnpm run build`
3. Install Woo Update Manager an activate it
4. Check ID of your docker container running wp-env
5. Create the fake plugin with a Woo header so WooCommerce Helper recognizes it:
```bash
  docker exec <container_id> mkdir -p /var/www/html/wp-content/plugins/fake-wccom-extension
  docker exec <container_id> php -r 'file_put_contents("/var/www/html/wp-content/plugins/fake-wccom-extension/fake-wccom-extension.php", "<?php\n/**\n * Plugin Name: Fake WCCOM Extension\n * Version: 1.0.0\n * Woo: 99999:fake-file-id\n */\n");'
```
6. Activate the plugin:
```bash
pnpm wp-env run cli wp plugin activate fake-wccom-extension
```

7. Create a mu-plugin (or add this filter somewhere in the code) that intercepts the WCCOM update-check request and returns mock data with tested and icons:

```php

// Intercept the HTTP request to WCCOM and inject mock update data.
add_filter( 'pre_http_request', function( $preempt, $args, $url ) {
	if ( strpos( $url, 'helper/1.0/update-check' ) === false ) {
		return $preempt;
	}

	$body = json_decode( $args['body'], true );
	if ( ! isset( $body['products'][99999] ) ) {
		return $preempt;
	}

	$response_body = [
		99999 => [
			'version'        => '2.0.0',
			'slug'           => 'fake-wccom-extension',
			'url'            => 'https://woocommerce.com/products/fake-extension/',
			'package'        => '',
			'upgrade_notice' => 'Test update with compatibility info.',
			'tested'         => '6.9.4',
			'icons'          => [
				'1x'      => 'https://woocommerce.com/wp-content/uploads/2019/10/auctions-for-woocommerce-icon.png',
				'default' => 'https://woocommerce.com/wp-content/uploads/2019/10/auctions-for-woocommerce-icon.png',
			],
		],
	];

	return [
		'response' => [ 'code' => 200 ],
		'body'     => wp_json_encode( $response_body ),
	];
}, 10, 3 );
```

8. Delete the WC Helper update cache:
```bash
pnpm wp-env run cli wp transient delete _woocommerce_helper_updates
```

9. Navigate to WP Admin -> Dashboard -> Updates (/wp-admin/update-core.php).
10. Expected: "Fake WCCOM Extension" appears in the plugin updates list with:
    - "Compatibility with WordPress X.X: 100% (according to its author)" instead of "Unknown"
    - The extension icon displayed instead of the generic plugin dashicon

<img width="629" height="376" alt="image" src="https://github.com/user-attachments/assets/3779e773-08a3-41d1-86f7-b2245e007af9" />


11. Update the mu-plugin to remove the tested keys (`tested` and `icons`) — edit the file inside the container or recreate it without the tested line.
12. Delete the transient again:
```bash
pnpm wp-env run cli wp transient delete _woocommerce_helper_updates
```
  12. Reload /wp-admin/update-core.php.
  13. Expected: "Fake WCCOM Extension" shows "Compatibility with WordPress X.X: Unknown" — same as current behavior.

<img width="631" height="200" alt="image" src="https://github.com/user-attachments/assets/1e29c6df-8e2c-41ab-9387-a637fbabde0a" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Pass `tested` and `icons` fields from WooCommerce.com update-check API response into the `update_plugins` site transient, allowing WordPress to display compatibility info and extension icons on the Updates page.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
