### PR TITLE
Fix: Mini-cart does not update or open when adding through legacy events

### DIFF
--- a/plugins/woocommerce/changelog/64152-wooplug-6527-regression-mini-cart-does-not-update-or-open-when-adding
+++ b/plugins/woocommerce/changelog/64152-wooplug-6527-regression-mini-cart-does-not-update-or-open-when-adding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Mini-cart does not update or open when adding through legacy events

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts
@@ -57,7 +57,7 @@ export const translateJQueryEventToNative = (
 	nativeEventName: string
 ): ( () => void ) => {
 	const eventDispatcher = () => {
-		dispatchEvent( nativeEventName, {} );
+		dispatchEvent( nativeEventName, { bubbles: true } );
 	};
 
 	jQuery( document ).on( jQueryEventName, eventDispatcher );

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts
@@ -54,10 +54,12 @@ export const translateJQueryEventToNative = (
 	// Name of the jQuery event to listen to.
 	jQueryEventName: string,
 	// Name of the native event to dispatch.
-	nativeEventName: string
+	nativeEventName: string,
+	// Whether the event bubbles.
+	bubbles = false
 ): ( () => void ) => {
 	const eventDispatcher = () => {
-		dispatchEvent( nativeEventName, { bubbles: true } );
+		dispatchEvent( nativeEventName, { bubbles } );
 	};
 
 	jQuery( document ).on( jQueryEventName, eventDispatcher );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -368,12 +368,14 @@ store< MiniCart >(
 				const removeJQueryAddedToCartEvent =
 					translateJQueryEventToNative(
 						'added_to_cart',
-						'wc-blocks_added_to_cart'
+						'wc-blocks_added_to_cart',
+						true
 					);
 				const removeJQueryRemovedFromCartEvent =
 					translateJQueryEventToNative(
 						'removed_from_cart',
-						'wc-blocks_removed_from_cart'
+						'wc-blocks_removed_from_cart',
+						true
 					);
 
 				return () => {

--- a/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
@@ -82,12 +82,8 @@ module.exports = {
 			combineAssets: true,
 			combinedOutputFile: './interactivity-blocks-frontend-assets.php',
 			requestToExternalModule( request ) {
-				if (
-					request.startsWith( '@woocommerce/stores/woocommerce/' )
-				) {
+				if ( request.startsWith( '@woocommerce/stores/' ) ) {
 					return `module ${ request }`;
-				} else if ( request.startsWith( '@woocommerce/stores/' ) ) {
-					return `import ${ request }`;
 				}
 			},
 		} ),

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.classic_theme.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { test, expect, CLASSIC_THEME_SLUG } from '@woocommerce/e2e-utils';
+
+test.describe( 'Mini-Cart: classic theme', () => {
+	test.use( {
+		storageState: {
+			origins: [],
+			cookies: [],
+		},
+	} );
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( CLASSIC_THEME_SLUG );
+	} );
+
+	test( 'opens the drawer when a classic AJAX add-to-cart button is clicked', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		// Create a page with a mini-cart block (open_drawer) and a classic
+		// [products] shortcode that renders AJAX add-to-cart links.
+		const testPage = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/pages',
+			data: {
+				status: 'publish',
+				title: 'Classic add-to-cart test page',
+				content:
+					'<!-- wp:woocommerce/mini-cart {"addToCartBehaviour":"open_drawer"} /-->\n\n<!-- wp:shortcode -->\n[products limit="3"]\n<!-- /wp:shortcode -->',
+			},
+		} );
+
+		// Wait for networkidle to ensure the IAPI mini-cart store has
+		// hydrated and the jQuery event bridge is set up.
+		await page.goto( `/?p=${ testPage.id }` );
+
+		const miniCartButton = page.locator( '.wc-block-mini-cart__button' );
+		await expect( miniCartButton ).toBeVisible();
+
+		const addToCartLink = page.getByLabel( /Add to cart/ ).first();
+		// Wait for the GET /cart request (refreshCartItems) to complete.
+		const cartResponse = page.waitForResponse( '**/wc/store/v1/cart**' );
+		await addToCartLink.click();
+		await cartResponse;
+		const dialog = page.getByRole( 'dialog' );
+		await expect( dialog ).toBeVisible();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.classic_theme.spec.ts
@@ -32,18 +32,16 @@ test.describe( 'Mini-Cart: classic theme', () => {
 			},
 		} );
 
-		// Wait for networkidle to ensure the IAPI mini-cart store has
-		// hydrated and the jQuery event bridge is set up.
 		await page.goto( `/?p=${ testPage.id }` );
 
 		const miniCartButton = page.locator( '.wc-block-mini-cart__button' );
 		await expect( miniCartButton ).toBeVisible();
 
 		const addToCartLink = page.getByLabel( /Add to cart/ ).first();
-		// Wait for the GET /cart request (refreshCartItems) to complete.
-		const cartResponse = page.waitForResponse( '**/wc/store/v1/cart**' );
+		const ajaxCall = page.waitForResponse( '**wc-ajax=add_to_cart**' );
 		await addToCartLink.click();
-		await cartResponse;
+		// Wait for the AJAX call to complete.
+		await ajaxCall;
 		const dialog = page.getByRole( 'dialog' );
 		await expect( dialog ).toBeVisible();
 	} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.classic_theme.spec.ts
@@ -35,7 +35,9 @@ test.describe( 'Mini-Cart: classic theme', () => {
 		await page.goto( `/?p=${ testPage.id }` );
 
 		const miniCartButton = page.locator( '.wc-block-mini-cart__button' );
+		const miniCartBadge = page.locator( '.wc-block-mini-cart__badge' );
 		await expect( miniCartButton ).toBeVisible();
+		await expect( miniCartBadge ).toBeHidden();
 
 		const addToCartLink = page.getByLabel( /Add to cart/ ).first();
 		const ajaxCall = page.waitForResponse( '**wc-ajax=add_to_cart**' );
@@ -44,5 +46,8 @@ test.describe( 'Mini-Cart: classic theme', () => {
 		await ajaxCall;
 		const dialog = page.getByRole( 'dialog' );
 		await expect( dialog ).toBeVisible();
+		await expect( miniCartButton ).toBeVisible();
+		await expect( miniCartBadge ).toBeVisible();
+		await expect( miniCartBadge ).toHaveText( '1' );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.classic_theme.spec.ts
@@ -37,7 +37,6 @@ test.describe( 'Mini-Cart: classic theme', () => {
 		const miniCartButton = page.locator( '.wc-block-mini-cart__button' );
 		const miniCartBadge = page.locator( '.wc-block-mini-cart__badge' );
 		await expect( miniCartButton ).toBeVisible();
-		await expect( miniCartBadge ).toBeHidden();
 
 		const addToCartLink = page.getByLabel( /Add to cart/ ).first();
 		const ajaxCall = page.waitForResponse( '**wc-ajax=add_to_cart**' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/64054

Fixes an issue where AJAX Add to cart buttons don't open the minicart drawer.

The IAPI mini-cart listens on `document` via `data-wp-on-document--` directives. The legacy events are dispatched on `document.body` with `bubbles: false`, so they never reach `document`. Adding `bubbles: true` makes the event propagate up, consistent with how `triggerAddedToCartEvent` in the same file already works.

One-line change in `translateJQueryEventToNative` (line 60):
```ts
// Before:
dispatchEvent( nativeEventName, {} );
// After:
dispatchEvent( nativeEventName, { bubbles: true } );
```

I added an e2e test to handle this use case:

- Activates Storefront (classic theme)
- Creates a page via REST API with a mini-cart block (`addToCartBehaviour: open_drawer`) and a `[products]` shortcode
- Clicks a real classic AJAX add-to-cart link, triggering WooCommerce Core's `added_to_cart` jQuery event
- Waits for the Store API `/cart` response to avoid race conditions
- Asserts the mini-cart drawer opens

As part of this fix, I also changed how `store-notices` is configured in WebPack because it is now being imported statically by the minicart after [this PR](https://github.com/woocommerce/woocommerce/commit/bc6ccee8202ce78459603bae45f35a4eecce6b12#diff-e5321b2c65fe5066069deccc33f89005ef1a93a664f49f9791960613fbf35e4f). This means that the Mini-Cart was running after `DOMContentLoaded`, causing a race condition where the init callbacks weren't running in some scenarios.  

### Screenshots or screen recordings:

**Before**

https://github.com/user-attachments/assets/57652818-d854-4eb9-a823-7b8e798e846f

**After**

https://github.com/user-attachments/assets/663dd5cf-30f2-43ff-9e39-e3a5eed15090


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install a classic theme like Twenty Twenty.
2. Add a test page with the minicart block with the setting "Open drawer when added" activated.
3. Add an AJAX button in that same page. I'm using the Shortcode block with `[products limit="3"]`.
This is my page content:
```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:woocommerce/mini-cart {"addToCartBehaviour":"open_drawer"} /-->

<!-- wp:shortcode -->
[products limit="3"]
<!-- /wp:shortcode --></div>
<!-- /wp:group -->
```
4. In the frontend, adding a product to the cart should open the minicart drawer.

<!-- End testing instructions -->

### Testing that has already taken place:

Both the testing instructions and the e2e test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Fix Mini-cart does not update or open when adding through legacy events

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
