### PR TITLE
Fix email preview padding for template-level blocks with preset variables

### DIFF
--- a/packages/php/email-editor/changelog/fix-email-editor-preset-padding-resolution
+++ b/packages/php/email-editor/changelog/fix-email-editor-preset-padding-resolution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolve preset variable references in Spacing_Preprocessor container padding to fix padding mismatch for template-level blocks in email previews.

--- a/packages/php/email-editor/changelog/fix-email-editor-preset-padding-resolution
+++ b/packages/php/email-editor/changelog/fix-email-editor-preset-padding-resolution
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Resolve preset variable references in Spacing_Preprocessor container padding to fix padding mismatch for template-level blocks in email previews.
+Resolve preset variable references in Spacing_Preprocessor container padding to fix padding mismatch for template-level blocks in email previews. Extract shared Preset_Variable_Resolver utility to eliminate duplicated resolution logic across Content_Renderer, Blocks_Width_Preprocessor, Spacing_Preprocessor, and Theme_Controller.

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-blocks-width-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-blocks-width-preprocessor.php
@@ -8,6 +8,8 @@
 declare(strict_types = 1);
 namespace Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Preprocessors;
 
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Preset_Variable_Resolver;
+
 /**
  * This class sets the width of the blocks based on the layout width or column count.
  * The final width in pixels is stored in the email_attrs array because we would like to avoid changing the original attributes.
@@ -64,8 +66,8 @@ class Blocks_Width_Preprocessor implements Preprocessor {
 				$layout_width -= $this->parse_number_from_string_with_pixels( $block['email_attrs']['root-padding-left'] ?? '0px' );
 				$layout_width -= $this->parse_number_from_string_with_pixels( $block['email_attrs']['root-padding-right'] ?? '0px' );
 				// Container padding may be preset references (var:preset|spacing|20).
-				$layout_width -= $this->parse_number_from_string_with_pixels( $this->resolve_preset_value( $block['email_attrs']['container-padding-left'] ?? '0px', $variables_map ) );
-				$layout_width -= $this->parse_number_from_string_with_pixels( $this->resolve_preset_value( $block['email_attrs']['container-padding-right'] ?? '0px', $variables_map ) );
+				$layout_width -= $this->parse_number_from_string_with_pixels( Preset_Variable_Resolver::resolve( $block['email_attrs']['container-padding-left'] ?? '0px', $variables_map ) );
+				$layout_width -= $this->parse_number_from_string_with_pixels( Preset_Variable_Resolver::resolve( $block['email_attrs']['container-padding-right'] ?? '0px', $variables_map ) );
 			}
 
 			// Resolve block padding — may be preset references like var:preset|spacing|20.
@@ -73,8 +75,8 @@ class Blocks_Width_Preprocessor implements Preprocessor {
 			// has been distributed per-block by the Spacing_Preprocessor. Zero it out
 			// so children get the full available width.
 			$suppress_h_padding  = ! empty( $block['email_attrs']['suppress-horizontal-padding'] );
-			$block_padding_left  = $suppress_h_padding ? '0px' : $this->resolve_preset_value( $block['attrs']['style']['spacing']['padding']['left'] ?? '0px', $variables_map );
-			$block_padding_right = $suppress_h_padding ? '0px' : $this->resolve_preset_value( $block['attrs']['style']['spacing']['padding']['right'] ?? '0px', $variables_map );
+			$block_padding_left  = $suppress_h_padding ? '0px' : Preset_Variable_Resolver::resolve( $block['attrs']['style']['spacing']['padding']['left'] ?? '0px', $variables_map );
+			$block_padding_right = $suppress_h_padding ? '0px' : Preset_Variable_Resolver::resolve( $block['attrs']['style']['spacing']['padding']['right'] ?? '0px', $variables_map );
 
 			$width_input = $block['attrs']['width'] ?? '100%';
 			// Currently we support only % and px units in case only the number is provided we assume it's %
@@ -139,27 +141,6 @@ class Blocks_Width_Preprocessor implements Preprocessor {
 	}
 
 	/**
-	 * Resolve a CSS value that may contain a preset variable reference.
-	 *
-	 * Block attributes store padding as preset references like
-	 * "var:preset|spacing|20" which resolve to actual pixel values
-	 * (e.g. "8px"). This method converts the reference to its resolved
-	 * value using the variables map passed through styles.
-	 *
-	 * @param string $value The CSS value, possibly a preset reference.
-	 * @param array  $variables_map Map of CSS variable names to resolved values.
-	 * @return string The resolved value (e.g. "8px") or the original value.
-	 */
-	private function resolve_preset_value( string $value, array $variables_map ): string {
-		if ( strpos( $value, 'var:preset|' ) !== 0 ) {
-			return $value;
-		}
-
-		$css_var_name = '--wp--' . str_replace( '|', '--', str_replace( 'var:', '', $value ) );
-		return $variables_map[ $css_var_name ] ?? $value;
-	}
-
-	/**
 	 * Add missing column widths
 	 *
 	 * @param array $columns Columns.
@@ -177,8 +158,8 @@ class Blocks_Width_Preprocessor implements Preprocessor {
 				$defined_column_width += $this->convert_width_to_pixels( $column['attrs']['width'], $columns_width );
 			} else {
 				// When width is not set we need to add padding to the defined column width for better ratio accuracy.
-				$defined_column_width += $this->parse_number_from_string_with_pixels( $this->resolve_preset_value( $column['attrs']['style']['spacing']['padding']['left'] ?? '0px', $variables_map ) );
-				$defined_column_width += $this->parse_number_from_string_with_pixels( $this->resolve_preset_value( $column['attrs']['style']['spacing']['padding']['right'] ?? '0px', $variables_map ) );
+				$defined_column_width += $this->parse_number_from_string_with_pixels( Preset_Variable_Resolver::resolve( $column['attrs']['style']['spacing']['padding']['left'] ?? '0px', $variables_map ) );
+				$defined_column_width += $this->parse_number_from_string_with_pixels( Preset_Variable_Resolver::resolve( $column['attrs']['style']['spacing']['padding']['right'] ?? '0px', $variables_map ) );
 				$border_width          = $column['attrs']['style']['border']['width'] ?? '0px';
 				$defined_column_width += $this->parse_number_from_string_with_pixels( $column['attrs']['style']['border']['left']['width'] ?? $border_width );
 				$defined_column_width += $this->parse_number_from_string_with_pixels( $column['attrs']['style']['border']['right']['width'] ?? $border_width );
@@ -191,8 +172,8 @@ class Blocks_Width_Preprocessor implements Preprocessor {
 				if ( ! isset( $column['attrs']['width'] ) || empty( $column['attrs']['width'] ) ) {
 					// Add padding to the specific column width because it's not included in the default width.
 					$column_width                      = $default_columns_width;
-					$column_width                     += $this->parse_number_from_string_with_pixels( $this->resolve_preset_value( $column['attrs']['style']['spacing']['padding']['left'] ?? '0px', $variables_map ) );
-					$column_width                     += $this->parse_number_from_string_with_pixels( $this->resolve_preset_value( $column['attrs']['style']['spacing']['padding']['right'] ?? '0px', $variables_map ) );
+					$column_width                     += $this->parse_number_from_string_with_pixels( Preset_Variable_Resolver::resolve( $column['attrs']['style']['spacing']['padding']['left'] ?? '0px', $variables_map ) );
+					$column_width                     += $this->parse_number_from_string_with_pixels( Preset_Variable_Resolver::resolve( $column['attrs']['style']['spacing']['padding']['right'] ?? '0px', $variables_map ) );
 					$border_width                      = $column['attrs']['style']['border']['width'] ?? '0px';
 					$column_width                     += $this->parse_number_from_string_with_pixels( $column['attrs']['style']['border']['left']['width'] ?? $border_width );
 					$column_width                     += $this->parse_number_from_string_with_pixels( $column['attrs']['style']['border']['right']['width'] ?? $border_width );

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
@@ -8,6 +8,8 @@
 declare(strict_types = 1);
 namespace Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Preprocessors;
 
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Preset_Variable_Resolver;
+
 /**
  * This preprocessor is responsible for setting default spacing values for blocks.
  * In the early development phase, we are setting only margin-top for blocks that are not first or last in the columns block.
@@ -64,8 +66,8 @@ class Spacing_Preprocessor implements Preprocessor {
 
 		// Resolve preset variable references (e.g. "var:preset|spacing|20")
 		// to their pixel values so downstream consumers get usable CSS values.
-		$left  = $this->resolve_preset_value( $left, $variables_map );
-		$right = $this->resolve_preset_value( $right, $variables_map );
+		$left  = Preset_Variable_Resolver::resolve( $left, $variables_map );
+		$right = Preset_Variable_Resolver::resolve( $right, $variables_map );
 
 		if ( $this->is_zero_value( $left ) && $this->is_zero_value( $right ) ) {
 			return array();
@@ -336,25 +338,6 @@ class Spacing_Preprocessor implements Preprocessor {
 			'left'  => $left,
 			'right' => $right,
 		);
-	}
-
-	/**
-	 * Resolve a CSS value that may contain a preset variable reference.
-	 *
-	 * Block attributes store padding as preset references like
-	 * "var:preset|spacing|20" which resolve to actual pixel values.
-	 *
-	 * @param string $value The CSS value, possibly a preset reference.
-	 * @param array  $variables_map Map of CSS variable names to resolved values.
-	 * @return string The resolved value (e.g. "20px") or the original value.
-	 */
-	private function resolve_preset_value( string $value, array $variables_map ): string {
-		if ( empty( $variables_map ) || strpos( $value, 'var:preset|' ) !== 0 ) {
-			return $value;
-		}
-
-		$css_var_name = '--wp--' . str_replace( '|', '--', str_replace( 'var:', '', $value ) );
-		return $variables_map[ $css_var_name ] ?? $value;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
@@ -31,17 +31,22 @@ class Spacing_Preprocessor implements Preprocessor {
 	public function preprocess( array $parsed_blocks, array $layout, array $styles ): array {
 		$root_padding      = $this->get_root_padding( $styles );
 		$container_padding = $styles['__container_padding'] ?? array();
-		$parsed_blocks     = $this->add_block_gaps( $parsed_blocks, $styles['spacing']['blockGap'] ?? '', null, $root_padding, false, $container_padding );
+		$variables_map     = $styles['__variables_map'] ?? array();
+		$parsed_blocks     = $this->add_block_gaps( $parsed_blocks, $styles['spacing']['blockGap'] ?? '', null, $root_padding, false, $container_padding, $variables_map );
 		return $parsed_blocks;
 	}
 
 	/**
 	 * Extract and validate horizontal padding from a block's style attributes.
 	 *
+	 * Preset variable references (e.g. "var:preset|spacing|20") are resolved
+	 * to their pixel values using the variables map when provided.
+	 *
 	 * @param array $block The block to extract padding from.
+	 * @param array $variables_map Map of CSS variable names to resolved values.
 	 * @return array Padding with 'left' and 'right' keys, or empty array if invalid/absent.
 	 */
-	private function get_block_horizontal_padding( array $block ): array {
+	private function get_block_horizontal_padding( array $block, array $variables_map = array() ): array {
 		$padding   = $block['attrs']['style']['spacing']['padding'] ?? array();
 		$has_left  = isset( $padding['left'] );
 		$has_right = isset( $padding['right'] );
@@ -56,6 +61,11 @@ class Spacing_Preprocessor implements Preprocessor {
 		if ( ! is_string( $left ) || ! is_string( $right ) || preg_match( '/[<>"\']/', $left . $right ) ) {
 			return array();
 		}
+
+		// Resolve preset variable references (e.g. "var:preset|spacing|20")
+		// to their pixel values so downstream consumers get usable CSS values.
+		$left  = $this->resolve_preset_value( $left, $variables_map );
+		$right = $this->resolve_preset_value( $right, $variables_map );
 
 		if ( $this->is_zero_value( $left ) && $this->is_zero_value( $right ) ) {
 			return array();
@@ -101,9 +111,10 @@ class Spacing_Preprocessor implements Preprocessor {
 	 * @param array      $root_padding Root horizontal padding with 'left' and 'right' keys.
 	 * @param bool       $apply_root_padding Whether this block should receive root padding (delegated by parent container).
 	 * @param array      $container_padding Container horizontal padding with 'left' and 'right' keys.
+	 * @param array      $variables_map Map of CSS variable names to resolved values for preset resolution.
 	 * @return array
 	 */
-	private function add_block_gaps( array $parsed_blocks, string $gap = '', $parent_block = null, array $root_padding = array(), bool $apply_root_padding = false, array $container_padding = array() ): array {
+	private function add_block_gaps( array $parsed_blocks, string $gap = '', $parent_block = null, array $root_padding = array(), bool $apply_root_padding = false, array $container_padding = array(), array $variables_map = array() ): array {
 		foreach ( $parsed_blocks as $key => $block ) {
 			$block_name        = $block['blockName'] ?? '';
 			$parent_block_name = $parent_block['blockName'] ?? '';
@@ -177,7 +188,7 @@ class Spacing_Preprocessor implements Preprocessor {
 				// When a container wrapping post-content has its own non-zero
 				// horizontal padding, distribute it as container-padding to
 				// descendant blocks and suppress the container's own CSS padding.
-				$block_padding = $this->get_block_horizontal_padding( $block );
+				$block_padding = $this->get_block_horizontal_padding( $block, $variables_map );
 				if ( ! empty( $block_padding ) ) {
 					$children_container_pad                              = $block_padding;
 					$block['email_attrs']['suppress-horizontal-padding'] = true;
@@ -186,7 +197,7 @@ class Spacing_Preprocessor implements Preprocessor {
 				// Root-level container with own padding that wraps post-content:
 				// distribute its padding as container-padding and suppress its own CSS.
 				$children_apply = true;
-				$block_padding  = $this->get_block_horizontal_padding( $block );
+				$block_padding  = $this->get_block_horizontal_padding( $block, $variables_map );
 				if ( ! empty( $block_padding ) ) {
 					$children_container_pad                              = $block_padding;
 					$block['email_attrs']['suppress-horizontal-padding'] = true;
@@ -197,7 +208,7 @@ class Spacing_Preprocessor implements Preprocessor {
 				unset( $block['email_attrs']['root-padding-left'], $block['email_attrs']['root-padding-right'] );
 			}
 
-			$block['innerBlocks']  = $this->add_block_gaps( $block['innerBlocks'] ?? array(), $gap, $block, $root_padding, $children_apply, $children_container_pad );
+			$block['innerBlocks']  = $this->add_block_gaps( $block['innerBlocks'] ?? array(), $gap, $block, $root_padding, $children_apply, $children_container_pad, $variables_map );
 			$parsed_blocks[ $key ] = $block;
 		}
 
@@ -325,6 +336,25 @@ class Spacing_Preprocessor implements Preprocessor {
 			'left'  => $left,
 			'right' => $right,
 		);
+	}
+
+	/**
+	 * Resolve a CSS value that may contain a preset variable reference.
+	 *
+	 * Block attributes store padding as preset references like
+	 * "var:preset|spacing|20" which resolve to actual pixel values.
+	 *
+	 * @param string $value The CSS value, possibly a preset reference.
+	 * @param array  $variables_map Map of CSS variable names to resolved values.
+	 * @return string The resolved value (e.g. "20px") or the original value.
+	 */
+	private function resolve_preset_value( string $value, array $variables_map ): string {
+		if ( empty( $variables_map ) || strpos( $value, 'var:preset|' ) !== 0 ) {
+			return $value;
+		}
+
+		$css_var_name = '--wp--' . str_replace( '|', '--', str_replace( 'var:', '', $value ) );
+		return $variables_map[ $css_var_name ] ?? $value;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
@@ -319,10 +319,10 @@ class Content_Renderer {
 				$padding = $block['attrs']['style']['spacing']['padding'] ?? array();
 				$result  = array();
 				if ( isset( $padding['left'] ) && is_string( $padding['left'] ) ) {
-					$result['left'] = $this->resolve_preset_padding( $padding['left'], $variables_map );
+					$result['left'] = Preset_Variable_Resolver::resolve( $padding['left'], $variables_map );
 				}
 				if ( isset( $padding['right'] ) && is_string( $padding['right'] ) ) {
-					$result['right'] = $this->resolve_preset_padding( $padding['right'], $variables_map );
+					$result['right'] = Preset_Variable_Resolver::resolve( $padding['right'], $variables_map );
 				}
 				if ( ! empty( $result ) ) {
 					return $result;
@@ -472,25 +472,6 @@ class Content_Renderer {
 			$sum += (float) str_replace( 'px', '', $value2 );
 		}
 		return $sum;
-	}
-
-	/**
-	 * Resolve a CSS value that may contain a preset variable reference.
-	 *
-	 * Block attributes store padding as preset references like
-	 * "var:preset|spacing|20" which resolve to actual pixel values.
-	 *
-	 * @param string $value The CSS value, possibly a preset reference.
-	 * @param array  $variables_map Map of CSS variable names to resolved values.
-	 * @return string The resolved value (e.g. "8px") or the original value.
-	 */
-	private function resolve_preset_padding( string $value, array $variables_map ): string {
-		if ( strpos( $value, 'var:preset|' ) !== 0 ) {
-			return $value;
-		}
-
-		$css_var_name = '--wp--' . str_replace( '|', '--', str_replace( 'var:', '', $value ) );
-		return $variables_map[ $css_var_name ] ?? $value;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-preset-variable-resolver.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-preset-variable-resolver.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer;
+
+/**
+ * Resolves WordPress preset variable references to their actual values.
+ *
+ * Block attributes store spacing values as preset references like
+ * "var:preset|spacing|20". This class provides shared methods to:
+ * - Convert these references to CSS variable names (--wp--preset--spacing--20)
+ * - Resolve them to pixel values (e.g. "20px") using a variables map
+ * - Convert them to CSS var() syntax for stylesheet use
+ *
+ * Used by Content_Renderer, Spacing_Preprocessor, and Blocks_Width_Preprocessor
+ * to avoid duplicating the same resolution logic.
+ */
+class Preset_Variable_Resolver {
+	/**
+	 * Convert a preset variable reference to its CSS variable name.
+	 *
+	 * Transforms "var:preset|spacing|20" to "--wp--preset--spacing--20".
+	 *
+	 * @param string $value The preset reference string.
+	 * @return string The CSS variable name.
+	 */
+	public static function to_css_variable_name( string $value ): string {
+		return '--wp--' . str_replace( '|', '--', str_replace( 'var:', '', $value ) );
+	}
+
+	/**
+	 * Check if a value is a preset variable reference.
+	 *
+	 * @param string $value The CSS value to check.
+	 * @return bool True if the value starts with "var:preset|".
+	 */
+	public static function is_preset_reference( string $value ): bool {
+		return strpos( $value, 'var:preset|' ) === 0;
+	}
+
+	/**
+	 * Resolve a preset variable reference to its actual value.
+	 *
+	 * Converts "var:preset|spacing|20" to the resolved pixel value (e.g. "20px")
+	 * using the provided variables map. Returns the original value if not a preset
+	 * reference or if the variable is not found in the map.
+	 *
+	 * @param string $value The CSS value, possibly a preset reference.
+	 * @param array  $variables_map Map of CSS variable names to resolved values.
+	 * @return string The resolved value or the original value.
+	 */
+	public static function resolve( string $value, array $variables_map ): string {
+		if ( empty( $variables_map ) || ! self::is_preset_reference( $value ) ) {
+			return $value;
+		}
+
+		$css_var_name = self::to_css_variable_name( $value );
+		return $variables_map[ $css_var_name ] ?? $value;
+	}
+
+	/**
+	 * Convert a preset variable reference to CSS var() syntax.
+	 *
+	 * Transforms "var:preset|spacing|20" to "var(--wp--preset--spacing--20)".
+	 * Returns the original value if not a preset reference.
+	 *
+	 * @param string $value The CSS value, possibly a preset reference.
+	 * @return string The CSS var() expression or the original value.
+	 */
+	public static function to_css_var( string $value ): string {
+		if ( ! self::is_preset_reference( $value ) ) {
+			return $value;
+		}
+
+		return 'var(' . self::to_css_variable_name( $value ) . ')';
+	}
+}

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-preset-variable-resolver.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-preset-variable-resolver.php
@@ -29,7 +29,7 @@ class Preset_Variable_Resolver {
 	 * @param string $value The preset reference string.
 	 * @return string The CSS variable name.
 	 */
-	public static function to_css_variable_name( string $value ): string {
+	private static function to_css_variable_name( string $value ): string {
 		return '--wp--' . str_replace( '|', '--', str_replace( 'var:', '', $value ) );
 	}
 

--- a/packages/php/email-editor/src/Engine/class-theme-controller.php
+++ b/packages/php/email-editor/src/Engine/class-theme-controller.php
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 namespace Automattic\WooCommerce\EmailEditor\Engine;
 
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Preset_Variable_Resolver;
 use WP_Block_Template;
 use WP_Post;
 use WP_Theme_JSON;
@@ -118,9 +119,8 @@ class Theme_Controller {
 		foreach ( $styles as $key => $style_value ) {
 			if ( is_array( $style_value ) ) {
 				$styles[ $key ] = $this->recursive_extract_preset_variables( $style_value );
-			} elseif ( is_string( $style_value ) && strpos( $style_value, 'var:preset|' ) === 0 ) {
-				/** @var string $style_value */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-				$styles[ $key ] = 'var(--wp--' . str_replace( '|', '--', str_replace( 'var:', '', $style_value ) ) . ')';
+			} elseif ( is_string( $style_value ) && Preset_Variable_Resolver::is_preset_reference( $style_value ) ) {
+				$styles[ $key ] = Preset_Variable_Resolver::to_css_var( $style_value );
 			} else {
 				$styles[ $key ] = $style_value;
 			}

--- a/packages/php/email-editor/tests/integration/Engine/Theme_Controller_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Theme_Controller_Test.php
@@ -192,6 +192,6 @@ class Theme_Controller_Test extends \Email_Editor_Integration_Test_Case {
 	public function testItReturnsCorrectPresetVariablesMap(): void {
 		$variable_map = $this->theme_controller->get_variables_values_map();
 		$this->assertSame( '#000000', $variable_map['--wp--preset--color--black'] );
-		$this->assertSame( '20px', $variable_map['--wp--preset--spacing--20'] );
+		$this->assertSame( '24px', $variable_map['--wp--preset--spacing--20'] );
 	}
 }

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
@@ -912,4 +912,50 @@ class Spacing_Preprocessor_Test extends \Email_Editor_Unit_Test {
 		// Should not have padding-left due to malicious value.
 		$this->assertArrayNotHasKey( 'padding-left', $second_column['email_attrs'] );
 	}
+
+	/**
+	 * Test preset variable references in container padding are resolved to pixel values
+	 */
+	public function testItResolvesPresetReferencesInContainerPadding(): void {
+		$styles                    = $this->styles;
+		$styles['__variables_map'] = array(
+			'--wp--preset--spacing--20' => '24px',
+		);
+
+		$blocks = array(
+			array(
+				'blockName'   => 'core/group',
+				'attrs'       => array(
+					'style' => array(
+						'spacing' => array(
+							'padding' => array(
+								'left'  => 'var:preset|spacing|20',
+								'right' => 'var:preset|spacing|20',
+							),
+						),
+					),
+				),
+				'innerBlocks' => array(
+					array(
+						'blockName'   => 'core/post-content',
+						'attrs'       => array(),
+						'innerBlocks' => array(
+							array(
+								'blockName'   => 'core/paragraph',
+								'attrs'       => array(),
+								'innerBlocks' => array(),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$result    = $this->preprocessor->preprocess( $blocks, $this->layout, $styles );
+		$paragraph = $result[0]['innerBlocks'][0]['innerBlocks'][0];
+
+		// Container padding should be resolved pixel values, not raw preset references.
+		$this->assertEquals( '24px', $paragraph['email_attrs']['container-padding-left'] );
+		$this->assertEquals( '24px', $paragraph['email_attrs']['container-padding-right'] );
+	}
 }

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preset_Variable_Resolver_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preset_Variable_Resolver_Test.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer;
+
+/**
+ * Unit test for Preset_Variable_Resolver
+ */
+class Preset_Variable_Resolver_Test extends \Email_Editor_Unit_Test {
+
+	/**
+	 * Variables map used across tests.
+	 *
+	 * @var array
+	 */
+	private array $variables_map;
+
+	/**
+	 * Set up the test
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->variables_map = array(
+			'--wp--preset--spacing--10'  => '10px',
+			'--wp--preset--spacing--20'  => '24px',
+			'--wp--preset--spacing--30'  => '30px',
+			'--wp--preset--color--black' => '#000000',
+		);
+	}
+
+	/**
+	 * Test resolve returns pixel value for a preset reference.
+	 */
+	public function testResolveConvertsPresetToPixelValue(): void {
+		$this->assertSame( '24px', Preset_Variable_Resolver::resolve( 'var:preset|spacing|20', $this->variables_map ) );
+	}
+
+	/**
+	 * Test resolve returns original value when not a preset reference.
+	 */
+	public function testResolveReturnsOriginalForNonPreset(): void {
+		$this->assertSame( '20px', Preset_Variable_Resolver::resolve( '20px', $this->variables_map ) );
+	}
+
+	/**
+	 * Test resolve returns original value when variables map is empty.
+	 */
+	public function testResolveReturnsOriginalWhenMapIsEmpty(): void {
+		$this->assertSame( 'var:preset|spacing|20', Preset_Variable_Resolver::resolve( 'var:preset|spacing|20', array() ) );
+	}
+
+	/**
+	 * Test resolve returns original preset when key is not in the map.
+	 */
+	public function testResolveReturnsOriginalWhenKeyNotFound(): void {
+		$this->assertSame( 'var:preset|spacing|99', Preset_Variable_Resolver::resolve( 'var:preset|spacing|99', $this->variables_map ) );
+	}
+
+	/**
+	 * Test resolve works with non-spacing presets (e.g. color).
+	 */
+	public function testResolveWorksWithColorPresets(): void {
+		$this->assertSame( '#000000', Preset_Variable_Resolver::resolve( 'var:preset|color|black', $this->variables_map ) );
+	}
+
+	/**
+	 * Test resolve passes through zero values.
+	 */
+	public function testResolvePassesThroughZeroValues(): void {
+		$this->assertSame( '0px', Preset_Variable_Resolver::resolve( '0px', $this->variables_map ) );
+		$this->assertSame( '0', Preset_Variable_Resolver::resolve( '0', $this->variables_map ) );
+	}
+
+	/**
+	 * Test is_preset_reference returns true for preset references.
+	 */
+	public function testIsPresetReferenceReturnsTrueForPreset(): void {
+		$this->assertTrue( Preset_Variable_Resolver::is_preset_reference( 'var:preset|spacing|20' ) );
+		$this->assertTrue( Preset_Variable_Resolver::is_preset_reference( 'var:preset|color|black' ) );
+	}
+
+	/**
+	 * Test is_preset_reference returns false for non-preset values.
+	 */
+	public function testIsPresetReferenceReturnsFalseForNonPreset(): void {
+		$this->assertFalse( Preset_Variable_Resolver::is_preset_reference( '20px' ) );
+		$this->assertFalse( Preset_Variable_Resolver::is_preset_reference( '0' ) );
+		$this->assertFalse( Preset_Variable_Resolver::is_preset_reference( '' ) );
+		$this->assertFalse( Preset_Variable_Resolver::is_preset_reference( 'var(--wp--preset--spacing--20)' ) );
+	}
+
+	/**
+	 * Test to_css_var converts preset reference to CSS var() syntax.
+	 */
+	public function testToCssVarConvertsPresetToCssVar(): void {
+		$this->assertSame( 'var(--wp--preset--spacing--20)', Preset_Variable_Resolver::to_css_var( 'var:preset|spacing|20' ) );
+		$this->assertSame( 'var(--wp--preset--color--black)', Preset_Variable_Resolver::to_css_var( 'var:preset|color|black' ) );
+	}
+
+	/**
+	 * Test to_css_var returns original value for non-preset.
+	 */
+	public function testToCssVarReturnsOriginalForNonPreset(): void {
+		$this->assertSame( '20px', Preset_Variable_Resolver::to_css_var( '20px' ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes WOOPRD-3313

**Bug fix:** The `Spacing_Preprocessor::get_block_horizontal_padding()` returns raw preset variable references (e.g. `var:preset|spacing|20`) without resolving them. When this unresolved padding is distributed as `container-padding-left/right` to template-level blocks (like the site title), `Content_Renderer::sum_padding_values()` cannot parse the preset string — `(float)"var:preset|spacing|20"` yields `0.0` — causing a visible padding mismatch in email previews.

The CSS variables map is already available at preprocessing time via `$styles['__variables_map']` (set by `Content_Renderer::preprocess_parsed_blocks()`), and `Blocks_Width_Preprocessor` already uses it for the same purpose. This PR passes the variables map through `add_block_gaps()` to `get_block_horizontal_padding()`, which now resolves preset references before returning padding values.

**Refactor:** The preset resolution logic (`var:preset|spacing|20` → CSS variable name → pixel value lookup) was duplicated in 3 identical private methods across `Content_Renderer`, `Blocks_Width_Preprocessor`, and `Spacing_Preprocessor`, plus a 4th copy in `Theme_Controller` for `var()` CSS syntax conversion. This PR extracts all 4 into a shared `Preset_Variable_Resolver` utility class with a clean static API: `resolve()`, `to_css_var()`, and `is_preset_reference()`.

**Test fix:** Corrected a pre-existing wrong assertion in `Theme_Controller_Test` where spacing preset slug "20" was expected to resolve to "20px", but the `theme.json` defines it as "24px" (the slug is an identifier, not the pixel value).

**Changes:**
- New `Preset_Variable_Resolver` utility class with static methods for preset resolution
- `Spacing_Preprocessor` — thread `$variables_map` through `add_block_gaps()` → `get_block_horizontal_padding()` to resolve presets
- `Blocks_Width_Preprocessor` — replace private `resolve_preset_value()` with `Preset_Variable_Resolver::resolve()`
- `Content_Renderer` — replace private `resolve_preset_padding()` with `Preset_Variable_Resolver::resolve()`
- `Theme_Controller` — replace inline preset-to-CSS-var logic with `Preset_Variable_Resolver::to_css_var()`

### How to test the changes in this Pull Request:

1. Create or use an email template with a root-level group that has preset spacing (e.g. `var:preset|spacing|20` for left/right padding) wrapping a site-title block and a group containing post-content.
2. Open the email editor for any transactional email (e.g. Order confirmation).
3. Click the device icon → "Preview in new tab".
4. Verify the site title and email body content are left-aligned at the same horizontal position.
5. Without this fix, the site title would appear indented ~20px less than the body content.

### Testing that has already taken place:

- All 221 unit tests pass (17 Spacing_Preprocessor tests including new preset resolution test, 10 new Preset_Variable_Resolver tests)
- PHPCS lint clean
- Visual QA in CIAB admin environment confirmed padding alignment

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

> Significance: patch
> Type: fix
>
> Resolve preset variable references in Spacing_Preprocessor container padding to fix padding mismatch for template-level blocks in email previews. Extract shared Preset_Variable_Resolver utility to eliminate duplicated resolution logic across Content_Renderer, Blocks_Width_Preprocessor, Spacing_Preprocessor, and Theme_Controller.


🤖 Generated with [Claude Code](https://claude.com/claude-code)