### PR TITLE
Add tests to verify PendingNotificationStore dispatches notifications

### DIFF
--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
@@ -145,6 +145,8 @@ class PendingNotificationStoreTest extends WC_Unit_Test_Case {
 		$store->add( $this->create_order_mock( 1 ) );
 
 		$store->dispatch_all();
+
+		remove_action( 'shutdown', array( $store, 'dispatch_all' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
@@ -132,6 +132,37 @@ class PendingNotificationStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should call the dispatcher when dispatching pending notifications.
+	 */
+	public function test_dispatch_all_calls_dispatcher(): void {
+		$dispatcher = $this->createMock( InternalNotificationDispatcher::class );
+		$dispatcher->expects( $this->once() )
+			->method( 'dispatch' );
+
+		$store = new PendingNotificationStore();
+		$store->init( $dispatcher );
+		$store->register();
+		$store->add( $this->create_order_mock( 1 ) );
+
+		$store->dispatch_all();
+	}
+
+	/**
+	 * @testdox Should not call the dispatcher when there are no pending notifications.
+	 */
+	public function test_dispatch_all_does_not_call_dispatcher_when_empty(): void {
+		$dispatcher = $this->createMock( InternalNotificationDispatcher::class );
+		$dispatcher->expects( $this->never() )
+			->method( 'dispatch' );
+
+		$store = new PendingNotificationStore();
+		$store->init( $dispatcher );
+		$store->register();
+
+		$store->dispatch_all();
+	}
+
+	/**
 	 * @testdox Should return all pending notifications via get_all.
 	 */
 	public function test_get_all_returns_pending_notifications(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The existing `test_dispatch_all_clears_store` test only asserted the store count was zero after `dispatch_all()`, which would pass even if the `$this->dispatcher->dispatch()` call were removed.

This PR adds two tests to `PendingNotificationStoreTest`:

- **`test_dispatch_all_calls_dispatcher`** — asserts `InternalNotificationDispatcher::dispatch()` is called exactly once when there are pending notifications.
- **`test_dispatch_all_does_not_call_dispatcher_when_empty`** — asserts `dispatch()` is never called when the store is empty.

Verified via mutation testing: temporarily removing the `$this->dispatcher->dispatch()` line causes `test_dispatch_all_calls_dispatcher` to fail.

Closes WOO6-42

### How to test the changes in this Pull Request:

1. Run `pnpm test:php:env -- --filter PendingNotificationStoreTest` — all 10 tests should pass.
2. Optionally, remove the `$this->dispatcher->dispatch( array_values( $this->pending ) );` line from `PendingNotificationStore::dispatch_all()` and re-run — `test_dispatch_all_calls_dispatcher` should fail with "Method was expected to be called 1 times, actually called 0 times."

### Testing that has already taken place:

- All 10 `PendingNotificationStoreTest` tests pass (PHPUnit 9.6.29, PHP 8.1, wp-env).
- Mutation test confirmed the new test catches the reported bug.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only change — no user-facing behavior modified.

</details>