### PR TITLE
Try: Update wordpress/mcp-adapter to v0.5.0 (dev-trunk)

### DIFF
--- a/.ai/skills/woocommerce-mcp-inspector/SKILL.md
+++ b/.ai/skills/woocommerce-mcp-inspector/SKILL.md
@@ -1,0 +1,457 @@
+---
+name: woocommerce-mcp-inspector
+description: E2E test the WooCommerce MCP server using the official MCP Inspector CLI against a local wp-env instance. Use when testing MCP tool calls, listing tools, debugging MCP responses, or verifying WooCommerce abilities behavior.
+allowed-tools: Bash, Read, Grep, Glob, Agent, TodoWrite
+---
+
+# WooCommerce MCP Inspector Testing Skill
+
+Fully automated E2E test of the WooCommerce MCP server using the **official MCP Inspector CLI** ([github.com/modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector)) against a local `wp-env` environment. All commands run in bash.
+
+**Important constraints:**
+- This skill is **read-only / test-only**. It must NEVER modify source code, fix bugs, or apply patches. Its sole purpose is to discover what exists, test how it works, and report problems found.
+- After all tests complete, you MUST produce the structured report defined in the "Report Format" section. The report is the deliverable.
+
+## Prerequisites
+
+- Node.js 18+ and `npx`
+- Docker running (for wp-env)
+- wp-env started: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env start`
+
+## Environment Setup
+
+Before running any MCP Inspector commands, the wp-env environment must be configured. Run these steps once per session.
+
+### 1. Detect wp-env Site URL
+
+```bash
+SITE_URL=$(pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option get siteurl 2>&1 | grep '^http')
+echo "Site URL: $SITE_URL"
+```
+
+### 2. Enable the MCP Feature Flag
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option update woocommerce_feature_mcp_integration_enabled yes
+```
+
+### 3. Allow Insecure Transport (Required for Local HTTP)
+
+The WooCommerce MCP transport requires HTTPS by default. For local testing over HTTP, install a mu-plugin to bypass this:
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli -- sh -c \
+  "mkdir -p /var/www/html/wp-content/mu-plugins && echo '<?php add_filter(\"woocommerce_mcp_allow_insecure_transport\", \"__return_true\");' > /var/www/html/wp-content/mu-plugins/mcp-allow-insecure.php"
+```
+
+### 4. Create a WooCommerce REST API Key
+
+WooCommerce MCP uses `X-MCP-API-Key` header authentication with `consumer_key:consumer_secret` format.
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp eval '
+global $wpdb;
+$ck = "ck_mcp_inspector_test";
+$cs = "cs_mcp_inspector_secret";
+$existing = $wpdb->get_var($wpdb->prepare(
+    "SELECT key_id FROM {$wpdb->prefix}woocommerce_api_keys WHERE consumer_key = %s",
+    wc_api_hash($ck)
+));
+if ($existing) { echo "key_exists"; exit; }
+$wpdb->insert(
+    $wpdb->prefix . "woocommerce_api_keys",
+    array(
+        "user_id"         => 1,
+        "description"     => "MCP Inspector Test",
+        "permissions"     => "read_write",
+        "consumer_key"    => wc_api_hash($ck),
+        "consumer_secret" => $cs,
+        "truncated_key"   => substr($ck, -7),
+    )
+);
+echo "key_created:" . $wpdb->insert_id;
+'
+```
+
+### 5. Verify Setup
+
+Quick sanity check that the endpoint responds:
+
+```bash
+SITE_URL=$(pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option get siteurl 2>&1 | grep '^http')
+
+curl -s -X POST "$SITE_URL/?rest_route=/woocommerce/mcp" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-API-Key: ck_mcp_inspector_test:cs_mcp_inspector_secret" \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"setup-check","version":"1.0"}}}'
+```
+
+Expected: HTTP 200 with JSON-RPC response containing `serverInfo.name` and `capabilities`.
+
+> **Note:** The `protocolVersion` value must match what the server supports. Check the server's `initialize` response to confirm the current version.
+
+## MCP Endpoint
+
+```
+{SITE_URL}/?rest_route=/woocommerce/mcp
+```
+
+Uses the WordPress REST API query-string route format. wp-env does not enable pretty permalinks by default.
+
+## Authentication
+
+WooCommerce MCP uses a custom `X-MCP-API-Key` header (not OAuth or Basic Auth):
+
+```
+X-MCP-API-Key: ck_mcp_inspector_test:cs_mcp_inspector_secret
+```
+
+## Raw curl Session Management
+
+The MCP server requires a `Mcp-Session-Id` header on all calls after `initialize`. The Inspector CLI handles this automatically, but when using raw curl (e.g., to extract response data when the Inspector fails on schema validation), you must manage the session manually:
+
+```bash
+SITE_URL=$(pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option get siteurl 2>&1 | grep '^http')
+
+# Step 1: Initialize and capture session ID from response header
+curl -s -D /tmp/mcp_headers -X POST "$SITE_URL/?rest_route=/woocommerce/mcp" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-API-Key: ck_mcp_inspector_test:cs_mcp_inspector_secret" \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl-session","version":"1.0"}}}'
+
+SESSION_ID=$(grep -i 'mcp-session-id' /tmp/mcp_headers | awk '{print $2}' | tr -d '\r')
+
+# Step 2: Send initialized notification
+curl -s -X POST "$SITE_URL/?rest_route=/woocommerce/mcp" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-API-Key: ck_mcp_inspector_test:cs_mcp_inspector_secret" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+# Step 3: Make tool calls with the session ID
+curl -s -X POST "$SITE_URL/?rest_route=/woocommerce/mcp" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-API-Key: ck_mcp_inspector_test:cs_mcp_inspector_secret" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  --output /tmp/mcp_result.bin \
+  -d '{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"woocommerce-products-list","arguments":{"per_page":2}}}'
+```
+
+This is especially useful when schema validation errors (`-32602`) prevent the Inspector from returning data — the operation succeeds server-side and the raw response contains `structuredContent` with the actual data.
+
+## Inspector CLI Reference
+
+### Base Command
+
+```bash
+SITE_URL=$(pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option get siteurl 2>&1 | grep '^http')
+
+npx @modelcontextprotocol/inspector@latest --cli \
+  "$SITE_URL/?rest_route=/woocommerce/mcp" \
+  --transport http \
+  --header "X-MCP-API-Key: ck_mcp_inspector_test:cs_mcp_inspector_secret" \
+  --header "Content-Type: application/json" \
+  --method <method> \
+  [method-specific flags]
+```
+
+The Inspector handles the full MCP handshake (initialize -> initialized -> method call) automatically.
+
+### Helper Function
+
+For repeated testing, define a shell function:
+
+```bash
+SITE_URL=$(pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option get siteurl 2>&1 | grep '^http')
+
+woo_mcp() {
+  npx @modelcontextprotocol/inspector@latest --cli \
+    "$SITE_URL/?rest_route=/woocommerce/mcp" \
+    --transport http \
+    --header "X-MCP-API-Key: ck_mcp_inspector_test:cs_mcp_inspector_secret" \
+    --header "Content-Type: application/json" \
+    "$@"
+}
+```
+
+### Supported Methods
+
+| Method | Description | Key Flags |
+|--------|-------------|-----------|
+| `tools/list` | List all registered tools | — |
+| `tools/call` | Execute a tool | `--tool-name`, `--tool-arg 'key=value'` |
+| `resources/list` | List available resources | — |
+| `resources/read` | Read a specific resource | `--uri` |
+| `resources/templates/list` | List resource templates | — |
+| `prompts/list` | List available prompts | — |
+| `prompts/get` | Get a specific prompt | `--prompt-name` |
+| `logging/setLevel` | Set server log level | `--log-level` |
+
+### Tool Argument Typing
+
+The Inspector auto-types `--tool-arg` values: bare numbers like `9.99` are sent as JSON numbers. If the schema expects a string (e.g., `regular_price`), wrap the value in escaped quotes:
+
+```bash
+--tool-arg 'regular_price="9.99"'    # sent as string "9.99"
+--tool-arg 'per_page=5'               # sent as number 5 (fine for integer fields)
+```
+
+## Test Strategy
+
+The test is fully dynamic. **Do not hard-code tool names, resource URIs, or prompt names.** Discover everything at runtime from the server's own responses.
+
+### Phase 1: Server Capabilities
+
+1. Verify the MCP endpoint responds to the `initialize` handshake (use the curl command from setup step 5).
+2. Record the server's `protocolVersion`, `serverInfo` (name, version), and `capabilities` (which primitives are supported: tools, resources, prompts).
+
+### Phase 2: Discovery
+
+Test all MCP discovery methods. Each should succeed even if it returns an empty list.
+
+1. `tools/list` — record all tool names, titles, descriptions, and input schemas.
+2. `resources/list` — record all resource URIs and descriptions.
+3. `resources/templates/list` — record whether supported or returns `-32601 Method not found`.
+4. `prompts/list` — record all prompt names and descriptions.
+
+Group discovered tools by resource type. Tool names follow the pattern `woocommerce-{resource}-{operation}` (e.g., `woocommerce-products-list`, `woocommerce-orders-create`). Extract the resource and operation from each name.
+
+### Phase 3: Tool CRUD Testing
+
+For **each resource group** discovered in Phase 2, run a full CRUD cycle:
+
+#### a) List (read, no ID required)
+Call the `{resource}-list` tool with `per_page=2`. This tests read operations and output schema validation.
+
+#### b) Create (write, generates an ID)
+Call the `{resource}-create` tool with **minimal valid arguments**. Inspect the tool's `inputSchema` to determine required fields and their types. Extract the created resource's `id` from the response for subsequent steps.
+
+#### c) Get (read, requires ID)
+Call the `{resource}-get` tool with the `id` from the create step.
+
+#### d) Update (write, requires ID)
+Call the `{resource}-update` tool with the `id` and one changed field (e.g., update the name).
+
+#### e) Delete (write, requires ID, cleanup)
+Call the `{resource}-delete` tool with the `id` to clean up test data.
+
+#### f) List after delete
+Call `{resource}-list` again to verify the deleted resource is gone.
+
+**If a resource group doesn't have all CRUD operations** (e.g., only `list` and `get`), test whatever operations are available.
+
+### Phase 4: Resource Testing
+
+For each resource discovered in Phase 2, call `resources/read` with its URI. Verify the response contains content.
+
+### Phase 5: Prompt Testing
+
+For each prompt discovered in Phase 2, call `prompts/get` with its name. Verify the response contains messages.
+
+### Phase 6: Error Handling
+
+Test how the server handles invalid inputs:
+
+1. Call a `get` tool with a non-existent ID (e.g., `id=999999`) — expect a structured error, not a crash.
+2. Call a `create` tool with missing required fields — expect a validation error.
+3. Call a `list` tool with invalid filter values (e.g., `status=nonexistent`) — expect an error or empty results.
+4. Call `resources/read` with a non-existent URI (if resources exist).
+5. Call `resources/templates/list` — record whether the method is supported or returns `-32601 Method not found`.
+
+### Handling Failures
+
+- If a tool call fails, **record the full error message** and continue testing remaining tools.
+- If `create` fails, skip `get`, `update`, and `delete` for that resource (they depend on the created ID) but still test `list`.
+- Output schema validation errors (`-32602: Structured content does not match the tool's output schema`) mean the operation succeeded server-side but the declared schema doesn't match the actual response. These are bugs in the schema definition.
+- **When schema errors prevent the Inspector from returning data**, use raw curl with session management (see "Raw curl Session Management" section above) to extract the `structuredContent` from the response. This lets you get the created resource's `id` and continue the CRUD chain (get, update, delete).
+- Protocol errors (`-32601 Method not found`) mean the server doesn't implement that MCP method. Record it.
+- **Inspector exit code:** The Inspector CLI exits with code 1 on schema validation errors. To prevent one failing test from blocking subsequent tests, run each tool test as a separate command or append `|| true` to allow the script to continue.
+
+## Report Format
+
+After all tests complete, you MUST produce the structured report below. This is the deliverable of the skill. Do NOT attempt to fix any issues found — only report them. Do NOT modify any source code.
+
+### 1. Environment
+- Site URL, MCP server name, server version, protocol version
+- Declared capabilities (tools, resources, prompts — which are enabled)
+
+### 2. Discovery Results
+- Table of all discovered tools: name, title, operation type (list/get/create/update/delete)
+- List of discovered resources (if any)
+- List of discovered prompts (if any)
+- Unsupported discovery methods (if any returned `-32601`)
+
+### 3. Test Results
+- Table with one row per test: test number, tool/resource/prompt name, operation, result (PASS/FAIL), error summary if failed
+
+### 4. Schema Validation Issues
+For each output schema error, list:
+- The field path (e.g., `data/date_created`)
+- What the schema declares (type, format)
+- What the API actually returns (observed value/type)
+- The source file and line where the schema is defined (if identifiable by searching the codebase)
+
+### 5. Protocol Issues
+- Unsupported methods that the server's `capabilities` claim to support
+- Methods that return unexpected error codes
+- Any initialize handshake anomalies
+
+### 6. Other Issues
+- Authentication errors, input validation failures, unexpected responses, server errors
+
+### 7. Summary
+- Total: tools discovered, resources discovered, prompts discovered
+- Total tests run, pass count, fail count
+- Categorized failure breakdown (schema mismatch, input validation, protocol error, server error, etc.)
+
+### 8. Analysis
+
+Write a narrative analysis that goes beyond the tables. This section should:
+
+- **Explain the big picture:** What is the overall health of the MCP server? Is it fundamentally working with surface-level schema issues, or are there deeper problems?
+- **Identify root causes:** Group related failures and trace them back to common causes. For example, if 8 tools fail with the same date-time schema error, explain that once clearly instead of listing it 8 times.
+- **Assess impact:** Which issues actually block MCP clients from using the server, and which are cosmetic? A schema mismatch that causes the Inspector to reject a valid response is different from a missing capability.
+- **Highlight surprises:** Call out anything unexpected — behaviors that contradict the documentation, capabilities advertised but not implemented, error responses with wrong `isError` flags, etc.
+- **Suggest priorities:** If someone were to fix these issues, what should they tackle first and why?
+
+The analysis should read like a senior engineer's assessment, not a generated table. Use plain language and be direct about what works and what doesn't.
+
+## Debugging
+
+### Enable WordPress Debug Logging
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp config set WP_DEBUG true --raw
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp config set WP_DEBUG_LOG true --raw
+```
+
+### Read Debug Log
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli -- cat /var/www/html/wp-content/debug.log
+```
+
+### Check WooCommerce Logs
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli -- ls -la /var/www/html/wp-content/uploads/wc-logs/
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli -- cat /var/www/html/wp-content/uploads/wc-logs/woocommerce-mcp-*.log
+```
+
+### Test Authentication Directly (curl)
+
+```bash
+SITE_URL=$(pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option get siteurl 2>&1 | grep '^http')
+
+curl -s -D - -X POST "$SITE_URL/?rest_route=/woocommerce/mcp" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-API-Key: ck_mcp_inspector_test:cs_mcp_inspector_secret" \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"debug","version":"1.0"}}}'
+```
+
+### Check MCP Feature Flag
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option get woocommerce_feature_mcp_integration_enabled
+```
+
+### Verify Classes Are Autoloaded
+
+> **Note:** The class names below come from the `wp-mcp` library and WooCommerce MCP integration. They may change between versions — verify against the current `composer.lock` if results show "MISSING" unexpectedly.
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli -- php -r '
+require_once "/var/www/html/wp-content/plugins/woocommerce/vendor/autoload.php";
+$classes = [
+    "WP\MCP\Core\McpAdapter",
+    "WP\MCP\Transport\HttpTransport",
+    "WP\MCP\Transport\Contracts\McpRestTransportInterface",
+    "Automattic\WooCommerce\Internal\MCP\MCPAdapterProvider",
+    "Automattic\WooCommerce\Internal\MCP\Transport\WooCommerceRestTransport",
+];
+foreach ($classes as $c) {
+    echo (class_exists($c) || interface_exists($c) ? "OK" : "MISSING") . ": $c\n";
+}
+'
+```
+
+## Common Issues
+
+### 403 Insecure Transport
+
+```json
+{"code":"insecure_transport","message":"HTTPS is required for MCP requests."}
+```
+
+The mu-plugin for insecure transport is missing or not loaded. Re-run step 3 of Environment Setup.
+
+### 401 Authentication Failed
+
+```json
+{"code":"authentication_failed","message":"Authentication failed."}
+```
+
+- The API key was created with the wrong hash. WooCommerce uses `wc_api_hash()` (not plain `sha256`). Re-run step 4 of Environment Setup.
+- Check the key format: `X-MCP-API-Key: consumer_key:consumer_secret` (colon-separated).
+
+### 401 Missing API Key
+
+```json
+{"code":"missing_api_key","message":"X-MCP-API-Key header required."}
+```
+
+The `--header "X-MCP-API-Key: ..."` flag is missing from the Inspector command.
+
+### HTTP 200 Empty Body
+
+The MCP endpoint matched but returned nothing. This usually means:
+- The MCP feature flag is disabled. Run step 2 of Environment Setup.
+- The request hit the wrong container (tests vs dev). Verify `SITE_URL`.
+
+### Tools List Empty
+
+If `tools/list` returns an empty array, no abilities are registered:
+- Check that `AbilitiesRegistry` has WooCommerce abilities
+- The MCP feature flag may be enabled but the abilities module is not loaded
+
+### Port Conflicts (Inspector)
+
+If the Inspector reports "Proxy Server PORT IS IN USE":
+
+```bash
+pkill -f "@modelcontextprotocol/inspector"
+```
+
+### wp-env Not Running
+
+If curl returns connection refused:
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env start
+```
+
+## Test Data Cleanup
+
+After testing, clean up any resources that couldn't be deleted via MCP tools (e.g., orders, which have no `delete` tool):
+
+```bash
+# Delete test orders by title/status pattern
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp post list --post_type=shop_order --post_status=any --format=ids | xargs -I{} pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp post delete {} --force
+
+# Delete test products (if any remain)
+pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp post list --post_type=product --post_status=any --s="MCP Test" --format=ids | xargs -I{} pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp post delete {} --force
+```
+
+> **Note:** Orders don't have a `delete` MCP tool, so test orders accumulate across test runs. Always clean up after testing.
+
+## API Key Permissions
+
+The test key is created with `read_write` permissions. WooCommerce MCP enforces permissions per HTTP method:
+
+| Permission | Allowed Methods |
+|-----------|----------------|
+| `read` | GET, HEAD |
+| `write` | POST, PUT, PATCH, DELETE |
+| `read_write` | All methods |
+
+To test with restricted permissions, create additional keys with different `permissions` values.

--- a/plugins/woocommerce/bin/composer/phpunit/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpunit/composer.lock
@@ -139,16 +139,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.2",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -191,9 +191,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-10-21T19:32:17+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -634,16 +634,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.29",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -665,7 +665,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -717,7 +717,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -741,7 +741,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:29:11+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -912,16 +912,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -974,7 +974,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -994,7 +994,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",

--- a/plugins/woocommerce/bin/composer/wp/composer.lock
+++ b/plugins/woocommerce/bin/composer/wp/composer.lock
@@ -148,16 +148,16 @@
         },
         {
             "name": "gettext/languages",
-            "version": "2.12.1",
+            "version": "2.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Languages.git",
-                "reference": "0b0b0851c55168e1dfb14305735c64019732b5f1"
+                "reference": "079d6f4842cbcbf5673a70d8e93169a684e7aadd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/0b0b0851c55168e1dfb14305735c64019732b5f1",
-                "reference": "0b0b0851c55168e1dfb14305735c64019732b5f1",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/079d6f4842cbcbf5673a70d8e93169a684e7aadd",
+                "reference": "079d6f4842cbcbf5673a70d8e93169a684e7aadd",
                 "shasum": ""
             },
             "require": {
@@ -207,7 +207,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.12.1"
+                "source": "https://github.com/php-gettext/Languages/tree/2.12.2"
             },
             "funding": [
                 {
@@ -219,20 +219,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-19T11:14:02+00:00"
+            "time": "2026-02-23T14:05:50+00:00"
         },
         {
             "name": "mck89/peast",
-            "version": "v1.17.4",
+            "version": "v1.17.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "c6a63f32410d2e4ee2cd20fe94b35af147fb852d"
+                "reference": "e19a8bd896b7f04941a38fd38a140c9a6531c84f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/c6a63f32410d2e4ee2cd20fe94b35af147fb852d",
-                "reference": "c6a63f32410d2e4ee2cd20fe94b35af147fb852d",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/e19a8bd896b7f04941a38fd38a140c9a6531c84f",
+                "reference": "e19a8bd896b7f04941a38fd38a140c9a6531c84f",
                 "shasum": ""
             },
             "require": {
@@ -245,7 +245,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17.4-dev"
+                    "dev-master": "1.17.5-dev"
                 }
             },
             "autoload": {
@@ -266,9 +266,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.17.4"
+                "source": "https://github.com/mck89/peast/tree/v1.17.5"
             },
-            "time": "2025-10-10T12:53:17+00:00"
+            "time": "2026-03-15T10:47:07+00:00"
         },
         {
             "name": "symfony/finder",
@@ -324,16 +324,16 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.6.5",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "5e73d417398993625331a9f69f6c2ef60f234070"
+                "reference": "e91e6903d212486e32ed2c916171f661bfc539ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/5e73d417398993625331a9f69f6c2ef60f234070",
-                "reference": "5e73d417398993625331a9f69f6c2ef60f234070",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/e91e6903d212486e32ed2c916171f661bfc539ce",
+                "reference": "e91e6903d212486e32ed2c916171f661bfc539ce",
                 "shasum": ""
             },
             "require": {
@@ -344,7 +344,7 @@
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^4.3.9"
+                "wp-cli/wp-cli-tests": "^5.0.0"
             },
             "suggest": {
                 "ext-json": "Used for reading and generating JSON translation files",
@@ -355,6 +355,7 @@
                 "bundled": true,
                 "commands": [
                     "i18n",
+                    "i18n audit",
                     "i18n make-pot",
                     "i18n make-json",
                     "i18n make-mo",
@@ -387,9 +388,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.6.5"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.7.0"
             },
-            "time": "2025-04-25T21:49:29+00:00"
+            "time": "2026-03-16T17:13:39+00:00"
         },
         {
             "name": "wp-cli/mustache",
@@ -445,16 +446,16 @@
         },
         {
             "name": "wp-cli/mustangostang-spyc",
-            "version": "0.6.3",
+            "version": "0.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/spyc.git",
-                "reference": "6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7"
+                "reference": "30f25baaaba939caaff1f4b8c7ed998632f59fe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/spyc/zipball/6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7",
-                "reference": "6aa0b4da69ce9e9a2c8402dab8d43cf32c581cc7",
+                "url": "https://api.github.com/repos/wp-cli/spyc/zipball/30f25baaaba939caaff1f4b8c7ed998632f59fe2",
+                "reference": "30f25baaaba939caaff1f4b8c7ed998632f59fe2",
                 "shasum": ""
             },
             "require": {
@@ -490,9 +491,9 @@
             "description": "A simple YAML loader/dumper class for PHP (WP-CLI fork)",
             "homepage": "https://github.com/mustangostang/spyc/",
             "support": {
-                "source": "https://github.com/wp-cli/spyc/tree/autoload"
+                "source": "https://github.com/wp-cli/spyc/tree/0.6.6"
             },
-            "time": "2017-04-25T11:26:20+00:00"
+            "time": "2026-03-12T12:30:41+00:00"
         },
         {
             "name": "wp-cli/php-cli-tools",

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -57,7 +57,7 @@
 		"woocommerce/blueprint": "*",
 		"woocommerce/email-editor": "*",
 		"wordpress/abilities-api": "^0.4.0",
-		"wordpress/mcp-adapter": "^0.3.0"
+		"wordpress/mcp-adapter": "dev-trunk"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",
@@ -170,6 +170,9 @@
 				"woocommerce/action-scheduler",
 				"woocommerce/email-editor",
 				"woocommerce/blueprint"
+			],
+			"vendor/{$vendor}/{$name}": [
+				"wordpress/mcp-adapter"
 			]
 		},
 		"scripts-description": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9dcd2cbeb75aa25b1b43c237292c908",
+    "content-hash": "ae5d1230df25c2f64bdedbf0cadbe8c9",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1351,23 +1351,26 @@
         },
         {
             "name": "wordpress/mcp-adapter",
-            "version": "v0.3.0",
+            "version": "dev-trunk",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/mcp-adapter.git",
-                "reference": "653ca8d95180b25809b1a1dc489d8305ec5beb63"
+                "reference": "912c0ba15f60bd1038c1215b6d1fede0ec66075d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/653ca8d95180b25809b1a1dc489d8305ec5beb63",
-                "reference": "653ca8d95180b25809b1a1dc489d8305ec5beb63",
+                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/912c0ba15f60bd1038c1215b6d1fede0ec66075d",
+                "reference": "912c0ba15f60bd1038c1215b6d1fede0ec66075d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0",
+                "wordpress/php-mcp-schema": "^0.1.0"
             },
             "require-dev": {
                 "automattic/vipwpcs": "^3.0",
+                "php-stubs/wordpress-stubs": "^6.9",
                 "php-stubs/wp-cli-stubs": "^2.12",
                 "phpcompatibility/php-compatibility": "10.x-dev as 9.99.99",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
@@ -1382,7 +1385,8 @@
                 "wpackagist-plugin/plugin-check": "^1.6",
                 "yoast/phpunit-polyfills": "^4.0"
             },
-            "type": "library",
+            "default-branch": true,
+            "type": "wordpress-plugin",
             "extra": {
                 "installer-paths": {
                     "vendor/{$vendor}/{$name}/": [
@@ -1441,7 +1445,58 @@
                 "issues": "https://github.com/wordpress/mcp-adapter/issues",
                 "source": "https://github.com/wordpress/mcp-adapter"
             },
-            "time": "2025-11-06T14:56:51+00:00"
+            "time": "2026-04-07T09:56:11+00:00"
+        },
+        {
+            "name": "wordpress/php-mcp-schema",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/php-mcp-schema.git",
+                "reference": "b1003dd4d223ef727f19a3163755163461009289"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/b1003dd4d223ef727f19a3163755163461009289",
+                "reference": "b1003dd4d223ef727f19a3163755163461009289",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WP\\McpSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress",
+                    "homepage": "https://wordpress.org"
+                }
+            ],
+            "description": "PHP DTOs for the Model Context Protocol (MCP) specification",
+            "homepage": "https://github.com/WordPress/php-mcp-schema",
+            "keywords": [
+                "dto",
+                "mcp",
+                "model-context-protocol",
+                "php",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/php-mcp-schema/issues",
+                "source": "https://github.com/WordPress/php-mcp-schema/tree/v0.1.0"
+            },
+            "time": "2026-03-02T08:25:49+00:00"
         }
     ],
     "packages-dev": [
@@ -5586,7 +5641,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "wordpress/mcp-adapter": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Updates the `wordpress/mcp-adapter` Composer dependency from `^0.3.0` to `dev-trunk` (upcoming v0.5.0). **This is a draft for others to try the new adapter — not intended for merge yet.**

**What changed in the adapter:**
- Typed protocol DTOs via new `wordpress/php-mcp-schema ^0.1.0` dependency
- MCP spec updated from `2025-06-18` to `2025-11-25`
- Interfaces moved from `WP\MCP\Transport\Interfaces\` to `WP\MCP\Transport\Contracts\`
- `HttpTransport::check_permission()` now casts results to `bool` and uses fail-closed security (returns `false` on error)
- `McpTransportContext` constructor now validates required/optional keys strictly
- Composer package type changed from `library` to `wordpress-plugin`

**What changed in WooCommerce:**
- `composer.json`: Version bump + `installer-paths` override to keep the package in `vendor/` (needed because the package type changed)
- `composer.lock`: Regenerated with new dependency tree
- **No PHP code changes** — all public APIs used by WooCommerce (`McpAdapter::create_server()`, `HttpTransport`, transport interfaces) are backward compatible

**Pre-existing issues found during E2E testing (not caused by this update):**

Full MCP Inspector E2E testing revealed issues that exist on trunk today and are unrelated to the adapter update:

1. **Output schema validation failures (8 of 9 tools)** — All product/order tools (except `products-delete`) fail strict schema validation because:
   - Date-time fields lack timezone suffix (`2026-04-07T16:06:06` instead of RFC 3339 `2026-04-07T16:06:06Z`)
   - Nullable fields (`date_on_sale_from`, `stock_quantity`, `date_paid`, etc.) return `null` but schemas declare them as `string`/`integer` without allowing `null`
   - `shipping_class_id` schema says `string`, API returns `integer`
   - `external_url` and `billing.email` use format constraints (`uri`, `email`) but return empty strings

2. **`isError` flag not set on error responses** — When tools like `products-get` or `orders-get` receive a non-existent ID, the server returns the error payload but with `isError: false`. MCP clients rely on `isError: true` to distinguish errors from successful results.

These issues should be tracked and addressed in separate PRs.

### How to test the changes in this Pull Request:

1. Check out this branch and run `composer install` from `plugins/woocommerce/`
2. Start wp-env: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env start`
3. Enable the MCP feature: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option update woocommerce_feature_mcp_integration_enabled yes`
4. Run unit tests:
   ```
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter MCPAdapterProviderTest
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WooCommerceRestTransportTest
   ```
5. Verify all 25 tests pass (10 + 15)
6. For E2E testing, use the `woocommerce-mcp-inspector` skill or follow the manual steps:
   - Set up insecure transport mu-plugin (for local HTTP)
   - Create a WooCommerce API key
   - Run `npx @modelcontextprotocol/inspector@latest --cli` against the endpoint
   - Verify `tools/list` returns all 9 tools and `tools/call` executes successfully

### Testing that has already taken place:

- **PHPStan**: No errors on `MCPAdapterProvider.php` and `WooCommerceRestTransport.php`
- **Unit tests**: 25 tests, 37 assertions — all pass
- **PHP lint**: Clean on all changed files
- **API surface diff**: Full comparison of v0.3.0 vs v0.5.0 public APIs — all WooCommerce-used classes/interfaces/methods are backward compatible
- **Integration test**: MCP `initialize` handshake returns valid response with protocol version `2025-11-25`
- **E2E test**: Full CRUD cycle (products + orders) via MCP Inspector CLI — all operations succeed server-side
- **Autoload verification**: All MCP classes/interfaces load correctly in wp-env (including renamed `Contracts` namespace)

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
Draft PR for testing the new MCP adapter version — not intended for merge yet.

</details>