### PR TITLE
Fix product filters not applying when Full Page Reload is enabled

### DIFF
--- a/plugins/woocommerce/changelog/64057-fix-product-filters-full-page-reload
+++ b/plugins/woocommerce/changelog/64057-fix-product-filters-full-page-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product filters not applying when Full Page Reload is enabled in the Product Collection block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/__tests__/frontend.test.ts
@@ -182,4 +182,77 @@ describe( 'product filters interactivity store', () => {
 			} );
 		}
 	);
+
+	it( 'calls window.location.assign instead of router when forcePageReload is true', () => {
+		if ( ! mockRegisteredStore ) {
+			throw new Error( 'Product filters store was not registered.' );
+		}
+
+		const originalLocation = window.location;
+		const assignMock = jest.fn();
+
+		delete ( window as unknown as Record< string, unknown > ).location;
+		Object.defineProperty( window, 'location', {
+			value: {
+				href: 'https://example.com/shop/',
+				assign: assignMock,
+			},
+			writable: true,
+			configurable: true,
+		} );
+
+		const canonicalUrl = 'https://example.com/shop/';
+
+		const context = {
+			isOverlayOpened: false,
+			params: { color: 'blue' },
+			activeFilters: [],
+			item: {
+				type: 'attribute/color',
+				label: 'Blue',
+				value: 'blue',
+				selected: true,
+				count: 1,
+				attributeQueryType: 'or' as const,
+			},
+			activeLabelTemplate: '{{label}}',
+			filterType: 'attribute/color',
+		};
+
+		mockGetContext.mockReturnValue( context );
+		mockGetServerContext.mockReturnValue( context );
+
+		mockGetConfig.mockImplementation( ( key: string ) => {
+			if ( key === 'woocommerce/product-filters' ) {
+				return { canonicalUrl, forcePageReload: true };
+			}
+			return {};
+		} );
+
+		Object.defineProperty( mockRegisteredStore.state, 'params', {
+			get: () => ( { color: 'blue' } ),
+		} );
+
+		const routerNavigate = jest.fn();
+
+		try {
+			const iterator = mockRegisteredStore.actions.navigate();
+
+			// forcePageReload exits early before yielding the router import
+			const result = iterator.next();
+			expect( result.done ).toBe( true );
+
+			expect( assignMock ).toHaveBeenCalledTimes( 1 );
+			expect( assignMock ).toHaveBeenCalledWith(
+				'https://example.com/shop/?color=blue'
+			);
+			expect( routerNavigate ).not.toHaveBeenCalled();
+		} finally {
+			Object.defineProperty( window, 'location', {
+				value: originalLocation,
+				writable: true,
+				configurable: true,
+			} );
+		}
+	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -227,6 +227,12 @@ const productFiltersStore = {
 				return;
 			}
 
+			const config = getConfig( BLOCK_NAME );
+			if ( config?.forcePageReload ) {
+				window.location.assign( url.href );
+				return;
+			}
+
 			const routerModule: typeof import('@wordpress/interactivity-router') =
 				yield import( '@wordpress/interactivity-router' );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
@@ -340,6 +340,16 @@ class Controller extends AbstractBlock {
 		 */
 		$this->asset_data_registry->add( 'isRenderingPhpTemplate', true );
 
+		/*
+		 * When forcePageReload is enabled, the product collection has no data-wp-router-region,
+		 * so the Interactivity Router cannot update it client-side. Signal the product-filters
+		 * block so its navigate action falls back to a full page reload instead of using the
+		 * router, without affecting other blocks on the page.
+		 */
+		if ( $parsed_block['attrs']['forcePageReload'] ?? false ) {
+			wp_interactivity_config( 'woocommerce/product-filters', array( 'forcePageReload' => true ) );
+		}
+
 		return $pre_render;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When "Reload full page" is enabled on the Product Collection block, applying a product filter had no effect — the URL updated but the product list stayed the same. The root cause is that `forcePageReload` intentionally removes `data-wp-router-region` from the Product Collection, so the Interactivity Router navigates to the new URL but has nothing to patch in the DOM.

The fix sets `forcePageReload: true` in the `woocommerce/product-filters` interactivity config when the associated Product Collection has the option enabled. The product-filters `navigate` action then calls `window.location.assign()` directly instead of going through the router, triggering a full page reload that re-runs the server-side product query with the applied filters.

Closes #64057.
Bug introduced in PR #63230.

### How to test the changes in this Pull Request:

1. Create a page with a Product Collection block and product filter blocks (e.g. Filter by Attribute, Filter by Price).
2. In the Product Collection block settings (Advanced), enable "Reload full page".
3. Save and visit the page on the frontend.
4. Apply any filter — the page should fully reload and products should update to match the filter.
5. Disable "Reload full page" and verify filters still work via client-side navigation (no full reload).

### Testing that has already taken place:

Manually tested on the frontend with "Reload full page" enabled. Applying filters triggers a full page reload and products are correctly filtered. Client-side navigation (toggle off) is unaffected.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix

#### Message

Fix product filters not applying when Full Page Reload is enabled in the Product Collection block.

</details>