### PR TITLE
SEO: add noindex for filtered archive pages and update robots.txt

### DIFF
--- a/plugins/woocommerce/changelog/tangerine-a4456b63
+++ b/plugins/woocommerce/changelog/tangerine-a4456b63
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-SEO: Add noindex to filtered archive pages and disallow filter params in robots.txt to prevent bot exploitation of filter URLs.
+SEO: Add opt-in noindex support for filtered archive pages via the woocommerce_noindex_filtered_pages filter, and disallow filter params in robots.txt defaults.

--- a/plugins/woocommerce/changelog/tangerine-a4456b63
+++ b/plugins/woocommerce/changelog/tangerine-a4456b63
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-SEO: Add opt-in noindex support for filtered archive pages via the woocommerce_noindex_filtered_pages filter, and disallow filter params in robots.txt defaults.
+SEO: Add opt-in noindex and robots.txt disallow support for filtered archive pages via woocommerce_noindex_filtered_pages and woocommerce_disallow_filter_params_in_robots_txt filters.

--- a/plugins/woocommerce/changelog/tangerine-a4456b63
+++ b/plugins/woocommerce/changelog/tangerine-a4456b63
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+SEO: Add noindex to filtered archive pages and disallow filter params in robots.txt to prevent bot exploitation of filter URLs.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1207,8 +1207,11 @@ final class WooCommerce {
 		$above[] = 'Disallow: /*?filter_*';
 		$above[] = 'Disallow: /*?*filter_*';
 		$above[] = 'Disallow: /*?rating_filter=*';
+		$above[] = 'Disallow: /*?*rating_filter=*';
 		$above[] = 'Disallow: /*?min_price=*';
+		$above[] = 'Disallow: /*?*min_price=*';
 		$above[] = 'Disallow: /*?max_price=*';
+		$above[] = 'Disallow: /*?*max_price=*';
 
 		$lines = array_merge( $above, $below );
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1204,14 +1204,27 @@ final class WooCommerce {
 		$above[] = "Disallow: $path/wp-content/uploads/woocommerce_uploads/";
 		$above[] = 'Disallow: /*?add-to-cart=';
 		$above[] = 'Disallow: /*?*add-to-cart=';
-		$above[] = 'Disallow: /*?filter_*';
-		$above[] = 'Disallow: /*?*filter_*';
-		$above[] = 'Disallow: /*?rating_filter=*';
-		$above[] = 'Disallow: /*?*rating_filter=*';
-		$above[] = 'Disallow: /*?min_price=*';
-		$above[] = 'Disallow: /*?*min_price=*';
-		$above[] = 'Disallow: /*?max_price=*';
-		$above[] = 'Disallow: /*?*max_price=*';
+
+		/**
+		 * Filters whether filter query parameter URLs should be disallowed in robots.txt.
+		 *
+		 * Defaults to false to preserve existing behavior. Set to true to prevent crawlers
+		 * from following filtered archive URLs, reducing SEO bloat and limiting filter URL
+		 * enumeration by bots.
+		 *
+		 * @since 10.8.0
+		 * @param bool $disallow True to add Disallow rules for filter params, false to omit them.
+		 */
+		if ( apply_filters( 'woocommerce_disallow_filter_params_in_robots_txt', false ) ) {
+			$above[] = 'Disallow: /*?filter_*';
+			$above[] = 'Disallow: /*?*filter_*';
+			$above[] = 'Disallow: /*?rating_filter=*';
+			$above[] = 'Disallow: /*?*rating_filter=*';
+			$above[] = 'Disallow: /*?min_price=*';
+			$above[] = 'Disallow: /*?*min_price=*';
+			$above[] = 'Disallow: /*?max_price=*';
+			$above[] = 'Disallow: /*?*max_price=*';
+		}
 
 		$lines = array_merge( $above, $below );
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1169,7 +1169,7 @@ final class WooCommerce {
 	}
 
 	/**
-	 * Tell bots not to index some WooCommerce-created directories.
+	 * Tell bots not to index some WooCommerce-created directories and filter URLs.
 	 *
 	 * We try to detect the default "User-agent: *" added by WordPress and add our rules to that group, because
 	 * it's possible that some bots will only interpret the first group of rules if there are multiple groups with
@@ -1204,6 +1204,11 @@ final class WooCommerce {
 		$above[] = "Disallow: $path/wp-content/uploads/woocommerce_uploads/";
 		$above[] = 'Disallow: /*?add-to-cart=';
 		$above[] = 'Disallow: /*?*add-to-cart=';
+		$above[] = 'Disallow: /*?filter_*';
+		$above[] = 'Disallow: /*?*filter_*';
+		$above[] = 'Disallow: /*?rating_filter=*';
+		$above[] = 'Disallow: /*?min_price=*';
+		$above[] = 'Disallow: /*?max_price=*';
 
 		$lines = array_merge( $above, $below );
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4304,10 +4304,14 @@ function wc_page_no_robots( $robots ) {
 	/**
 	 * Filters whether filtered archive pages (e.g. ?filter_color=blue) should be marked noindex.
 	 *
+	 * Defaults to false to preserve existing behavior. Set to true to prevent search engines
+	 * from indexing filtered archive pages, which reduces SEO bloat and limits filter URL
+	 * enumeration by bots.
+	 *
 	 * @since 10.8.0
 	 * @param bool $noindex True to add noindex to filtered archive pages, false to allow indexing.
 	 */
-	if ( apply_filters( 'woocommerce_noindex_filtered_pages', true ) && ( is_shop() || is_product_taxonomy() ) && wc_has_product_filter_params() ) {
+	if ( apply_filters( 'woocommerce_noindex_filtered_pages', false ) && ( is_shop() || is_product_taxonomy() ) && wc_has_product_filter_params() ) {
 		return wp_robots_no_robots( $robots );
 	}
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4301,9 +4301,47 @@ function wc_page_no_robots( $robots ) {
 		return wp_robots_no_robots( $robots );
 	}
 
+	/**
+	 * Filters whether filtered archive pages (e.g. ?filter_color=blue) should be marked noindex.
+	 *
+	 * @since 10.8.0
+	 * @param bool $noindex True to add noindex to filtered archive pages, false to allow indexing.
+	 */
+	if ( apply_filters( 'woocommerce_noindex_filtered_pages', true ) && wc_has_product_filter_params() ) {
+		return wp_robots_no_robots( $robots );
+	}
+
 	return $robots;
 }
 add_filter( 'wp_robots', 'wc_page_no_robots' );
+
+/**
+ * Check if the current request contains product filter query parameters.
+ *
+ * Returns true when any of the standard WooCommerce filter params are present:
+ * filter_*, rating_filter, min_price, max_price.
+ *
+ * @since 10.8.0
+ * @return bool
+ */
+function wc_has_product_filter_params() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
+	foreach ( array_keys( $_GET ) as $key ) {
+		if ( 0 === strpos( $key, 'filter_' ) ) {
+			return true;
+		}
+	}
+
+	$filter_params = array( 'rating_filter', 'min_price', 'max_price' );
+	foreach ( $filter_params as $param ) {
+		if ( isset( $_GET[ $param ] ) ) {
+			return true;
+		}
+	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	return false;
+}
 
 /**
  * Get a slug identifying the current theme.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4307,7 +4307,7 @@ function wc_page_no_robots( $robots ) {
 	 * @since 10.8.0
 	 * @param bool $noindex True to add noindex to filtered archive pages, false to allow indexing.
 	 */
-	if ( apply_filters( 'woocommerce_noindex_filtered_pages', true ) && wc_has_product_filter_params() ) {
+	if ( apply_filters( 'woocommerce_noindex_filtered_pages', true ) && ( is_shop() || is_product_taxonomy() ) && wc_has_product_filter_params() ) {
 		return wp_robots_no_robots( $robots );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -82,8 +82,11 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'Disallow: /*?filter_*', $output, 'robots.txt should disallow filter_ params' );
 		$this->assertStringContainsString( 'Disallow: /*?*filter_*', $output, 'robots.txt should disallow filter_ params with prefix' );
 		$this->assertStringContainsString( 'Disallow: /*?rating_filter=*', $output, 'robots.txt should disallow rating_filter param' );
+		$this->assertStringContainsString( 'Disallow: /*?*rating_filter=*', $output, 'robots.txt should disallow rating_filter when not first param' );
 		$this->assertStringContainsString( 'Disallow: /*?min_price=*', $output, 'robots.txt should disallow min_price param' );
+		$this->assertStringContainsString( 'Disallow: /*?*min_price=*', $output, 'robots.txt should disallow min_price when not first param' );
 		$this->assertStringContainsString( 'Disallow: /*?max_price=*', $output, 'robots.txt should disallow max_price param' );
+		$this->assertStringContainsString( 'Disallow: /*?*max_price=*', $output, 'robots.txt should disallow max_price when not first param' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -70,4 +70,36 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
 		$this->assertEquals( WC()->is_rest_api_request(), true );
 	}
+
+	/**
+	 * @testdox Should include filter param disallow rules in robots.txt output.
+	 */
+	public function test_robots_txt_includes_filter_disallow_rules(): void {
+		$base = "User-agent: *\nDisallow: /wp-admin/\n";
+
+		$output = WC()->robots_txt( $base );
+
+		$this->assertStringContainsString( 'Disallow: /*?filter_*', $output, 'robots.txt should disallow filter_ params' );
+		$this->assertStringContainsString( 'Disallow: /*?*filter_*', $output, 'robots.txt should disallow filter_ params with prefix' );
+		$this->assertStringContainsString( 'Disallow: /*?rating_filter=*', $output, 'robots.txt should disallow rating_filter param' );
+		$this->assertStringContainsString( 'Disallow: /*?min_price=*', $output, 'robots.txt should disallow min_price param' );
+		$this->assertStringContainsString( 'Disallow: /*?max_price=*', $output, 'robots.txt should disallow max_price param' );
+	}
+
+	/**
+	 * @testdox Should include filter disallow rules inside the User-agent wildcard group.
+	 */
+	public function test_robots_txt_filter_rules_inside_wildcard_group(): void {
+		$base = "User-agent: *\nDisallow: /wp-admin/\n";
+
+		$output = WC()->robots_txt( $base );
+		$lines  = explode( PHP_EOL, $output );
+
+		$agent_index  = array_search( 'User-agent: *', $lines, true );
+		$filter_index = array_search( 'Disallow: /*?filter_*', $lines, true );
+
+		$this->assertNotFalse( $agent_index, 'User-agent: * line should exist' );
+		$this->assertNotFalse( $filter_index, 'Disallow: /*?filter_* line should exist' );
+		$this->assertGreaterThan( $agent_index, $filter_index, 'Filter disallow rule should appear after User-agent: * directive' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -72,27 +72,43 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should include filter param disallow rules in robots.txt output.
+	 * @testdox Should not include filter param disallow rules in robots.txt by default.
 	 */
-	public function test_robots_txt_includes_filter_disallow_rules(): void {
+	public function test_robots_txt_omits_filter_disallow_rules_by_default(): void {
 		$base = "User-agent: *\nDisallow: /wp-admin/\n";
 
 		$output = WC()->robots_txt( $base );
 
-		$this->assertStringContainsString( 'Disallow: /*?filter_*', $output, 'robots.txt should disallow filter_ params' );
-		$this->assertStringContainsString( 'Disallow: /*?*filter_*', $output, 'robots.txt should disallow filter_ params with prefix' );
-		$this->assertStringContainsString( 'Disallow: /*?rating_filter=*', $output, 'robots.txt should disallow rating_filter param' );
-		$this->assertStringContainsString( 'Disallow: /*?*rating_filter=*', $output, 'robots.txt should disallow rating_filter when not first param' );
-		$this->assertStringContainsString( 'Disallow: /*?min_price=*', $output, 'robots.txt should disallow min_price param' );
-		$this->assertStringContainsString( 'Disallow: /*?*min_price=*', $output, 'robots.txt should disallow min_price when not first param' );
-		$this->assertStringContainsString( 'Disallow: /*?max_price=*', $output, 'robots.txt should disallow max_price param' );
-		$this->assertStringContainsString( 'Disallow: /*?*max_price=*', $output, 'robots.txt should disallow max_price when not first param' );
+		$this->assertStringNotContainsString( 'Disallow: /*?filter_*', $output, 'robots.txt should not disallow filter params by default' );
+		$this->assertStringNotContainsString( 'Disallow: /*?min_price=*', $output, 'robots.txt should not disallow min_price by default' );
 	}
 
 	/**
-	 * @testdox Should include filter disallow rules inside the User-agent wildcard group.
+	 * @testdox Should include filter param disallow rules in robots.txt when opted in.
+	 */
+	public function test_robots_txt_includes_filter_disallow_rules_when_opted_in(): void {
+		add_filter( 'woocommerce_disallow_filter_params_in_robots_txt', '__return_true' );
+		$base = "User-agent: *\nDisallow: /wp-admin/\n";
+
+		$output = WC()->robots_txt( $base );
+
+		$this->assertStringContainsString( 'Disallow: /*?filter_*', $output );
+		$this->assertStringContainsString( 'Disallow: /*?*filter_*', $output );
+		$this->assertStringContainsString( 'Disallow: /*?rating_filter=*', $output );
+		$this->assertStringContainsString( 'Disallow: /*?*rating_filter=*', $output );
+		$this->assertStringContainsString( 'Disallow: /*?min_price=*', $output );
+		$this->assertStringContainsString( 'Disallow: /*?*min_price=*', $output );
+		$this->assertStringContainsString( 'Disallow: /*?max_price=*', $output );
+		$this->assertStringContainsString( 'Disallow: /*?*max_price=*', $output );
+
+		remove_all_filters( 'woocommerce_disallow_filter_params_in_robots_txt' );
+	}
+
+	/**
+	 * @testdox Should include filter disallow rules inside the User-agent wildcard group when opted in.
 	 */
 	public function test_robots_txt_filter_rules_inside_wildcard_group(): void {
+		add_filter( 'woocommerce_disallow_filter_params_in_robots_txt', '__return_true' );
 		$base = "User-agent: *\nDisallow: /wp-admin/\n";
 
 		$output = WC()->robots_txt( $base );
@@ -104,5 +120,7 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		$this->assertNotFalse( $agent_index, 'User-agent: * line should exist' );
 		$this->assertNotFalse( $filter_index, 'Disallow: /*?filter_* line should exist' );
 		$this->assertGreaterThan( $agent_index, $filter_index, 'Filter disallow rule should appear after User-agent: * directive' );
+
+		remove_all_filters( 'woocommerce_disallow_filter_params_in_robots_txt' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -119,29 +119,29 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * @testdox Should add noindex when filter params are present on the shop page.
+	 * @testdox Should not add noindex by default when filter params are present on the shop page.
 	 */
-	public function test_page_no_robots_adds_noindex_for_filtered_shop_page(): void {
+	public function test_page_no_robots_does_not_add_noindex_by_default(): void {
 		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'filter_color' => 'blue' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$result = wc_page_no_robots( array() );
 
-		$this->assertArrayHasKey( 'noindex', $result, 'noindex directive should be added for filtered shop pages' );
-		$this->assertTrue( $result['noindex'], 'noindex directive should be true for filtered shop pages' );
+		$this->assertArrayNotHasKey( 'noindex', $result, 'noindex should not be added by default (opt-in behavior)' );
 	}
 
 	/**
-	 * @testdox Should not add noindex when filter params are present but feature is disabled.
+	 * @testdox Should add noindex when filter params are present on the shop page and feature is enabled.
 	 */
-	public function test_page_no_robots_respects_disabled_filter(): void {
+	public function test_page_no_robots_adds_noindex_when_opted_in(): void {
 		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'filter_color' => 'blue' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		add_filter( 'woocommerce_noindex_filtered_pages', '__return_false' );
+		add_filter( 'woocommerce_noindex_filtered_pages', '__return_true' );
 
 		$result = wc_page_no_robots( array() );
 
-		$this->assertArrayNotHasKey( 'noindex', $result, 'noindex should not be added when feature is disabled' );
+		$this->assertArrayHasKey( 'noindex', $result, 'noindex directive should be added when feature is opted in' );
+		$this->assertTrue( $result['noindex'], 'noindex directive should be true when feature is opted in' );
 	}
 
 	/**
@@ -169,11 +169,12 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should add noindex when min_price param is present on the shop page.
+	 * @testdox Should add noindex when min_price param is present on the shop page and feature is enabled.
 	 */
 	public function test_page_no_robots_adds_noindex_for_min_price(): void {
 		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'min_price' => '10' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		add_filter( 'woocommerce_noindex_filtered_pages', '__return_true' );
 
 		$result = wc_page_no_robots( array() );
 
@@ -181,11 +182,12 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should add noindex when max_price param is present on the shop page.
+	 * @testdox Should add noindex when max_price param is present on the shop page and feature is enabled.
 	 */
 	public function test_page_no_robots_adds_noindex_for_max_price(): void {
 		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'max_price' => '100' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		add_filter( 'woocommerce_noindex_filtered_pages', '__return_true' );
 
 		$result = wc_page_no_robots( array() );
 
@@ -193,11 +195,12 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should add noindex when rating_filter param is present on the shop page.
+	 * @testdox Should add noindex when rating_filter param is present on the shop page and feature is enabled.
 	 */
 	public function test_page_no_robots_adds_noindex_for_rating_filter(): void {
 		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'rating_filter' => '4' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		add_filter( 'woocommerce_noindex_filtered_pages', '__return_true' );
 
 		$result = wc_page_no_robots( array() );
 

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -1,0 +1,162 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for functions in includes/wc-template-functions.php.
+ */
+class WC_Template_Functions_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Backup of $_GET superglobal.
+	 *
+	 * @var array
+	 */
+	private $original_get;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->original_get = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Restore $_GET after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$_GET = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		remove_all_filters( 'woocommerce_noindex_filtered_pages' );
+	}
+
+	// -------------------------------------------------------------------------
+	// wc_has_product_filter_params()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @testdox Should return false when no filter params are present.
+	 */
+	public function test_has_product_filter_params_returns_false_with_no_params(): void {
+		$_GET = array(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertFalse( wc_has_product_filter_params() );
+	}
+
+	/**
+	 * @testdox Should return true when a filter_ prefixed param is present.
+	 */
+	public function test_has_product_filter_params_returns_true_for_filter_prefix(): void {
+		$_GET = array( 'filter_color' => 'blue' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertTrue( wc_has_product_filter_params() );
+	}
+
+	/**
+	 * @testdox Should return true when rating_filter param is present.
+	 */
+	public function test_has_product_filter_params_returns_true_for_rating_filter(): void {
+		$_GET = array( 'rating_filter' => '4' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertTrue( wc_has_product_filter_params() );
+	}
+
+	/**
+	 * @testdox Should return true when min_price param is present.
+	 */
+	public function test_has_product_filter_params_returns_true_for_min_price(): void {
+		$_GET = array( 'min_price' => '10' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertTrue( wc_has_product_filter_params() );
+	}
+
+	/**
+	 * @testdox Should return true when max_price param is present.
+	 */
+	public function test_has_product_filter_params_returns_true_for_max_price(): void {
+		$_GET = array( 'max_price' => '100' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertTrue( wc_has_product_filter_params() );
+	}
+
+	/**
+	 * @testdox Should return false when unrelated query params are present.
+	 */
+	public function test_has_product_filter_params_returns_false_for_unrelated_params(): void {
+		$_GET = array( 'orderby' => 'price', 'paged' => '2', 's' => 'shirt' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertFalse( wc_has_product_filter_params() );
+	}
+
+	// -------------------------------------------------------------------------
+	// wc_page_no_robots() — filtered pages branch
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @testdox Should add noindex when filter params are present and feature is enabled.
+	 */
+	public function test_page_no_robots_adds_noindex_for_filtered_pages(): void {
+		$_GET = array( 'filter_color' => 'blue' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$result = wc_page_no_robots( array() );
+
+		$this->assertArrayHasKey( 'noindex', $result, 'noindex directive should be added for filtered pages' );
+		$this->assertTrue( $result['noindex'], 'noindex directive should be true for filtered pages' );
+	}
+
+	/**
+	 * @testdox Should not add noindex when filter params are present but feature is disabled.
+	 */
+	public function test_page_no_robots_respects_disabled_filter(): void {
+		$_GET = array( 'filter_color' => 'blue' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		add_filter( 'woocommerce_noindex_filtered_pages', '__return_false' );
+
+		$result = wc_page_no_robots( array() );
+
+		$this->assertArrayNotHasKey( 'noindex', $result, 'noindex should not be added when feature is disabled' );
+	}
+
+	/**
+	 * @testdox Should not add noindex when no filter params are present.
+	 */
+	public function test_page_no_robots_does_not_add_noindex_without_filter_params(): void {
+		$_GET = array( 'orderby' => 'price' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$result = wc_page_no_robots( array() );
+
+		$this->assertArrayNotHasKey( 'noindex', $result, 'noindex should not be added when no filter params are present' );
+	}
+
+	/**
+	 * @testdox Should add noindex when min_price param is present.
+	 */
+	public function test_page_no_robots_adds_noindex_for_min_price(): void {
+		$_GET = array( 'min_price' => '10' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$result = wc_page_no_robots( array() );
+
+		$this->assertArrayHasKey( 'noindex', $result );
+	}
+
+	/**
+	 * @testdox Should add noindex when max_price param is present.
+	 */
+	public function test_page_no_robots_adds_noindex_for_max_price(): void {
+		$_GET = array( 'max_price' => '100' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$result = wc_page_no_robots( array() );
+
+		$this->assertArrayHasKey( 'noindex', $result );
+	}
+
+	/**
+	 * @testdox Should add noindex when rating_filter param is present.
+	 */
+	public function test_page_no_robots_adds_noindex_for_rating_filter(): void {
+		$_GET = array( 'rating_filter' => '4' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$result = wc_page_no_robots( array() );
+
+		$this->assertArrayHasKey( 'noindex', $result );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -14,19 +14,45 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	private $original_get;
 
 	/**
+	 * ID of the shop page created for archive tests.
+	 *
+	 * @var int
+	 */
+	private $shop_page_id;
+
+	/**
+	 * Original shop page option value.
+	 *
+	 * @var int|bool
+	 */
+	private $original_shop_page_id;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
 		parent::setUp();
 		$this->original_get = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->shop_page_id          = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Shop',
+			)
+		);
+		$this->original_shop_page_id = get_option( 'woocommerce_shop_page_id' );
+		update_option( 'woocommerce_shop_page_id', $this->shop_page_id );
 	}
 
 	/**
-	 * Restore $_GET after each test.
+	 * Restore $_GET and shop page option after each test.
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
 		$_GET = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		update_option( 'woocommerce_shop_page_id', $this->original_shop_page_id );
+		wp_delete_post( $this->shop_page_id, true );
 		remove_all_filters( 'woocommerce_noindex_filtered_pages' );
 	}
 
@@ -93,21 +119,23 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * @testdox Should add noindex when filter params are present and feature is enabled.
+	 * @testdox Should add noindex when filter params are present on the shop page.
 	 */
-	public function test_page_no_robots_adds_noindex_for_filtered_pages(): void {
+	public function test_page_no_robots_adds_noindex_for_filtered_shop_page(): void {
+		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'filter_color' => 'blue' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$result = wc_page_no_robots( array() );
 
-		$this->assertArrayHasKey( 'noindex', $result, 'noindex directive should be added for filtered pages' );
-		$this->assertTrue( $result['noindex'], 'noindex directive should be true for filtered pages' );
+		$this->assertArrayHasKey( 'noindex', $result, 'noindex directive should be added for filtered shop pages' );
+		$this->assertTrue( $result['noindex'], 'noindex directive should be true for filtered shop pages' );
 	}
 
 	/**
 	 * @testdox Should not add noindex when filter params are present but feature is disabled.
 	 */
 	public function test_page_no_robots_respects_disabled_filter(): void {
+		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'filter_color' => 'blue' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		add_filter( 'woocommerce_noindex_filtered_pages', '__return_false' );
 
@@ -117,9 +145,10 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should not add noindex when no filter params are present.
+	 * @testdox Should not add noindex when no filter params are present on the shop page.
 	 */
 	public function test_page_no_robots_does_not_add_noindex_without_filter_params(): void {
+		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'orderby' => 'price' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$result = wc_page_no_robots( array() );
@@ -128,9 +157,22 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should add noindex when min_price param is present.
+	 * @testdox Should not add noindex when filter params are present but current page is not a product archive.
+	 */
+	public function test_page_no_robots_does_not_add_noindex_on_non_archive_pages(): void {
+		$this->go_to( home_url( '/' ) );
+		$_GET = array( 'min_price' => '10' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$result = wc_page_no_robots( array() );
+
+		$this->assertArrayNotHasKey( 'noindex', $result, 'noindex should not be added on non-archive pages even with filter params' );
+	}
+
+	/**
+	 * @testdox Should add noindex when min_price param is present on the shop page.
 	 */
 	public function test_page_no_robots_adds_noindex_for_min_price(): void {
+		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'min_price' => '10' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$result = wc_page_no_robots( array() );
@@ -139,9 +181,10 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should add noindex when max_price param is present.
+	 * @testdox Should add noindex when max_price param is present on the shop page.
 	 */
 	public function test_page_no_robots_adds_noindex_for_max_price(): void {
+		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'max_price' => '100' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$result = wc_page_no_robots( array() );
@@ -150,9 +193,10 @@ class WC_Template_Functions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should add noindex when rating_filter param is present.
+	 * @testdox Should add noindex when rating_filter param is present on the shop page.
 	 */
 	public function test_page_no_robots_adds_noindex_for_rating_filter(): void {
+		$this->go_to( get_permalink( $this->shop_page_id ) );
 		$_GET = array( 'rating_filter' => '4' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$result = wc_page_no_robots( array() );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Two opt-in defenses against filter URL bot exploitation and SEO bloat. Both default to `false` — no behavior change for existing stores.

**1. `noindex` for filtered archives** — new `woocommerce_noindex_filtered_pages` filter. When `true`, adds `noindex` on `is_shop()||is_product_taxonomy()` pages with `filter_*`, `rating_filter`, `min_price`, or `max_price` params. Covers both classic widgets and block filters.

**2. `robots.txt` disallow rules** — new `woocommerce_disallow_filter_params_in_robots_txt` filter. When `true`, adds `Disallow` rules for all filter params with `/*?*param=*` wildcard variants to cover non-leading positions.

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Confirm default: visit `/shop/?filter_color=blue` — no `noindex`, check `robots.txt` — no filter `Disallow` rules
2. Opt in: add both filters returning `true`
3. Visit `/shop/?filter_color=blue` — `noindex` in page source
4. Visit `/shop/` without params — no `noindex`
5. Visit non-archive with `?min_price=10` — no `noindex`
6. Check `robots.txt` — all filter `Disallow` rules present

### Testing that has already taken place:

PHPStan, PHPCS, branch lint — clean. Unit tests cover default (opt-out) and opted-in behavior for both features.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Added manually at `plugins/woocommerce/changelog/tangerine-a4456b63`.
</details>