### PR TITLE
Prime attachment caches in product gallery meta box to reduce edit screen queries

### DIFF
--- a/plugins/woocommerce/changelog/64089-fix-prime-product-images-metabox
+++ b/plugins/woocommerce/changelog/64089-fix-prime-product-images-metabox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduce the number of database queries on the product edit screen by priming attachment caches before rendering the product gallery meta box.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
@@ -43,6 +43,9 @@ class WC_Meta_Box_Product_Images {
 				$updated_gallery_ids = array();
 
 				if ( ! empty( $attachments ) ) {
+					// Prime caches to reduce future queries.
+					_prime_post_caches( $attachments );
+
 					foreach ( $attachments as $attachment_id ) {
 						$attachment = wp_get_attachment_image( $attachment_id, 'thumbnail' );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Prime attachment post caches for the product gallery before the product images meta box renders each image. Previously the `foreach ( $attachments as $attachment_id )` loop in `WC_Meta_Box_Product_Images::output()` called `wp_get_attachment_image()` per image, which issued an individual `get_post()` query (plus meta fetches for alt text and attachment metadata) for every gallery item. For products with large galleries, each edit screen load triggered N extra queries. Priming the attachment posts in a single call warms the cache once, so the per-item reads hit it.

Part of https://github.com/woocommerce/woocommerce/issues/64069.

### How to test the changes in this Pull Request:

1. Pick (or create) a product with a large Product Gallery, the more images, the more visible the win. 20+ gallery items make the improvement more obvious.
2. Install and activate the [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin.
3. Open the product edit page in the admin.
4. Note the total query count in the Query Monitor Queries panel.
5. Switch to `trunk` and reload the page.
6. Compare the total query counts. You should see a substantial reduction with the prime in place.

### Testing that has already taken place:

Tested locally on a product with a 30-image gallery. Total queries on the product edit page measured with Query Monitor:

- **Before:** 178 queries
- **After:** 122 queries
- **Saved:** 56 queries (~31%)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Performance - Address performance issues

#### Message

Reduce the number of database queries on the product edit screen by priming attachment caches before rendering the product gallery meta box.

</details>
