### PR TITLE
Fix further admin styling issues with WordPress 7.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-wordpress-70-styling-issues
+++ b/plugins/woocommerce/changelog/fix-wordpress-70-styling-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Admin styling adjustments with WordPress 7.0

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8397,11 +8397,6 @@ table.bar_chart {
 		}
 	}
 
-	// Help tips: vertically center with taller WP 7.0 inputs.
-	.woocommerce_options_panel .form-field .woocommerce-help-tip {
-		margin-top: 12px;
-	}
-
 	// Search box select: match WP 7.0 compact search-box sizing (32px).
 	.search-box select {
 		min-height: 32px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8316,9 +8316,8 @@ table.bar_chart {
 
 		.select2-selection--multiple {
 			min-height: 40px;
-			height: 38px;
 
-			.select2-selection__rendered li {
+			.select2-selection__rendered li:not(:first-child) {
 				margin-top: 0; // Prevent extra spacing inside multi-select.
 			}
 		}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8316,6 +8316,14 @@ table.bar_chart {
 
 		.select2-selection--multiple {
 			min-height: 40px;
+
+			.select2-selection__rendered {
+				display: block;
+
+				.select2-search--inline {
+					margin: 0;
+				}
+			}
 		}
 
 		.select2-search--inline .select2-search__field {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8397,13 +8397,6 @@ table.bar_chart {
 		}
 	}
 
-	// Product data panel labels: vertically center with taller WP 7.0 inputs.
-	.woocommerce_options_panel p.form-field label,
-	.woocommerce_options_panel fieldset.form-field label,
-	.woocommerce_options_panel fieldset.form-field legend {
-		padding-top: 8px;
-	}
-
 	// Help tips: vertically center with taller WP 7.0 inputs.
 	.woocommerce_options_panel .form-field .woocommerce-help-tip {
 		margin-top: 12px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8316,10 +8316,6 @@ table.bar_chart {
 
 		.select2-selection--multiple {
 			min-height: 40px;
-
-			.select2-selection__rendered li:not(:first-child) {
-				margin-top: 0; // Prevent extra spacing inside multi-select.
-			}
 		}
 
 		.select2-search--inline .select2-search__field {

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-linked-products.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-linked-products.php
@@ -8,13 +8,24 @@
 use Automattic\WooCommerce\Enums\ProductType;
 
 defined( 'ABSPATH' ) || exit;
+
+// In WP 7.0, we made the inputs wider.
+// @see https://github.com/woocommerce/woocommerce/pull/63779/changes#diff-dfef13b204157e98982fb3af978fbabfaa7f6bedd31bf02f2c9070718d59642eR8402-R8408.
+$version = get_bloginfo( 'version' );
+
+if ( $version ) {
+	$version_parts = explode( '-', $version );
+	$version       = count( $version_parts ) > 1 ? $version_parts[0] : $version;
+}
+
+$width = $version && version_compare( $version, '7.0', '>=' ) ? 'width: 55%;' : 'width: 50%;';
 ?>
 <div id="linked_product_data" class="panel woocommerce_options_panel hidden">
 
 	<div class="options_group show_if_grouped">
 		<p class="form-field">
 			<label for="grouped_products"><?php esc_html_e( 'Grouped products', 'woocommerce' ); ?></label>
-			<select class="wc-product-search" multiple="multiple" style="width: 50%;" id="grouped_products" name="grouped_products[]" data-sortable="true" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products" data-exclude="<?php echo intval( $post->ID ); ?>">
+			<select class="wc-product-search" multiple="multiple" style="<?php echo esc_attr( $width ); ?>" id="grouped_products" name="grouped_products[]" data-sortable="true" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products" data-exclude="<?php echo intval( $post->ID ); ?>">
 				<?php
 				$product_ids = $product_object->is_type( ProductType::GROUPED ) ? $product_object->get_children( 'edit' ) : array();
 
@@ -37,7 +48,7 @@ defined( 'ABSPATH' ) || exit;
 	<div class="options_group">
 		<p class="form-field">
 			<label for="upsell_ids"><?php esc_html_e( 'Upsells', 'woocommerce' ); ?></label>
-			<select class="wc-product-search" multiple="multiple" style="width: 50%;" id="upsell_ids" name="upsell_ids[]" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations" data-exclude="<?php echo intval( $post->ID ); ?>">
+			<select class="wc-product-search" multiple="multiple" style="<?php echo esc_attr( $width ); ?>" id="upsell_ids" name="upsell_ids[]" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations" data-exclude="<?php echo intval( $post->ID ); ?>">
 				<?php
 				$product_ids = $product_object->get_upsell_ids( 'edit' );
 
@@ -58,7 +69,7 @@ defined( 'ABSPATH' ) || exit;
 
 		<p class="form-field hide_if_grouped hide_if_external">
 			<label for="crosssell_ids"><?php esc_html_e( 'Cross-sells', 'woocommerce' ); ?></label>
-			<select class="wc-product-search" multiple="multiple" style="width: 50%;" id="crosssell_ids" name="crosssell_ids[]" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations" data-exclude="<?php echo intval( $post->ID ); ?>">
+			<select class="wc-product-search" multiple="multiple" style="<?php echo esc_attr( $width ); ?>" id="crosssell_ids" name="crosssell_ids[]" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations" data-exclude="<?php echo intval( $post->ID ); ?>">
 				<?php
 				$product_ids = $product_object->get_cross_sell_ids( 'edit' );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Reverts several WP 7.0 CSS overrides in the admin that were causing some visual regressions.                                                                                                                          
                                                                                                                                                                                                                                                
- **Select2 multi-select**: Remove conflicting `height: 38px` (fought with `min-height: 40px`) and `margin-top: 0` on selected values that squished tags together                                                                             
- **Product data panel labels & help tips**: Remove `padding-top` / `margin-top` adjustments that assumed labels and tips were previously vertically centered with inputs — they were not, so the overrides introduced misalignment in other cases, for example with checkboxes that kept their original size.
                                                                                                                                                                                                                                                
All changes are deletions of rules added in the original WP 7.0 compatibility pass (#63779).

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1039" height="365" alt="image" src="https://github.com/user-attachments/assets/eed64ba4-3289-4804-a708-abf8fe7a76f5" />     |    <img width="959" height="476" alt="image" src="https://github.com/user-attachments/assets/65f83233-866e-4cf0-bf6d-560386e01295" />   |
|  <img width="955" height="285" alt="image" src="https://github.com/user-attachments/assets/d02dd2d3-f6bb-40de-883f-5909da5f3d4e" /> |  <img width="1088" height="316" alt="image" src="https://github.com/user-attachments/assets/d19e91cc-5da7-4908-9dd0-d726b0afea3d" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Use WordPress 7.0
2. Go to Admin and edit product
3. Browse tabs, try especially Linked Products
4. Expected: See screenshots

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
