### PR TITLE
Improve messages in the Reviews Form block when users can't leave reviews

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPRD-1944-product-review-form-messages
+++ b/plugins/woocommerce/changelog/fix-WOOPRD-1944-product-review-form-messages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve messages in the Reviews Form block when users can't leave reviews

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -41,8 +41,21 @@ class ProductReviewForm extends AbstractBlock {
 			return '';
 		}
 
-		if ( get_option( 'woocommerce_review_rating_verification_required' ) !== 'no' && ! wc_customer_bought_product( '', get_current_user_id(), $product->get_id() ) ) {
-			return '<p class="woocommerce-verification-required">' . esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) . '</p>';
+		if ( get_option( 'woocommerce_review_rating_verification_required' ) !== 'no' ) {
+			$is_user_logged_in   = is_user_logged_in();
+			$product_has_reviews = $product->get_review_count() > 0;
+			$no_reviews_message  = $product_has_reviews ? '' : esc_html__( 'There are no reviews yet.', 'woocommerce' );
+
+			if ( ! $is_user_logged_in ) {
+				$account_page_url = wc_get_page_permalink( 'myaccount' );
+				// translators: %1$s is the log in link, %2$s is the product title.
+				$login_message = $account_page_url ? sprintf( esc_html__( '%1$sLog in%2$s', 'woocommerce' ), ' <a href="' . esc_url( $account_page_url ) . '">', '</a>' ) : '';
+				return '<p class="woocommerce-verification-required">' . $no_reviews_message . ' ' . esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) . $login_message . '</p>';
+			}
+
+			if ( ! wc_customer_bought_product( '', get_current_user_id(), $product->get_id() ) ) {
+				return '<p class="woocommerce-verification-required">' . $no_reviews_message . ' ' . esc_html__( 'Only customers who have purchased this product may leave a review.', 'woocommerce' ) . '</p>';
+			}
 		}
 
 		$interactivity_state  = [];

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -44,17 +44,17 @@ class ProductReviewForm extends AbstractBlock {
 		if ( get_option( 'woocommerce_review_rating_verification_required' ) !== 'no' ) {
 			$is_user_logged_in   = is_user_logged_in();
 			$product_has_reviews = $product->get_review_count() > 0;
-			$no_reviews_message  = $product_has_reviews ? '' : esc_html__( 'There are no reviews yet.', 'woocommerce' );
+			$no_reviews_message  = $product_has_reviews ? '' : esc_html__( 'There are no reviews yet.', 'woocommerce' ) . ' ';
 
 			if ( ! $is_user_logged_in ) {
 				$account_page_url = wc_get_page_permalink( 'myaccount' );
 				// translators: %1$s is the opening link tag, %2$s is the closing link tag.
 				$login_message = $account_page_url ? sprintf( esc_html__( '%1$sLog in%2$s', 'woocommerce' ), ' <a href="' . esc_url( $account_page_url ) . '">', '</a>' ) : '';
-				return '<p class="woocommerce-verification-required">' . $no_reviews_message . ' ' . esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) . $login_message . '</p>';
+				return '<p class="woocommerce-verification-required">' . $no_reviews_message . esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) . $login_message . '</p>';
 			}
 
 			if ( ! wc_customer_bought_product( '', get_current_user_id(), $product->get_id() ) ) {
-				return '<p class="woocommerce-verification-required">' . $no_reviews_message . ' ' . esc_html__( 'Only customers who have purchased this product may leave a review.', 'woocommerce' ) . '</p>';
+				return '<p class="woocommerce-verification-required">' . $no_reviews_message . esc_html__( 'Only customers who have purchased this product may leave a review.', 'woocommerce' ) . '</p>';
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -48,7 +48,7 @@ class ProductReviewForm extends AbstractBlock {
 
 			if ( ! $is_user_logged_in ) {
 				$account_page_url = wc_get_page_permalink( 'myaccount' );
-				// translators: %1$s is the log in link, %2$s is the product title.
+				// translators: %1$s is the opening link tag, %2$s is the closing link tag.
 				$login_message = $account_page_url ? sprintf( esc_html__( '%1$sLog in%2$s', 'woocommerce' ), ' <a href="' . esc_url( $account_page_url ) . '">', '</a>' ) : '';
 				return '<p class="woocommerce-verification-required">' . $no_reviews_message . ' ' . esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) . $login_message . '</p>';
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPRD-1944.

Updates the messages shown in the _Reviews Form_ block when _Reviews can only be left by "verified owners"_ is checked, adding a "No review yet" text when necessary and a link to "Log in" if the user is not logged in.

### How to test the changes in this Pull Request:

1. Go to _WooCommerce_ > _Settings_ > _Products_ and check _Reviews can only be left by "verified owners"_.
2. Test the different use cases for users (user not logged in, logged in and verified customer and logged in and not verified customer) and whether the product has or not reviews and verify the messages area always aligned with the designs (see WOOPRD-1944 for a link to the designs).

Screenshot | Product has reviews | Product has no reviews
--- | --- | ---
Not logged in | <img width="842" height="500" alt="image" src="https://github.com/user-attachments/assets/a4434923-919a-4af6-81bd-04014dcc020a" /> | <img width="842" height="168" alt="image" src="https://github.com/user-attachments/assets/5df61c93-7b3c-48b1-a4d0-1bf35bbcb7a7" />
Not verified customer | <img width="786" height="495" alt="image" src="https://github.com/user-attachments/assets/64758685-13f7-437a-b350-d08279c07401" /> | <img width="842" height="187" alt="image" src="https://github.com/user-attachments/assets/aa2a4169-ded4-4109-804d-b153944adc95" />
Verified customer | <img width="842" height="1081" alt="image" src="https://github.com/user-attachments/assets/925bf494-6e0f-4ce9-81a1-e263ddaa21eb" /> | <img width="842" height="733" alt="image" src="https://github.com/user-attachments/assets/0322fa9d-bbff-4370-a4a8-de38be6a7745" />

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.