### PR TITLE
[Performance] Orders: added `transaction_id` index for `wc_orders` table.

### DIFF
--- a/plugins/woocommerce/changelog/performance-orders-table-add-new-index
+++ b/plugins/woocommerce/changelog/performance-orders-table-add-new-index
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-A new index has been added to the wc_orders table to enhance order search performance by transaction ID.
+A new index has been added to the wc_orders table to improve the performance of order resolution by transaction ID.

--- a/plugins/woocommerce/changelog/performance-orders-table-add-new-index
+++ b/plugins/woocommerce/changelog/performance-orders-table-add-new-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+A new index has been added to the wc_orders table to enhance order search performance by transaction ID.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -3257,6 +3257,7 @@ CREATE TABLE $orders_table_name (
 	KEY customer_id_billing_email (customer_id, billing_email({$composite_customer_id_email_length})),
 	KEY customer_id_status (customer_id, status),
 	KEY billing_email (billing_email($max_index_length)),
+	KEY transaction_id (transaction_id(20)),
 	KEY type_status_date (type, status, date_created_gmt),
 	KEY parent_order_id (parent_order_id),
 	KEY date_updated (date_updated_gmt)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Following up on https://github.com/Automattic/woocommerce-payments/issues/11552, this PR introduces a new index to improve order resolution by transaction_id when HPOS is enabled.

The index size, set to 20 characters, aligns with similar indexes and was selected by an AI based on the following constraints:
- Orders tables are optimized for writing data
- The index should be efficient across the popular payment gateways for WooCommerce to resolve order by transaction ID
- Highlight the feasible length range: the range was prompted by AI to be 16 - 20 characters

### How to test the changes in this Pull Request:

- On the testing site, remove the `woocommerce_version` and `woocommerce_db_version` options from the `wp_options` table.
- Access the WordPress admin area.
- Confirm that the index appeared in the DB.
