### PR TITLE
Introduce new 'Create value' modal in variable product editor

### DIFF
--- a/plugins/woocommerce/changelog/update-create-term-modal
+++ b/plugins/woocommerce/changelog/update-create-term-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Introduce new 'Create value' modal in variable product editor

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1002,6 +1002,26 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 	}
 }
 
+.wc-backbone-modal-add-attribute-term.wc-backbone-modal {
+	.wc-backbone-modal-content {
+		min-width: auto;
+		max-width: 400px;
+	}
+
+	input[type="text"] {
+		display: block;
+		font-size: 13px;
+		line-height: 16px;
+		margin: 6px 0;
+		padding: 12px;
+		width: 100%;
+	}
+
+	.wc-backbone-modal-main footer {
+		border-top: none;
+	}
+}
+
 /**
   * Variations related variables
   */
@@ -4263,7 +4283,7 @@ table.wc_shipping {
 }
 
 /**
-* New Refresh Modal Styles
+* New Shipping Settings Refresh Modal Styles
 **/
 .wc-backbone-modal-add-attribute-term,
 .wc-backbone-modal-add-shipping-method,
@@ -4426,57 +4446,57 @@ table.wc_shipping {
 		fieldset {
 			margin-bottom: 24px;
 			position: relative;
-		}
 
-		input,
-		select {
-			margin: 6px 0;
-			padding: 12px;
-			font-size: 13px;
-			line-height: 16px;
+			input,
+			select {
+				margin: 6px 0;
+				padding: 12px;
+				font-size: 13px;
+				line-height: 16px;
 
-			&:not([type="checkbox"]) {
-				width: 100%;
-				max-width: 100%;
-			}
-			&[type="checkbox"] {
-				border-radius: 2px;
-				margin: 4px 8px 6px 0;
-
-				& + .woocommerce-help-tip {
-					margin: 6px 0 4px 8px;
+				&:not([type="checkbox"]) {
+					width: 100%;
+					max-width: 100%;
 				}
-			}
+				&[type="checkbox"] {
+					border-radius: 2px;
+					margin: 4px 8px 6px 0;
 
-			&.wc-shipping-modal-price {
-				&.wc-shipping-currency-position-left,
-				&.wc-shipping-currency-position-left_space {
-
-					&.wc-shipping-currency-size-1 {
-						padding-left: 28px;
-					}
-					&.wc-shipping-currency-size-2 {
-						padding-left: 33px;
-					}
-					&.wc-shipping-currency-size-3 {
-						padding-left: 38px;
-					}
-					&.wc-shipping-currency-size-4 {
-						padding-left: 43px;
-					}
-					&.wc-shipping-currency-size-5 {
-						padding-left: 48px;
+					& + .woocommerce-help-tip {
+						margin: 6px 0 4px 8px;
 					}
 				}
 
-				&.wc-shipping-currency-position-right,
-				&.wc-shipping-currency-position-right_space {
-					padding-left: 12px;
-				}
-				&.wc-shipping-invalid-price {
-					border: 2px solid var( --wc-red, #a00);
-				}
+				&.wc-shipping-modal-price {
+					&.wc-shipping-currency-position-left,
+					&.wc-shipping-currency-position-left_space {
 
+						&.wc-shipping-currency-size-1 {
+							padding-left: 28px;
+						}
+						&.wc-shipping-currency-size-2 {
+							padding-left: 33px;
+						}
+						&.wc-shipping-currency-size-3 {
+							padding-left: 38px;
+						}
+						&.wc-shipping-currency-size-4 {
+							padding-left: 43px;
+						}
+						&.wc-shipping-currency-size-5 {
+							padding-left: 48px;
+						}
+					}
+
+					&.wc-shipping-currency-position-right,
+					&.wc-shipping-currency-position-right_space {
+						padding-left: 12px;
+					}
+					&.wc-shipping-invalid-price {
+						border: 2px solid var( --wc-red, #a00);
+					}
+
+				}
 			}
 		}
 
@@ -4538,15 +4558,6 @@ table.wc_shipping {
 		animation-range-start: normal;
 		color: #757575;
 	}
-}
-
-.wc-backbone-modal-add-attribute-term.wc-backbone-modal,
-.wc-backbone-modal-add-attribute-term.wc-backbone-modal .wc-backbone-modal-content {
-	min-width: auto;
-	max-width: 400px;
-}
-.wc-backbone-modal-add-attribute-term .wc-backbone-modal-main footer {
-	border-top: none;
 }
 
 .wc-backbone-modal-add-shipping-method .wc-backbone-modal-main article {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4263,9 +4263,9 @@ table.wc_shipping {
 }
 
 /**
-* New Shipping Settings Refresh Modal Styles
+* New Refresh Modal Styles
 **/
-
+.wc-backbone-modal-add-attribute-term,
 .wc-backbone-modal-add-shipping-method,
 .wc-backbone-modal-shipping-method-settings,
 .wc-shipping-class-modal {
@@ -4406,6 +4406,7 @@ table.wc_shipping {
 		}
 	}
 
+	.wc-add-attribute-term-fields,
 	.wc-shipping-zone-method-fields {
 
 		& > label {
@@ -4425,57 +4426,57 @@ table.wc_shipping {
 		fieldset {
 			margin-bottom: 24px;
 			position: relative;
+		}
 
-			input,
-			select {
-				margin: 6px 0;
-				padding: 12px;
-				font-size: 13px;
-				line-height: 16px;
+		input,
+		select {
+			margin: 6px 0;
+			padding: 12px;
+			font-size: 13px;
+			line-height: 16px;
 
-				&:not([type="checkbox"]) {
-					width: 100%;
-					max-width: 100%;
+			&:not([type="checkbox"]) {
+				width: 100%;
+				max-width: 100%;
+			}
+			&[type="checkbox"] {
+				border-radius: 2px;
+				margin: 4px 8px 6px 0;
+
+				& + .woocommerce-help-tip {
+					margin: 6px 0 4px 8px;
 				}
-				&[type="checkbox"] {
-					border-radius: 2px;
-					margin: 4px 8px 6px 0;
+			}
 
-					& + .woocommerce-help-tip {
-						margin: 6px 0 4px 8px;
+			&.wc-shipping-modal-price {
+				&.wc-shipping-currency-position-left,
+				&.wc-shipping-currency-position-left_space {
+
+					&.wc-shipping-currency-size-1 {
+						padding-left: 28px;
+					}
+					&.wc-shipping-currency-size-2 {
+						padding-left: 33px;
+					}
+					&.wc-shipping-currency-size-3 {
+						padding-left: 38px;
+					}
+					&.wc-shipping-currency-size-4 {
+						padding-left: 43px;
+					}
+					&.wc-shipping-currency-size-5 {
+						padding-left: 48px;
 					}
 				}
 
-				&.wc-shipping-modal-price {
-					&.wc-shipping-currency-position-left,
-					&.wc-shipping-currency-position-left_space {
-
-						&.wc-shipping-currency-size-1 {
-							padding-left: 28px;
-						}
-						&.wc-shipping-currency-size-2 {
-							padding-left: 33px;
-						}
-						&.wc-shipping-currency-size-3 {
-							padding-left: 38px;
-						}
-						&.wc-shipping-currency-size-4 {
-							padding-left: 43px;
-						}
-						&.wc-shipping-currency-size-5 {
-							padding-left: 48px;
-						}
-					}
-
-					&.wc-shipping-currency-position-right,
-					&.wc-shipping-currency-position-right_space {
-						padding-left: 12px;
-					}
-					&.wc-shipping-invalid-price {
-						border: 2px solid var( --wc-red, #a00);
-					}
-
+				&.wc-shipping-currency-position-right,
+				&.wc-shipping-currency-position-right_space {
+					padding-left: 12px;
 				}
+				&.wc-shipping-invalid-price {
+					border: 2px solid var( --wc-red, #a00);
+				}
+
 			}
 		}
 
@@ -4537,6 +4538,15 @@ table.wc_shipping {
 		animation-range-start: normal;
 		color: #757575;
 	}
+}
+
+.wc-backbone-modal-add-attribute-term.wc-backbone-modal,
+.wc-backbone-modal-add-attribute-term.wc-backbone-modal .wc-backbone-modal-content {
+	min-width: auto;
+	max-width: 400px;
+}
+.wc-backbone-modal-add-attribute-term .wc-backbone-modal-main footer {
+	border-top: none;
 }
 
 .wc-backbone-modal-add-shipping-method .wc-backbone-modal-main article {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1002,26 +1002,6 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 	}
 }
 
-.wc-backbone-modal-add-attribute-term.wc-backbone-modal {
-	.wc-backbone-modal-content {
-		min-width: auto;
-		max-width: 400px;
-	}
-
-	input[type="text"] {
-		display: block;
-		font-size: 13px;
-		line-height: 16px;
-		margin: 6px 0;
-		padding: 12px;
-		width: 100%;
-	}
-
-	.wc-backbone-modal-main footer {
-		border-top: none;
-	}
-}
-
 /**
   * Variations related variables
   */
@@ -4557,6 +4537,26 @@ table.wc_shipping {
 		animation-timeline: auto;
 		animation-range-start: normal;
 		color: #757575;
+	}
+}
+
+.wc-backbone-modal-add-attribute-term.wc-backbone-modal {
+	.wc-backbone-modal-content {
+		min-width: auto;
+		max-width: 400px;
+	}
+
+	input[type="text"] {
+		display: block;
+		font-size: 13px;
+		line-height: 16px;
+		margin: 6px 0;
+		padding: 12px;
+		width: 100%;
+	}
+
+	.wc-backbone-modal-main footer {
+		border-top: none;
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -984,7 +984,7 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			const $wrapper = $( currentAttributeTermCreationContext.wrapper );
+			const wrapper = currentAttributeTermCreationContext.wrapper;
 			const data = {
 				action: 'woocommerce_add_new_attribute',
 				taxonomy: currentAttributeTermCreationContext.attribute,
@@ -1001,18 +1001,22 @@ jQuery( function ( $ ) {
 						window.alert( response.error );
 					} else if ( response.slug ) {
 						// Success.
-						$wrapper
-							.find( 'select.attribute_values' )
-							.append(
-								'<option value="' +
-									response.term_id +
-									'" selected="selected">' +
-									response.name +
-									'</option>'
-							);
-						$wrapper
-							.find( 'select.attribute_values' )
-							.trigger( 'change' );
+						const select = wrapper.querySelector(
+							'select.attribute_values'
+						);
+						if ( select ) {
+							const option = document.createElement( 'option' );
+							option.value = String( response.term_id );
+							option.selected = true;
+							option.textContent = response.name;
+							select.appendChild( option );
+
+							// Trigger change event natively.
+							const changeEvent = new Event( 'change', {
+								bubbles: true,
+							} );
+							select.dispatchEvent( changeEvent );
+						}
 					}
 
 					$( '.product_attributes' ).unblock();

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -477,6 +477,7 @@ jQuery( function ( $ ) {
 	}
 
 	var selectedAttributes = [];
+	var currentAttributeTermCreationContext = null;
 	$( '.product_attributes .woocommerce_attribute' ).each( function (
 		index,
 		el
@@ -861,6 +862,99 @@ jQuery( function ( $ ) {
 		},
 	} );
 
+	function enable_or_disable_add_attribute_term_modal_submit_button( postedData ) {
+		var createButton = document.getElementById( 'btn-ok' );
+
+		if ( ! createButton ) {
+			return;
+		}
+
+		var termName = postedData && postedData.term ? postedData.term.trim() : '';
+		var hasValue = termName.length > 0;
+
+		createButton.disabled = ! hasValue;
+		createButton.classList.toggle( 'disabled', ! hasValue );
+	}
+
+	$( document.body ).on(
+		'wc_backbone_modal_loaded',
+		function ( event, target ) {
+			if ( 'wc-modal-add-attribute-term' !== target ) {
+				return;
+			}
+
+			var termInput = document.getElementById( 'wc-new-attribute-term' );
+			if ( termInput ) {
+				termInput.focus();
+			}
+		}
+	);
+
+	$( document.body ).on(
+		'wc_backbone_modal_validation',
+		function ( event, target, postedData ) {
+			if ( 'wc-modal-add-attribute-term' !== target ) {
+				return;
+			}
+
+			enable_or_disable_add_attribute_term_modal_submit_button( postedData );
+		}
+	);
+
+	$( document.body ).on(
+		'wc_backbone_modal_response',
+		function ( event, target, postedData ) {
+			if ( 'wc-modal-add-attribute-term' !== target ) {
+				return;
+			}
+
+			if (
+				! currentAttributeTermCreationContext ||
+				! currentAttributeTermCreationContext.$wrapper ||
+				! currentAttributeTermCreationContext.attribute
+			) {
+				$( '.product_attributes' ).unblock();
+				return;
+			}
+
+			var termName =
+				postedData && postedData.term ? postedData.term.trim() : '';
+
+			if ( ! termName ) {
+				$( '.product_attributes' ).unblock();
+				return;
+			}
+
+			var $wrapper = currentAttributeTermCreationContext.$wrapper;
+			var data = {
+				action: 'woocommerce_add_new_attribute',
+				taxonomy: currentAttributeTermCreationContext.attribute,
+				term: termName,
+				security: woocommerce_admin_meta_boxes.add_attribute_nonce,
+			};
+
+			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function ( response ) {
+				if ( response.error ) {
+					// Error.
+					window.alert( response.error );
+				} else if ( response.slug ) {
+					// Success.
+					$wrapper.find( 'select.attribute_values' ).append(
+						'<option value="' +
+							response.term_id +
+							'" selected="selected">' +
+							response.name +
+							'</option>'
+					);
+					$wrapper.find( 'select.attribute_values' ).trigger( 'change' );
+				}
+
+				$( '.product_attributes' ).unblock();
+				currentAttributeTermCreationContext = null;
+			} );
+		}
+	);
+
 	// Add a new attribute (via ajax).
 	$( '.product_attributes' ).on(
 		'click',
@@ -879,47 +973,31 @@ jQuery( function ( $ ) {
 
 			var $wrapper = $( this ).closest( '.woocommerce_attribute' );
 			var attribute = $wrapper.data( 'taxonomy' );
-			var new_attribute_name = window.prompt(
-				woocommerce_admin_meta_boxes.new_attribute_prompt
-			);
 
-			if ( new_attribute_name ) {
-				var data = {
-					action: 'woocommerce_add_new_attribute',
-					taxonomy: attribute,
-					term: new_attribute_name,
-					security: woocommerce_admin_meta_boxes.add_attribute_nonce,
-				};
+			currentAttributeTermCreationContext = {
+				$wrapper,
+				attribute,
+			};
 
-				$.post(
-					woocommerce_admin_meta_boxes.ajax_url,
-					data,
-					function ( response ) {
-						if ( response.error ) {
-							// Error.
-							window.alert( response.error );
-						} else if ( response.slug ) {
-							// Success.
-							$wrapper
-								.find( 'select.attribute_values' )
-								.append(
-									'<option value="' +
-										response.term_id +
-										'" selected="selected">' +
-										response.name +
-										'</option>'
-								);
-							$wrapper
-								.find( 'select.attribute_values' )
-								.trigger( 'change' );
-						}
+			$( this ).WCBackboneModal( {
+				template: 'wc-modal-add-attribute-term',
+			} );
+		}
+	);
 
-						$( '.product_attributes' ).unblock();
-					}
-				);
-			} else {
-				$( '.product_attributes' ).unblock();
+	$( document.body ).on(
+		'wc_backbone_modal_before_remove',
+		function ( event, target, postedData, addButtonCalled ) {
+			if ( 'wc-modal-add-attribute-term' !== target ) {
+				return;
 			}
+
+			if ( addButtonCalled ) {
+				return;
+			}
+
+			$( '.product_attributes' ).unblock();
+			currentAttributeTermCreationContext = null;
 		}
 	);
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1417,7 +1417,9 @@ jQuery( function ( $ ) {
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );
-	const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${ woocommerce_admin_meta_boxes.i18n_product_image_tip }"></span>`;
+	const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${
+		woocommerce_admin_meta_boxes.i18n_product_image_tip
+	}"></span>`;
 	const tooltipData = {
 		attribute: 'data-tip',
 		content: woocommerce_admin_meta_boxes.i18n_product_image_tip,

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -902,11 +902,31 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			const termInput = document.getElementById(
-				'wc-modal-add-attribute-term-input'
+			const modal = document.querySelector(
+				'.wc-backbone-modal-add-attribute-term'
+			);
+
+			if ( ! modal ) {
+				return;
+			}
+
+			const termInput = modal.querySelector(
+				'#wc-modal-add-attribute-term-input'
 			);
 			if ( termInput ) {
 				termInput.focus();
+			}
+
+			const form = modal.querySelector( '.wc-add-attribute-term-fields' );
+			if ( form ) {
+				form.addEventListener( 'submit', ( submitEvent ) => {
+					submitEvent.preventDefault();
+
+					const submitButton = modal.querySelector( '#btn-ok' );
+					if ( submitButton && ! submitButton.disabled ) {
+						submitButton.click();
+					}
+				} );
 			}
 		}
 	);

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -938,7 +938,15 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			const submitButton = document.getElementById( 'btn-ok' );
+			const modal = document.querySelector(
+				'.wc-backbone-modal-add-attribute-term'
+			);
+
+			if ( ! modal ) {
+				return;
+			}
+
+			const submitButton = modal.querySelector( '#btn-ok' );
 
 			if ( ! submitButton ) {
 				return;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -144,11 +144,13 @@ jQuery( function ( $ ) {
 				$( 'input#_virtual' ).prop( 'checked', false );
 			}
 
-			const cogs_field_tip = $( '._cogs_value_field' ).find( '.woocommerce-help-tip' );
+			const cogs_field_tip = $( '._cogs_value_field' ).find(
+				'.woocommerce-help-tip'
+			);
 			const cogs_field_tip_text =
-				'variable' === select_val ?
-					woocommerce_admin_meta_boxes.cogs_value_tooltip_variable_products :
-					woocommerce_admin_meta_boxes.cogs_value_tooltip_simple_products;
+				'variable' === select_val
+					? woocommerce_admin_meta_boxes.cogs_value_tooltip_variable_products
+					: woocommerce_admin_meta_boxes.cogs_value_tooltip_simple_products;
 			$( cogs_field_tip ).attr( 'aria-label', cogs_field_tip_text );
 			$( cogs_field_tip ).tipTip( {
 				attribute: 'aria-label',
@@ -191,16 +193,16 @@ jQuery( function ( $ ) {
 		$( '#tiptip_holder' ).removeAttr( 'style' );
 		$( '#tiptip_arrow' ).removeAttr( 'style' );
 		$( '.woocommerce-product-type-tip' )
-		.attr( 'tabindex', '0' )
-		.attr( 'aria-label', $( '<div />' ).html( content ).text() ) // Remove HTML tags.
-		.tipTip( {
-			attribute: 'data-tip',
-			content: content,
-			fadeIn: 50,
-			fadeOut: 50,
-			delay: 200,
-			keepAlive: true,
-		} );
+			.attr( 'tabindex', '0' )
+			.attr( 'aria-label', $( '<div />' ).html( content ).text() ) // Remove HTML tags.
+			.tipTip( {
+				attribute: 'data-tip',
+				content: content,
+				fadeIn: 50,
+				fadeOut: 50,
+				delay: 200,
+				keepAlive: true,
+			} );
 	}
 
 	function get_product_tip_content( product_type ) {
@@ -259,7 +261,9 @@ jQuery( function ( $ ) {
 		$( '.hide_if_' + product_type, context ).hide();
 
 		// POS visibility - requires combination of type AND downloadable status.
-		var is_pos_supported = ( product_type === 'simple' || product_type === 'variable' ) && ! is_downloadable;
+		var is_pos_supported =
+			( product_type === 'simple' || product_type === 'variable' ) &&
+			! is_downloadable;
 		if ( is_pos_supported ) {
 			$( '#pos_visibility_supported', context ).show();
 			$( '#pos_visibility_unsupported', context ).hide();
@@ -435,18 +439,22 @@ jQuery( function ( $ ) {
 	const $product_attributes = $( '.product_attributes' );
 	if ( $product_attributes.length === 1 ) {
 		// When the attributes tab is shown, add an empty attribute to be filled out by the user.
-		$( '#product_attributes' ).on( 'woocommerce_tab_shown', function() {
+		$( '#product_attributes' ).on( 'woocommerce_tab_shown', function () {
 			remove_blank_custom_attribute_if_no_other_attributes();
 
-			const woocommerce_attribute_items = $product_attributes.find( '.woocommerce_attribute' ).get();
+			const woocommerce_attribute_items = $product_attributes
+				.find( '.woocommerce_attribute' )
+				.get();
 
 			// If the product has no attributes, add an empty attribute to be filled out by the user.
-			if ( woocommerce_attribute_items.length === 0  ) {
+			if ( woocommerce_attribute_items.length === 0 ) {
 				add_custom_attribute_to_list();
 			}
 		} );
 
-		const woocommerce_attribute_items = $product_attributes.find( '.woocommerce_attribute' ).get();
+		const woocommerce_attribute_items = $product_attributes
+			.find( '.woocommerce_attribute' )
+			.get();
 
 		// Sort the attributes by their position.
 		woocommerce_attribute_items.sort( function ( a, b ) {
@@ -492,13 +500,17 @@ jQuery( function ( $ ) {
 				.attr( 'disabled', 'disabled' );
 		}
 
-		if ( 'undefined' === $(el).attr( 'data-taxonomy' ) ||
-			false === $(el).attr( 'data-taxonomy' ) ||
-			'' === $(el).attr( 'data-taxonomy' ) ) {
-			add_placeholder_to_attribute_values_field( $(el) );
+		if (
+			'undefined' === $( el ).attr( 'data-taxonomy' ) ||
+			false === $( el ).attr( 'data-taxonomy' ) ||
+			'' === $( el ).attr( 'data-taxonomy' )
+		) {
+			add_placeholder_to_attribute_values_field( $( el ) );
 
-			$( '.woocommerce_attribute input.woocommerce_attribute_used_for_variations' ).on( 'change', function() {
-				add_placeholder_to_attribute_values_field( $(el) );
+			$(
+				'.woocommerce_attribute input.woocommerce_attribute_used_for_variations'
+			).on( 'change', function () {
+				add_placeholder_to_attribute_values_field( $( el ) );
 			} );
 		}
 	} );
@@ -553,15 +565,27 @@ jQuery( function ( $ ) {
 	}
 
 	function add_placeholder_to_attribute_values_field( $attributeListItem ) {
+		var $used_for_variations_checkbox = $attributeListItem.find(
+			'input.woocommerce_attribute_used_for_variations'
+		);
 
-		var $used_for_variations_checkbox = $attributeListItem.find( 'input.woocommerce_attribute_used_for_variations' );
-
-		if ( $used_for_variations_checkbox.length && $used_for_variations_checkbox.is( ':checked' ) ) {
-			$attributeListItem.find( 'textarea' )
-				.attr( 'placeholder', woocommerce_admin_meta_boxes.i18n_attributes_used_for_variations_placeholder );
+		if (
+			$used_for_variations_checkbox.length &&
+			$used_for_variations_checkbox.is( ':checked' )
+		) {
+			$attributeListItem
+				.find( 'textarea' )
+				.attr(
+					'placeholder',
+					woocommerce_admin_meta_boxes.i18n_attributes_used_for_variations_placeholder
+				);
 		} else {
-			$attributeListItem.find( 'textarea' )
-				.attr( 'placeholder', woocommerce_admin_meta_boxes.i18n_attributes_default_placeholder );
+			$attributeListItem
+				.find( 'textarea' )
+				.attr(
+					'placeholder',
+					woocommerce_admin_meta_boxes.i18n_attributes_default_placeholder
+				);
 		}
 	}
 
@@ -602,8 +626,12 @@ jQuery( function ( $ ) {
 			if ( 'undefined' === typeof globalAttributeId ) {
 				add_placeholder_to_attribute_values_field( $attributeListItem );
 
-				$( '.woocommerce_attribute input.woocommerce_attribute_used_for_variations' ).on( 'change', function() {
-					add_placeholder_to_attribute_values_field( $(this).closest( '.woocommerce_attribute' ) );
+				$(
+					'.woocommerce_attribute input.woocommerce_attribute_used_for_variations'
+				).on( 'change', function () {
+					add_placeholder_to_attribute_values_field(
+						$( this ).closest( '.woocommerce_attribute' )
+					);
 				} );
 			}
 
@@ -617,7 +645,9 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			alert( woocommerce_admin_meta_boxes.i18n_add_attribute_error_notice );
+			alert(
+				woocommerce_admin_meta_boxes.i18n_add_attribute_error_notice
+			);
 			throw error;
 		} finally {
 			unblock_attributes_tab_container();
@@ -664,14 +694,17 @@ jQuery( function ( $ ) {
 
 	// Handle the Attributes onboarding dismissible notice.
 	// If users dismiss the notice, never show it again.
-	if ( localStorage.getItem('attributes-notice-dismissed' ) ) {
+	if ( localStorage.getItem( 'attributes-notice-dismissed' ) ) {
 		$( '#product_attributes .notice' ).hide();
 	}
 
-	$( '#product_attributes .notice.woocommerce-message button' ).on( 'click', function( e ) {
-		$( '#product_attributes .notice' ).hide();
-		localStorage.setItem( 'attributes-notice-dismissed', 'true');
-	} );
+	$( '#product_attributes .notice.woocommerce-message button' ).on(
+		'click',
+		function ( e ) {
+			$( '#product_attributes .notice' ).hide();
+			localStorage.setItem( 'attributes-notice-dismissed', 'true' );
+		}
+	);
 
 	$( 'select.wc-attribute-search' ).on( 'select2:select', function ( e ) {
 		const attributeId = e && e.params && e.params.data && e.params.data.id;
@@ -862,14 +895,17 @@ jQuery( function ( $ ) {
 		},
 	} );
 
-	function enable_or_disable_add_attribute_term_modal_submit_button( postedData ) {
+	function enable_or_disable_add_attribute_term_modal_submit_button(
+		postedData
+	) {
 		var createButton = document.getElementById( 'btn-ok' );
 
 		if ( ! createButton ) {
 			return;
 		}
 
-		var termName = postedData && postedData.term ? postedData.term.trim() : '';
+		var termName =
+			postedData && postedData.term ? postedData.term.trim() : '';
 		var hasValue = termName.length > 0;
 
 		createButton.disabled = ! hasValue;
@@ -897,7 +933,9 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			enable_or_disable_add_attribute_term_modal_submit_button( postedData );
+			enable_or_disable_add_attribute_term_modal_submit_button(
+				postedData
+			);
 		}
 	);
 
@@ -933,25 +971,33 @@ jQuery( function ( $ ) {
 				security: woocommerce_admin_meta_boxes.add_attribute_nonce,
 			};
 
-			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function ( response ) {
-				if ( response.error ) {
-					// Error.
-					window.alert( response.error );
-				} else if ( response.slug ) {
-					// Success.
-					$wrapper.find( 'select.attribute_values' ).append(
-						'<option value="' +
-							response.term_id +
-							'" selected="selected">' +
-							response.name +
-							'</option>'
-					);
-					$wrapper.find( 'select.attribute_values' ).trigger( 'change' );
-				}
+			$.post(
+				woocommerce_admin_meta_boxes.ajax_url,
+				data,
+				function ( response ) {
+					if ( response.error ) {
+						// Error.
+						window.alert( response.error );
+					} else if ( response.slug ) {
+						// Success.
+						$wrapper
+							.find( 'select.attribute_values' )
+							.append(
+								'<option value="' +
+									response.term_id +
+									'" selected="selected">' +
+									response.name +
+									'</option>'
+							);
+						$wrapper
+							.find( 'select.attribute_values' )
+							.trigger( 'change' );
+					}
 
-				$( '.product_attributes' ).unblock();
-				currentAttributeTermCreationContext = null;
-			} );
+					$( '.product_attributes' ).unblock();
+					currentAttributeTermCreationContext = null;
+				}
+			);
 		}
 	);
 
@@ -1358,8 +1404,7 @@ jQuery( function ( $ ) {
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );
-	const tooltipMarkup =
-		`<span class="woocommerce-help-tip" tabindex="0" aria-label="${ woocommerce_admin_meta_boxes.i18n_product_image_tip }"></span>`;
+	const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${ woocommerce_admin_meta_boxes.i18n_product_image_tip }"></span>`;
 	const tooltipData = {
 		attribute: 'data-tip',
 		content: woocommerce_admin_meta_boxes.i18n_product_image_tip,

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -895,23 +895,6 @@ jQuery( function ( $ ) {
 		},
 	} );
 
-	function enable_or_disable_add_attribute_term_modal_submit_button(
-		postedData
-	) {
-		var createButton = document.getElementById( 'btn-ok' );
-
-		if ( ! createButton ) {
-			return;
-		}
-
-		var termName =
-			postedData && postedData.term ? postedData.term.trim() : '';
-		var hasValue = termName.length > 0;
-
-		createButton.disabled = ! hasValue;
-		createButton.classList.toggle( 'disabled', ! hasValue );
-	}
-
 	$( document.body ).on(
 		'wc_backbone_modal_loaded',
 		function ( event, target ) {
@@ -919,7 +902,9 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			var termInput = document.getElementById( 'wc-new-attribute-term' );
+			const termInput = document.getElementById(
+				'wc-modal-add-attribute-term-input'
+			);
 			if ( termInput ) {
 				termInput.focus();
 			}
@@ -933,9 +918,17 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			enable_or_disable_add_attribute_term_modal_submit_button(
-				postedData
-			);
+			const submitButton = document.getElementById( 'btn-ok' );
+
+			if ( ! submitButton ) {
+				return;
+			}
+
+			const termName =
+				postedData && postedData.term ? postedData.term.trim() : '';
+			const hasValue = termName.length > 0;
+
+			submitButton.disabled = ! hasValue;
 		}
 	);
 
@@ -948,14 +941,14 @@ jQuery( function ( $ ) {
 
 			if (
 				! currentAttributeTermCreationContext ||
-				! currentAttributeTermCreationContext.$wrapper ||
+				! currentAttributeTermCreationContext.wrapper ||
 				! currentAttributeTermCreationContext.attribute
 			) {
 				$( '.product_attributes' ).unblock();
 				return;
 			}
 
-			var termName =
+			const termName =
 				postedData && postedData.term ? postedData.term.trim() : '';
 
 			if ( ! termName ) {
@@ -963,8 +956,8 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			var $wrapper = currentAttributeTermCreationContext.$wrapper;
-			var data = {
+			const $wrapper = $( currentAttributeTermCreationContext.wrapper );
+			const data = {
 				action: 'woocommerce_add_new_attribute',
 				taxonomy: currentAttributeTermCreationContext.attribute,
 				term: termName,
@@ -1006,7 +999,7 @@ jQuery( function ( $ ) {
 		'click',
 		'button.add_new_attribute',
 		function ( event ) {
-			// prevent form submission but allow event propagation
+			// Prevent form submission but allow event propagation.
 			event.preventDefault();
 
 			$( '.product_attributes' ).block( {
@@ -1017,11 +1010,11 @@ jQuery( function ( $ ) {
 				},
 			} );
 
-			var $wrapper = $( this ).closest( '.woocommerce_attribute' );
-			var attribute = $wrapper.data( 'taxonomy' );
+			const wrapper = this.closest( '.woocommerce_attribute' );
+			const attribute = wrapper ? wrapper.dataset.taxonomy : '';
 
 			currentAttributeTermCreationContext = {
-				$wrapper,
+				wrapper,
 				attribute,
 			};
 
@@ -1033,12 +1026,12 @@ jQuery( function ( $ ) {
 
 	$( document.body ).on(
 		'wc_backbone_modal_before_remove',
-		function ( event, target, postedData, addButtonCalled ) {
+		function ( event, target, postedData, submitButtonCalled ) {
 			if ( 'wc-modal-add-attribute-term' !== target ) {
 				return;
 			}
 
-			if ( addButtonCalled ) {
+			if ( submitButtonCalled ) {
 				return;
 			}
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -75,15 +75,15 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 				</header>
 				<article>
 					<form class="wc-add-attribute-term-fields" action="" method="post">
-						<label for="wc-new-attribute-term"><?php esc_html_e( 'Name', 'woocommerce' ); ?></label>
-						<input id="wc-new-attribute-term" type="text" name="term" value="" />
+						<label for="wc-modal-add-attribute-term-input"><?php esc_html_e( 'Name', 'woocommerce' ); ?></label>
+						<input id="wc-modal-add-attribute-term-input" type="text" name="term" value="" />
 					</form>
 				</article>
 				<footer>
 					<div class="inner">
 						<div>
 							<button class="modal-close button button-large"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-							<button id="btn-ok" disabled class="button button-primary button-large disabled"><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
+							<button id="btn-ok" disabled class="button button-primary button-large"><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
 						</div>
 					</div>
 				</footer>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -62,3 +62,33 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 	</div>
 	<?php do_action( 'woocommerce_product_options_attributes' ); ?>
 </div>
+
+<script type="text/template" id="tmpl-wc-modal-add-attribute-term">
+	<div class="wc-backbone-modal wc-backbone-modal-add-attribute-term">
+		<div class="wc-backbone-modal-content">
+			<section class="wc-backbone-modal-main" role="main">
+				<header class="wc-backbone-modal-header">
+					<h1><?php esc_html_e( 'Create value', 'woocommerce' ); ?></h1>
+					<button class="modal-close modal-close-link dashicons dashicons-no-alt">
+						<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'woocommerce' ); ?></span>
+					</button>
+				</header>
+				<article>
+					<form class="wc-add-attribute-term-fields" action="" method="post">
+						<label for="wc-new-attribute-term"><?php esc_html_e( 'Name', 'woocommerce' ); ?></label>
+						<input id="wc-new-attribute-term" type="text" name="term" value="" placeholder="<?php esc_attr_e( 'Name', 'woocommerce' ); ?>" />
+					</form>
+				</article>
+				<footer>
+					<div class="inner">
+						<div>
+							<button class="modal-close button button-large"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+							<button id="btn-ok" disabled class="button button-primary button-large disabled"><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
+						</div>
+					</div>
+				</footer>
+			</section>
+		</div>
+	</div>
+	<div class="wc-backbone-modal-backdrop modal-close"></div>
+</script>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -42,7 +42,7 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 		$i = -1;
 
 		foreach ( $product_attributes as $attribute ) {
-			$i++;
+			++$i;
 			$metabox_class = array();
 
 			if ( $attribute->is_taxonomy() ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -76,7 +76,7 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 				<article>
 					<form class="wc-add-attribute-term-fields" action="" method="post">
 						<label for="wc-new-attribute-term"><?php esc_html_e( 'Name', 'woocommerce' ); ?></label>
-						<input id="wc-new-attribute-term" type="text" name="term" value="" placeholder="<?php esc_attr_e( 'Name', 'woocommerce' ); ?>" />
+						<input id="wc-new-attribute-term" type="text" name="term" value="" />
 					</form>
 				</article>
 				<footer>

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/create-product-attributes.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/create-product-attributes.spec.ts
@@ -301,10 +301,10 @@ test( 'can create attribute terms from the attributes modal', async ( {
 			await submitButton.click();
 		} );
 
-		await test.step( `Expect "${ newTerm }" to be selected in attribute values`, async () => {
+		await test.step( `Expect "${ newTerm }" to be in attribute values`, async () => {
 			await expect(
 				page.locator(
-					'.woocommerce_attribute .attribute_values option[selected="selected"]',
+					'.woocommerce_attribute .attribute_values option',
 					{
 						hasText: newTerm,
 					}

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/create-product-attributes.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/create-product-attributes.spec.ts
@@ -223,3 +223,113 @@ test( 'can add custom product attributes', async ( { page, product } ) => {
 		} );
 	}
 } );
+
+test( 'can create attribute terms from the attributes modal', async ( {
+	page,
+	restApi,
+} ) => {
+	const attributeName = 'Fabric';
+	const initialTerm = 'Cotton';
+	const newTerm = `Linen-${ Date.now() }`;
+	let attributeId: number | undefined;
+	let createdProductId: number | undefined;
+
+	try {
+		await test.step( `Create a global attribute "${ attributeName }"`, async () => {
+			const response = await restApi.post(
+				`${ WC_API_PATH }/products/attributes`,
+				{
+					name: attributeName,
+				}
+			);
+
+			attributeId = response.data.id;
+		} );
+
+		await test.step( 'Create a variable product with that global attribute', async () => {
+			const response = await restApi.post( `${ WC_API_PATH }/products`, {
+				...getFakeProduct( { type: 'variable' } ),
+				attributes: [
+					{
+						id: attributeId,
+						visible: true,
+						variation: true,
+						options: [ initialTerm ],
+					},
+				],
+			} );
+
+			createdProductId = response.data.id;
+		} );
+
+		await test.step( `Open "Edit product" page of product id ${ createdProductId }`, async () => {
+			await page.goto(
+				`wp-admin/post.php?post=${ createdProductId }&action=edit`
+			);
+			await toggleVariableProductTour( page, false );
+		} );
+
+		await goToAttributesTab( page );
+
+		await test.step( `Expand the "${ attributeName }" attribute`, async () => {
+			await page
+				.getByRole( 'heading', {
+					name: attributeName,
+				} )
+				.last()
+				.click();
+		} );
+
+		await test.step( `Create a new term "${ newTerm }" from the modal`, async () => {
+			await page.getByRole( 'button', { name: 'Create value' } ).click();
+
+			const modal = page.locator(
+				'.wc-backbone-modal-add-attribute-term .wc-backbone-modal-content'
+			);
+			await expect( modal ).toBeVisible();
+
+			const modalHeader = modal.getByRole( 'heading', {
+				name: 'Create value',
+			} );
+			await expect( modalHeader ).toBeVisible();
+
+			const submitButton = page.getByRole( 'button', { name: 'OK' } );
+			await expect( submitButton ).toBeDisabled();
+
+			await modal.getByLabel( 'Name' ).fill( newTerm );
+			await expect( submitButton ).toBeEnabled();
+			await submitButton.click();
+		} );
+
+		await test.step( `Expect "${ newTerm }" to be selected in attribute values`, async () => {
+			await expect(
+				page.locator(
+					'.woocommerce_attribute .attribute_values option[selected="selected"]',
+					{
+						hasText: newTerm,
+					}
+				)
+			).toBeVisible();
+		} );
+	} finally {
+		// eslint-disable-next-line playwright/no-conditional-in-test
+		if ( createdProductId ) {
+			await restApi.delete(
+				`${ WC_API_PATH }/products/${ createdProductId }`,
+				{
+					force: true,
+				}
+			);
+		}
+
+		// eslint-disable-next-line playwright/no-conditional-in-test
+		if ( attributeId ) {
+			await restApi.delete(
+				`${ WC_API_PATH }/products/attributes/${ attributeId }`,
+				{
+					force: true,
+				}
+			);
+		}
+	}
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the Create value modal when editing variable products to use the same styling as other modals in the admin instead of using the default browser UI.

### How to test the changes in this Pull Request:

1. Create or edit a variable product.
2. Go to the Attributes tab, open one of them and click on 'Create value'.
3. Debug the modal: make sure it can be closed, opened again, and submitting creates the term.

<img width="1353" height="771" alt="imatge" src="https://github.com/user-attachments/assets/00046f2e-70a9-481a-8b3a-b1100b434b1f" />

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.