### PR TITLE
Fix WOOPLUG-5211: remove duplicate tfoot in order/order-details.php template

### DIFF
--- a/plugins/woocommerce/changelog/64209-fix-duplicate-tfoot-order-details
+++ b/plugins/woocommerce/changelog/64209-fix-duplicate-tfoot-order-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Templates: remove duplicate tfoot element in order/order-details.php to restore valid HTML table structure.

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.1.0
+ * @version 10.8.0
  *
  * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */
@@ -89,31 +89,6 @@ if ( $show_downloads ) {
 			?>
 		</tbody>
 
-		<?php
-		if ( ! empty( $actions ) ) :
-			?>
-		<tfoot>
-			<tr>
-				<th class="order-actions--heading"><?php esc_html_e( 'Actions', 'woocommerce' ); ?>:</th>
-				<td>
-						<?php
-						$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
-						foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							if ( empty( $action['aria-label'] ) ) {
-								// Generate the aria-label based on the action name.
-								/* translators: %1$s Action name, %2$s Order number. */
-								$action_aria_label = sprintf( __( '%1$s order number %2$s', 'woocommerce' ), $action['name'], $order->get_order_number() );
-							} else {
-								$action_aria_label = $action['aria-label'];
-							}
-								echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button' . esc_attr( $wp_button_class ) . ' button ' . sanitize_html_class( $key ) . ' order-actions-button " aria-label="' . esc_attr( $action_aria_label ) . '">' . esc_html( $action['name'] ) . '</a>';
-								unset( $action_aria_label );
-						}
-						?>
-					</td>
-				</tr>
-			</tfoot>
-			<?php endif ?>
 		<tfoot>
 			<?php
 			foreach ( $order->get_order_item_totals() as $key => $total ) {
@@ -133,6 +108,27 @@ if ( $show_downloads ) {
 					$customer_note = wc_wptexturize_order_note( $order->get_customer_note() );
 					echo wp_kses( nl2br( $customer_note ), array( 'br' => array() ) );
 					?>
+					</td>
+				</tr>
+			<?php endif; ?>
+			<?php if ( ! empty( $actions ) ) : ?>
+			<tr>
+				<th class="order-actions--heading"><?php esc_html_e( 'Actions', 'woocommerce' ); ?>:</th>
+				<td>
+						<?php
+						$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
+						foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+							if ( empty( $action['aria-label'] ) ) {
+								// Generate the aria-label based on the action name.
+								/* translators: %1$s Action name, %2$s Order number. */
+								$action_aria_label = sprintf( __( '%1$s order number %2$s', 'woocommerce' ), $action['name'], $order->get_order_number() );
+							} else {
+								$action_aria_label = $action['aria-label'];
+							}
+								echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button' . esc_attr( $wp_button_class ) . ' button ' . sanitize_html_class( $key ) . ' order-actions-button " aria-label="' . esc_attr( $action_aria_label ) . '">' . esc_html( $action['name'] ) . '</a>';
+								unset( $action_aria_label );
+						}
+						?>
 					</td>
 				</tr>
 			<?php endif; ?>

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -112,23 +112,23 @@ if ( $show_downloads ) {
 				</tr>
 			<?php endif; ?>
 			<?php if ( ! empty( $actions ) ) : ?>
-			<tr>
-				<th class="order-actions--heading"><?php esc_html_e( 'Actions', 'woocommerce' ); ?>:</th>
-				<td>
-						<?php
-						$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
-						foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							if ( empty( $action['aria-label'] ) ) {
-								// Generate the aria-label based on the action name.
-								/* translators: %1$s Action name, %2$s Order number. */
-								$action_aria_label = sprintf( __( '%1$s order number %2$s', 'woocommerce' ), $action['name'], $order->get_order_number() );
-							} else {
-								$action_aria_label = $action['aria-label'];
-							}
-								echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button' . esc_attr( $wp_button_class ) . ' button ' . sanitize_html_class( $key ) . ' order-actions-button " aria-label="' . esc_attr( $action_aria_label ) . '">' . esc_html( $action['name'] ) . '</a>';
-								unset( $action_aria_label );
+				<tr>
+					<th class="order-actions--heading"><?php esc_html_e( 'Actions', 'woocommerce' ); ?>:</th>
+					<td>
+					<?php
+					$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
+					foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+						if ( empty( $action['aria-label'] ) ) {
+							// Generate the aria-label based on the action name.
+							/* translators: %1$s Action name, %2$s Order number. */
+							$action_aria_label = sprintf( __( '%1$s order number %2$s', 'woocommerce' ), $action['name'], $order->get_order_number() );
+						} else {
+							$action_aria_label = $action['aria-label'];
 						}
-						?>
+							echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button' . esc_attr( $wp_button_class ) . ' button ' . sanitize_html_class( $key ) . ' order-actions-button " aria-label="' . esc_attr( $action_aria_label ) . '">' . esc_html( $action['name'] ) . '</a>';
+							unset( $action_aria_label );
+					}
+					?>
 					</td>
 				</tr>
 			<?php endif; ?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
-   I have checked there are no other open Pull Requests for the same change.
-   I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

The order/order-details.php template contained two separate tfoot elements, which is invalid per the HTML spec — a table may only have one. This consolidates them into a single tfoot with the correct element order: totals rows first, then optional customer note, then the conditional actions row last.

A previous community attempt (PR #60089) fixed the duplicate but was abandoned before addressing a reviewer note about element ordering. This PR was manually tested on a staging site to confirm the correct visual output.

Closes #60086.

### Screenshots or screen recordings:

Tested on a staging site with an order in Pending payment status (which triggers the Actions row):

| Before (two tfoot, invalid HTML) | After (single tfoot, correct order) |
| --- | --- |
| Actions row appears above totals due to invalid HTML | Subtotal → Shipping → Tax → Total → Payment method → Actions |

### How to test the changes in this Pull Request:

1. Place an order on a test store.
2. From the admin, set the order status to **Pending payment** (this triggers the Actions row in the footer).
3. Log in as the customer and go to My Account > Orders, then open the order detail page.
4. Inspect the page source or DevTools. Verify there is only one tfoot element in the order table.
5. Verify the order totals (Subtotal, Shipping, Tax, Total, Payment method) appear first, followed by the customer note row (if one was set on the order), then the Actions row (e.g. Pay, Cancel) at the bottom.
6. Repeat with a Completed order that has a customer note — confirm totals, then customer note, then no Actions row.

### Testing that has already taken place:

- Manually tested on a staging site with WooCommerce 10.7.0 and Twenty Twenty-Four theme.
- Confirmed single tfoot in page source.
- Confirmed correct visual order: order item totals first, then customer note (when present on the order), then actions last.
- Changelog entry created manually (plugins/woocommerce/changelog/64209-fix-duplicate-tfoot-order-details) since pnpm toolchain was not available in the authoring environment.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fix - Fixes an existing bug

#### Message
Templates: remove duplicate tfoot element in order/order-details.php to restore valid HTML table structure.

</details>