### PR TITLE
Suppress harmless dbDelta duplicate key errors during table creation

### DIFF
--- a/plugins/woocommerce/changelog/63962-fix-dbdelta-duplicate-key-errors
+++ b/plugins/woocommerce/changelog/63962-fix-dbdelta-duplicate-key-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Suppress harmless duplicate key database errors logged during WooCommerce table creation on update.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1835,7 +1835,9 @@ class WC_Install {
 			}
 		}
 
+		$suppress        = $wpdb->suppress_errors( true );
 		$db_delta_result = dbDelta( self::get_schema() );
+		$wpdb->suppress_errors( $suppress );
 
 		$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
 		if ( null === $comment_type_index_exists ) {

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1835,9 +1835,9 @@ class WC_Install {
 			}
 		}
 
-		$suppress        = $wpdb->suppress_errors( true );
+		$suppress_errors = $wpdb->suppress_errors( true );
 		$db_delta_result = dbDelta( self::get_schema() );
-		$wpdb->suppress_errors( $suppress );
+		$wpdb->suppress_errors( $suppress_errors );
 
 		$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
 		if ( null === $comment_type_index_exists ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WordPress's `dbDelta()` can generate "Multiple primary key defined" and "Duplicate key name" MySQL errors when it detects index definition mismatches on existing WooCommerce tables (e.g., from third-party index optimization plugins or MariaDB formatting differences) and attempts to ADD indexes that already exist. This is a known WordPress core limitation (core trac #34870, referenced in an existing code comment). WooCommerce already called `$wpdb->hide_errors()` before `dbDelta()`, but that only prevents display — it doesn't prevent `error_log()` calls. This wraps the `dbDelta()` call with `$wpdb->suppress_errors()` to fully suppress these benign errors, following the existing pattern in `DatabaseUtil::get_missing_tables()`. Genuine missing-table failures are caught by `verify_base_tables()` which runs immediately after.

Fixes #63962.

### How to test the changes in this Pull Request:

1. Set up a WooCommerce site with `WP_DEBUG` and `WP_DEBUG_LOG` enabled in `wp-config.php`.
2. Install and activate the "Index WP MySQL For Speed" plugin — let it optimize WooCommerce table indexes (specifically `woocommerce_order_itemmeta`).
3. Update WooCommerce (or trigger the install routine by changing the `woocommerce_version` option to an older value).
4. Check `wp-content/debug.log` — confirm no "Multiple primary key defined" or "Duplicate key name" errors appear for `woocommerce_order_itemmeta`.
5. Go to WooCommerce > Status and verify no "missing tables" notice is shown (confirms `verify_base_tables()` still works as a safety net).

### Testing that has already taken place:

Code review confirming the fix follows the existing pattern in `DatabaseUtil::get_missing_tables()` (same `suppress_errors()` wrapper around `dbDelta()`). Verified `verify_base_tables()` runs immediately after `create_tables()` to catch genuine failures.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually: `plugins/woocommerce/changelog/63962-fix-dbdelta-duplicate-key-errors`

</details>