### PR TITLE
Prevent shop rewrite corruption from WP-CLI and cron contexts

### DIFF
--- a/plugins/woocommerce/changelog/fix-63954-skip-themes-flush-rewrite-rules
+++ b/plugins/woocommerce/changelog/fix-63954-skip-themes-flush-rewrite-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not update theme support option or queue rewrite rule flush when running in WP-CLI or cron contexts, preventing hosts that run WP-CLI with --skip-themes from corrupting the shop page rewrite rules.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -341,9 +341,13 @@ class WC_Post_Types {
 		}
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
-		$theme_support = wc_current_theme_supports_woocommerce_or_fse() ? 'yes' : 'no';
-		if ( get_option( 'current_theme_supports_woocommerce' ) !== $theme_support && update_option( 'current_theme_supports_woocommerce', $theme_support ) ) {
-			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+		// Skip this check in WP-CLI and cron contexts: themes may not be loaded (e.g. --skip-themes),
+		// which would incorrectly record theme support as "no" and corrupt rewrite rules on the frontend.
+		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) && ! wp_doing_cron() ) {
+			$theme_support = wc_current_theme_supports_woocommerce_or_fse() ? 'yes' : 'no';
+			if ( get_option( 'current_theme_supports_woocommerce' ) !== $theme_support && update_option( 'current_theme_supports_woocommerce', $theme_support ) ) {
+				update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+			}
 		}
 
 		register_post_type(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Hosts that run WP-CLI with `--skip-themes` never load the classic theme's `functions.php`, so `add_theme_support( 'woocommerce' )` is missing. WooCommerce records `current_theme_supports_woocommerce=no`, queues a rewrite flush, and writes product rewrites with `has_archive=false` — wiping the shop/product archive rules.

This is a race condition: the option update happens at `init`, but the rewrite flush is deferred to `wp_loaded`. A concurrent request can restore the option to `yes` before the flush runs, so the self-heal trigger (option mismatch) never fires again — leaving broken rules permanently.

This fix skips the theme-support option update and rewrite-queue logic in WP-CLI and `wp_doing_cron()` contexts, preventing unsafe requests from creating the bad state.

Block themes and Twenty* themes are unaffected.

See https://github.com/woocommerce/woocommerce/issues/63954#issuecomment-4234777151 for the detailed investigation and reproducer plugin.

Kudos to @kaushikasomaiya for big the help investigate the issue!

Closes #63954.

### How to test the changes in this Pull Request:

**Requirements:** Storefront (or any classic non-Twenty* theme).

**Setup:**

1. Activate Storefront and flush rewrites: `wp rewrite flush --hard`
2. Install and activate the [reproducer plugin from this comment](https://github.com/woocommerce/woocommerce/issues/63954#issuecomment-4234777151) (save as `wp-content/plugins/wc-rewrite-race-reproducer.php`).

**Reproduce the bug on trunk (without fix):**

3. Visit `/shop/?wcrace=go` (takes ~5s).
4. Check DB state:
   ```
   wp eval '$rules = get_option("rewrite_rules"); echo "option=" . get_option("current_theme_supports_woocommerce") . "\n"; echo "has_shop_rule=" . ( isset($rules["shop/?$"]) ? "yes" : "no" ) . "\n";'
   ```
5. Expected: `option=yes`, `has_shop_rule=no` — the broken mixed state. `/shop/` shows the static page, not the product archive.

**Verify the fix:**

6. Apply this PR, reset: `wp rewrite flush --hard`
7. Visit `/shop/?wcrace=go` again.
8. Repeat step 4. Expected: `option=yes`, `has_shop_rule=yes` — rules intact. `/shop/` shows the product archive.

**Verify normal theme-switch detection still works:**

9. Deactivate the reproducer plugin, switch to a theme without WooCommerce support.
10. Load any page — confirm `current_theme_supports_woocommerce` flips to `no`.

### Testing that has already taken place:

Verified locally with Storefront using the reproducer plugin:

-   On trunk, visiting `/shop/?wcrace=go` produces the broken mixed state.
-   With this fix, rewrite rules stay intact and `/shop/` correctly shows the product archive.
-   Normal theme-switch detection continues to work.


https://github.com/user-attachments/assets/bc61cbc1-3619-416b-a56e-982bfece2bb9



### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry.

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Created manually: `plugins/woocommerce/changelog/fix-63954-skip-themes-flush-rewrite-rules`.

</details>