### PR TITLE
Align Woo admin primary text color with WordPress 7.0

### DIFF
--- a/plugins/woocommerce/changelog/tweak-admin-primary-text-color-wp7-align
+++ b/plugins/woocommerce/changelog/tweak-admin-primary-text-color-wp7-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Replace hardcoded #2c3338 primary text color with #1e1e1e to align with the WordPress 7.0 admin gray scale.

--- a/plugins/woocommerce/client/admin/client/launch-your-store/status/style.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/status/style.scss
@@ -11,7 +11,7 @@
 	display: flex;
 	align-items: center;
 	background-color: #eaeaeb;
-	color: #2c3338;
+	color: #1e1e1e;
 	padding: 0 3px 0 10px;
 	font-size: 12px;
 	font-weight: 500;

--- a/plugins/woocommerce/client/admin/client/lib/wordpress-logo/style.scss
+++ b/plugins/woocommerce/client/admin/client/lib/wordpress-logo/style.scss
@@ -1,5 +1,5 @@
 .wordpress-logo {
-	fill: #2c3338;
+	fill: #1e1e1e;
 	margin: 0 auto 20px;
 }
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -251,7 +251,7 @@
 	padding: 2px 8px;
 	border-radius: 2px;
 	background-color: #f6f7f7;
-	color: #2c3338;
+	color: #1e1e1e;
 	font-size: 12px;
 	font-weight: 400;
 	line-height: 16px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -626,7 +626,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 				}
 
 				p {
-					color: #2c3338;
+					color: #1e1e1e;
 					font-size: 14px;
 					line-height: 20px;
 					margin: 14px 64px 0 0;
@@ -9080,7 +9080,7 @@ table.bar_chart {
 				a:visited,
 				a:hover,
 				a:active {
-					color: #2c3338;
+					color: #1e1e1e;
 					padding: 10px 16px !important;
 				}
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WordPress 7.0 updated its admin primary text color from `#2c3338` to `#1e1e1e` (the `$gray-900` value in `@wordpress/base-styles/_colors.native.scss`). This PR sweeps Woo admin SCSS for remaining hardcoded `#2c3338` text colors and updates them to `#1e1e1e` so Woo admin matches WP 7.0's gray scale.

5 swaps across 4 files:

- `client/legacy/css/admin.scss` — 2 occurrences (paragraph text in a card, and `a:visited/hover/active` text color)
- `client/admin/client/launch-your-store/status/style.scss` — `.woocommerce-lys-status-pill` text color
- `client/admin/client/lib/wordpress-logo/style.scss` — SVG `fill` on the WP logo
- `client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss` — onboarding step text color

One existing occurrence in `admin.scss:624` (`color: var(--wp-admin-theme-color, #2c3338)`) was left alone — it's a theme-color fallback, not a primary text color use.

### Note on tokens vs hardcoded values

This PR uses hardcoded `#1e1e1e` rather than the `$gray-900` token because token adoption would require adding per-file SCSS imports (`@wordpress/base-styles/_colors.native.scss`) that aren't consistently in place across Woo admin. Visual outcome is identical — `$gray-900` resolves to `#1e1e1e` today. A broader token-adoption sweep belongs under the WP 7.0 alignment audit's "CSS Architecture / Design tokens" row as a separate follow-up.

### Screenshots or screen recordings:

Here is the updated, verified from Inspect after the change.

<img width="668" height="384" alt="CleanShot 2026-04-21 at 01 06 34@2x" src="https://github.com/user-attachments/assets/4fd16722-9696-46fc-a9b8-fbe99accb922" />


_Visual change is subtle — text shifts from `#2c3338` (dark gray) to `#1e1e1e` (slightly darker gray). Both pass contrast on white. No screenshots included; the diff speaks for itself._

### How to test the changes in this Pull Request:

1. Install this branch on a WordPress 7.0+ site with WooCommerce activated.
2. Build both admin and legacy assets: `pnpm --filter='@woocommerce/plugin-woocommerce' build:admin build:classic-assets`.
3. Spot-check affected areas:
   - **Launch Your Store status page** — the status pill should display `#1e1e1e` text
   - **Settings → Payments → WooPayments onboarding** — payment methods selection step text
   - **WordPress logo rendering** anywhere it appears — should fill with `#1e1e1e`
   - **Legacy admin.scss** — paragraphs in cards / `a:hover` states
4. DevTools → Computed → text `color` should read `rgb(30, 30, 30)` (= `#1e1e1e`) on affected elements.

### Testing that has already taken place:

- Stylelint clean on all modified files.
- `build:admin` and `build:classic-assets` run cleanly.
- Compiled CSS verified to contain the new hex in both `assets/css/admin.css` and `assets/client/admin/app/style.css`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry created manually for `@woocommerce/plugin-woocommerce`.