### PR TITLE
Remove deprecated husky v8 hook headers

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,6 +1,3 @@
-#!/usr/bin/env bash
-. "$(dirname "$0")/_/husky.sh"
-
 # The hook documentation: https://git-scm.com/docs/githooks.html#_post_checkout
 CHECKOUT_TYPE=$3
 HEAD_NEW=$2

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,6 +1,3 @@
-#!/usr/bin/env bash
-. "$(dirname "$0")/_/husky.sh"
-
 # The hook documentation: https://git-scm.com/docs/githooks.html#_post_merge
 
 # Auto-switch pnpm versions when pulled changes include pnpm version change.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 ./bin/pre-push.sh


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Husky v9.1.7 is installed, but our three client-side hooks (`post-merge`, `post-checkout`, `pre-push`) still start with the old v8 two-line header (shebang + `. "$(dirname "$0")/_/husky.sh"`). In v9 each hook is run via husky's own wrapper at `.husky/_/<hook>` → `_/h` → `sh -e <hook>`, so the shebang is ignored and the `husky.sh` source line is dead code that only exists to print the deprecation warning on every `git pull` / `git checkout` / `git push`. Husky v10 will remove `_/husky.sh` entirely, at which point the source line would hard-fail the hooks.

Remove the deprecated two-line header from all three hooks. All hook bodies use only POSIX shell features and continue to work correctly under `sh -e`.