### PR TITLE
Block checkout: hide radio button when only one option available

### DIFF
--- a/plugins/woocommerce/changelog/mikejolley-wooplug-2692-checkout-block-when-there-is-only-one-shipping-or-payment
+++ b/plugins/woocommerce/changelog/mikejolley-wooplug-2692-checkout-block-when-there-is-only-one-shipping-or-payment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Block checkout: hide radio button and use thinner border when only one shipping, pickup, or payment option is available.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -117,6 +117,9 @@ export const LocalPickupSelect = ( {
 		>
 			{ header }
 			<RadioControl
+				className={ clsx( {
+					'has-single-option': pickupLocations.length === 1,
+				} ) }
 				onChange={ onChange }
 				highlightChecked={ true }
 				selected={ selectedOption }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -255,6 +255,42 @@ describe( 'LocalPickupSelect', () => {
 		);
 	} );
 
+	it( 'Applies has-single-option class when there is only one pickup location', () => {
+		render(
+			<LocalPickupSelect
+				title="Package 1"
+				onChange={ jest.fn() }
+				selectedOption=""
+				pickupLocations={ [
+					generateShippingRate( {
+						rateId: '1',
+						name: 'Store 1',
+						instanceID: 1,
+						price: '0',
+					} ),
+				] }
+				packageCount={ 1 }
+				renderPickupLocation={ defaultRenderPickupLocation }
+			/>
+		);
+
+		expect(
+			document.querySelector(
+				'.wc-block-components-radio-control.has-single-option'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'Does not apply has-single-option class when there are multiple pickup locations', () => {
+		render( <TestComponent /> );
+
+		expect(
+			document.querySelector(
+				'.wc-block-components-radio-control.has-single-option'
+			)
+		).not.toBeInTheDocument();
+	} );
+
 	describe( 'packageData prop', () => {
 		it( 'Renders package name when multiple packages are present', () => {
 			const packageDataWithName = {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -74,8 +74,7 @@ const PackageRates = ( {
 	return (
 		<RadioControl
 			className={ clsx( className, {
-				'has-single-option':
-					highlightChecked && options.length === 1,
+				'has-single-option': highlightChecked && options.length === 1,
 			} ) }
 			onChange={ ( value: string ) => {
 				setSelectedOption( value );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -3,6 +3,7 @@
  */
 import { useState, useEffect } from '@wordpress/element';
 import { RadioControl } from '@woocommerce/blocks-components';
+import clsx from 'clsx';
 import type { CartShippingPackageShippingRate } from '@woocommerce/types';
 
 /**
@@ -68,9 +69,14 @@ const PackageRates = ( {
 		return noResultsMessage;
 	}
 
+	const options = rates.map( renderOption );
+
 	return (
 		<RadioControl
-			className={ className }
+			className={ clsx( className, {
+				'has-single-option':
+					highlightChecked && options.length === 1,
+			} ) }
 			onChange={ ( value: string ) => {
 				setSelectedOption( value );
 				onSelectRate( value );
@@ -78,7 +84,7 @@ const PackageRates = ( {
 			highlightChecked={ highlightChecked }
 			disabled={ disabled }
 			selected={ selectedOption ?? '' }
-			options={ rates.map( renderOption ) }
+			options={ options }
 			descriptionStackingDirection="column"
 		/>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/test/index.tsx
@@ -117,6 +117,135 @@ test( 'changes rate selection locally and informs API about it', async () => {
 	expect( selectShippingRate ).toHaveBeenLastCalledWith( 'flat_rate:2', 0 );
 } );
 
+test( 'applies has-single-option class when highlightChecked is true and there is only one rate', async () => {
+	const singleRatePackage = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'flat_rate:1',
+				name: 'Flat rate',
+				price: '1000',
+				instanceID: 1,
+			} ),
+		],
+	} );
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: [ singleRatePackage ],
+		};
+	} );
+
+	( useStoreCart as jest.Mock ).mockImplementation( () => {
+		return {
+			cartItems: [],
+		};
+	} );
+
+	render(
+		<ShippingRatesControlPackage
+			packageData={ singleRatePackage }
+			packageId={ singleRatePackage.package_id }
+			highlightChecked={ true }
+			noResultsMessage={
+				<span>No shipping rates available at the moment</span>
+			}
+		/>
+	);
+
+	await screen.findByText( 'Flat rate' );
+
+	expect(
+		document.querySelector(
+			'.wc-block-components-radio-control.has-single-option'
+		)
+	).toBeInTheDocument();
+} );
+
+test( 'does not apply has-single-option class when there are multiple rates', async () => {
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: [ testPackageData ],
+		};
+	} );
+
+	( useStoreCart as jest.Mock ).mockImplementation( () => {
+		return {
+			cartItems: [],
+		};
+	} );
+
+	render(
+		<ShippingRatesControlPackage
+			packageData={ testPackageData }
+			packageId={ testPackageData.package_id }
+			highlightChecked={ true }
+			noResultsMessage={
+				<span>No shipping rates available at the moment</span>
+			}
+		/>
+	);
+
+	await screen.findByRole( 'radio', { name: 'Flat rate $10.00' } );
+
+	expect(
+		document.querySelector(
+			'.wc-block-components-radio-control.has-single-option'
+		)
+	).not.toBeInTheDocument();
+} );
+
+test( 'does not apply has-single-option class when highlightChecked is false', async () => {
+	const singleRatePackage = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'flat_rate:1',
+				name: 'Flat rate',
+				price: '1000',
+				instanceID: 1,
+			} ),
+		],
+	} );
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: [ singleRatePackage ],
+		};
+	} );
+
+	( useStoreCart as jest.Mock ).mockImplementation( () => {
+		return {
+			cartItems: [],
+		};
+	} );
+
+	render(
+		<ShippingRatesControlPackage
+			packageData={ singleRatePackage }
+			packageId={ singleRatePackage.package_id }
+			highlightChecked={ false }
+			noResultsMessage={
+				<span>No shipping rates available at the moment</span>
+			}
+		/>
+	);
+
+	await screen.findByText( 'Flat rate' );
+
+	expect(
+		document.querySelector(
+			'.wc-block-components-radio-control.has-single-option'
+		)
+	).not.toBeInTheDocument();
+} );
+
 test( 'upstream rate selection updates are properly reflected in local state', async () => {
 	const packageData = generateShippingPackage( {
 		packageId: 0,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -8,6 +8,7 @@ import {
 import { cloneElement, useCallback } from '@wordpress/element';
 import { useEditorContext } from '@woocommerce/base-context';
 import { RadioControlAccordion } from '@woocommerce/blocks-components';
+import clsx from 'clsx';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getPaymentMethods } from '@woocommerce/blocks-registry';
 import { paymentStore } from '@woocommerce/block-data';
@@ -29,6 +30,7 @@ const PaymentMethodOptions = () => {
 		activePaymentMethod,
 		isExpressPaymentMethodActive,
 		availablePaymentMethods,
+		savedPaymentMethods,
 	} = useSelect( ( select ) => {
 		const store = select( paymentStore );
 		return {
@@ -36,6 +38,7 @@ const PaymentMethodOptions = () => {
 			activePaymentMethod: store.getActivePaymentMethod(),
 			isExpressPaymentMethodActive: store.isExpressPaymentMethodActive(),
 			availablePaymentMethods: store.getAvailablePaymentMethods(),
+			savedPaymentMethods: store.getSavedPaymentMethods(),
 		};
 	} );
 	const { __internalSetActivePaymentMethod } = useDispatch( paymentStore );
@@ -83,8 +86,14 @@ const PaymentMethodOptions = () => {
 		]
 	);
 
+	const hasSavedTokens = Object.keys( savedPaymentMethods ).length > 0;
+
 	return isExpressPaymentMethodActive ? null : (
 		<RadioControlAccordion
+			className={ clsx( {
+				'has-single-option':
+					options.length === 1 && ! hasSavedTokens,
+			} ) }
 			highlightChecked={ true }
 			id={ 'wc-payment-method-options' }
 			selected={ activeSavedToken ? null : activePaymentMethod }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -86,7 +86,9 @@ const PaymentMethodOptions = () => {
 		]
 	);
 
-	const hasSavedTokens = Object.keys( savedPaymentMethods ).length > 0;
+	const hasSavedTokens = Object.values( savedPaymentMethods ).some(
+		( methods ) => Array.isArray( methods ) && methods.length > 0
+	);
 
 	return isExpressPaymentMethodActive ? null : (
 		<RadioControlAccordion

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -91,8 +91,7 @@ const PaymentMethodOptions = () => {
 	return isExpressPaymentMethodActive ? null : (
 		<RadioControlAccordion
 			className={ clsx( {
-				'has-single-option':
-					options.length === 1 && ! hasSavedTokens,
+				'has-single-option': options.length === 1 && ! hasSavedTokens,
 			} ) }
 			highlightChecked={ true }
 			id={ 'wc-payment-method-options' }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
@@ -315,4 +315,63 @@ describe( 'PaymentMethods', () => {
 
 		act( () => resetMockSinglePaymentMethod() );
 	} );
+
+	test( 'should apply has-single-option class when only one payment method and no saved tokens', async () => {
+		act( () => {
+			registerMockSinglePaymentMethod();
+		} );
+
+		wpDataFunctions.dispatch( CART_STORE_KEY ).receiveCart( {
+			...previewCart,
+			payment_methods: [ 'cod' ],
+		} );
+
+		await waitFor( () => {
+			expect(
+				wpDataFunctions.select( paymentStore ).getActivePaymentMethod()
+			).toBe( 'cod' );
+		} );
+
+		render( <PaymentMethods /> );
+
+		await waitFor( () => {
+			const paymentMethodOptions = screen.queryByText(
+				/Payment method options/
+			);
+			expect( paymentMethodOptions ).not.toBeNull();
+		} );
+
+		expect(
+			screen.getByTestId( 'payment-method-options-class-name' )
+		).toHaveTextContent( 'has-single-option' );
+
+		act( () => resetMockSinglePaymentMethod() );
+	} );
+
+	test( 'should not apply has-single-option class when multiple payment methods are available', async () => {
+		act( () => {
+			registerMockPaymentMethods();
+		} );
+
+		await waitFor( () => {
+			expect(
+				wpDataFunctions.select( paymentStore ).getActivePaymentMethod()
+			).toBe( 'cod' );
+		} );
+
+		render( <PaymentMethods /> );
+
+		await waitFor( () => {
+			const paymentMethodOptions = screen.queryByText(
+				/Payment method options/
+			);
+			expect( paymentMethodOptions ).not.toBeNull();
+		} );
+
+		expect(
+			screen.getByTestId( 'payment-method-options-class-name' )
+		).not.toHaveTextContent( 'has-single-option' );
+
+		act( () => resetMockPaymentMethods() );
+	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
@@ -374,4 +374,58 @@ describe( 'PaymentMethods', () => {
 
 		act( () => resetMockPaymentMethods() );
 	} );
+
+	test( 'should not apply has-single-option class when saved payment tokens exist', async () => {
+		const originalWpData = jest.requireActual( '@wordpress/data' );
+		const realStore = originalWpData.select( paymentStore );
+
+		// Spy on the real registry selector to simulate saved tokens.
+		const spy = jest
+			.spyOn( realStore, 'getSavedPaymentMethods' )
+			.mockReturnValue( {
+				cc: [
+					{
+						method: {
+							gateway: 'cod',
+							last4: '1234',
+							brand: 'Visa',
+						},
+						expires: '12/30',
+						is_default: true,
+						tokenId: 1,
+					},
+				],
+			} );
+
+		act( () => {
+			registerMockSinglePaymentMethod();
+		} );
+
+		wpDataFunctions.dispatch( CART_STORE_KEY ).receiveCart( {
+			...previewCart,
+			payment_methods: [ 'cod' ],
+		} );
+
+		await waitFor( () => {
+			expect(
+				wpDataFunctions.select( paymentStore ).getActivePaymentMethod()
+			).toBe( 'cod' );
+		} );
+
+		render( <PaymentMethods /> );
+
+		await waitFor( () => {
+			const paymentMethodOptions = screen.queryByText(
+				/Payment method options/
+			);
+			expect( paymentMethodOptions ).not.toBeNull();
+		} );
+
+		expect(
+			screen.getByTestId( 'payment-method-options-class-name' )
+		).not.toHaveTextContent( 'has-single-option' );
+
+		spy.mockRestore();
+		act( () => resetMockSinglePaymentMethod() );
+	} );
 } );

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -120,7 +120,17 @@ $content-padding-left: calc($gap + 24px + $gap-smaller);
 	}
 
 	.wc-block-components-radio-control__input {
-		display: none;
+		// Visually hidden but remains in the accessibility tree so screen
+		// readers still announce the selected state.
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 
 	// Reset the container ::after border so first/last-selected modifiers

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -106,6 +106,32 @@ $content-padding-left: calc($gap + 24px + $gap-smaller);
 	}
 }
 
+// When there is only one option and it shouldn't appear selectable (no
+// alternative to choose), the parent component adds has-single-option.
+.wc-block-components-radio-control.has-single-option {
+	label.wc-block-components-radio-control__option,
+	.wc-block-components-radio-control-accordion-option {
+		box-shadow: none;
+	}
+
+	.wc-block-components-radio-control__option {
+		padding-left: $gap;
+		cursor: default;
+	}
+
+	.wc-block-components-radio-control__input {
+		display: none;
+	}
+
+	// Reset the container ::after border so first/last-selected modifiers
+	// don't remove the top or bottom border.
+	&::after {
+		border: 1px solid $universal-border-light;
+		border-radius: $universal-border-radius;
+		margin: 0;
+	}
+}
+
 // extracted from the styles below to increase specificity
 .wc-block-components-radio-control .wc-block-components-radio-control__option {
 	margin: 0;

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
@@ -259,10 +259,14 @@ test.describe( 'Shopper → Shipping', () => {
 			postcode: 'SW19 5AE',
 		} );
 
-		// With only one shipping rate, the radio button is hidden and the
-		// rate is displayed as plain text (has-single-option styling).
+		// With only one shipping rate, the radio button is visually hidden
+		// (has-single-option styling) but remains in the accessibility tree.
 		await expect(
-			checkoutPageObject.page.getByText( 'Flat rate' )
+			checkoutPageObject.page
+				.getByLabel( 'Checkout' )
+				.locator(
+					'.wc-block-components-radio-control__label:has-text("Flat rate")'
+				)
 		).toBeVisible();
 	} );
 
@@ -309,10 +313,12 @@ test.describe( 'Shopper → Shipping', () => {
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
 		await frontendUtils.goToCheckout();
 
-		// With only one pickup location, the radio button is hidden and the
-		// location is displayed as plain text (has-single-option styling).
+		// With only one pickup location, the radio button is visually hidden
+		// (has-single-option styling) but remains in the accessibility tree.
 		await expect(
-			frontendUtils.page.getByText( 'Automattic, Inc.' )
+			frontendUtils.page.locator(
+				'.wc-block-components-radio-control__label:has-text("Automattic, Inc.")'
+			)
 		).toBeVisible();
 
 		await expect(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
@@ -259,11 +259,11 @@ test.describe( 'Shopper → Shipping', () => {
 			postcode: 'SW19 5AE',
 		} );
 
+		// With only one shipping rate, the radio button is hidden and the
+		// rate is displayed as plain text (has-single-option styling).
 		await expect(
-			checkoutPageObject.page.getByRole( 'radio', {
-				name: 'Flat rate Free',
-			} )
-		).toBeChecked();
+			checkoutPageObject.page.getByText( 'Flat rate' )
+		).toBeVisible();
 	} );
 
 	test( '7. With no shipping methods for the default location, no shipping methods for _any_ other location, local pickup enabled the shopper sees local pickup rates only', async ( {
@@ -309,11 +309,11 @@ test.describe( 'Shopper → Shipping', () => {
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
 		await frontendUtils.goToCheckout();
 
+		// With only one pickup location, the radio button is hidden and the
+		// location is displayed as plain text (has-single-option styling).
 		await expect(
-			frontendUtils.page.getByRole( 'radio', {
-				name: 'Automattic, Inc. free 60 29th',
-			} )
-		).toBeChecked();
+			frontendUtils.page.getByText( 'Automattic, Inc.' )
+		).toBeVisible();
 
 		await expect(
 			frontendUtils.page.getByRole( 'radio', {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When there is only a single shipping rate, pickup location, or payment method in the block checkout, the radio button is hidden and the border uses the thinner unselected style — matching the shipping address section's appearance.

Each consuming component adds a `has-single-option` CSS class to the `RadioControl`/`RadioControlAccordion` when it determines there is only one option:

- **Shipping rates** (`package-rates.tsx`): Applied when `highlightChecked` is true and there is exactly one rate.
- **Local pickup** (`local-pickup-select/index.tsx`): Applied when there is exactly one pickup location.
- **Payment methods** (`payment-method-options.js`): Applied when there is exactly one payment method **and** no saved payment tokens exist (so users can still toggle between saved and new methods).

CSS in `radio-control/style.scss` handles the `has-single-option` class by hiding the radio input, removing the bold box-shadow, adjusting padding, and resetting the container border.

### How to test the changes in this Pull Request:

1. Set up a WooCommerce store with block checkout.
2. Configure only **one shipping method** (e.g., Flat Rate) for the shipping zone.
3. Go to checkout — the shipping section should show the single method without a radio button, with a thin border.
4. Add a second shipping method — both should now show radio buttons with the standard bold-border selection styling.
5. Set up **one pickup location** in WooCommerce > Settings > Shipping > Local pickup. Select "Local pickup" at checkout — the single location should display without a radio button.
6. Add a second pickup location — radio buttons should appear.
7. Configure only **one payment method** (e.g., Cash on Delivery). At checkout, the single payment method should appear without a radio button.
8. Add a second payment method — radio buttons should appear for both.
9. Test with a **saved payment token** (e.g., saved card): even with only one payment gateway, radio buttons should still appear because the user needs to toggle between the saved token and the new payment method form.
10. Verify the **cart page** is unaffected — cart shipping rates should not get the single-option styling (since `highlightChecked` is false on cart).

### Testing that has already taken place:

- Manual testing of all scenarios above in Chrome.
- Jest unit tests added for shipping, pickup, and payment method `has-single-option` class toggling (7 new tests, all passing).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry created manually.

### Screenshots

Multiple shipping methods unchanged:
<img width="684" height="195" alt="Screenshot 2026-04-07 at 19 39 35" src="https://github.com/user-attachments/assets/f570cbdb-5cc6-4325-9d7e-8cba7e616fea" />

Single items have borders and no radio buttons:
<img width="662" height="282" alt="Screenshot 2026-04-07 at 19 26 33" src="https://github.com/user-attachments/assets/fafd5936-2b28-442a-bc18-db019caf2e47" />
<img width="669" height="452" alt="Screenshot 2026-04-07 at 19 26 25" src="https://github.com/user-attachments/assets/5646913a-c6cb-4ca9-9696-7cc97e369fbb" />
