### PR TITLE
Fix fatal error in PaymentsProviders when gateway order has integer keys

### DIFF
--- a/plugins/woocommerce/changelog/64051-fix-WOOPLUG-6508-fatal-error-order-map-integer-keys
+++ b/plugins/woocommerce/changelog/64051-fix-WOOPLUG-6508-fatal-error-order-map-integer-keys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error on Payments settings page when `woocommerce_gateway_order` option contains legacy integer keys.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -163,6 +163,13 @@ class Utils {
 	 * @return array The normalized order map.
 	 */
 	public static function order_map_normalize( array $order_map ): array {
+		// Remove entries with non-string keys (legacy/corrupt data).
+		$order_map = array_filter(
+			$order_map,
+			fn( $key ) => is_string( $key ),
+			ARRAY_FILTER_USE_KEY
+		);
+
 		asort( $order_map );
 
 		return array_flip( array_keys( $order_map ) );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/UtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/UtilsTest.php
@@ -1462,6 +1462,37 @@ class UtilsTest extends WC_Unit_Test_Case {
 					'provider3' => 2,
 				),
 			),
+			'integer keys are removed'                => array(
+				array(
+					0           => 0,
+					'provider1' => 1,
+					'provider2' => 2,
+				),
+				array(
+					'provider1' => 0,
+					'provider2' => 1,
+				),
+			),
+			'only integer keys'                       => array(
+				array(
+					0 => 0,
+					1 => 1,
+					2 => 2,
+				),
+				array(),
+			),
+			'mixed integer and string keys'           => array(
+				array(
+					0           => 5,
+					'provider1' => 10,
+					1           => 15,
+					'provider2' => 20,
+				),
+				array(
+					'provider1' => 0,
+					'provider2' => 1,
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When the `woocommerce_gateway_order` option contains legacy integer array keys (from older WooCommerce versions or corrupt data), the `is_offline_group_last()` method passes them to `is_offline_payment_method(string $id)`, which crashes under `declare(strict_types=1)`.

The fix sanitizes integer keys in `Utils::order_map_normalize()` — the existing normalization entry point for all order maps. Integer keys don't correspond to any real gateway ID (gateway IDs are always strings like `bacs`, `stripe`, etc.), so removing them is safe and consistent with how the legacy code in `WC_Payment_Gateways` already treats them (it only accesses keys by `$gateway->id`).

Closes https://github.com/woocommerce/woocommerce/issues/63991.

Bug introduced in PR #63604.

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set up a store with a payment gateway that registers additional gateways (e.g. Stripe).
2. Insert a corrupt `woocommerce_gateway_order` option with integer keys into the database:
   ```sql
   UPDATE wp_options SET option_value = 'a:4:{i:0;i:0;s:4:"bacs";i:1;s:6:"cheque";i:2;s:3:"cod";i:3;}' WHERE option_name = 'woocommerce_gateway_order';
   ```
3. Navigate to WooCommerce > Settings > Payments.
4. **Before fix:** Fatal error. **After fix:** Page loads normally, gateways display in correct order.
5. Verify that your normal gateway ordering is preserved (only the junk integer entries are removed).

### Testing that has already taken place:

- Unit tests added for `order_map_normalize()` covering integer keys, mixed keys, and integer-only scenarios (11/11 passing).
- Verified the crash path via code analysis: `enhance_order_map()` → `order_map_add_gateway()` → `is_offline_group_last()` → `is_offline_payment_method(string $id)`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix fatal error on Payments settings page when `woocommerce_gateway_order` option contains legacy integer keys.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
