### PR TITLE
Remove unused build step from highlight-changes workflow

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -25,7 +25,6 @@ jobs:
         name: 'Setup WooCommerce Monorepo'
         with:
           install: 'code-analyzer...'
-          build: 'code-analyzer'
           pull-package-deps: 'code-analyzer'
 
       - name: 'Analyze'

--- a/plugins/woocommerce/changelog/fix-ci-highlight-changes-pnpm10
+++ b/plugins/woocommerce/changelog/fix-ci-highlight-changes-pnpm10
@@ -1,1 +1,5 @@
+Significance: patch
+Type: dev
 Comment: Remove unused build step from highlight-changes CI workflow.
+
+

--- a/plugins/woocommerce/changelog/fix-ci-highlight-changes-pnpm10
+++ b/plugins/woocommerce/changelog/fix-ci-highlight-changes-pnpm10
@@ -1,4 +1,1 @@
-Significance: patch
-Type: dev
-
-Remove unused build step from highlight-changes CI workflow.
+Comment: Remove unused build step from highlight-changes CI workflow.

--- a/plugins/woocommerce/changelog/fix-ci-highlight-changes-pnpm10
+++ b/plugins/woocommerce/changelog/fix-ci-highlight-changes-pnpm10
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove unused build step from highlight-changes CI workflow.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `code-analyzer` package has no `build` script — the `build: 'code-analyzer'` parameter in this workflow was always a no-op. After the pnpm 9 → 10 upgrade (PR #63964), pnpm now errors on `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` instead of silently skipping, breaking the "Analyze Branch Changes" job. This has been blocking multiple PRs that touch template files from merging. This removes the unnecessary build parameter.

See [failing PRs](https://github.com/woocommerce/woocommerce/actions/workflows/pr-highlight-changes.yml).

### How to test the changes in this Pull Request:

1. The "Analyze Branch Changes" CI job should trigger and pass on this PR, since the workflow file itself is in the trigger paths.

### Testing that has already taken place:

Verified that `code-analyzer` package has no `build` script and uses `ts-node` at runtime, so the build step was always a no-op.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI-only change — no user-facing impact.

</details>