### PR TITLE
ProductFilters: normalise query vars before hashing cache keys

### DIFF
--- a/plugins/woocommerce/changelog/fix-filter-cache-key-normalisation
+++ b/plugins/woocommerce/changelog/fix-filter-cache-key-normalisation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Normalise filter query vars before hashing cache keys so equivalent filter combinations (e.g. filter_color=red,blue vs blue,red) share the same cache entry.

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -521,6 +521,7 @@ class FilterData {
 			if ( str_starts_with( $key, 'filter_' ) || 'rating_filter' === $key || in_array( $key, $taxonomy_set_params, true ) ) {
 				$pieces = array_map( 'trim', explode( ',', $value ) );
 				$pieces = array_map( 'strtolower', $pieces );
+				$pieces = array_values( array_unique( array_filter( $pieces, static fn( string $p ): bool => '' !== $p ) ) );
 				sort( $pieces );
 				$query_vars[ $key ] = implode( ',', $pieces );
 			} elseif ( str_starts_with( $key, 'query_type_' ) ) {

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -495,7 +495,8 @@ class FilterData {
 	 *
 	 * Rules applied (cache key only – the original $query_vars are never modified):
 	 * - All keys are sorted alphabetically (ksort).
-	 * - Values for keys that start with "filter_" or equal "rating_filter":
+	 * - Values for keys that start with "filter_", equal "rating_filter", or are
+	 *   built-in taxonomy short-names ("categories", "tags", "brands"):
 	 *   comma-separated items are trimmed, lower-cased, sorted, then re-joined.
 	 * - Values for keys that start with "query_type_": trimmed and lower-cased.
 	 * - Values for "min_price" / "max_price": trimmed.
@@ -506,6 +507,10 @@ class FilterData {
 	 * @return array Normalised copy of $query_vars.
 	 */
 	private function normalize_query_vars( array $query_vars ): array {
+		// Built-in taxonomy filter params that are treated as unordered sets.
+		// See Params::get_taxonomy_params() for the source of these short names.
+		$taxonomy_set_params = array( 'categories', 'tags', 'brands' );
+
 		ksort( $query_vars );
 
 		foreach ( $query_vars as $key => $value ) {
@@ -513,7 +518,7 @@ class FilterData {
 				continue;
 			}
 
-			if ( str_starts_with( $key, 'filter_' ) || 'rating_filter' === $key ) {
+			if ( str_starts_with( $key, 'filter_' ) || 'rating_filter' === $key || in_array( $key, $taxonomy_set_params, true ) ) {
 				$pieces = array_map( 'trim', explode( ',', $value ) );
 				$pieces = array_map( 'strtolower', $pieces );
 				sort( $pieces );

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -480,13 +480,52 @@ class FilterData {
 			md5(
 				wp_json_encode(
 					array(
-						'query_vars'  => $query_vars,
+						'query_vars'  => $this->normalize_query_vars( $query_vars ),
 						'extra'       => $extra,
 						'filter_type' => $filter_type,
 					)
 				)
 			)
 		);
+	}
+
+	/**
+	 * Normalise query vars for cache key generation so that logically equivalent
+	 * filter combinations produce the same hash.
+	 *
+	 * Rules applied (cache key only – the original $query_vars are never modified):
+	 * - All keys are sorted alphabetically (ksort).
+	 * - Values for keys that start with "filter_" or equal "rating_filter":
+	 *   comma-separated items are trimmed, lower-cased, sorted, then re-joined.
+	 * - Values for keys that start with "query_type_": trimmed and lower-cased.
+	 * - Values for "min_price" / "max_price": trimmed.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param array $query_vars Raw query vars.
+	 * @return array Normalised copy of $query_vars.
+	 */
+	private function normalize_query_vars( array $query_vars ): array {
+		ksort( $query_vars );
+
+		foreach ( $query_vars as $key => $value ) {
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+
+			if ( str_starts_with( $key, 'filter_' ) || 'rating_filter' === $key ) {
+				$pieces = array_map( 'trim', explode( ',', $value ) );
+				$pieces = array_map( 'strtolower', $pieces );
+				sort( $pieces );
+				$query_vars[ $key ] = implode( ',', $pieces );
+			} elseif ( str_starts_with( $key, 'query_type_' ) ) {
+				$query_vars[ $key ] = strtolower( trim( $value ) );
+			} elseif ( 'min_price' === $key || 'max_price' === $key ) {
+				$query_vars[ $key ] = trim( $value );
+			}
+		}
+
+		return $query_vars;
 	}
 
 	/**
@@ -547,7 +586,7 @@ class FilterData {
 	 * @return string Comma-separated list of product IDs.
 	 */
 	private function get_cached_product_ids( array $query_vars ) {
-		$cache_key = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . md5( wp_json_encode( $query_vars ) );
+		$cache_key = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . md5( wp_json_encode( $this->normalize_query_vars( $query_vars ) ) );
 		$cache     = wp_cache_get( $cache_key );
 
 		if ( $cache ) {

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -514,7 +514,7 @@ class FilterData {
 		ksort( $query_vars );
 
 		foreach ( $query_vars as $key => $value ) {
-			if ( ! is_string( $value ) ) {
+			if ( ! is_string( $key ) || ! is_string( $value ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataNormalisationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataNormalisationTest.php
@@ -95,6 +95,25 @@ class FilterDataNormalisationTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Built-in taxonomy short-name params (categories, tags, brands) are normalised as sets.
+	 */
+	public function test_taxonomy_set_params_are_normalised(): void {
+		$a = $this->normalize( array( 'categories' => 'shirts,hats' ) );
+		$b = $this->normalize( array( 'categories' => 'hats,shirts' ) );
+
+		$this->assertSame( $a['categories'], $b['categories'] );
+		$this->assertSame( 'hats,shirts', $a['categories'] );
+
+		$a = $this->normalize( array( 'tags' => 'sale,new' ) );
+		$b = $this->normalize( array( 'tags' => 'new,sale' ) );
+		$this->assertSame( $a['tags'], $b['tags'] );
+
+		$a = $this->normalize( array( 'brands' => 'nike,adidas' ) );
+		$b = $this->normalize( array( 'brands' => 'adidas,nike' ) );
+		$this->assertSame( $a['brands'], $b['brands'] );
+	}
+
+	/**
 	 * @testdox rating_filter is treated the same as filter_ keys.
 	 */
 	public function test_rating_filter_is_normalised(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataNormalisationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataNormalisationTest.php
@@ -199,4 +199,23 @@ class FilterDataNormalisationTest extends \WC_Unit_Test_Case {
 
 		$this->assertSame( array( 'red', 'blue' ), $result['filter_color'] );
 	}
+
+	/**
+	 * @testdox Empty tokens from malformed comma lists are removed.
+	 */
+	public function test_empty_tokens_are_removed(): void {
+		$result = $this->normalize( array( 'filter_color' => 'red,,blue,' ) );
+
+		$this->assertSame( 'blue,red', $result['filter_color'] );
+	}
+
+	/**
+	 * @testdox Duplicate tokens are deduplicated.
+	 */
+	public function test_duplicate_tokens_are_deduplicated(): void {
+		$a = $this->normalize( array( 'filter_color' => 'red,blue,red' ) );
+		$b = $this->normalize( array( 'filter_color' => 'blue,red' ) );
+
+		$this->assertSame( $a['filter_color'], $b['filter_color'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataNormalisationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataNormalisationTest.php
@@ -1,0 +1,183 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Internal\ProductFilters;
+
+use Automattic\WooCommerce\Internal\ProductFilters\FilterData;
+use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
+use Automattic\WooCommerce\Internal\ProductFilters\TaxonomyHierarchyData;
+
+/**
+ * Unit tests for FilterData::normalize_query_vars().
+ *
+ * @covers \Automattic\WooCommerce\Internal\ProductFilters\FilterData
+ */
+class FilterDataNormalisationTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * The private method under test, exposed via reflection.
+	 *
+	 * @var \ReflectionMethod
+	 */
+	private $normalize;
+
+	/**
+	 * A FilterData instance to invoke the method on.
+	 *
+	 * @var FilterData
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$query_clauses           = $this->createMock( QueryClausesGenerator::class );
+		$taxonomy_hierarchy_data = $this->createMock( TaxonomyHierarchyData::class );
+
+		$this->sut = new FilterData( $query_clauses, $taxonomy_hierarchy_data );
+
+		$reflection      = new \ReflectionClass( FilterData::class );
+		$this->normalize = $reflection->getMethod( 'normalize_query_vars' );
+		$this->normalize->setAccessible( true );
+	}
+
+	/**
+	 * Invoke normalize_query_vars() with the given array.
+	 *
+	 * @param array $query_vars Input query vars.
+	 * @return array Normalised copy.
+	 */
+	private function normalize( array $query_vars ): array {
+		return $this->normalize->invoke( $this->sut, $query_vars );
+	}
+
+	/**
+	 * @testdox Keys are sorted alphabetically regardless of insertion order.
+	 */
+	public function test_ksort_normalises_key_order(): void {
+		$a = $this->normalize(
+			array(
+				'z_key' => 'val',
+				'a_key' => 'val',
+			)
+		);
+		$b = $this->normalize(
+			array(
+				'a_key' => 'val',
+				'z_key' => 'val',
+			)
+		);
+
+		$this->assertSame( $a, $b );
+		$this->assertSame( array_keys( $a ), array( 'a_key', 'z_key' ) );
+	}
+
+	/**
+	 * @testdox filter_ values: comma items are sorted, trimmed and lowercased.
+	 */
+	public function test_filter_values_are_normalised(): void {
+		$result = $this->normalize( array( 'filter_color' => ' Blue , Red , green ' ) );
+
+		$this->assertSame( 'blue,green,red', $result['filter_color'] );
+	}
+
+	/**
+	 * @testdox Equivalent filter_ values in different orders produce the same output.
+	 */
+	public function test_filter_values_different_order_produces_same_result(): void {
+		$a = $this->normalize( array( 'filter_color' => 'red,blue' ) );
+		$b = $this->normalize( array( 'filter_color' => 'blue,red' ) );
+
+		$this->assertSame( $a['filter_color'], $b['filter_color'] );
+	}
+
+	/**
+	 * @testdox rating_filter is treated the same as filter_ keys.
+	 */
+	public function test_rating_filter_is_normalised(): void {
+		$a = $this->normalize( array( 'rating_filter' => '5,3' ) );
+		$b = $this->normalize( array( 'rating_filter' => '3,5' ) );
+
+		$this->assertSame( $a['rating_filter'], $b['rating_filter'] );
+		$this->assertSame( '3,5', $a['rating_filter'] );
+	}
+
+	/**
+	 * @testdox query_type_ values are trimmed and lowercased.
+	 */
+	public function test_query_type_values_are_normalised(): void {
+		$result = $this->normalize( array( 'query_type_color' => '  OR  ' ) );
+
+		$this->assertSame( 'or', $result['query_type_color'] );
+	}
+
+	/**
+	 * @testdox min_price is trimmed.
+	 */
+	public function test_min_price_is_trimmed(): void {
+		$result = $this->normalize( array( 'min_price' => ' 10 ' ) );
+
+		$this->assertSame( '10', $result['min_price'] );
+	}
+
+	/**
+	 * @testdox max_price is trimmed.
+	 */
+	public function test_max_price_is_trimmed(): void {
+		$result = $this->normalize( array( 'max_price' => ' 99 ' ) );
+
+		$this->assertSame( '99', $result['max_price'] );
+	}
+
+	/**
+	 * @testdox Non-filter keys are left unchanged.
+	 */
+	public function test_unrelated_keys_are_unchanged(): void {
+		$result = $this->normalize(
+			array(
+				'post_type'      => 'product',
+				'posts_per_page' => -1,
+			)
+		);
+
+		$this->assertSame( 'product', $result['post_type'] );
+		$this->assertSame( -1, $result['posts_per_page'] );
+	}
+
+	/**
+	 * @testdox Combined normalisation: key order + filter value order produce the same hash.
+	 */
+	public function test_combined_normalisation_produces_same_hash(): void {
+		$a = $this->normalize(
+			array(
+				'filter_color'     => 'red,blue',
+				'min_price'        => ' 10 ',
+				'query_type_color' => ' OR ',
+				'post_type'        => 'product',
+			)
+		);
+
+		$b = $this->normalize(
+			array(
+				'post_type'        => 'product',
+				'query_type_color' => 'or',
+				'min_price'        => '10',
+				'filter_color'     => 'blue,red',
+			)
+		);
+
+		$this->assertSame( $a, $b );
+	}
+
+	/**
+	 * @testdox Non-string values are not modified.
+	 */
+	public function test_non_string_values_are_not_modified(): void {
+		$result = $this->normalize( array( 'filter_color' => array( 'red', 'blue' ) ) );
+
+		$this->assertSame( array( 'red', 'blue' ), $result['filter_color'] );
+	}
+}


### PR DESCRIPTION
### Submission review guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Bots enumerating filter combos (e.g. `filter_color=red,blue` vs `blue,red`) generate separate cache entries for logically identical queries.

Adds `FilterData::normalize_query_vars()` called before hashing in both `get_transient_key()` and `get_cached_product_ids()`. Original `$query_vars` are never mutated — normalisation is on a copy used only for the key.

Rules: `ksort` all keys; sort/trim/lowercase comma values for `filter_*`, `rating_filter`, `categories`, `tags`, `brands`; lowercase `query_type_*`; trim `min_price`/`max_price`.

Related cap task: #64039.

### Screenshots or screen recordings:

N/A.

### How to test the changes in this Pull Request:

1. On a product archive, apply a colour filter (e.g. Red + Blue). Note the transient key via Query Monitor.
2. Reload with filters reversed (Blue + Red).
3. Both requests should hit the same transient key.
4. Repeat with category/tag filters to verify taxonomy params are also normalised.

### Testing that has already taken place:

PHPStan level 8 + PHPCS clean. Unit tests in `FilterDataNormalisationTest.php` cover all normalisation rules.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
