### PR TITLE
Fix some inputs misalignment in Settings on WP 7.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-wp7.0-extra-settings-alignment
+++ b/plugins/woocommerce/changelog/fix-wp7.0-extra-settings-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix some input misalignment in Settings on WP 7.0

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8295,6 +8295,14 @@ table.bar_chart {
 	.woocommerce table.form-table th {
 		padding-top: 25px;
 	}
+	.woocommerce table.form-table td.forminp-checkbox,
+	.woocommerce table.form-table td.forminp-radio,
+	.woocommerce table.form-table td.forminp-textarea {
+		padding-top: 20px;
+	}
+	.woocommerce table.form-table textarea {
+		padding: 6px 8px;
+	}
 
 	// Colour picker swatch: match WP 7.0 input height (40px).
 	.woocommerce table.form-table .colorpickpreview {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While reviewing a separate PR I noticed we still had a few elements in the Settings that were not correctly aligned. This PR fixes them.

### How to test the changes in this Pull Request:

1. Enable taxes if not enabled and go to Settings > Taxes.
2. Verify _Prices entered with tax_ is aligned with the first option. Verify the _Additional tax classes_ textarea has enough top padding.

Before | After
--- | ---
<img width="1132" height="1215" alt="imatge" src="https://github.com/user-attachments/assets/f70c13f3-2e4e-44dc-9a59-6f83e072e006" /> | <img width="1132" height="1215" alt="imatge" src="https://github.com/user-attachments/assets/2827c161-4f4b-4712-abbf-58038b11a51d" />

3. Ideally, go through all other settings pages and verify all form labels are aligned with the inputs.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->