### PR TITLE
Add conditional rules API for core checkout fields

### DIFF
--- a/docs/block-development/tutorials/how-to-conditional-core-fields.md
+++ b/docs/block-development/tutorials/how-to-conditional-core-fields.md
@@ -1,0 +1,131 @@
+---
+post_title: How to Add Conditional Rules to Core Checkout Fields
+sidebar_label: How to add conditional rules to core checkout fields
+---
+
+# How to Add Conditional Rules to Core Checkout Fields in the Checkout Block
+
+This feature requires a minimum version of WooCommerce 10.8.0.
+
+The Checkout block has long supported conditional `required`, `hidden`, and `validation` rules on additional fields registered via `woocommerce_register_additional_checkout_field()`. The same mechanism is now available for **core fields** - the built-in fields like `first_name`, `last_name`, `country`, `postcode`, `phone`, and `email`.
+
+Rules use JSON Schema and are evaluated identically on the client (for live UI updates) and on the server (in the Store API, so rules cannot be bypassed by crafted requests).
+
+## When to Use This
+
+You might want conditional rules on core fields to:
+
+- Make the `phone` field required only in certain countries.
+- Hide the `postcode` for regions that do not use postcodes.
+- Attach a country-specific regex to `postcode`.
+- Require `company` only when the customer is checking out as a business.
+- Enforce that `first_name` and `last_name` meet a project-specific pattern.
+
+## The API
+
+Rules are attached to a core field with `woocommerce_register_checkout_core_field_rules()`:
+
+```php
+woocommerce_register_checkout_core_field_rules(
+    string $field_id, // 'first_name', 'last_name', 'country', 'postcode', 'email', ...
+    array  $rules     // Any subset of 'required', 'hidden', 'validation'
+);
+```
+
+The accepted field ids are the keys returned by `CheckoutFields::get_core_fields_keys()`:
+
+- `email`
+- `country`
+- `first_name`
+- `last_name`
+- `company`
+- `address_1`
+- `address_2`
+- `city`
+- `state`
+- `postcode`
+- `phone`
+
+Rule values use the same JSON Schema shape as additional fields. See `how-to-conditional-additional-fields.md` for more detail on writing JSON Schema rules.
+
+## Examples
+
+### Require the phone number only for orders shipping to Germany
+
+```php
+add_action(
+    'woocommerce_blocks_loaded',
+    function () {
+        woocommerce_register_checkout_core_field_rules(
+            'phone',
+            array(
+                'required' => array(
+                    'customer' => array(
+                        'properties' => array(
+                            'shipping_address' => array(
+                                'properties' => array(
+                                    'country' => array( 'const' => 'DE' ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        );
+    }
+);
+```
+
+### Hide the postcode for Hong Kong addresses
+
+```php
+woocommerce_register_checkout_core_field_rules(
+    'postcode',
+    array(
+        'hidden' => array(
+            'customer' => array(
+                'properties' => array(
+                    'shipping_address' => array(
+                        'properties' => array(
+                            'country' => array( 'const' => 'HK' ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+);
+```
+
+### Enforce a UK-specific postcode pattern
+
+```php
+woocommerce_register_checkout_core_field_rules(
+    'postcode',
+    array(
+        'validation' => array(
+            'type'    => 'string',
+            'pattern' => '^[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}$',
+        ),
+    )
+);
+```
+
+Multiple rule types can be registered in a single call, and subsequent calls for the same field are merged.
+
+## How Evaluation Works
+
+The `required`, `hidden`, and `validation` rules are evaluated against a DocumentObject that contains the current cart, checkout, and customer state. This is the same object used for additional fields, and the same path rules apply:
+
+- Core address fields (`first_name`, `last_name`, `country`, `postcode`, etc.) are validated against `customer.billing_address` or `customer.shipping_address`.
+- `email` is validated against the billing address.
+- A hidden field is never reported as required, and its value is not enforced.
+
+## Server-Side Enforcement
+
+When the Checkout block posts to the Store API, the server re-evaluates every rule against the same DocumentObject. A request that bypasses the client UI still receives the same errors the UI would surface.
+
+## Related
+
+- [How to add conditional rules to additional fields](./how-to-conditional-additional-fields.md)
+- [How to add additional checkout fields](./how-to-additional-checkout-fields-guide.md)

--- a/plugins/woocommerce/changelog/add-core-field-conditional-rules
+++ b/plugins/woocommerce/changelog/add-core-field-conditional-rules
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woocommerce_register_checkout_core_field_rules() for attaching conditional required/hidden/validation rules to core checkout fields (first_name, last_name, country, postcode, email, etc.). Rules use the same JSON Schema shape as additional fields and are enforced on both client and server.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -72717,7 +72717,7 @@ parameters:
 		-
 			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentResult\:\:\$status\.$#'
 			identifier: property.protected
-			count: 1
+			count: 2
 			path: src/StoreApi/Routes/V1/Checkout.php
 
 		-
@@ -72729,7 +72729,7 @@ parameters:
 		-
 			message: '#^Expression on left side of \?\? is not nullable\.$#'
 			identifier: nullCoalesce.expr
-			count: 3
+			count: 4
 			path: src/StoreApi/Routes/V1/Checkout.php
 
 		-

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -55798,6 +55798,18 @@ parameters:
 			path: src/Blocks/Domain/Services/functions.php
 
 		-
+			message: '#^Function woocommerce_register_checkout_core_field_rules\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Blocks/Domain/Services/functions.php
+
+		-
+			message: '#^Function __internal_woocommerce_blocks_deregister_core_field_rules\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Blocks/Domain/Services/functions.php
+
+		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\InboxNotifications\:\:delete_surface_cart_checkout_blocks_notification\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -72705,7 +72717,7 @@ parameters:
 		-
 			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentResult\:\:\$status\.$#'
 			identifier: property.protected
-			count: 2
+			count: 1
 			path: src/StoreApi/Routes/V1/Checkout.php
 
 		-
@@ -72717,7 +72729,7 @@ parameters:
 		-
 			message: '#^Expression on left side of \?\? is not nullable\.$#'
 			identifier: nullCoalesce.expr
-			count: 4
+			count: 3
 			path: src/StoreApi/Routes/V1/Checkout.php
 
 		-

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -26,6 +26,16 @@ class CheckoutFields {
 	private $additional_fields = [];
 
 	/**
+	 * Conditional rules registered for core fields, keyed by field id.
+	 *
+	 * Each entry may contain any subset of 'required', 'hidden', 'validation' schema rules
+	 * that extend the default core field definitions returned from get_core_fields().
+	 *
+	 * @var array<string, array{required?: mixed, hidden?: mixed, validation?: array}>
+	 */
+	private $core_field_rules = [];
+
+	/**
 	 * Fields locations.
 	 *
 	 * @var array
@@ -228,6 +238,112 @@ class CheckoutFields {
 	}
 
 	/**
+	 * Registers conditional rules (required/hidden/validation) for a core checkout field.
+	 *
+	 * Core fields are the built-in fields such as first_name, last_name, country, postcode, etc.
+	 * This API lets extensions attach the same JSON-Schema-based conditional rules that
+	 * additional fields support, so they can run on both client and server identically.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param string $field_id The core field id (e.g. 'first_name', 'postcode', 'email').
+	 * @param array  $rules    The rules to apply. May contain any subset of 'required', 'hidden',
+	 *                         'validation' keys, using the same JSON Schema shape as additional fields.
+	 * @return bool True if the rules were registered, false otherwise.
+	 */
+	public function register_core_field_rules( $field_id, $rules ) {
+		if ( ! is_string( $field_id ) || '' === $field_id ) {
+			_doing_it_wrong( 'woocommerce_register_checkout_core_field_rules', 'A core field id is required.', '10.8.0' );
+			return false;
+		}
+
+		if ( ! in_array( $field_id, $this->get_core_fields_keys(), true ) ) {
+			$message = sprintf( 'Unable to register rules for field id "%s". The field is not a recognized core checkout field.', $field_id );
+			_doing_it_wrong( 'woocommerce_register_checkout_core_field_rules', esc_html( $message ), '10.8.0' );
+			return false;
+		}
+
+		if ( ! is_array( $rules ) || empty( $rules ) ) {
+			$message = sprintf( 'Unable to register rules for field id "%s". Rules must be a non-empty array.', $field_id );
+			_doing_it_wrong( 'woocommerce_register_checkout_core_field_rules', esc_html( $message ), '10.8.0' );
+			return false;
+		}
+
+		$allowed_keys = [ 'required', 'hidden', 'validation' ];
+		$allow_bool   = [ 'required', 'hidden' ];
+		$sanitized    = [];
+
+		foreach ( $allowed_keys as $rule_key ) {
+			if ( ! array_key_exists( $rule_key, $rules ) ) {
+				continue;
+			}
+
+			$value = $rules[ $rule_key ];
+
+			if ( in_array( $rule_key, $allow_bool, true ) && is_bool( $value ) ) {
+				$sanitized[ $rule_key ] = $value;
+				continue;
+			}
+
+			$valid = Validation::is_valid_schema( $value );
+
+			if ( is_wp_error( $valid ) ) {
+				$message = sprintf( 'Unable to register rules for field id "%s". %s: %s', $field_id, $rule_key, $valid->get_error_message() );
+				_doing_it_wrong( 'woocommerce_register_checkout_core_field_rules', esc_html( $message ), '10.8.0' );
+				return false;
+			}
+
+			$sanitized[ $rule_key ] = $value;
+		}
+
+		if ( empty( $sanitized ) ) {
+			return false;
+		}
+
+		// Merge on top of any previously registered rules for this field.
+		$this->core_field_rules[ $field_id ] = array_merge(
+			$this->core_field_rules[ $field_id ] ?? [],
+			$sanitized
+		);
+
+		return true;
+	}
+
+	/**
+	 * Deregisters all conditional rules previously registered for a core field.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param string $field_id The core field id.
+	 * @return void
+	 * @internal
+	 */
+	public function deregister_core_field_rules( $field_id ) {
+		unset( $this->core_field_rules[ $field_id ] );
+	}
+
+	/**
+	 * Returns the merged definition for a field by key, looking in both additional fields and core fields.
+	 *
+	 * @param string $field_key The field key.
+	 * @return array The field definition, or an empty array if not found.
+	 */
+	private function get_field_definition( $field_key ) {
+		if ( isset( $this->additional_fields[ $field_key ] ) ) {
+			return $this->additional_fields[ $field_key ];
+		}
+		$core_fields = $this->get_core_fields();
+		if ( isset( $core_fields[ $field_key ] ) ) {
+			$field       = $core_fields[ $field_key ];
+			$field['id'] = $field_key;
+			// Ensure the shape matches additional fields for downstream consumers.
+			$field['validation'] = $field['validation'] ?? [];
+			return $field;
+		}
+		return [];
+	}
+
+	/**
 	 * Returns true if the field is required. Takes rules into consideration if a document object is provided.
 	 *
 	 * @param array|string        $field The field array or field key.
@@ -236,7 +352,7 @@ class CheckoutFields {
 	 */
 	public function is_required_field( $field, $document_object = null ) {
 		if ( is_string( $field ) ) {
-			$field = $this->additional_fields[ $field ] ?? [];
+			$field = $this->get_field_definition( $field );
 		}
 
 		if ( empty( $field ) ) {
@@ -248,11 +364,11 @@ class CheckoutFields {
 			if ( $this->is_hidden_field( $field, $document_object ) ) {
 				return false;
 			}
-			if ( $this->contains_valid_rules( $field['required'] ) ) {
+			if ( $this->contains_valid_rules( $field['required'] ?? null ) ) {
 				return true === Validation::validate_document_object( $document_object, $field['required'] );
 			}
 		}
-		return true === $field['required'];
+		return true === ( $field['required'] ?? false );
 	}
 
 	/**
@@ -264,9 +380,12 @@ class CheckoutFields {
 	 */
 	public function is_hidden_field( $field, $document_object = null ) {
 		if ( is_string( $field ) ) {
-			$field = $this->additional_fields[ $field ] ?? [];
+			$field = $this->get_field_definition( $field );
 		}
-		if ( $document_object && $this->contains_valid_rules( $field['hidden'] ) ) {
+		if ( empty( $field ) ) {
+			return false;
+		}
+		if ( $document_object && $this->contains_valid_rules( $field['hidden'] ?? null ) ) {
 			return true === Validation::validate_document_object( $document_object, $field['hidden'] );
 		}
 		return false; // Fields cannot be registered as hidden.
@@ -280,9 +399,12 @@ class CheckoutFields {
 	 */
 	public function is_conditional_field( $field ) {
 		if ( is_string( $field ) ) {
-			$field = $this->additional_fields[ $field ] ?? [];
+			$field = $this->get_field_definition( $field );
 		}
-		return $this->contains_valid_rules( $field['required'] ) || $this->contains_valid_rules( $field['hidden'] );
+		if ( empty( $field ) ) {
+			return false;
+		}
+		return $this->contains_valid_rules( $field['required'] ?? null ) || $this->contains_valid_rules( $field['hidden'] ?? null );
 	}
 
 	/**
@@ -293,7 +415,13 @@ class CheckoutFields {
 	 * @return bool|\WP_Error True if the field is valid, a WP_Error otherwise.
 	 */
 	public function is_valid_field( $field, $document_object = null ) {
-		if ( $document_object && $this->contains_valid_rules( $field['validation'] ) ) {
+		if ( is_string( $field ) ) {
+			$field = $this->get_field_definition( $field );
+		}
+		if ( empty( $field ) ) {
+			return true;
+		}
+		if ( $document_object && $this->contains_valid_rules( $field['validation'] ?? null ) ) {
 			$field_schema = Validation::get_field_schema_with_context( $field['id'], $field['validation'], $document_object->get_context() );
 			return Validation::validate_document_object( $document_object, $field_schema );
 		}
@@ -313,15 +441,18 @@ class CheckoutFields {
 	/**
 	 * Returns the validate callback for a given field.
 	 *
-	 * @param array               $field The field.
+	 * @param array|string        $field The field array or field key.
 	 * @param DocumentObject|null $document_object The document object.
-	 * @return callable The validate callback.
+	 * @return callable|null The validate callback, or null if one is not defined for the field.
 	 */
 	public function get_validate_callback( $field, $document_object = null ) {
 		if ( is_string( $field ) ) {
-			$field = $this->additional_fields[ $field ] ?? [];
+			$field = $this->get_field_definition( $field );
 		}
-		if ( $document_object && $this->contains_valid_rules( $field['validation'] ) ) {
+		if ( empty( $field ) ) {
+			return null;
+		}
+		if ( $document_object && $this->contains_valid_rules( $field['validation'] ?? null ) ) {
 			return function ( $field_value, $field ) use ( $document_object ) {
 				$errors = new WP_Error();
 
@@ -659,10 +790,14 @@ class CheckoutFields {
 	/**
 	 * Returns an array of all core fields.
 	 *
+	 * Any conditional rules registered via register_core_field_rules() are merged on top of
+	 * the default definition, so that 'required', 'hidden' and 'validation' can be evaluated
+	 * against a DocumentObject exactly like additional fields.
+	 *
 	 * @return array An array of fields.
 	 */
 	public function get_core_fields() {
-		return [
+		$fields = [
 			'email'      => [
 				'label'          => __( 'Email address', 'woocommerce' ),
 				'optionalLabel'  => __(
@@ -797,6 +932,21 @@ class CheckoutFields {
 				'index'          => 100,
 			],
 		];
+
+		// Merge in any conditional rules registered against core fields so that both the
+		// client (via defaultFields asset data) and the server evaluate identical schemas.
+		foreach ( $this->core_field_rules as $field_id => $rules ) {
+			if ( ! isset( $fields[ $field_id ] ) ) {
+				continue;
+			}
+			foreach ( [ 'required', 'hidden', 'validation' ] as $rule_key ) {
+				if ( array_key_exists( $rule_key, $rules ) ) {
+					$fields[ $field_id ][ $rule_key ] = $rules[ $rule_key ];
+				}
+			}
+		}
+
+		return $fields;
 	}
 
 	/**
@@ -1018,6 +1168,58 @@ class CheckoutFields {
 			);
 		}
 		return [];
+	}
+
+	/**
+	 * Returns the core field keys that belong to a given location.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param string $location The location (address|contact).
+	 * @return array An array of core field keys.
+	 */
+	public function get_core_field_keys_for_location( $location ) {
+		switch ( $location ) {
+			case 'address':
+				return array_values( array_diff( $this->get_core_fields_keys(), [ 'email' ] ) );
+			case 'contact':
+				return [ 'email' ];
+			default:
+				return [];
+		}
+	}
+
+	/**
+	 * Returns core field definitions for a given location, with conditional rules evaluated
+	 * against the provided DocumentObject.
+	 *
+	 * Only core fields that have rules registered (via register_core_field_rules) are returned.
+	 * Fields evaluated as hidden are excluded. The returned definitions have `required` and
+	 * `validate_callback` resolved identically to additional fields, so the Store API can
+	 * enforce the same behaviour server-side that the client enforces.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param string              $location        The location (address|contact).
+	 * @param DocumentObject|null $document_object The document object.
+	 * @return array Map of core field key => field definition.
+	 */
+	public function get_contextual_core_fields_for_location( $location, $document_object = null ) {
+		$keys   = $this->get_core_field_keys_for_location( $location );
+		$fields = [];
+		foreach ( $keys as $key ) {
+			if ( empty( $this->core_field_rules[ $key ] ) ) {
+				continue;
+			}
+			if ( $this->is_hidden_field( $key, $document_object ) ) {
+				continue;
+			}
+			$field                      = $this->get_field_definition( $key );
+			$field['required']          = $this->is_required_field( $field, $document_object );
+			$field['validate_callback'] = $this->get_validate_callback( $field, $document_object );
+			$fields[ $key ]             = $field;
+		}
+		return $fields;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
@@ -47,6 +47,55 @@ if ( ! function_exists( '__experimental_woocommerce_blocks_register_checkout_fie
 	}
 }
 
+if ( ! function_exists( 'woocommerce_register_checkout_core_field_rules' ) ) {
+	/**
+	 * Register conditional rules for a core checkout field.
+	 *
+	 * Attaches JSON-Schema-based `required`, `hidden` and `validation` rules to a built-in
+	 * checkout field such as `first_name`, `last_name`, `country`, `postcode`, etc. Rules use
+	 * the same shape and semantics as those for additional checkout fields and are evaluated
+	 * on both the client and the server.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param string $field_id The core field id (e.g. 'first_name', 'postcode', 'email').
+	 * @param array  $rules    The rules. May contain any subset of 'required', 'hidden', 'validation'.
+	 * @throws \Exception If registration fails.
+	 */
+	function woocommerce_register_checkout_core_field_rules( $field_id, $rules ) {
+		// Mirror the deferred registration behaviour of additional fields.
+		if ( ! did_action( 'woocommerce_blocks_loaded' ) ) {
+			add_action(
+				'woocommerce_blocks_loaded',
+				function () use ( $field_id, $rules ) {
+					woocommerce_register_checkout_core_field_rules( $field_id, $rules );
+				}
+			);
+			return;
+		}
+		$checkout_fields = Package::container()->get( CheckoutFields::class );
+		$result          = $checkout_fields->register_core_field_rules( $field_id, $rules );
+		if ( is_wp_error( $result ) ) {
+			throw new \Exception( esc_attr( $result->get_error_message() ) );
+		}
+	}
+}
+
+if ( ! function_exists( '__internal_woocommerce_blocks_deregister_core_field_rules' ) ) {
+	/**
+	 * Deregister conditional rules previously registered for a core checkout field.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param string $field_id The core field id.
+	 * @internal
+	 */
+	function __internal_woocommerce_blocks_deregister_core_field_rules( $field_id ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
+		$checkout_fields = Package::container()->get( CheckoutFields::class );
+		$checkout_fields->deregister_core_field_rules( $field_id );
+	}
+}
+
 if ( ! function_exists( '__internal_woocommerce_blocks_deregister_checkout_field' ) ) {
 	/**
 	 * Deregister a checkout field.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -300,6 +300,61 @@ class Checkout extends AbstractCartRoute {
 				}
 			}
 
+			// Validate core fields that have conditional rules registered against them. Core fields
+			// such as first_name, postcode, email, etc. live in billing_address/shipping_address
+			// (not additional_fields), so we look up their values accordingly.
+			$core_fields = $this->additional_fields_controller->get_contextual_core_fields_for_location( $context_data['location'], $document_object );
+
+			if ( ! empty( $core_fields ) ) {
+				$billing_param = (array) ( $request->get_param( 'billing_address' ) ?? [] );
+				if ( 'contact' === $context_data['location'] ) {
+					// Email is part of billing_address in the request, not additional_fields.
+					$core_field_values = [ 'email' => $billing_param['email'] ?? '' ];
+				} else {
+					$core_field_values = $field_values;
+				}
+
+				foreach ( $core_fields as $field_key => $field ) {
+					// Skip values that were not posted if the request is partial or the field is not required.
+					if ( ! isset( $core_field_values[ $field_key ] ) && ( $is_partial || true !== $field['required'] ) ) {
+						continue;
+					}
+
+					$field_value = wc_clean( wp_unslash( $core_field_values[ $field_key ] ?? '' ) );
+
+					if ( empty( $field_value ) ) {
+						if ( true === $field['required'] ) {
+							/* translators: %s: is the field label */
+							$error_message = sprintf( __( '%s is required', 'woocommerce' ), $field['label'] );
+							if ( 'shipping_address' === $context ) {
+								/* translators: %s: is the field error message */
+								$error_message = sprintf( __( 'There was a problem with the provided shipping address: %s', 'woocommerce' ), $error_message );
+							} elseif ( 'billing_address' === $context ) {
+								/* translators: %s: is the field error message */
+								$error_message = sprintf( __( 'There was a problem with the provided billing address: %s', 'woocommerce' ), $error_message );
+							}
+							$errors->add( 'woocommerce_required_checkout_field', $error_message, [ 'key' => $field_key ] );
+						}
+						continue;
+					}
+
+					$valid_check = $this->additional_fields_controller->validate_field( $field, $field_value );
+
+					if ( is_wp_error( $valid_check ) && $valid_check->has_errors() ) {
+						foreach ( $valid_check->get_error_codes() as $code ) {
+							$valid_check->add_data(
+								array(
+									'location' => $context_data['location'],
+									'key'      => $field_key,
+								),
+								$code
+							);
+						}
+						$errors->merge_from( $valid_check );
+					}
+				}
+			}
+
 			// Validate all fields for this location (this runs custom validation callbacks).
 			$valid_location_check = $this->additional_fields_controller->validate_fields_for_location( $field_values, $context_data['location'], $context_data['group'] );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -127,6 +127,10 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 	private function unregister_fields() {
 		$fields = $this->controller->get_additional_fields();
 		array_map( '__internal_woocommerce_blocks_deregister_checkout_field', array_keys( $fields ) );
+		array_map(
+			'__internal_woocommerce_blocks_deregister_core_field_rules',
+			array( 'first_name', 'last_name', 'postcode', 'country', 'email', 'phone' )
+		);
 	}
 
 	/**
@@ -187,5 +191,196 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 		$fields = $this->controller->get_contextual_fields_for_location( 'address', $document_object );
 		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields );
 		$this->assertArrayNotHasKey( 'namespace/vat-number', $fields );
+	}
+
+	/**
+	 * Registering rules for a non-core field id should fail silently and not mutate state.
+	 */
+	public function test_register_core_field_rules_rejects_unknown_field() {
+		$result = $this->controller->register_core_field_rules(
+			'not_a_core_field',
+			array( 'required' => true )
+		);
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Registering rules for a core field should merge them into get_core_fields() output.
+	 */
+	public function test_register_core_field_rules_merges_into_core_fields() {
+		$rules = array(
+			'validation' => array(
+				'type'    => 'string',
+				'pattern' => '^[A-Z]{2,}$',
+			),
+		);
+		$this->assertTrue( $this->controller->register_core_field_rules( 'first_name', $rules ) );
+
+		$core_fields = $this->controller->get_core_fields();
+		$this->assertArrayHasKey( 'first_name', $core_fields );
+		$this->assertArrayHasKey( 'validation', $core_fields['first_name'] );
+		$this->assertSame( $rules['validation'], $core_fields['first_name']['validation'] );
+	}
+
+	/**
+	 * Conditional hidden rule on a core field is evaluated against the DocumentObject.
+	 */
+	public function test_core_field_hidden_rule_evaluates_against_document_object() {
+		$hidden_rule = array(
+			'customer' => array(
+				'properties' => array(
+					'address' => array(
+						'properties' => array(
+							'country' => array(
+								'const' => 'US',
+							),
+						),
+					),
+				),
+			),
+		);
+		$this->controller->register_core_field_rules( 'phone', array( 'hidden' => $hidden_rule ) );
+
+		$customer        = \WC_Helper_Customer::create_mock_customer();
+		$document_object = new DocumentObject();
+		$document_object->set_context( 'shipping_address' );
+
+		$customer->set_shipping_country( 'US' );
+		$document_object->set_customer( $customer );
+		$this->assertTrue( $this->controller->is_hidden_field( 'phone', $document_object ) );
+
+		$customer->set_shipping_country( 'GB' );
+		$document_object->set_customer( $customer );
+		$this->assertFalse( $this->controller->is_hidden_field( 'phone', $document_object ) );
+	}
+
+	/**
+	 * Conditional required rule on a core field is evaluated against the DocumentObject,
+	 * and hidden fields are never reported as required.
+	 */
+	public function test_core_field_conditional_required_rule() {
+		$required_rule = array(
+			'customer' => array(
+				'properties' => array(
+					'address' => array(
+						'properties' => array(
+							'country' => array(
+								'const' => 'GB',
+							),
+						),
+					),
+				),
+			),
+		);
+		$this->controller->register_core_field_rules( 'postcode', array( 'required' => $required_rule ) );
+
+		$customer        = \WC_Helper_Customer::create_mock_customer();
+		$document_object = new DocumentObject();
+		$document_object->set_context( 'shipping_address' );
+
+		$customer->set_shipping_country( 'GB' );
+		$document_object->set_customer( $customer );
+		$this->assertTrue( $this->controller->is_required_field( 'postcode', $document_object ) );
+
+		$customer->set_shipping_country( 'US' );
+		$document_object->set_customer( $customer );
+		$this->assertFalse( $this->controller->is_required_field( 'postcode', $document_object ) );
+
+		// Hidden fields never report as required.
+		$this->controller->register_core_field_rules(
+			'postcode',
+			array(
+				'hidden' => array(
+					'customer' => array(
+						'properties' => array(
+							'address' => array(
+								'properties' => array(
+									'country' => array( 'const' => 'GB' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+		$customer->set_shipping_country( 'GB' );
+		$document_object->set_customer( $customer );
+		$this->assertFalse( $this->controller->is_required_field( 'postcode', $document_object ) );
+	}
+
+	/**
+	 * is_conditional_field() returns true once rules are registered for a core field.
+	 */
+	public function test_is_conditional_field_for_core_field() {
+		$this->assertFalse( $this->controller->is_conditional_field( 'first_name' ) );
+
+		$this->controller->register_core_field_rules(
+			'first_name',
+			array(
+				'hidden' => array(
+					'customer' => array(
+						'properties' => array(
+							'id' => array( 'const' => 0 ),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $this->controller->is_conditional_field( 'first_name' ) );
+	}
+
+	/**
+	 * get_contextual_core_fields_for_location() returns only core fields with rules,
+	 * with hidden fields excluded and required/validate_callback resolved.
+	 */
+	public function test_get_contextual_core_fields_for_location() {
+		$this->controller->register_core_field_rules(
+			'first_name',
+			array(
+				'validation' => array(
+					'type'    => 'string',
+					'pattern' => '^.{2,}$',
+				),
+			)
+		);
+
+		$customer        = \WC_Helper_Customer::create_mock_customer();
+		$document_object = new DocumentObject();
+		$document_object->set_context( 'shipping_address' );
+		$document_object->set_customer( $customer );
+
+		$fields = $this->controller->get_contextual_core_fields_for_location( 'address', $document_object );
+		$this->assertArrayHasKey( 'first_name', $fields );
+		$this->assertArrayNotHasKey( 'last_name', $fields, 'Only fields with rules should be returned.' );
+		$this->assertTrue( $fields['first_name']['required'], 'Default core field is required.' );
+		$this->assertIsCallable( $fields['first_name']['validate_callback'] );
+	}
+
+	/**
+	 * is_valid_field() runs the JSON Schema validation rule for a core field.
+	 */
+	public function test_is_valid_field_runs_validation_rule_for_core_field() {
+		$this->controller->register_core_field_rules(
+			'first_name',
+			array(
+				'validation' => array(
+					'type'    => 'string',
+					'pattern' => '^[A-Z][a-z]+$',
+				),
+			)
+		);
+
+		$customer        = \WC_Helper_Customer::create_mock_customer();
+		$document_object = new DocumentObject();
+		$document_object->set_context( 'shipping_address' );
+
+		$customer->set_shipping_first_name( 'Alice' );
+		$document_object->set_customer( $customer );
+		$this->assertTrue( $this->controller->is_valid_field( 'first_name', $document_object ) );
+
+		$customer->set_shipping_first_name( 'x' );
+		$document_object->set_customer( $customer );
+		$this->assertNotTrue( $this->controller->is_valid_field( 'first_name', $document_object ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -194,9 +194,11 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Registering rules for a non-core field id should fail silently and not mutate state.
+	 * Registering rules for a non-core field id should reject and emit a _doing_it_wrong notice.
 	 */
 	public function test_register_core_field_rules_rejects_unknown_field() {
+		$this->setExpectedIncorrectUsage( 'woocommerce_register_checkout_core_field_rules' );
+
 		$result = $this->controller->register_core_field_rules(
 			'not_a_core_field',
 			array( 'required' => true )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Checkout block already supports conditional `required` / `hidden` / `validation` rules for **additional** fields registered via `woocommerce_register_additional_checkout_field()`. This PR extends that same mechanism to **core** fields (`first_name`, `last_name`, `country`, `postcode`, `email`, `phone`, etc.) so extensions can express country-specific postcode patterns, require phone only in certain regions, hide `postcode` for regions without one, etc.

Rules are attached with a new `woocommerce_register_checkout_core_field_rules( $field_id, $rules )` function using the same JSON Schema shape as additional fields. They flow to the client via the existing `defaultFields` asset-data bridge (so the existing `useFormFields` / `useFormValidation` hooks pick them up with no client changes) and are enforced server-side by the Store API `Checkout` route using the same `DocumentObject` evaluation path, so a crafted request cannot bypass what the UI enforces.

### How to test the changes in this Pull Request:

1. Drop the following snippet into a mu-plugin or `functions.php`:

    ```php
    add_action( 'woocommerce_blocks_loaded', function () {
        // Require phone only when shipping to Germany.
        woocommerce_register_checkout_core_field_rules( 'phone', array(
            'required' => array(
                'customer' => array(
                    'properties' => array(
                        'shipping_address' => array(
                            'properties' => array(
                                'country' => array( 'const' => 'DE' ),
                            ),
                        ),
                    ),
                ),
            ),
        ) );

        // Enforce a UK-style postcode pattern.
        woocommerce_register_checkout_core_field_rules( 'postcode', array(
            'validation' => array(
                'type'    => 'string',
                'pattern' => '^[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}$',
            ),
        ) );
    } );
    ```

2. Open the Checkout block. Set shipping country to something other than Germany — the phone field should be optional. Switch shipping to Germany — the phone field becomes required and blocks submit when empty.
3. With shipping country set to the United Kingdom, enter an invalid postcode (e.g. `ABC`). The field should show an inline error. Enter a valid postcode (e.g. `SW1A 1AA`) and confirm it clears.
4. Open DevTools and POST directly to `/wp-json/wc/store/v1/checkout` with an invalid postcode while country is `GB`, or with an empty phone while country is `DE`. The Store API should reject the request with the same error surfaced in the UI.
5. Remove the rules — core fields behave exactly as before. No behavioural change for stores that don't register any rules.

### Testing that has already taken place:

-   Added PHP unit tests in `tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php` covering rule registration, conditional `required`/`hidden` evaluation against a `DocumentObject`, `is_conditional_field` detection, `get_contextual_core_fields_for_location`, and `is_valid_field` running the JSON Schema pattern.
-   Ran `phpcs` on all modified PHP files — clean.
-   Ran `phpstan` on all modified PHP files — clean (baseline updated for two stale counts in `Checkout.php` that were surfaced by the new analysis; added entries for two new functions in `functions.php`).
-   Docker wasn't available in the dev sandbox, so the PHPUnit suite runs in CI.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually at `plugins/woocommerce/changelog/add-core-field-conditional-rules` and is included in this PR.

</details>
