### PR TITLE
Update Featured Product and Featured Category block previews in the inserter so they better match the frontend

### DIFF
--- a/plugins/woocommerce/changelog/fix-64205-featured-items-preview
+++ b/plugins/woocommerce/changelog/fix-64205-featured-items-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update Featured Product and Featured Category block previews in the inserter so they better match the frontend

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
@@ -11,6 +11,9 @@ import {
 	useBlockProps,
 	PlainText,
 } from '@wordpress/block-editor';
+import { usePreviewMode } from '@woocommerce/base-hooks';
+import { previewCategories } from '@woocommerce/resource-previews';
+
 interface Props {
 	attributes: {
 		textAlign?: string;
@@ -47,6 +50,20 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			String( termId )
 		);
 
+	const isPreviewMode = usePreviewMode();
+	const displayRawDescription =
+		isPreviewMode && typeof rawDescription === 'string'
+			? rawDescription
+			: previewCategories[ 0 ].description;
+	const displayFullDescription =
+		! isPreviewMode &&
+		typeof fullDescription === 'object' &&
+		fullDescription !== null &&
+		'rendered' in fullDescription &&
+		typeof fullDescription.rendered === 'string'
+			? fullDescription?.rendered
+			: previewCategories[ 0 ].description;
+
 	const blockProps = useBlockProps( {
 		className: clsx( { [ `has-text-align-${ textAlign }` ]: textAlign } ),
 	} );
@@ -60,7 +77,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			<PlainText
 				tagName="p"
 				placeholder={ __( 'No description', 'woocommerce' ) as string }
-				value={ rawDescription }
+				value={ displayRawDescription }
 				onChange={ ( v: string ) =>
 					( setDescription as ( v: string ) => void )( v )
 				}
@@ -71,7 +88,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			<p
 				{ ...blockProps }
 				dangerouslySetInnerHTML={ {
-					__html: fullDescription?.rendered,
+					__html: displayFullDescription,
 				} }
 			/>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
@@ -51,18 +51,25 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		);
 
 	const isPreviewMode = usePreviewMode();
-	const displayRawDescription =
-		isPreviewMode && typeof rawDescription === 'string'
-			? rawDescription
-			: previewCategories[ 0 ].description;
-	const displayFullDescription =
-		! isPreviewMode &&
+
+	let displayRawDescription = '';
+	if ( isPreviewMode ) {
+		displayRawDescription = previewCategories[ 0 ].description;
+	} else if ( typeof rawDescription === 'string' ) {
+		displayRawDescription = rawDescription;
+	}
+
+	let displayFullDescription = '';
+	if ( isPreviewMode ) {
+		displayFullDescription = previewCategories[ 0 ].description;
+	} else if (
 		typeof fullDescription === 'object' &&
 		fullDescription !== null &&
 		'rendered' in fullDescription &&
 		typeof fullDescription.rendered === 'string'
-			? fullDescription?.rendered
-			: previewCategories[ 0 ].description;
+	) {
+		displayFullDescription = fullDescription.rendered;
+	}
 
 	const blockProps = useBlockProps( {
 		className: clsx( { [ `has-text-align-${ textAlign }` ]: textAlign } ),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
@@ -15,6 +15,8 @@ import {
 	PlainText,
 	HeadingLevelDropdown,
 } from '@wordpress/block-editor';
+import { usePreviewMode } from '@woocommerce/base-hooks';
+import { previewCategories } from '@woocommerce/resource-previews';
 // eslint-disable-next-line @woocommerce/dependency-group
 import {
 	ToggleControl,
@@ -78,12 +80,25 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		[ termId, termTaxonomy ]
 	);
 
+	const isPreviewMode = usePreviewMode();
 	const [ rawTitle = '', setTitle, fullTitle ] = useEntityProp(
 		'taxonomy',
 		termTaxonomy || 'product_cat',
 		'name',
 		termId ? String( termId ) : undefined
 	);
+	const displayRawTitle =
+		isPreviewMode && typeof rawTitle === 'string'
+			? rawTitle
+			: previewCategories[ 0 ].name;
+	const displayFullTitle =
+		! isPreviewMode &&
+		typeof fullTitle === 'object' &&
+		fullTitle !== null &&
+		'rendered' in fullTitle &&
+		typeof fullTitle.rendered === 'string'
+			? fullTitle?.rendered
+			: previewCategories[ 0 ].name;
 
 	const link = useSelect(
 		( select ) => {
@@ -116,7 +131,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			<PlainText
 				tagName={ TagName }
 				placeholder={ __( 'No title', 'woocommerce' ) }
-				value={ rawTitle }
+				value={ displayRawTitle }
 				onChange={ ( v ) => setTitle( v ) }
 				__experimentalVersion={ 2 }
 				{ ...blockProps }
@@ -126,7 +141,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 				tagName={ TagName }
 				{ ...blockProps }
 				dangerouslySetInnerHTML={ {
-					__html: fullTitle?.rendered,
+					__html: displayFullTitle,
 				} }
 			/>
 		);
@@ -141,11 +156,11 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 					target={ linkTarget }
 					rel={ rel }
 					placeholder={
-						! rawTitle?.length
+						! displayRawTitle?.length
 							? __( 'No title', 'woocommerce' )
 							: undefined
 					}
-					value={ rawTitle }
+					value={ displayRawTitle }
 					onChange={ ( v ) => setTitle( v ) }
 					__experimentalVersion={ 2 }
 				/>
@@ -158,7 +173,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 					rel={ rel }
 					onClick={ ( event ) => event.preventDefault() }
 					dangerouslySetInnerHTML={ {
-						__html: fullTitle?.rendered,
+						__html: displayFullTitle,
 					} }
 				/>
 			</ContainerElement>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
@@ -87,18 +87,25 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		'name',
 		termId ? String( termId ) : undefined
 	);
-	const displayRawTitle =
-		isPreviewMode && typeof rawTitle === 'string'
-			? rawTitle
-			: previewCategories[ 0 ].name;
-	const displayFullTitle =
-		! isPreviewMode &&
+
+	let displayRawTitle = '';
+	if ( isPreviewMode ) {
+		displayRawTitle = previewCategories[ 0 ].description;
+	} else if ( typeof rawTitle === 'string' ) {
+		displayRawTitle = rawTitle;
+	}
+
+	let displayFullTitle = '';
+	if ( isPreviewMode ) {
+		displayFullTitle = previewCategories[ 0 ].description;
+	} else if (
 		typeof fullTitle === 'object' &&
 		fullTitle !== null &&
 		'rendered' in fullTitle &&
 		typeof fullTitle.rendered === 'string'
-			? fullTitle?.rendered
-			: previewCategories[ 0 ].name;
+	) {
+		displayFullTitle = fullTitle.rendered;
+	}
 
 	const link = useSelect(
 		( select ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
@@ -54,7 +54,11 @@ export const FEATURED_PRODUCT_DEFAULT_TEMPLATE = (
 		{
 			isLink: true,
 			level: 2,
-			textAlign: 'center',
+			style: {
+				typography: {
+					textAlign: 'center',
+				},
+			},
 			__woocommerceNamespace: PRODUCT_TITLE_VARIATION_NAME,
 		},
 	],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
@@ -54,11 +54,7 @@ export const FEATURED_PRODUCT_DEFAULT_TEMPLATE = (
 		{
 			isLink: true,
 			level: 2,
-			style: {
-				typography: {
-					textAlign: 'center',
-				},
-			},
+			textAlign: 'center',
 			__woocommerceNamespace: PRODUCT_TITLE_VARIATION_NAME,
 		},
 	],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-edit-mode.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-edit-mode.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { usePreviewMode } from '@woocommerce/base-hooks';
 import type { ComponentType } from 'react';
 import { useEffect, useState } from '@wordpress/element';
 import { info } from '@wordpress/icons';
@@ -102,7 +103,13 @@ export const withEditMode =
 			itemType: name,
 		} );
 
+		const isPreviewMode = usePreviewMode();
+
 		useEffect( () => {
+			if ( isPreviewMode ) {
+				return;
+			}
+
 			if ( ! isLoading ) {
 				const currEditModeValue =
 					( name === BLOCK_NAMES.featuredProduct &&
@@ -113,7 +120,7 @@ export const withEditMode =
 					setEditMode( currEditModeValue );
 				}
 			}
-		}, [ status, isDeleted, name, isLoading ] );
+		}, [ status, isDeleted, name, isLoading, isPreviewMode ] );
 
 		if ( editMode ) {
 			return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -221,6 +221,8 @@ export const withFeaturedItem =
 
 		const renderInnerBlocks = () => {
 			if ( product ) {
+				const innerBlocksTemplate =
+					FEATURED_PRODUCT_DEFAULT_TEMPLATE( product );
 				return (
 					<BlockContextProvider
 						value={ { postId: product.id, postType: 'product' } }
@@ -238,35 +240,33 @@ export const withFeaturedItem =
 										// set the text to the preview product
 										// name.
 										isPreviewMode
-											? FEATURED_PRODUCT_DEFAULT_TEMPLATE(
-													product
-											  ).map( ( block ) => {
-													if (
-														block[ 0 ] ===
-														'core/post-title'
-													) {
-														return [
-															'core/heading',
-															{
-																level: 2,
-																content:
-																	previewProducts[ 0 ]
-																		.name,
-																style: {
-																	typography:
-																		{
-																			textAlign:
-																				'center',
-																		},
-																},
-															} as BlockAttributes,
-														];
+											? innerBlocksTemplate.map(
+													( block ) => {
+														if (
+															block[ 0 ] ===
+															'core/post-title'
+														) {
+															return [
+																'core/heading',
+																{
+																	level: 2,
+																	content:
+																		previewProducts[ 0 ]
+																			.name,
+																	style: {
+																		typography:
+																			{
+																				textAlign:
+																					'center',
+																			},
+																	},
+																} as BlockAttributes,
+															];
+														}
+														return block;
 													}
-													return block;
-											  } )
-											: FEATURED_PRODUCT_DEFAULT_TEMPLATE(
-													product
 											  )
+											: innerBlocksTemplate
 									}
 									templateLock={ false }
 								/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -17,9 +17,9 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import { WP_REST_API_Category } from 'wp-types';
-import { useStyleProps } from '@woocommerce/base-hooks';
+import { usePreviewMode, useStyleProps } from '@woocommerce/base-hooks';
+import { previewProducts } from '@woocommerce/resource-previews';
 import { InnerBlocks, BlockContextProvider } from '@wordpress/block-editor';
-import { usePreviewMode } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -37,7 +37,6 @@ import {
 	FEATURED_CATEGORY_DEFAULT_TEMPLATE,
 	FEATURED_PRODUCT_DEFAULT_TEMPLATE,
 } from './constants';
-import { previewProducts } from '@woocommerce/resource-previews';
 
 interface WithFeaturedItemConfig extends GenericBlockUIConfig {
 	emptyMessage: string;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import type { BlockAlignment } from '@wordpress/blocks';
+import type { BlockAlignment, BlockAttributes } from '@wordpress/blocks';
 import type { ComponentType, Dispatch, SetStateAction } from 'react';
 import { ProductResponseItem } from '@woocommerce/types';
 import { Icon, Placeholder, Spinner } from '@wordpress/components';
@@ -19,6 +19,7 @@ import {
 import { WP_REST_API_Category } from 'wp-types';
 import { useStyleProps } from '@woocommerce/base-hooks';
 import { InnerBlocks, BlockContextProvider } from '@wordpress/block-editor';
+import { usePreviewMode } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -36,6 +37,7 @@ import {
 	FEATURED_CATEGORY_DEFAULT_TEMPLATE,
 	FEATURED_PRODUCT_DEFAULT_TEMPLATE,
 } from './constants';
+import { previewProducts } from '@woocommerce/resource-previews';
 
 interface WithFeaturedItemConfig extends GenericBlockUIConfig {
 	emptyMessage: string;
@@ -216,6 +218,8 @@ export const withFeaturedItem =
 			);
 		};
 
+		const isPreviewMode = usePreviewMode();
+
 		const renderInnerBlocks = () => {
 			if ( product ) {
 				return (
@@ -228,9 +232,43 @@ export const withFeaturedItem =
 						>
 							<div className={ `${ className }__inner-blocks` }>
 								<InnerBlocks
-									template={ FEATURED_PRODUCT_DEFAULT_TEMPLATE(
-										product
-									) }
+									template={
+										// When previewing the block, replace
+										// the core/post-title block with a
+										// core/heading block. This way, we can
+										// set the text to the preview product
+										// name.
+										isPreviewMode
+											? FEATURED_PRODUCT_DEFAULT_TEMPLATE(
+													product
+											  ).map( ( block ) => {
+													if (
+														block[ 0 ] ===
+														'core/post-title'
+													) {
+														return [
+															'core/heading',
+															{
+																level: 2,
+																content:
+																	previewProducts[ 0 ]
+																		.name,
+																style: {
+																	typography:
+																		{
+																			textAlign:
+																				'center',
+																		},
+																},
+															} as BlockAttributes,
+														];
+													}
+													return block;
+											  } )
+											: FEATURED_PRODUCT_DEFAULT_TEMPLATE(
+													product
+											  )
+									}
 									templateLock={ false }
 								/>
 							</div>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import type { BlockAlignment, BlockAttributes } from '@wordpress/blocks';
+import type { BlockAlignment } from '@wordpress/blocks';
 import type { ComponentType, Dispatch, SetStateAction } from 'react';
 import { ProductResponseItem } from '@woocommerce/types';
 import { Icon, Placeholder, Spinner } from '@wordpress/components';
@@ -17,7 +17,7 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import { WP_REST_API_Category } from 'wp-types';
-import { usePreviewMode, useStyleProps } from '@woocommerce/base-hooks';
+import { useStyleProps } from '@woocommerce/base-hooks';
 import { InnerBlocks, BlockContextProvider } from '@wordpress/block-editor';
 
 /**
@@ -216,8 +216,6 @@ export const withFeaturedItem =
 			);
 		};
 
-		const isPreviewMode = usePreviewMode();
-
 		const renderInnerBlocks = () => {
 			if ( product ) {
 				const innerBlocksTemplate =
@@ -232,40 +230,7 @@ export const withFeaturedItem =
 						>
 							<div className={ `${ className }__inner-blocks` }>
 								<InnerBlocks
-									template={
-										// When previewing the block, replace
-										// the core/post-title block with a
-										// core/heading block. This way, we can
-										// set the text to the preview product
-										// name.
-										isPreviewMode
-											? innerBlocksTemplate.map(
-													( block ) => {
-														if (
-															block[ 0 ] ===
-															'core/post-title'
-														) {
-															return [
-																'core/heading',
-																{
-																	level: 2,
-																	content:
-																		product.name,
-																	style: {
-																		typography:
-																			{
-																				textAlign:
-																					'center',
-																			},
-																	},
-																} as BlockAttributes,
-															];
-														}
-														return block;
-													}
-											  )
-											: innerBlocksTemplate
-									}
+									template={ innerBlocksTemplate }
 									templateLock={ false }
 								/>
 							</div>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -18,7 +18,6 @@ import {
 } from '@wordpress/element';
 import { WP_REST_API_Category } from 'wp-types';
 import { usePreviewMode, useStyleProps } from '@woocommerce/base-hooks';
-import { previewProducts } from '@woocommerce/resource-previews';
 import { InnerBlocks, BlockContextProvider } from '@wordpress/block-editor';
 
 /**
@@ -251,8 +250,7 @@ export const withFeaturedItem =
 																{
 																	level: 2,
 																	content:
-																		previewProducts[ 0 ]
-																			.name,
+																		product.name,
 																	style: {
 																		typography:
 																			{


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #64205.

The Featured Product and Featured Category blocks were not displaying the correct preview in the inserter. That was because of two reasons:

1. The blocks were aware of the context, so even though they were in preview mode, the edit UI was being loaded.
2. Since we blockified the blocks, the inner blocks were lacking the context from the preview product and category.

This PR fixes both issues by relying on `usePreviewMode()` in blocks to detect the context (see https://github.com/woocommerce/woocommerce/issues/53125). In the case of Post Title, we are using the upstream block so we can't do that, so instead I made it so we replaced it with a simple Heading block with the product name as the content.

### How to test the changes in this Pull Request:

1. Create a post or page.
2. Open the sidebar inserter.
3. Search for "Featured".
4. Hover over the "Featured Product" and "Featured Category" blocks.
5. Notice the preview shows the product/category selector instead of a preview matching the frontend.

Before | After
--- | ---
<img width="996" height="716" alt="Captura de pantalla de 2026-04-17 15-12-49" src="https://github.com/user-attachments/assets/f706dc15-611f-42d4-82bf-3c207499676e" /> | <img width="996" height="716" alt="imatge" src="https://github.com/user-attachments/assets/719ea16e-64ba-4d66-95a1-e876089895be" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->