### PR TITLE
Restructure review notification payload into title and message.

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
@@ -59,7 +59,7 @@ class NewReviewNotification extends Notification {
 				),
 			),
 			'message'     => array(
-				'format' => '%s',
+				'format' => '%1$s',
 				'args'   => array(
 					wp_strip_all_tags( $comment->comment_content ),
 				),

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
@@ -48,19 +48,18 @@ class NewReviewNotification extends Notification {
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(
-				'format' => 'You have a new review! ⭐️',
-			),
-			'message'     => array(
 				/**
 				 * This will be translated in WordPress.com, format:
-				 * 1: reviewer name, 2: product name, 3: comment content
+				 * 1: reviewer name, 2: product name
 				 */
-				'format' => '%1$s left a review on %2$s: %3$s',
+				'format' => '%1$s left a review on %2$s',
 				'args'   => array(
 					wp_strip_all_tags( $comment->comment_author ),
 					wp_strip_all_tags( get_the_title( (int) $comment->comment_post_ID ) ),
-					wp_strip_all_tags( $comment->comment_content ),
 				),
+			),
+			'message'     => array(
+				'format' => wp_strip_all_tags( $comment->comment_content ),
 			),
 			'icon'        => get_avatar_url( $comment->comment_author_email ),
 			'meta'        => array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
@@ -59,7 +59,10 @@ class NewReviewNotification extends Notification {
 				),
 			),
 			'message'     => array(
-				'format' => wp_strip_all_tags( $comment->comment_content ),
+				'format' => '%s',
+				'args'   => array(
+					wp_strip_all_tags( $comment->comment_content ),
+				),
 			),
 			'icon'        => get_avatar_url( $comment->comment_author_email ),
 			'meta'        => array(

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewReviewNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewReviewNotificationTest.php
@@ -30,6 +30,7 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'args', $payload['title'] );
 		$this->assertArrayHasKey( 'message', $payload );
 		$this->assertArrayHasKey( 'format', $payload['message'] );
+		$this->assertArrayHasKey( 'args', $payload['message'] );
 		$this->assertArrayHasKey( 'icon', $payload );
 		$this->assertArrayHasKey( 'meta', $payload );
 		$this->assertArrayHasKey( 'comment_id', $payload['meta'] );
@@ -55,7 +56,7 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @testdox Should include the reviewer name and product name in the title args,
-	 * and the review content in the message format.
+	 * and the review content in the message args.
 	 */
 	public function test_to_payload_splits_review_details_between_title_and_message(): void {
 		$product    = WC_Helper_Product::create_simple_product();
@@ -67,7 +68,7 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( $comment->comment_author, $payload['title']['args'][0] );
 		$this->assertSame( $product->get_name(), $payload['title']['args'][1] );
-		$this->assertSame( $comment->comment_content, $payload['message']['format'] );
+		$this->assertSame( $comment->comment_content, $payload['message']['args'][0] );
 	}
 
 	/**
@@ -95,7 +96,7 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @testdox Should strip HTML tags, and script tags including content, from
-	 * review content in the message format.
+	 * review content in the message args.
 	 */
 	public function test_to_payload_strips_html_and_script_content_from_comment_content(): void {
 		$product    = WC_Helper_Product::create_simple_product();
@@ -113,7 +114,7 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 		$notification = new NewReviewNotification( $comment_id );
 		$payload      = $notification->to_payload();
 
-		$this->assertSame( 'Great product!', $payload['message']['format'] );
+		$this->assertSame( 'Great product!', $payload['message']['args'][0] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewReviewNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewReviewNotificationTest.php
@@ -118,6 +118,36 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should preserve percent signs in review content so downstream
+	 * sprintf-style formatting doesn't break.
+	 */
+	public function test_to_payload_preserves_percent_signs_in_review_content(): void {
+		$product    = WC_Helper_Product::create_simple_product();
+		$content    = 'Works 100% great %1$s';
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $product->get_id(),
+				'comment_author'       => 'Reviewer',
+				'comment_author_email' => 'test@test.local',
+				'comment_content'      => $content,
+				'comment_approved'     => 1,
+				'comment_type'         => 'review',
+			)
+		);
+
+		$notification = new NewReviewNotification( $comment_id );
+		$payload      = $notification->to_payload();
+
+		$this->assertSame( $content, $payload['message']['args'][0] );
+		$this->assertSame(
+			$content,
+			vsprintf( $payload['message']['format'], $payload['message']['args'] )
+		);
+		$this->assertSame( 'Reviewer', $payload['title']['args'][0] );
+		$this->assertSame( $product->get_name(), $payload['title']['args'][1] );
+	}
+
+	/**
 	 * @testdox Should return null when the comment no longer exists.
 	 */
 	public function test_to_payload_returns_null_for_deleted_comment(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewReviewNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewReviewNotificationTest.php
@@ -27,9 +27,9 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'resource_id', $payload );
 		$this->assertArrayHasKey( 'title', $payload );
 		$this->assertArrayHasKey( 'format', $payload['title'] );
+		$this->assertArrayHasKey( 'args', $payload['title'] );
 		$this->assertArrayHasKey( 'message', $payload );
 		$this->assertArrayHasKey( 'format', $payload['message'] );
-		$this->assertArrayHasKey( 'args', $payload['message'] );
 		$this->assertArrayHasKey( 'icon', $payload );
 		$this->assertArrayHasKey( 'meta', $payload );
 		$this->assertArrayHasKey( 'comment_id', $payload['meta'] );
@@ -54,10 +54,10 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should include the reviewer name, product name, and review
-	 * content in the message args.
+	 * @testdox Should include the reviewer name and product name in the title args,
+	 * and the review content in the message format.
 	 */
-	public function test_to_payload_message_args_contains_expected_values(): void {
+	public function test_to_payload_splits_review_details_between_title_and_message(): void {
 		$product    = WC_Helper_Product::create_simple_product();
 		$comment_id = WC_Helper_Product::create_product_review( $product->get_id() );
 		$comment    = get_comment( $comment_id );
@@ -65,14 +65,14 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 		$notification = new NewReviewNotification( $comment_id );
 		$payload      = $notification->to_payload();
 
-		$this->assertSame( $comment->comment_author, $payload['message']['args'][0] );
-		$this->assertSame( $product->get_name(), $payload['message']['args'][1] );
-		$this->assertSame( $comment->comment_content, $payload['message']['args'][2] );
+		$this->assertSame( $comment->comment_author, $payload['title']['args'][0] );
+		$this->assertSame( $product->get_name(), $payload['title']['args'][1] );
+		$this->assertSame( $comment->comment_content, $payload['message']['format'] );
 	}
 
 	/**
 	 * @testdox Should strip HTML tags, and script tags including content, from
-	 * reviewer name in message args.
+	 * reviewer name in title args.
 	 */
 	public function test_to_payload_strips_html_and_script_content_from_comment_author(): void {
 		$product    = WC_Helper_Product::create_simple_product();
@@ -90,12 +90,12 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 		$notification = new NewReviewNotification( $comment_id );
 		$payload      = $notification->to_payload();
 
-		$this->assertSame( 'Evil Author', $payload['message']['args'][0] );
+		$this->assertSame( 'Evil Author', $payload['title']['args'][0] );
 	}
 
 	/**
 	 * @testdox Should strip HTML tags, and script tags including content, from
-	 * review content in message args.
+	 * review content in the message format.
 	 */
 	public function test_to_payload_strips_html_and_script_content_from_comment_content(): void {
 		$product    = WC_Helper_Product::create_simple_product();
@@ -113,7 +113,7 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 		$notification = new NewReviewNotification( $comment_id );
 		$payload      = $notification->to_payload();
 
-		$this->assertSame( 'Great product!', $payload['message']['args'][2] );
+		$this->assertSame( 'Great product!', $payload['message']['format'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
**Focus**: WooCommerce-driven Push Notifications
**Team**: Apps Infrastructure
**Relates to**: AINFRA-2260
**Roadmap**: [ROADMAP.md](https://github.com/woocommerce/woocommerce/blob/293189544c9eb8353b4d46027424dbfe28fde461/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md) or paaHJt-9vT-p2

Apps Infrastructure are currently working with Kiwi to allow WooCommerce instances to trigger their own push notifications, rather than relying on Jetpack Sync. This change alters the payload content so that WPCOM can correctly translate the review notification content.

**Key requirements:**
* Omit the generic title from the payload, which will be hardcoded by WPCOM instead
* Split the notification message and comment content between `title` and `message` to match the expected translation format of `%1$s left a review on %2$s`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
This should have no user-facing changes, so we mainly want to ensure notification content doesn't change based on the changes in this PR.

#### Prerequisites

**Before testing, ensure:**
- You have a WooCommerce site with Jetpack Connection package installed and connected (I couldn't find a way to connect without installing the full Jetpack plugin, but I think they're working on that)
- Replace the WooCommerce core files with the files from this PR
- You have at least 1 test user with `shop_manager` or `administrator` roles
- You have enabled the feature (see below)
- You have registered an iOS* token with your WooCommerce site (see below) - the current version of the iOS app supports remote notifications, Android does not
- **IMPORTANT:** If you have Jetpack Sync installed (via the Jetpack plugin), then also disable it or you won't know if Woo or Jetpack Sync is sending the notifications. I had to install Jetpack, connect, and then deactivate it to get to the right state

**Enabling/Disabling the Feature:**
The push notifications feature is controlled by the FeaturesController and requires both the feature flag to be
enabled AND Jetpack to be connected.
```
update_option( 'woocommerce_feature_push_notifications_enabled', 'yes' );
```

**Registering a Token:**
You can find your token by finding the most recently active token on [this page](https://mc.a8c.com/mobile/push-notifications/) for WooCommerce iOS, then using this cURL example to send it to your site:
```
curl --location 'https://YOUR_TEST_SITE_HERE/wp-json/wc-push-notifications/push-tokens' \
	--header 'Accept: application/json' \
	--header 'Authorization: YOUR_BASIC_AUTH_TOKEN_HERE' \
	--form 'token="YOUR_TOKEN_HERE"' \
	--form 'platform="apple"' \
	--form 'device_uuid="ABCDEF-123ABC-DEF123-ABCDE81"' \
	--form 'origin="com.automattic.woocommerce"' \
	--form 'metadata[app_version]="1.0"' \
	--form 'device_locale="fr_FR"'
```

#### Testing steps

1. Ensure you have a token registered with a non-English locale
2. Place an order on your store
4. Assert all notification content is translated (before, the main message 'X left a review on Y' was not)
5. Update your token to have an English locale (same request as above but with new locale)
6. Place an order on your store
7. Assert notifications received have the same content as they did before applying this PR

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an internal library, and is not yet complete.

</details>
