### PR TITLE
Update Product Collection and Featured Products blocks so product titles are centered in WP 7.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-title-centering
+++ b/plugins/woocommerce/changelog/fix-product-title-centering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update Product Collection and Featured Products blocks so product titles are centered in WP 7.0

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
@@ -54,7 +54,11 @@ export const FEATURED_PRODUCT_DEFAULT_TEMPLATE = (
 		{
 			isLink: true,
 			level: 2,
-			textAlign: 'center',
+			style: {
+				typography: {
+					textAlign: 'center',
+				},
+			},
 			__woocommerceNamespace: PRODUCT_TITLE_VARIATION_NAME,
 		},
 	],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
@@ -3,6 +3,7 @@
  */
 import { WP_REST_API_Category } from 'wp-types';
 import { ProductResponseItem } from '@woocommerce/types';
+import { isWpVersion } from '@woocommerce/settings';
 import { InnerBlockTemplate } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -10,6 +11,22 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { VARIATION_NAME as PRODUCT_TITLE_VARIATION_NAME } from '../product-collection/variations/elements/product-title';
+
+const getPostTitleTextAlignAttributes = () => {
+	if ( isWpVersion( '7.0.0-rc', '>=' ) ) {
+		return {
+			style: {
+				typography: {
+					textAlign: 'center',
+				},
+			},
+		};
+	}
+
+	return {
+		textAlign: 'center',
+	};
+};
 
 export const DEFAULT_EDITOR_SIZE = {
 	height: 500,
@@ -54,11 +71,7 @@ export const FEATURED_PRODUCT_DEFAULT_TEMPLATE = (
 		{
 			isLink: true,
 			level: 2,
-			style: {
-				typography: {
-					textAlign: 'center',
-				},
-			},
+			...getPostTitleTextAlignAttributes(),
 			__woocommerceNamespace: PRODUCT_TITLE_VARIATION_NAME,
 		},
 	],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -76,7 +76,11 @@ const v1 = {
 			createBlock( 'core/post-title', {
 				level: 2,
 				isLink: false,
-				textAlign: 'center',
+				style: {
+					typography: {
+						textAlign: 'center',
+					},
+				},
 				__woocommerceNamespace:
 					'woocommerce/product-collection/product-title',
 			} )

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -3,6 +3,7 @@
  */
 import { BlockInstance, createBlock } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';
+import { isWpVersion } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -14,6 +15,22 @@ interface BlockAttributes {
 	showPrice?: boolean;
 	[ key: string ]: unknown;
 }
+
+const getPostTitleTextAlignAttributes = (): Record< string, unknown > => {
+	if ( isWpVersion( '7.0.0-rc', '>=' ) ) {
+		return {
+			style: {
+				typography: {
+					textAlign: 'center',
+				},
+			},
+		};
+	}
+
+	return {
+		textAlign: 'center',
+	};
+};
 
 // Version 1: Migration from legacy showDesc/showPrice attributes to inner blocks
 const v1 = {
@@ -76,11 +93,7 @@ const v1 = {
 			createBlock( 'core/post-title', {
 				level: 2,
 				isLink: false,
-				style: {
-					typography: {
-						textAlign: 'center',
-					},
-				},
+				...getPostTitleTextAlignAttributes(),
 				__woocommerceNamespace:
 					'woocommerce/product-collection/product-title',
 			} )

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/constants.ts
@@ -146,7 +146,6 @@ export const INNER_BLOCKS_PRODUCT_TEMPLATE: InnerBlockTemplate = [
 		[
 			'core/post-title',
 			{
-				textAlign: 'center',
 				level: 2,
 				fontSize: 'medium',
 				style: {
@@ -158,6 +157,7 @@ export const INNER_BLOCKS_PRODUCT_TEMPLATE: InnerBlockTemplate = [
 					},
 					typography: {
 						lineHeight: '1.4',
+						textAlign: 'center',
 					},
 				},
 				isLink: true,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/constants.ts
@@ -9,7 +9,7 @@
 /**
  * External dependencies
  */
-import { getSetting } from '@woocommerce/settings';
+import { getSetting, isWpVersion } from '@woocommerce/settings';
 import { objectOmit } from '@woocommerce/utils';
 import type { InnerBlockTemplate } from '@wordpress/blocks';
 
@@ -27,6 +27,8 @@ import { ImageSizing } from '../../atomic/blocks/product-elements/image/types';
 
 export const PRODUCT_COLLECTION_BLOCK_NAME = blockJson.name;
 const PRODUCT_TITLE_NAME = `${ PRODUCT_COLLECTION_BLOCK_NAME }/product-title`;
+
+const shouldUseTypographyTextAlign = isWpVersion( '7.0.0-rc', '>=' );
 
 export const STOCK_STATUS_OPTIONS = getSetting< Record< string, string > >(
 	'stockStatusOptions',
@@ -157,9 +159,14 @@ export const INNER_BLOCKS_PRODUCT_TEMPLATE: InnerBlockTemplate = [
 					},
 					typography: {
 						lineHeight: '1.4',
-						textAlign: 'center',
+						...( shouldUseTypographyTextAlign
+							? { textAlign: 'center' }
+							: {} ),
 					},
 				},
+				...( shouldUseTypographyTextAlign
+					? {}
+					: { textAlign: 'center' } ),
 				isLink: true,
 				__woocommerceNamespace: PRODUCT_TITLE_NAME,
 			},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since WP 7.0, `textAlign: center` needs to be defined inside `style.typography` for it to work in the `core/post-title` block. The PR updates the Product Collection and Featured Product blocks to use the new approach.

Note: I intentionally didn't update the Products (Beta) block, as it's deprecated and it can't be inserted anymore.

### How to test the changes in this Pull Request:

1. Create a post or page.
2. Add the Featured Product block to the page and select one product.
3. Verify the title is correctly centered.
4. Repeat with the Product Collection block selecting any collection.

Before | After
--- | ---
<img width="996" height="778" alt="imatge" src="https://github.com/user-attachments/assets/52ddf189-a3e4-484b-8dba-07f31d2dee4c" /> | <img width="996" height="778" alt="imatge" src="https://github.com/user-attachments/assets/1eee9299-4733-4606-b23b-8b49e0975706" />

5. Now insert the non-blockified Featured Product block `<!-- wp:woocommerce/featured-product {"editMode":false,"productId":287} -->` by pasting it (<kbd>Ctrl</kbd>+<kbd>V</kbd>). You will probably need to change the `productId` to match a product in your store.
6. Verify the title is correctly centered.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->