### PR TITLE
Unify trash icon across cart and mini-cart blocks

### DIFF
--- a/plugins/woocommerce/changelog/64105-wooprd-3422-trash-icon-across-cart-and-checkout-needs-to-be-updated
+++ b/plugins/woocommerce/changelog/64105-wooprd-3422-trash-icon-across-cart-and-checkout-needs-to-be-updated
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Unify trash icon across cart and mini-cart blocks to use the current Gutenberg design system icon.

--- a/plugins/woocommerce/changelog/64105-wooprd-3422-trash-icon-across-cart-and-checkout-needs-to-be-updated
+++ b/plugins/woocommerce/changelog/64105-wooprd-3422-trash-icon-across-cart-and-checkout-needs-to-be-updated
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Unify trash icon across cart and mini-cart blocks to use the current Gutenberg design system icon.

--- a/plugins/woocommerce/changelog/wooprd-3422-trash-icon-across-cart-and-checkout-needs-to-be-updated
+++ b/plugins/woocommerce/changelog/wooprd-3422-trash-icon-across-cart-and-checkout-needs-to-be-updated
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Unify trash icon across cart and mini-cart blocks to use the current Gutenberg design system icon.

--- a/plugins/woocommerce/changelog/wooprd-3422-trash-icon-across-cart-and-checkout-needs-to-be-updated
+++ b/plugins/woocommerce/changelog/wooprd-3422-trash-icon-across-cart-and-checkout-needs-to-be-updated
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Unify trash icon across cart and mini-cart blocks to use the current Gutenberg design system icon.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -21,7 +21,8 @@ import { forwardRef, useMemo } from '@wordpress/element';
 import type { CartItem } from '@woocommerce/types';
 import { objectHasProp, Currency } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
-import { Icon, trash } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
+import { trash } from '@woocommerce/icons';
 import { calculateSaleAmount } from '@woocommerce/base-utils';
 import { dinero, transformScale, toSnapshot, type Dinero } from 'dinero.js';
 import { USD } from 'dinero.js/currencies'; // USD is used as a placeholder currency for arithmetic; actual formatting is handled elsewhere.

--- a/plugins/woocommerce/client/blocks/assets/js/icons/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/icons/index.js
@@ -34,4 +34,5 @@ export { default as stacks } from './library/stacks';
 export { default as thumbUp } from './library/thumb-up';
 export { default as toggle } from './library/toggle';
 export { default as totals } from './library/totals';
+export { default as trash } from './library/trash';
 export { default as woo } from './library/woo';

--- a/plugins/woocommerce/client/blocks/assets/js/icons/library/trash.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/icons/library/trash.tsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const trash = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"
+		/>
+	</SVG>
+);
+
+export default trash;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The cart block (React) was importing the `trash` icon from `@wordpress/icons@9.36.0`, which ships an older, visually different trash icon than the current Gutenberg design system. The mini-cart (PHP/Interactivity API) had the newer Gutenberg trash SVG hardcoded in `MiniCartProductsTableBlock.php`, causing the two to look different.

This PR adds the current Gutenberg trash icon to `@woocommerce/icons` and switches the cart block to import it from there, so both cart and mini-cart render the same icon regardless of the installed `@wordpress/icons` version.

Closes: WOOPRD-3422

### How to test the changes in this Pull Request:

1. Add products to the cart.
2. Visit the Cart block page — verify the remove (trash) icon on each line item matches the Gutenberg design system trash icon (outlined trash can with lid).
3. Open the Mini-Cart drawer — verify the remove icon on each line item is visually identical to the Cart block's icon.
4. Confirm both icons look the same across cart and mini-cart.

### Testing that has already taken place:

Visual verification that the trash icon renders identically in both the cart block and mini-cart.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Unify trash icon across cart and mini-cart blocks to use the current Gutenberg design system icon.

</details>