### PR TITLE
Product Collection: Cap editor product count and show placeholders for overflow

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
@@ -32,9 +32,18 @@ import {
 	parseTemplateSlug,
 } from './utils';
 import { getDefaultStockStatuses } from '../product-collection/constants';
-import { usePlaceholderProducts } from './use-placeholder-products';
+import {
+	usePlaceholderProducts,
+	useOverflowPlaceholder,
+} from './use-placeholder-products';
 
 const DEFAULT_QUERY_CONTEXT_ATTRIBUTES = [ 'collection' ];
+
+/**
+ * Maximum number of real products to fetch and display in the editor.
+ * Any products beyond this cap are represented by a single placeholder.
+ */
+const MAX_EDITOR_PRODUCTS = 12;
 
 const ProductTemplateInnerBlocks = () => {
 	const innerBlocksProps = useInnerBlocksProps(
@@ -295,7 +304,7 @@ const ProductTemplateEdit = (
 				}
 			}
 			if ( perPage ) {
-				query.per_page = perPage;
+				query.per_page = Math.min( perPage, MAX_EDITOR_PRODUCTS );
 			}
 			if ( search ) {
 				query.search = search;
@@ -329,7 +338,10 @@ const ProductTemplateEdit = (
 						}
 					}
 				}
-				query.per_page = loopShopPerPage;
+				query.per_page = Math.min(
+					loopShopPerPage,
+					MAX_EDITOR_PRODUCTS
+				);
 
 				const settings = getEditedEntityRecord(
 					'root',
@@ -411,6 +423,15 @@ const ProductTemplateEdit = (
 		isPreviewWithNoProducts,
 		count: perPage ?? 4,
 	} );
+
+	const effectivePerPage = inherit ? loopShopPerPage : perPage ?? 0;
+	const overflowCount = Math.max( effectivePerPage - MAX_EDITOR_PRODUCTS, 0 );
+
+	const {
+		blockContext: overflowBlockContext,
+		placeholderProduct: overflowProduct,
+		isReady: overflowReady,
+	} = useOverflowPlaceholder( { overflowCount } );
 
 	// Apply layout styles when products are present or when showing preview placeholders.
 	if (
@@ -534,6 +555,27 @@ const ProductTemplateEdit = (
 						/>
 					);
 				} ) }
+			{ overflowCount > 0 &&
+				overflowReady &&
+				overflowBlockContext &&
+				overflowProduct &&
+				Array.from( { length: overflowCount }, ( _, i ) => (
+					<ProductDataContextProvider
+						key={ `overflow-${ i }` }
+						product={ overflowProduct }
+						isLoading={ false }
+					>
+						<ProductContent
+							attributes={ {
+								productId: overflowBlockContext.postId,
+							} }
+							blocks={ blocks }
+							displayTemplate={ false }
+							blockContext={ overflowBlockContext }
+							setActiveBlockContextId={ setActiveBlockContextId }
+						/>
+					</ProductDataContextProvider>
+				) ) }
 		</ul>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/use-placeholder-products.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/use-placeholder-products.ts
@@ -31,7 +31,9 @@ const getPlaceholderPriceMinorUnits = () =>
  * Used by ProductDataContextProvider so child blocks (price, image, button)
  * can render previews without fetching from the Store API.
  */
-const createPlaceholderResponseItem = ( id: number ): ProductResponseItem => {
+export const createPlaceholderResponseItem = (
+	id: number
+): ProductResponseItem => {
 	const placeholderName = __( 'Product name', 'woocommerce' );
 	const priceInMinorUnits = getPlaceholderPriceMinorUnits();
 
@@ -96,37 +98,25 @@ const createPlaceholderResponseItem = ( id: number ): ProductResponseItem => {
 };
 
 /**
- * Creates placeholder product entities and injects them into the
- * WordPress core data stores so that child blocks (product-image,
- * product-price, product-button, post-title) render meaningful
- * previews instead of hardcoded HTML.
+ * Injects placeholder product entities into WordPress core data stores
+ * so that child blocks (product-image, product-price, product-button,
+ * post-title) render meaningful previews without fetching from the API.
  *
  * Two entity stores are populated:
  * - ('postType', 'product') for core post-title block (uses useEntityProp)
  * - ('root', 'product') for WooCommerce child blocks (uses useProduct hook)
  */
-export const usePlaceholderProducts = ( {
-	isPreviewWithNoProducts,
-	count,
+const useInjectPlaceholderEntities = ( {
+	enabled,
+	placeholderIds,
 }: {
-	isPreviewWithNoProducts: boolean;
-	count: number;
+	enabled: boolean;
+	placeholderIds: number[];
 } ) => {
 	const [ entitiesReady, setEntitiesReady ] = useState( false );
 
-	const placeholderIds = useMemo( () => {
-		if ( ! isPreviewWithNoProducts ) {
-			return [];
-		}
-		const safeCount = Math.max( 1, Math.min( count, 10 ) );
-		return Array.from(
-			{ length: safeCount },
-			( _, i ) => PLACEHOLDER_ID_BASE - i
-		);
-	}, [ isPreviewWithNoProducts, count ] );
-
 	useEffect( () => {
-		if ( ! isPreviewWithNoProducts || placeholderIds.length === 0 ) {
+		if ( ! enabled || placeholderIds.length === 0 ) {
 			setEntitiesReady( false );
 			return;
 		}
@@ -233,7 +223,33 @@ export const usePlaceholderProducts = ( {
 		}
 
 		setEntitiesReady( true );
-	}, [ isPreviewWithNoProducts, placeholderIds ] );
+	}, [ enabled, placeholderIds ] );
+
+	return entitiesReady;
+};
+
+export const usePlaceholderProducts = ( {
+	isPreviewWithNoProducts,
+	count,
+}: {
+	isPreviewWithNoProducts: boolean;
+	count: number;
+} ) => {
+	const placeholderIds = useMemo( () => {
+		if ( ! isPreviewWithNoProducts ) {
+			return [];
+		}
+		const safeCount = Math.max( 1, Math.min( count, 10 ) );
+		return Array.from(
+			{ length: safeCount },
+			( _, i ) => PLACEHOLDER_ID_BASE - i
+		);
+	}, [ isPreviewWithNoProducts, count ] );
+
+	const entitiesReady = useInjectPlaceholderEntities( {
+		enabled: isPreviewWithNoProducts,
+		placeholderIds,
+	} );
 
 	const blockContexts = useMemo( () => {
 		if ( ! entitiesReady ) {
@@ -262,4 +278,52 @@ export const usePlaceholderProducts = ( {
 	}, [ entitiesReady, placeholderIds ] );
 
 	return { blockContexts, placeholderProductMap, isReady: entitiesReady };
+};
+
+/**
+ * A separate ID range for the overflow placeholder to avoid
+ * collisions with the preview placeholder IDs.
+ */
+const OVERFLOW_PLACEHOLDER_ID = PLACEHOLDER_ID_BASE - 100;
+
+/**
+ * Creates a single placeholder product to represent overflow products
+ * beyond MAX_EDITOR_PRODUCTS in the editor. Injects it into entity
+ * stores so child blocks render correctly.
+ */
+export const useOverflowPlaceholder = ( {
+	overflowCount,
+}: {
+	overflowCount: number;
+} ) => {
+	const enabled = overflowCount > 0;
+
+	const placeholderIds = useMemo(
+		() => ( enabled ? [ OVERFLOW_PLACEHOLDER_ID ] : [] ),
+		[ enabled ]
+	);
+
+	const entitiesReady = useInjectPlaceholderEntities( {
+		enabled,
+		placeholderIds,
+	} );
+
+	const blockContext = useMemo( () => {
+		if ( ! entitiesReady ) {
+			return null;
+		}
+		return {
+			postType: 'product' as const,
+			postId: OVERFLOW_PLACEHOLDER_ID,
+		};
+	}, [ entitiesReady ] );
+
+	const placeholderProduct = useMemo( () => {
+		if ( ! entitiesReady ) {
+			return null;
+		}
+		return createPlaceholderResponseItem( OVERFLOW_PLACEHOLDER_ID );
+	}, [ entitiesReady ] );
+
+	return { blockContext, placeholderProduct, isReady: entitiesReady };
 };


### PR DESCRIPTION
## Summary

- Caps the number of real products fetched in the Product Collection editor to 12 (via `MAX_EDITOR_PRODUCTS`)
- Products beyond the cap are rendered as placeholder product cards reusing the existing `usePlaceholderProducts` entity injection infrastructure
- No additional API requests — a single placeholder entity is injected into WP data stores and rendered N times
- Placeholder cards preserve the visual volume of the page in the editor

Part of https://github.com/woocommerce/woocommerce/issues/60795
Part of https://github.com/woocommerce/woocommerce/issues/52960
Related to https://github.com/woocommerce/woocommerce/pull/60826

## How to test the changes in this Pull Request

1. Set up a Product Collection block with `perPage` > 12 (e.g. 20 or more)
2. Open the template in the editor
3. Verify only 12 real products are fetched (check Network tab — single REST request with `per_page=12`)
4. Verify the remaining products appear as placeholder cards with generic product name and price
5. Confirm the layout grid is preserved and visually represents the full page volume

## Testing that has already taken place

- TypeScript compilation — no new errors
- ESLint — passes clean

<!-- Changelog entry will be added before merge -->