### PR TITLE
Fix post_types missing from view context on WP 7.0

### DIFF
--- a/packages/php/email-editor/changelog/fix-register-post-types-view-context-check
+++ b/packages/php/email-editor/changelog/fix-register-post-types-view-context-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `register_post_types_to_api()` to verify view context availability before skipping field registration on WordPress 7.0+

--- a/packages/php/email-editor/src/Engine/Templates/class-templates.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates.php
@@ -107,8 +107,11 @@ class Templates {
 	public function register_post_types_to_api(): void {
 		$controller = new \WP_REST_Templates_Controller( 'wp_template' );
 		$schema     = $controller->get_item_schema();
-		// Future compatibility check if the post_types property is already registered.
-		if ( isset( $schema['properties']['post_types'] ) ) {
+		// Skip registration only when post_types is natively available in the view context.
+		// WP 7.0 adds the property but only in the edit context; we must still register
+		// the field so that context=view responses include it.
+		$post_types_context = $schema['properties']['post_types']['context'] ?? array();
+		if ( in_array( 'view', $post_types_context, true ) ) {
 			return;
 		}
 		register_rest_field(

--- a/packages/php/email-editor/tests/unit/Engine/Templates/Templates_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Templates/Templates_Test.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package.
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare(strict_types=1);
+
+use Automattic\WooCommerce\EmailEditor\Engine\Templates\Templates;
+use Automattic\WooCommerce\EmailEditor\Engine\Templates\Templates_Registry;
+
+/**
+ * Test cases for Templates::register_post_types_to_api().
+ */
+class Templates_Test extends Email_Editor_Unit_Test {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var Templates
+	 */
+	private Templates $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['wc_ee_rest_field_registered'] = false;
+		$GLOBALS['wc_ee_test_schema']           = array( 'properties' => array() );
+		$this->sut                              = new Templates( new Templates_Registry() );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['wc_ee_rest_field_registered'], $GLOBALS['wc_ee_test_schema'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the field is registered when post_types is absent.
+	 *
+	 * @testdox Should register the field when post_types is absent from the schema (WP ≤ 6.9).
+	 */
+	public function test_registers_field_when_post_types_absent_from_schema(): void {
+		$GLOBALS['wc_ee_test_schema'] = array( 'properties' => array() );
+
+		$this->sut->register_post_types_to_api();
+
+		$this->assertTrue( $GLOBALS['wc_ee_rest_field_registered'], 'Field should be registered when post_types is absent from the schema.' );
+	}
+
+	/**
+	 * Test that registration is skipped when view context is present.
+	 *
+	 * @testdox Should skip registration when post_types is present with view context (future WP).
+	 */
+	public function test_skips_registration_when_view_context_present(): void {
+		$GLOBALS['wc_ee_test_schema'] = array(
+			'properties' => array(
+				'post_types' => array( 'context' => array( 'view', 'edit', 'embed' ) ),
+			),
+		);
+
+		$this->sut->register_post_types_to_api();
+
+		$this->assertFalse( $GLOBALS['wc_ee_rest_field_registered'], 'Field should not be registered when post_types is natively available in the view context.' );
+	}
+
+	/**
+	 * Test that the field is registered when view context is missing (WP 7.0 scenario).
+	 *
+	 * @testdox Should register the field when post_types is present but view context is missing (WP 7.0).
+	 */
+	public function test_registers_field_when_post_types_present_but_view_context_missing(): void {
+		$GLOBALS['wc_ee_test_schema'] = array(
+			'properties' => array(
+				'post_types' => array( 'context' => array( 'edit' ) ),
+			),
+		);
+
+		$this->sut->register_post_types_to_api();
+
+		$this->assertTrue( $GLOBALS['wc_ee_rest_field_registered'], 'Field should be registered when post_types is present but only in the edit context.' );
+	}
+
+	/**
+	 * Test that the field is registered when post_types has no context key.
+	 *
+	 * @testdox Should register the field when post_types is present but has no context key.
+	 */
+	public function test_registers_field_when_post_types_present_but_no_context_key(): void {
+		$GLOBALS['wc_ee_test_schema'] = array(
+			'properties' => array(
+				'post_types' => array( 'type' => 'array' ),
+			),
+		);
+
+		$this->sut->register_post_types_to_api();
+
+		$this->assertTrue( $GLOBALS['wc_ee_rest_field_registered'], 'Field should be registered when post_types has no context key.' );
+	}
+}

--- a/packages/php/email-editor/tests/unit/stubs.php
+++ b/packages/php/email-editor/tests/unit/stubs.php
@@ -451,3 +451,40 @@ if ( ! class_exists( \IntegrationTester::class ) ) {
 		}
 	}
 }
+
+if ( ! class_exists( \WP_REST_Templates_Controller::class ) ) {
+	/**
+	 * Stub for WP_REST_Templates_Controller used in unit tests.
+	 */
+	class WP_REST_Templates_Controller {
+		/**
+		 * Constructor.
+		 *
+		 * @param string $post_type Post type slug.
+		 */
+		public function __construct( string $post_type ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		}
+
+		/**
+		 * Returns the schema configured via $GLOBALS['wc_ee_test_schema'].
+		 *
+		 * @return array
+		 */
+		public function get_item_schema(): array {
+			return $GLOBALS['wc_ee_test_schema'] ?? array( 'properties' => array() );
+		}
+	}
+}
+
+if ( ! function_exists( 'register_rest_field' ) ) {
+	/**
+	 * Mock register_rest_field function.
+	 *
+	 * @param string|array $object_type Object type or array of types.
+	 * @param string       $attribute   Attribute name.
+	 * @param array        $args        Optional. Field arguments.
+	 */
+	function register_rest_field( $object_type, $attribute, $args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$GLOBALS['wc_ee_rest_field_registered'] = true;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The compatibility guard in `Templates::register_post_types_to_api()` only checked whether `post_types` existed in the `wp_template` REST schema (`isset($schema['properties']['post_types'])`). On WordPress 7.0 RC2 the property is present in the schema but without a `view` context entry, so the guard returned early and `register_rest_field` was never called. Downstream JS consumers requesting `context=view` then received no `post_types` field, breaking the template-select modal — no templates appeared and the "Start from scratch" button stayed in isBusy state.

The fix checks for `view` in the property's `context` array instead of mere presence, so the field is still registered when WordPress adds `post_types` without exposing it in the view context.

### How to test the changes in this Pull Request:

1. Start wp-env with WordPress 7.0 RC2 (`pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env start`).
2. Enable the block email editor feature at **WooCommerce > Settings > Advanced > Features**.
3. As admin, check the REST API response: `GET /wp/v2/templates?context=view` — verify that email templates (`wooemailtemplate`, `email-general`) have `post_types: ["woo_email"]` in the response.
4. Navigate to **WooCommerce > Settings > Emails** and click "Edit template" — verify the email editor opens without getting stuck.
5. Repeat steps 3–4 on WordPress 6.9 to confirm no regression.

### Testing that has already taken place:

- Unit tests: 210/210 pass (4 new tests covering all guard scenarios: field absent, view context present, edit-only context, no context key).
- PHPCS lint: clean on all modified files.
- Manual verification on wp-env with WordPress 7.0 RC2-62162:
  - Confirmed `post_types` is present in `context=view` REST responses after the fix.
  - Confirmed the old guard (`isset`) incorrectly returns early on WP 7.0 RC2.
  - Confirmed the email editor loads correctly.


### Screenshots

| Before | After |
| ------ | ----- |
| <img width="3256" height="1756" alt="Before" src="https://github.com/user-attachments/assets/cb4ec713-42a8-4eee-956a-52c70d0f4b05" />  |  <img width="1439" height="612" alt="After" src="https://github.com/user-attachments/assets/5c558105-a6f2-41eb-aaa4-650cba146443" /> |



### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually in `packages/php/email-editor/changelog/fix-register-post-types-view-context-check`.

</details>