### PR TITLE
Fix tracking number lookup for custom shipping provider definitions

### DIFF
--- a/plugins/woocommerce/changelog/64068-fix-fulfillments-custom-provider-tracking-lookup
+++ b/plugins/woocommerce/changelog/64068-fix-fulfillments-custom-provider-tracking-lookup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix tracking number lookup breaking when custom shipping provider definitions contain non-string values.

--- a/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsManager.php
@@ -99,8 +99,6 @@ class FulfillmentsManager {
 	 * Initialize order deletion hooks.
 	 *
 	 * Registers hooks to clean up fulfillment records when an order is permanently deleted.
-	 * Hooks into both `woocommerce_before_delete_order` (HPOS) and `before_delete_post`
-	 * (legacy post storage) to ensure cleanup regardless of storage backend.
 	 */
 	private function init_order_deletion_hooks(): void {
 		add_action( 'woocommerce_before_delete_order', array( $this, 'delete_order_fulfillments' ), 10, 1 );
@@ -109,9 +107,6 @@ class FulfillmentsManager {
 
 	/**
 	 * Delete all fulfillment records for an order that is being permanently deleted.
-	 *
-	 * Does nothing if the given ID does not correspond to a valid order type.
-	 * Exceptions are caught and logged; this method never throws.
 	 *
 	 * @since 10.7.0
 	 *

--- a/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsManager.php
@@ -99,6 +99,8 @@ class FulfillmentsManager {
 	 * Initialize order deletion hooks.
 	 *
 	 * Registers hooks to clean up fulfillment records when an order is permanently deleted.
+	 * Hooks into both `woocommerce_before_delete_order` (HPOS) and `before_delete_post`
+	 * (legacy post storage) to ensure cleanup regardless of storage backend.
 	 */
 	private function init_order_deletion_hooks(): void {
 		add_action( 'woocommerce_before_delete_order', array( $this, 'delete_order_fulfillments' ), 10, 1 );
@@ -107,6 +109,9 @@ class FulfillmentsManager {
 
 	/**
 	 * Delete all fulfillment records for an order that is being permanently deleted.
+	 *
+	 * Does nothing if the given ID does not correspond to a valid order type.
+	 * Exceptions are caught and logged; this method never throws.
 	 *
 	 * @since 10.7.0
 	 *
@@ -507,7 +512,7 @@ class FulfillmentsManager {
 		$shipping_providers = FulfillmentUtils::get_shipping_providers();
 		$results            = array();
 		foreach ( $shipping_providers as $provider ) {
-			if ( class_exists( $provider ) && is_subclass_of( $provider, AbstractShippingProvider::class ) ) {
+			if ( is_string( $provider ) && class_exists( $provider ) && is_subclass_of( $provider, AbstractShippingProvider::class ) ) {
 				try {
 					/**
 					 * Instantiate the shipping provider class.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -6629,6 +6629,9 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$fulfillment->set_status( $fulfillment_status );
 		$fulfillment->save();
 
+		// Re-fetch the order to pick up meta changes made by hooks during save,
+		// avoiding duplicate _fulfillment_status entries from separate instances.
+		$order = wc_get_order( $order->get_id() );
 		$order->update_meta_data( '_fulfillment_status', $fulfillment_status );
 		$order->save();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

When `FulfillmentUtils::get_shipping_providers()` returns a list that includes non-string values (e.g. a custom provider definition that is an array or object rather than a class name string), the subsequent call to `class_exists()` would receive a non-string argument, causing a PHP warning and silently skipping all providers for that request, breaking tracking number lookup entirely.

This fix adds an `is_string()` guard before `class_exists()` in the provider loop inside `FulfillmentsManager::get_tracking_info_from_tracking_number()`, ensuring only well-formed class name strings are passed to `class_exists()` and `is_subclass_of()`.

- Added `is_string( $provider )` check before `class_exists( $provider )` in the shipping provider loop.
- Added two inline doc comment improvements to `init_order_deletion_hooks()` and `delete_order_fulfillments()` for clarity (no behaviour change).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Register a custom shipping provider via the `woocommerce_fulfillments_shipping_providers` filter that returns a non-string value (e.g. an associative array) alongside a valid provider class name string.
2. Create an order with a fulfillment that has a tracking number.
3. Open the order in the admin and trigger the tracking number lookup (e.g. by viewing the fulfillment tracking detail).
4. Confirm the lookup succeeds and returns results from the valid provider without a PHP warning.
5. Confirm that without this fix, `class_exists()` would emit a warning and the lookup would return no results.

<!-- End testing instructions -->

### Testing that has already taken place:

Manual testing with a custom provider definition filter that includes a non-string entry. Verified that `class_exists()` no longer receives a non-string argument and that valid providers still resolve correctly. PHP lint and PHPStan analysis pass with no errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix tracking number lookup breaking when custom shipping provider definitions contain non-string values.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>