### PR TITLE
Fix shipping provider filter meta key mismatch

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-provider-filter-meta-key-mismatch
+++ b/plugins/woocommerce/changelog/fix-shipping-provider-filter-meta-key-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shipping provider filter on orders list using wrong meta key, causing no results to appear.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -4057,7 +4057,7 @@ class WC_AJAX {
 			$wpdb->prepare(
 				"SELECT 1 FROM {$fulfillments_table} f
 				INNER JOIN {$meta_table} m ON f.fulfillment_id = m.fulfillment_id
-				WHERE m.meta_key = '_shipping_provider'
+				WHERE m.meta_key = '_shipment_provider'
 				AND m.meta_value = %s
 				AND f.date_deleted IS NULL
 				AND m.date_deleted IS NULL

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -4062,7 +4062,7 @@ class WC_AJAX {
 				AND f.date_deleted IS NULL
 				AND m.date_deleted IS NULL
 				LIMIT 1",
-				$provider_slug
+				wp_json_encode( $provider_slug )
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsRenderer.php
@@ -687,7 +687,7 @@ class FulfillmentsRenderer {
 						AND m.meta_value != ''
 						AND f.date_deleted IS NULL
 						AND m.date_deleted IS NULL",
-						'_shipping_provider'
+						'_shipment_provider'
 					)
 				);
 			} else {
@@ -697,7 +697,7 @@ class FulfillmentsRenderer {
 						"SELECT DISTINCT f.entity_id
 						FROM {$fulfillments_table} f
 						INNER JOIN {$meta_table} m ON f.fulfillment_id = m.fulfillment_id
-						WHERE m.meta_key = '_shipping_provider'
+						WHERE m.meta_key = '_shipment_provider'
 						AND m.meta_value NOT IN ({$placeholders})
 						AND m.meta_value IS NOT NULL
 						AND m.meta_value != ''
@@ -713,7 +713,7 @@ class FulfillmentsRenderer {
 					"SELECT DISTINCT f.entity_id
 					FROM {$fulfillments_table} f
 					INNER JOIN {$meta_table} m ON f.fulfillment_id = m.fulfillment_id
-					WHERE m.meta_key = '_shipping_provider'
+					WHERE m.meta_key = '_shipment_provider'
 					AND m.meta_value = %s
 					AND f.date_deleted IS NULL
 					AND m.date_deleted IS NULL",

--- a/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsRenderer.php
@@ -703,7 +703,7 @@ class FulfillmentsRenderer {
 						AND m.meta_value != ''
 						AND f.date_deleted IS NULL
 						AND m.date_deleted IS NULL",
-						...$known_keys
+						...array_map( 'wp_json_encode', $known_keys )
 					)
 				);
 			}
@@ -717,7 +717,7 @@ class FulfillmentsRenderer {
 					AND m.meta_value = %s
 					AND f.date_deleted IS NULL
 					AND m.date_deleted IS NULL",
-					$shipping_provider
+					wp_json_encode( $shipping_provider )
 				)
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Two bugs prevented the shipping provider filter on the orders list from working:

1. **Wrong meta key**: SQL queries used `_shipping_provider` but the fulfillment model stores the provider under `_shipment_provider`. Fixed in `FulfillmentsRenderer.php` (3 occurrences) and `class-wc-ajax.php` (1 occurrence).

2. **Missing JSON encoding**: The data store saves meta values with `wp_json_encode()`, so a string like `dhl` is stored as `"dhl"` (with literal quotes) in the database. The filter queries were comparing raw strings (e.g., `dhl`) which never matched the JSON-encoded values. Fixed by wrapping comparison values with `wp_json_encode()`.

The same bugs also affected `is_shipping_provider_in_use()` in `WC_AJAX`, which could allow deletion of custom providers that are still in use.

Closes # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create an order and add a fulfillment with a known shipping provider (e.g., DHL).
2. Go to WooCommerce > Orders.
3. Use the "Filter by shipping provider" dropdown, select the provider used in step 1, and click "Filter".
4. Verify the order from step 1 appears in the results.
5. Select "Other" in the filter and verify orders with non-standard providers appear.
6. Go to WooCommerce > Settings > Shipping > Shipping Providers, add a custom provider, assign it to a fulfillment on an order, then try to delete it. Verify the deletion is blocked with an "in use" message.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified the stored meta values in the database are JSON-encoded (e.g., `"ups"` with literal quotes). Confirmed the fix correctly matches by JSON-encoding comparison values before querying.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix shipping provider filter on orders list using wrong meta key, causing no results to appear.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>