### PR TITLE
Fix customer account block icon padding for consistent spacing

### DIFF
--- a/plugins/woocommerce/changelog/64123-fix-customer-account-icon-spacing
+++ b/plugins/woocommerce/changelog/64123-fix-customer-account-icon-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix inconsistent icon spacing in the customer account block header on mobile.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
@@ -16,10 +16,6 @@
 }
 
 :where(.wp-block-woocommerce-customer-account) {
-	--wc-customer-account-padding: var(
-		--wp--preset--spacing--20,
-		#{em($gap-smaller)}
-	);
 	--wc-customer-account-viewport-gutter: var(--wp--preset--spacing--20, 16px);
 	--wc-customer-account-dropdown-padding-inline: var(
 		--wp--preset--spacing--30,
@@ -57,7 +53,7 @@
 	font-size: inherit;
 	font-weight: inherit;
 	line-height: 1;
-	padding: var(--wc-customer-account-padding);
+	padding: em($gap-smaller);
 	text-decoration: none;
 	white-space: nowrap;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The customer account block used a theme-dependent CSS custom property (`--wc-customer-account-padding`) for its link/toggle padding, which could produce inconsistent spacing relative to neighboring header icons (cart, burger menu) depending on the theme's spacing presets. This replaces it with a fixed `em($gap-smaller)` value and removes the now-unused custom property.

Bug introduced in PR #63301.

### Screenshots or screen recordings:

Case | Before | After |
-- | ------ | ----- |
With dropdown |    <img width="507" height="148" alt="image" src="https://github.com/user-attachments/assets/d2fb0be6-d015-4ee6-a0b7-ac996f63c75d" />    |    <img width="476" height="147" alt="image" src="https://github.com/user-attachments/assets/438b1d46-737b-438a-af8e-e56f7de36b22" />
Without dropdown |    <img width="485" height="156" alt="image" src="https://github.com/user-attachments/assets/60a1c9fb-7510-4127-8694-5eb19436513b" />    |    <img width="467" height="171" alt="image" src="https://github.com/user-attachments/assets/6fa96b56-ddb6-4024-ad6c-097db07c1a91" />   |
Mobile | <img width="395" height="150" alt="image" src="https://github.com/user-attachments/assets/df32a6e1-5a24-4d67-a11d-70afad3a98b7" /> | <img width="386" height="153" alt="image" src="https://github.com/user-attachments/assets/af931efe-216d-4b07-a690-c2745969f7df" />


### How to test the changes in this Pull Request:

1. Add the Customer Account block to a header template (e.g., via Site Editor).
2. Place it next to the Mini Cart block and navigation/burger menu.
3. View the page on a mobile viewport.
4. Verify that the spacing between all header icons is consistent.

### Testing that has already taken place:

Manual testing.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix inconsistent icon spacing in the customer account block header on mobile.

</details>