### PR TITLE
Fix failing Metrics action

### DIFF
--- a/.github/workflows/scripts/run-metrics.sh
+++ b/.github/workflows/scripts/run-metrics.sh
@@ -71,7 +71,7 @@ if [ "$GITHUB_EVENT_NAME" == "push" ] || [ "$GITHUB_EVENT_NAME" == "pull_request
 		title "##[group]Building baseline"
 		( git -c core.hooksPath=/dev/null checkout --quiet $BASE_SHA > /dev/null || git reset --hard $BASE_SHA ) && echo 'On' $(git rev-parse HEAD)
 		pnpm run --if-present clean:build &
-		pnpm install --filter='@woocommerce/plugin-woocommerce...' --frozen-lockfile --config.dedupe-peer-dependents=false
+		pnpm install --filter='@woocommerce/plugin-woocommerce...' --filter='compare-perf...' --frozen-lockfile --config.dedupe-peer-dependents=false
 		WIREIT_CACHE=local pnpm --filter='@woocommerce/plugin-woocommerce' build
 		echo '##[endgroup]'
 


### PR DESCRIPTION
## Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

## Changes proposed in this Pull Request:

Fixes intermittent `Metrics - @woocommerce/plugin-woocommerce [performance]` CI failures caused by:

- `Error: Cannot find module 'ts-node/register'`
- `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL ... test:metrics:ci`

The baseline build step in [`.github/workflows/scripts/run-metrics.sh`](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/scripts/run-metrics.sh) only installed `@woocommerce/plugin-woocommerce...` dependencies. In failing runs, `compare-perf` dependencies were no longer available by the time we executed:

- `pnpm --filter="compare-perf" run compare ...`

This PR updates the baseline install step to include `compare-perf` as well.

### Why this is needed

This issue reproduces on both `trunk` and `release/10.7` backport PRs, so it is not branch-specific.

The failure started after [#63964](https://github.com/woocommerce/woocommerce/pull/63964) (pnpm 10 migration), first observed on:

- Run: [23910152867](https://github.com/woocommerce/woocommerce/actions/runs/23910152867)
- Job: [69729735610](https://github.com/woocommerce/woocommerce/actions/runs/23910152867/job/69729735610)
- Commit: [`c37dad1b29c5578cb0e55c1853f765214cae7067`](https://github.com/woocommerce/woocommerce/commit/c37dad1b29c5578cb0e55c1853f765214cae7067)

The previous trunk push run had Metrics passing:

- Run: [23907455502](https://github.com/woocommerce/woocommerce/actions/runs/23907455502)
- Job: [69720113611](https://github.com/woocommerce/woocommerce/actions/runs/23907455502/job/69720113611)

### Additional failing examples with same signature

- [23921146725](https://github.com/woocommerce/woocommerce/actions/runs/23921146725)
- [23924564784](https://github.com/woocommerce/woocommerce/actions/runs/23924564784)
- [23935053899](https://github.com/woocommerce/woocommerce/actions/runs/23935053899)
- [24235552520](https://github.com/woocommerce/woocommerce/actions/runs/24235552520) / job [70760877795](https://github.com/woocommerce/woocommerce/actions/runs/24235552520/job/70760877795)
- [24253295229](https://github.com/woocommerce/woocommerce/actions/runs/24253295229) / job [70818349888](https://github.com/woocommerce/woocommerce/actions/runs/24253295229/job/70818349888)
- [24255810053](https://github.com/woocommerce/woocommerce/actions/runs/24255810053) / job [70827250360](https://github.com/woocommerce/woocommerce/actions/runs/24255810053/job/70827250360)

### Intermittent nature

This is not a test assertion flake; it is an environment/install-state issue. Same branch can pass or fail depending on install state during the job:

- Failed: [24262938012](https://github.com/woocommerce/woocommerce/actions/runs/24262938012) / [70851133285](https://github.com/woocommerce/woocommerce/actions/runs/24262938012/job/70851133285)
- Passed: [24258990271](https://github.com/woocommerce/woocommerce/actions/runs/24258990271) / [70849454860](https://github.com/woocommerce/woocommerce/actions/runs/24258990271/job/70849454860)

## How to test the changes in this Pull Request:

1. Trigger CI for this branch.
2. Verify `Metrics - @woocommerce/plugin-woocommerce [performance]` no longer fails with `Cannot find module 'ts-node/register'`.
3. Confirm the compare step runs successfully:
   - `pnpm --filter="compare-perf" run compare ...`
4. Optionally rerun the Metrics job to verify stability across reruns.

## Testing that has already taken place:

- Verified historical run logs and identified earliest failure/regression point.
- Confirmed failures across both `trunk` and `release/10.7` backport PR runs.
- Applied minimal fix to baseline install filter in `run-metrics.sh` to keep `compare-perf` dependencies available.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Just CI improvement.

</details>
