### PR TITLE
Fix missing heading separator in settings pages with tabs

### DIFF
--- a/packages/js/settings-editor/changelog/fix-heading-separator
+++ b/packages/js/settings-editor/changelog/fix-heading-separator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing heading separator line in settings pages with tabs

--- a/packages/js/settings-editor/src/style.scss
+++ b/packages/js/settings-editor/src/style.scss
@@ -14,12 +14,6 @@
 // Import form controls styles
 @import "./form-controls/style.scss";
 
-.woocommerce-settings-header {
-	&.woocommerce-site-page-header.woocommerce-settings-header--has-tabs {
-		border-bottom: none;
-	}
-}
-
 .woocommerce-settings-section-tabs {
 	.components-tab-panel__tabs {
 		border-bottom: 1px solid #f0f0f0;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The heading separator line (border-bottom) is missing on settings pages that use tabs, including:

- Settings > Marketing > Email marketing
- Settings > Notifications > Admin notifications
- Settings > Notifications > Customer notifications
- Settings > Notifications > Customer Notifications > Order Confirmation

The root cause is a CSS rule in `packages/js/settings-editor/src/style.scss` that explicitly sets `border-bottom: none` on `.woocommerce-settings-header--has-tabs`, overriding the base `border-bottom: 1px solid $gray-100` from the page header styles. This PR removes that override so the heading separator is visible on all settings pages, matching the [Figma design](https://www.figma.com/design/ICsQ6tv81KMVbsbS09eFVE/CIAB-Settings?node-id=6365-46933).

Closes https://linear.app/a8c/issue/STOMAIL-7762/heading-separator-missing-in-email-settings

### How to test the changes in this Pull Request:

1. Enable the CIAB feature flag (or use a build that has CIAB enabled)
2. Navigate to **Settings > Marketing > Email marketing** -- verify a separator line appears under the page heading
3. Navigate to **Settings > Notifications > Admin notifications** -- verify separator line is present
4. Navigate to **Settings > Notifications > Customer notifications** -- verify separator line is present
5. Open any individual notification (e.g., **Order Confirmation**) -- verify separator line is present
6. Navigate to other settings pages (e.g., **Settings > General**) -- verify no visual regressions or double borders

### Testing that has already taken place:

Code review and static analysis of CSS specificity to confirm the change restores the intended border without introducing double borders (the tabs have their own separate border-bottom below them).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
Changelog entry already added manually in packages/js/settings-editor/changelog/fix-heading-separator.

</details>
