### PR TITLE
Fix button border-radius mismatch in email editor

### DIFF
--- a/packages/php/email-editor/changelog/fix-email-editor-button-border-radius
+++ b/packages/php/email-editor/changelog/fix-email-editor-button-border-radius
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix button border-radius mismatch between email editor preview and rendered output.

--- a/packages/php/email-editor/src/Engine/theme.json
+++ b/packages/php/email-editor/src/Engine/theme.json
@@ -259,6 +259,11 @@
       }
     },
     "elements": {
+      "button": {
+        "border": {
+          "radius": "0px"
+        }
+      },
       "heading": {
         "typography": {
           "fontWeight": "700",


### PR DESCRIPTION
### Submission Review Guidelines:

Closes STOMAIL-7312

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WordPress core `theme.json` sets `styles.elements.button.border.radius` to `9999px`. The WooCommerce Email Editor inherits this value, but the email renderer does not output any border-radius (effectively `0`). This causes a mismatch between the editor preview (rounded buttons) and the rendered email (square buttons).

This PR adds an explicit `border-radius: 0px` override for the button element in `packages/php/email-editor/src/Engine/theme.json`, so the editor preview matches the rendered output for all consumers (MailPoet, WooCommerce transactional emails, etc.).

Previously this was being worked around downstream in MailPoet via the `woocommerce_email_editor_theme_json` filter (mailpoet/mailpoet#6600), but fixing it here benefits all email editor consumers.

### How to test the changes in this Pull Request:

1. Enable the WooCommerce block email editor (if behind a feature flag).
2. Create or edit an email that contains a button block.
3. Observe that the button in the editor preview has square corners (no border-radius), matching the rendered email output.
4. Send a preview email and confirm the button border-radius matches what is shown in the editor.

### Testing that has already taken place:

- Verified the `theme.json` change is consistent with the existing pattern used for other element overrides (e.g., `heading`).
- Reviewed the email renderer to confirm it outputs no border-radius by default.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entry was created manually in `packages/php/email-editor/changelog/`.
