### PR TITLE
Fix: Correct two typos in available-slot-fills.md documentation

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/available-slot-fills.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/available-slot-fills.md
@@ -108,7 +108,7 @@ const render = () => {
 		<ExperimentalOrderLocalPickupPackages>
 			<div>
 				{ __(
-					'By using our convenient local pickup option, you can come to our store and pick up your order. We will send you and email when your order is ready for pickup.',
+					'By using our convenient local pickup option, you can come to our store and pick up your order. We will send you an email when your order is ready for pickup.',
 					'YOUR-TEXTDOMAIN'
 				) }
 			</div>

--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/available-slot-fills.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/available-slot-fills.md
@@ -85,7 +85,7 @@ Checkout:
 ### Passed parameters
 
 -   `collapsible`: `Boolean|undefined` If a shipping package panel should be collapsible or not, this is false in Checkout and undefined in Cart.
--   `collapse`: `Boolean` If a panel should be collapsed by default, this is true if if panels are collapsible.
+-   `collapse`: `Boolean` If a panel should be collapsed by default, this is true if panels are collapsible.
 -   `showItems`: `Boolean|undefined` If we should show the content of each package, this is undefined in Cart and Checkout and is left to the actual package logic to decide.
 -   `noResultsMessage`: A React element that you can render if there are no shipping options.
 -   `renderOption`: a render function that takes a rate object and returns a render option.

--- a/plugins/woocommerce/changelog/fix-issue-64227
+++ b/plugins/woocommerce/changelog/fix-issue-64227
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix two typos in available-slot-fills.md — remove duplicate word and correct wrong article.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes two typos in `docs/block-development/extensible-blocks/cart-and-checkout-blocks/available-slot-fills.md`:

1. **Line 88** — Duplicate word removed:
   - Before: `this is true if if panels are collapsible`
   - After: `this is true if panels are collapsible`

2. **Line 111** — Wrong article corrected:
   - Before: `We will send you and email when your order is ready for pickup.`
   - After: `We will send you an email when your order is ready for pickup.`

Closes #64227 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A — documentation text changes only.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open `docs/block-development/extensible-blocks/cart-and-checkout-blocks/available-slot-fills.md`.
2. Check line 88 — confirm only one `if` appears before `panels are collapsible`.
3. Check line 111 — confirm `an email` is used instead of `and email`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Docs-only change to developer documentation.
</details>
