### PR TITLE
Unify admin modal styles

### DIFF
--- a/plugins/woocommerce/changelog/update-create-term-modal-ii
+++ b/plugins/woocommerce/changelog/update-create-term-modal-ii
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update admin modals styles to keep them more consistent

--- a/plugins/woocommerce/changelog/update-create-term-modal-ii
+++ b/plugins/woocommerce/changelog/update-create-term-modal-ii
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Update admin modals styles to keep them more consistent
+Update admin modal styles to keep them more consistent

--- a/plugins/woocommerce/client/admin/client/layout/style.scss
+++ b/plugins/woocommerce/client/admin/client/layout/style.scss
@@ -156,39 +156,6 @@
 	display: none;
 }
 
-.components-modal__frame.woocommerce-usage-modal {
-	width: 600px;
-	max-width: 100%;
-
-	.components-modal__header {
-		margin-bottom: 0;
-	}
-
-	.woocommerce-usage-modal__wrapper {
-		flex-grow: 1;
-		display: flex;
-		flex-direction: column;
-
-		a {
-			color: $studio-gray-60;
-		}
-
-		button.is-primary {
-			align-self: flex-end;
-		}
-	}
-
-	.woocommerce-usage-modal__actions {
-		display: flex;
-		justify-content: flex-end;
-		margin-top: $gap;
-
-		button {
-			margin-left: $gap;
-		}
-	}
-}
-
 .woocommerce-payments__usage-modal {
 	.components-modal__header {
 		height: auto;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -979,26 +979,23 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 	}
 }
 
-.woocommerce-set-price-variations {
-	.woocommerce-usage-modal__wrapper {
-		.woocommerce-usage-modal__message {
-			height: 60px;
-			flex-wrap: wrap;
-			display: flex;
-			> span {
-				padding-bottom: 16px;
-			}
-		}
-		.woocommerce-usage-modal__actions {
-			display: flex;
-			justify-content: flex-end;
-			margin-top: 20px;
-			> button {
-				margin-left: 16px;
-				width: auto;
-				display: unset;
-			}
-		}
+/**
+ * Create attribute term modal
+ */
+ .woocommerce-set-price-variations, // @todo unify class name style
+ .wc-backbone-modal-add-attribute-term {
+	.wc-backbone-modal-content {
+		max-width: 400px;
+		min-width: auto;
+	}
+
+	input[type="text"] {
+		display: block;
+		font-size: 13px;
+		line-height: 16px;
+		margin: 6px 0;
+		padding: 12px;
+		width: 100%;
 	}
 }
 
@@ -2262,6 +2259,8 @@ ul.wc_coupon_list_block {
 }
 
 #woocommerce-order-items .woocommerce_order_items_wrapper, .wc-order-preview-table-wrapper {
+	padding-bottom: 1.5em;
+
 	small.refunded {
 		display: block;
 		color: red;
@@ -3271,7 +3270,13 @@ ul.wc_coupon_list_block {
 
 		td:first-child,
 		th:first-child {
+			padding-left: 2em;
 			text-align: left;
+		}
+
+		td:last-child,
+		th:last-child {
+			padding-right: 2em;
 		}
 
 		th {
@@ -3305,7 +3310,7 @@ ul.wc_coupon_list_block {
 
 	.wc-order-preview-addresses {
 		overflow: hidden;
-		padding-bottom: 1.5em;
+		padding: 0 0.5em 1.5em;
 
 		.wc-order-preview-address,
 		.wc-order-preview-note {
@@ -3338,8 +3343,6 @@ ul.wc_coupon_list_block {
 
 		.button.button-large {
 			margin-left: 10px;
-			padding: 0 10px !important;
-			line-height: 28px;
 			height: auto;
 			display: inline-block;
 		}
@@ -3372,10 +3375,8 @@ ul.wc_coupon_list_block {
 	.wc-action-button {
 		margin: 0 0 0 -1px !important;
 		border: 1px solid #ccc;
-		padding: 0 10px !important;
 		border-radius: 0 !important;
 		float: none;
-		line-height: 28px;
 		height: auto;
 		z-index: 1;
 		position: relative;
@@ -4265,7 +4266,6 @@ table.wc_shipping {
 /**
 * New Shipping Settings Refresh Modal Styles
 **/
-.wc-backbone-modal-add-attribute-term,
 .wc-backbone-modal-add-shipping-method,
 .wc-backbone-modal-shipping-method-settings,
 .wc-shipping-class-modal {
@@ -4275,7 +4275,6 @@ table.wc_shipping {
 	color: #1e1e1e;
 
 	&.wc-backbone-modal .wc-backbone-modal-content {
-		border-radius: var(--wc-card-border-radius, 8px);
 		border-top: 8px solid transparent;
 		border-bottom: 8px solid transparent;
 		max-width: 600px;
@@ -4291,7 +4290,7 @@ table.wc_shipping {
 		padding: 0 32px 32px 32px;
 	}
 
-	.wc-backbone-modal-main header{
+	.wc-backbone-modal-main header {
 		padding: 20px 32px;
 	}
 
@@ -4304,8 +4303,6 @@ table.wc_shipping {
 	}
 
 	.wc-backbone-modal-main .wc-backbone-modal-header {
-		background-color: #fff;
-		border-bottom: none;
 		font-size: 20px;
 		line-height: 28px;
 
@@ -4318,9 +4315,7 @@ table.wc_shipping {
 		}
 	}
 	.wc-backbone-modal-main footer {
-		box-shadow: none;
 		border-top: 1px solid #E0E0E0;
-		background-color: #fff;
 
 		.inner {
 			display: flex;
@@ -4406,7 +4401,6 @@ table.wc_shipping {
 		}
 	}
 
-	.wc-add-attribute-term-fields,
 	.wc-shipping-zone-method-fields {
 
 		& > label {
@@ -4537,26 +4531,6 @@ table.wc_shipping {
 		animation-timeline: auto;
 		animation-range-start: normal;
 		color: #757575;
-	}
-}
-
-.wc-backbone-modal-add-attribute-term.wc-backbone-modal {
-	.wc-backbone-modal-content {
-		min-width: auto;
-		max-width: 400px;
-	}
-
-	input[type="text"] {
-		display: block;
-		font-size: 13px;
-		line-height: 16px;
-		margin: 6px 0;
-		padding: 12px;
-		width: 100%;
-	}
-
-	.wc-backbone-modal-main footer {
-		border-top: none;
 	}
 }
 
@@ -7885,6 +7859,7 @@ table.bar_chart {
 	}
 
 	.wc-backbone-modal-content {
+		border-radius: 8px;
 		position: fixed;
 		background: #fff;
 		z-index: 100000;
@@ -7934,7 +7909,7 @@ table.bar_chart {
 }
 
 .wc-backbone-modal-main {
-	padding-bottom: 55px;
+	padding-bottom: 60px;
 
 	header,
 	article {
@@ -7944,18 +7919,17 @@ table.bar_chart {
 
 	.wc-backbone-modal-header {
 		height: auto;
-		background: #fcfcfc;
-		padding: 1em 1.5em;
-		border-bottom: 1px solid #ddd;
+		padding: 1.25em 2em 1em;
 
 		h1 {
 			margin: 0;
 			font-size: 18px;
-			font-weight: 700;
+			font-weight: 400;
 			line-height: 1.5em;
 		}
 
 		.modal-close-link {
+			border-radius: 0 8px 0 0;
 			cursor: pointer;
 			color: #777;
 			height: 54px;
@@ -7966,7 +7940,6 @@ table.bar_chart {
 			right: 0;
 			text-align: center;
 			border: 0;
-			border-left: 1px solid #ddd;
 			background-color: transparent;
 			transition: color 0.1s ease-in-out, background 0.1s ease-in-out;
 
@@ -7992,7 +7965,7 @@ table.bar_chart {
 	}
 
 	article {
-		padding: 1.5em;
+		padding: 1em 2em 1.5em;
 
 		p {
 			margin: 1.5em 0;
@@ -8060,10 +8033,7 @@ table.bar_chart {
 		right: 0;
 		bottom: 0;
 		z-index: 100;
-		padding: 1em 1.5em;
-		background: #fcfcfc;
-		border-top: 1px solid #dfdfdf;
-		box-shadow: 0 -4px 4px -4px rgba(0, 0, 0, 0.1);
+		padding: 1em 2em 1.5em;
 
 		.inner {
 			text-align: right;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7844,19 +7844,6 @@ table.bar_chart {
 	}
 }
 
-@media screen and (max-width: 782px) {
-	.wc-backbone-modal .wc-backbone-modal-content {
-		border-radius: 0;
-		transform: none;
-		left: 0;
-		right: 0;
-		top: 0;
-		bottom: 0;
-		min-width: auto;
-		width: 100%;
-	}
-}
-
 .wc-backbone-modal-backdrop {
 	position: fixed;
 	top: 0;
@@ -8005,6 +7992,22 @@ table.bar_chart {
 				margin-bottom: 0;
 			}
 		}
+	}
+}
+
+@media screen and (max-width: 782px) {
+	.wc-backbone-modal .wc-backbone-modal-content {
+		border-radius: 0;
+		transform: none;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 0;
+		min-width: auto;
+		width: 100%;
+	}
+	.wc-backbone-modal-main .wc-backbone-modal-header .modal-close-link {
+		border-radius: 0;
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7996,9 +7996,10 @@ table.bar_chart {
 		z-index: 100;
 		padding: 1em 2em 1.5em;
 
-		.inner {
-			text-align: right;
-			line-height: 23px;
+		.wc-backbone-modal-buttons {
+			display: flex;
+			justify-content: end;
+			gap: 8px;
 
 			.button {
 				margin-bottom: 0;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -993,7 +993,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 	}
 
 	article {
-		padding-bottom: 1em 2em 2em;
+		padding-bottom: 2em;
 	}
 
 	input[type="text"] {
@@ -9553,5 +9553,3 @@ body.woocommerce-settings-payments-section_legacy {
 		background: #f0f0f1;
 	}
 }
-
-

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7819,7 +7819,7 @@ table.bar_chart {
 	}
 
 	.wc-backbone-modal-content {
-		border-radius: 8px;
+		border-radius: var(--wc-card-border-radius, 8px);
 		position: fixed;
 		background: #fff;
 		z-index: 100000;
@@ -7890,7 +7890,7 @@ table.bar_chart {
 		}
 
 		.modal-close-link {
-			border-radius: 0 8px 0 0;
+			border-radius: 0 var(--wc-card-border-radius, 8px) 0 0;
 			cursor: pointer;
 			color: #777;
 			height: 54px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -980,7 +980,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 }
 
 /**
- * Create attribute term modal
+ * Product editor modals
  */
 .wc-backbone-modal-set-price-variations.wc-backbone-modal,
 .wc-backbone-modal-add-attribute-term.wc-backbone-modal {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -984,10 +984,12 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
  */
 .wc-backbone-modal-set-price-variations.wc-backbone-modal,
 .wc-backbone-modal-add-attribute-term.wc-backbone-modal {
-	.wc-backbone-modal-content {
-		max-width: 400px;
-		min-width: auto;
-		width: 100%;
+	@media screen and (min-width: 783px) {
+		.wc-backbone-modal-content {
+			max-width: 400px;
+			min-width: auto;
+			width: 100%;
+		}
 	}
 
 	input[type="text"] {
@@ -7891,6 +7893,7 @@ table.bar_chart {
 
 @media screen and (max-width: 782px) {
 	.wc-backbone-modal .wc-backbone-modal-content {
+		border-radius: 0;
 		width: 100%;
 		height: 100%;
 		min-width: 100%;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -992,6 +992,10 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 		}
 	}
 
+	article {
+		padding-bottom: 2em;
+	}
+
 	input[type="text"] {
 		display: block;
 		font-size: 13px;
@@ -7857,7 +7861,7 @@ table.bar_chart {
 }
 
 .wc-backbone-modal-main {
-	padding-bottom: 60px;
+	padding-bottom: calc( 1.5rem + 40px );
 
 	header,
 	article {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4272,54 +4272,15 @@ table.wc_shipping {
 .wc-backbone-modal-add-shipping-method,
 .wc-backbone-modal-shipping-method-settings,
 .wc-shipping-class-modal {
-	font-size: 13px;
-	font-weight: 400;
-	line-height: 16px;
-	color: #1e1e1e;
-
 	&.wc-backbone-modal .wc-backbone-modal-content {
-		border-top: 8px solid transparent;
-		border-bottom: 8px solid transparent;
 		max-width: 600px;
-
-		@media screen and (max-width: 782px) {
-			border-radius: none;
-			border-top: none;
-			border-bottom: none;
-		}
-	}
-
-	.wc-backbone-modal-main article {
-		padding: 0 32px 32px 32px;
-	}
-
-	.wc-backbone-modal-main header {
-		padding: 20px 32px;
-	}
-
-	.wc-backbone-modal-main footer {
-		padding: 20px 32px 12px 32px;
 	}
 
 	.wc-backbone-modal-main .wc-backbone-modal-header h1 {
 		font-weight: 400;
 	}
 
-	.wc-backbone-modal-main .wc-backbone-modal-header {
-		font-size: 20px;
-		line-height: 28px;
-
-		.modal-close-link {
-			border-left: none;
-
-			&:hover {
-				background-color: #fff;
-			}
-		}
-	}
 	.wc-backbone-modal-main footer {
-		border-top: 1px solid #E0E0E0;
-
 		.inner {
 			display: flex;
 			justify-content: space-between;
@@ -7876,10 +7837,6 @@ table.bar_chart {
 		article {
 			overflow: auto;
 		}
-	}
-
-	&.wc-backbone-modal-shipping-method-settings .wc-backbone-modal-content {
-		min-width: 500px;
 	}
 
 	&.wc-backbone-modal-add-shipping-method .wc-backbone-modal-content article {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -982,11 +982,12 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 /**
  * Create attribute term modal
  */
- .woocommerce-set-price-variations, // @todo unify class name style
- .wc-backbone-modal-add-attribute-term {
+.wc-backbone-modal-set-price-variations.wc-backbone-modal,
+.wc-backbone-modal-add-attribute-term.wc-backbone-modal {
 	.wc-backbone-modal-content {
 		max-width: 400px;
 		min-width: auto;
+		width: 100%;
 	}
 
 	input[type="text"] {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4498,10 +4498,6 @@ table.wc_shipping {
 	}
 }
 
-.wc-backbone-modal-add-shipping-method .wc-backbone-modal-main article {
-	padding: 0 32px 50px 32px;
-}
-
 table {
 	tr,
 	tr:hover {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7847,9 +7847,13 @@ table.bar_chart {
 @media screen and (max-width: 782px) {
 	.wc-backbone-modal .wc-backbone-modal-content {
 		border-radius: 0;
+		transform: none;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 0;
+		min-width: auto;
 		width: 100%;
-		height: 100%;
-		min-width: 100%;
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -993,7 +993,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 	}
 
 	article {
-		padding-bottom: 2em;
+		padding-bottom: 1em 2em 2em;
 	}
 
 	input[type="text"] {
@@ -3343,11 +3343,6 @@ ul.wc_coupon_list_block {
 	}
 
 	footer {
-		.wc-action-button-group {
-			display: inline-block;
-			float: left;
-		}
-
 		.button.button-large {
 			margin-left: 10px;
 			height: auto;
@@ -3361,29 +3356,10 @@ ul.wc_coupon_list_block {
 }
 
 .wc-action-button-group {
-	vertical-align: middle;
-	line-height: 26px;
-	text-align: left;
-
-	label {
-		margin-right: 6px;
-		cursor: default;
-		font-weight: bold;
-		line-height: 28px;
-	}
-
-	.wc-action-button-group__items {
-		display: inline-flex;
-		flex-flow: row wrap;
-		align-content: flex-start;
-		justify-content: flex-start;
-	}
-
 	.wc-action-button {
 		margin: 0 0 0 -1px !important;
 		border: 1px solid #ccc;
 		border-radius: 0 !important;
-		float: none;
 		height: auto;
 		z-index: 1;
 		position: relative;
@@ -3416,26 +3392,6 @@ ul.wc_coupon_list_block {
 @media screen and (max-width: 782px) {
 	.woocommerce_page_wc-orders #order-search-filter {
 		display: none;
-	}
-
-	.wc-order-preview footer {
-		.wc-action-button-group .wc-action-button-group__items {
-			display: flex;
-		}
-
-		.wc-action-button-group {
-			float: none;
-			display: block;
-			margin-bottom: 4px;
-		}
-
-		.button.button-large {
-			width: 100%;
-			float: none;
-			text-align: center;
-			margin: 0;
-			display: block;
-		}
 	}
 
 	.woocommerce_page_wc-orders .wc-orders-list-table.wp-list-table,
@@ -4286,8 +4242,6 @@ table.wc_shipping {
 
 	.wc-backbone-modal-main footer {
 		.inner {
-			display: flex;
-			justify-content: space-between;
 			flex-direction: row-reverse;
 		}
 
@@ -7987,8 +7941,14 @@ table.bar_chart {
 		z-index: 100;
 		padding: 1em 2em 1.5em;
 
+		.inner {
+			display: flex;
+			justify-content: space-between;
+		}
+
 		.wc-backbone-modal-buttons {
 			display: flex;
+			align-items: end;
 			justify-content: end;
 			gap: 8px;
 
@@ -8343,11 +8303,6 @@ table.bar_chart {
 		.button.button-large {
 			min-height: 0;
 		}
-	}
-
-	// Action button groups.
-	.wc-action-button-group .wc-action-button {
-		min-height: 0 !important;
 	}
 
 	// Order actions: select + button overflow container due to WP 7.0 select margins.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -979,26 +979,23 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 	}
 }
 
-.woocommerce-set-price-variations {
-	.woocommerce-usage-modal__wrapper {
-		.woocommerce-usage-modal__message {
-			height: 60px;
-			flex-wrap: wrap;
-			display: flex;
-			> span {
-				padding-bottom: 16px;
-			}
-		}
-		.woocommerce-usage-modal__actions {
-			display: flex;
-			justify-content: flex-end;
-			margin-top: 20px;
-			> button {
-				margin-left: 16px;
-				width: auto;
-				display: unset;
-			}
-		}
+/**
+ * Create attribute term modal
+ */
+ .woocommerce-set-price-variations, // @todo unify class name style
+ .wc-backbone-modal-add-attribute-term {
+	.wc-backbone-modal-content {
+		max-width: 400px;
+		min-width: auto;
+	}
+
+	input[type="text"] {
+		display: block;
+		font-size: 13px;
+		line-height: 16px;
+		margin: 6px 0;
+		padding: 12px;
+		width: 100%;
 	}
 }
 
@@ -2262,6 +2259,8 @@ ul.wc_coupon_list_block {
 }
 
 #woocommerce-order-items .woocommerce_order_items_wrapper, .wc-order-preview-table-wrapper {
+	padding-bottom: 1.5em;
+
 	small.refunded {
 		display: block;
 		color: red;
@@ -3271,7 +3270,13 @@ ul.wc_coupon_list_block {
 
 		td:first-child,
 		th:first-child {
+			padding-left: 2em;
 			text-align: left;
+		}
+
+		td:last-child,
+		th:last-child {
+			padding-right: 2em;
 		}
 
 		th {
@@ -3305,7 +3310,7 @@ ul.wc_coupon_list_block {
 
 	.wc-order-preview-addresses {
 		overflow: hidden;
-		padding-bottom: 1.5em;
+		padding: 0 0.5em 1.5em;
 
 		.wc-order-preview-address,
 		.wc-order-preview-note {
@@ -3338,8 +3343,6 @@ ul.wc_coupon_list_block {
 
 		.button.button-large {
 			margin-left: 10px;
-			padding: 0 10px !important;
-			line-height: 28px;
 			height: auto;
 			display: inline-block;
 		}
@@ -3372,10 +3375,8 @@ ul.wc_coupon_list_block {
 	.wc-action-button {
 		margin: 0 0 0 -1px !important;
 		border: 1px solid #ccc;
-		padding: 0 10px !important;
 		border-radius: 0 !important;
 		float: none;
-		line-height: 28px;
 		height: auto;
 		z-index: 1;
 		position: relative;
@@ -4265,7 +4266,6 @@ table.wc_shipping {
 /**
 * New Shipping Settings Refresh Modal Styles
 **/
-.wc-backbone-modal-add-attribute-term,
 .wc-backbone-modal-add-shipping-method,
 .wc-backbone-modal-shipping-method-settings,
 .wc-shipping-class-modal {
@@ -4275,7 +4275,6 @@ table.wc_shipping {
 	color: #1e1e1e;
 
 	&.wc-backbone-modal .wc-backbone-modal-content {
-		border-radius: 8px;
 		border-top: 8px solid transparent;
 		border-bottom: 8px solid transparent;
 		max-width: 600px;
@@ -4291,7 +4290,7 @@ table.wc_shipping {
 		padding: 0 32px 32px 32px;
 	}
 
-	.wc-backbone-modal-main header{
+	.wc-backbone-modal-main header {
 		padding: 20px 32px;
 	}
 
@@ -4304,8 +4303,6 @@ table.wc_shipping {
 	}
 
 	.wc-backbone-modal-main .wc-backbone-modal-header {
-		background-color: #fff;
-		border-bottom: none;
 		font-size: 20px;
 		line-height: 28px;
 
@@ -4318,9 +4315,7 @@ table.wc_shipping {
 		}
 	}
 	.wc-backbone-modal-main footer {
-		box-shadow: none;
 		border-top: 1px solid #E0E0E0;
-		background-color: #fff;
 
 		.inner {
 			display: flex;
@@ -4406,7 +4401,6 @@ table.wc_shipping {
 		}
 	}
 
-	.wc-add-attribute-term-fields,
 	.wc-shipping-zone-method-fields {
 
 		& > label {
@@ -4537,26 +4531,6 @@ table.wc_shipping {
 		animation-timeline: auto;
 		animation-range-start: normal;
 		color: #757575;
-	}
-}
-
-.wc-backbone-modal-add-attribute-term.wc-backbone-modal {
-	.wc-backbone-modal-content {
-		min-width: auto;
-		max-width: 400px;
-	}
-
-	input[type="text"] {
-		display: block;
-		font-size: 13px;
-		line-height: 16px;
-		margin: 6px 0;
-		padding: 12px;
-		width: 100%;
-	}
-
-	.wc-backbone-modal-main footer {
-		border-top: none;
 	}
 }
 
@@ -7885,6 +7859,7 @@ table.bar_chart {
 	}
 
 	.wc-backbone-modal-content {
+		border-radius: 8px;
 		position: fixed;
 		background: #fff;
 		z-index: 100000;
@@ -7934,7 +7909,7 @@ table.bar_chart {
 }
 
 .wc-backbone-modal-main {
-	padding-bottom: 55px;
+	padding-bottom: 60px;
 
 	header,
 	article {
@@ -7944,18 +7919,17 @@ table.bar_chart {
 
 	.wc-backbone-modal-header {
 		height: auto;
-		background: #fcfcfc;
-		padding: 1em 1.5em;
-		border-bottom: 1px solid #ddd;
+		padding: 1.25em 2em 1em;
 
 		h1 {
 			margin: 0;
 			font-size: 18px;
-			font-weight: 700;
+			font-weight: 400;
 			line-height: 1.5em;
 		}
 
 		.modal-close-link {
+			border-radius: 0 8px 0 0;
 			cursor: pointer;
 			color: #777;
 			height: 54px;
@@ -7966,7 +7940,6 @@ table.bar_chart {
 			right: 0;
 			text-align: center;
 			border: 0;
-			border-left: 1px solid #ddd;
 			background-color: transparent;
 			transition: color 0.1s ease-in-out, background 0.1s ease-in-out;
 
@@ -7992,7 +7965,7 @@ table.bar_chart {
 	}
 
 	article {
-		padding: 1.5em;
+		padding: 1em 2em 1.5em;
 
 		p {
 			margin: 1.5em 0;
@@ -8060,10 +8033,7 @@ table.bar_chart {
 		right: 0;
 		bottom: 0;
 		z-index: 100;
-		padding: 1em 1.5em;
-		background: #fcfcfc;
-		border-top: 1px solid #dfdfdf;
-		box-shadow: 0 -4px 4px -4px rgba(0, 0, 0, 0.1);
+		padding: 1em 2em 1.5em;
 
 		.inner {
 			text-align: right;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php
@@ -654,7 +654,7 @@ class WC_Admin_Setup_Wizard {
 							</p>
 						</article>
 						<footer>
-							<div class="inner">
+							<div class="wc-backbone-modal-buttons">
 								<button class="button button-primary button-large" id="wc_tracker_submit" aria-label="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
 							</div>
 						</footer>

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -182,7 +182,6 @@ class WC_Meta_Box_Product_Data {
 		$variations_count       = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_count', $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private')", $post->ID ) ), $post->ID ) );
 		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
 		$variations_total_pages = ceil( $variations_count / $variations_per_page );
-		$modal_title            = get_bloginfo( 'name' ) . __( ' says', 'woocommerce' );
 		/* phpcs: enable */
 
 		include __DIR__ . '/views/html-product-data-variations.php';

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -449,7 +449,7 @@ if ( wc_tax_enabled() ) {
 					</form>
 				</article>
 				<footer>
-					<div class="inner">
+					<div class="wc-backbone-modal-buttons">
 						<button id="btn-ok" class="button button-primary button-large"><?php esc_html_e( 'Add', 'woocommerce' ); ?></button>
 					</div>
 				</footer>
@@ -505,7 +505,7 @@ if ( wc_tax_enabled() ) {
 					</form>
 				</article>
 				<footer>
-					<div class="inner">
+					<div class="wc-backbone-modal-buttons">
 						<button id="btn-ok" class="button button-primary button-large"><?php esc_html_e( 'Add', 'woocommerce' ); ?></button>
 					</div>
 				</footer>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -80,11 +80,9 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 					</form>
 				</article>
 				<footer>
-					<div class="inner">
-						<div>
-							<button class="modal-close button button-large"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-							<button id="btn-ok" disabled class="button button-primary button-large"><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
-						</div>
+					<div class="wc-backbone-modal-buttons">
+						<button class="modal-close button button-large"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+						<button id="btn-ok" disabled class="button button-primary button-large"><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
 					</div>
 				</footer>
 			</section>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -74,7 +74,7 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 					</button>
 				</header>
 				<article>
-					<form class="wc-add-attribute-term-fields" action="" method="post">
+					<form action="" method="post">
 						<label for="wc-modal-add-attribute-term-input"><?php esc_html_e( 'Name', 'woocommerce' ); ?></label>
 						<input id="wc-modal-add-attribute-term-input" type="text" name="term" value="" />
 					</form>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -74,7 +74,7 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 					</button>
 				</header>
 				<article>
-					<form action="" method="post">
+					<form class="wc-add-attribute-term-fields" action="" method="post">
 						<label for="wc-modal-add-attribute-term-input"><?php esc_html_e( 'Name', 'woocommerce' ); ?></label>
 						<input id="wc-modal-add-attribute-term-input" type="text" name="term" value="" />
 					</form>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -203,22 +203,29 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 	</div>
 </div>
 <script type="text/template" id="tmpl-wc-modal-set-price-variations">
-	<div class="wc-backbone-modal">
+	<div class="wc-backbone-modal woocommerce-set-price-variations">
 		<div class="wc-backbone-modal-content">
-			<div class="components-modal__content woocommerce-set-price-variations" role="document">
-				<div class="components-modal__header">
-					<h2><?php echo esc_attr( $modal_title ); ?></h2>
-				</div>
-				<div class="woocommerce-usage-modal__wrapper">
+			<div class="wc-backbone-modal-main" role="document">
+				<header class="wc-backbone-modal-header">
+					<h1><?php esc_html_e( 'Set variation prices', 'woocommerce' ); ?></h1>
+					<button class="modal-close modal-close-link dashicons dashicons-no-alt">
+						<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'woocommerce' ); ?></span>
+					</button>
+				</header>
+				<article class="woocommerce-usage-modal__wrapper">
 					<div class="woocommerce-usage-modal__message">
 						<span><?php esc_html_e( 'Add price to all variations that don\'t have a price', 'woocommerce' ); ?> (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
 						<input type="text" class="components-text-control__input wc_input_variations_price"/>
 					</div>
-					<div class="woocommerce-usage-modal__actions">
-						<button class="modal-close components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-						<button class="modal-close button components-button add_variations_price_button button-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
+				</article>
+				<footer>
+					<div class="inner">
+						<div class="woocommerce-usage-modal__actions">
+							<button class="modal-clos button components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+							<button class="modal-close button components-button add_variations_price_button button-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
+						</div>
 					</div>
-				</div>
+				</footer>
 			</div>
 		</div>
 	</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -205,7 +205,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 <script type="text/template" id="tmpl-wc-modal-set-price-variations">
 	<div class="wc-backbone-modal wc-backbone-modal-set-price-variations">
 		<div class="wc-backbone-modal-content">
-			<div class="wc-backbone-modal-main" role="document">
+			<section class="wc-backbone-modal-main" role="main">
 				<header class="wc-backbone-modal-header">
 					<h1><?php esc_html_e( 'Set variation prices', 'woocommerce' ); ?></h1>
 					<button class="modal-close modal-close-link dashicons dashicons-no-alt">
@@ -226,7 +226,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 						</div>
 					</div>
 				</footer>
-			</div>
+			</section>
 		</div>
 	</div>
 	<div class="wc-backbone-modal-backdrop modal-close"></div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -203,7 +203,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 	</div>
 </div>
 <script type="text/template" id="tmpl-wc-modal-set-price-variations">
-	<div class="wc-backbone-modal woocommerce-set-price-variations">
+	<div class="wc-backbone-modal wc-backbone-modal-set-price-variations">
 		<div class="wc-backbone-modal-content">
 			<div class="wc-backbone-modal-main" role="document">
 				<header class="wc-backbone-modal-header">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -219,11 +219,9 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 					</div>
 				</article>
 				<footer>
-					<div class="inner">
-						<div>
-							<button class="modal-close button components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-							<button class="modal-close button components-button add_variations_price_button button-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
-						</div>
+					<div class="wc-backbone-modal-buttons">
+						<button class="modal-close button components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+						<button class="modal-close button components-button add_variations_price_button button-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
 					</div>
 				</footer>
 			</section>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -212,15 +212,15 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 						<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'woocommerce' ); ?></span>
 					</button>
 				</header>
-				<article class="woocommerce-usage-modal__wrapper">
-					<div class="woocommerce-usage-modal__message">
+				<article>
+					<div>
 						<span><?php esc_html_e( 'Add price to all variations that don\'t have a price', 'woocommerce' ); ?> (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
 						<input type="text" class="components-text-control__input wc_input_variations_price"/>
 					</div>
 				</article>
 				<footer>
 					<div class="inner">
-						<div class="woocommerce-usage-modal__actions">
+						<div>
 							<button class="modal-clos button components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
 							<button class="modal-close button components-button add_variations_price_button button-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
 						</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -221,7 +221,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 				<footer>
 					<div class="inner">
 						<div>
-							<button class="modal-clos button components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+							<button class="modal-close button components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
 							<button class="modal-close button components-button add_variations_price_button button-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
 						</div>
 					</div>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-classes.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-classes.php
@@ -108,7 +108,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</form>
 				</article>
 				<footer>
-					<div class="inner">
+					<div class="wc-backbone-modal-buttons">
 						<button id="btn-ok" disabled class="button button-primary button-large disabled">
 							<div class="wc-backbone-modal-action-{{ data.action === 'create' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Create', 'woocommerce' ); ?></div>
 							<div class="wc-backbone-modal-action-{{ data.action === 'edit' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Save', 'woocommerce' ); ?></div>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-providers.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-providers.php
@@ -121,7 +121,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</form>
 				</article>
 				<footer>
-					<div class="inner">
+					<div class="wc-backbone-modal-buttons">
 						<button id="btn-ok" disabled class="button button-primary button-large disabled">
 							<div class="wc-backbone-modal-action-{{ data.action === 'create' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Create', 'woocommerce' ); ?></div>
 							<div class="wc-backbone-modal-action-{{ data.action === 'edit' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Save', 'woocommerce' ); ?></div>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -157,7 +157,7 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 				</article>
 				<footer>
 					<div class="inner">
-						<div>
+						<div class="wc-backbone-modal-buttons">
 							<button id="btn-back" class="button button-large wc-backbone-modal-back-{{ data.status === 'new' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Back', 'woocommerce' ); ?></button>
 							<button id="btn-ok" data-status='{{ data.status }}' class="button button-primary button-large">
 								<div class="wc-backbone-modal-action-{{ data.status === 'new' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Create and save', 'woocommerce' ); ?></div>
@@ -267,7 +267,9 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 				</article>
 				<footer>
 					<div class="inner">
-						<button id="btn-next" disabled class="button button-primary button-large disabled"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
+						<div class="wc-backbone-modal-buttons">
+							<button id="btn-next" disabled class="button button-primary button-large disabled"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
+						</div>
 						<div class="wc-shipping-zone-method-modal-info"><?php esc_html_e( 'STEP 1 OF 2', 'woocommerce' ); ?></div>
 					</div>
 				</footer>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
@@ -147,7 +147,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</form>
 				</article>
 				<footer>
-					<div class="inner">
+					<div class="wc-backbone-modal-buttons">
 						<button id="btn-ok" class="button button-primary button-large"><?php _e( 'Add shipping method', 'woocommerce' ); ?></button>
 					</div>
 				</footer>

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -6307,12 +6307,6 @@ parameters:
 			path: includes/admin/meta-boxes/views/html-product-data-variations.php
 
 		-
-			message: '#^Variable \$modal_title might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: includes/admin/meta-boxes/views/html-product-data-variations.php
-
-		-
 			message: '#^Variable \$product_object might not be defined\.$#'
 			identifier: variable.undefined
 			count: 2

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1751,7 +1751,7 @@ class ListTable extends WP_List_Table {
 						</article>
 						<# if ( data.actions_html || data.is_editable ) { #>
 						<footer>
-							<div class="inner">
+							<div class="wc-backbone-modal-buttons">
 								{{{ data.actions_html }}}
 
 								<# if ( data.is_editable ) { #>

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1751,11 +1751,13 @@ class ListTable extends WP_List_Table {
 						</article>
 						<# if ( data.actions_html || data.is_editable ) { #>
 						<footer>
-							<div class="wc-backbone-modal-buttons">
+							<div class="inner">
 								{{{ data.actions_html }}}
 
 								<# if ( data.is_editable ) { #>
-								<a class="button button-primary button-large" aria-label="<?php esc_attr_e( 'Edit this order', 'woocommerce' ); ?>" href="<?php echo $order_edit_url_placeholder; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
+								<div class="wc-backbone-modal-buttons">
+									<a class="button button-primary button-large" aria-label="<?php esc_attr_e( 'Edit this order', 'woocommerce' ); ?>" href="<?php echo $order_edit_url_placeholder; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
+								</div>
 								<# } #>
 							</div>
 						</footer>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of #64251.

This PR updates the styling of several WC core modals in the admin to make them more consistent and reduce the amount of CSS needed to style them.

### How to test the changes in this Pull Request:

Smoke test modals in the admin to make sure they are not broken because of the style changes.:

1. Go to WooCommerce > Settings > Shipping and create or edit shipping zones.

Before | After
--- | ---
<img width="961" height="630" alt="imatge" src="https://github.com/user-attachments/assets/db4d6e51-53e8-427b-8853-57017b52819a" /> | <img width="961" height="630" alt="imatge" src="https://github.com/user-attachments/assets/03e30c68-6dc3-4156-aaf2-53cebda0788e" />

2. Go to WooCommerce > Orders > open an order > Add items > Add products and Add Tax.

Before | After
--- | ---
<img width="1163" height="427" alt="imatge" src="https://github.com/user-attachments/assets/ad285ba4-ad4f-4f29-9cf8-27018f66c26e" /> | <img width="1163" height="427" alt="imatge" src="https://github.com/user-attachments/assets/ea57d3a7-30ba-4801-9223-b294bcc94932" />
<img width="1163" height="427" alt="imatge" src="https://github.com/user-attachments/assets/a3e30e90-1659-4930-8965-0ac6d3d06249" /> | <img width="1163" height="427" alt="imatge" src="https://github.com/user-attachments/assets/2a2aaac3-be36-46d2-a724-533c2e6ba800" />

3. Go to WooCommerce > Orders and click on the eye icon next to an order to preview it in a modal.
4. Create a new variable product, select at least one attribute, create variations for every attribute, an "Add price" banner will appear. Click on it.

Before | After
--- | ---
<img width="1347" height="738" alt="imatge" src="https://github.com/user-attachments/assets/9269b775-e4d0-45c6-86f8-414b0840753d" /> | <img width="1018" height="738" alt="imatge" src="https://github.com/user-attachments/assets/4ea2ac48-2ad9-4e8c-88c8-8bea9078f974" />

5. Also test the modal introduced in https://github.com/woocommerce/woocommerce/pull/64251.

Before | After
--- | ---
<img width="1018" height="738" alt="imatge" src="https://github.com/user-attachments/assets/cabb41f8-add9-45e0-9cd4-a9d9e29ce5f7" /> | <img width="1018" height="738" alt="imatge" src="https://github.com/user-attachments/assets/b0d367f4-0c5b-4bcc-9e2f-d3d4a6a283a2" />


### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->