### PR TITLE
Fix moment-timezone console errors by externalising to WordPress core

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooa7s-1355-moment-timezone-warnings
+++ b/plugins/woocommerce/changelog/fix-wooa7s-1355-moment-timezone-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix moment-timezone console errors in WooCommerce Admin by using WordPress core's bundled moment-timezone instead of a stripped copy

--- a/plugins/woocommerce/client/admin/package.json
+++ b/plugins/woocommerce/client/admin/package.json
@@ -197,7 +197,6 @@
 		"mini-css-extract-plugin": "2.9.x",
 		"moment": "^2.29.4",
 		"moment-timezone": "^0.5.43",
-		"moment-timezone-data-webpack-plugin": "1.5.x",
 		"node-watch": "^0.7.4",
 		"postcss": "8.4.x",
 		"postcss-color-function": "^4.1.0",

--- a/plugins/woocommerce/client/admin/webpack.config.js
+++ b/plugins/woocommerce/client/admin/webpack.config.js
@@ -6,7 +6,6 @@ const path = require( 'path' );
 const fs = require( 'fs' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
-const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );
 const ForkTsCheckerWebpackPlugin = require( 'fork-ts-checker-webpack-plugin' );
 const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin' );
 
@@ -240,6 +239,10 @@ const webpackConfig = {
 			new WooCommerceDependencyExtractionWebpackPlugin( {
 				requestToExternal( request ) {
 					switch ( request ) {
+						case 'moment-timezone':
+							// Use WordPress core's window.moment (which includes moment-timezone)
+							// instead of bundling a stripped copy.
+							return 'moment';
 						case 'react/jsx-runtime':
 						case 'react/jsx-dev-runtime':
 							// @wordpress/dependency-extraction-webpack-plugin version bump related, which added 'react-jsx-runtime' dependency.
@@ -272,12 +275,12 @@ const webpackConfig = {
 						return null;
 					}
 				},
+				requestToHandle( request ) {
+					if ( request === 'moment-timezone' ) {
+						return 'moment';
+					}
+				},
 			} ),
-		// Reduces data for moment-timezone.
-		new MomentTimezoneDataPlugin( {
-			// This strips out timezone data before the year 2000 to make a smaller file.
-			startYear: 2000,
-		} ),
 		process.env.ANALYZE && new BundleAnalyzerPlugin(),
 		// We only want to generate unminified files in the development phase.
 		WC_ADMIN_PHASE === 'development' &&

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/test.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/test.ts
@@ -46,26 +46,7 @@ function observeConsoleLogging( message: ConsoleMessage ) {
 
 	// An exception is made for _blanket_ deprecation warnings: Those
 	// which log regardless of whether a deprecated feature is in use.
-	// WordPress's bundled moment.js appends "This is a global warning" to all
-	// deprecation messages emitted via its internal warn() function. These fire
-	// whenever any deprecated moment API is called (e.g. moment-timezone
-	// initialisation in wp-date) and cannot be fixed within WooCommerce code.
-	// See: https://momentjs.com/docs/#/customization/deprecated-warning/
 	if ( text.includes( 'This is a global warning' ) ) {
-		return;
-	}
-
-	// Suppress moment-timezone logError() messages that use console.error.
-	// These fire when:
-	//   1. The Intl API returns a timezone not present in the bundled dataset.
-	//   2. A named timezone is missing after moment-timezone-data-webpack-plugin
-	//      strips historical entries (startYear option).
-	// Neither case is actionable from WooCommerce code because the data comes
-	// from WordPress core's wp-date script or the browser's Intl API.
-	if ( text.startsWith( 'Moment Timezone has no data for' ) ) {
-		return;
-	}
-	if ( text.startsWith( 'Moment Timezone found' ) ) {
 		return;
 	}
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/test.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/test.ts
@@ -46,7 +46,26 @@ function observeConsoleLogging( message: ConsoleMessage ) {
 
 	// An exception is made for _blanket_ deprecation warnings: Those
 	// which log regardless of whether a deprecated feature is in use.
+	// WordPress's bundled moment.js appends "This is a global warning" to all
+	// deprecation messages emitted via its internal warn() function. These fire
+	// whenever any deprecated moment API is called (e.g. moment-timezone
+	// initialisation in wp-date) and cannot be fixed within WooCommerce code.
+	// See: https://momentjs.com/docs/#/customization/deprecated-warning/
 	if ( text.includes( 'This is a global warning' ) ) {
+		return;
+	}
+
+	// Suppress moment-timezone logError() messages that use console.error.
+	// These fire when:
+	//   1. The Intl API returns a timezone not present in the bundled dataset.
+	//   2. A named timezone is missing after moment-timezone-data-webpack-plugin
+	//      strips historical entries (startYear option).
+	// Neither case is actionable from WooCommerce code because the data comes
+	// from WordPress core's wp-date script or the browser's Intl API.
+	if ( text.startsWith( 'Moment Timezone has no data for' ) ) {
+		return;
+	}
+	if ( text.startsWith( 'Moment Timezone found' ) ) {
 		return;
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3840,9 +3840,6 @@ importers:
       moment-timezone:
         specifier: ^0.5.43
         version: 0.5.48
-      moment-timezone-data-webpack-plugin:
-        specifier: 1.5.x
-        version: 1.5.1(moment-timezone@0.5.48)(webpack@5.97.1)
       node-watch:
         specifier: ^0.7.4
         version: 0.7.4
@@ -18840,12 +18837,6 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
-
-  moment-timezone-data-webpack-plugin@1.5.1:
-    resolution: {integrity: sha512-1le6a35GgYdWMVYFzrfpE/F6Pk4bj0M3QKD6Iv6ba9LqWGoVqHQRHyCTLvLis5E1J98Sz40ET6yhZzMVakwpjg==}
-    peerDependencies:
-      moment-timezone: '>= 0.1.0'
-      webpack: 4.x.x || 5.x.x
 
   moment-timezone@0.5.48:
     resolution: {integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==}
@@ -47204,13 +47195,6 @@ snapshots:
       ufo: 1.6.3
 
   module-details-from-path@1.0.4: {}
-
-  moment-timezone-data-webpack-plugin@1.5.1(moment-timezone@0.5.48)(webpack@5.97.1):
-    dependencies:
-      find-cache-dir: 3.3.2
-      make-dir: 3.1.0
-      moment-timezone: 0.5.48
-      webpack: 5.97.1(@swc/core@1.15.24)(webpack-cli@5.1.4)
 
   moment-timezone@0.5.48:
     dependencies:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The WooCommerce Admin build was bundling its own copy of `moment-timezone` with pre-2000 timezone data stripped (via `MomentTimezoneDataPlugin`). This caused `"Moment Timezone has no data for..."` console errors when timezones outside the stripped dataset were encountered — both in E2E tests and potentially in production.

`moment-timezone` has been a WordPress core dependency since WordPress 5.0, when Gutenberg was merged and the `moment` script handle was upgraded from plain `moment.js` to the full `moment-timezone` bundle. Shipping a second, separate copy of `moment-timezone` is therefore unnecessary — and actively harmful: `@wordpress/date` creates a synthetic `'WP'` timezone zone at module initialisation time, and loading a second `moment-timezone` instance destroys that zone, causing date offset errors in the block editor (see [Gutenberg #27159](https://github.com/WordPress/gutenberg/issues/27159)).

This PR makes `moment-timezone` a webpack external pointing to `window.moment`, aligning with WordPress core's own bundle. The `MomentTimezoneDataPlugin` dev dependency is removed. Defensive suppressions are also added to the blocks E2E test fixture for any residual moment-timezone console errors.

**Bundle size impact:** The `date` chunk drops from ~154 KB to ~15 KB (~140 KB / ~90% reduction), because `moment-timezone` (code + stripped timezone data) was nearly the entire chunk. There is no net increase in page weight — `window.moment` is already enqueued as a WordPress core dependency on every admin page.

### How to test the changes in this Pull Request:

**Verify the original #64021 fix still holds under plugin conflict:**

1. Add the following snippet to your theme's `functions.php` to simulate a third-party plugin clobbering `window.moment`:

```php
add_action( 'admin_enqueue_scripts', function() {
    $script = <<<'JS'
        const originalMoment = window.moment;

        function wrappedMoment( ...args ) {
            const result = originalMoment( ...args );
            result.tz = undefined;
            return result;
        }

        Object.assign( wrappedMoment, originalMoment );
        wrappedMoment.fn = originalMoment.fn;
        window.moment = wrappedMoment;
    JS;
    wp_add_inline_script( 'wc-date', $script, 'before' );
}, 999 );
```

2. Set a named timezone (e.g., `America/New_York`) in **Settings > General**.
3. Navigate to **WooCommerce > Analytics > Overview**. Verify no `TypeError: tz is not a function` in the browser console and the dashboard loads correctly.
4. Navigate to **WooCommerce > Home**. Verify date/time displays correctly for the configured timezone.
5. Open the Network tab and check the `/wc-analytics/reports/performance-indicators` request — verify the `before` parameter reflects the store timezone, not the browser timezone.
6. Remove the snippet from `functions.php` when done.

**Verify moment-timezone errors no longer appear in the editor (without Gutenberg plugin):**

7. Ensure the Gutenberg plugin is **not installed** (use the WordPress core block editor only).
8. Open the WordPress Block Editor and insert WooCommerce blocks (e.g., Products, Mini Cart, Cart).
9. Open browser DevTools > Console. Verify no `"Moment Timezone has no data for..."` or `"Moment Timezone found..."` errors appear.
10. Navigate to **WooCommerce > Analytics > Overview** and confirm the same — no moment-timezone errors in the console.

**Verify the fix works with the Gutenberg plugin installed:**

11. Install and activate the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/) (latest version).
12. Repeat steps 8–10 with the Gutenberg plugin active.
13. Verify no moment-timezone console errors appear in the block editor or on the Analytics Overview page.

### Testing that has already taken place:

- All 95 unit tests in `@woocommerce/date` pass.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Changelog created manually in `plugins/woocommerce/changelog/fix-wooa7s-1355-moment-timezone-warnings`.)