### PR TITLE
Harden email footer placeholder replacements against null input

### DIFF
--- a/plugins/woocommerce/changelog/64056-wooplug-6479-public-function-replace_placeholders-error
+++ b/plugins/woocommerce/changelog/64056-wooplug-6479-public-function-replace_placeholders-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors in email footer placeholder replacement when third-party filters return non-string values.

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -393,6 +393,10 @@ class WC_Emails {
 	 * @return string       Email footer text with any replacements done.
 	 */
 	public function replace_placeholders( $text ) {
+		if ( ! is_string( $text ) ) {
+			$text = is_scalar( $text ) ? (string) $text : '';
+		}
+
 		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
 		return str_replace(

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-completed-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-completed-order.php
@@ -506,6 +506,10 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Completed_Order', false ) ) :
 				return $footer_text;
 			}
 
+			if ( ! is_string( $footer_text ) ) {
+				$footer_text = is_scalar( $footer_text ) ? (string) $footer_text : '';
+			}
+
 			return str_replace(
 				array(
 					'{site_title}',

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-refunded-order.php
@@ -620,6 +620,10 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Refunded_Order', false ) ) :
 				return $footer_text;
 			}
 
+			if ( ! is_string( $footer_text ) ) {
+				$footer_text = is_scalar( $footer_text ) ? (string) $footer_text : '';
+			}
+
 			return str_replace(
 				array(
 					'{site_title}',

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -42,6 +42,26 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that replace_placeholders safely handles null values.
+	 */
+	public function test_replace_placeholders_handles_null_value() {
+		$email_object = new WC_Emails();
+		$this->assertSame( '', $email_object->replace_placeholders( null ) );
+	}
+
+	/**
+	 * Test that replace_placeholders replaces known placeholders.
+	 */
+	public function test_replace_placeholders_replaces_site_title() {
+		$email_object = new WC_Emails();
+		$placeholder  = '{site_title}';
+		$actual       = $email_object->replace_placeholders( $placeholder );
+		$expected     = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
 	 * Test that order meta function outputs linked meta.
 	 */
 	public function test_order_meta() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes a PHP 8 fatal in email footer placeholder replacement when a third-party filter returns `null` (or any non-string value) for `woocommerce_email_footer_text`.

- Added defensive input normalization in `WC_Emails::replace_placeholders()` so non-string values are safely converted to a string (or empty string for non-scalar values) before `str_replace()`.
- Applied the same guard in POS email footer placeholder replacement methods for consistency.
- Added PHPUnit coverage in `WC_Emails_Tests` for null handling and normal `{site_title}` replacement.

Closes #63894, closes WOOPLUG-6479.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add a temporary filter on `woocommerce_email_footer_text` that returns `null`.
2. Trigger an order email (for example, bulk update order statuses in wp-admin).
3. Confirm no PHP fatal is thrown from `WC_Emails::replace_placeholders()` and the email still renders.
4. Run `pnpm run test:php:env -- --filter WC_Emails_Tests --verbose` from `plugins/woocommerce`.
5. Confirm tests pass.

### Testing that has already taken place:

- Ran `pnpm run test:php:env -- --filter WC_Emails_Tests --verbose` from `plugins/woocommerce`.
- Result: `OK (6 tests, 10 assertions)`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent fatal errors in email footer placeholder replacement when third-party filters return non-string values.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

Made with [Cursor](https://cursor.com)