### PR TITLE
Fix duplicate wc_customer_lookup rows on delayed account creation

### DIFF
--- a/plugins/woocommerce/changelog/63989-fix-customer-lookup-duplicate-on-delayed-registration
+++ b/plugins/woocommerce/changelog/63989-fix-customer-lookup-duplicate-on-delayed-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix duplicate wc_customer_lookup rows when a guest registers via delayed account creation on the order confirmation page.

--- a/plugins/woocommerce/changelog/fix-customer-lookup-duplicate-on-delayed-registration
+++ b/plugins/woocommerce/changelog/fix-customer-lookup-duplicate-on-delayed-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix duplicate wc_customer_lookup rows when a guest registers via delayed account creation on the order confirmation page.

--- a/plugins/woocommerce/changelog/fix-customer-lookup-duplicate-on-delayed-registration
+++ b/plugins/woocommerce/changelog/fix-customer-lookup-duplicate-on-delayed-registration
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix duplicate wc_customer_lookup rows when a guest registers via delayed account creation on the order confirmation page.

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -111,6 +111,45 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'anonymize_customer' ) );
 
 		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 15, 2 );
+
+		add_action( 'woocommerce_created_customer', array( __CLASS__, 'merge_guest_customer_on_delayed_account_creation' ), 5, 2 );
+	}
+
+	/**
+	 * When a customer registers via delayed account creation (order confirmation page),
+	 * merge the existing guest lookup row instead of creating a duplicate.
+	 *
+	 * This runs on woocommerce_created_customer at priority 5, before the analytics
+	 * hooks (woocommerce_new_customer) that call update_registered_customer(). It updates
+	 * the guest row's user_id so that update_registered_customer() finds it via
+	 * get_customer_id_by_user_id() and updates in place rather than inserting a new row.
+	 *
+	 * @param int   $customer_id       New WP user ID.
+	 * @param array $new_customer_data Customer data including 'source'.
+	 */
+	public static function merge_guest_customer_on_delayed_account_creation( $customer_id, $new_customer_data ) {
+		if ( empty( $new_customer_data['source'] ) || 'delayed-account-creation' !== $new_customer_data['source'] ) {
+			return;
+		}
+
+		$email = $new_customer_data['user_email'] ?? '';
+		if ( empty( $email ) ) {
+			return;
+		}
+
+		$guest_customer_id = self::get_guest_id_by_email( $email );
+		if ( ! $guest_customer_id ) {
+			return;
+		}
+
+		global $wpdb;
+		$wpdb->update(
+			self::get_db_table_name(),
+			array( 'user_id' => $customer_id ),
+			array( 'customer_id' => $guest_customer_id ),
+			array( '%d' ),
+			array( '%d' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -127,7 +127,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param int   $customer_id       New WP user ID.
 	 * @param array $new_customer_data Customer data including 'source'.
 	 */
-	public static function merge_guest_customer_on_delayed_account_creation( $customer_id, $new_customer_data ) {
+	public static function merge_guest_customer_on_delayed_account_creation( $customer_id, $new_customer_data ): void {
 		if ( empty( $new_customer_data['source'] ) || 'delayed-account-creation' !== $new_customer_data['source'] ) {
 			return;
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
@@ -178,15 +178,19 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		// Should have two rows — guest row is NOT merged for normal registration.
+		// The guest row must remain untouched: same customer_id, user_id still NULL.
+		// (update_registered_customer skips users with no orders, so no second row is
+		// inserted either — what we're guarding against here is the merge function
+		// silently claiming the guest row for an unverified registration.)
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT customer_id, user_id FROM {$wpdb->prefix}wc_customer_lookup WHERE email = %s",
-				$email
+				"SELECT customer_id, user_id FROM {$wpdb->prefix}wc_customer_lookup WHERE customer_id = %d",
+				$guest_customer_id
 			)
 		);
 
-		$this->assertCount( 2, $rows, 'Normal registration should not merge guest row.' );
+		$this->assertCount( 1, $rows, 'Guest row should still exist.' );
+		$this->assertNull( $rows[0]->user_id, 'Guest row user_id should remain NULL for normal registration.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
@@ -179,9 +179,9 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// The guest row must remain untouched: same customer_id, user_id still NULL.
-		// (update_registered_customer skips users with no orders, so no second row is
-		// inserted either — what we're guarding against here is the merge function
-		// silently claiming the guest row for an unverified registration.)
+		// update_registered_customer skips users with no orders, so no second row is
+		// inserted either. What we're guarding against here is the merge function
+		// silently claiming the guest row for an unverified registration.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT customer_id, user_id FROM {$wpdb->prefix}wc_customer_lookup WHERE customer_id = %d",

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
@@ -99,6 +99,97 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that delayed account creation (order confirmation page) merges the
+	 * guest customer_lookup row instead of creating a duplicate.
+	 *
+	 * @covers \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::merge_guest_customer_on_delayed_account_creation
+	 */
+	public function test_delayed_account_creation_merges_guest_row() {
+		global $wpdb;
+
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$email = 'guest-merge-test@example.com';
+
+		// Create a guest order.
+		$order = WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		// Verify guest row exists.
+		$guest_customer_id = \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_guest_id_by_email( $email );
+		$this->assertNotFalse( $guest_customer_id, 'Guest customer row should exist after guest order.' );
+
+		// Register via delayed account creation (same source as the order confirmation page).
+		$user_id = wc_create_new_customer(
+			$email,
+			'',
+			'test_password',
+			array(
+				'first_name' => 'John',
+				'last_name'  => 'Doe',
+				'source'     => 'delayed-account-creation',
+			)
+		);
+		$this->assertNotWPError( $user_id );
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		// The guest row should have been updated in place, not duplicated.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT customer_id, user_id FROM {$wpdb->prefix}wc_customer_lookup WHERE email = %s",
+				$email
+			)
+		);
+
+		$this->assertCount( 1, $rows, 'There should be exactly one customer_lookup row for this email.' );
+		$this->assertEquals( $guest_customer_id, (int) $rows[0]->customer_id, 'The original customer_id should be preserved.' );
+		$this->assertEquals( $user_id, (int) $rows[0]->user_id, 'The user_id should be updated to the new registered user.' );
+	}
+
+	/**
+	 * Test that normal (non-delayed) registration does NOT merge a guest row.
+	 *
+	 * @covers \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::merge_guest_customer_on_delayed_account_creation
+	 */
+	public function test_normal_registration_does_not_merge_guest_row() {
+		global $wpdb;
+
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$email = 'normal-register-test@example.com';
+
+		// Create a guest order.
+		$order = WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$guest_customer_id = \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_guest_id_by_email( $email );
+		$this->assertNotFalse( $guest_customer_id, 'Guest customer row should exist.' );
+
+		// Register via normal flow (no source = no merge).
+		$user_id = wc_create_new_customer( $email, '', 'test_password' );
+		$this->assertNotWPError( $user_id );
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		// Should have two rows — guest row is NOT merged for normal registration.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT customer_id, user_id FROM {$wpdb->prefix}wc_customer_lookup WHERE email = %s",
+				$email
+			)
+		);
+
+		$this->assertCount( 2, $rows, 'Normal registration should not merge guest row.' );
+	}
+
+	/**
 	 * Get a customer's record from the database.
 	 *
 	 * @param int $customer_id Analytics Customer ID (not WP User ID).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a guest places an order, `sync_order_customer()` creates a `wc_customer_lookup` row with `user_id=NULL`. If that guest later registers an account from the order confirmation page (delayed account creation), `update_registered_customer()` inserts a **new** row with the new `user_id` instead of updating the existing guest row. This results in duplicate rows for the same person, causing them to appear twice in `/wc-analytics/reports/customers`.

**Fix:** Add `merge_guest_customer_on_delayed_account_creation()` hooked on `woocommerce_created_customer` at priority 5. It:
1. Checks for `source === 'delayed-account-creation'` (only set by the order confirmation `CreateAccount` block)
2. Looks up an existing guest row by email (`user_id IS NULL`)
3. Updates that row's `user_id` to the new user ID, so `update_registered_customer()` finds it via `get_customer_id_by_user_id()` and updates in place

The fix is intentionally scoped to the delayed account creation flow only. Other registration paths (my-account, checkout checkbox, admin) are not affected, since those don't have the same email verification guarantee that the order confirmation page provides.

### How to test the changes in this Pull Request:

1. Enable guest checkout and delayed account creation in WooCommerce settings
2. Place an order as a guest
3. On the order confirmation page, create an account
4. Check the `wc_customer_lookup` table — there should be exactly **one** row for that email, with the new `user_id` set
5. Verify the customer appears only once in **Analytics > Customers**
6. Also verify: register a new account from the my-account page using an email that has a guest order — the guest row should **not** be merged (two rows expected)

### Testing that has already taken place:

- PHP linting passes (`pnpm lint:php:changes`)
- Unit tests added for both the merge path and the no-merge path

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix duplicate wc_customer_lookup rows when a guest registers via delayed account creation on the order confirmation page.

</details>