### PR TITLE
Fix logo image inheriting unintended margin-right in improved email design

### DIFF
--- a/plugins/woocommerce/changelog/64137-fix-email-logo-margin-right
+++ b/plugins/woocommerce/changelog/64137-fix-email-logo-margin-right
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix logo image inheriting unintended margin-right from global img rule in improved email design.

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -167,6 +167,7 @@ body {
 
 #template_header_image img {
 	width: <?php echo esc_attr( $logo_image_width ); ?>px;
+	margin-<?php echo is_rtl() ? 'left' : 'right'; ?>: 0;
 }
 
 .email-logo-text {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The global `img {}` rule in `email-styles.php` applies `margin-right: 24px` (or `margin-left` for RTL) when the improved email design feature is enabled. This margin is intended for product images in order tables but unintentionally affects the header logo. This fix adds `margin-right: 0` to the existing `#template_header_image img` rule to override the global margin for the logo image.

Closes #63373.
Closes WOOPLUG-6330

### How to test the changes in this Pull Request:

1. Enable "Modern email design" under WooCommerce > Settings > Advanced > Features.
2. Go to WooCommerce > Settings > Emails and upload a header logo image.
3. Open any transactional email preview (e.g., New Order).
4. Inspect the logo `<img>` element — it should **not** have `margin-right: 24px`.
5. Verify product images in the order table still have their expected spacing.
6. If using an RTL language, verify `margin-left: 0` is applied to the logo instead.

### Testing that has already taken place:

- 125/125 email-related PHPUnit tests pass
- PHP lint clean
- Manual visual QA confirms the logo renders without extra margin
- Reviewed by two independent code reviewers (correctness + security/performance) — no issues found

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix logo image inheriting unintended margin-right from global img rule in improved email design.

</details>