### PR TITLE
Fix Product SKU not visible for variable products inside Product Collections

### DIFF
--- a/plugins/woocommerce/changelog/fix-63988-product-sku-variable-product
+++ b/plugins/woocommerce/changelog/fix-63988-product-sku-variable-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Product SKU not visible for variable products inside Product Collections

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -54670,12 +54670,6 @@ parameters:
 			path: src/Blocks/BlockTypes/ProductResultsCount.php
 
 		-
-			message: '#^Access to property \$context on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\WP_Block\.$#'
-			identifier: class.notFound
-			count: 2
-			path: src/Blocks/BlockTypes/ProductSKU.php
-
-		-
 			message: '#^Call to an undefined method WC_Product\:\:get_available_variations\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -54690,12 +54684,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\ProductSKU\:\:register_block_type_assets\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Blocks/BlockTypes/ProductSKU.php
-
-		-
-			message: '#^Parameter \$block of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\ProductSKU\:\:render\(\) has invalid type Automattic\\WooCommerce\\Blocks\\BlockTypes\\WP_Block\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/Blocks/BlockTypes/ProductSKU.php
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -68,9 +68,8 @@ class ProductSKU extends AbstractBlock {
 			return '';
 		}
 
-		$is_descendant_of_product_collection       = isset( $block->context['query']['isProductCollectionBlock'] );
-		$is_descendant_of_grouped_product_selector = isset( $block->context['isDescendantOfGroupedProductSelector'] );
-		$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product->is_type( ProductType::VARIABLE );
+		$is_descendant_of_product_collection = isset( $block->context['query']['isProductCollectionBlock'] );
+		$is_interactive                      = ! $is_descendant_of_product_collection && $product->is_type( ProductType::VARIABLE );
 
 		if ( $is_interactive ) {
 			$variations                = $product->get_available_variations( 'objects' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Enums\ProductType;
+use WP_Block;
 
 /**
  * ProductSKU class.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -68,7 +68,9 @@ class ProductSKU extends AbstractBlock {
 			return '';
 		}
 
-		$is_interactive = $product->is_type( ProductType::VARIABLE );
+		$is_descendant_of_product_collection       = isset( $block->context['query']['isProductCollectionBlock'] );
+		$is_descendant_of_grouped_product_selector = isset( $block->context['isDescendantOfGroupedProductSelector'] );
+		$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product->is_type( ProductType::VARIABLE );
 
 		if ( $is_interactive ) {
 			$variations                = $product->get_available_variations( 'objects' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #63988.
Closes WOOPLUG-6507.

This PR marks the Product SKU block as non-interactive when it's inside a _Product Collection_ block. This way, it doesn't try to update the sku unnecessarily, which was causing it not to show up in variable products.

### How to test the changes in this Pull Request:

1. Create a variable product with an SKU.
2. Create a page and add the Product Collection block.
3. Add the Product SKU inside the Product Collection block, like below the image.
4. View the page in the frontend.
5. Verify the SKU of the variable product shows up.

Before | After
--- | ---
<img width="803" height="592" alt="Captura de pantalla de 2026-04-02 15-27-15" src="https://github.com/user-attachments/assets/dfc2110d-26a8-4a3d-a8f0-9823380b9942" /> | <img width="803" height="592" alt="Captura de pantalla de 2026-04-02 15-28-24" src="https://github.com/user-attachments/assets/1e7c344d-0f51-4c32-943a-62a12d57e339" />

Test there are no regressions in the Single Product template:

1. Edit the Single Product template, adding the Product Meta block somewhere.
2. In the frontend, visit a variable product (assuming it has different SKUs for each variation, otherwise, update the product).
3. Verify that the SKU updates based on the selected attributes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
