### PR TITLE
Align Woo admin placeholder text color with WordPress 7.0

### DIFF
--- a/plugins/woocommerce/changelog/tweak-admin-placeholder-text-color-wp7-align
+++ b/plugins/woocommerce/changelog/tweak-admin-placeholder-text-color-wp7-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Replace hardcoded #646970 placeholder/secondary text color with #757575 to align with the WordPress 7.0 admin gray scale.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -679,7 +679,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 				}
 
 				.price-suffix {
-					color: #646970; // Gray 50
+					color: #757575;
 				}
 
 				.product-reviews-block {
@@ -708,7 +708,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 					}
 
 					.product-reviews-count {
-						color: #646970; // Gray 50
+						color: #757575;
 						font-size: 12px;
 						font-family: sans-serif;
 						line-height: 24px;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WordPress 7.0 updated its admin placeholder / secondary text color from `#646970` to `#757575` (the `$gray-700` value in `@wordpress/base-styles/_colors.native.scss`). This PR sweeps Woo admin SCSS for remaining hardcoded `#646970` values and updates them so Woo matches WP 7.0's gray scale.

2 swaps in a single file:

- `client/legacy/css/admin.scss:682` — `.price-suffix` text color
- `client/legacy/css/admin.scss:711` — `.product-reviews-count` text color

Both previously carried an outdated `// Gray 50` comment referring to WP 6.9's color naming; comment removed since the new value maps to `$gray-700` under the WP 7.0 naming scheme.

### Note on tokens vs hardcoded values

Matches the approach from #64257 — hardcoded `#757575` rather than the `$gray-700` token, because token adoption would require adding per-file `@wordpress/base-styles/_colors.native.scss` imports that aren't consistently in place across Woo admin. Visual outcome is identical. A broader token-adoption sweep belongs under the WP 7.0 alignment audit's "CSS Architecture / Design tokens" row.

### Screenshots or screen recordings:

_Value swap between two similar grays (`#646970` → `#757575`); visual difference is minor by design. Compiled CSS verified in `assets/css/admin.css`._

### How to test the changes in this Pull Request:

1. Install this branch on a WordPress 7.0+ site with WooCommerce activated.
2. Build legacy assets: `pnpm --filter='@woocommerce/plugin-woocommerce' build:classic-assets`.
3. Spot-check:
   - **Product list with prices** — price suffix text (e.g. "each", per-unit hints) should show computed `color: rgb(117, 117, 117)` (= `#757575`)
   - **Product reviews display** — the review count text likewise
4. DevTools → Computed → `color` on those elements.

### Testing that has already taken place:

- Stylelint clean on the modified file.
- `build:classic-assets` runs cleanly.
- Compiled CSS in `assets/css/admin.css` verified to contain the new hex on both selectors.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry created manually for `@woocommerce/plugin-woocommerce`.