### PR TITLE
Fix template-select modal not showing on WP 7.0

### DIFF
--- a/packages/js/email-editor/changelog/fix-template-selection-hasedits-wp7
+++ b/packages/js/email-editor/changelog/fix-template-selection-hasedits-wp7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix template-select modal not appearing on WordPress 7.0 due to hasEdits() returning true on fresh posts

--- a/packages/js/email-editor/src/components/template-select/template-selection.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-selection.tsx
@@ -12,15 +12,17 @@ import { SelectTemplateModal } from './select-modal';
 
 export function TemplateSelection() {
 	const [ templateSelected, setTemplateSelected ] = useState( false );
-	const { emailContentIsEmpty, emailHasEdits, postType } = useSelect(
+	const { emailContentIsEmpty, postType } = useSelect(
 		( select ) => ( {
 			emailContentIsEmpty: select( storeName ).hasEmptyContent(),
-			emailHasEdits: select( storeName ).hasEdits(),
 			postType: select( storeName ).getEmailPostType(),
 		} ),
 		[]
 	);
-	if ( ! emailContentIsEmpty || emailHasEdits || templateSelected ) {
+	// Show the template modal whenever content is empty, regardless of WP's dirty state.
+	// WP 7.0 auto-inserts an empty paragraph block on fresh posts, causing hasEdits()
+	// to return true before the user does anything.
+	if ( ! emailContentIsEmpty || templateSelected ) {
 		return null;
 	}
 

--- a/packages/js/email-editor/src/components/template-select/template-selection.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-selection.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,14 +10,16 @@ import { storeName } from '../../store';
 import { SelectTemplateModal } from './select-modal';
 
 export function TemplateSelection() {
-	const [ templateSelected, setTemplateSelected ] = useState( false );
-	const { emailContentIsEmpty, postType } = useSelect(
+	const { emailContentIsEmpty, templateSelected, postType } = useSelect(
 		( select ) => ( {
 			emailContentIsEmpty: select( storeName ).hasEmptyContent(),
+			templateSelected: select( storeName ).isTemplateSelected(),
 			postType: select( storeName ).getEmailPostType(),
 		} ),
 		[]
 	);
+	const { setTemplateSelected } = useDispatch( storeName );
+
 	// Show the template modal whenever content is empty, regardless of WP's dirty state.
 	// WP 7.0 auto-inserts an empty paragraph block on fresh posts, causing hasEdits()
 	// to return true before the user does anything.
@@ -28,7 +29,7 @@ export function TemplateSelection() {
 
 	return (
 		<SelectTemplateModal
-			onSelectCallback={ () => setTemplateSelected( true ) }
+			onSelectCallback={ () => void setTemplateSelected() }
 			postType={ postType }
 		/>
 	);

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -100,6 +100,12 @@ export const setTemplateToPost =
 			} );
 	};
 
+export function setTemplateSelected() {
+	return {
+		type: 'SET_TEMPLATE_SELECTED',
+	} as const;
+}
+
 export function* requestSendingNewsletterPreview( email: string ) {
 	// If preview is already sending do nothing
 	const previewState = select( storeName ).getPreviewState();

--- a/packages/js/email-editor/src/store/initial-state.ts
+++ b/packages/js/email-editor/src/store/initial-state.ts
@@ -21,5 +21,6 @@ export function getInitialState(): State {
 			sendingPreviewStatus: null,
 		},
 		contentValidation: undefined,
+		templateSelected: false,
 	};
 }

--- a/packages/js/email-editor/src/store/reducer.ts
+++ b/packages/js/email-editor/src/store/reducer.ts
@@ -20,6 +20,11 @@ export function reducer( state: State, action ): State {
 				...state,
 				contentValidation: action.validation,
 			};
+		case 'SET_TEMPLATE_SELECTED':
+			return {
+				...state,
+				templateSelected: true,
+			};
 		case 'SET_EDITOR_SETTINGS':
 			return {
 				...state,

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -475,3 +475,7 @@ export function getContentValidation(
 ): State[ 'contentValidation' ] {
 	return state.contentValidation;
 }
+
+export function isTemplateSelected( state: State ): boolean {
+	return state.templateSelected;
+}

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -140,6 +140,7 @@ export type State = {
 		errorMessage?: string;
 	};
 	contentValidation?: ContentValidation;
+	templateSelected: boolean;
 };
 
 export type EmailTemplatePreview = Omit<


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WordPress 7.0 auto-inserts an empty `core/paragraph` block into fresh posts with empty content. This causes the block editor's dirty state (`hasEdits()`) to return `true` before the user does anything. The `TemplateSelection` component's guard condition checked `emailHasEdits` and returned early, preventing the "Start with an email preset" modal from ever appearing on WP 7.0.

The fix removes `emailHasEdits` from the guard. The `hasEmptyContent` check alone is sufficient — it reads from the saved entity record (not the edited state) and correctly identifies fresh posts on all WP versions.

This is the second piece of the WP 7.0 email editor compatibility fix. The first piece (PHP-side `post_types` REST API fix) was shipped in `woocommerce/email-editor` 2.11.0 via #64023.

### How to test the changes in this Pull Request:

1. Start wp-env with WordPress 7.0 RC2.
2. Enable the block email editor feature at **WooCommerce > Settings > Advanced > Features**.
3. Create a new `woo_email` post: `wp-env run cli -- wp post create --post_type=woo_email --post_status=draft --post_title="Test"`.
4. Open the post in the editor (`/wp-admin/post.php?post=<ID>&action=edit`).
5. Verify the "Start with an email preset" modal appears with the template list and "Start from scratch" button.
6. Click a template or "Start from scratch" — verify the modal closes and the editor loads correctly.
7. Repeat steps 3–6 on WordPress 6.9 to confirm no regression.

### Testing that has already taken place:

- Manual verification on wp-env with WordPress 7.0 RC2-62197:
  - **Before fix:** Fresh email post shows blank editor with "Type / to choose a block" — no modal.
  - **After fix:** Fresh email post shows "Start with an email preset" modal with template listed.
- Verified the modal correctly dismisses after selecting a template.
- Verified on WP 7.0 RC2 that `hasEmptyContent` correctly returns `true` for fresh posts.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually in `packages/js/email-editor/changelog/fix-template-selection-hasedits-wp7`.

</details>