### PR TITLE
[Performance] Optimize SQL performance in the wc_customer_bought_product function.

### DIFF
--- a/plugins/woocommerce/changelog/performance-slow-sql-customer-bought-product
+++ b/plugins/woocommerce/changelog/performance-slow-sql-customer-bought-product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Optimize SQL performance in the wc_customer_bought_product function.

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -439,106 +439,129 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 		$cache_version = WC_Cache_Helper::get_transient_version( 'orders' );
 	}
 
-	$cache_group = 'orders';
-	$cache_key   = 'wc_customer_bought_product_' . md5( $customer_email . '-' . $user_id . '-' . $use_lookup_tables );
-	$cache_value = wp_cache_get( $cache_key, $cache_group );
+	$aggregation_version = 'v2'; // Update the version when modifying the aggregation implementation to ensure the cache is repopulated.
+	$cache_group         = 'orders';
+	$cache_key           = 'wc_customer_bought_product_' . md5( $customer_email . '-' . $user_id . '-' . $use_lookup_tables . '-' . $aggregation_version );
+	$cache_value         = wp_cache_get( $cache_key, $cache_group );
 
 	if ( isset( $cache_value['value'], $cache_value['version'] ) && $cache_value['version'] === $cache_version ) {
 		$result = $cache_value['value'];
 	} else {
-		$customer_data = array( $user_id );
+		// Identify the customer using the provided data. Use Customer ID to optimize performance in the following SQL
+		// queries. If an account has been deleted, use the supplied ID to ensure graceful handling.
+		$user             = null;
+		$original_user_id = $user_id;
+		if ( ! $user_id && $customer_email && is_email( $customer_email ) ) {
+			$user    = get_user_by( 'email', $customer_email );
+			$user_id = $user->ID ?? $user_id;
+		}
+		if ( $user_id && ! $user ) {
+			$user    = get_user_by( 'id', $user_id );
+			$user_id = $user->ID ?? $user_id;
+		}
 
-		if ( $user_id ) {
-			$user = get_user_by( 'id', $user_id );
-
-			if ( isset( $user->user_email ) ) {
-				$customer_data[] = $user->user_email;
+		// Deduplicate emails to ensure the Customer ID remains the primary performance driver in subsequent SQL queries.
+		$emails = array( $customer_email );
+		if ( $original_user_id ) {
+			$user_email = $user->user_email ?? '';
+			if ( $user_email && is_email( $user_email ) && strtolower( $user_email ) === strtolower( $customer_email ) ) {
+				$emails = array();
 			}
 		}
+		$emails = array_unique( array_filter( $emails, static fn( $email ) => $email && is_email( $email ) ) );
 
-		if ( is_email( $customer_email ) ) {
-			$customer_data[] = $customer_email;
-		}
+		if ( empty( $emails ) && ! $user_id ) {
+			wp_cache_set(
+				$cache_key,
+				array(
+					'version' => $cache_version,
+					'value'   => array(),
+				),
+				$cache_group,
+				MONTH_IN_SECONDS
+			);
 
-		$customer_data = array_map( 'esc_sql', array_filter( array_unique( $customer_data ) ) );
-		$statuses      = array_map( 'esc_sql', wc_get_is_paid_statuses() );
-
-		if ( count( $customer_data ) === 0 ) {
 			return false;
 		}
 
+		$emails   = array_map( 'esc_sql', $emails );
+		$statuses = array_map( 'esc_sql', wc_get_is_paid_statuses() );
+
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			$statuses       = array_map(
-				function ( $status ) {
-					return "wc-$status";
-				},
-				$statuses
-			);
-			$order_table    = OrdersTableDataStore::get_orders_table_name();
-			$user_id_clause = '';
+			$statuses    = array_map( static fn( $status ) => "wc-$status", $statuses );
+			$order_table = OrdersTableDataStore::get_orders_table_name();
+
+			$identity_clause = array();
 			if ( $user_id ) {
-				$user_id_clause = 'OR o.customer_id = ' . absint( $user_id );
+				$identity_clause[] = 'orders.customer_id = ' . absint( $user_id );
 			}
+			if ( ! empty( $emails ) ) {
+				$identity_clause[] = "orders.billing_email IN ( '" . implode( "','", $emails ) . "' )";
+			}
+			$identity_clause = implode( ' OR ', $identity_clause );
+
 			if ( $use_lookup_tables ) {
 				// HPOS: yes, Lookup table: yes.
-				$sql = "
-SELECT DISTINCT product_or_variation_id FROM (
-SELECT CASE WHEN product_id != 0 THEN product_id ELSE variation_id END AS product_or_variation_id
-FROM {$wpdb->prefix}wc_order_product_lookup lookup
-INNER JOIN $order_table AS o ON lookup.order_id = o.ID
-WHERE o.status IN ('" . implode( "','", $statuses ) . "')
-AND ( o.billing_email IN ('" . implode( "','", $customer_data ) . "') $user_id_clause )
-) AS subquery
-WHERE product_or_variation_id != 0
-";
+				$sql = "SELECT DISTINCT product_or_variation_id
+				FROM (
+					SELECT CASE WHEN product_id != 0 THEN product_id ELSE variation_id END AS product_or_variation_id
+					FROM {$wpdb->prefix}wc_order_product_lookup lookup
+						INNER JOIN $order_table AS orders ON lookup.order_id = orders.ID
+					WHERE orders.status IN ( '" . implode( "','", $statuses ) . "' )
+						AND ( $identity_clause )
+				) AS subquery
+				WHERE product_or_variation_id != 0";
 			} else {
 				// HPOS: yes, Lookup table: no.
-				$sql = "
-SELECT DISTINCT im.meta_value FROM $order_table AS o
-INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON o.id = i.order_id
-INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
-WHERE o.status IN ('" . implode( "','", $statuses ) . "')
-AND im.meta_key IN ('_product_id', '_variation_id' )
-AND im.meta_value != 0
-AND ( o.billing_email IN ('" . implode( "','", $customer_data ) . "') $user_id_clause )
-";
+				$sql = "SELECT DISTINCT itemmeta.meta_value
+				FROM $order_table AS orders
+					INNER JOIN {$wpdb->prefix}woocommerce_order_items AS items ON orders.id = items.order_id
+					INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS itemmeta ON items.order_item_id = itemmeta.order_item_id
+				WHERE orders.status IN ( '" . implode( "','", $statuses ) . "' )
+					AND itemmeta.meta_key   IN ( '_product_id', '_variation_id' )
+					AND itemmeta.meta_value != '0'
+					AND ( $identity_clause )";
 			}
-			$result = $wpdb->get_col( $sql );
-		} elseif ( $use_lookup_tables ) {
-			// HPOS: no, Lookup table: yes.
-			$result = $wpdb->get_col(
-				"
-SELECT DISTINCT product_or_variation_id FROM (
-SELECT CASE WHEN lookup.product_id != 0 THEN lookup.product_id ELSE lookup.variation_id END AS product_or_variation_id
-FROM {$wpdb->prefix}wc_order_product_lookup AS lookup
-INNER JOIN {$wpdb->posts} AS p ON p.ID = lookup.order_id
-INNER JOIN {$wpdb->postmeta} AS pm ON p.ID = pm.post_id
-WHERE p.post_status IN ( 'wc-" . implode( "','wc-", $statuses ) . "' )
-AND pm.meta_key IN ( '_billing_email', '_customer_user' )
-AND pm.meta_value IN ( '" . implode( "','", $customer_data ) . "' )
-) AS subquery
-WHERE product_or_variation_id != 0
-		"
-			); // WPCS: unprepared SQL ok.
 		} else {
-			// HPOS: no, Lookup table: no.
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-			$result = $wpdb->get_col(
-				"
-SELECT DISTINCT im.meta_value FROM {$wpdb->posts} AS p
-INNER JOIN {$wpdb->postmeta} AS pm ON p.ID = pm.post_id
-INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON p.ID = i.order_id
-INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
-WHERE p.post_status IN ( 'wc-" . implode( "','wc-", $statuses ) . "' ) AND p.post_type = 'shop_order'
-AND pm.meta_key IN ( '_billing_email', '_customer_user' )
-AND im.meta_key IN ( '_product_id', '_variation_id' )
-AND im.meta_value != 0
-AND pm.meta_value IN ( '" . implode( "','", $customer_data ) . "' )
-		"
-			);
-			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+			$identity_clause = array();
+			if ( $user_id ) {
+				$identity_clause[] = "( postmeta.meta_key = '_customer_user' AND postmeta.meta_value = '" . absint( $user_id ) . "' )";
+			}
+			if ( ! empty( $emails ) ) {
+				$identity_clause[] = "( postmeta.meta_key = '_billing_email' AND postmeta.meta_value IN ( '" . implode( "','", $emails ) . "' ) )";
+			}
+			$identity_clause = implode( ' OR ', $identity_clause );
+
+			if ( $use_lookup_tables ) {
+				// HPOS: no, Lookup table: yes.
+				$sql = "SELECT DISTINCT product_or_variation_id
+				FROM (
+					SELECT CASE WHEN lookup.product_id != 0 THEN lookup.product_id ELSE lookup.variation_id END AS product_or_variation_id
+					FROM {$wpdb->prefix}wc_order_product_lookup AS lookup
+						INNER JOIN {$wpdb->posts} AS posts ON posts.ID = lookup.order_id
+						INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
+					WHERE posts.post_status IN ( 'wc-" . implode( "','wc-", $statuses ) . "' )
+						AND ( $identity_clause )
+				) AS subquery
+				WHERE product_or_variation_id != 0";
+			} else {
+				// HPOS: no, Lookup table: no.
+				$sql = "SELECT DISTINCT itemmeta.meta_value
+				FROM {$wpdb->prefix}woocommerce_order_items AS items
+					INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS itemmeta ON items.order_item_id = itemmeta.order_item_id
+				WHERE items.order_id IN (
+						SELECT posts.ID as order_id
+						FROM {$wpdb->posts} AS posts
+							INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
+						WHERE posts.post_type   = 'shop_order'
+						  AND posts.post_status IN ( 'wc-" . implode( "','wc-", $statuses ) . "' )
+						  AND ( $identity_clause )
+				)
+				AND itemmeta.meta_key   IN ( '_product_id', '_variation_id' )
+				AND itemmeta.meta_value != '0'";
+			}
 		}
-		$result = array_map( 'absint', $result );
+		$result = array_map( 'absint', $wpdb->get_col( $sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		wp_cache_set(
 			$cache_key,

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -36898,12 +36898,6 @@ parameters:
 			path: includes/wc-user-functions.php
 
 		-
-			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(int\<min, \-1\>\|int\<1, max\>\|non\-falsy\-string\)\: mixed\)\|null, ''esc_sql'' given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/wc-user-functions.php
-
-		-
 			message: '#^Parameter \#1 \$object_or_class of function property_exists expects object\|string, WP_User\|false given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
@@ -263,12 +263,22 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 	public function test_wc_customer_bought_product() {
 		$customer_id_1 = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );
 		$customer_id_2 = wc_create_new_customer( 'test2@example.com', 'testuser2', 'testpassword2' );
+		$customer_id_3 = wc_create_new_customer( 'account@example.com', 'testuser3', 'testpassword3' );
 		$product_1     = new WC_Product_Simple();
 		$product_1->save();
 		$product_id_1 = $product_1->get_id();
 		$product_2    = new WC_Product_Simple();
 		$product_2->save();
 		$product_id_2 = $product_2->get_id();
+		$product_3    = new WC_Product_Simple();
+		$product_3->save();
+		$product_id_3 = $product_3->get_id();
+		$product_4    = new WC_Product_Simple();
+		$product_4->save();
+		$product_id_4 = $product_4->get_id();
+		$product_5    = new WC_Product_Simple();
+		$product_5->save();
+		$product_id_5 = $product_5->get_id();
 
 		$order_1 = WC_Helper_Order::create_order( $customer_id_1, $product_1 );
 		$order_1->set_billing_email( 'test@example.com' );
@@ -283,16 +293,44 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 		$order_3->set_status( OrderStatus::PENDING );
 		$order_3->save();
 
+		$guest_order = wc_create_order();
+		$guest_order->add_product( $product_3 );
+		$guest_order->set_billing_email( 'guest@example.com' );
+		$guest_order->set_status( OrderStatus::COMPLETED );
+		$guest_order->save();
+
+		$different_billing_email_order = WC_Helper_Order::create_order( $customer_id_3, $product_4 );
+		$different_billing_email_order->set_billing_email( 'billing@example.com' );
+		$different_billing_email_order->set_status( OrderStatus::COMPLETED );
+		$different_billing_email_order->save();
+
+		$unlinked_guest_order = wc_create_order();
+		$unlinked_guest_order->add_product( $product_5 );
+		$unlinked_guest_order->set_billing_email( 'test@example.com' );
+		$unlinked_guest_order->set_status( OrderStatus::COMPLETED );
+		$unlinked_guest_order->save();
+
 		// Manually trigger the product lookup tables update, since it may take a few moments for it to happen automatically.
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		foreach ( array( '__return_true', '__return_false' ) as $lookup_tables ) {
 			add_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
+
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1 ) );
 			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1 ) );
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1 ) );
 			$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2 ) );
 			$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1 ) );
+
+			$this->assertTrue( wc_customer_bought_product( 'guest@example.com', 0, $product_id_3 ) );
+			$this->assertFalse( wc_customer_bought_product( 'other@example.com', 0, $product_id_3 ) );
+
+			$this->assertTrue( wc_customer_bought_product( 'billing@example.com', $customer_id_3, $product_id_4 ) );
+			$this->assertTrue( wc_customer_bought_product( '', $customer_id_3, $product_id_4 ) );
+			$this->assertTrue( wc_customer_bought_product( 'billing@example.com', 0, $product_id_4 ) );
+
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_5 ) );
+
 			remove_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -37,12 +37,22 @@ class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 	public function test_hpos_wc_customer_bought_product() {
 		$customer_id_1 = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );
 		$customer_id_2 = wc_create_new_customer( 'test2@example.com', 'testuser2', 'testpassword2' );
+		$customer_id_3 = wc_create_new_customer( 'account@example.com', 'testuser3', 'testpassword3' );
 		$product_1     = new WC_Product_Simple();
 		$product_1->save();
 		$product_id_1 = $product_1->get_id();
 		$product_2    = new WC_Product_Simple();
 		$product_2->save();
 		$product_id_2 = $product_2->get_id();
+		$product_3    = new WC_Product_Simple();
+		$product_3->save();
+		$product_id_3 = $product_3->get_id();
+		$product_4    = new WC_Product_Simple();
+		$product_4->save();
+		$product_id_4 = $product_4->get_id();
+		$product_5    = new WC_Product_Simple();
+		$product_5->save();
+		$product_id_5 = $product_5->get_id();
 
 		$order_1 = WC_Helper_Order::create_order( $customer_id_1, $product_1 );
 		$order_1->set_billing_email( 'test@example.com' );
@@ -61,16 +71,44 @@ class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 		$order_4->set_status( OrderStatus::COMPLETED );
 		$order_4->save();
 
+		$guest_order = wc_create_order();
+		$guest_order->add_product( $product_3 );
+		$guest_order->set_billing_email( 'guest@example.com' );
+		$guest_order->set_status( OrderStatus::COMPLETED );
+		$guest_order->save();
+
+		$different_billing_email_order = WC_Helper_Order::create_order( $customer_id_3, $product_4 );
+		$different_billing_email_order->set_billing_email( 'billing@example.com' );
+		$different_billing_email_order->set_status( OrderStatus::COMPLETED );
+		$different_billing_email_order->save();
+
+		$unlinked_guest_order = wc_create_order();
+		$unlinked_guest_order->add_product( $product_5 );
+		$unlinked_guest_order->set_billing_email( 'test@example.com' );
+		$unlinked_guest_order->set_status( OrderStatus::COMPLETED );
+		$unlinked_guest_order->save();
+
 		// Manually trigger the product lookup tables update, since it may take a few moments for it to happen automatically.
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		foreach ( array( '__return_true', '__return_false' ) as $lookup_tables ) {
 			add_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
+
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1 ) );
 			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1 ) );
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1 ) );
 			$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2 ) );
 			$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1 ) );
+
+			$this->assertTrue( wc_customer_bought_product( 'guest@example.com', 0, $product_id_3 ) );
+			$this->assertFalse( wc_customer_bought_product( 'other@example.com', 0, $product_id_3 ) );
+
+			$this->assertTrue( wc_customer_bought_product( 'billing@example.com', $customer_id_3, $product_id_4 ) );
+			$this->assertTrue( wc_customer_bought_product( '', $customer_id_3, $product_id_4 ) );
+			$this->assertTrue( wc_customer_bought_product( 'billing@example.com', 0, $product_id_4 ) );
+
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_5 ) );
+
 			remove_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes WOOPLUG-6510, #63999

Implements an optimized approach that prioritizes resolving customer IDs from the provided data. When filtering by customer ID is possible, avoid using billing email filtering. The changes are backward-compatible and consistent with WooCommerce's codebase's use of this function.

Here are some numbers based on a test system with 1K products and 50K orders:

```
AI summary for the numbers (for WooCommerce core itself we are in best-case scenario):
┌───────────┬────────────────────────────────────────────────────┬──────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────┐
  │  Branch   │                Old version problems                │                Best case improvements                │                          Parity: regression / scale                           │
  ├───────────┼────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────┤
  │ 1 HPOS +  │ index_merge sort_union across two indexes (128     │ Single range on customer_id_status — Using index     │ No regression (127 rows, same index_merge); merge order now                   │
  │ Lookup    │ rows); user_id integer injected into billing_email │ (covering, no row fetches); exec ~12ms → ~6ms warm   │ customer_id_status first (more selective); scales with customer's order count │
  │           │  IN list                                           │                                                      │  via covered index — stable as store grows                                    │
  ├───────────┼────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────┤
  │           │ Same index_merge (128 rows); user_id in email      │ Same range + Using index on orders; != '0' fixed;    │ No regression (127 rows, ~22ms); join chain grows linearly with customer's    │
  │ 2 HPOS +  │ list; != 0 implicit cast on varchar itemmeta       │ exec flat (~23ms) — order_items × order_itemmeta     │ paid orders × avg items — this is the structural bottleneck that persists in  │
  │ No Lookup │ column                                             │ join chain dominates, absorbs the orders-side saving │ both variants at scale                                                        │
  │           │                                                    │  at 50K scale                                        │                                                                               │
  ├───────────┼────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────┤
  │           │ range on meta_key — 200,070 rows scanned;          │                                                      │ No regression (~3.4s, 200,070 rows — same as before); both variants scale     │
  │ 3 Legacy  │ cross-product IN lists allow semantically invalid  │ ref/const on meta_key — 104,016 rows (~49% fewer);   │ with total store postmeta size not customer's order count — fundamental       │
  │ + Lookup  │ key/value combinations (_customer_user = email);   │ single precise condition per meta_key; exec ~1.7s    │ ceiling of the legacy schema                                                  │
  │           │ execution ~3.3s                                    │                                                      │                                                                               │
  ├───────────┼────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────┤
  │ 4 Legacy  │ range on meta_key — 200,070 rows; same             │ ref/const on postmeta (104,016 rows); subquery       │ No regression in execution (~3.4s); structural improvement even at parity —   │
  │ + No      │ cross-product IN issue; 4-table flat join where    │ decouples fans — semi-join materialization           │ semi-join materialization prevents fan multiplication regardless of           │
  │ Lookup    │ postmeta fan × order_itemmeta fan multiply; != 0   │ (Start/End temporary); != '0' fixed; exec ~1.7s      │ email/user_id OR; as orders grow, old code degraded multiplicatively          │
  │           │ implicit cast; execution ~3.4s                     │ (~50%)                                               │ (postmeta × itemmeta), new parity degrades additively                         │
  └───────────┴────────────────────────────────────────────────────┴──────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────┘

  The standout insight across the table: Branches 1–2 (HPOS) are a timing story — small but real gains now, stable scaling. Branches 3–4 (legacy) are a severity story — 3s queries dropping to 1.7s, with
  Branch 4 parity also getting a structural decoupling win that doesn't show in the 50K numbers but matters at scale.

```

```sql
# Branch 1
# Before

EXPLAIN SELECT SQL_NO_CACHE DISTINCT product_or_variation_id FROM (
     SELECT CASE WHEN product_id != 0 THEN product_id ELSE variation_id END AS product_or_variation_id
     FROM wp_wc_order_product_lookup lookup
              INNER JOIN wp_wc_orders AS o ON lookup.order_id = o.ID
     WHERE o.status IN ('wc-processing','wc-completed')
       AND ( o.billing_email IN ('1', 'wordpress@example.com') OR o.customer_id = 1 )
 ) AS subquery
WHERE product_or_variation_id != 0;

# 1,SIMPLE,o,index_merge,"PRIMARY,status,customer_id_billing_email,billing_email,customer_id_status","billing_email,customer_id_status","767,92",,128,"Using sort_union(billing_email,customer_id_status); Using where; Using temporary"
# 1,SIMPLE,lookup,ref,order_id,order_id,8,wordpress.o.id,4,Using where

# 22 rows retrieved starting from 1 in 462 ms (execution: 28 ms, fetching: 434 ms)
# 22 rows retrieved starting from 1 in 458 ms (execution: 13 ms, fetching: 445 ms)
# 22 rows retrieved starting from 1 in 449 ms (execution: 12 ms, fetching: 437 ms)

#After
#Best case
EXPLAIN SELECT SQL_NO_CACHE  DISTINCT product_or_variation_id
FROM (
         SELECT CASE WHEN product_id != 0 THEN product_id ELSE variation_id END AS product_or_variation_id
         FROM wp_wc_order_product_lookup lookup
                  INNER JOIN wp_wc_orders AS orders ON lookup.order_id = orders.ID
         WHERE orders.status IN ( 'wc-processing','wc-completed' )
           AND ( orders.customer_id = 1 )
     ) AS subquery
WHERE product_or_variation_id != 0;
# orders,range,"PRIMARY,status,customer_id_billing_email,customer_id_status",customer_id_status,92,,119,Using where; Using index; Using temporary
# lookup,ref,order_id,order_id,8,wordpress.orders.id,4,Using where

# 22 rows retrieved starting from 1 in 429 ms (execution: 12 ms, fetching: 417 ms)
# 22 rows retrieved starting from 1 in 416 ms (execution: 10 ms, fetching: 406 ms)
# 22 rows retrieved starting from 1 in 405 ms (execution: 6 ms, fetching: 399 ms)

#Parity
EXPLAIN SELECT SQL_NO_CACHE  DISTINCT product_or_variation_id
FROM (
         SELECT CASE WHEN product_id != 0 THEN product_id ELSE variation_id END AS product_or_variation_id
         FROM wp_wc_order_product_lookup lookup
                  INNER JOIN wp_wc_orders AS orders ON lookup.order_id = orders.ID
         WHERE orders.status IN ( 'wc-processing','wc-completed' )
           AND ( orders.customer_id = 1 OR orders.billing_email IN ( 'wordpress@example.com' ) )
     ) AS subquery
WHERE product_or_variation_id != 0;
# orders,index_merge,"PRIMARY,status,customer_id_billing_email,billing_email,customer_id_status","customer_id_status,billing_email","92,767",,127,"Using sort_union(customer_id_status,billing_email); Using where; Using temporary"
# lookup,ref,order_id,order_id,8,wordpress.orders.id,4,Using where

# 22 rows retrieved starting from 1 in 504 ms (execution: 12 ms, fetching: 492 ms)
# 22 rows retrieved starting from 1 in 463 ms (execution: 13 ms, fetching: 450 ms)
# 22 rows retrieved starting from 1 in 465 ms (execution: 12 ms, fetching: 453 ms)
```

```sql
# Branch 2
# Before
EXPLAIN SELECT SQL_NO_CACHE DISTINCT im.meta_value FROM wp_wc_orders AS o
   INNER JOIN wp_woocommerce_order_items AS i ON o.id = i.order_id
   INNER JOIN wp_woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
WHERE o.status IN ('wc-processing','wc-completed')
  AND im.meta_key IN ('_product_id', '_variation_id' )
  AND im.meta_value != 0
  AND ( o.billing_email IN ('1', 'wordpress@example.com') OR o.customer_id = 1 );
# 1,SIMPLE,o,index_merge,"PRIMARY,status,customer_id_billing_email,billing_email,customer_id_status","billing_email,customer_id_status","767,92",,128,"Using sort_union(billing_email,customer_id_status); Using where; Using temporary"
# 1,SIMPLE,i,ref,"PRIMARY,order_id",order_id,8,wordpress.o.id,6,Using index
# 1,SIMPLE,im,ref,"meta_key,order_item_id",order_item_id,8,wordpress.i.order_item_id,9,Using where

# 25 rows retrieved starting from 1 in 483 ms (execution: 30 ms, fetching: 453 ms)
# 25 rows retrieved starting from 1 in 459 ms (execution: 25 ms, fetching: 434 ms)
# 25 rows retrieved starting from 1 in 428 ms (execution: 22 ms, fetching: 406 ms)

# After
# Best case
EXPLAIN SELECT SQL_NO_CACHE  DISTINCT itemmeta.meta_value
FROM wp_wc_orders AS orders
         INNER JOIN wp_woocommerce_order_items AS items ON orders.id = items.order_id
         INNER JOIN wp_woocommerce_order_itemmeta AS itemmeta ON items.order_item_id = itemmeta.order_item_id
WHERE orders.status IN ( 'wc-processing','wc-completed' )
  AND itemmeta.meta_key   IN ( '_product_id', '_variation_id' )
  AND itemmeta.meta_value != '0'
  AND ( orders.customer_id = 1 );
# range,"PRIMARY,status,customer_id_billing_email,customer_id_status",customer_id_status,92,,119,Using where; Using index; Using temporary
# ref,"PRIMARY,order_id",order_id,8,wordpress.orders.id,6,Using index
# ref,"meta_key,order_item_id",order_item_id,8,wordpress.items.order_item_id,9,Using where

# 25 rows retrieved starting from 1 in 482 ms (execution: 23 ms, fetching: 459 ms)
# 25 rows retrieved starting from 1 in 448 ms (execution: 24 ms, fetching: 424 ms)
# 25 rows retrieved starting from 1 in 442 ms (execution: 23 ms, fetching: 419 ms)

# Parity
EXPLAIN SELECT SQL_NO_CACHE  DISTINCT itemmeta.meta_value
FROM wp_wc_orders AS orders
         INNER JOIN wp_woocommerce_order_items AS items ON orders.id = items.order_id
         INNER JOIN wp_woocommerce_order_itemmeta AS itemmeta ON items.order_item_id = itemmeta.order_item_id
WHERE orders.status IN ( 'wc-processing','wc-completed' )
  AND itemmeta.meta_key   IN ( '_product_id', '_variation_id' )
  AND itemmeta.meta_value != '0'
  AND ( orders.customer_id = 1 OR orders.billing_email IN ( 'wordpress@example.com' ) );
# index_merge,"PRIMARY,status,customer_id_billing_email,billing_email,customer_id_status","customer_id_status,billing_email","92,767",,127,"Using sort_union(customer_id_status,billing_email); Using where; Using temporary"
# ref,"PRIMARY,order_id",order_id,8,wordpress.orders.id,6,Using index
# ref,"meta_key,order_item_id",order_item_id,8,wordpress.items.order_item_id,9,Using where

# 25 rows retrieved starting from 1 in 544 ms (execution: 23 ms, fetching: 521 ms)
# 25 rows retrieved starting from 1 in 453 ms (execution: 21 ms, fetching: 432 ms)
# 25 rows retrieved starting from 1 in 435 ms (execution: 22 ms, fetching: 413 ms)
```

```sql
# Branch 3
# Before

EXPLAIN SELECT SQL_NO_CACHE DISTINCT product_or_variation_id FROM (
 SELECT CASE WHEN lookup.product_id != 0 THEN lookup.product_id ELSE lookup.variation_id END AS product_or_variation_id
 FROM wp_wc_order_product_lookup AS lookup
          INNER JOIN wp_posts AS p ON p.ID = lookup.order_id
          INNER JOIN wp_postmeta AS pm ON p.ID = pm.post_id
 WHERE p.post_status IN ( 'wc-processing','wc-completed' )
   AND pm.meta_key IN ( '_billing_email', '_customer_user' )
   AND pm.meta_value IN ( '1', 'wordpress@example.com' )
) AS subquery
WHERE product_or_variation_id != 0;
# 1,SIMPLE,pm,range,"post_id,meta_key",meta_key,767,,200070,Using where; Using temporary
# 1,SIMPLE,p,eq_ref,PRIMARY,PRIMARY,8,wordpress.pm.post_id,1,Using where
# 1,SIMPLE,lookup,ref,order_id,order_id,8,wordpress.pm.post_id,4,Using where

# 22 rows retrieved starting from 1 in 3 s 664 ms (execution: 3 s 267 ms, fetching: 397 ms)
# 22 rows retrieved starting from 1 in 3 s 832 ms (execution: 3 s 485 ms, fetching: 347 ms)
# 22 rows retrieved starting from 1 in 3 s 690 ms (execution: 3 s 343 ms, fetching: 347 ms)

# After
# Best case
EXPLAIN SELECT SQL_NO_CACHE DISTINCT product_or_variation_id
FROM (
         SELECT CASE WHEN lookup.product_id != 0 THEN lookup.product_id ELSE lookup.variation_id END AS product_or_variation_id
         FROM wp_wc_order_product_lookup AS lookup
                  INNER JOIN wp_posts AS posts ON posts.ID = lookup.order_id
                  INNER JOIN wp_postmeta AS postmeta ON posts.ID = postmeta.post_id
         WHERE posts.post_status IN ( 'wc-processing','wc-completed' )
           AND ( ( postmeta.meta_key = '_customer_user' AND postmeta.meta_value = '1' ) )
     ) AS subquery
WHERE product_or_variation_id != 0;
# 1,SIMPLE,postmeta,ref,"post_id,meta_key",meta_key,767,const,104016,Using where; Using temporary
# 1,SIMPLE,posts,eq_ref,PRIMARY,PRIMARY,8,wordpress.postmeta.post_id,1,Using where
# 1,SIMPLE,lookup,ref,order_id,order_id,8,wordpress.postmeta.post_id,4,Using where

# 22 rows retrieved starting from 1 in 2 s 74 ms (execution: 1 s 674 ms, fetching: 400 ms)
# 22 rows retrieved starting from 1 in 2 s 40 ms (execution: 1 s 698 ms, fetching: 342 ms)
# 22 rows retrieved starting from 1 in 2 s 84 ms (execution: 1 s 741 ms, fetching: 343 ms)

# Parity
EXPLAIN SELECT SQL_NO_CACHE DISTINCT product_or_variation_id
FROM (
         SELECT CASE WHEN lookup.product_id != 0 THEN lookup.product_id ELSE lookup.variation_id END AS product_or_variation_id
         FROM wp_wc_order_product_lookup AS lookup
                  INNER JOIN wp_posts AS posts ON posts.ID = lookup.order_id
                  INNER JOIN wp_postmeta AS postmeta ON posts.ID = postmeta.post_id
         WHERE posts.post_status IN ( 'wc-processing','wc-completed' )
           AND ( ( postmeta.meta_key = '_customer_user' AND postmeta.meta_value = '1' ) OR ( postmeta.meta_key = '_billing_email' AND postmeta.meta_value IN ( 'wordpress@example.com' ) ) )
     ) AS subquery
WHERE product_or_variation_id != 0;

# 1,SIMPLE,postmeta,range,"post_id,meta_key",meta_key,767,,200070,Using where; Using temporary
# 1,SIMPLE,posts,eq_ref,PRIMARY,PRIMARY,8,wordpress.postmeta.post_id,1,Using where
# 1,SIMPLE,lookup,ref,order_id,order_id,8,wordpress.postmeta.post_id,4,Using where

# 22 rows retrieved starting from 1 in 3 s 719 ms (execution: 3 s 367 ms, fetching: 352 ms)
# 22 rows retrieved starting from 1 in 3 s 800 ms (execution: 3 s 450 ms, fetching: 350 ms)
# 22 rows retrieved starting from 1 in 3 s 761 ms (execution: 3 s 408 ms, fetching: 353 ms)
```

```sql
# Branch 4
# Before

EXPLAIN SELECT SQL_NO_CACHE DISTINCT im.meta_value FROM wp_posts AS p
INNER JOIN wp_postmeta AS pm ON p.ID = pm.post_id
    INNER JOIN wp_woocommerce_order_items AS i ON p.ID = i.order_id
    INNER JOIN wp_woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
WHERE p.post_status IN ( 'wc-processing','wc-completed' ) AND p.post_type = 'shop_order'
  AND pm.meta_key IN ( '_billing_email', '_customer_user' )
  AND im.meta_key IN ( '_product_id', '_variation_id' )
  AND im.meta_value != 0
  AND pm.meta_value IN ( '1', 'wordpress@example.com' );
# 1,SIMPLE,pm,range,"post_id,meta_key",meta_key,767,,200070,Using where; Using temporary
# 1,SIMPLE,p,eq_ref,"PRIMARY,type_status_date,type_status_author",PRIMARY,8,wordpress.pm.post_id,1,Using where
# 1,SIMPLE,i,ref,"PRIMARY,order_id",order_id,8,wordpress.pm.post_id,6,Using index
# 1,SIMPLE,im,ref,"meta_key,order_item_id",order_item_id,8,wordpress.i.order_item_id,9,Using where

# 25 rows retrieved starting from 1 in 3 s 740 ms (execution: 3 s 355 ms, fetching: 385 ms)
# 25 rows retrieved starting from 1 in 3 s 765 ms (execution: 3 s 437 ms, fetching: 328 ms)
# 25 rows retrieved starting from 1 in 3 s 772 ms (execution: 3 s 424 ms, fetching: 348 ms)

# After
# Best case
EXPLAIN SELECT SQL_NO_CACHE DISTINCT itemmeta.meta_value
FROM wp_woocommerce_order_items AS items
         INNER JOIN wp_woocommerce_order_itemmeta AS itemmeta ON items.order_item_id = itemmeta.order_item_id
WHERE items.order_id IN (
    SELECT posts.ID as order_id
    FROM wp_posts AS posts
             INNER JOIN wp_postmeta AS postmeta ON posts.ID = postmeta.post_id
    WHERE posts.post_type   = 'shop_order'
      AND posts.post_status IN ( 'wc-processing','wc-completed' )
      AND ( ( postmeta.meta_key = '_customer_user' AND postmeta.meta_value = '1' ) )
)
  AND itemmeta.meta_key   IN ( '_product_id', '_variation_id' )
  AND itemmeta.meta_value != '0';
# 1,PRIMARY,postmeta,ref,"post_id,meta_key",meta_key,767,const,104016,Using where; Start temporary; Using temporary
# 1,PRIMARY,posts,eq_ref,"PRIMARY,type_status_date,type_status_author",PRIMARY,8,wordpress.postmeta.post_id,1,Using where
# 1,PRIMARY,items,ref,"PRIMARY,order_id",order_id,8,wordpress.postmeta.post_id,6,Using index; End temporary
# 1,PRIMARY,itemmeta,ref,"meta_key,order_item_id",order_item_id,8,wordpress.items.order_item_id,9,Using where

# 25 rows retrieved starting from 1 in 2 s 63 ms (execution: 1 s 690 ms, fetching: 373 ms)
# 25 rows retrieved starting from 1 in 2 s 1 ms (execution: 1 s 656 ms, fetching: 345 ms)
# 25 rows retrieved starting from 1 in 2 s 60 ms (execution: 1 s 715 ms, fetching: 345 ms)

# Parity
EXPLAIN SELECT SQL_NO_CACHE DISTINCT itemmeta.meta_value
FROM wp_woocommerce_order_items AS items
         INNER JOIN wp_woocommerce_order_itemmeta AS itemmeta ON items.order_item_id = itemmeta.order_item_id
WHERE items.order_id IN (
    SELECT posts.ID as order_id
    FROM wp_posts AS posts
             INNER JOIN wp_postmeta AS postmeta ON posts.ID = postmeta.post_id
    WHERE posts.post_type   = 'shop_order'
      AND posts.post_status IN ( 'wc-processing','wc-completed' )
      AND ( ( postmeta.meta_key = '_customer_user' AND postmeta.meta_value = '1' ) OR ( postmeta.meta_key = '_billing_email' AND postmeta.meta_value IN ( 'wordpress@example.com' ) ) )
)
  AND itemmeta.meta_key   IN ( '_product_id', '_variation_id' )
  AND itemmeta.meta_value != '0';
# 1,PRIMARY,postmeta,range,"post_id,meta_key",meta_key,767,,200070,Using where; Start temporary; Using temporary
# 1,PRIMARY,posts,eq_ref,"PRIMARY,type_status_date,type_status_author",PRIMARY,8,wordpress.postmeta.post_id,1,Using where
# 1,PRIMARY,items,ref,"PRIMARY,order_id",order_id,8,wordpress.postmeta.post_id,6,Using index; End temporary
# 1,PRIMARY,itemmeta,ref,"meta_key,order_item_id",order_item_id,8,wordpress.items.order_item_id,9,Using where

# 25 rows retrieved starting from 1 in 3 s 691 ms (execution: 3 s 321 ms, fetching: 370 ms)
# 25 rows retrieved starting from 1 in 3 s 799 ms (execution: 3 s 462 ms, fetching: 337 ms)
# 25 rows retrieved starting from 1 in 3 s 758 ms (execution: 3 s 412 ms, fetching: 346 ms)
```

### How to test the changes in this Pull Request:

Smoke test:
- Confirm that the Query Monitor plugin is enabled on your testing site and that no object cache is active.
- Navigate to `WooCommerce -> Settings -> Products`
- Enable the options `Show "verified owner" label on customer reviews` and `Reviews can only be left by "verified owners"`, then save the settings.
- Navigate to a product you have purchased
- Verify that you can leave a comment and confirm that customer products have been queried (search for `'wc-processing','wc-completed'`).
- Navigate to a product you have NOT purchased
- Confirm that you cannot leave a comment and that customer products have been queried by searching for `'wc-processing','wc-completed'`.
- Add `add_filter( 'woocommerce_customer_bought_product_use_lookup_tables', '__return_true' );` as a MU-plugin or directly in `woocommerce.php`.
- Visit the same pages, confirm the behavior remains consistent, and verify that the SQL changed.

