### PR TITLE
Unify Add to Cart + Options e2e test utils

### DIFF
--- a/plugins/woocommerce/changelog/update-add-to-cart-with-options-e2e-tests-unify-utils
+++ b/plugins/woocommerce/changelog/update-add-to-cart-with-options-e2e-tests-unify-utils
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Unify Add to Cart + Options e2e test utils
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect, wpCLI, Editor } from '@woocommerce/e2e-utils';
+import { test as base, expect, wpCLI } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -464,11 +464,11 @@ test.describe( 'Add to Cart + Options Block', () => {
 				exact: true,
 			} );
 
-			await expect( petitOption ).not.toBeDisabled();
-			await expect( grandOption ).not.toBeDisabled();
+			await expect( petitOption ).toBeEnabled();
+			await expect( grandOption ).toBeEnabled();
 
 			await petitOption.click();
-			await expect( addToCartButton ).not.toBeDisabled();
+			await expect( addToCartButton ).toBeEnabled();
 			await addToCartButton.click();
 			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 		} );
@@ -499,11 +499,11 @@ test.describe( 'Add to Cart + Options Block', () => {
 				exact: true,
 			} );
 
-			await expect( petitOption ).not.toBeDisabled();
-			await expect( grandOption ).not.toBeDisabled();
+			await expect( petitOption ).toBeEnabled();
+			await expect( grandOption ).toBeEnabled();
 			await select.selectOption( { label: 'Petit' } );
 
-			await expect( addToCartButton ).not.toBeDisabled();
+			await expect( addToCartButton ).toBeEnabled();
 			await addToCartButton.click();
 			await expect( page.getByText( '2 in cart' ) ).toBeVisible();
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -475,10 +475,12 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await test.step( 'when in dropdown mode', async () => {
 			await pageObject.updateSingleProductTemplate();
-
-			await pageObject.switchToDropdownMode();
-
-			await editor.saveSiteEditorEntities();
+			await pageObject.setVariationSelectorAttributes( {
+				optionStyle: 'dropdown',
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: false,
+			} );
 
 			await page.goto( '/product/custom-slug-variable/' );
 
@@ -805,10 +807,12 @@ test.describe( 'Add to Cart + Options Block', () => {
 		editor,
 	} ) => {
 		await pageObject.updateSingleProductTemplate();
-
-		await pageObject.switchToDropdownMode();
-
-		await editor.saveSiteEditorEntities();
+		await pageObject.setVariationSelectorAttributes( {
+			optionStyle: 'dropdown',
+		} );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: false,
+		} );
 
 		await page.goto( '/product/hoodie/' );
 
@@ -1427,86 +1431,6 @@ test.describe( 'Add to Cart + Options Block', () => {
 			},
 		];
 
-		async function setAddToCartWithOptionsBlockAttributes(
-			pageObject: AddToCartWithOptionsPage,
-			editor: Editor,
-			{
-				optionStyle = 'Pills',
-				autoselect = false,
-				disabledAttributesAction = 'disable',
-			}: {
-				optionStyle?: 'Pills' | 'Dropdown';
-				autoselect?: boolean;
-				disabledAttributesAction?: 'disable' | 'hide';
-			} = {}
-		) {
-			const page = editor.page;
-			let isOnlyCurrentEntityDirty = true;
-
-			await pageObject.switchProductType( 'Variable product' );
-			await page.getByRole( 'tab', { name: 'Block' } ).click();
-			const addToCartWithOptionsBlock = editor.canvas.getByLabel(
-				'Block: Add to Cart + Options'
-			);
-			await addToCartWithOptionsBlock.click();
-			await addToCartWithOptionsBlock
-				.getByLabel( 'Block: Variation Selector: Attribute Options' )
-				.first()
-				.click();
-
-			const optionStyleInput = page.getByRole( 'radio', {
-				name: optionStyle,
-				exact: true,
-			} );
-			if ( ! ( await optionStyleInput.isChecked() ) ) {
-				isOnlyCurrentEntityDirty = false;
-				await optionStyleInput.click();
-			}
-
-			const autoselectInput = page.getByRole( 'checkbox', {
-				name: 'Auto-select when only one option is available',
-			} );
-			const invalidOptionsLabel =
-				disabledAttributesAction === 'disable'
-					? 'Grayed-out'
-					: 'Hidden';
-			const invalidOptionsRadio = page
-				.getByLabel( 'Invalid options' )
-				.getByRole( 'radio', { name: invalidOptionsLabel } );
-
-			const isAutoselectChecked = await autoselectInput.isChecked();
-			const isInvalidOptionSelected =
-				( await invalidOptionsRadio.getAttribute( 'aria-checked' ) ) ===
-				'true';
-
-			if (
-				isAutoselectChecked !== autoselect ||
-				! isInvalidOptionSelected
-			) {
-				isOnlyCurrentEntityDirty = false;
-			}
-
-			await autoselectInput.setChecked( autoselect );
-			if ( ! isInvalidOptionSelected ) {
-				await invalidOptionsRadio.click();
-			}
-			if (
-				await page
-					.getByRole( 'region', {
-						name: 'Editor top bar',
-					} )
-					.getByRole( 'button', {
-						name: 'Save',
-						exact: true,
-					} )
-					.isEnabled()
-			) {
-				await editor.saveSiteEditorEntities( {
-					isOnlyCurrentEntityDirty,
-				} );
-			}
-		}
-
 		test.beforeEach( async () => {
 			const cliOutput = await wpCLI(
 				`wc product create --user=1 --slug="${ productSlug }" --name="${ productName }" --type="variable" --attributes='${ JSON.stringify(
@@ -1536,9 +1460,9 @@ test.describe( 'Add to Cart + Options Block', () => {
 			}
 		} );
 
-		for ( const optionStyle of [ 'Pills', 'Dropdown' ] as (
-			| 'Pills'
-			| 'Dropdown'
+		for ( const optionStyle of [ 'pills', 'dropdown' ] as (
+			| 'pills'
+			| 'dropdown'
 		 )[] ) {
 			// eslint-disable-next-line playwright/expect-expect
 			test( `${ optionStyle }: Test the autoselect block attribute`, async ( {
@@ -1547,16 +1471,24 @@ test.describe( 'Add to Cart + Options Block', () => {
 				editor,
 			} ) => {
 				await pageObject.updateSingleProductTemplate();
-				await setAddToCartWithOptionsBlockAttributes(
-					pageObject,
-					editor,
-					{ optionStyle }
-				);
+
+				if ( optionStyle === 'pills' ) {
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: true,
+					} );
+				} else {
+					await pageObject.setVariationSelectorAttributes( {
+						optionStyle,
+					} );
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: false,
+					} );
+				}
 
 				await test.step( `${ optionStyle }: Expect NOTHING to be auto-selected (on page load)`, async () => {
 					await page.goto( productPermalink );
 
-					await pageObject.expectSelectedAttributes(
+					await pageObject.expectVariationSelectorAttributes(
 						productAttributes,
 						{ Type: '', Color: '', Size: '' },
 						optionStyle
@@ -1566,14 +1498,14 @@ test.describe( 'Add to Cart + Options Block', () => {
 				await test.step( `${ optionStyle }: Expect attributes to NOT auto-select when user selects something`, async () => {
 					await page.goto( productPermalink );
 
-					await pageObject.selectVariationSelectorOptionsBlockAttribute(
+					await pageObject.selectVariationSelectorOptions(
 						'Color',
 						'Blue',
 						optionStyle
 					);
 
 					// Expect nothing to be auto-selected
-					await pageObject.expectSelectedAttributes(
+					await pageObject.expectVariationSelectorAttributes(
 						productAttributes,
 						{ Type: '', Color: 'Blue', Size: '' },
 						optionStyle
@@ -1582,18 +1514,20 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 				await test.step( `${ optionStyle }: Set the autoselect setting to true`, async () => {
 					await pageObject.updateSingleProductTemplate();
-					await setAddToCartWithOptionsBlockAttributes(
-						pageObject,
-						editor,
-						{ optionStyle, autoselect: true }
-					);
+					await pageObject.setVariationSelectorAttributes( {
+						optionStyle,
+						autoselect: true,
+					} );
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: false,
+					} );
 				} );
 
 				await test.step( `${ optionStyle }: Expect only the Type attribute to be auto-selected (on page load)`, async () => {
 					await page.goto( productPermalink );
 
 					// Expect the Type attribute to be auto-selected (on page load) to "T-shirt", the rest of the attributes should not be selected.
-					await pageObject.expectSelectedAttributes(
+					await pageObject.expectVariationSelectorAttributes(
 						productAttributes,
 						{ Type: 'T-shirt', Color: '', Size: '' },
 						optionStyle
@@ -1604,13 +1538,13 @@ test.describe( 'Add to Cart + Options Block', () => {
 					await page.goto( productPermalink );
 
 					// By setting the Color to "Blue", we expect the Type attribute to be auto-selected to "T-shirt", and the Size to "XL".
-					await pageObject.selectVariationSelectorOptionsBlockAttribute(
+					await pageObject.selectVariationSelectorOptions(
 						'Color',
 						'Blue',
 						optionStyle
 					);
 
-					await pageObject.expectSelectedAttributes(
+					await pageObject.expectVariationSelectorAttributes(
 						productAttributes,
 						{ Type: 'T-shirt', Color: 'Blue', Size: 'XL' },
 						optionStyle
@@ -1624,20 +1558,15 @@ test.describe( 'Add to Cart + Options Block', () => {
 			} ) => {
 				await test.step( `${ optionStyle }: Set the disabledAttributesAction block attribute to "disable"`, async () => {
 					await pageObject.updateSingleProductTemplate();
-					await setAddToCartWithOptionsBlockAttributes(
-						pageObject,
-						editor,
-						{
-							optionStyle,
-							disabledAttributesAction: 'disable',
-						}
-					);
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: true,
+					} );
 				} );
 				await test.step( `${ optionStyle }: Expect invalid options to be disabled (by prop) and visible`, async () => {
 					await page.goto( productPermalink );
 
 					// By setting the Color to "Blue", the only possible Size remaining is "XL".
-					await pageObject.selectVariationSelectorOptionsBlockAttribute(
+					await pageObject.selectVariationSelectorOptions(
 						'Color',
 						'Blue',
 						optionStyle
@@ -1657,20 +1586,19 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 				await test.step( `${ optionStyle }: Set the disabledAttributesAction block attribute to "hide"`, async () => {
 					await pageObject.updateSingleProductTemplate();
-					await setAddToCartWithOptionsBlockAttributes(
-						pageObject,
-						editor,
-						{
-							optionStyle,
-							disabledAttributesAction: 'hide',
-						}
-					);
+					await pageObject.setVariationSelectorAttributes( {
+						optionStyle,
+						disabledAttributesAction: 'hide',
+					} );
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: false,
+					} );
 				} );
 				await test.step( `${ optionStyle }: Expect invalid options to be isabled (by prop) and hidden`, async () => {
 					await page.goto( productPermalink );
 
 					// By setting the Color to "Blue", the only possible Size remaining is "XL".
-					await pageObject.selectVariationSelectorOptionsBlockAttribute(
+					await pageObject.selectVariationSelectorOptions(
 						'Color',
 						'Blue',
 						optionStyle
@@ -1701,27 +1629,26 @@ test.describe( 'Add to Cart + Options Block', () => {
 					await pageObject.updateSingleProductTemplate();
 
 					await test.step( `${ optionStyle }: Set the disabledAttributesAction block attribute to "${ disabledAttributesAction }"`, async () => {
-						await setAddToCartWithOptionsBlockAttributes(
-							pageObject,
-							editor,
-							{
-								autoselect: true,
-								optionStyle,
-								disabledAttributesAction,
-							}
-						);
+						await pageObject.setVariationSelectorAttributes( {
+							autoselect: true,
+							optionStyle,
+							disabledAttributesAction,
+						} );
+						await editor.saveSiteEditorEntities( {
+							isOnlyCurrentEntityDirty: false,
+						} );
 					} );
 					await test.step( `disabledAttributesAction === ${ disabledAttributesAction }: Expect options to be properly auto-selected`, async () => {
 						await page.goto( productPermalink );
 
 						// By selecting the Color to "Blue", the only possible Size remaining is "XL".
-						await pageObject.selectVariationSelectorOptionsBlockAttribute(
+						await pageObject.selectVariationSelectorOptions(
 							'Color',
 							'Blue',
 							optionStyle
 						);
 						// Now, we deselect the Color.
-						await pageObject.selectVariationSelectorOptionsBlockAttribute(
+						await pageObject.selectVariationSelectorOptions(
 							'Color',
 							'',
 							optionStyle
@@ -1732,7 +1659,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 						// Size: XL
 						// Because the Size is XL, the only Colors possible are Red and Blue.
 						// Now if we select Size: S, the Color should auto-select to Green.
-						await pageObject.selectVariationSelectorOptionsBlockAttribute(
+						await pageObject.selectVariationSelectorOptions(
 							'Size',
 							'S',
 							optionStyle
@@ -1742,7 +1669,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 						// Color: Green
 						// Size: S
 
-						await pageObject.expectSelectedAttributes(
+						await pageObject.expectVariationSelectorAttributes(
 							productAttributes,
 							{ Type: 'T-shirt', Color: 'Green', Size: 'S' },
 							optionStyle
@@ -1758,26 +1685,29 @@ test.describe( 'Add to Cart + Options Block', () => {
 			editor,
 		} ) => {
 			await pageObject.updateSingleProductTemplate();
-			await setAddToCartWithOptionsBlockAttributes( pageObject, editor, {
-				optionStyle: 'Pills',
+			await pageObject.setVariationSelectorAttributes( {
+				optionStyle: 'pills',
 				autoselect: true,
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: false,
 			} );
 
 			await test.step( 'Add the Blue/XL variation to cart', async () => {
 				await page.goto( productPermalink );
 
 				// Select Blue and XL to match the T-shirt, Blue, XL variation
-				await pageObject.selectVariationSelectorOptionsBlockAttribute(
+				await pageObject.selectVariationSelectorOptions(
 					'Color',
 					'Blue',
-					'Pills'
+					'pills'
 				);
 
 				// Type and Size should auto-select to T-shirt and XL
-				await pageObject.expectSelectedAttributes(
+				await pageObject.expectVariationSelectorAttributes(
 					productAttributes,
 					{ Type: 'T-shirt', Color: 'Blue', Size: 'XL' },
-					'Pills'
+					'pills'
 				);
 
 				// Add to cart
@@ -1801,10 +1731,10 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 				// Now select Blue - this should auto-select Size to XL
 				// (since Blue only has one valid size: XL)
-				await pageObject.selectVariationSelectorOptionsBlockAttribute(
+				await pageObject.selectVariationSelectorOptions(
 					'Color',
 					'Blue',
-					'Pills'
+					'pills'
 				);
 
 				// After auto-selection completes, the button should show "1 in cart"

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -468,7 +468,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( grandOption ).toBeEnabled();
 
 			await petitOption.click();
-			await expect( addToCartButton ).toBeEnabled();
+			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 			await addToCartButton.click();
 			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 		} );
@@ -503,7 +503,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( grandOption ).toBeEnabled();
 			await select.selectOption( { label: 'Petit' } );
 
-			await expect( addToCartButton ).toBeEnabled();
+			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 			await addToCartButton.click();
 			await expect( page.getByText( '2 in cart' ) ).toBeVisible();
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1482,7 +1482,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 				await test.step( `${ optionStyle }: Expect NOTHING to be auto-selected (on page load)`, async () => {
 					await page.goto( productPermalink );
 
-					await pageObject.expectVariationSelectorAttributes(
+					await pageObject.expectVariationSelectorOptions(
 						productAttributes,
 						{ Type: '', Color: '', Size: '' },
 						optionStyle
@@ -1499,7 +1499,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 					);
 
 					// Expect nothing to be auto-selected
-					await pageObject.expectVariationSelectorAttributes(
+					await pageObject.expectVariationSelectorOptions(
 						productAttributes,
 						{ Type: '', Color: 'Blue', Size: '' },
 						optionStyle
@@ -1519,7 +1519,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 					await page.goto( productPermalink );
 
 					// Expect the Type attribute to be auto-selected (on page load) to "T-shirt", the rest of the attributes should not be selected.
-					await pageObject.expectVariationSelectorAttributes(
+					await pageObject.expectVariationSelectorOptions(
 						productAttributes,
 						{ Type: 'T-shirt', Color: '', Size: '' },
 						optionStyle
@@ -1536,7 +1536,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 						optionStyle
 					);
 
-					await pageObject.expectVariationSelectorAttributes(
+					await pageObject.expectVariationSelectorOptions(
 						productAttributes,
 						{ Type: 'T-shirt', Color: 'Blue', Size: 'XL' },
 						optionStyle
@@ -1665,7 +1665,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 						// Color: Green
 						// Size: S
 
-						await pageObject.expectVariationSelectorAttributes(
+						await pageObject.expectVariationSelectorOptions(
 							productAttributes,
 							{ Type: 'T-shirt', Color: 'Green', Size: 'S' },
 							optionStyle
@@ -1698,7 +1698,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 				);
 
 				// Type and Size should auto-select to T-shirt and XL
-				await pageObject.expectVariationSelectorAttributes(
+				await pageObject.expectVariationSelectorOptions(
 					productAttributes,
 					{ Type: 'T-shirt', Color: 'Blue', Size: 'XL' },
 					'pills'

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -478,9 +478,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await pageObject.setVariationSelectorAttributes( {
 				optionStyle: 'dropdown',
 			} );
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: false,
-			} );
+			await editor.saveSiteEditorEntities();
 
 			await page.goto( '/product/custom-slug-variable/' );
 
@@ -810,9 +808,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await pageObject.setVariationSelectorAttributes( {
 			optionStyle: 'dropdown',
 		} );
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: false,
-		} );
+		await editor.saveSiteEditorEntities();
 
 		await page.goto( '/product/hoodie/' );
 
@@ -1480,9 +1476,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 					await pageObject.setVariationSelectorAttributes( {
 						optionStyle,
 					} );
-					await editor.saveSiteEditorEntities( {
-						isOnlyCurrentEntityDirty: false,
-					} );
+					await editor.saveSiteEditorEntities();
 				}
 
 				await test.step( `${ optionStyle }: Expect NOTHING to be auto-selected (on page load)`, async () => {
@@ -1518,9 +1512,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 						optionStyle,
 						autoselect: true,
 					} );
-					await editor.saveSiteEditorEntities( {
-						isOnlyCurrentEntityDirty: false,
-					} );
+					await editor.saveSiteEditorEntities();
 				} );
 
 				await test.step( `${ optionStyle }: Expect only the Type attribute to be auto-selected (on page load)`, async () => {
@@ -1590,9 +1582,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 						optionStyle,
 						disabledAttributesAction: 'hide',
 					} );
-					await editor.saveSiteEditorEntities( {
-						isOnlyCurrentEntityDirty: false,
-					} );
+					await editor.saveSiteEditorEntities();
 				} );
 				await test.step( `${ optionStyle }: Expect invalid options to be isabled (by prop) and hidden`, async () => {
 					await page.goto( productPermalink );
@@ -1634,9 +1624,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 							optionStyle,
 							disabledAttributesAction,
 						} );
-						await editor.saveSiteEditorEntities( {
-							isOnlyCurrentEntityDirty: false,
-						} );
+						await editor.saveSiteEditorEntities();
 					} );
 					await test.step( `disabledAttributesAction === ${ disabledAttributesAction }: Expect options to be properly auto-selected`, async () => {
 						await page.goto( productPermalink );
@@ -1689,9 +1677,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 				optionStyle: 'pills',
 				autoselect: true,
 			} );
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: false,
-			} );
+			await editor.saveSiteEditorEntities();
 
 			await test.step( 'Add the Blue/XL variation to cart', async () => {
 				await page.goto( productPermalink );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1592,7 +1592,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 					} );
 					await editor.saveSiteEditorEntities();
 				} );
-				await test.step( `${ optionStyle }: Expect invalid options to be isabled (by prop) and hidden`, async () => {
+				await test.step( `${ optionStyle }: Expect invalid options to be disabled (by prop) and hidden`, async () => {
 					await page.goto( productPermalink );
 
 					// By setting the Color to "Blue", the only possible Size remaining is "XL".

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1550,9 +1550,17 @@ test.describe( 'Add to Cart + Options Block', () => {
 			} ) => {
 				await test.step( `${ optionStyle }: Set the disabledAttributesAction block attribute to "disable"`, async () => {
 					await pageObject.updateSingleProductTemplate();
-					await editor.saveSiteEditorEntities( {
-						isOnlyCurrentEntityDirty: true,
-					} );
+
+					if ( optionStyle === 'pills' ) {
+						await editor.saveSiteEditorEntities( {
+							isOnlyCurrentEntityDirty: true,
+						} );
+					} else {
+						await pageObject.setVariationSelectorAttributes( {
+							optionStyle,
+						} );
+						await editor.saveSiteEditorEntities();
+					}
 				} );
 				await test.step( `${ optionStyle }: Expect invalid options to be disabled (by prop) and visible`, async () => {
 					await page.goto( productPermalink );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -214,7 +214,7 @@ class AddToCartWithOptionsPage {
 		}
 	}
 
-	async expectVariationSelectorAttributes(
+	async expectVariationSelectorOptions(
 		productAttributes: {
 			name: string;
 			options: string[];

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -122,14 +122,20 @@ class AddToCartWithOptionsPage {
 
 		await this.switchProductType( 'Variable product' );
 		await page.getByRole( 'tab', { name: 'Block' } ).click();
-		const addToCartWithOptionsBlock = this.editor.canvas.getByLabel(
-			'Block: Add to Cart + Options'
+
+		// Verify inner blocks have loaded.
+		await expect(
+			this.editor.canvas
+				.getByLabel(
+					'Block: Variation Selector: Attribute Options (Beta)'
+				)
+				.first()
+		).toBeVisible();
+
+		const attributeOptionsBlock = await this.editor.getBlockByName(
+			'woocommerce/add-to-cart-with-options-variation-selector-attribute-options'
 		);
-		await addToCartWithOptionsBlock.click();
-		await addToCartWithOptionsBlock
-			.getByLabel( 'Block: Variation Selector: Attribute Options' )
-			.first()
-			.click();
+		await this.editor.selectBlocks( attributeOptionsBlock.first() );
 
 		// Option style attribute.
 		if ( optionStyle ) {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -132,7 +132,7 @@ class AddToCartWithOptionsPage {
 			.click();
 
 		// Option style attribute.
-		if ( optionStyle === 'pills' || optionStyle === 'dropdown' ) {
+		if ( optionStyle ) {
 			const optionStyleInput = page.getByRole( 'radio', {
 				name: optionStyle,
 			} );
@@ -148,10 +148,7 @@ class AddToCartWithOptionsPage {
 		}
 
 		// Invalid options attribute.
-		if (
-			disabledAttributesAction === 'disable' ||
-			disabledAttributesAction === 'hide'
-		) {
+		if ( disabledAttributesAction ) {
 			const invalidOptionsLabel =
 				disabledAttributesAction === 'disable'
 					? 'Grayed-out'
@@ -241,7 +238,7 @@ class AddToCartWithOptionsPage {
 				await expect( attributeNameLocator ).toHaveValue(
 					expectedValue
 				);
-				return;
+				continue;
 			}
 			if (
 				attributeName in expectedValues &&

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -109,26 +109,58 @@ class AddToCartWithOptionsPage {
 		await this.updateAddToCartWithOptionsBlock();
 	}
 
-	async switchToDropdownMode() {
+	async setVariationSelectorAttributes( {
+		optionStyle,
+		autoselect,
+		disabledAttributesAction,
+	}: {
+		optionStyle?: 'pills' | 'dropdown';
+		autoselect?: boolean;
+		disabledAttributesAction?: 'disable' | 'hide';
+	} = {} ) {
+		const page = this.editor.page;
+
 		await this.switchProductType( 'Variable product' );
-
-		await this.page.getByRole( 'tab', { name: 'Block' } ).click();
-
-		// Verify inner blocks have loaded.
-		await expect(
-			this.editor.canvas
-				.getByLabel(
-					'Block: Variation Selector: Attribute Options (Beta)'
-				)
-				.first()
-		).toBeVisible();
-
-		const attributeOptionsBlock = await this.editor.getBlockByName(
-			'woocommerce/add-to-cart-with-options-variation-selector-attribute-options'
+		await page.getByRole( 'tab', { name: 'Block' } ).click();
+		const addToCartWithOptionsBlock = this.editor.canvas.getByLabel(
+			'Block: Add to Cart + Options'
 		);
-		await this.editor.selectBlocks( attributeOptionsBlock.first() );
+		await addToCartWithOptionsBlock.click();
+		await addToCartWithOptionsBlock
+			.getByLabel( 'Block: Variation Selector: Attribute Options' )
+			.first()
+			.click();
 
-		await this.page.getByRole( 'radio', { name: 'Dropdown' } ).click();
+		// Option style attribute.
+		if ( optionStyle === 'pills' || optionStyle === 'dropdown' ) {
+			const optionStyleInput = page.getByRole( 'radio', {
+				name: optionStyle,
+			} );
+			await optionStyleInput.click();
+		}
+
+		// Auto-select attribute.
+		if ( typeof autoselect === 'boolean' ) {
+			const autoselectInput = page.getByRole( 'checkbox', {
+				name: 'Auto-select when only one option is available',
+			} );
+			await autoselectInput.setChecked( autoselect );
+		}
+
+		// Invalid options attribute.
+		if (
+			disabledAttributesAction === 'disable' ||
+			disabledAttributesAction === 'hide'
+		) {
+			const invalidOptionsLabel =
+				disabledAttributesAction === 'disable'
+					? 'Grayed-out'
+					: 'Hidden';
+			const invalidOptionsRadio = page
+				.getByLabel( 'Invalid options' )
+				.getByRole( 'radio', { name: invalidOptionsLabel } );
+			await invalidOptionsRadio.click();
+		}
 	}
 
 	async createPostWithProductBlock( product: string, variation?: string ) {
@@ -157,31 +189,29 @@ class AddToCartWithOptionsPage {
 		await this.editor.publishAndVisitPost();
 	}
 
-	async selectVariationSelectorOptionsBlockAttribute(
+	async selectVariationSelectorOptions(
 		attributeName: string,
 		attributeValue: string,
-		optionStyle: 'Pills' | 'Dropdown'
+		optionStyle: 'pills' | 'dropdown'
 	) {
-		if ( optionStyle === 'Dropdown' ) {
+		if ( optionStyle === 'dropdown' ) {
 			await this.page
 				.getByLabel( attributeName )
 				.selectOption( attributeValue );
-			return;
-		}
-		if ( attributeValue !== '' ) {
+		} else if ( attributeValue !== '' ) {
 			await this.page
 				.getByLabel( attributeName )
 				.getByText( attributeValue )
 				.click();
-			return;
+		} else {
+			await this.page
+				.getByLabel( attributeName )
+				.locator( 'label:has(:checked)' )
+				.click();
 		}
-		await this.page
-			.getByLabel( attributeName )
-			.locator( 'label:has(:checked)' )
-			.click();
 	}
 
-	async expectSelectedAttributes(
+	async expectVariationSelectorAttributes(
 		productAttributes: {
 			name: string;
 			options: string[];
@@ -189,7 +219,7 @@ class AddToCartWithOptionsPage {
 			visible: boolean;
 		}[],
 		expectedValues: Record< string, string | RegExp > = {},
-		optionStyle: 'Pills' | 'Dropdown'
+		optionStyle: 'pills' | 'dropdown'
 	) {
 		for ( let {
 			name: attributeName,
@@ -198,7 +228,7 @@ class AddToCartWithOptionsPage {
 			const attributeNameLocator = this.page.getByLabel( attributeName, {
 				exact: true,
 			} );
-			if ( optionStyle === 'Dropdown' ) {
+			if ( optionStyle === 'dropdown' ) {
 				let expectedValue: string | RegExp;
 				if (
 					attributeName in expectedValues &&


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/pull/64031/changes#r3041485890.

This PR adds several improvements to _Add to Cart + Options_ e2e tests:

* `switchToDropdownMode()` is removed in favor of `setVariationSelectorAttributes()`.
* `setVariationSelectorAttributes()` is moved to the page object, its arguments are simplified, and it doesn't contain the logic to save the template.
* option style params (`'Dropdown'` and `'Style'`) are now lowercase
* a few other linting improvements

### How to test the changes in this Pull Request:

1. Make sure e2e tests pass.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.