### PR TITLE
Reduce Terser compression passes in WooCommerce Blocks

### DIFF
--- a/plugins/woocommerce/changelog/build-blocks-terser-single-pass
+++ b/plugins/woocommerce/changelog/build-blocks-terser-single-pass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduce WooCommerce Blocks production build time by using a single Terser compression pass.

--- a/plugins/woocommerce/changelog/build-blocks-terser-single-pass
+++ b/plugins/woocommerce/changelog/build-blocks-terser-single-pass
@@ -1,4 +1,4 @@
-Significance: patch
-Type: performance
+Significance: minor
+Type: dev
 
-Reduce WooCommerce Blocks production build time by using a single Terser compression pass.
+Reduce WooCommerce Blocks non-production build time by using a single Terser compression pass outside production.

--- a/plugins/woocommerce/client/blocks/bin/webpack-shared-config.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-shared-config.js
@@ -16,7 +16,7 @@ const sharedOptimizationConfig = {
 					comments: /translators:/i,
 				},
 				compress: {
-					passes: 2,
+					passes: 1,
 				},
 				mangle: {
 					reserved: [ '__', '_n', '_nx', '_x' ],

--- a/plugins/woocommerce/client/blocks/bin/webpack-shared-config.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-shared-config.js
@@ -16,7 +16,7 @@ const sharedOptimizationConfig = {
 					comments: /translators:/i,
 				},
 				compress: {
-					passes: 1,
+					passes: isProduction ? 2 : 1,
 				},
 				mangle: {
 					reserved: [ '__', '_n', '_nx', '_x' ],


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This is a split-out follow-up from #64077.

It reduces the WooCommerce Blocks shared Terser configuration from `compress.passes = 2` to `compress.passes = 1`.

The change is intentionally narrow:
- it only touches the shared blocks minifier config
- it does not change build orchestration, caching strategy, or watch behavior
- it keeps the optimization discussion focused on one measurable tweak

| Benchmark | `trunk` | This branch |
| --- | ---: | ---: |
| Blocks production bundle build | 26.150s | 25.010s |

Closes # N/A.

(For Bug Fixes) Bug introduced in PR # N/A.

### Screenshots or screen recordings:

N/A.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. From `plugins/woocommerce/client/blocks`, run `pnpm run build:project:bundle` and confirm the build succeeds.
3. Compare the measured build time and generated assets with `trunk`.

### Testing that has already taken place:

I benchmarked the blocks production bundle after clearing `plugins/woocommerce/client/blocks/build` and `node_modules/.cache/babel-loader` before each run.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

Created manually in this branch.
