### PR TITLE
Add to Cart + Options: Ensure attributes with spaces and special characters work well in dropdown mode

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-6403-ii
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-6403-ii
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: Ensure attributes with spaces and special characters work well in dropdown mode

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -453,23 +453,60 @@ test.describe( 'Add to Cart + Options Block', () => {
 			isOnlyCurrentEntityDirty: true,
 		} );
 
-		await page.goto( '/product/custom-slug-variable/' );
+		await test.step( 'when in pills mode', async () => {
+			await page.goto( '/product/custom-slug-variable/' );
 
-		// Verify the pills show term names (not slugs).
-		const petitOption = page.locator( 'label:has-text("Petit")' );
-		const grandOption = page.locator( 'label:has-text("Grand")' );
-		const addToCartButton = page.getByRole( 'button', {
-			name: 'Add to cart',
-			exact: true,
+			// Verify the pills show term names (not slugs).
+			const petitOption = page.locator( 'label:has-text("Petit")' );
+			const grandOption = page.locator( 'label:has-text("Grand")' );
+			const addToCartButton = page.getByRole( 'button', {
+				name: 'Add to cart',
+				exact: true,
+			} );
+
+			await expect( petitOption ).not.toBeDisabled();
+			await expect( grandOption ).not.toBeDisabled();
+
+			await petitOption.click();
+			await expect( addToCartButton ).not.toBeDisabled();
+			await addToCartButton.click();
+			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 		} );
 
-		await expect( petitOption ).not.toBeDisabled();
-		await expect( grandOption ).not.toBeDisabled();
+		await test.step( 'when in dropdown mode', async () => {
+			await pageObject.updateSingleProductTemplate();
 
-		await petitOption.click();
-		await expect( addToCartButton ).not.toBeDisabled();
-		await addToCartButton.click();
-		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+			await pageObject.switchToDropdownMode();
+
+			await editor.saveSiteEditorEntities();
+
+			await page.goto( '/product/custom-slug-variable/' );
+
+			const select = page.getByRole( 'combobox', {
+				name: 'Taille',
+				exact: true,
+			} );
+			const petitOption = page.getByRole( 'option', {
+				name: 'Petit',
+				exact: true,
+			} );
+			const grandOption = page.getByRole( 'option', {
+				name: 'Grand',
+				exact: true,
+			} );
+			const addToCartButton = page.getByRole( 'button', {
+				name: '1 in cart',
+				exact: true,
+			} );
+
+			await expect( petitOption ).not.toBeDisabled();
+			await expect( grandOption ).not.toBeDisabled();
+			await select.selectOption( { label: 'Petit' } );
+
+			await expect( addToCartButton ).not.toBeDisabled();
+			await addToCartButton.click();
+			await expect( page.getByText( '2 in cart' ) ).toBeVisible();
+		} );
 	} );
 
 	test( 'allows adding grouped products to cart', async ( {
@@ -769,25 +806,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 	} ) => {
 		await pageObject.updateSingleProductTemplate();
 
-		await pageObject.switchProductType( 'Variable product' );
-
-		await page.getByRole( 'tab', { name: 'Block' } ).click();
-
-		// Verify inner blocks have loaded.
-		await expect(
-			editor.canvas
-				.getByLabel(
-					'Block: Variation Selector: Attribute Options (Beta)'
-				)
-				.first()
-		).toBeVisible();
-
-		const attributeOptionsBlock = await editor.getBlockByName(
-			'woocommerce/add-to-cart-with-options-variation-selector-attribute-options'
-		);
-		await editor.selectBlocks( attributeOptionsBlock.first() );
-
-		await page.getByRole( 'radio', { name: 'Dropdown' } ).click();
+		await pageObject.switchToDropdownMode();
 
 		await editor.saveSiteEditorEntities();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -109,6 +109,28 @@ class AddToCartWithOptionsPage {
 		await this.updateAddToCartWithOptionsBlock();
 	}
 
+	async switchToDropdownMode() {
+		await this.switchProductType( 'Variable product' );
+
+		await this.page.getByRole( 'tab', { name: 'Block' } ).click();
+
+		// Verify inner blocks have loaded.
+		await expect(
+			this.editor.canvas
+				.getByLabel(
+					'Block: Variation Selector: Attribute Options (Beta)'
+				)
+				.first()
+		).toBeVisible();
+
+		const attributeOptionsBlock = await this.editor.getBlockByName(
+			'woocommerce/add-to-cart-with-options-variation-selector-attribute-options'
+		);
+		await this.editor.selectBlocks( attributeOptionsBlock.first() );
+
+		await this.page.getByRole( 'radio', { name: 'Dropdown' } ).click();
+	}
+
 	async createPostWithProductBlock( product: string, variation?: string ) {
 		await this.admin.createNewPost();
 		await this.editor.insertBlock( { name: 'woocommerce/single-product' } );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -238,9 +238,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				'data-wp-bind--disabled' => 'state.isOptionDisabled',
 				'data-wp-bind--hidden'   => 'hide' === $disabled_attributes_action ? 'state.isOptionDisabled' : null,
 				'data-wp-context'        => array(
-					'option'  => $attribute_term,
-					'name'    => $attribute_slug,
-					'options' => $attribute_terms,
+					'option' => $attribute_term,
 				),
 			);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/63635.

In the _Dropdown_ mode, we were setting some additional context to the `<option>` element: `name` and `options`. Besides not being used anywhere, they were taking priority over the `<select>`'s context, which is the one we use to match attribute names.

This PR removes the unused context from `<option>`, fixing #63635 for the _Dropdown_ mode.

### How to test the changes in this Pull Request:

1. Create an attribute with spaces or special characters in the name. 
2. Create a variable product using that attribute for the variations.
3. Edit the _Single Product_ template and set the _Add to Cart + Options_ to use _Dropdown_ mode in variable products.
4. In the frontend, verify those attributes don't look disabled and can be selected.

<img width="1143" height="736" alt="imatge" src="https://github.com/user-attachments/assets/1475c5c0-a2a2-4ac5-9df5-174574bb1b86" />