### PR TITLE
Fix WP 7.0 styling of dismiss notice and select2 tablenav outside orders/products

### DIFF
--- a/plugins/woocommerce/changelog/fix-select2-wp-7.0-less-specific
+++ b/plugins/woocommerce/changelog/fix-select2-wp-7.0-less-specific
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Already covered by other WP 7.0 UI changes.
+
+

--- a/plugins/woocommerce/client/legacy/css/activation.scss
+++ b/plugins/woocommerce/client/legacy/css/activation.scss
@@ -53,3 +53,16 @@ p.woocommerce-actions,
 .woocommerce-about-text {
 	margin-bottom: 1em !important;
 }
+
+// WP 7.0 changed .notice-dismiss to display:flex, width:24px, height:24px.
+// Reset these so the floated .woocommerce-message-close layout still works and the X icon aligns.
+.wc-wp-version-gte-70 .woocommerce-message a.woocommerce-message-close {
+	display: inline;
+	width: auto;
+	height: auto;
+	color: #1e1e1e;
+
+	&::before {
+		top: 18px;
+	}
+}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8522,6 +8522,15 @@ table.bar_chart {
 			}
 		}
 	}
+
+	// WP 7.0 sets display:flex, width:24px, height:24px on .notice-dismiss.
+	// Reset these so the floated .woocommerce-message-close layout still works.
+	.woocommerce-message a.woocommerce-message-close {
+		display: inline;
+		width: auto;
+		height: auto;
+		color: #1e1e1e;
+	}
 }
 
 /**

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8523,6 +8523,12 @@ table.bar_chart {
 		}
 	}
 
+	// .woocommerce-embed-page sets notice padding to 1px 12px, which is too small for WP 7.0's dismiss button positioning.
+	// Restore WP 7.0's padding so the dismiss button aligns correctly.
+	&.woocommerce-embed-page .notice {
+		padding: 8px 12px;
+	}
+
 	// WP 7.0 sets display:flex, width:24px, height:24px on .notice-dismiss.
 	// Reset these so the floated .woocommerce-message-close layout still works.
 	.woocommerce-message a.woocommerce-message-close {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8511,29 +8511,11 @@ table.bar_chart {
 		}
 	}
 
-	// Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.
-	// Match Select2 to 32px here (not the global 40px).
+	// Current page in pagination gets smaller than surrounding buttons at 782px breakpoint.
 	&.woocommerce_page_wc-customer-stock-notifications .tablenav,
 	&.woocommerce_page_wc-orders .tablenav,
 	&.post-type-product .tablenav,
 	&.post-type-shop_order .tablenav {
-		.select2-container {
-			margin-top: 0; // Align with other tablenav elements.
-		}
-
-		.select2-container .select2-selection--single {
-			height: 32px; // WP 7.0 tablenav uses compact 32px, not 40px.
-
-			.select2-selection__rendered {
-				line-height: 30px;
-			}
-
-			.select2-selection__arrow {
-				height: 30px;
-			}
-		}
-
-		// Current page in pagination gets smaller than surrounding buttons at 782px breakpoint.
 		@media screen and (max-width: 782px) {
 			#current-page-selector {
 				height: 44px;
@@ -8601,6 +8583,26 @@ table.bar_chart {
 		font-size: 14px;
 		vertical-align: middle;
 		margin: 1px 6px 4px 1px;
+	}
+}
+
+// Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.
+// Match Select2 to 32px here (not the global 40px).
+.wc-wp-version-gte-70 .tablenav {
+	.select2-container {
+		margin-top: 0; // Align with other tablenav elements.
+	}
+
+	.select2-container .select2-selection--single {
+		height: 32px; // WP 7.0 tablenav uses compact 32px, not 40px.
+
+		.select2-selection__rendered {
+			line-height: 30px;
+		}
+
+		.select2-selection__arrow {
+			height: 30px;
+		}
 	}
 }
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -708,7 +708,7 @@ class CustomOrdersTableController {
 					);
 
 					$sync_message[] = sprintf(
-						'<a href="%1$s" class="button button-link">%2$s</a>',
+						'<a href="%1$s" class="button-link">%2$s</a>',
 						esc_url( $stop_sync_url ),
 						__( 'Stop sync', 'woocommerce' )
 					);
@@ -731,7 +731,7 @@ class CustomOrdersTableController {
 				}
 
 				$sync_message[] = sprintf(
-					'<a href="%1$s" class="button button-link">%2$s</a>',
+					'<a href="%1$s" class="button-link">%2$s</a>',
 					esc_url( $sync_now_url ),
 					__( 'Sync orders now', 'woocommerce' )
 				);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds some CSS fixes when running under WP 7.0. In particular:

- Broadens the select2 sizing fixes to apply to all `.tablenav` table list sections, not just orders or products. This helps compatibility with 3rd party plugins and makes sense given WC already ships the _default_ select2 styles.
- Fixes the color and positioning of dismiss links inside `.woocommerce-message`.
- Removes unnecessary CSS class from HPOS sync button.

Closes https://linear.app/a8c/issue/STORMA-155/fix-points-and-rewards-admin-settings-issues.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

|WP 6.9| Before (WP 7.0) | After (WP 7.0) |
| ----- | ------ | ----- |
<img width="1033" height="151" alt="wp69" src="https://github.com/user-attachments/assets/aa82a78a-612b-4b58-a991-e470f98d12cf" />|<img width="1173" height="161" alt="before" src="https://github.com/user-attachments/assets/5bad1a9e-9041-4912-b2b9-7e02b093a822" />|<img width="1167" height="159" alt="Screenshot 2026-04-03 at 10 06 43" src="https://github.com/user-attachments/assets/8597cc35-9227-4066-a36c-5d22184d93b4" />|
<img width="1084" height="195" alt="Screenshot 2026-04-06 at 21 39 50" src="https://github.com/user-attachments/assets/1cb34496-4913-4aed-ae16-4246e1c74bc6" />|<img width="1079" height="207" alt="Screenshot 2026-04-06 at 21 37 31" src="https://github.com/user-attachments/assets/bfe10edc-9879-4b38-90dc-f901b6546253" />|<img width="1095" height="188" alt="Screenshot 2026-04-06 at 21 37 46" src="https://github.com/user-attachments/assets/07e227cd-9b8c-4f5a-a4a2-bb00f7715f42" />|
<img width="1323" height="67" alt="Screenshot 2026-04-07 at 09 20 52" src="https://github.com/user-attachments/assets/40409853-a2d2-463f-802e-81413ffb7457" />|<img width="1315" height="55" alt="Screenshot 2026-04-07 at 09 19 59" src="https://github.com/user-attachments/assets/22700f9c-7776-4949-98c4-d76eef428dd5" />|<img width="1328" height="79" alt="Screenshot 2026-04-07 at 09 17 07" src="https://github.com/user-attachments/assets/bdaa5ab3-611f-4cd9-bcd1-ccbd1cdfa59d" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Ensure you're running WordPress 7.0 on your test site.
   ```
   wp core update --version=7.0-RC2
   ```
1. Install the **Points & Rewards** plugin. This provides an easy way to confirm the changes in `tablenav` as well as notices.
1. Go to **WooCommerce > Points & Rewards**.
1. Confirm that the dismiss-able notice and the customers filter on top of the table look correct. See screenshots above.
1. Downgrade to WordPress 6.9 (`wp core update --version=6.9.4 --force`) and confirm things still look correct.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.