### PR TITLE
Follow-up to #63895: Remove duplicate changelog and add meta_data test coverage

### DIFF
--- a/plugins/woocommerce/changelog/63895-woo6-38-codex-review-v4-product-endpoint-now-exposes-sensitive-data
+++ b/plugins/woocommerce/changelog/63895-woo6-38-codex-review-v4-product-endpoint-now-exposes-sensitive-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Strip sensitive fields (downloads, COGS, purchase note) from V4 products REST API response for users without product management capabilities.

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
@@ -2147,6 +2147,7 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		);
 		$product->set_downloads( array( $download ) );
+		$product->add_meta_data( 'secret_key', 'secret_value', true );
 		$product->save();
 
 		$author = $this->factory->user->create(
@@ -2164,6 +2165,7 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayNotHasKey( 'download_limit', $data, 'Author should not see download limit' );
 		$this->assertArrayNotHasKey( 'download_expiry', $data, 'Author should not see download expiry' );
 		$this->assertArrayNotHasKey( 'purchase_note', $data, 'Author should not see purchase note' );
+		$this->assertArrayNotHasKey( 'meta_data', $data, 'Author should not see meta data' );
 	}
 
 	/**
@@ -2219,6 +2221,7 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 		);
 		$product->set_downloads( array( $download ) );
 		$product->set_cogs_value( 5.00 );
+		$product->add_meta_data( 'secret_key', 'secret_value', true );
 		$product->save();
 
 		$shop_manager = $this->factory->user->create(
@@ -2237,5 +2240,6 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'download_expiry', $data, 'Shop manager should see download expiry' );
 		$this->assertArrayHasKey( 'purchase_note', $data, 'Shop manager should see purchase note' );
 		$this->assertArrayHasKey( 'cost_of_goods_sold', $data, 'Shop manager should see COGS data' );
+		$this->assertArrayHasKey( 'meta_data', $data, 'Shop manager should see meta data' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Follow-up to #63895:
- Remove duplicate changelog file (`63895-woo6-38-codex-review-v4-product-endpoint-now-exposes-sensitive-data`) — an identical entry (`fix-v4-products-sensitive-field-exposure`) already exists
- Add `meta_data` assertions to the sensitive fields tests — the existing tests verified downloads, download_limit, download_expiry, purchase_note, and COGS were stripped/included but missed `meta_data`


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Verify the duplicate changelog file `63895-woo6-38-codex-review-v4-product-endpoint-now-exposes-sensitive-data` is removed while `fix-v4-products-sensitive-field-exposure` remains
2. Run: `pnpm test:php:env -- --filter "test_get_published_product_as_author_strips_sensitive_fields|test_get_product_as_shop_manager_includes_sensitive_fields"`
3. Both tests should pass with the new `meta_data` assertions

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHP linting passes clean
- Could not run PHPUnit locally (no Docker available)

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Cleanup only: removes a duplicate changelog file from #63895 and adds missing test assertions. No functional changes.

</details>