### PR TITLE
Inherit font color in Checkout block saved adresses

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-checkout-block-background-color
+++ b/plugins/woocommerce/changelog/fix-remove-checkout-block-background-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Inherit font color in Checkout block saved adresses
+Inherit font color in Checkout block saved addresses

--- a/plugins/woocommerce/changelog/fix-remove-checkout-block-background-color
+++ b/plugins/woocommerce/changelog/fix-remove-checkout-block-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Inherit font color in Checkout block saved adresses

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
@@ -16,7 +16,5 @@ $universal-border-light: color-mix(in srgb, currentColor 20%, transparent);
 $universal-border-medium: color-mix(in srgb, currentColor 48%, transparent);
 // #1e1e1e on white. Used for low contrast decorative elements such as input borders.
 $universal-border-strong: color-mix(in srgb, currentColor 80%, transparent);
-// Used for low emphasis text such as input labels.
-$universal-body-low-emphasis: rgba(17, 17, 17, 0.7);
 // Used for low contrast decorative elements background color.
 $universal-background: rgba(17, 17, 17, 0.02);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/style.scss
@@ -12,14 +12,6 @@
 			&--primary {
 				font-weight: 500;
 			}
-
-			&--secondary {
-				color: $universal-body-low-emphasis;
-
-				.has-dark-controls & {
-					color: $input-placeholder-dark;
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPRD-3454.

I noticed this issue while working on a separate PR and thought I would open a quick PR to fix it. :slightly_smiling_face: 

This PR simply removes the hardcoded color from saved addresses in the Checkout block. First, I experimented with reducing the opacity to mimic the previous gray color, but that would be problematic in certain themes like Storefront. Also, I believe nowhere else in the block we use opacity in texts, so I think it makes sense to keep the address also full opacity.

### How to test the changes in this Pull Request:

1. Make an order so your customer address is saved.
2. Go to the Checkout page again.
3. Verify the saved address has the same color as the rest of the text.

Before | After
--- | ---
<img width="617" height="300" alt="imatge" src="https://github.com/user-attachments/assets/061133e5-3099-48d7-a3f5-29d86c1b260a" /> | <img width="617" height="300" alt="imatge" src="https://github.com/user-attachments/assets/bfc704cd-879b-4af4-8543-2cbb5a2edd29" />
<img width="1355" height="344" alt="imatge" src="https://github.com/user-attachments/assets/4e31dfd8-90f1-410c-a306-286c25956ed9" /> | <img width="1355" height="344" alt="imatge" src="https://github.com/user-attachments/assets/55857272-3f33-42bc-a3a0-f274777b5a2a" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->