### PR TITLE
POC: Convert Cart proceed-to-checkout block to Interactivity API

### DIFF
--- a/docs/superpowers/plans/2026-04-05-cart-iapi-poc.md
+++ b/docs/superpowers/plans/2026-04-05-cart-iapi-poc.md
@@ -1,0 +1,788 @@
+# Cart IAPI POC: Proceed-to-Checkout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the Cart proceed-to-checkout inner block from React to the Interactivity API as a proof of concept, behind a feature flag, with full backwards compatibility.
+
+**Architecture:** Feature-flag-gated dual rendering. PHP renders IAPI HTML when flag is on. A pass-through React component preserves the IAPI HTML inside React's DOM tree. A new cart event emitter (`window.wc.blocksCartEvents`) replaces the React-only observer pattern, with the existing React `CartEventsProvider` delegating to it for backwards compatibility.
+
+**Tech Stack:** WordPress Interactivity API, PHP, TypeScript, Webpack script modules
+
+**Spec:** `docs/superpowers/specs/2026-04-05-cart-iapi-poc-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `client/blocks/assets/js/events/cart-events.ts` | Cart event emitter instance with `onProceedToCheckout` |
+| `client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts` | IAPI store for proceed-to-checkout |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `client/blocks/assets/js/events/index.ts` | Re-export cart events |
+| `client/blocks/bin/webpack-helpers.js` | Add `blocksCartEvents` external mapping |
+| `client/blocks/bin/webpack-entries.js` | Add `blocksCartEvents` build entry |
+| `client/blocks/bin/webpack-config-interactive-blocks.js` | Add manual entry for proceed-to-checkout IAPI frontend |
+| `client/blocks/assets/js/base/stores/woocommerce/cart.ts` | Expose `isProcessing` from mutation batcher |
+| `client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx` | Delegate to shared cart event emitter |
+| `client/blocks/assets/js/blocks/cart/inner-blocks/register-components.ts` | Skip React registration when IAPI detected in DOM |
+| `src/Blocks/BlockTypes/ProceedToCheckoutBlock.php` | Add IAPI render path behind feature flag |
+| `client/admin/config/core.json` | Add `experimental-iapi-cart` flag |
+| `client/admin/config/development.json` | Add `experimental-iapi-cart` flag |
+
+All paths below are relative to `plugins/woocommerce/`.
+
+---
+
+## Task 1: Feature Flag Registration
+
+**Files:**
+- Modify: `client/admin/config/core.json`
+- Modify: `client/admin/config/development.json`
+
+- [ ] **Step 1: Add feature flag to core.json**
+
+In `client/admin/config/core.json`, add after the `experimental-iapi-mini-cart` line:
+
+```json
+"experimental-iapi-cart": false,
+```
+
+Set to `false` in core (production off by default).
+
+- [ ] **Step 2: Add feature flag to development.json**
+
+In `client/admin/config/development.json`, add after the `experimental-iapi-mini-cart` line:
+
+```json
+"experimental-iapi-cart": true,
+```
+
+Set to `true` in development (on for testing).
+
+- [ ] **Step 3: Verify flag is generated**
+
+Run: `pnpm --filter=@woocommerce/plugin-woocommerce build:feature-config`
+
+Check that `includes/react-admin/feature-config.php` now contains `'experimental-iapi-cart'`. If the build command doesn't exist, check git diff to confirm the JSON changes are correct — the PHP file is auto-generated during the full build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/woocommerce/client/admin/config/core.json plugins/woocommerce/client/admin/config/development.json
+git commit -m "feat: add experimental-iapi-cart feature flag"
+```
+
+---
+
+## Task 2: Cart Event Emitter
+
+**Files:**
+- Create: `client/blocks/assets/js/events/cart-events.ts`
+- Modify: `client/blocks/assets/js/events/index.ts`
+- Modify: `client/blocks/bin/webpack-helpers.js`
+- Modify: `client/blocks/bin/webpack-entries.js`
+
+- [ ] **Step 1: Create cart-events.ts**
+
+Create `client/blocks/assets/js/events/cart-events.ts`:
+
+```typescript
+/**
+ * Internal dependencies
+ */
+import { createEmitter } from './event-emitter';
+
+export const CART_EVENTS = {
+	/**
+	 * Event emitted when the user clicks "Proceed to Checkout" in the cart.
+	 * Observers can return an error/fail response to prevent navigation.
+	 */
+	PROCEED_TO_CHECKOUT: 'cart_proceed_to_checkout',
+};
+
+export const cartEventsEmitter = createEmitter();
+
+export const cartEvents = {
+	onProceedToCheckout: cartEventsEmitter.createSubscribeFunction(
+		CART_EVENTS.PROCEED_TO_CHECKOUT
+	),
+};
+```
+
+- [ ] **Step 2: Export from index.ts**
+
+In `client/blocks/assets/js/events/index.ts`, add:
+
+```typescript
+export * from './cart-events';
+```
+
+So the file becomes:
+
+```typescript
+export * from './checkout-events';
+export * from './cart-events';
+```
+
+- [ ] **Step 3: Add webpack external mapping**
+
+In `client/blocks/bin/webpack-helpers.js`, find the `wcDepMap` object and add:
+
+```javascript
+'@woocommerce/blocks-cart-events': [ 'wc', 'blocksCartEvents' ],
+```
+
+Find the `wcHandleMap` object and add:
+
+```javascript
+'@woocommerce/blocks-cart-events': 'wc-blocks-cart-events',
+```
+
+- [ ] **Step 4: Add webpack build entry**
+
+In `client/blocks/bin/webpack-entries.js`, find the `core` section (where `blocksCheckoutEvents` is defined) and add:
+
+```javascript
+blocksCartEvents: './assets/js/events/cart-events.ts',
+```
+
+- [ ] **Step 5: Verify build**
+
+Run from `plugins/woocommerce/client/blocks/`:
+
+```bash
+pnpm run build
+```
+
+Check that `build/wc-blocks-cart-events.js` (or similar) is generated without errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/woocommerce/client/blocks/assets/js/events/ plugins/woocommerce/client/blocks/bin/webpack-helpers.js plugins/woocommerce/client/blocks/bin/webpack-entries.js
+git commit -m "feat: add cart events emitter (window.wc.blocksCartEvents)"
+```
+
+---
+
+## Task 3: Bridge CartEventsProvider to Shared Emitter
+
+**Files:**
+- Modify: `client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx`
+
+This is the backwards-compatibility bridge. The React `CartEventsProvider` currently uses its own internal reducer-based observer system. We change it to delegate to the shared `cartEventsEmitter` so both React hooks and IAPI stores use the same observer registry.
+
+- [ ] **Step 1: Rewrite CartEventsProvider to delegate to shared emitter**
+
+Replace the contents of `client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx`:
+
+```typescript
+/**
+ * External dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+import type { ObserverResponse } from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import { cartEventsEmitter, CART_EVENTS } from '../../../../events/cart-events';
+import type { EventListener } from '../../../../events/event-emitter';
+
+type CartEventsContextType = {
+	onProceedToCheckout: (
+		callback: EventListener,
+		priority?: number
+	) => () => void;
+	dispatchOnProceedToCheckout: () => Promise< ObserverResponse[] >;
+};
+
+const CartEventsContext = createContext< CartEventsContextType >( {
+	onProceedToCheckout: () => () => void null,
+	dispatchOnProceedToCheckout: () => Promise.resolve( [] ),
+} );
+
+export const useCartEventsContext = () => {
+	return useContext( CartEventsContext );
+};
+
+/**
+ * Cart Events provider
+ * Delegates to the shared cartEventsEmitter so that both React hooks
+ * and Interactivity API stores share the same observer registry.
+ */
+export const CartEventsProvider = ( {
+	children,
+}: {
+	children: React.ReactNode;
+} ): JSX.Element => {
+	const cartEventsValue: CartEventsContextType = {
+		onProceedToCheckout: ( callback: EventListener, priority = 10 ) =>
+			cartEventsEmitter.subscribe(
+				callback,
+				priority,
+				CART_EVENTS.PROCEED_TO_CHECKOUT
+			),
+		dispatchOnProceedToCheckout: () =>
+			cartEventsEmitter.emitWithAbort(
+				CART_EVENTS.PROCEED_TO_CHECKOUT,
+				null
+			),
+	};
+
+	return (
+		<CartEventsContext.Provider value={ cartEventsValue }>
+			{ children }
+		</CartEventsContext.Provider>
+	);
+};
+```
+
+- [ ] **Step 2: Run existing cart block tests to verify backwards compat**
+
+Run from monorepo root:
+
+```bash
+pnpm --filter=@woocommerce/block-library test:js -- --testPathPattern="cart-events|proceed-to-checkout"
+```
+
+If no unit tests match, that's OK — the E2E tests will cover this. The key thing is the build succeeds.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd plugins/woocommerce/client/blocks && pnpm run build
+```
+
+No errors expected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/
+git commit -m "refactor: bridge CartEventsProvider to shared cart event emitter"
+```
+
+---
+
+## Task 4: Expose isProcessing in Shared Cart Store
+
+**Files:**
+- Modify: `client/blocks/assets/js/base/stores/woocommerce/cart.ts`
+
+The shared IAPI cart store needs to expose whether the mutation batcher is currently processing, so the IAPI proceed-to-checkout block can disable the button during cart operations.
+
+- [ ] **Step 1: Add isProcessing getter to cart store state**
+
+In `client/blocks/assets/js/base/stores/woocommerce/cart.ts`, find the store definition and add an `isProcessing` getter to the state. The mutation batcher's `getStatus()` method returns `{ isProcessing, pendingCount }`.
+
+Find where `cartQueue` is defined (it's lazily initialized in `sendCartRequest()`). The `isProcessing` state needs to check `cartQueue?.getStatus().isProcessing`.
+
+Add to the store's `state` object:
+
+```typescript
+get isProcessing(): boolean {
+	return cartQueue?.getStatus().isProcessing ?? false;
+},
+```
+
+Look at the existing state properties to find the right location. It should go near the top of the `state` section alongside other cart status properties.
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd plugins/woocommerce/client/blocks && pnpm run build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+git commit -m "feat: expose isProcessing state in shared woocommerce cart store"
+```
+
+---
+
+## Task 5: PHP IAPI Render Path
+
+**Files:**
+- Modify: `src/Blocks/BlockTypes/ProceedToCheckoutBlock.php`
+
+- [ ] **Step 1: Add IAPI rendering to ProceedToCheckoutBlock.php**
+
+Replace the entire file with:
+
+```php
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Admin\Features\Features;
+
+/**
+ * ProceedToCheckoutBlock class.
+ */
+class ProceedToCheckoutBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'proceed-to-checkout-block';
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		$this->asset_data_registry->register_page_id( isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0 );
+	}
+
+	/**
+	 * Enable interactivity support when the feature flag is on.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		if ( Features::is_enabled( 'experimental-iapi-cart' ) ) {
+			add_action( 'init', array( $this, 'enable_interactivity_support' ), 20 );
+		}
+	}
+
+	/**
+	 * Dynamically enable interactivity support on the block type.
+	 */
+	public function enable_interactivity_support() {
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'woocommerce/' . $this->block_name );
+		if ( $block_type ) {
+			$block_type->supports['interactivity'] = true;
+		}
+	}
+
+	/**
+	 * Render the block. When the IAPI flag is enabled, render interactive markup.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param \WP_Block $block     Block instance.
+	 * @return string Rendered block output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( ! Features::is_enabled( 'experimental-iapi-cart' ) ) {
+			return $content;
+		}
+
+		return $this->render_iapi( $attributes, $content, $block );
+	}
+
+	/**
+	 * Render the IAPI version of the proceed-to-checkout block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param \WP_Block $block     Block instance.
+	 * @return string Rendered block output.
+	 */
+	private function render_iapi( $attributes, $content, $block ) {
+		wp_enqueue_script_module( 'woocommerce/proceed-to-checkout' );
+
+		$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
+		BlocksSharedState::load_cart_state( $consent );
+
+		// Resolve checkout URL.
+		$checkout_page_id = isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0;
+		$checkout_url     = $checkout_page_id ? get_permalink( $checkout_page_id ) : wc_get_checkout_url();
+		if ( ! $checkout_url ) {
+			$checkout_url = wc_get_checkout_url();
+		}
+
+		// Resolve button label.
+		$button_label = isset( $attributes['buttonLabel'] ) && ! empty( $attributes['buttonLabel'] )
+			? $attributes['buttonLabel']
+			: __( 'Proceed to Checkout', 'woocommerce' );
+
+		$context = array(
+			'checkoutUrl' => $checkout_url,
+			'buttonLabel' => $button_label,
+			'isLoading'   => false,
+		);
+
+		$context_attr = wp_interactivity_data_wp_context( $context );
+
+		return sprintf(
+			'<div
+				class="wc-block-cart__submit"
+				data-wp-interactive="woocommerce/proceed-to-checkout"
+				%1$s
+			>
+				<div aria-hidden="true" style="height:0;overflow:hidden;position:relative" data-wp-init="callbacks.initStickyObserver"></div>
+				<div
+					class="wc-block-cart__submit-container"
+					data-wp-class--wc-block-cart__submit-container--sticky="state.isStickyVisible"
+					data-wp-style--background-color="state.stickyBackgroundColor"
+				>
+					<a
+						class="wc-block-cart__submit-button wc-block-components-button wp-element-button"
+						data-wp-bind--href="context.checkoutUrl"
+						data-wp-bind--aria-disabled="state.isDisabled"
+						data-wp-class--wc-block-cart__submit-button--loading="context.isLoading"
+						data-wp-on--click="actions.handleClick"
+						href="%2$s"
+					>
+						<span class="wc-block-components-button__text" data-wp-text="context.buttonLabel">%3$s</span>
+					</a>
+				</div>
+			</div>',
+			$context_attr,
+			esc_url( $checkout_url ),
+			esc_html( $button_label )
+		);
+	}
+}
+```
+
+**Key details:**
+- `render()` returns `$content` unchanged when flag is off (existing React behavior)
+- When flag is on, `render_iapi()` produces server-rendered HTML with `data-wp-interactive` directives
+- The sentinel div (height:0) is used by `initStickyObserver` callback
+- The button is an `<a>` tag with `href` for accessibility (E2E tests expect `role="link"`)
+- Initial values are rendered as HTML attributes for SSR (visible before JS loads)
+- `BlocksSharedState::load_cart_state()` ensures the shared `woocommerce` store is hydrated
+
+- [ ] **Step 2: Verify PHP syntax**
+
+```bash
+php -l plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
+```
+
+Expected: `No syntax errors detected`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
+git commit -m "feat: add IAPI render path for proceed-to-checkout block"
+```
+
+---
+
+## Task 6: IAPI Store (Frontend)
+
+**Files:**
+- Create: `client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts`
+- Modify: `client/blocks/bin/webpack-config-interactive-blocks.js`
+
+- [ ] **Step 1: Create iapi-frontend.ts**
+
+Create `client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts`:
+
+```typescript
+/**
+ * External dependencies
+ */
+import { store, getContext, getElement } from '@wordpress/interactivity';
+import { isErrorResponse } from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import { cartEventsEmitter, CART_EVENTS } from '../../../../events/cart-events';
+
+type WooCommerce = {
+	state: {
+		cart: {
+			items: unknown[];
+		};
+		isProcessing: boolean;
+	};
+};
+
+type ProceedToCheckoutContext = {
+	checkoutUrl: string;
+	buttonLabel: string;
+	isLoading: boolean;
+};
+
+type ProceedToCheckoutStore = {
+	state: {
+		readonly isDisabled: boolean;
+		isStickyVisible: boolean;
+		stickyBackgroundColor: string;
+	};
+	actions: {
+		handleClick: ( event: MouseEvent ) => void;
+	};
+	callbacks: {
+		onPageShow: () => () => void;
+		initStickyObserver: () => () => void;
+	};
+};
+
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+// Access shared woocommerce store for cart state.
+const { state: woocommerceState } = store< WooCommerce >(
+	'woocommerce',
+	{},
+	{ lock: universalLock }
+);
+
+// Store-level state for sticky behavior. These are in the store's state
+// object so the IAPI reactivity system tracks reads/writes and triggers
+// re-renders of directives that depend on them.
+const { state: ptcState } = store< ProceedToCheckoutStore >(
+	'woocommerce/proceed-to-checkout',
+	{
+		state: {
+			get isDisabled(): boolean {
+				return woocommerceState.isProcessing;
+			},
+			isStickyVisible: false,
+			stickyBackgroundColor: '',
+		},
+		actions: {
+			*handleClick( event: MouseEvent ) {
+				event.preventDefault();
+
+				const context = getContext< ProceedToCheckoutContext >();
+
+				if ( woocommerceState.isProcessing || context.isLoading ) {
+					return;
+				}
+
+				// Dispatch proceed-to-checkout event. Observers can abort.
+				const responses: Awaited<
+					ReturnType< typeof cartEventsEmitter.emitWithAbort >
+				> = yield cartEventsEmitter.emitWithAbort(
+					CART_EVENTS.PROCEED_TO_CHECKOUT,
+					null
+				);
+
+				if ( responses.some( isErrorResponse ) ) {
+					return;
+				}
+
+				context.isLoading = true;
+				window.location.href = context.checkoutUrl;
+			},
+		},
+		callbacks: {
+			onPageShow() {
+				// Capture context while in directive scope (getContext only
+				// works inside IAPI directive callbacks, not in event handlers).
+				const context = getContext< ProceedToCheckoutContext >();
+				const callback = () => {
+					context.isLoading = false;
+				};
+				window.addEventListener( 'pageshow', callback );
+				return () => {
+					window.removeEventListener( 'pageshow', callback );
+				};
+			},
+			initStickyObserver() {
+				const { ref } = getElement();
+				if ( ! ref ) {
+					return;
+				}
+
+				// Compute body background color once.
+				const computedColor =
+					getComputedStyle( document.body ).backgroundColor;
+				const bgColor =
+					! computedColor ||
+					computedColor === 'rgba(0, 0, 0, 0)' ||
+					computedColor === 'transparent'
+						? '#fff'
+						: computedColor;
+
+				const observer = new IntersectionObserver(
+					( entries ) => {
+						const entry = entries[ 0 ];
+						if ( entry.isIntersecting ) {
+							ptcState.isStickyVisible = false;
+							ptcState.stickyBackgroundColor = '';
+						} else {
+							const isBelow =
+								entry.boundingClientRect.top > 0;
+							ptcState.isStickyVisible = isBelow;
+							ptcState.stickyBackgroundColor = isBelow
+								? bgColor
+								: '';
+						}
+					},
+					{ threshold: [ 0, 0.5, 1 ] }
+				);
+
+				observer.observe( ref );
+
+				return () => {
+					observer.disconnect();
+				};
+			},
+		},
+	},
+	{ lock: true }
+);
+```
+
+- [ ] **Step 2: Add webpack entry**
+
+In `client/blocks/bin/webpack-config-interactive-blocks.js`, add a manual entry alongside the mini-cart one (around line 31):
+
+```javascript
+// Experimental proceed-to-checkout IAPI frontend, only enqueued when experimental-iapi-cart feature flag is enabled.
+'woocommerce/proceed-to-checkout':
+	'./assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts',
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd plugins/woocommerce/client/blocks && pnpm run build
+```
+
+Check that `build/woocommerce/proceed-to-checkout.js` is generated.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+git commit -m "feat: add IAPI store for proceed-to-checkout block"
+```
+
+---
+
+## Task 7: Unregister React Component When IAPI Enabled
+
+**Files:**
+- Modify: `client/blocks/assets/js/blocks/cart/inner-blocks/register-components.ts`
+
+When the IAPI flag is on, the server renders `data-wp-interactive` HTML. The parent Cart block's React `renderInnerBlocks()` finds blocks via `data-block-name` and replaces them with registered React components. If we **don't register** a React component for this block, `renderInnerBlocks` falls through to `html-react-parser` (line 167-212 of `render-parent-block.tsx`) which preserves the HTML as React elements. The IAPI runtime then binds to the real DOM nodes independently.
+
+This is simpler and more reliable than a pass-through component — no risk of React re-rendering and destroying IAPI bindings.
+
+- [ ] **Step 1: Conditionally skip registration**
+
+In `client/blocks/assets/js/blocks/cart/inner-blocks/register-components.ts`, find the proceed-to-checkout registration:
+
+```typescript
+registerCheckoutBlock( {
+	metadata: metadata.PROCEED_TO_CHECKOUT,
+	component: ProceedToCheckoutFrontend,
+} );
+```
+
+Wrap it in an IAPI detection check. The detection uses the DOM since this script runs after DOM is available (cart scripts are deferred and load in footer):
+
+```typescript
+// When the IAPI flag is on, PHP renders data-wp-interactive markup.
+// Skip React registration so renderInnerBlocks preserves the server HTML
+// and the IAPI runtime can bind to it.
+if (
+	! document.querySelector(
+		'[data-wp-interactive="woocommerce/proceed-to-checkout"]'
+	)
+) {
+	registerCheckoutBlock( {
+		metadata: metadata.PROCEED_TO_CHECKOUT,
+		component: ProceedToCheckoutFrontend,
+	} );
+}
+```
+
+- [ ] **Step 2: Verify `frontend.tsx` is unchanged**
+
+The existing `frontend.tsx` stays as-is. It's only loaded when the React path is active (i.e., when the block IS registered).
+
+```typescript
+// frontend.tsx — no changes needed
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
+import Block from './block';
+import attributes from './attributes';
+export default withFilteredAttributes( attributes )( Block );
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd plugins/woocommerce/client/blocks && pnpm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/register-components.ts
+git commit -m "feat: skip React registration for proceed-to-checkout when IAPI enabled"
+```
+
+---
+
+## Task 8: E2E Verification
+
+The existing Cart E2E tests are our validation. They test:
+- "Proceed to Checkout" button navigation (`cart-block.shopper.block_theme.spec.ts:233`)
+- Button disabled during network requests (`cart-block.shopper.block_theme.spec.ts:174-224`)
+- Button visibility and translation (`cart-checkout-block-translations.shopper.block_theme.spec.ts`)
+
+- [ ] **Step 1: Start the test environment**
+
+```bash
+cd plugins/woocommerce/client/blocks && pnpm env:start
+```
+
+- [ ] **Step 2: Enable the feature flag**
+
+The development config has `experimental-iapi-cart: true`, so it should be enabled in the test env. Verify by checking wp-admin or by running:
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli -- wp option get woocommerce_feature_flags
+```
+
+If the flag isn't automatically picked up, enable it manually:
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli -- wp option update woocommerce_feature_experimental-iapi-cart yes
+```
+
+- [ ] **Step 3: Run cart E2E tests**
+
+```bash
+cd plugins/woocommerce/client/blocks && pnpm test:e2e -- --grep "cart-block.shopper"
+```
+
+Key tests that must pass:
+- "User can proceed to checkout" — button navigates to checkout
+- "User can update product quantity" — button disables during network requests
+- "User can remove a product" — cart still works after removal
+
+- [ ] **Step 4: Run broader cart E2E suite**
+
+```bash
+cd plugins/woocommerce/client/blocks && pnpm test:e2e -- --grep "cart"
+```
+
+This runs all cart-related tests including coupons, shipping, translations.
+
+- [ ] **Step 5: If tests fail, debug**
+
+Common failure modes:
+- **Button not found as `role="link"`**: The IAPI HTML must render `<a>` not `<button>`. Check PHP output.
+- **Button not disabling**: `isProcessing` not being read correctly. Check cart store getter.
+- **Navigation blocked**: Event emitter not dispatching correctly. Check CartEventsProvider bridge.
+- **Sticky not working**: IntersectionObserver not binding. Check sentinel element rendering.
+
+- [ ] **Step 6: Commit any fixes and tag as complete**
+
+```bash
+git add -A
+git commit -m "fix: address E2E test feedback for IAPI proceed-to-checkout"
+```

--- a/docs/superpowers/specs/2026-04-05-cart-iapi-poc-design.md
+++ b/docs/superpowers/specs/2026-04-05-cart-iapi-poc-design.md
@@ -25,7 +25,7 @@ Existing IAPI infrastructure in WooCommerce:
 
 When the `experimental-iapi-cart` feature flag is **enabled**:
 
-1. **PHP** (`ProceedToCheckoutBlock.php`): Renders the button as server-side HTML with `data-wp-interactive="woocommerce/proceed-to-checkout"` directives. Sets context via `wp_interactivity_data_wp_context()` with `checkoutUrl` and `buttonLabel`. Includes a sentinel `<div>` for the sticky intersection observer. Enqueues script module instead of traditional script.
+1. **PHP** (`ProceedToCheckoutBlock.php`): Renders the button as server-side HTML with `data-wp-interactive="woocommerce/proceed-to-checkout"` directives. Sets context via `wp_interactivity_data_wp_context()` with `checkoutUrl` and `buttonLabel`. Includes a sentinel `<div>` for the sticky intersection observer. Enqueues script module via `wp_enqueue_script_module()`. The `iapi-frontend.ts` file is built as a script module by the existing `webpack-config-interactive-blocks.js` config (same build pipeline as mini-cart and add-to-cart-with-options IAPI blocks).
 
 2. **React pass-through component**: Registered via `registerCheckoutBlock()` so `renderInnerBlocks()` finds the block. Renders a single `<div ref={...}>` that preserves the server-rendered IAPI HTML. React sees one opaque container and won't re-render into it. This component also bridges the `CartEventsProvider` context — it calls `useCartEventsContext()` and is available because the parent Cart block's React tree still wraps everything.
 
@@ -56,14 +56,14 @@ Store namespace: `woocommerce/proceed-to-checkout` (locked, private).
 - `isLoading` — toggled on click, reset on pageshow
 
 **State (derived):**
-- `isDisabled` — reads from the shared `woocommerce` store's cart state
+- `isDisabled` — the shared `woocommerce` IAPI store does not currently expose `cartIsLoading` or `isCalculating` flags (those live in React `@wordpress/data` stores). For the POC, we add an `isProcessing` boolean to the shared `woocommerce` store that is set `true` while the mutation batcher has pending requests. This gives the IAPI proceed-to-checkout block a signal to disable the button during cart operations.
 
 **Actions:**
-- `*handleClick` — generator function. Calls `emitWithAbort()` on the cart event emitter. If any observer returns error/fail, aborts. Otherwise sets `isLoading = true` and navigates via `window.location.href`.
+- `*handleClick` — generator function. Calls `emitWithAbort()` on the cart event emitter. If any observer returns error/fail, aborts. Otherwise sets `isLoading = true` and navigates. The button renders as an `<a>` tag with `href` (preserving anchor semantics for middle-click/cmd-click). The click handler uses `data-wp-on--click` which calls `event.preventDefault()` first, runs observers, then navigates via `window.location.href` on success — same pattern as the current React implementation.
 
 **Callbacks:**
 - `onPageShow` — listens for browser `pageshow` event to reset `isLoading` (Safari back-button fix)
-- `initStickyObserver` — sets up `IntersectionObserver` on a sentinel element to toggle sticky class on mobile viewports
+- `initStickyObserver` — sets up `IntersectionObserver` on a sentinel element to toggle sticky class on mobile viewports. Also computes `document.body` background color and applies it as inline style on the sticky container (matching current React behavior).
 
 ### 4. Feature Flag
 
@@ -94,13 +94,14 @@ Registered in the same system as `experimental-iapi-mini-cart`. Controls:
 | `assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/frontend.tsx` | Swap to pass-through component when IAPI flag enabled |
 | `assets/js/blocks/cart/inner-blocks/register-components.ts` | Register pass-through variant |
 | `src/Blocks/BlockTypes/ProceedToCheckoutBlock.php` | Add IAPI render path behind feature flag |
-| Feature flag registration (location TBD — `Bootstrap.php` or similar) | Register `experimental-iapi-cart` flag |
+| Feature flag registration (same location as `experimental-iapi-mini-cart`: `includes/react-admin/feature-config.php` and `client/admin/config/core.json`) | Register `experimental-iapi-cart` flag |
+| `base/stores/woocommerce/cart.ts` | Add `isProcessing` state derived from mutation batcher |
 
 ### Unchanged Files
 
 - `block.json`, `edit.tsx`, `attributes.tsx`, `constants.tsx` — editor side unchanged
 - Cart block parent (`block.js`, `frontend.js`) — no changes
-- Shared `woocommerce` cart store (`base/stores/woocommerce/cart.ts`) — already has needed state
+- `block.json` for proceed-to-checkout — no changes to block metadata
 
 ## Success Criteria
 
@@ -118,6 +119,6 @@ With `experimental-iapi-cart` enabled:
 Items explicitly deferred from this POC:
 
 - **`applyCheckoutFilter` support**: The React-side checkout filter registry (`proceedToCheckoutButtonLabel`, `proceedToCheckoutButtonLink`) is not available in IAPI. Needs either a PHP-side filter or new IAPI-compatible filter mechanism. Will address after POC validates.
-- **Approach B bridge layer**: Syncing `cartIsLoading`, `isCalculating` from React context into IAPI state. Needed when converting more inner blocks that depend on richer Cart context.
+- **Approach B bridge layer**: Syncing richer React Cart context (e.g., `isCalculating` from the checkout store) into IAPI state. Becomes relevant when converting inner blocks that depend on checkout-specific state beyond what the shared `woocommerce` store provides.
 - **Full Cart migration**: Converting all 17 remaining inner blocks and the parent Cart block to IAPI, eliminating React entirely (following the mini-cart precedent).
 - **Cart events emitter as canonical API**: After full migration, the React hook becomes a permanent thin wrapper over the emitter. Non-React extensions get first-class access.

--- a/docs/superpowers/specs/2026-04-05-cart-iapi-poc-design.md
+++ b/docs/superpowers/specs/2026-04-05-cart-iapi-poc-design.md
@@ -1,0 +1,123 @@
+# Cart Block Interactivity API POC: Proceed-to-Checkout
+
+## Goal
+
+Validate that a single Cart inner block can be converted from React to the Interactivity API while coexisting with the remaining React-based Cart block. The proceed-to-checkout block is the target because it exercises state reads, user interaction, async observer patterns, and mobile-specific UI (sticky positioning) — enough complexity to prove the pattern without being a full migration.
+
+## Context
+
+The Cart block currently renders entirely via React. Inner blocks are server-rendered as HTML with `data-block-name` attributes, then `renderInnerBlocks()` maps them to registered React components at hydration time. The mini-cart block has already migrated to IAPI behind the `experimental-iapi-mini-cart` feature flag using a dual-track approach (PHP conditionally renders either React or IAPI markup).
+
+Existing IAPI infrastructure in WooCommerce:
+- Shared `woocommerce` store (`base/stores/woocommerce/cart.ts`) with cart state, mutation batching, optimistic updates
+- `BlocksSharedState.php` hydrates cart data into `wp_interactivity_state('woocommerce', ...)`
+- `EventEmitter` (`assets/js/events/event-emitter.ts`) powers `window.wc.blocksCheckoutEvents` with priority-based listeners and abort-on-error semantics
+
+## Approach
+
+**Approach A (chosen):** Standalone IAPI block within the existing React Cart. A feature flag gates the rendering path. A thin React pass-through component preserves server-rendered IAPI HTML inside the React-owned DOM tree.
+
+**Approach B (noted for later):** Full bridge layer syncing React Cart context (`cartIsLoading`, `isCalculating`, event dispatch) into IAPI state. Becomes relevant when converting multiple inner blocks that need richer Cart context. Not needed for this single-block POC since the shared `woocommerce` store already exposes cart state.
+
+## Design
+
+### 1. Rendering Strategy
+
+When the `experimental-iapi-cart` feature flag is **enabled**:
+
+1. **PHP** (`ProceedToCheckoutBlock.php`): Renders the button as server-side HTML with `data-wp-interactive="woocommerce/proceed-to-checkout"` directives. Sets context via `wp_interactivity_data_wp_context()` with `checkoutUrl` and `buttonLabel`. Includes a sentinel `<div>` for the sticky intersection observer. Enqueues script module instead of traditional script.
+
+2. **React pass-through component**: Registered via `registerCheckoutBlock()` so `renderInnerBlocks()` finds the block. Renders a single `<div ref={...}>` that preserves the server-rendered IAPI HTML. React sees one opaque container and won't re-render into it. This component also bridges the `CartEventsProvider` context — it calls `useCartEventsContext()` and is available because the parent Cart block's React tree still wraps everything.
+
+3. **IAPI runtime**: Binds to the `data-wp-interactive` directives in the preserved HTML. The `woocommerce/proceed-to-checkout` store handles all interactivity.
+
+When the feature flag is **disabled**: Current React behavior, zero changes.
+
+### 2. Cart Event Emitter
+
+A new `window.wc.blocksCartEvents` emitter, built on the existing `EventEmitter` infrastructure:
+
+- **`onProceedToCheckout(callback, priority)`** — registers an observer. Returns unsubscribe function. Supports async callbacks. Abort-on-error semantics (stops processing if any observer returns error/fail response).
+- Same contract as the current React hook `useCartEventsContext().onProceedToCheckout`.
+
+**Backwards compatibility:** The existing React `CartEventsProvider` delegates to this shared emitter internally. `useCartEventsContext().onProceedToCheckout` registers on the shared emitter. `dispatchOnProceedToCheckout()` calls `emitWithAbort()` on the shared emitter. Extensions using the React hook see zero change.
+
+**IAPI access:** The IAPI store imports the cart event emitter directly (no React bridge needed for dispatching events). The pass-through React component is not involved in event dispatch.
+
+### 3. IAPI Store
+
+Store namespace: `woocommerce/proceed-to-checkout` (locked, private).
+
+**State (from PHP context):**
+- `checkoutUrl` — resolved checkout page permalink
+- `buttonLabel` — button text
+
+**State (local):**
+- `isLoading` — toggled on click, reset on pageshow
+
+**State (derived):**
+- `isDisabled` — reads from the shared `woocommerce` store's cart state
+
+**Actions:**
+- `*handleClick` — generator function. Calls `emitWithAbort()` on the cart event emitter. If any observer returns error/fail, aborts. Otherwise sets `isLoading = true` and navigates via `window.location.href`.
+
+**Callbacks:**
+- `onPageShow` — listens for browser `pageshow` event to reset `isLoading` (Safari back-button fix)
+- `initStickyObserver` — sets up `IntersectionObserver` on a sentinel element to toggle sticky class on mobile viewports
+
+### 4. Feature Flag
+
+Name: `experimental-iapi-cart`
+
+Registered in the same system as `experimental-iapi-mini-cart`. Controls:
+- PHP render path in `ProceedToCheckoutBlock.php`
+- Whether `interactivity` support is enabled on the block type
+- Which frontend script is loaded (script module vs traditional)
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `assets/js/events/cart-events.ts` | Cart event emitter instance (mirrors `checkout-events.ts`) |
+| `assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts` | IAPI store definition |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `assets/js/events/index.ts` | Export cart events |
+| `bin/webpack-helpers.js` | Add `@woocommerce/blocks-cart-events` external mapping |
+| `bin/webpack-entries.js` | Add `blocksCartEvents` entry point |
+| `assets/js/base/context/providers/cart-checkout/cart-events/index.tsx` | Delegate to shared cart event emitter |
+| `assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/frontend.tsx` | Swap to pass-through component when IAPI flag enabled |
+| `assets/js/blocks/cart/inner-blocks/register-components.ts` | Register pass-through variant |
+| `src/Blocks/BlockTypes/ProceedToCheckoutBlock.php` | Add IAPI render path behind feature flag |
+| Feature flag registration (location TBD — `Bootstrap.php` or similar) | Register `experimental-iapi-cart` flag |
+
+### Unchanged Files
+
+- `block.json`, `edit.tsx`, `attributes.tsx`, `constants.tsx` — editor side unchanged
+- Cart block parent (`block.js`, `frontend.js`) — no changes
+- Shared `woocommerce` cart store (`base/stores/woocommerce/cart.ts`) — already has needed state
+
+## Success Criteria
+
+With `experimental-iapi-cart` enabled:
+
+1. Proceed-to-checkout button renders server-side and is interactive via IAPI
+2. Sticky behavior works on mobile (< 782px viewport)
+3. Extensions registering `onProceedToCheckout` via the React hook still fire and can block navigation
+4. Loading spinner shows during navigation
+5. Button disables when cart is loading
+6. No visible difference to the shopper compared to flag-off behavior
+
+## Follow-Up Work
+
+Items explicitly deferred from this POC:
+
+- **`applyCheckoutFilter` support**: The React-side checkout filter registry (`proceedToCheckoutButtonLabel`, `proceedToCheckoutButtonLink`) is not available in IAPI. Needs either a PHP-side filter or new IAPI-compatible filter mechanism. Will address after POC validates.
+- **Approach B bridge layer**: Syncing `cartIsLoading`, `isCalculating` from React context into IAPI state. Needed when converting more inner blocks that depend on richer Cart context.
+- **Full Cart migration**: Converting all 17 remaining inner blocks and the parent Cart block to IAPI, eliminating React entirely (following the mini-cart precedent).
+- **Cart events emitter as canonical API**: After full migration, the React hook becomes a permanent thin wrapper over the emitter. Non-React extensions get first-class access.

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -7,6 +7,7 @@
 		"product-data-views": false,
 		"experimental-blocks": false,
 		"experimental-iapi-mini-cart": true,
+		"experimental-iapi-cart": false,
 		"experimental-iapi-runtime": false,
 		"coming-soon-newsletter-template": false,
 		"coupons": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -7,6 +7,7 @@
 		"product-data-views": false,
 		"experimental-blocks": true,
 		"experimental-iapi-mini-cart": true,
+		"experimental-iapi-cart": true,
 		"experimental-iapi-runtime": false,
 		"coming-soon-newsletter-template": false,
 		"coupons": true,

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
@@ -7,8 +7,8 @@ import type { ObserverResponse } from '@woocommerce/types';
 /**
  * Internal dependencies
  */
-import { cartEventsEmitter, CART_EVENTS } from '../../../../events/cart-events';
-import type { EventListener } from '../../../../events/event-emitter';
+import { cartEventsEmitter, CART_EVENTS } from '../../../../../events/cart-events';
+import type { EventListener } from '../../../../../events/event-emitter';
 
 type CartEventsContextType = {
 	onProceedToCheckout: (

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
@@ -1,36 +1,26 @@
 /**
  * External dependencies
  */
-
-import {
-	createContext,
-	useContext,
-	useReducer,
-	useRef,
-	useEffect,
-} from '@wordpress/element';
+import { createContext, useContext } from '@wordpress/element';
+import type { ObserverResponse } from '@woocommerce/types';
 
 /**
  * Internal dependencies
  */
-import {
-	useEventEmitters,
-	reducer as emitReducer,
-	emitEventWithAbort,
-	EVENTS,
-} from './event-emit';
-import type { emitterCallback } from '../../../event-emit';
+import { cartEventsEmitter, CART_EVENTS } from '../../../../events/cart-events';
+import type { EventListener } from '../../../../events/event-emitter';
 
 type CartEventsContextType = {
-	// Used to register a callback that will fire when the cart has been processed and has an error.
-	onProceedToCheckout: ReturnType< typeof emitterCallback >;
-	// Used to register a callback that will fire when the cart has been processed and has an error.
-	dispatchOnProceedToCheckout: () => Promise< unknown[] >;
+	onProceedToCheckout: (
+		callback: EventListener,
+		priority?: number
+	) => () => void;
+	dispatchOnProceedToCheckout: () => Promise< ObserverResponse[] >;
 };
 
 const CartEventsContext = createContext< CartEventsContextType >( {
 	onProceedToCheckout: () => () => void null,
-	dispatchOnProceedToCheckout: () => new Promise( () => void null ),
+	dispatchOnProceedToCheckout: () => Promise.resolve( [] ),
 } );
 
 export const useCartEventsContext = () => {
@@ -38,40 +28,31 @@ export const useCartEventsContext = () => {
 };
 
 /**
- * Checkout Events provider
- * Emit Checkout events and provide access to Checkout event handlers
- *
- * @param {Object} props          Incoming props for the provider.
- * @param {Object} props.children The children being wrapped.
+ * Cart Events provider
+ * Delegates to the shared cartEventsEmitter so that both React hooks
+ * and Interactivity API stores share the same observer registry.
  */
 export const CartEventsProvider = ( {
 	children,
 }: {
 	children: React.ReactNode;
 } ): JSX.Element => {
-	const [ observers, observerDispatch ] = useReducer( emitReducer, {} );
-	const currentObservers = useRef( observers );
-	const { onProceedToCheckout } = useEventEmitters( observerDispatch );
-
-	// set observers on ref so it's always current.
-	useEffect( () => {
-		currentObservers.current = observers;
-	}, [ observers ] );
-
-	const dispatchOnProceedToCheckout = async () => {
-		return await emitEventWithAbort(
-			currentObservers.current,
-			EVENTS.PROCEED_TO_CHECKOUT,
-			null
-		);
+	const cartEventsValue: CartEventsContextType = {
+		onProceedToCheckout: ( callback: EventListener, priority = 10 ) =>
+			cartEventsEmitter.subscribe(
+				callback,
+				priority,
+				CART_EVENTS.PROCEED_TO_CHECKOUT
+			),
+		dispatchOnProceedToCheckout: () =>
+			cartEventsEmitter.emitWithAbort(
+				CART_EVENTS.PROCEED_TO_CHECKOUT,
+				null
+			),
 	};
 
-	const cartEvents = {
-		onProceedToCheckout,
-		dispatchOnProceedToCheckout,
-	};
 	return (
-		<CartEventsContext.Provider value={ cartEvents }>
+		<CartEventsContext.Provider value={ cartEventsValue }>
 			{ children }
 		</CartEventsContext.Provider>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -102,6 +102,7 @@ export type Store = {
 		};
 		restUrl: string;
 		nonce: string;
+		isProcessing: boolean;
 		findItemInCart: ( args: {
 			id: ClientCartItem[ 'id' ];
 			key?: ClientCartItem[ 'key' ];
@@ -288,6 +289,9 @@ const { actions } = store< Store >(
 	'woocommerce',
 	{
 		state: {
+			get isProcessing(): boolean {
+				return cartQueue?.getStatus().isProcessing ?? false;
+			},
 			findItemInCart( {
 				id,
 				key,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import { store, getContext, getElement } from '@wordpress/interactivity';
+import { isErrorResponse } from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import { cartEventsEmitter, CART_EVENTS } from '../../../../events/cart-events';
+
+type WooCommerce = {
+	state: {
+		cart: {
+			items: unknown[];
+		};
+		isProcessing: boolean;
+	};
+};
+
+type ProceedToCheckoutContext = {
+	checkoutUrl: string;
+	buttonLabel: string;
+	isLoading: boolean;
+};
+
+type ProceedToCheckoutStore = {
+	state: {
+		readonly isDisabled: boolean;
+		isStickyVisible: boolean;
+		stickyBackgroundColor: string;
+	};
+	actions: {
+		handleClick: ( event: MouseEvent ) => void;
+	};
+	callbacks: {
+		onPageShow: () => () => void;
+		initStickyObserver: () => () => void;
+	};
+};
+
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+// Access shared woocommerce store for cart state.
+const { state: woocommerceState } = store< WooCommerce >(
+	'woocommerce',
+	{},
+	{ lock: universalLock }
+);
+
+// Store-level state for sticky behavior. These are in the store's state
+// object so the IAPI reactivity system tracks reads/writes and triggers
+// re-renders of directives that depend on them.
+const { state: ptcState } = store< ProceedToCheckoutStore >(
+	'woocommerce/proceed-to-checkout',
+	{
+		state: {
+			get isDisabled(): boolean {
+				return woocommerceState.isProcessing;
+			},
+			isStickyVisible: false,
+			stickyBackgroundColor: '',
+		},
+		actions: {
+			*handleClick( event: MouseEvent ) {
+				event.preventDefault();
+
+				const context = getContext< ProceedToCheckoutContext >();
+
+				if ( woocommerceState.isProcessing || context.isLoading ) {
+					return;
+				}
+
+				// Dispatch proceed-to-checkout event. Observers can abort.
+				const responses: Awaited<
+					ReturnType< typeof cartEventsEmitter.emitWithAbort >
+				> = yield cartEventsEmitter.emitWithAbort(
+					CART_EVENTS.PROCEED_TO_CHECKOUT,
+					null
+				);
+
+				if ( responses.some( isErrorResponse ) ) {
+					return;
+				}
+
+				context.isLoading = true;
+				window.location.href = context.checkoutUrl;
+			},
+		},
+		callbacks: {
+			onPageShow() {
+				// Capture context while in directive scope (getContext only
+				// works inside IAPI directive callbacks, not in event handlers).
+				const context = getContext< ProceedToCheckoutContext >();
+				const callback = () => {
+					context.isLoading = false;
+				};
+				window.addEventListener( 'pageshow', callback );
+				return () => {
+					window.removeEventListener( 'pageshow', callback );
+				};
+			},
+			initStickyObserver() {
+				const { ref } = getElement();
+				if ( ! ref ) {
+					return;
+				}
+
+				// Compute body background color once.
+				const computedColor =
+					getComputedStyle( document.body ).backgroundColor;
+				const bgColor =
+					! computedColor ||
+					computedColor === 'rgba(0, 0, 0, 0)' ||
+					computedColor === 'transparent'
+						? '#fff'
+						: computedColor;
+
+				const observer = new IntersectionObserver(
+					( entries ) => {
+						const entry = entries[ 0 ];
+						if ( entry.isIntersecting ) {
+							ptcState.isStickyVisible = false;
+							ptcState.stickyBackgroundColor = '';
+						} else {
+							const isBelow =
+								entry.boundingClientRect.top > 0;
+							ptcState.isStickyVisible = isBelow;
+							ptcState.stickyBackgroundColor = isBelow
+								? bgColor
+								: '';
+						}
+					},
+					{ threshold: [ 0, 0.5, 1 ] }
+				);
+
+				observer.observe( ref );
+
+				return () => {
+					observer.disconnect();
+				};
+			},
+		},
+	},
+	{ lock: true }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts
@@ -2,12 +2,42 @@
  * External dependencies
  */
 import { store, getContext, getElement } from '@wordpress/interactivity';
-import { isErrorResponse } from '@woocommerce/types';
+/**
+ * The cart events emitter is loaded as a traditional script and exposed
+ * on window.wc.blocksCartEvents. We access it at runtime rather than
+ * importing from source to avoid pulling @woocommerce/types into the
+ * script module build.
+ */
+type CartEventsEmitter = {
+	emitWithAbort: (
+		eventName: string,
+		data: unknown
+	) => Promise< Array< { type: string } > >;
+};
+
+const getCartEventsEmitter = (): CartEventsEmitter =>
+	( window as unknown as { wc: { blocksCartEvents: CartEventsEmitter } } ).wc
+		.blocksCartEvents;
+
+const CART_EVENTS = {
+	PROCEED_TO_CHECKOUT: 'cart_proceed_to_checkout',
+} as const;
 
 /**
- * Internal dependencies
+ * Check if an observer response is an error type.
+ * Inlined to avoid importing @woocommerce/types (not available in script modules).
  */
-import { cartEventsEmitter, CART_EVENTS } from '../../../../events/cart-events';
+const isErrorOrFailResponse = ( response: unknown ): boolean => {
+	if (
+		typeof response !== 'object' ||
+		response === null ||
+		! ( 'type' in response )
+	) {
+		return false;
+	}
+	const type = ( response as { type: string } ).type;
+	return type === 'error' || type === 'failure';
+};
 
 type WooCommerce = {
 	state: {
@@ -73,14 +103,14 @@ const { state: ptcState } = store< ProceedToCheckoutStore >(
 				}
 
 				// Dispatch proceed-to-checkout event. Observers can abort.
-				const responses: Awaited<
-					ReturnType< typeof cartEventsEmitter.emitWithAbort >
-				> = yield cartEventsEmitter.emitWithAbort(
+				const emitter = getCartEventsEmitter();
+				const responses: Array< { type: string } > =
+					yield emitter.emitWithAbort(
 					CART_EVENTS.PROCEED_TO_CHECKOUT,
 					null
 				);
 
-				if ( responses.some( isErrorResponse ) ) {
+				if ( responses.some( isErrorOrFailResponse ) ) {
 					return;
 				}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts
@@ -16,8 +16,11 @@ type CartEventsEmitter = {
 };
 
 const getCartEventsEmitter = (): CartEventsEmitter =>
-	( window as unknown as { wc: { blocksCartEvents: CartEventsEmitter } } ).wc
-		.blocksCartEvents;
+	(
+		window as unknown as {
+			wc: { blocksCartEvents: { cartEventsEmitter: CartEventsEmitter } };
+		}
+	).wc.blocksCartEvents.cartEventsEmitter;
 
 const CART_EVENTS = {
 	PROCEED_TO_CHECKOUT: 'cart_proceed_to_checkout',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/register-components.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/register-components.ts
@@ -72,10 +72,19 @@ registerCheckoutBlock( {
 	component: CartExpressPaymentFrontend,
 } );
 
-registerCheckoutBlock( {
-	metadata: metadata.PROCEED_TO_CHECKOUT,
-	component: ProceedToCheckoutFrontend,
-} );
+// When the IAPI flag is on, PHP renders data-wp-interactive markup.
+// Skip React registration so renderInnerBlocks preserves the server HTML
+// and the IAPI runtime can bind to it.
+if (
+	! document.querySelector(
+		'[data-wp-interactive="woocommerce/proceed-to-checkout"]'
+	)
+) {
+	registerCheckoutBlock( {
+		metadata: metadata.PROCEED_TO_CHECKOUT,
+		component: ProceedToCheckoutFrontend,
+	} );
+}
 
 registerCheckoutBlock( {
 	metadata: metadata.CART_ACCEPTED_PAYMENT_METHODS,

--- a/plugins/woocommerce/client/blocks/assets/js/events/cart-events.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/events/cart-events.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { createEmitter } from './event-emitter';
+
+export const CART_EVENTS = {
+	/**
+	 * Event emitted when the user clicks "Proceed to Checkout" in the cart.
+	 * Observers can return an error/fail response to prevent navigation.
+	 */
+	PROCEED_TO_CHECKOUT: 'cart_proceed_to_checkout',
+};
+
+export const cartEventsEmitter = createEmitter();
+
+export const cartEvents = {
+	onProceedToCheckout: cartEventsEmitter.createSubscribeFunction(
+		CART_EVENTS.PROCEED_TO_CHECKOUT
+	),
+};

--- a/plugins/woocommerce/client/blocks/assets/js/events/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/events/index.ts
@@ -1,1 +1,2 @@
 export * from './checkout-events';
+export * from './cart-events';

--- a/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
@@ -30,6 +30,10 @@ const entries = {
 	// Experimental mini cart frontend modules, only enqueued when experimental-iapi-mini-cart feature flag is enabled.
 	'woocommerce/mini-cart': './assets/js/blocks/mini-cart/iapi-frontend.ts',
 
+	// Experimental proceed-to-checkout IAPI frontend, only enqueued when experimental-iapi-cart feature flag is enabled.
+	'woocommerce/proceed-to-checkout':
+		'./assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/iapi-frontend.ts',
+
 	// Product elements frontend module. Share by several blocks.
 	'woocommerce/product-elements':
 		'./assets/js/atomic/blocks/product-elements/frontend.ts',

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -339,6 +339,7 @@ const entries = {
 	core: {
 		wcBlocksRegistry: './assets/js/blocks-registry/index.js',
 		blocksCheckoutEvents: './assets/js/events/index.ts',
+		blocksCartEvents: './assets/js/events/cart-events.ts',
 		wcSettings: './assets/js/settings/shared/index.ts',
 		wcBlocksData: './assets/js/data/index.ts',
 		wcBlocksMiddleware: './assets/js/middleware/index.js',

--- a/plugins/woocommerce/client/blocks/bin/webpack-helpers.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-helpers.js
@@ -11,6 +11,7 @@ const ASSET_CHECK = process.env.ASSET_CHECK === 'true';
 const wcDepMap = {
 	'@woocommerce/blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
 	'@woocommerce/blocks-checkout-events': [ 'wc', 'blocksCheckoutEvents' ],
+	'@woocommerce/blocks-cart-events': [ 'wc', 'blocksCartEvents' ],
 	'@woocommerce/settings': [ 'wc', 'wcSettings' ],
 	'@woocommerce/block-data': [ 'wc', 'wcBlocksData' ],
 	'@woocommerce/data': [ 'wc', 'data' ],
@@ -34,6 +35,7 @@ const wcHandleMap = {
 	'@woocommerce/price-format': 'wc-price-format',
 	'@woocommerce/blocks-checkout': 'wc-blocks-checkout',
 	'@woocommerce/blocks-checkout-events': 'wc-blocks-checkout-events',
+	'@woocommerce/blocks-cart-events': 'wc-blocks-cart-events',
 	'@woocommerce/blocks-components': 'wc-blocks-components',
 	'@woocommerce/types': 'wc-types',
 	'@woocommerce/customer-effort-score': 'wc-customer-effort-score',

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -118,6 +118,7 @@ final class AssetsController {
 		$this->api->register_script( 'wc-cart-checkout-base', $this->api->get_block_asset_build_path( 'wc-cart-checkout-base-frontend' ), array(), true );
 		$this->api->register_script( 'wc-blocks-checkout', 'assets/client/blocks/blocks-checkout.js' );
 		$this->api->register_script( 'wc-blocks-checkout-events', 'assets/client/blocks/blocks-checkout-events.js' );
+		$this->api->register_script( 'wc-blocks-cart-events', 'assets/client/blocks/blocks-cart-events.js' );
 		$this->api->register_script( 'wc-blocks-components', 'assets/client/blocks/blocks-components.js' );
 		$this->api->register_script( 'wc-schema-parser', 'assets/client/blocks/wc-schema-parser.js', array(), false );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
@@ -117,6 +117,7 @@ class ProceedToCheckoutBlock extends AbstractInnerBlock {
 						data-wp-on--click="actions.handleClick"
 						href="%2$s"
 					>
+						<span class="wc-block-components-spinner" aria-hidden="true" data-wp-bind--hidden="!context.isLoading"></span>
 						<span class="wc-block-components-button__text" data-wp-text="context.buttonLabel">%3$s</span>
 					</a>
 				</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
@@ -1,6 +1,9 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Admin\Features\Features;
+
 /**
  * ProceedToCheckoutBlock class.
  */
@@ -15,11 +18,110 @@ class ProceedToCheckoutBlock extends AbstractInnerBlock {
 	/**
 	 * Extra data passed through from server to client for block.
 	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 *                           Note, this will be empty in the editor context when the block is
-	 *                           not in the post content on editor load.
+	 * @param array $attributes Any attributes that currently are available from the block.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
 		$this->asset_data_registry->register_page_id( isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0 );
+	}
+
+	/**
+	 * Enable interactivity support when the feature flag is on.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		if ( Features::is_enabled( 'experimental-iapi-cart' ) ) {
+			add_action( 'init', array( $this, 'enable_interactivity_support' ), 20 );
+		}
+	}
+
+	/**
+	 * Dynamically enable interactivity support on the block type.
+	 */
+	public function enable_interactivity_support() {
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'woocommerce/' . $this->block_name );
+		if ( $block_type ) {
+			$block_type->supports['interactivity'] = true;
+		}
+	}
+
+	/**
+	 * Render the block. When the IAPI flag is enabled, render interactive markup.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param \WP_Block $block     Block instance.
+	 * @return string Rendered block output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( ! Features::is_enabled( 'experimental-iapi-cart' ) ) {
+			return $content;
+		}
+
+		return $this->render_iapi( $attributes, $content, $block );
+	}
+
+	/**
+	 * Render the IAPI version of the proceed-to-checkout block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param \WP_Block $block     Block instance.
+	 * @return string Rendered block output.
+	 */
+	private function render_iapi( $attributes, $content, $block ) {
+		wp_enqueue_script_module( 'woocommerce/proceed-to-checkout' );
+
+		$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
+		BlocksSharedState::load_cart_state( $consent );
+
+		// Resolve checkout URL.
+		$checkout_page_id = isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0;
+		$checkout_url     = $checkout_page_id ? get_permalink( $checkout_page_id ) : wc_get_checkout_url();
+		if ( ! $checkout_url ) {
+			$checkout_url = wc_get_checkout_url();
+		}
+
+		// Resolve button label.
+		$button_label = isset( $attributes['buttonLabel'] ) && ! empty( $attributes['buttonLabel'] )
+			? $attributes['buttonLabel']
+			: __( 'Proceed to Checkout', 'woocommerce' );
+
+		$context = array(
+			'checkoutUrl' => $checkout_url,
+			'buttonLabel' => $button_label,
+			'isLoading'   => false,
+		);
+
+		$context_attr = wp_interactivity_data_wp_context( $context );
+
+		return sprintf(
+			'<div
+				class="wc-block-cart__submit"
+				data-wp-interactive="woocommerce/proceed-to-checkout"
+				%1$s
+			>
+				<div aria-hidden="true" style="height:0;overflow:hidden;position:relative" data-wp-init="callbacks.initStickyObserver"></div>
+				<div
+					class="wc-block-cart__submit-container"
+					data-wp-class--wc-block-cart__submit-container--sticky="state.isStickyVisible"
+					data-wp-style--background-color="state.stickyBackgroundColor"
+				>
+					<a
+						class="wc-block-cart__submit-button wc-block-components-button wp-element-button"
+						data-wp-bind--href="context.checkoutUrl"
+						data-wp-bind--aria-disabled="state.isDisabled"
+						data-wp-class--wc-block-cart__submit-button--loading="context.isLoading"
+						data-wp-on--click="actions.handleClick"
+						href="%2$s"
+					>
+						<span class="wc-block-components-button__text" data-wp-text="context.buttonLabel">%3$s</span>
+					</a>
+				</div>
+			</div>',
+			$context_attr,
+			esc_url( $checkout_url ),
+			esc_html( $button_label )
+		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
@@ -99,6 +99,7 @@ class ProceedToCheckoutBlock extends AbstractInnerBlock {
 			'<div
 				class="wc-block-cart__submit"
 				data-wp-interactive="woocommerce/proceed-to-checkout"
+				data-wp-init="callbacks.onPageShow"
 				%1$s
 			>
 				<div aria-hidden="true" style="height:0;overflow:hidden;position:relative" data-wp-init="callbacks.initStickyObserver"></div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProceedToCheckoutBlock.php
@@ -71,6 +71,7 @@ class ProceedToCheckoutBlock extends AbstractInnerBlock {
 	 */
 	private function render_iapi( $attributes, $content, $block ) {
 		wp_enqueue_script_module( 'woocommerce/proceed-to-checkout' );
+		wp_enqueue_script( 'wc-blocks-cart-events' );
 
 		$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
 		BlocksSharedState::load_cart_state( $consent );

--- a/plugins/woocommerce/src/Blocks/DependencyDetection.php
+++ b/plugins/woocommerce/src/Blocks/DependencyDetection.php
@@ -49,6 +49,7 @@ final class DependencyDetection {
 		'priceFormat'           => 'wc-price-format',
 		'blocksCheckout'        => 'wc-blocks-checkout',
 		'blocksCheckoutEvents'  => 'wc-blocks-checkout-events',
+		'blocksCartEvents'      => 'wc-blocks-cart-events',
 		'blocksComponents'      => 'wc-blocks-components',
 		'wcTypes'               => 'wc-types',
 		'sanitize'              => 'wc-sanitize',


### PR DESCRIPTION
## Summary

Proof of concept converting the Cart proceed-to-checkout inner block from React to the WordPress Interactivity API, behind the `experimental-iapi-cart` feature flag.

- Adds a new `window.wc.blocksCartEvents` emitter (mirrors checkout events pattern) with `onProceedToCheckout` observer support
- Bridges `CartEventsProvider` to the shared emitter for full backwards compatibility with React hook consumers
- PHP renders IAPI HTML with `data-wp-interactive` directives when flag is on, falls back to existing React behavior when off
- IAPI store handles click → observer dispatch → navigation, button disabled state, sticky positioning, and loading spinner
- Skips React component registration when IAPI markup detected, letting `renderInnerBlocks` preserve server HTML

**Flag:** `experimental-iapi-cart` (off in production, on in development)

**Spec:** `docs/superpowers/specs/2026-04-05-cart-iapi-poc-design.md`

## Test plan

- [ ] Enable `experimental-iapi-cart` feature flag
- [ ] Visit cart page with items — "Proceed to Checkout" button renders and navigates to checkout
- [ ] Update item quantity — button disables during network request, re-enables after
- [ ] Click button — spinner shows, navigates to checkout
- [ ] On mobile viewport (< 782px), button sticks to bottom when scrolled below
- [ ] Disable feature flag — existing React behavior unchanged
- [ ] E2E: `cart-block.shopper.block_theme.spec.ts` passes (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>