### PR TITLE
[Performance]: Reduce the number of SQLs required to populate cart data in StoreApi

### DIFF
--- a/plugins/woocommerce/changelog/performance-cart-checkout-cache-priming
+++ b/plugins/woocommerce/changelog/performance-cart-checkout-cache-priming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduced the number of SQLs required to populate cart data in StoreApi.

--- a/plugins/woocommerce/changelog/performance-cart-checkout-cache-priming
+++ b/plugins/woocommerce/changelog/performance-cart-checkout-cache-priming
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-Reduced the number of SQLs required to populate cart data in StoreApi.
+Reduced the number of SQL queries needed to populate cart data in StoreApi.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -128,6 +128,17 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @since 3.0.0
 	 */
 	protected function read_product_data( &$product ) {
+		// Prime caches to reduce future queries.
+		$product_id = $product->get_id();
+		wp_prime_option_caches(
+			array(
+				'_transient_wc_var_prices_' . $product_id,
+				'_transient_timeout_wc_var_prices_' . $product_id,
+				'_transient_wc_product_children_' . $product_id,
+				'_transient_timeout_wc_product_children_' . $product_id,
+			)
+		);
+
 		parent::read_product_data( $product );
 
 		// Make sure data which does not apply to variables is unset.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -449,6 +449,21 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'addressAutocompleteProviders', $providers_payload );
 		$this->asset_data_registry->add( 'countryData', $country_data );
 		$this->asset_data_registry->add( 'defaultAddressFormat', $address_formats['default'] );
+
+		// Prime caches to reduce future queries.
+		wp_prime_option_caches(
+			array(
+				'woocommerce_enable_guest_checkout',
+				'woocommerce_enable_signup_and_login_from_checkout',
+				'woocommerce_enable_checkout_login_reminder',
+				'woocommerce_tax_display_cart', // This one is autoloaded, but we add it here for clarity.
+				'woocommerce_tax_total_display',
+				'woocommerce_ship_to_destination',
+				'woocommerce_registration_generate_password',
+				'pickup_location_pickup_locations',
+			)
+		);
+
 		$this->asset_data_registry->add(
 			'checkoutAllowsGuest',
 			false === filter_var(
@@ -461,16 +476,6 @@ class Checkout extends AbstractBlock {
 			filter_var(
 				wc()->checkout()->is_registration_enabled(),
 				FILTER_VALIDATE_BOOLEAN
-			)
-		);
-		// Prime caches to reduce future queries.
-		wp_prime_option_caches(
-			array(
-				'woocommerce_enable_checkout_login_reminder',
-				'woocommerce_tax_display_cart', // This one is autoloaded, but we add it here for clarity.
-				'woocommerce_tax_total_display',
-				'woocommerce_ship_to_destination',
-				'woocommerce_registration_generate_password',
 			)
 		);
 		$this->asset_data_registry->add( 'checkoutShowLoginReminder', filter_var( get_option( 'woocommerce_enable_checkout_login_reminder' ), FILTER_VALIDATE_BOOLEAN ) );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
@@ -347,17 +347,19 @@ class CartSchema extends AbstractSchema {
 		if ( ! empty( $cross_sell_ids ) ) {
 			// Prime caches to reduce future queries.
 			_prime_post_caches( $cross_sell_ids );
-			$cross_sells = array_filter( array_map( 'wc_get_product', $cross_sell_ids ), 'wc_products_array_filter_visible' );
+			$cross_sells = array_values( array_filter( array_map( 'wc_get_product', $cross_sell_ids ), 'wc_products_array_filter_visible' ) );
 			/** @var \WC_Product[] $cross_sells */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			// Identify which images need priming.
-			$image_ids[] = array_values( array_filter( array_map( static fn( $product ) => (int) $product->get_image_id(), $cross_sells ) ) );
+			$ids         = array_map( static fn( $product ) => array( (int) $product->get_image_id(), ...$product->get_gallery_image_ids() ), $cross_sells );
+			$image_ids[] = array_values( array_filter( array_merge( ...$ids ) ) );
 		}
 
 		$cart_all_items  = $cart->get_cart();
-		$cart_line_items = array_filter( $cart_all_items, static fn( $item ) => ( $item['data'] ?? null ) instanceof \WC_Product );
+		$cart_line_items = array_values( array_filter( $cart_all_items, static fn( $item ) => ( $item['data'] ?? null ) instanceof \WC_Product ) );
 		if ( ! empty( $cart_line_items ) ) {
 			// Identify which images need priming.
-			$image_ids[] = array_values( array_filter( array_map( static fn( $item ) => (int) $item['data']->get_image_id(), $cart_line_items ) ) );
+			$ids         = array_map( static fn( $item ) => array( (int) $item['data']->get_image_id(), ...$item['data']->get_gallery_image_ids() ), $cart_line_items );
+			$image_ids[] = array_values( array_filter( array_merge( ...array_values( $ids ) ) ) );
 		}
 
 		if ( ! empty( $image_ids ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Follow up on https://github.com/woocommerce/woocommerce/pull/63319

The original PR did not include priming for gallery images. This update adds priming to prevent gallery images from triggering additional SQL queries on cart and checkout pages. Also, we cover priming for missed options in the same StoreAPI endpoint and priming for transients in the variable product data store. 

> The key point is that only two SQL queries are required to populate product images and galleries for upsells and cart items (on cart and checkout pages). This approach ensures a stable, predictable database load for image fetching, which is critical in HVM/BFCM scenarios.

- Cart page: 125 SQLs -> 121 SQLs
- Product page: 160 SQLs => 155 SQLs, 180 SQLs -> 175 SQLs for the test products respectively

### How to test the changes in this Pull Request:

- Ensure that the Query Monitor plugin is enabled on your testing site and that no object cache is active.
- Identify two variable products and add additional images to each.
- Add these products to the cart and proceed to the cart page.
- Verify that the number of SQL queries is reduced in this branch compared to trunk.