### PR TITLE
Add WPCOM-authenticated endpoint to retrieve push tokens.

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Controllers;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\Jetpack\Connection\Rest_Authentication;
 use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenNotFoundException;
@@ -67,10 +68,15 @@ class PushTokenRestController extends RestApiControllerBase {
 			$this->rest_base,
 			array(
 				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'index' ),
+					'permission_callback' => array( $this, 'authorize_as_from_wpcom' ),
+				),
+				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => fn ( WP_REST_Request $request ) => $this->run( $request, 'create' ),
 					'args'                => $this->get_args( 'create' ),
-					'permission_callback' => array( $this, 'authorize' ),
+					'permission_callback' => array( $this, 'authorize_as_authenticated' ),
 					'schema'              => array( $this, 'get_schema' ),
 				),
 			)
@@ -84,10 +90,38 @@ class PushTokenRestController extends RestApiControllerBase {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => fn ( WP_REST_Request $request ) => $this->run( $request, 'delete' ),
 					'args'                => $this->get_args( 'delete' ),
-					'permission_callback' => array( $this, 'authorize' ),
+					'permission_callback' => array( $this, 'authorize_as_authenticated' ),
 					'schema'              => array( $this, 'get_schema' ),
 				),
 			)
+		);
+	}
+
+	/**
+	 * Returns all push tokens for roles that can receive push notifications,
+	 * formatted for the WPCOM push notifications endpoint.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return WP_REST_Response
+	 */
+	public function index( WP_REST_Request $request ): WP_REST_Response {
+		$tokens = wc_get_container()
+			->get( PushTokensDataStore::class )
+			->get_tokens_for_roles(
+				PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED
+			);
+
+		return new WP_REST_Response(
+			array(
+				'tokens' => array_map(
+					fn ( $token ) => $token->to_wpcom_format(),
+					$tokens
+				),
+			),
+			WP_Http::OK
 		);
 	}
 
@@ -217,7 +251,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	}
 
 	/**
-	 * Checks user is authorized to access this endpoint.
+	 * Checks user is authenticated and authorized to access this endpoint.
 	 *
 	 * @since 10.6.0
 	 *
@@ -225,7 +259,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 * @return bool|WP_Error
 	 */
-	public function authorize( WP_REST_Request $request ) {
+	public function authorize_as_authenticated( WP_REST_Request $request ) {
 		if ( ! get_current_user_id() ) {
 			return new WP_Error(
 				'woocommerce_rest_cannot_view',
@@ -249,6 +283,35 @@ class PushTokenRestController extends RestApiControllerBase {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Validates that the request is signed with a Jetpack blog token,
+	 * ensuring only WPCOM can access this endpoint.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return bool|WP_Error
+	 */
+	public function authorize_as_from_wpcom( WP_REST_Request $request ) {
+		if ( ! wc_get_container()->get( PushNotifications::class )->should_be_enabled() ) {
+			return false;
+		}
+
+		if (
+			class_exists( Rest_Authentication::class )
+			&& Rest_Authentication::is_signed_with_blog_token()
+		) {
+			return true;
+		}
+
+		return new WP_Error(
+			'woocommerce_rest_cannot_view',
+			__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -105,14 +105,18 @@ class PushTokenRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
-	public function index( WP_REST_Request $request ): WP_REST_Response {
-		$tokens = wc_get_container()
-			->get( PushTokensDataStore::class )
-			->get_tokens_for_roles(
-				PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED
-			);
+	public function index( WP_REST_Request $request ) {
+		try {
+			$tokens = wc_get_container()
+				->get( PushTokensDataStore::class )
+				->get_tokens_for_roles(
+					PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED
+				);
+		} catch ( Exception $e ) {
+			return $this->convert_exception_to_wp_error( $e );
+		}
 
 		return new WP_REST_Response(
 			array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -69,7 +69,7 @@ class PushTokenRestController extends RestApiControllerBase {
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'index' ),
+					'callback'            => fn ( WP_REST_Request $request ) => $this->run( $request, 'index' ),
 					'permission_callback' => array( $this, 'authorize_as_from_wpcom' ),
 				),
 				array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -131,6 +131,11 @@ class PushTokenRestController extends RestApiControllerBase {
 		$per_page = (int) $request->get_param( 'per_page' );
 
 		try {
+			/**
+			 * Paginated result from get_tokens_for_roles.
+			 *
+			 * @var array{tokens: PushToken[], total: int, total_pages: int} $result
+			 */
 			$result = wc_get_container()
 				->get( PushTokensDataStore::class )
 				->get_tokens_for_roles(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -71,6 +71,25 @@ class PushTokenRestController extends RestApiControllerBase {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => fn ( WP_REST_Request $request ) => $this->run( $request, 'index' ),
 					'permission_callback' => array( $this, 'authorize_as_from_wpcom' ),
+					'args'                => array(
+						'page'     => array(
+							'description'       => __( 'Current page of the collection.', 'woocommerce' ),
+							'type'              => 'integer',
+							'default'           => 1,
+							'minimum'           => 1,
+							'sanitize_callback' => 'absint',
+							'validate_callback' => 'rest_validate_request_arg',
+						),
+						'per_page' => array(
+							'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
+							'type'              => 'integer',
+							'default'           => 10,
+							'minimum'           => 1,
+							'maximum'           => 100,
+							'sanitize_callback' => 'absint',
+							'validate_callback' => 'rest_validate_request_arg',
+						),
+					),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
@@ -108,25 +127,35 @@ class PushTokenRestController extends RestApiControllerBase {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function index( WP_REST_Request $request ) {
+		$page     = (int) $request->get_param( 'page' );
+		$per_page = (int) $request->get_param( 'per_page' );
+
 		try {
-			$tokens = wc_get_container()
+			$result = wc_get_container()
 				->get( PushTokensDataStore::class )
 				->get_tokens_for_roles(
-					PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED
+					PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED,
+					$page,
+					$per_page
 				);
 		} catch ( Exception $e ) {
 			return $this->convert_exception_to_wp_error( $e );
 		}
 
-		return new WP_REST_Response(
+		$response = new WP_REST_Response(
 			array(
 				'tokens' => array_map(
 					fn ( $token ) => $token->to_wpcom_format(),
-					$tokens
+					$result['tokens']
 				),
 			),
 			WP_Http::OK
 		);
+
+		$response->header( 'X-WP-Total', (string) $result['total'] );
+		$response->header( 'X-WP-TotalPages', (string) $result['total_pages'] );
+
+		return $response;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -25,10 +25,10 @@ use WP_Query;
 class PushTokensDataStore {
 	/**
 	 * In-memory cache for get_tokens_for_roles() results, keyed by the
-	 * comma-joined role list. Avoids repeated DB queries within the same
-	 * PHP request.
+	 * comma-joined role list (with optional pagination suffix). Avoids
+	 * repeated DB queries within the same PHP request.
 	 *
-	 * @var array<string, PushToken[]>
+	 * @var array<string, PushToken[]|array{tokens: PushToken[], total: int, total_pages: int}>
 	 */
 	private array $tokens_by_roles_cache = array();
 
@@ -326,9 +326,16 @@ class PushTokensDataStore {
 	 * @since 10.7.0
 	 */
 	public function get_tokens_for_roles( array $roles, ?int $page = null, ?int $per_page = null ) {
-		$paginate     = null !== $page && null !== $per_page;
-		$cache_key    = $paginate ? implode( ',', $roles ) . ":$page:$per_page" : implode( ',', $roles );
-		$empty_result = $paginate ? array( 'tokens' => array(), 'total' => 0, 'total_pages' => 0 ) : array();
+		$paginate  = null !== $page && null !== $per_page;
+		$cache_key = $paginate ? implode( ',', $roles ) . ":$page:$per_page" : implode( ',', $roles );
+
+		$empty_result = $paginate
+			? array(
+				'tokens'      => array(),
+				'total'       => 0,
+				'total_pages' => 0,
+			)
+			: array();
 
 		if ( empty( $roles ) ) {
 			return $empty_result;
@@ -399,9 +406,9 @@ class PushTokensDataStore {
 
 		$result = $paginate
 			? array(
-				'tokens' => $tokens,
-				'total' => (int) $query->found_posts,
-				'total_pages' => (int) $query->max_num_pages
+				'tokens'      => $tokens,
+				'total'       => (int) $query->found_posts,
+				'total_pages' => (int) $query->max_num_pages,
 			)
 			: $tokens;
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -312,19 +312,27 @@ class PushTokensDataStore {
 	}
 
 	/**
-	 * Returns all push tokens belonging to users with the given roles.
+	 * Returns push tokens belonging to users with the given roles.
 	 *
-	 * @param string[] $roles The roles to query tokens for.
-	 * @return PushToken[]
+	 * When called without pagination parameters, returns all tokens as a
+	 * flat array (cached per-request). When $page and $per_page are
+	 * provided, returns a paginated result with total counts.
+	 *
+	 * @param string[] $roles    The roles to query tokens for.
+	 * @param int|null $page     Optional page number (1-based).
+	 * @param int|null $per_page Optional number of tokens per page.
+	 * @return PushToken[]|array{tokens: PushToken[], total: int, total_pages: int}
 	 *
 	 * @since 10.7.0
 	 */
-	public function get_tokens_for_roles( array $roles ): array {
-		if ( empty( $roles ) ) {
-			return array();
-		}
+	public function get_tokens_for_roles( array $roles, ?int $page = null, ?int $per_page = null ) {
+		$paginate     = null !== $page && null !== $per_page;
+		$cache_key    = $paginate ? implode( ',', $roles ) . ":$page:$per_page" : implode( ',', $roles );
+		$empty_result = $paginate ? array( 'tokens' => array(), 'total' => 0, 'total_pages' => 0 ) : array();
 
-		$cache_key = implode( ',', $roles );
+		if ( empty( $roles ) ) {
+			return $empty_result;
+		}
 
 		if ( isset( $this->tokens_by_roles_cache[ $cache_key ] ) ) {
 			return $this->tokens_by_roles_cache[ $cache_key ];
@@ -338,19 +346,25 @@ class PushTokensDataStore {
 		);
 
 		if ( empty( $user_ids ) ) {
-			$this->tokens_by_roles_cache[ $cache_key ] = array();
+			$this->tokens_by_roles_cache[ $cache_key ] = $empty_result;
 			return $this->tokens_by_roles_cache[ $cache_key ];
 		}
 
-		$query = new WP_Query(
-			array(
-				'post_type'      => PushToken::POST_TYPE,
-				'post_status'    => 'private',
-				'author__in'     => $user_ids,
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-			)
+		$query_args = array(
+			'post_type'      => PushToken::POST_TYPE,
+			'post_status'    => 'private',
+			'author__in'     => $user_ids,
+			'posts_per_page' => $paginate ? $per_page : -1,
+			'fields'         => 'ids',
 		);
+
+		if ( $paginate ) {
+			$query_args['paged']   = $page;
+			$query_args['orderby'] = 'ID';
+			$query_args['order']   = 'ASC';
+		}
+
+		$query = new WP_Query( $query_args );
 
 		/**
 		 * Typehint for PHPStan, specifies these are IDs and not instances of
@@ -361,7 +375,7 @@ class PushTokensDataStore {
 		$post_ids = $query->posts;
 
 		if ( empty( $post_ids ) ) {
-			$this->tokens_by_roles_cache[ $cache_key ] = array();
+			$this->tokens_by_roles_cache[ $cache_key ] = $empty_result;
 			return $this->tokens_by_roles_cache[ $cache_key ];
 		}
 
@@ -383,9 +397,16 @@ class PushTokensDataStore {
 			}
 		}
 
-		$this->tokens_by_roles_cache[ $cache_key ] = $tokens;
+		$result = $paginate
+			? array(
+				'tokens' => $tokens,
+				'total' => (int) $query->found_posts,
+				'total_pages' => (int) $query->max_num_pages
+			)
+			: $tokens;
 
-		return $tokens;
+		$this->tokens_by_roles_cache[ $cache_key ] = $result;
+		return $result;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Services;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\WpcomNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
@@ -122,6 +123,11 @@ class NotificationProcessor {
 			$notification->write_meta( self::CLAIMED_META_KEY );
 		}
 
+		/**
+		 * Non-paginated result from get_tokens_for_roles.
+		 *
+		 * @var PushToken[] $tokens
+		 */
 		$tokens = $this->data_store->get_tokens_for_roles(
 			PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1056,7 +1056,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$controller = new PushTokenRestController();
 		$request    = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
 
-		$result = $controller->authorize( $request );
+		$result = $controller->authorize_as_authenticated( $request );
 
 		$this->assertFalse( $result );
 	}
@@ -1073,7 +1073,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$controller = new PushTokenRestController();
 		$request    = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
 
-		$result = $controller->authorize( $request );
+		$result = $controller->authorize_as_authenticated( $request );
 
 		$this->assertTrue( $result );
 	}
@@ -1089,7 +1089,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$controller = new PushTokenRestController();
 		$request    = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
 
-		$result = $controller->authorize( $request );
+		$result = $controller->authorize_as_authenticated( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'woocommerce_rest_cannot_view', $result->get_error_code() );
@@ -1106,7 +1106,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$controller = new PushTokenRestController();
 		$request    = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
 
-		$result = $controller->authorize( $request );
+		$result = $controller->authorize_as_authenticated( $request );
 
 		$this->assertFalse( $result );
 	}
@@ -1417,5 +1417,83 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'en_US', $meta['device_locale'] );
 		$this->assertArrayHasKey( 'metadata', $meta );
 		$this->assertEquals( array( 'app_version' => '1.0' ), maybe_unserialize( $meta['metadata'] ) );
+	}
+
+	/**
+	 * @testdox Should reject WPCOM tokens endpoint when push notifications are disabled.
+	 */
+	public function test_authorize_as_from_wpcom_returns_false_when_disabled(): void {
+		$this->mock_jetpack_connection_manager_is_connected( false );
+
+		$controller = new PushTokenRestController();
+		$request    = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
+
+		$result = $controller->authorize_as_from_wpcom( $request );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @testdox Should reject WPCOM tokens endpoint without Jetpack blog token authentication.
+	 */
+	public function test_index_rejects_without_blog_token(): void {
+		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( rest_authorization_required_code(), $response->get_status() );
+	}
+
+	/**
+	 * @testdox Should return tokens in WPCOM format from the tokens endpoint.
+	 */
+	public function test_index_returns_wpcom_formatted_tokens(): void {
+		$this->mock_jetpack_connection_manager_is_connected();
+		wc_get_container()->get( PushNotifications::class )->on_init();
+
+		$data_store = wc_get_container()->get( PushTokensDataStore::class );
+
+		$data_store->create(
+			array(
+				'user_id'       => $this->user_id,
+				'token'         => 'wpcom-test-token',
+				'platform'      => PushToken::PLATFORM_APPLE,
+				'device_uuid'   => 'wpcom-test-uuid',
+				'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+				'device_locale' => 'en_US',
+			)
+		);
+
+		$controller = new PushTokenRestController();
+		$request    = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
+		$response   = $controller->index( $request );
+
+		$this->assertEquals( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'tokens', $data );
+		$this->assertGreaterThanOrEqual( 1, count( $data['tokens'] ) );
+
+		$token_data = $data['tokens'][0];
+
+		$this->assertSame( 'wpcom-test-token', $token_data['token'] );
+		$this->assertSame( PushToken::ORIGIN_WOOCOMMERCE_IOS, $token_data['origin'] );
+		$this->assertSame( 'en_US', $token_data['device_locale'] );
+	}
+
+	/**
+	 * @testdox Should return empty tokens array from the tokens endpoint when no tokens exist.
+	 */
+	public function test_index_returns_empty_when_no_tokens(): void {
+		$controller = new PushTokenRestController();
+		$request    = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
+		$response   = $controller->index( $request );
+
+		$this->assertEquals( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'tokens', $data );
+		$this->assertCount( 0, $data['tokens'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1470,7 +1470,9 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$controller = new PushTokenRestController();
 		$request    = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
-		$response   = $controller->index( $request );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 100 );
+		$response = $controller->index( $request );
 
 		$this->assertEquals( WP_Http::OK, $response->get_status() );
 
@@ -1484,6 +1486,9 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 'wpcom-test-token', $token_data['token'] );
 		$this->assertSame( PushToken::ORIGIN_WOOCOMMERCE_IOS, $token_data['origin'] );
 		$this->assertSame( 'en_US', $token_data['device_locale'] );
+
+		$this->assertNotEmpty( $response->get_headers()['X-WP-Total'] );
+		$this->assertNotEmpty( $response->get_headers()['X-WP-TotalPages'] );
 	}
 
 	/**
@@ -1492,7 +1497,9 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function test_index_returns_empty_when_no_tokens(): void {
 		$controller = new PushTokenRestController();
 		$request    = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
-		$response   = $controller->index( $request );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 100 );
+		$response = $controller->index( $request );
 
 		$this->assertEquals( WP_Http::OK, $response->get_status() );
 
@@ -1500,5 +1507,46 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->assertArrayHasKey( 'tokens', $data );
 		$this->assertCount( 0, $data['tokens'] );
+		$this->assertSame( '0', $response->get_headers()['X-WP-Total'] );
+		$this->assertSame( '0', $response->get_headers()['X-WP-TotalPages'] );
+	}
+
+	/**
+	 * @testdox Should respect per_page parameter and return pagination headers.
+	 */
+	public function test_index_respects_pagination(): void {
+		$this->mock_jetpack_connection_manager_is_connected();
+		wc_get_container()->get( PushNotifications::class )->on_init();
+
+		$data_store = wc_get_container()->get( PushTokensDataStore::class );
+
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$data_store->create(
+				array(
+					'user_id'       => $this->user_id,
+					'token'         => "token-$i",
+					'platform'      => PushToken::PLATFORM_APPLE,
+					'device_uuid'   => "uuid-$i",
+					'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+					'device_locale' => 'en_US',
+				)
+			);
+		}
+
+		$controller = new PushTokenRestController();
+		$request    = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 2 );
+		$response = $controller->index( $request );
+
+		$this->assertEquals( WP_Http::OK, $response->get_status() );
+		$this->assertCount( 2, $response->get_data()['tokens'] );
+		$this->assertSame( '3', $response->get_headers()['X-WP-Total'] );
+		$this->assertSame( '2', $response->get_headers()['X-WP-TotalPages'] );
+
+		$request->set_param( 'page', 2 );
+		$response = $controller->index( $request );
+
+		$this->assertCount( 1, $response->get_data()['tokens'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1437,10 +1437,15 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * @testdox Should reject WPCOM tokens endpoint without Jetpack blog token authentication.
 	 */
 	public function test_index_rejects_without_blog_token(): void {
-		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
-		$response = $this->server->dispatch( $request );
+		$this->mock_jetpack_connection_manager_is_connected();
 
-		$this->assertEquals( rest_authorization_required_code(), $response->get_status() );
+		$controller = new PushTokenRestController();
+		$request    = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
+
+		$result = $controller->authorize_as_from_wpcom( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'woocommerce_rest_cannot_view', $result->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
**Focus**: WooCommerce-driven Push Notifications
**Team**: Apps Infrastructure
**Relates to**: AINFRA-2095
**Roadmap**: [ROADMAP.md](https://github.com/woocommerce/woocommerce/blob/293189544c9eb8353b4d46027424dbfe28fde461/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md) or paaHJt-9vT-p2

Apps Infrastructure are currently working with Kiwi to allow WooCommerce instances to trigger their own push notifications, rather than relying on Jetpack Sync. When discussing this with Woo teams, there was a concern that WPCOM would no longer have access to device tokens. This was relevant as Peacock are scoping a marketing project that involves sending push notifications to store owners. To support this, WPCOM needs a way to retrieve device tokens from Woo stores.

**Key requirements:**
* Add `index` method to `PushTokenRestController` which can be used to retrieve tokens
* New `index` method should only be available to WPCOM - the approach used follows those of `AgenticCheckoutUtils` and `WC_REST_PayPal_Webhooks_Controller`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
These new files are not yet used so there is no new functionality to test, however you can run through some regression test steps. My suggested steps are below.

#### Prerequisites

**Before testing, ensure:**
- You have a WooCommerce site with Jetpack Connection package installed and connected (I couldn't find a way to connect without installing the full Jetpack plugin, but I think they're working on that)
- Replace the WooCommerce core files with the files from this PR
- You have at least 1 test user with `shop_manager` or `administrator` roles
- You have enabled the feature (see below)
- You have registered an iOS* token with your WooCommerce site (see below) - the current version of the iOS app supports remote notifications, Android does not
- **IMPORTANT:** If you have Jetpack Sync installed (via the Jetpack plugin), then also disable it or you won't know if Woo or Jetpack Sync is sending the notifications. I had to install Jetpack, connect, and then deactivate it to get to the right state

**Enabling/Disabling the Feature:**
The push notifications feature is controlled by the FeaturesController and requires both the feature flag to be
enabled AND Jetpack to be connected.
```
update_option( 'woocommerce_feature_push_notifications_enabled', 'yes' );
```

**Registering a Token:**
You can find your token by finding the most recently active token on [this page](https://mc.a8c.com/mobile/push-notifications/) for WooCommerce iOS, then using this cURL example to send it to your site:
```
curl --location 'https://YOUR_TEST_SITE_HERE/wp-json/wc-push-notifications/push-tokens' \
	--header 'Accept: application/json' \
	--header 'Authorization: YOUR_BASIC_AUTH_TOKEN_HERE' \
	--form 'token="YOUR_TOKEN_HERE"' \
	--form 'platform="apple"' \
	--form 'device_uuid="ABCDEF-123ABC-DEF123-ABCDE81"' \
	--form 'origin="com.automattic.woocommerce"' \
	--form 'metadata[app_version]="1.0"' \
	--form 'device_locale="en_US"'
```

#### Testing steps

You can test this on your own setup, or use the JN blog that I set up with this branch's changes (ID: 254010274). 

1. Make a request to the new endpoint with a valid blog token - this is easiest to do from your WPCOM sandbox as the Jetpack tokens are hard to generate otherwise. You can so this by pasting this onto your sandbox file:
```
$blog_id =<BLOG_ID>;
$site_url = get_blog_option( $blog_id, 'siteurl' );
$target_url = trailingslashit( $site_url ) . 'wp-json/wc-push-notifications/push-tokens';

/** Make a signed GET request using the Jetpack blog token. */
$response = Jetpack_Client::remote_request(
	array(
		'blog_id' => $blog_id,
		'user_id' => 0,
		'url'     => $target_url,
		'method'  => 'GET',
		'timeout' => 15,
	)
);

var_export( wp_remote_retrieve_body( $response ) );
exit;
```
2. Assert you see tokens in the response

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an internal library, and is not yet complete.

</details>
