### PR TITLE
Repair stale shop rewrites when state drifts

### DIFF
--- a/plugins/woocommerce/changelog/repair-stale-shop-rewrites-when-state-drifts
+++ b/plugins/woocommerce/changelog/repair-stale-shop-rewrites-when-state-drifts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Repair stale shop rewrite rules when WooCommerce theme support state and rewrite rules drift out of sync.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -634,6 +634,8 @@ class WC_Install {
 		// Use add_option() here to avoid overwriting this value with each
 		// plugin version update. We base plugin age off of this value.
 		add_option( 'woocommerce_admin_install_timestamp', time() );
+		// Retry product archive rewrite verification on the next trusted request after install/update.
+		WC_Post_Types::queue_product_archive_rewrite_rules_verification();
 
 		// Force a flush of rewrite rules even if the corresponding hook isn't initialized yet.
 		if ( ! has_action( 'woocommerce_flush_rewrite_rules' ) ) {

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -18,6 +18,10 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * Post types Class.
  */
 class WC_Post_Types {
+	/**
+	 * Option used to retry product archive rewrite verification on trusted requests.
+	 */
+	private const PRODUCT_ARCHIVE_REWRITE_RULES_VERIFICATION_OPTION = 'woocommerce_verify_product_archive_rewrite_rules';
 
 	/**
 	 * Hook in methods.
@@ -591,7 +595,7 @@ class WC_Post_Types {
 	}
 
 	/**
-	 * Queue a flush when theme support changes or product archive rewrites drift from the expected shape.
+	 * Queue a flush when theme support changes and verify product archive rewrites when a retry is pending.
 	 *
 	 * @param string       $theme_support Whether the current theme supports WooCommerce.
 	 * @param string|false $has_archive Archive slug for the product post type.
@@ -600,9 +604,55 @@ class WC_Post_Types {
 		$theme_support_changed = get_option( 'current_theme_supports_woocommerce' ) !== $theme_support
 			&& update_option( 'current_theme_supports_woocommerce', $theme_support );
 
-		if ( $theme_support_changed || self::should_flush_rewrite_rules_for_product_archive( $has_archive ) ) {
+		if ( $theme_support_changed ) {
+			self::queue_product_archive_rewrite_rules_verification();
 			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+			return;
 		}
+
+		self::maybe_verify_product_archive_rewrite_rules( $has_archive );
+	}
+
+	/**
+	 * Queue product archive rewrite verification for the next trusted request.
+	 */
+	public static function queue_product_archive_rewrite_rules_verification(): void {
+		update_option( self::PRODUCT_ARCHIVE_REWRITE_RULES_VERIFICATION_OPTION, 'yes' );
+	}
+
+	/**
+	 * Verify product archive rewrite rules when a retry is pending.
+	 *
+	 * @param string|false $has_archive Archive slug for the product post type.
+	 */
+	private static function maybe_verify_product_archive_rewrite_rules( $has_archive ): void {
+		if ( ! self::should_verify_product_archive_rewrite_rules() ) {
+			return;
+		}
+
+		if ( self::should_flush_rewrite_rules_for_product_archive( $has_archive ) ) {
+			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+			return;
+		}
+
+		delete_option( self::PRODUCT_ARCHIVE_REWRITE_RULES_VERIFICATION_OPTION );
+	}
+
+	/**
+	 * Determine whether the current request should verify product archive rewrites.
+	 *
+	 * @return bool
+	 */
+	private static function should_verify_product_archive_rewrite_rules(): bool {
+		if ( 'yes' !== get_option( self::PRODUCT_ARCHIVE_REWRITE_RULES_VERIFICATION_OPTION, 'no' ) ) {
+			return false;
+		}
+
+		if ( wp_doing_cron() ) {
+			return false;
+		}
+
+		return ! ( defined( 'WP_CLI' ) && WP_CLI );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -342,9 +342,7 @@ class WC_Post_Types {
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
 		$theme_support = wc_current_theme_supports_woocommerce_or_fse() ? 'yes' : 'no';
-		if ( get_option( 'current_theme_supports_woocommerce' ) !== $theme_support && update_option( 'current_theme_supports_woocommerce', $theme_support ) ) {
-			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
-		}
+		self::maybe_queue_flush_rewrite_rules( $theme_support, $has_archive );
 
 		register_post_type(
 			'product',
@@ -590,6 +588,88 @@ class WC_Post_Types {
 		}
 
 		do_action( 'woocommerce_after_register_post_type' );
+	}
+
+	/**
+	 * Queue a flush when theme support changes or product archive rewrites drift from the expected shape.
+	 *
+	 * @param string       $theme_support Whether the current theme supports WooCommerce.
+	 * @param string|false $has_archive Archive slug for the product post type.
+	 */
+	private static function maybe_queue_flush_rewrite_rules( $theme_support, $has_archive ): void {
+		$theme_support_changed = get_option( 'current_theme_supports_woocommerce' ) !== $theme_support
+			&& update_option( 'current_theme_supports_woocommerce', $theme_support );
+
+		if ( $theme_support_changed || self::should_flush_rewrite_rules_for_product_archive( $has_archive ) ) {
+			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+		}
+	}
+
+	/**
+	 * Determine whether product archive rewrite rules have drifted from the expected shape.
+	 *
+	 * @param string|false $has_archive Archive slug for the product post type.
+	 * @param array|null   $rewrite_rules Optional rewrite rules for testing.
+	 * @return bool
+	 */
+	private static function should_flush_rewrite_rules_for_product_archive( $has_archive, $rewrite_rules = null ): bool {
+		$actual_product_archive_rules   = self::get_product_archive_rewrite_rules( $rewrite_rules );
+		$expected_product_archive_rules = self::get_expected_product_archive_rewrite_rules( $has_archive );
+
+		if ( empty( $expected_product_archive_rules ) ) {
+			return ! empty( $actual_product_archive_rules );
+		}
+
+		foreach ( $expected_product_archive_rules as $regex => $query ) {
+			if ( ! isset( $actual_product_archive_rules[ $regex ] ) || $actual_product_archive_rules[ $regex ] !== $query ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the current product archive rewrite rules from the rewrite rules option.
+	 *
+	 * @param array|null $rewrite_rules Optional rewrite rules for testing.
+	 * @return array
+	 */
+	private static function get_product_archive_rewrite_rules( $rewrite_rules = null ): array {
+		if ( ! is_array( $rewrite_rules ) ) {
+			$rewrite_rules = get_option( 'rewrite_rules', array() );
+		}
+
+		$product_archive_rules = array();
+
+		foreach ( $rewrite_rules as $regex => $query ) {
+			if ( is_string( $query ) && str_contains( $query, 'post_type=product' ) ) {
+				$product_archive_rules[ $regex ] = $query;
+			}
+		}
+
+		return $product_archive_rules;
+	}
+
+	/**
+	 * Get the expected product archive rewrite rules for the current archive slug.
+	 *
+	 * @param string|false $has_archive Archive slug for the product post type.
+	 * @return array
+	 */
+	private static function get_expected_product_archive_rewrite_rules( $has_archive ): array {
+		if ( false === $has_archive || '' === $has_archive ) {
+			return array();
+		}
+
+		$has_archive = trim( (string) $has_archive, '/' );
+
+		return array(
+			$has_archive . '/?$'                          => 'index.php?post_type=product',
+			$has_archive . '/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?post_type=product&feed=$matches[1]',
+			$has_archive . '/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?post_type=product&feed=$matches[1]',
+			$has_archive . '/page/([0-9]{1,})/?$'         => 'index.php?post_type=product&paged=$matches[1]',
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-post-types-test.php
@@ -1,0 +1,183 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_Post_Types.
+ */
+class WC_Post_Types_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Stored option values to restore after each test.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_options = array();
+
+	/**
+	 * Set up each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_options = array(
+			'rewrite_rules'                         => get_option( 'rewrite_rules', '__missing__' ),
+			'current_theme_supports_woocommerce'    => get_option( 'current_theme_supports_woocommerce', '__missing__' ),
+			'woocommerce_queue_flush_rewrite_rules' => get_option( 'woocommerce_queue_flush_rewrite_rules', '__missing__' ),
+		);
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->original_options as $option_name => $value ) {
+			if ( '__missing__' === $value ) {
+				delete_option( $option_name );
+			} else {
+				update_option( $option_name, $value );
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox maybe_queue_flush_rewrite_rules repairs missing product archive rules when theme support already matches.
+	 */
+	public function test_maybe_queue_flush_rewrite_rules_repairs_missing_product_archive_rules(): void {
+		update_option( 'current_theme_supports_woocommerce', 'yes' );
+		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option( 'rewrite_rules', array() );
+
+		$this->invoke_static_method(
+			'maybe_queue_flush_rewrite_rules',
+			array( 'yes', $this->get_shop_archive() )
+		);
+
+		$this->assertSame( 'yes', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+	}
+
+	/**
+	 * @testdox maybe_queue_flush_rewrite_rules repairs stale product archive rules when the shop archive slug changes.
+	 */
+	public function test_maybe_queue_flush_rewrite_rules_repairs_stale_product_archive_rules(): void {
+		update_option( 'current_theme_supports_woocommerce', 'yes' );
+		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option(
+			'rewrite_rules',
+			$this->invoke_static_method(
+				'get_expected_product_archive_rewrite_rules',
+				array( 'outdated-shop' )
+			)
+		);
+
+		$this->invoke_static_method(
+			'maybe_queue_flush_rewrite_rules',
+			array( 'yes', $this->get_shop_archive() )
+		);
+
+		$this->assertSame( 'yes', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+	}
+
+	/**
+	 * @testdox maybe_queue_flush_rewrite_rules repairs stale product archive rules when the archive is disabled.
+	 */
+	public function test_maybe_queue_flush_rewrite_rules_repairs_stale_product_archive_rules_when_archive_is_disabled(): void {
+		update_option( 'current_theme_supports_woocommerce', 'no' );
+		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option(
+			'rewrite_rules',
+			$this->invoke_static_method(
+				'get_expected_product_archive_rewrite_rules',
+				array( $this->get_shop_archive() )
+			)
+		);
+
+		$this->invoke_static_method(
+			'maybe_queue_flush_rewrite_rules',
+			array( 'no', false )
+		);
+
+		$this->assertSame( 'yes', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+	}
+
+	/**
+	 * @testdox maybe_queue_flush_rewrite_rules does not queue a flush when product archive rules already match.
+	 */
+	public function test_maybe_queue_flush_rewrite_rules_does_not_queue_flush_when_product_archive_rules_match(): void {
+		update_option( 'current_theme_supports_woocommerce', 'yes' );
+		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option(
+			'rewrite_rules',
+			$this->invoke_static_method(
+				'get_expected_product_archive_rewrite_rules',
+				array( $this->get_shop_archive() )
+			)
+		);
+
+		$this->invoke_static_method(
+			'maybe_queue_flush_rewrite_rules',
+			array( 'yes', $this->get_shop_archive() )
+		);
+
+		$this->assertSame( 'no', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+	}
+
+	/**
+	 * @testdox maybe_queue_flush_rewrite_rules ignores extra custom product archive rules when the expected rules are present.
+	 */
+	public function test_maybe_queue_flush_rewrite_rules_ignores_extra_custom_product_archive_rules(): void {
+		update_option( 'current_theme_supports_woocommerce', 'yes' );
+		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+
+		$rewrite_rules                              = $this->invoke_static_method(
+			'get_expected_product_archive_rewrite_rules',
+			array( $this->get_shop_archive() )
+		);
+		$rewrite_rules['custom-product-archive/?$'] = 'index.php?post_type=product&custom_archive=1';
+
+		update_option( 'rewrite_rules', $rewrite_rules );
+
+		$this->invoke_static_method(
+			'maybe_queue_flush_rewrite_rules',
+			array( 'yes', $this->get_shop_archive() )
+		);
+
+		$this->assertSame( 'no', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+	}
+
+	/**
+	 * Invoke a private static method.
+	 *
+	 * @param string $method_name Method name to call.
+	 * @param array  $parameters Array of parameters to pass to method.
+	 * @return mixed
+	 */
+	private function invoke_static_method( string $method_name, array $parameters = array() ) {
+		$reflection = new \ReflectionMethod( WC_Post_Types::class, $method_name );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( null, $parameters );
+	}
+
+	/**
+	 * Get the current shop archive slug.
+	 *
+	 * @return string
+	 */
+	private function get_shop_archive(): string {
+		$shop_page_id = wc_get_page_id( 'shop' );
+
+		if ( ! $shop_page_id || ! get_post( $shop_page_id ) ) {
+			return 'shop';
+		}
+
+		$shop_page_uri = get_page_uri( $shop_page_id );
+
+		if ( false === $shop_page_uri ) {
+			return 'shop';
+		}
+
+		return urldecode( $shop_page_uri );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-post-types-test.php
@@ -23,6 +23,7 @@ class WC_Post_Types_Test extends \WC_Unit_Test_Case {
 			'rewrite_rules'                         => get_option( 'rewrite_rules', '__missing__' ),
 			'current_theme_supports_woocommerce'    => get_option( 'current_theme_supports_woocommerce', '__missing__' ),
 			'woocommerce_queue_flush_rewrite_rules' => get_option( 'woocommerce_queue_flush_rewrite_rules', '__missing__' ),
+			$this->get_verification_option_name()   => get_option( $this->get_verification_option_name(), '__missing__' ),
 		);
 	}
 
@@ -42,9 +43,43 @@ class WC_Post_Types_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox maybe_queue_flush_rewrite_rules repairs missing product archive rules when theme support already matches.
+	 * @testdox maybe_queue_flush_rewrite_rules queues a flush and verification when theme support changes.
 	 */
-	public function test_maybe_queue_flush_rewrite_rules_repairs_missing_product_archive_rules(): void {
+	public function test_maybe_queue_flush_rewrite_rules_queues_flush_and_verification_when_theme_support_changes(): void {
+		update_option( 'current_theme_supports_woocommerce', 'no' );
+		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+
+		$this->invoke_static_method(
+			'maybe_queue_flush_rewrite_rules',
+			array( 'yes', $this->get_shop_archive() )
+		);
+
+		$this->assertSame( 'yes', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+		$this->assertSame( 'yes', get_option( $this->get_verification_option_name() ) );
+	}
+
+	/**
+	 * @testdox maybe_queue_flush_rewrite_rules repairs missing product archive rules only when verification is queued.
+	 */
+	public function test_maybe_queue_flush_rewrite_rules_repairs_missing_product_archive_rules_when_verification_is_queued(): void {
+		update_option( 'current_theme_supports_woocommerce', 'yes' );
+		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option( $this->get_verification_option_name(), 'yes' );
+		update_option( 'rewrite_rules', array() );
+
+		$this->invoke_static_method(
+			'maybe_queue_flush_rewrite_rules',
+			array( 'yes', $this->get_shop_archive() )
+		);
+
+		$this->assertSame( 'yes', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+		$this->assertSame( 'yes', get_option( $this->get_verification_option_name() ) );
+	}
+
+	/**
+	 * @testdox maybe_queue_flush_rewrite_rules skips archive verification when no retry is queued.
+	 */
+	public function test_maybe_queue_flush_rewrite_rules_skips_archive_verification_when_no_retry_is_queued(): void {
 		update_option( 'current_theme_supports_woocommerce', 'yes' );
 		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
 		update_option( 'rewrite_rules', array() );
@@ -54,15 +89,17 @@ class WC_Post_Types_Test extends \WC_Unit_Test_Case {
 			array( 'yes', $this->get_shop_archive() )
 		);
 
-		$this->assertSame( 'yes', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+		$this->assertSame( 'no', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+		$this->assertFalse( get_option( $this->get_verification_option_name(), false ) );
 	}
 
 	/**
-	 * @testdox maybe_queue_flush_rewrite_rules repairs stale product archive rules when the shop archive slug changes.
+	 * @testdox maybe_queue_flush_rewrite_rules repairs stale product archive rules when the shop archive slug changes and verification is queued.
 	 */
-	public function test_maybe_queue_flush_rewrite_rules_repairs_stale_product_archive_rules(): void {
+	public function test_maybe_queue_flush_rewrite_rules_repairs_stale_product_archive_rules_when_verification_is_queued(): void {
 		update_option( 'current_theme_supports_woocommerce', 'yes' );
 		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option( $this->get_verification_option_name(), 'yes' );
 		update_option(
 			'rewrite_rules',
 			$this->invoke_static_method(
@@ -77,14 +114,16 @@ class WC_Post_Types_Test extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( 'yes', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+		$this->assertSame( 'yes', get_option( $this->get_verification_option_name() ) );
 	}
 
 	/**
-	 * @testdox maybe_queue_flush_rewrite_rules repairs stale product archive rules when the archive is disabled.
+	 * @testdox maybe_queue_flush_rewrite_rules repairs stale product archive rules when the archive is disabled and verification is queued.
 	 */
-	public function test_maybe_queue_flush_rewrite_rules_repairs_stale_product_archive_rules_when_archive_is_disabled(): void {
+	public function test_maybe_queue_flush_rewrite_rules_repairs_stale_product_archive_rules_when_archive_is_disabled_and_verification_is_queued(): void {
 		update_option( 'current_theme_supports_woocommerce', 'no' );
 		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option( $this->get_verification_option_name(), 'yes' );
 		update_option(
 			'rewrite_rules',
 			$this->invoke_static_method(
@@ -99,14 +138,16 @@ class WC_Post_Types_Test extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( 'yes', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+		$this->assertSame( 'yes', get_option( $this->get_verification_option_name() ) );
 	}
 
 	/**
-	 * @testdox maybe_queue_flush_rewrite_rules does not queue a flush when product archive rules already match.
+	 * @testdox maybe_queue_flush_rewrite_rules clears verification when product archive rules already match.
 	 */
-	public function test_maybe_queue_flush_rewrite_rules_does_not_queue_flush_when_product_archive_rules_match(): void {
+	public function test_maybe_queue_flush_rewrite_rules_clears_verification_when_product_archive_rules_match(): void {
 		update_option( 'current_theme_supports_woocommerce', 'yes' );
 		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option( $this->get_verification_option_name(), 'yes' );
 		update_option(
 			'rewrite_rules',
 			$this->invoke_static_method(
@@ -121,14 +162,16 @@ class WC_Post_Types_Test extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( 'no', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+		$this->assertFalse( get_option( $this->get_verification_option_name(), false ) );
 	}
 
 	/**
-	 * @testdox maybe_queue_flush_rewrite_rules ignores extra custom product archive rules when the expected rules are present.
+	 * @testdox maybe_queue_flush_rewrite_rules ignores extra custom product archive rules when the expected rules are present and verification is queued.
 	 */
-	public function test_maybe_queue_flush_rewrite_rules_ignores_extra_custom_product_archive_rules(): void {
+	public function test_maybe_queue_flush_rewrite_rules_ignores_extra_custom_product_archive_rules_when_verification_is_queued(): void {
 		update_option( 'current_theme_supports_woocommerce', 'yes' );
 		update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
+		update_option( $this->get_verification_option_name(), 'yes' );
 
 		$rewrite_rules                              = $this->invoke_static_method(
 			'get_expected_product_archive_rewrite_rules',
@@ -144,6 +187,7 @@ class WC_Post_Types_Test extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( 'no', get_option( 'woocommerce_queue_flush_rewrite_rules' ) );
+		$this->assertFalse( get_option( $this->get_verification_option_name(), false ) );
 	}
 
 	/**
@@ -179,5 +223,14 @@ class WC_Post_Types_Test extends \WC_Unit_Test_Case {
 		}
 
 		return urldecode( $shop_page_uri );
+	}
+
+	/**
+	 * Get the verification option name used by WC_Post_Types.
+	 *
+	 * @return string
+	 */
+	private function get_verification_option_name(): string {
+		return 'woocommerce_verify_product_archive_rewrite_rules';
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up to woocommerce/woocommerce#64117. That PR prevents unsafe WP-CLI and cron contexts from creating new rewrite corruption, but stores can still be left in a mixed state where `current_theme_supports_woocommerce = yes` while the shop and product archive rewrite rules are already missing. This PR adds a retry flag instead of scanning rewrites on every request: install/update and trusted theme-support changes queue product archive rewrite verification, and the next trusted request compares the expected core product archive rules, queues a repair flush if needed, then clears the flag once the rules match again. Related to woocommerce/woocommerce#63954.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Activate Storefront or another classic Woo-supported theme.
2. Flush rewrites and confirm a healthy baseline:

   ```bash
   wp rewrite flush --hard
   wp eval '$rules = get_option( "rewrite_rules" ); echo "option=" . get_option( "current_theme_supports_woocommerce" ) . "\n"; echo "queue=" . get_option( "woocommerce_queue_flush_rewrite_rules" ) . "\n"; echo "verify=" . get_option( "woocommerce_verify_product_archive_rewrite_rules", "no" ) . "\n"; echo "has_shop_rule=" . ( isset( $rules["shop/?$"] ) ? "yes" : "no" ) . "\n"; echo "product_archive_rules=" . count( array_filter( $rules, fn( $value ) => is_string( $value ) && str_contains( $value, "post_type=product" ) ) ) . "\n";'
   ```

   Expected:

   ```text
   option=yes
   queue=no
   verify=no
   has_shop_rule=yes
   product_archive_rules=4
   ```
3. Force the mixed broken state directly in the DB and queue a verification retry:

   ```bash
   wp eval '$rules = get_option( "rewrite_rules" ); foreach ( array_keys( $rules ) as $key ) { if ( "shop/?$" === $key || ( isset( $rules[ $key ] ) && is_string( $rules[ $key ] ) && str_contains( $rules[ $key ], "post_type=product" ) ) ) { unset( $rules[ $key ] ); } } update_option( "rewrite_rules", $rules ); update_option( "current_theme_supports_woocommerce", "yes" ); update_option( "woocommerce_queue_flush_rewrite_rules", "no" ); update_option( "woocommerce_verify_product_archive_rewrite_rules", "yes" );'
   ```
4. Confirm the store is now in the stale mixed state:

   ```bash
   wp eval '$rules = get_option( "rewrite_rules" ); echo "option=" . get_option( "current_theme_supports_woocommerce" ) . "\n"; echo "queue=" . get_option( "woocommerce_queue_flush_rewrite_rules" ) . "\n"; echo "verify=" . get_option( "woocommerce_verify_product_archive_rewrite_rules", "no" ) . "\n"; echo "has_shop_rule=" . ( isset( $rules["shop/?$"] ) ? "yes" : "no" ) . "\n"; echo "product_archive_rules=" . count( array_filter( $rules, fn( $value ) => is_string( $value ) && str_contains( $value, "post_type=product" ) ) ) . "\n";'
   ```

   Expected:

   ```text
   option=yes
   queue=no
   verify=yes
   has_shop_rule=no
   product_archive_rules=0
   ```
5. Load `/shop/` or another trusted frontend/admin request that runs WooCommerce post type registration.
6. Re-run the command from step 4.<br>Expected:

   ```text
   option=yes
   queue=no
   verify=no
   has_shop_rule=yes
   product_archive_rules=4
   ```
7. Repeat steps 3-4, but leave `woocommerce_verify_product_archive_rewrite_rules` unset or `no`, then load `/shop/` again.<br>Expected: the request does not queue a repair flush, which confirms the rewrite scan is no longer part of the steady-state hot path.
8. Switch between a Woo-supported theme and a theme without WooCommerce support, load a normal trusted request after each switch, and confirm the verification flag is queued then cleared once the expected archive state matches again.

### Testing that has already taken place:

* `php -l plugins/woocommerce/includes/class-wc-post-types.php`
* `php -l plugins/woocommerce/includes/class-wc-install.php`
* `php -l plugins/woocommerce/tests/php/includes/class-wc-post-types-test.php`
* `composer exec -- phpstan analyse includes/class-wc-post-types.php includes/class-wc-install.php --memory-limit=2G`
* `vendor/bin/phpcs-changed -s --git --git-unstaged includes/class-wc-post-types.php includes/class-wc-install.php tests/php/includes/class-wc-post-types-test.php`
* PHPUnit was not run here because `wp-env` could not start in this container (`docker` is unavailable).

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Manual changelog entry added in `plugins/woocommerce/changelog/repair-stale-shop-rewrites-when-state-drifts`.

</details>