### PR TITLE
Allow extensionCartUpdate to selectively overwrite shipping or billing address

### DIFF
--- a/plugins/woocommerce/changelog/opr-cart-update-partial-addr
+++ b/plugins/woocommerce/changelog/opr-cart-update-partial-addr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Allow extensionCartUpdate's overwriteDirtyCustomerData option to accept an object with per-address control ({ shipping_address?: boolean, billing_address?: boolean }) in addition to a boolean.

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
@@ -432,6 +432,22 @@ describe( 'applyExtensionCartUpdate', () => {
 		expect( received ).toHaveProperty( 'totals' );
 	} );
 
+	it( 'should strip both addresses when customer data is dirty and overwriteDirtyCustomerData is false', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: false,
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).not.toHaveProperty( 'shipping_address' );
+		expect( received ).not.toHaveProperty( 'billing_address' );
+		expect( received ).toHaveProperty( 'totals' );
+	} );
+
 	it( 'should include both addresses when overwriteDirtyCustomerData is true', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( true );
 		const dispatch = createMockDispatch();

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { ExtensionCartUpdateArgs } from '@woocommerce/types';
+
+/**
  * Internal dependencies
  */
 import {
@@ -518,5 +523,71 @@ describe( 'applyExtensionCartUpdate', () => {
 		expect( received.billing_address ).toEqual( {
 			address_1: '456 Bill Ave',
 		} );
+	} );
+
+	it( 'should treat null as false (no overwrite)', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData:
+				null as unknown as ExtensionCartUpdateArgs[ 'overwriteDirtyCustomerData' ],
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).not.toHaveProperty( 'shipping_address' );
+		expect( received ).not.toHaveProperty( 'billing_address' );
+	} );
+
+	it( 'should treat an array as false (no overwrite)', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: [
+				true,
+			] as unknown as ExtensionCartUpdateArgs[ 'overwriteDirtyCustomerData' ],
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).not.toHaveProperty( 'shipping_address' );
+		expect( received ).not.toHaveProperty( 'billing_address' );
+	} );
+
+	it( 'should treat non-boolean address fields as false', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: {
+				shipping_address: 'yes',
+				billing_address: 1,
+			} as unknown as ExtensionCartUpdateArgs[ 'overwriteDirtyCustomerData' ],
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).not.toHaveProperty( 'shipping_address' );
+		expect( received ).not.toHaveProperty( 'billing_address' );
+	} );
+
+	it( 'should default missing address fields to false', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: {},
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).not.toHaveProperty( 'shipping_address' );
+		expect( received ).not.toHaveProperty( 'billing_address' );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
@@ -520,6 +520,25 @@ describe( 'applyExtensionCartUpdate', () => {
 		} );
 	} );
 
+	it( 'should strip both addresses when object has explicit false flags', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: {
+				shipping_address: false,
+				billing_address: false,
+			},
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).not.toHaveProperty( 'shipping_address' );
+		expect( received ).not.toHaveProperty( 'billing_address' );
+		expect( received ).toHaveProperty( 'totals' );
+	} );
+
 	it( 'should overwrite specified address even when customer data is not dirty', async () => {
 		mockGetIsCustomerDataDirty.mockReturnValue( false );
 		const dispatch = createMockDispatch();

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
@@ -1,8 +1,13 @@
 /**
  * Internal dependencies
  */
-import { changeCartItemQuantity, receiveCart } from '../thunks';
+import {
+	changeCartItemQuantity,
+	receiveCart,
+	applyExtensionCartUpdate,
+} from '../thunks';
 import { apiFetchWithHeaders } from '../../shared-controls';
+import { getIsCustomerDataDirty } from '../utils';
 
 jest.mock( '../../shared-controls', () => ( {
 	apiFetchWithHeaders: jest.fn(),
@@ -15,6 +20,17 @@ jest.mock( '../notify-quantity-changes', () => ( {
 jest.mock( '../notify-errors', () => ( {
 	updateCartErrorNotices: jest.fn(),
 } ) );
+
+jest.mock( '../utils', () => ( {
+	getIsCustomerDataDirty: jest.fn( () => false ),
+	setIsCustomerDataDirty: jest.fn(),
+	setTriggerStoreSyncEvent: jest.fn(),
+} ) );
+
+const mockGetIsCustomerDataDirty =
+	getIsCustomerDataDirty as jest.MockedFunction<
+		typeof getIsCustomerDataDirty
+	>;
 
 const mockApiFetchWithHeaders = apiFetchWithHeaders as jest.MockedFunction<
 	typeof apiFetchWithHeaders
@@ -361,5 +377,146 @@ describe( 'receiveCart', () => {
 		} as never )( { dispatch, select } as never );
 
 		expect( dispatch.itemIsPendingDelete ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'applyExtensionCartUpdate', () => {
+	const mockResponse = {
+		items: [],
+		shipping_address: { address_1: '123 Ship St' },
+		billing_address: { address_1: '456 Bill Ave' },
+		totals: { total_price: '1000' },
+	};
+
+	const createMockDispatch = () => ( {
+		receiveCart: jest.fn(),
+		receiveError: jest.fn(),
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetIsCustomerDataDirty.mockReturnValue( false );
+		mockApiFetchWithHeaders.mockResolvedValue( {
+			response: mockResponse,
+		} );
+	} );
+
+	it( 'should include both addresses when customer data is not dirty', async () => {
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+		} )( { dispatch } as never );
+
+		expect( dispatch.receiveCart ).toHaveBeenCalledWith( mockResponse );
+	} );
+
+	it( 'should strip both addresses when customer data is dirty and no overwrite specified', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).not.toHaveProperty( 'shipping_address' );
+		expect( received ).not.toHaveProperty( 'billing_address' );
+		expect( received ).toHaveProperty( 'totals' );
+	} );
+
+	it( 'should include both addresses when overwriteDirtyCustomerData is true', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: true,
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).toHaveProperty( 'shipping_address' );
+		expect( received ).toHaveProperty( 'billing_address' );
+	} );
+
+	it( 'should overwrite only shipping_address when specified as object', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: { shipping_address: true },
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received.shipping_address ).toEqual( {
+			address_1: '123 Ship St',
+		} );
+		expect( received ).not.toHaveProperty( 'billing_address' );
+		expect( received ).toHaveProperty( 'totals' );
+	} );
+
+	it( 'should overwrite only billing_address when specified as object', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: { billing_address: true },
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received ).not.toHaveProperty( 'shipping_address' );
+		expect( received.billing_address ).toEqual( {
+			address_1: '456 Bill Ave',
+		} );
+	} );
+
+	it( 'should overwrite both addresses when both specified in object', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( true );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: {
+				shipping_address: true,
+				billing_address: true,
+			},
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		expect( received.shipping_address ).toEqual( {
+			address_1: '123 Ship St',
+		} );
+		expect( received.billing_address ).toEqual( {
+			address_1: '456 Bill Ave',
+		} );
+	} );
+
+	it( 'should overwrite specified address even when customer data is not dirty', async () => {
+		mockGetIsCustomerDataDirty.mockReturnValue( false );
+		const dispatch = createMockDispatch();
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+			overwriteDirtyCustomerData: { shipping_address: true },
+		} )( { dispatch } as never );
+
+		const received = dispatch.receiveCart.mock.calls[ 0 ][ 0 ];
+		// shipping_address should be included (overwrite requested)
+		expect( received.shipping_address ).toEqual( {
+			address_1: '123 Ship St',
+		} );
+		// billing_address should also be included (data is not dirty, no reason to strip)
+		expect( received.billing_address ).toEqual( {
+			address_1: '456 Bill Ave',
+		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -32,6 +32,7 @@ import {
 } from './notify-quantity-changes';
 import { updateCartErrorNotices } from './notify-errors';
 import { apiFetchWithHeaders } from '../shared-controls';
+import { isObject } from '../../types/type-guards/object';
 import {
 	getIsCustomerDataDirty,
 	setIsCustomerDataDirty,
@@ -141,11 +142,7 @@ export const applyExtensionCartUpdate =
 			} );
 			// Determine which addresses should be overwritten in the store.
 			const raw = args.overwriteDirtyCustomerData;
-			const isPlainObject =
-				typeof raw === 'object' &&
-				raw !== null &&
-				! Array.isArray( raw );
-			const overwrite = isPlainObject
+			const overwrite = isObject( raw )
 				? {
 						shipping_address: raw.shipping_address === true,
 						billing_address: raw.billing_address === true,

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -139,19 +139,46 @@ export const applyExtensionCartUpdate =
 				data: { namespace: args.namespace, data: args.data },
 				cache: 'no-store',
 			} );
-			if ( args.overwriteDirtyCustomerData === true ) {
-				dispatch.receiveCart( response );
-				return response;
-			}
-			if ( getIsCustomerDataDirty() ) {
-				// If the customer data is dirty, we don't want to overwrite it with the response.
-				// Remove shipping and billing address from the response and then receive the cart.
+			// Determine which addresses should be overwritten in the store.
+			const overwrite =
+				typeof args.overwriteDirtyCustomerData === 'object'
+					? args.overwriteDirtyCustomerData
+					: {
+							shipping_address:
+								args.overwriteDirtyCustomerData === true,
+							billing_address:
+								args.overwriteDirtyCustomerData === true,
+					  };
+
+			const isDirty = getIsCustomerDataDirty();
+
+			// Decide per-address: include it unless it's dirty and not being overwritten.
+			const includeShipping =
+				overwrite.shipping_address || ! isDirty;
+			const includeBilling =
+				overwrite.billing_address || ! isDirty;
+
+			if ( ! includeShipping || ! includeBilling ) {
 				const {
 					shipping_address: _,
 					billing_address: __,
-					...responseWithoutShippingOrBilling
+					...responseWithoutAddresses
 				} = response;
-				dispatch.receiveCart( responseWithoutShippingOrBilling );
+
+				const cartToReceive: Partial< CartResponse > = {
+					...responseWithoutAddresses,
+				};
+
+				if ( includeShipping ) {
+					cartToReceive.shipping_address =
+						response.shipping_address;
+				}
+				if ( includeBilling ) {
+					cartToReceive.billing_address =
+						response.billing_address;
+				}
+
+				dispatch.receiveCart( cartToReceive );
 				return response;
 			}
 			dispatch.receiveCart( response );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -140,15 +140,20 @@ export const applyExtensionCartUpdate =
 				cache: 'no-store',
 			} );
 			// Determine which addresses should be overwritten in the store.
-			const overwrite =
-				typeof args.overwriteDirtyCustomerData === 'object'
-					? args.overwriteDirtyCustomerData
-					: {
-							shipping_address:
-								args.overwriteDirtyCustomerData === true,
-							billing_address:
-								args.overwriteDirtyCustomerData === true,
-					  };
+			const raw = args.overwriteDirtyCustomerData;
+			const isPlainObject =
+				typeof raw === 'object' &&
+				raw !== null &&
+				! Array.isArray( raw );
+			const overwrite = isPlainObject
+				? {
+						shipping_address: raw.shipping_address === true,
+						billing_address: raw.billing_address === true,
+				  }
+				: {
+						shipping_address: raw === true,
+						billing_address: raw === true,
+				  };
 
 			const isDirty = getIsCustomerDataDirty();
 

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -153,10 +153,8 @@ export const applyExtensionCartUpdate =
 			const isDirty = getIsCustomerDataDirty();
 
 			// Decide per-address: include it unless it's dirty and not being overwritten.
-			const includeShipping =
-				overwrite.shipping_address || ! isDirty;
-			const includeBilling =
-				overwrite.billing_address || ! isDirty;
+			const includeShipping = overwrite.shipping_address || ! isDirty;
+			const includeBilling = overwrite.billing_address || ! isDirty;
 
 			if ( ! includeShipping || ! includeBilling ) {
 				const {
@@ -170,12 +168,10 @@ export const applyExtensionCartUpdate =
 				};
 
 				if ( includeShipping ) {
-					cartToReceive.shipping_address =
-						response.shipping_address;
+					cartToReceive.shipping_address = response.shipping_address;
 				}
 				if ( includeBilling ) {
-					cartToReceive.billing_address =
-						response.billing_address;
+					cartToReceive.billing_address = response.billing_address;
 				}
 
 				dispatch.receiveCart( cartToReceive );

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.ts
@@ -219,7 +219,13 @@ export interface CartMeta {
 export interface ExtensionCartUpdateArgs {
 	data: Record< string, unknown >;
 	namespace: string;
-	overwriteDirtyCustomerData?: undefined | boolean;
+	overwriteDirtyCustomerData?:
+		| undefined
+		| boolean
+		| {
+				shipping_address?: boolean;
+				billing_address?: boolean;
+		  };
 }
 
 export interface BillingAddressShippingAddress {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `overwriteDirtyCustomerData` option on `extensionCartUpdate` previously only supported a boolean — forcing both shipping and billing addresses to be overwritten or preserved together. This is limiting for use cases like address autocomplete, where an extension may only have data for one address type.

This PR extends `overwriteDirtyCustomerData` to also accept an object with per-address control:

```ts
extensionCartUpdate({
  namespace: 'my-extension',
  data: { /* ... */ },
  overwriteDirtyCustomerData: { shipping_address: true },
  // billing_address defaults to false — won't overwrite dirty billing data
});
```

The change is fully backwards compatible — passing `true`, `false`, or omitting the option works identically to before.

**Logic:** An address is included in the store update if it's explicitly being overwritten OR if customer data isn't dirty. An address is stripped only if customer data is dirty AND it's not being overwritten.

cc @nikmclaughlin

### How to test the changes in this Pull Request:

**1. Drop in this mu-plugin** to register a server-side callback that sets addresses from extension data:

Create `wp-content/mu-plugins/test-extension-cart-update.php`:

```php
<?php
add_action( 'woocommerce_blocks_loaded', function() {
    woocommerce_store_api_register_update_callback(
        [
            'namespace' => 'test-address-overwrite',
            'callback'  => function( $data ) {
                $customer = WC()->customer;

                if ( ! empty( $data['shipping_address_1'] ) ) {
                    $customer->set_shipping_address_1( $data['shipping_address_1'] );
                    $customer->set_shipping_city( $data['shipping_city'] ?? '' );
                    $customer->set_shipping_postcode( $data['shipping_postcode'] ?? '' );
                    $customer->set_shipping_state( $data['shipping_state'] ?? '' );
                }

                if ( ! empty( $data['billing_address_1'] ) ) {
                    $customer->set_billing_address_1( $data['billing_address_1'] );
                    $customer->set_billing_city( $data['billing_city'] ?? '' );
                    $customer->set_billing_postcode( $data['billing_postcode'] ?? '' );
                    $customer->set_billing_state( $data['billing_state'] ?? '' );
                }

                $customer->save();
            },
        ]
    );
});
```

**2. Add a product to the cart** and go to the checkout page (block checkout).

**3. Start editing the billing address** (type something in the billing address field to make customer data "dirty"). Note: you may need to change country so that the ZIP code is removed and the address doesn't automatically push on change. 

**4. Open the browser console** and run:

```js
// Only overwrite shipping — billing should be preserved
wc.blocksCheckout.extensionCartUpdate({
  namespace: 'test-address-overwrite',
  data: {
    shipping_address_1: '999 Test Blvd',
    shipping_city: 'Seattle',
    shipping_postcode: '98101',
    shipping_state: 'WA',
  },
  overwriteDirtyCustomerData: { shipping_address: true },
});
```

**5. Verify:** The shipping address fields update to "999 Test Blvd / Seattle" but the billing address you were editing is preserved.

**6. Test the inverse** — edit the shipping address, then overwrite only billing:

```js
wc.blocksCheckout.extensionCartUpdate({
  namespace: 'test-address-overwrite',
  data: {
    billing_address_1: '123 Billing Ln',
    billing_city: 'Portland',
    billing_postcode: '97201',
    billing_state: 'OR',
  },
  overwriteDirtyCustomerData: { billing_address: true },
});
```

**7. Test backwards compatibility** — `overwriteDirtyCustomerData: true` should still overwrite both, and omitting it while data is dirty should still preserve both.

**8. Remove the mu-plugin** when done and test checkout ensuring addresses update correctly and are correct in the order confirmation.

### Testing that has already taken place:

- Unit tests added covering all combinations (7 new test cases in `data/cart/test/thunks.ts`)
- TypeScript type checking passes with no new errors

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually at `plugins/woocommerce/changelog/opr-cart-update-partial-addr`.

</details>
