### PR TITLE
Align Marketplace product card focus ring with admin theme color

### DIFF
--- a/plugins/woocommerce/changelog/tweak-marketplace-product-card-focus-ring-theme-color
+++ b/plugins/woocommerce/changelog/tweak-marketplace-product-card-focus-ring-theme-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Align the Marketplace product card focus ring with the admin theme color so it adapts to the merchant's color scheme instead of staying on a hardcoded blue.

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.scss
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.scss
@@ -156,7 +156,7 @@
 			}
 
 			&:focus-visible {
-				box-shadow: 0 0 0 2px #2271b1;
+				box-shadow: 0 0 0 2px var(--wp-admin-theme-color, #2271b1);
 			}
 
 			/* Use the ::after trick to make the whole card clickable: */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `:focus-visible` outline on Marketplace product cards is hardcoded to `#2271b1` (an older WP admin blue). On WordPress 7.0's Modern color scheme, and on any custom admin color scheme (Coffee, Sunrise, etc.), every other focus ring in admin adopts the scheme's accent color via `--wp-admin-theme-color` — but this Woo ring stays on the legacy blue, sticking out visually for keyboard users.

This PR replaces the hardcoded value with `var(--wp-admin-theme-color, #2271b1)`, keeping the original hex as a safe fallback (matching the pattern from #64196).

Follow-up to #64196 — Jill's PR swept most admin focus rings, button backgrounds, and hover borders to the variable, but this spot survived the sweep.

### Screenshots or screen recordings:

| Before | After |
Before
<img width="906" height="364" alt="CleanShot 2026-04-20 at 20 12 31@2x" src="https://github.com/user-attachments/assets/6f84fb30-f3e5-4a27-bac0-53779eed9cf8" />

After
<img width="914" height="444" alt="CleanShot 2026-04-20 at 20 02 37@2x" src="https://github.com/user-attachments/assets/c9aba66b-597d-4b81-ba14-0cd83a847b59" />



### How to test the changes in this Pull Request:

1. Install this branch on a WordPress 7.0+ site with WooCommerce activated.
2. Build and sync the admin client: `pnpm --filter='@woocommerce/plugin-woocommerce' build:admin`.
3. Navigate to **WooCommerce → Extensions** (Marketplace).
4. Tab through the page with the keyboard until focus lands on a product card. A 2px focus ring should appear.
5. DevTools → inspect the card → find the computed `box-shadow`. On the default Modern scheme, the color component should be `rgb(56, 88, 233)` = `#3858e9`. Before this PR it would have been `#2271b1`.
6. Switch admin color scheme (Users → Profile → Admin Color Scheme) to Sunrise / Coffee / Ectoplasm. Repeat steps 3–5. The focus ring should now adopt that scheme's accent color.

### Testing that has already taken place:

- Stylelint clean on the modified file.
- Pattern and fallback match #64196.
- Visual verification on WordPress 7.1-alpha — confirmed `rgb(56, 88, 233)` on Modern scheme.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry created manually for `@woocommerce/plugin-woocommerce`.