### PR TITLE
Show country name instead of country code in checkout address validation

### DIFF
--- a/plugins/woocommerce/changelog/64008-fix-country-name
+++ b/plugins/woocommerce/changelog/64008-fix-country-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Show country name instead of country code in checkout address validation

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -957,8 +957,16 @@ class WC_Checkout {
 				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'woocommerce' ) );
 			} elseif ( ! in_array( $shipping_country, array_keys( WC()->countries->get_shipping_countries() ), true ) ) {
 				if ( WC()->countries->country_exists( $shipping_country ) ) {
-					/* translators: %s: shipping location (prefix e.g. 'to' + ISO 3166-1 alpha-2 country code) */
-					$errors->add( 'shipping', sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix( $shipping_country ) . ' ' . $shipping_country ) );
+					$shipping_country_name = WC()->countries->get_countries()[ $shipping_country ];
+					$errors->add(
+						'shipping',
+						sprintf(
+							/* translators: %1$s: shipping location prefix 'to' or 'to the', %2$s: shipping location country name */
+							__( 'Unfortunately, <strong>we do not ship %1$s %2$s</strong>. Please enter an alternative shipping address.', 'woocommerce' ),
+							WC()->countries->shipping_to_prefix( $shipping_country ),
+							$shipping_country_name
+						)
+					);
 				}
 			} else {
 				$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -957,7 +957,8 @@ class WC_Checkout {
 				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'woocommerce' ) );
 			} elseif ( ! in_array( $shipping_country, array_keys( WC()->countries->get_shipping_countries() ), true ) ) {
 				if ( WC()->countries->country_exists( $shipping_country ) ) {
-					$shipping_country_name = WC()->countries->get_countries()[ $shipping_country ];
+					$countries             = WC()->countries->get_countries();
+					$shipping_country_name = $countries[ $shipping_country ] ?? $shipping_country;
 					$errors->add(
 						'shipping',
 						sprintf(

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -384,12 +384,13 @@ class OrderController {
 
 			// If only local pickup is selected, we don't need to validate the shipping country.
 			if ( ! $selected_shipping_rates_are_all_local_pickup && ! $this->validate_allowed_country( $shipping_country, (array) wc()->countries->get_shipping_countries() ) ) {
+				$shipping_country_name = WC()->countries->get_countries()[ $shipping_country ];
 				throw new RouteException(
 					'woocommerce_rest_invalid_address_country',
 					sprintf(
-						/* translators: %s country code. */
+						/* translators: %s country name. */
 						esc_html__( 'Sorry, we do not ship orders to the provided country (%s)', 'woocommerce' ),
-						esc_html( $shipping_country )
+						esc_html( $shipping_country_name )
 					),
 					400,
 					array(
@@ -400,12 +401,13 @@ class OrderController {
 		}
 
 		if ( ! $this->validate_allowed_country( $billing_country, (array) wc()->countries->get_allowed_countries() ) ) {
+			$billing_country_name = WC()->countries->get_countries()[ $billing_country ];
 			throw new RouteException(
 				'woocommerce_rest_invalid_address_country',
 				sprintf(
-					/* translators: %s country code. */
+					/* translators: %s country name. */
 					esc_html__( 'Sorry, we do not allow orders from the provided country (%s)', 'woocommerce' ),
-					esc_html( $billing_country )
+					esc_html( $billing_country_name )
 				),
 				400,
 				array(

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -384,7 +384,8 @@ class OrderController {
 
 			// If only local pickup is selected, we don't need to validate the shipping country.
 			if ( ! $selected_shipping_rates_are_all_local_pickup && ! $this->validate_allowed_country( $shipping_country, (array) wc()->countries->get_shipping_countries() ) ) {
-				$shipping_country_name = WC()->countries->get_countries()[ $shipping_country ];
+				$countries             = WC()->countries->get_countries();
+				$shipping_country_name = $countries[ $shipping_country ] ?? $shipping_country;
 				throw new RouteException(
 					'woocommerce_rest_invalid_address_country',
 					sprintf(
@@ -401,7 +402,8 @@ class OrderController {
 		}
 
 		if ( ! $this->validate_allowed_country( $billing_country, (array) wc()->countries->get_allowed_countries() ) ) {
-			$billing_country_name = WC()->countries->get_countries()[ $billing_country ];
+			$countries            = WC()->countries->get_countries();
+			$billing_country_name = $countries[ $billing_country ] ?? $billing_country;
 			throw new RouteException(
 				'woocommerce_rest_invalid_address_country',
 				sprintf(

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -228,7 +228,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->sut->validate_checkout( $data, $errors );
 
 		$this->assertEquals(
-			$expect_we_dont_ship_error ? 'Unfortunately <strong>we do not ship to JP</strong>. Please enter an alternative shipping address.' : '',
+			$expect_we_dont_ship_error ? 'Unfortunately, <strong>we do not ship to Japan</strong>. Please enter an alternative shipping address.' : '',
 			$errors->get_error_message( 'shipping' )
 		);
 		remove_all_filters( 'woocommerce_countries_allowed_countries' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -1499,7 +1499,7 @@ class Checkout extends MockeryTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'woocommerce_rest_invalid_address_country', $response->get_data()['code'] );
-		$this->assertStringContainsString( 'Sorry, we do not allow orders from the provided country (FR)', $response->get_data()['message'] );
+		$this->assertStringContainsString( 'Sorry, we do not allow orders from the provided country (France)', $response->get_data()['message'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

- Show country name instead of country code in checkout address validation, both on the classic and blocks checkout, for example: `Unfortunately, <strong>we do not ship to Portugal</strong>. Please enter an alternative shipping address.` instead of `Unfortunately <strong>we do not ship to PT</strong>. Please enter an alternative shipping address.`


Closes #64006

### How to test the changes in this Pull Request:

Try checking out with a country where shipping is not allowed.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Show country name instead of country code in checkout address validation

</details>