### PR TITLE
Fix: taxes nor removed from variable product prices for VAT exempt customers

### DIFF
--- a/plugins/woocommerce/changelog/pr-64049
+++ b/plugins/woocommerce/changelog/pr-64049
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix: taxes nor removed from variable product prices for VAT exempt customers
+Fix: taxes not removed from variable product prices for VAT-exempt customers

--- a/plugins/woocommerce/changelog/pr-64049
+++ b/plugins/woocommerce/changelog/pr-64049
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: taxes nor removed from variable product prices for VAT exempt customers

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -563,10 +563,6 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			return false;
 		}
 
-		if ( ! empty( WC()->customer ) && WC()->customer->get_is_vat_exempt() ) {
-			return false;
-		}
-
 		return true;
 	}
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -18339,7 +18339,7 @@ parameters:
 		-
 			message: '#^Property WooCommerce\:\:\$customer \(WC_Customer\) in empty\(\) is not falsy\.$#'
 			identifier: empty.property
-			count: 2
+			count: 1
 			path: includes/data-stores/class-wc-product-variable-data-store-cpt.php
 
 		-

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -468,7 +468,6 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testWith [false, true, true, false]
 	 *           [false, false, true, false]
 	 *           [true, true, false, false]
-	 *           [true, true, true, true]
 	 *
 	 * @param bool $tax_enabled Taxes enabled shop-wide or not.
 	 * @param bool $taxable_product Product is taxable or not.
@@ -512,16 +511,19 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	/**
 	 * @testdox read_prices does separate caching for prices for display and not for display when they are different.
 	 *
-	 * @testWith [true]
-	 *           [false]
+	 * @testWith [true, false]
+	 *           [false, false]
+	 *           [true, true]
+	 *           [false, true]
 	 *
 	 * @param bool $for_display Test getting prices for display or not for display.
+	 * @param bool $is_vat_exempt Whether the customer is VAT exempt.
 	 */
-	public function test_read_prices_cache_when_taxes_influence_price( bool $for_display ) {
+	public function test_read_prices_cache_when_taxes_influence_price( bool $for_display, bool $is_vat_exempt ) {
 		add_filter( 'wc_tax_enabled', '__return_true' );
 		add_filter( 'woocommerce_product_is_taxable', '__return_true' );
 		add_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
-		WC()->customer->set_is_vat_exempt( false );
+		WC()->customer->set_is_vat_exempt( $is_vat_exempt );
 
 		$data_store     = new WC_Product_Variable_Data_Store_CPT();
 		$product        = WC_Helper_Product::create_variation_product();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`WC()->customer->set_is_vat_exempt(true)` stopped removing tax from variable product prices on shop/product pages starting in WooCommerce 10.4.0. Simple products were unaffected.

The `taxes_influence_price()` method introduced in #61286 incorrectly returned `false` when the customer is VAT-exempt. The reasoning was that "no VAT applied → taxes don't influence price", but that's backwards: when prices are stored inclusive of tax, a VAT-exempt customer needs tax *subtracted* from the displayed price, so taxes very much do influence the price. Returning `false` caused the double-caching optimization to serve the raw tax-inclusive price for variable products instead of the correct tax-excluded price.

The fix removes the VAT-exempt check from `taxes_influence_price()`. The other checks in the method (non-taxable product, no tax rates) remain correct because in those cases tax is truly never involved in any calculation.

Closes #63716.

Bug introduced in PR #61286.

### How to test the changes in this Pull Request:

1. Setup a store with the following configuration (in WooCommerce - Settings - Tax options):

- Prices are entered inclusive of tax.
- Prices are displayed with taxes.
- There's a 20% standard tax rate that applies to all products.

2. Create a variable product with a price of 100 for the variations.

3. Run the following snippet in `wp shell` (or create a `temp.php` file with this content and then `include` it), replacing `<product id>` and `<user id>` accordingly (any existing user id will do); verify that prices with and without taxes are different:

```php
wp_set_current_user(<user id>);
WC()->initialize_session();
WC()->initialize_cart();
WC()->customer->set_is_vat_exempt( false );
$p = wc_get_product(<product id>);
$v=wc_get_product($p->get_children()[0]);
echo "price with tax:    " . wc_get_price_including_tax($v) . "\n";
echo "price without tax: " . wc_get_price_excluding_tax($v) . "\n";
```

4. Repeat but with `set_is_vat_exempt( true )`: now the prices should be both the same (the price without taxes). Without this fix they would be different again.

5. Add the following snippet to the testing site:

```php
add_filter( 'wc_tax_enabled', function($enabled) {
	if(WC()->customer) WC()->customer->set_is_vat_exempt( true );
	return $enabled;
}
```

6. Open the variable product page in the shop. You should see the price without taxes for all the variations.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
