### PR TITLE
fix: use bundled momentTz.tz() to prevent plugin conflict crash

### DIFF
--- a/packages/js/date/changelog/fix-moment-tz-plugin-conflict
+++ b/packages/js/date/changelog/fix-moment-tz-plugin-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use bundled moment-timezone directly to prevent crash when plugins clobber global moment

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -184,7 +184,7 @@ export function getStoreTimeZoneMoment() {
 		return moment().utcOffset( timeZone );
 	}
 
-	return ( moment() as momentTz.Moment ).tz( timeZone );
+	return momentTz.tz( timeZone );
 }
 
 /**

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
+import momentTz from 'moment-timezone';
 import { format as formatDate } from '@wordpress/date';
 import { timeFormat as d3TimeFormat } from 'd3-time-format';
 /**
@@ -1032,13 +1033,15 @@ describe( 'getChartTypeForQuery', () => {
 
 describe( 'getStoreTimeZoneMoment', () => {
 	it( 'should return the default moment when no timezone exists', () => {
-		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const mockTz = jest.spyOn( momentTz, 'tz' );
 		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
 
 		expect( getStoreTimeZoneMoment() ).toHaveProperty( '_isAMomentObject' );
 
 		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).not.toHaveBeenCalled();
+
+		mockTz.mockRestore();
 	} );
 
 	it( 'should use the timezone string when one is set', () => {
@@ -1046,13 +1049,15 @@ describe( 'getStoreTimeZoneMoment', () => {
 			timeZone: 'Asia/Taipei',
 		};
 
-		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
 		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
 
 		getStoreTimeZoneMoment();
 
 		expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
 		expect( utcOffset ).not.toHaveBeenCalled();
+
+		mockTz.mockRestore();
 	} );
 
 	it( 'should use the utc offset when it is set', () => {
@@ -1060,7 +1065,7 @@ describe( 'getStoreTimeZoneMoment', () => {
 			timeZone: '+06:00',
 		};
 
-		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const mockTz = jest.spyOn( momentTz, 'tz' );
 		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
 
 		getStoreTimeZoneMoment();
@@ -1076,6 +1081,8 @@ describe( 'getStoreTimeZoneMoment', () => {
 
 		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '-04:00' );
+
+		mockTz.mockRestore();
 	} );
 
 	it( 'should fall back to wcSettings.admin.timeZone when wcSettings.timeZone is not set', () => {
@@ -1085,13 +1092,15 @@ describe( 'getStoreTimeZoneMoment', () => {
 			},
 		};
 
-		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
 		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
 
 		getStoreTimeZoneMoment();
 
 		expect( mockTz ).toHaveBeenCalledWith( 'America/New_York' );
 		expect( utcOffset ).not.toHaveBeenCalled();
+
+		mockTz.mockRestore();
 	} );
 
 	it( 'should use wcSettings.admin.timeZone utc offset when wcSettings.timeZone is not set', () => {
@@ -1101,13 +1110,15 @@ describe( 'getStoreTimeZoneMoment', () => {
 			},
 		};
 
-		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const mockTz = jest.spyOn( momentTz, 'tz' );
 		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
 
 		getStoreTimeZoneMoment();
 
 		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '+05:00' );
+
+		mockTz.mockRestore();
 	} );
 
 	it( 'should prefer wcSettings.timeZone over wcSettings.admin.timeZone', () => {
@@ -1118,13 +1129,15 @@ describe( 'getStoreTimeZoneMoment', () => {
 			},
 		};
 
-		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
 		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
 
 		getStoreTimeZoneMoment();
 
 		expect( mockTz ).toHaveBeenCalledWith( 'Europe/London' );
 		expect( utcOffset ).not.toHaveBeenCalled();
+
+		mockTz.mockRestore();
 	} );
 } );
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1032,16 +1032,22 @@ describe( 'getChartTypeForQuery', () => {
 } );
 
 describe( 'getStoreTimeZoneMoment', () => {
+	let mockTz: jest.SpyInstance;
+	let utcOffset: jest.SpyInstance;
+
+	afterEach( () => {
+		mockTz?.mockRestore();
+		utcOffset?.mockRestore();
+	} );
+
 	it( 'should return the default moment when no timezone exists', () => {
-		const mockTz = jest.spyOn( momentTz, 'tz' );
-		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+		mockTz = jest.spyOn( momentTz, 'tz' );
+		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
 
 		expect( getStoreTimeZoneMoment() ).toHaveProperty( '_isAMomentObject' );
 
 		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).not.toHaveBeenCalled();
-
-		mockTz.mockRestore();
 	} );
 
 	it( 'should use the timezone string when one is set', () => {
@@ -1049,15 +1055,13 @@ describe( 'getStoreTimeZoneMoment', () => {
 			timeZone: 'Asia/Taipei',
 		};
 
-		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
-		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+		mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
+		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
 
 		getStoreTimeZoneMoment();
 
 		expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
 		expect( utcOffset ).not.toHaveBeenCalled();
-
-		mockTz.mockRestore();
 	} );
 
 	it( 'should use the utc offset when it is set', () => {
@@ -1065,8 +1069,8 @@ describe( 'getStoreTimeZoneMoment', () => {
 			timeZone: '+06:00',
 		};
 
-		const mockTz = jest.spyOn( momentTz, 'tz' );
-		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+		mockTz = jest.spyOn( momentTz, 'tz' );
+		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
 
 		getStoreTimeZoneMoment();
 
@@ -1081,8 +1085,6 @@ describe( 'getStoreTimeZoneMoment', () => {
 
 		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '-04:00' );
-
-		mockTz.mockRestore();
 	} );
 
 	it( 'should fall back to wcSettings.admin.timeZone when wcSettings.timeZone is not set', () => {
@@ -1092,15 +1094,13 @@ describe( 'getStoreTimeZoneMoment', () => {
 			},
 		};
 
-		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
-		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+		mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
+		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
 
 		getStoreTimeZoneMoment();
 
 		expect( mockTz ).toHaveBeenCalledWith( 'America/New_York' );
 		expect( utcOffset ).not.toHaveBeenCalled();
-
-		mockTz.mockRestore();
 	} );
 
 	it( 'should use wcSettings.admin.timeZone utc offset when wcSettings.timeZone is not set', () => {
@@ -1110,15 +1110,13 @@ describe( 'getStoreTimeZoneMoment', () => {
 			},
 		};
 
-		const mockTz = jest.spyOn( momentTz, 'tz' );
-		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+		mockTz = jest.spyOn( momentTz, 'tz' );
+		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
 
 		getStoreTimeZoneMoment();
 
 		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '+05:00' );
-
-		mockTz.mockRestore();
 	} );
 
 	it( 'should prefer wcSettings.timeZone over wcSettings.admin.timeZone', () => {
@@ -1129,15 +1127,13 @@ describe( 'getStoreTimeZoneMoment', () => {
 			},
 		};
 
-		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
-		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+		mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
+		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
 
 		getStoreTimeZoneMoment();
 
 		expect( mockTz ).toHaveBeenCalledWith( 'Europe/London' );
 		expect( utcOffset ).not.toHaveBeenCalled();
-
-		mockTz.mockRestore();
 	} );
 
 	it( 'should use momentTz.tz() static function, not moment().tz() instance method', () => {
@@ -1157,13 +1153,12 @@ describe( 'getStoreTimeZoneMoment', () => {
 
 		// Mock momentTz.tz since its internals also use the shared prototype in tests.
 		// In production, momentTz's closure holds the original moment with .tz intact.
-		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
+		mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
 
 		try {
 			expect( () => getStoreTimeZoneMoment() ).not.toThrow();
 			expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
 		} finally {
-			mockTz.mockRestore();
 			moment.prototype.tz = originalTz;
 		}
 	} );

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1139,6 +1139,31 @@ describe( 'getStoreTimeZoneMoment', () => {
 
 		mockTz.mockRestore();
 	} );
+
+	it( 'should use momentTz.tz() static function, not moment().tz() instance method', () => {
+		// Regression test for plugin conflict where a third-party plugin
+		// clobbers window.moment, removing .tz() from new instances.
+		// The fix uses the bundled momentTz.tz() static function which
+		// operates on moment-timezone's closure reference, unaffected
+		// by the global being replaced.
+		global.window.wcSettings = {
+			timeZone: 'Asia/Taipei',
+		};
+
+		// Remove .tz from prototype to simulate clobbered moment instances.
+		const originalTz = moment.prototype.tz;
+		delete ( moment.prototype as any ).tz;
+
+		// Mock momentTz.tz since its internals also use the shared prototype in tests.
+		// In production, momentTz's closure holds the original moment with .tz intact.
+		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
+
+		expect( () => getStoreTimeZoneMoment() ).not.toThrow();
+		expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
+
+		mockTz.mockRestore();
+		moment.prototype.tz = originalTz;
+	} );
 } );
 
 describe( 'getDateFormatsForIntervalPhp', () => {

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1152,17 +1152,20 @@ describe( 'getStoreTimeZoneMoment', () => {
 
 		// Remove .tz from prototype to simulate clobbered moment instances.
 		const originalTz = moment.prototype.tz;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- need to delete typed property to simulate clobbering
 		delete ( moment.prototype as any ).tz;
 
 		// Mock momentTz.tz since its internals also use the shared prototype in tests.
 		// In production, momentTz's closure holds the original moment with .tz intact.
 		const mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
 
-		expect( () => getStoreTimeZoneMoment() ).not.toThrow();
-		expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
-
-		mockTz.mockRestore();
-		moment.prototype.tz = originalTz;
+		try {
+			expect( () => getStoreTimeZoneMoment() ).not.toThrow();
+			expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
+		} finally {
+			mockTz.mockRestore();
+			moment.prototype.tz = originalTz;
+		}
 	} );
 } );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Analytics dashboards crash with `TypeError: tz is not a function` when a third-party plugin clobbers `window.moment` after WooCommerce's bundle loads. The `.tz()` method (from `moment-timezone`) disappears because the code relies on the global `moment` instance being augmented by `moment-timezone`.

<img width="1147" height="613" alt="Screenshot 2026-04-06 at 11 29 49" src="https://github.com/user-attachments/assets/500425f0-169a-436a-8c66-aa3283acc5e4" />

This PR changes `getStoreTimeZoneMoment()` in `@woocommerce/date` to use the bundled `momentTz.tz()` static function directly instead of calling `.tz()` on a `moment()` instance. Since `moment-timezone` captures its `moment` dependency in a closure at init time, this call is safe even if `window.moment` is later replaced — the closure still holds the original reference.

The issue was surfaced by #62872 (10.6.0), which expanded the conditions under which `.tz()` is called. A plugin conflict that replaces `window.moment` after WooCommerce loads causes the crash.

WOOPLUG-6521

### How to test the changes in this Pull Request:

1. Add the following snippet to your theme's `functions.php` (or a custom plugin) to simulate a third-party plugin clobbering `window.moment`:

```php
add_action( 'admin_enqueue_scripts', function() {
    $script = <<<'JS'
        const originalMoment = window.moment;

        function wrappedMoment( ...args ) {
                const result = originalMoment( ...args );
                result.tz = undefined;
                return result;
        }

        Object.assign( wrappedMoment, originalMoment );
        wrappedMoment.fn = originalMoment.fn;

        window.moment = wrappedMoment;
    JS;
    wp_add_inline_script( 'wc-date', $script, 'before' );
}, 999 );
```

2. Test with named timezones (e.g., `America/New_York` in Settings > General)
3. **Without this PR's changes**: Navigate to `WooCommerce > Analytics > Overview`. Observe the dashboard crashes with `TypeError: tz is not a function` in the browser console.
4. **With this PR's changes**: Navigate to `WooCommerce > Analytics > Overview`. Verify the dashboard loads correctly without errors.
5. Navigate to the WooCommerce Admin Dashboard at `WooCommerce > Home`
6. Open browser DevTools, go to the Network tab
7. Look for the `/wc-analytics/reports/performance-indicators` request
8. Verify the `before` parameter uses the store timezone (not browser timezone)
9. Verify date/time displays correctly with respect to the store's timezone setting.
10. Remove the snippet from `functions.php` when done.

<img width="1147" height="618" alt="Screenshot 2026-04-06 at 11 35 53" src="https://github.com/user-attachments/assets/d8c752aa-8714-4d7b-8882-d0437948dd08" />

<img width="765" height="511" alt="Screenshot 2026-04-06 at 11 34 53" src="https://github.com/user-attachments/assets/f43b112c-0b0b-4c23-a6ed-a4db275e53a3" />


### Testing that has already taken place:

- All 95 unit tests in `@woocommerce/date` pass (including a new regression test for the clobbering scenario).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<!-- Changelog entry was manually created at packages/js/date/changelog/fix-moment-tz-plugin-conflict -->