### PR TITLE
Fix express payment button spacing in Safari on block cart

### DIFF
--- a/plugins/woocommerce/changelog/64074-wooplug-6512-block-cart-express-payment-buttons-have-excessive-spacing-in
+++ b/plugins/woocommerce/changelog/64074-wooplug-6512-block-cart-express-payment-buttons-have-excessive-spacing-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix excessive express payment button spacing in Safari on the block cart page by switching from block layout to flexbox with explicit gap.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -122,15 +122,18 @@ $border-width: 1px;
 
 .wc-block-components-express-payment--cart {
 	.wc-block-components-express-payment__event-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: $gap-small;
+
 		> div,
 		> li {
-			padding-bottom: $gap-small;
+			margin: 0;
+			padding: 0;
 			text-align: center;
 			width: 100%;
-
-			&:last-child {
-				padding-bottom: 0;
-			}
+			font-size: 0;
+			line-height: 0;
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

On the block cart page, express checkout payment buttons (Apple Pay, Google Pay, Link, etc.) render with excessive vertical spacing in Safari when using a block theme. This is caused by two issues:

1. The cart's express payment `<ul>` uses block layout with `padding-bottom` for spacing, which relies on margin collapse behavior that differs between browsers.
2. Safari adds extra whitespace for inline-replaced elements (iframes) due to the baseline gap problem, inflating each `<li>` beyond the visible button height.

This PR switches the cart's express payment button list from block layout to flexbox with explicit `gap`, and collapses the inline element line box with `font-size: 0; line-height: 0` to eliminate Safari's baseline gap. This mirrors the checkout page's approach (which already uses grid + gap) and removes the need for individual gateway plugins to carry their own defensive overrides.

Closes https://github.com/woocommerce/woocommerce/issues/64005.

### How to test the changes in this Pull Request:

1. Enable a block theme (e.g., Twenty Twenty-Four).
2. Enable multiple express payment methods (Apple Pay, Google Pay, Link, etc.) — or use gateway plugins that register express payment methods (e.g., WooCommerce Stripe Gateway).
3. Add items to cart and view the block cart page in **Safari**.
4. Verify the express payment buttons stack with consistent ~12px gaps between them, matching how they appear in Chrome.
5. Also verify the checkout page's express payment buttons are unaffected.

### Testing that has already taken place:

Tested locally in Safari and Chrome with multiple fake express payment methods registered via mu-plugin. Verified buttons render with consistent spacing in both browsers.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix excessive express payment button spacing in Safari on the block cart page by switching from block layout to flexbox with explicit gap.

</details>