### PR TITLE
Add PHPStan baseline policy to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes
 composer exec -- phpstan analyse path/to/modified/File.php --memory-limit=2G
 ```
 
-PHPStan failures often indicate the need to update the baseline file (`phpstan-baseline.neon`). If your fix resolves a previously baselined error, remove the corresponding entry from the baseline.
+**PHPStan Baseline Policy:** The baseline file (`phpstan-baseline.neon`) must never be added to. It should only shrink over time as existing errors are naturally resolved by code changes. If PHPStan reports a new error, fix it in the code rather than adding it to the baseline. If your fix resolves a previously baselined error, remove the corresponding entry from the baseline.
 
 ### Pre-push Checks
 

--- a/plugins/woocommerce/changelog/phpstan-baseline-policy
+++ b/plugins/woocommerce/changelog/phpstan-baseline-policy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add PHPStan baseline policy to AGENTS.md

--- a/plugins/woocommerce/changelog/phpstan-baseline-policy
+++ b/plugins/woocommerce/changelog/phpstan-baseline-policy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add PHPStan baseline policy to AGENTS.md


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Clarifies the PHPStan baseline policy in AGENTS.md: the baseline file (`phpstan-baseline.neon`) must never be added to. It should only shrink over time as existing errors are naturally resolved by code changes. New PHPStan errors must be fixed in code, not baselined.

### How to test the changes in this Pull Request:

1. Review the diff in AGENTS.md — the updated text replaces the previous guidance that suggested updating the baseline on PHPStan failures.

### Testing that has already taken place:

Documentation-only change; no functional testing required.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message
Add PHPStan baseline policy to AGENTS.md

</details>