### PR TITLE
Fix: handle 429 rate-limit responses in WC_Helper_Updater::_update_check()

### DIFF
--- a/plugins/woocommerce/changelog/64003-fix-wccom-2413-handle-429-in-update-check
+++ b/plugins/woocommerce/changelog/64003-fix-wccom-2413-handle-429-in-update-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 429 rate-limit responses from woocommerce.com being cached for 12 hours in WC_Helper_Updater, causing persistent admin error banners. The client now respects the Retry-After header and retries after the correct window.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -696,7 +696,21 @@ class WC_Helper_Updater {
 			);
 		}
 
-		if ( wp_remote_retrieve_response_code( $request ) !== 200 ) {
+		$response_code = wp_remote_retrieve_response_code( $request );
+
+		if ( 429 === $response_code ) {
+			$retry_after      = (int) wp_remote_retrieve_header( $request, 'retry-after' );
+			$cache_ttl        = $retry_after > 0 ? $retry_after : 15 * MINUTE_IN_SECONDS;
+			$data['errors'][] = 'rate-limited';
+			set_transient( $cache_key, $data, $cache_ttl );
+			wc_get_logger()->warning(
+				sprintf( 'Update check rate limited; retrying after %d seconds.', $cache_ttl ),
+				array( 'source' => 'wc-helper-updater' )
+			);
+			return array();
+		}
+
+		if ( 200 !== $response_code ) {
 			$data['errors'][] = 'http-error';
 		} else {
 			$data['products'] = json_decode( wp_remote_retrieve_body( $request ), true );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When the woocommerce.com `/helper/1.0/update-check` endpoint returns a 429 Too Many Requests response, `_update_check()` previously treated it identically to any other HTTP error: it cached the empty response for 12 hours and stored a generic `http-error` code. This caused persistent red error banners on the WP Admin Plugins page for the full 12-hour window, with no way for the site to recover until the transient expired.

Closes #[woocommerce/woocommerce issue] .

### How to test the changes in this Pull Request:

**Prerequisites:**
- A local WooCommerce dev environment (e.g. via `pnpm wp-env start`)
- A connected woocommerce.com account with at least one active subscription
- Optional: a local woocommerce.com instance to control rate-limit thresholds (see [WCCOM-1895](https://linear.app/a8c/issue/WCCOM-1895))

**On trunk (before) — reproduce the broken behaviour:**

1. Delete the update-check transient to force a fresh API call:
   ```
   pnpm wp-env run cli wp transient delete _woocommerce_helper_updates
   ```
2. Temporarily mock a 429 response from the `update-check` endpoint by adding a filter in a test plugin or `wp-config.php`:
   ```php
   add_filter( 'pre_http_request', function( $pre, $args, $url ) {
       if ( str_contains( $url, 'update-check' ) ) {
           return [ 'response' => [ 'code' => 429 ], 'headers' => new Requests_Utility_CaseInsensitiveDictionary( [ 'retry-after' => '300' ] ), 'body' => '' ];
       }
       return $pre;
   }, 10, 3 );
   ```
3. Navigate to **WP Admin → Plugins → Add New**. The update check fires and receives the mocked 429.
4. Check the transient TTL: `pnpm wp-env run cli wp transient get _woocommerce_helper_updates --format=json`
   - **Expected on trunk:** the transient is set with a 12-hour TTL and contains `errors: ["http-error"]`.
5. Remove the mock and navigate to Plugins → Add New again — the error persists for 12 hours.

**On this branch (after) — verify the fix:**

6. Repeat steps 1–3 with the same mock in place.
7. Check the transient: `pnpm wp-env run cli wp transient get _woocommerce_helper_updates --format=json`
   - **Expected:** the transient contains `errors: ["rate-limited"]` and has a TTL of ~300 seconds (matching the mocked `Retry-After: 300` header) rather than 12 hours.
8. Check the WooCommerce logs (**WP Admin → WooCommerce → Status → Logs**, source `wc-helper-updater`). You should see a warning: _"Update check rate limited; retrying after 300 seconds."_
9. Remove the mock. After 5 minutes (when the transient expires), navigating to Plugins → Add New should successfully fetch update data again.
10. Repeat with no `Retry-After` header in the mock response — the transient TTL should fall back to 15 minutes (900 seconds).

### Testing that has already taken place:

Code analysis and manual review. No automated tests added in this PR (the `_update_check()` method is a private static method tested via integration; unit test coverage for the rate-limit path can be added as a follow-up).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fix - Fixes an existing bug

#### Message
Fix 429 rate-limit responses from woocommerce.com being cached for 12 hours in WC_Helper_Updater, causing persistent admin error banners. The client now respects the Retry-After header and retries after the correct window.
</details>