### PR TITLE
Fix account password field showing error on display

### DIFF
--- a/plugins/woocommerce/changelog/64064-opr-fix-password-error-display
+++ b/plugins/woocommerce/changelog/64064-opr-fix-password-error-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix account password field showing validation error immediately when "Create an account" checkbox is checked on checkout.

--- a/plugins/woocommerce/changelog/fix-password-field-validation-on-display
+++ b/plugins/woocommerce/changelog/fix-password-field-validation-on-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix account password field showing validation error immediately when "Create an account" checkbox is checked on checkout.

--- a/plugins/woocommerce/changelog/fix-password-field-validation-on-display
+++ b/plugins/woocommerce/changelog/fix-password-field-validation-on-display
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix account password field showing validation error immediately when "Create an account" checkbox is checked on checkout.

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -320,7 +320,7 @@ jQuery( function ( $ ) {
 
 			if ( $( this ).is( ':checked' ) ) {
 				// Ensure password is not pre-populated.
-				$( '#account_password' ).val( '' ).trigger( 'change' );
+				$( '#account_password' ).val( '' );
 				$( 'div.create-account' ).slideDown();
 			}
 		},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When the "Create an account" checkbox is checked on the shortcode checkout page, the account password field immediately shows a validation error (red border / invalid state) before the user has typed anything.

The root cause is in `toggle_create_account` in `checkout.js`: after clearing the password field with `.val('')`, it calls `.trigger('change')`. The `change` event is handled by `validate_field`, which checks required field validation and marks the empty field as `woocommerce-invalid`.

The fix removes `.trigger('change')` — `.val('')` alone is sufficient to clear any pre-populated password, and there's no downstream listener that needs the change event here.

Closes https://github.com/woocommerce/woocommerce/issues/63787.
Closes WOOPLUG-6449

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Go to WordPress admin → WooCommerce → Settings → Account and Privacy.
2. Under "Account creation", check "Allow customers to create an account during checkout".
3. Under "Account creation options", **uncheck** "When creating an account, send the customer an email with a link to set their password" (so that the password field is shown inline).
4. Save settings.
5. Log out / use an incognito window. Add a product to the cart and proceed to checkout (shortcode checkout page).
6. Check the "Create an account?" checkbox.
7. **Expected:** The password field appears without any validation error styling.
8. **Before fix:** The password field immediately shows a red border / validation error state.

### Testing that has already taken place:

Code review and analysis of the `validate_field` event flow confirming that the `change` event triggers validation on the empty required field.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix account password field showing validation error immediately when "Create an account" checkbox is checked on checkout.

</details>