### PR TITLE
Fix fatal error in cart template when filter returns non-product

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6544-cart-template-null-product
+++ b/plugins/woocommerce/changelog/wooplug-6544-cart-template-null-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error in the cart template when a filter on `woocommerce_cart_item_product` returns a non-product value, by moving the product name lookup inside the existing product validity check.

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.1.0
+ * @version 10.8.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -40,17 +40,17 @@ do_action( 'woocommerce_before_cart' ); ?>
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 				$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 				$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
-				/**
-				 * Filter the product name.
-				 *
-				 * @since 2.1.0
-				 * @param string $product_name Name of the product in the cart.
-				 * @param array $cart_item The product in the cart.
-				 * @param string $cart_item_key Key for the product in the cart.
-				 */
-				$product_name = apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key );
 
 				if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+					/**
+					 * Filter the product name.
+					 *
+					 * @since 2.1.0
+					 * @param string $product_name Name of the product in the cart.
+					 * @param array $cart_item The product in the cart.
+					 * @param string $cart_item_key Key for the product in the cart.
+					 */
+					$product_name      = apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key );
 					$product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink( $cart_item ) : '', $cart_item, $cart_item_key );
 					?>
 					<tr class="woocommerce-cart-form__cart-item <?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -41,7 +41,17 @@ do_action( 'woocommerce_before_cart' ); ?>
 				$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 				$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
 
-				if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+				/**
+				 * Filter whether this cart item is visible in the cart.
+				 *
+				 * @since 2.1.0
+				 * @param bool   $visible     Whether the cart item is visible. Default true.
+				 * @param array  $cart_item     The cart item data.
+				 * @param string $cart_item_key The cart item key.
+				 */
+				$visible = apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key );
+
+				if ( $_product instanceof WC_Product && $_product->exists() && $cart_item['quantity'] > 0 && $visible ) {
 					/**
 					 * Filter the product name.
 					 *


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In `templates/cart/cart.php`, `$_product->get_name()` was called before the `if ( $_product && $_product->exists() ... )` validity check, so a filter hooked onto `woocommerce_cart_item_product` that returns anything other than a `WC_Product` (e.g. `false`) caused a fatal error. This PR moves the `$product_name` assignment inside the existing validity check, matching the pattern already used in `cart/mini-cart.php` and `checkout/review-order.php`.

Closes #64156.

### How to test the changes in this Pull Request:

1. Add any product to the cart.
2. In a snippet or `functions.php`, add:
   ```php
   add_filter( 'woocommerce_cart_item_product', function () {
       return false;
   } );
   ```
3. Visit the Cart page.
4. **Expected:** The cart renders without any row for the affected item and no fatal error. **Before this PR:** a fatal "Call to a member function get_name() on bool" error occurs.
5. Remove the snippet, reload the cart, and confirm the product row renders normally.

### Testing that has already taken place:

- Manually reproduced the fatal error on trunk using the snippet above and confirmed the patched template renders without error.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch` — clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

Changelog entry added manually in `plugins/woocommerce/changelog/wooplug-6544-cart-template-null-product`.