### PR TITLE
Gate modernised settings on per-page $is_modern opt-in

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3485-is-modern-opt-in
+++ b/plugins/woocommerce/changelog/wooprd-3485-is-modern-opt-in
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Refs WOOPRD-3485
+
+Gate modernised settings rendering on a per-page `$is_modern` opt-in so Core behaviour is unchanged unless a page explicitly opts in.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -115,8 +115,18 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		protected $label = '';
 
 		/**
-		 * Setting page is modern.
+		 * Whether this settings page opts in to the modernised React-based rendering.
 		 *
+		 * Setting this to `true` (combined with the `modern-settings` feature flag
+		 * being enabled) causes `output()` to render a React mount point instead of
+		 * the legacy HTML form for this page/section. Defaults to `false` so Core
+		 * retains the legacy experience; third-party settings pages opt in by
+		 * overriding this property.
+		 *
+		 * The per-section `woocommerce_react_settings_opt_out` filter can still
+		 * veto a specific tab/section even when this is `true`.
+		 *
+		 * @since 10.8.0
 		 * @var bool
 		 */
 		protected $is_modern = false;
@@ -157,6 +167,22 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 */
 		public function get_label() {
 			return $this->label;
+		}
+
+		/**
+		 * Whether this settings page opts in to the modernised React-based rendering.
+		 *
+		 * Returns the value of the `$is_modern` property so consumers outside the
+		 * class hierarchy can detect the opt-in without reflecting into the
+		 * protected property. Combined with the `modern-settings` feature flag,
+		 * a `true` return causes `output()` to render a React mount point instead
+		 * of the legacy HTML form.
+		 *
+		 * @since 10.8.0
+		 * @return bool
+		 */
+		public function is_modern(): bool {
+			return true === $this->is_modern;
 		}
 
 		/**
@@ -509,7 +535,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 			$settings_definitions = null;
 			$section_id           = $current_section ?? '';
 
-			if ( Features::is_enabled( 'modern-settings' ) ) {
+			if ( Features::is_enabled( 'modern-settings' ) && true === $this->is_modern ) {
 				$settings_definitions = $this->get_settings( $section_id );
 				if ( is_array( $settings_definitions ) ) {
 					$tab = $this->id;

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Marketplace_Suggestions;
+use WC_Settings_Page;
 
 /**
  * Contains logic in regards to WooCommerce Admin Settings.
@@ -361,22 +362,12 @@ class Settings {
 	/**
 	 * Check whether a settings page instance has opted in to the modernised rendering.
 	 *
-	 * Uses the public `is_modern()` getter on `WC_Settings_Page` when available.
-	 * Returns `false` for legacy page classes that predate the getter so they
-	 * keep the legacy experience.
-	 *
 	 * @since 10.8.0
 	 *
-	 * @param mixed $settings_page Settings page instance.
+	 * @param WC_Settings_Page $settings_page Settings page instance.
 	 * @return bool
 	 */
-	private function is_page_modern( $settings_page ): bool {
-		if ( ! is_object( $settings_page ) ) {
-			return false;
-		}
-		if ( ! method_exists( $settings_page, 'is_modern' ) ) {
-			return false;
-		}
+	private function is_page_modern( WC_Settings_Page $settings_page ): bool {
 		return true === $settings_page->is_modern();
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -289,6 +289,11 @@ class Settings {
 			return $settings;
 		}
 
+		// Only preload data for pages that have opted into the modernised rendering.
+		if ( ! $this->is_page_modern( $settings_page ) ) {
+			return $settings;
+		}
+
 		$settings_definitions = $settings_page->get_settings( $current_section );
 		if ( ! is_array( $settings_definitions ) ) {
 			return $settings;
@@ -351,6 +356,28 @@ class Settings {
 
 		$section = isset( $_GET['section'] ) ? sanitize_title( wp_unslash( $_GET['section'] ) ) : '';
 		return $section;
+	}
+
+	/**
+	 * Check whether a settings page instance has opted in to the modernised rendering.
+	 *
+	 * Uses the public `is_modern()` getter on `WC_Settings_Page` when available.
+	 * Returns `false` for legacy page classes that predate the getter so they
+	 * keep the legacy experience.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param mixed $settings_page Settings page instance.
+	 * @return bool
+	 */
+	private function is_page_modern( $settings_page ): bool {
+		if ( ! is_object( $settings_page ) ) {
+			return false;
+		}
+		if ( ! method_exists( $settings_page, 'is_modern' ) ) {
+			return false;
+		}
+		return true === $settings_page->is_modern();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsPageOptInTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsPageOptInTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Tests for the per-page `$is_modern` opt-in on WC_Settings_Page.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\Settings;
+
+use WC_Settings_Page;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests that the modernised React rendering only kicks in when a page
+ * explicitly opts in via `$is_modern` AND the `modern-settings` feature
+ * flag is enabled, and that the per-section opt-out filter still vetoes
+ * opted-in pages.
+ */
+class SettingsPageOptInTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Make sure the WC_Settings_Page base class is loaded.
+		if ( ! class_exists( 'WC_Settings_Page', false ) ) {
+			require_once WC_ABSPATH . 'includes/admin/settings/class-wc-settings-page.php';
+		}
+
+		// Ensure we start each test with a clean `current_section` global.
+		global $current_section;
+		$current_section = '';
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_modern_settings_feature' ) );
+		remove_all_filters( 'woocommerce_react_settings_opt_out' );
+		remove_all_filters( 'woocommerce_get_settings_wooprd_3485_optin' );
+		remove_all_filters( 'woocommerce_get_settings_wooprd_3485_legacy' );
+
+		global $current_section, $hide_save_button;
+		$current_section  = '';
+		$hide_save_button = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Enable the `modern-settings` feature via the `woocommerce_admin_features` filter.
+	 *
+	 * @param array $features Existing features.
+	 * @return array Modified features.
+	 */
+	public function enable_modern_settings_feature( $features ) {
+		$features[] = 'modern-settings';
+		return $features;
+	}
+
+	/**
+	 * @testdox Should render the legacy form when `$is_modern` is false even with the feature flag enabled.
+	 */
+	public function test_output_emits_legacy_when_is_modern_is_false_even_with_flag_on(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_modern_settings_feature' ) );
+
+		$page = $this->create_legacy_page();
+
+		ob_start();
+		$page->output();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'data-wc-modern-settings="1"',
+			$output,
+			'Legacy (non-opted-in) pages must never emit the React mount point.'
+		);
+	}
+
+	/**
+	 * @testdox Should render the React mount point when `$is_modern` is true and the feature flag is enabled.
+	 */
+	public function test_output_emits_react_mount_when_is_modern_is_true_and_flag_on(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_modern_settings_feature' ) );
+
+		$page = $this->create_opted_in_page();
+
+		ob_start();
+		$page->output();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString(
+			'data-wc-modern-settings="1"',
+			$output,
+			'Opted-in pages must emit the React mount point when the feature flag is enabled.'
+		);
+		$this->assertStringContainsString(
+			'data-wc-settings-tab="wooprd_3485_optin"',
+			$output,
+			'Mount element must carry the settings tab id.'
+		);
+	}
+
+	/**
+	 * @testdox Should fall back to the legacy form when the woocommerce_react_settings_opt_out filter vetoes the section.
+	 */
+	public function test_output_falls_back_when_opt_out_filter_vetoes(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_modern_settings_feature' ) );
+
+		$page = $this->create_opted_in_page();
+
+		add_filter(
+			'woocommerce_react_settings_opt_out',
+			function ( $opt_out, $tab ) {
+				if ( 'wooprd_3485_optin' === $tab ) {
+					return true;
+				}
+				return $opt_out;
+			},
+			10,
+			2
+		);
+
+		ob_start();
+		$page->output();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'data-wc-modern-settings="1"',
+			$output,
+			'Opt-out filter must prevent the React mount point from being emitted.'
+		);
+	}
+
+	/**
+	 * @testdox Should expose the is_modern() getter returning the opt-in state of the page.
+	 */
+	public function test_is_modern_getter_returns_opt_in_state(): void {
+		$legacy_page    = $this->create_legacy_page();
+		$opted_in_page  = $this->create_opted_in_page();
+
+		$this->assertFalse( $legacy_page->is_modern(), 'Legacy page must report is_modern() === false.' );
+		$this->assertTrue( $opted_in_page->is_modern(), 'Opted-in page must report is_modern() === true.' );
+	}
+
+	/**
+	 * Build a test page that has NOT opted in to the modern rendering.
+	 *
+	 * @return WC_Settings_Page
+	 */
+	private function create_legacy_page(): WC_Settings_Page {
+		return new class() extends WC_Settings_Page {
+			// phpcs:disable Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+				$this->id    = 'wooprd_3485_legacy';
+				$this->label = 'WOOPRD-3485 Legacy';
+				// Intentionally do NOT call parent::__construct() to avoid
+				// registering hooks with the global admin machinery.
+			}
+
+			protected function get_settings_for_default_section() {
+				return array(
+					array(
+						'type'  => 'title',
+						'id'    => 'wooprd_3485_legacy_group',
+						'title' => 'Test',
+					),
+					array(
+						'type'  => 'text',
+						'id'    => 'wooprd_3485_legacy_field',
+						'title' => 'Test field',
+					),
+					array(
+						'type' => 'sectionend',
+						'id'   => 'wooprd_3485_legacy_group',
+					),
+				);
+			}
+			// phpcs:enable Squiz.Commenting.FunctionComment.Missing
+		};
+	}
+
+	/**
+	 * Build a test page that HAS opted in to the modern rendering.
+	 *
+	 * @return WC_Settings_Page
+	 */
+	private function create_opted_in_page(): WC_Settings_Page {
+		return new class() extends WC_Settings_Page {
+			// phpcs:disable Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+				$this->id        = 'wooprd_3485_optin';
+				$this->label     = 'WOOPRD-3485 Opt-in';
+				$this->is_modern = true;
+				// Intentionally do NOT call parent::__construct() to avoid
+				// registering hooks with the global admin machinery.
+			}
+
+			protected function get_settings_for_default_section() {
+				return array(
+					array(
+						'type'  => 'title',
+						'id'    => 'wooprd_3485_optin_group',
+						'title' => 'Test',
+					),
+					array(
+						'type'  => 'text',
+						'id'    => 'wooprd_3485_optin_field',
+						'title' => 'Test field',
+					),
+					array(
+						'type' => 'sectionend',
+						'id'   => 'wooprd_3485_optin_group',
+					),
+				);
+			}
+			// phpcs:enable Squiz.Commenting.FunctionComment.Missing
+		};
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsPageOptInTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsPageOptInTest.php
@@ -5,7 +5,7 @@
 
 declare( strict_types=1 );
 
-namespace Automattic\WooCommerce\Tests\Admin\Settings;
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings;
 
 use WC_Settings_Page;
 use WC_Unit_Test_Case;
@@ -17,6 +17,13 @@ use WC_Unit_Test_Case;
  * opted-in pages.
  */
 class SettingsPageOptInTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Settings_Page
+	 */
+	private $sut;
 
 	/**
 	 * Set up test fixtures.
@@ -40,8 +47,6 @@ class SettingsPageOptInTest extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_modern_settings_feature' ) );
 		remove_all_filters( 'woocommerce_react_settings_opt_out' );
-		remove_all_filters( 'woocommerce_get_settings_wooprd_3485_optin' );
-		remove_all_filters( 'woocommerce_get_settings_wooprd_3485_legacy' );
 
 		global $current_section, $hide_save_button;
 		$current_section  = '';
@@ -67,10 +72,10 @@ class SettingsPageOptInTest extends WC_Unit_Test_Case {
 	public function test_output_emits_legacy_when_is_modern_is_false_even_with_flag_on(): void {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_modern_settings_feature' ) );
 
-		$page = $this->create_legacy_page();
+		$this->sut = $this->create_legacy_page();
 
 		ob_start();
-		$page->output();
+		$this->sut->output();
 		$output = (string) ob_get_clean();
 
 		$this->assertStringNotContainsString(
@@ -86,10 +91,10 @@ class SettingsPageOptInTest extends WC_Unit_Test_Case {
 	public function test_output_emits_react_mount_when_is_modern_is_true_and_flag_on(): void {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_modern_settings_feature' ) );
 
-		$page = $this->create_opted_in_page();
+		$this->sut = $this->create_opted_in_page();
 
 		ob_start();
-		$page->output();
+		$this->sut->output();
 		$output = (string) ob_get_clean();
 
 		$this->assertStringContainsString(
@@ -110,7 +115,7 @@ class SettingsPageOptInTest extends WC_Unit_Test_Case {
 	public function test_output_falls_back_when_opt_out_filter_vetoes(): void {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_modern_settings_feature' ) );
 
-		$page = $this->create_opted_in_page();
+		$this->sut = $this->create_opted_in_page();
 
 		add_filter(
 			'woocommerce_react_settings_opt_out',
@@ -125,7 +130,7 @@ class SettingsPageOptInTest extends WC_Unit_Test_Case {
 		);
 
 		ob_start();
-		$page->output();
+		$this->sut->output();
 		$output = (string) ob_get_clean();
 
 		$this->assertStringNotContainsString(
@@ -139,11 +144,11 @@ class SettingsPageOptInTest extends WC_Unit_Test_Case {
 	 * @testdox Should expose the is_modern() getter returning the opt-in state of the page.
 	 */
 	public function test_is_modern_getter_returns_opt_in_state(): void {
-		$legacy_page    = $this->create_legacy_page();
-		$opted_in_page  = $this->create_opted_in_page();
+		$this->sut = $this->create_legacy_page();
+		$this->assertFalse( $this->sut->is_modern(), 'Legacy page must report is_modern() === false.' );
 
-		$this->assertFalse( $legacy_page->is_modern(), 'Legacy page must report is_modern() === false.' );
-		$this->assertTrue( $opted_in_page->is_modern(), 'Opted-in page must report is_modern() === true.' );
+		$this->sut = $this->create_opted_in_page();
+		$this->assertTrue( $this->sut->is_modern(), 'Opted-in page must report is_modern() === true.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3485.

Wires `WC_Settings_Page::$is_modern` as the public opt-in signal for the React-based settings rendering. `WC_Settings_Page::output()` and `Settings::add_react_settings_data()` now bail from the React path unless `$is_modern === true` **and** the `modern-settings` feature flag is enabled. The `woocommerce_react_settings_opt_out` filter remains as a per-section veto for opted-in pages.

Before this change, enabling the `modern-settings` flag would auto-mount the React renderer on any settings page whose fields were all supported natively, with no way for an extension author to keep their tab on the legacy renderer. Per-page opt-in via `$is_modern = true` makes the React path explicit and additive.

**Files changed:**
- `includes/admin/settings/class-wc-settings-page.php` — `$is_modern` now acts as opt-in; docblock documents the contract; added public `is_modern(): bool` getter.
- `src/Internal/Admin/Settings.php` — `add_react_settings_data()` bails when the resolved page isn't opted in; `is_page_modern()` helper handles the check.
- `tests/php/src/Internal/Admin/Settings/SettingsPageOptInTest.php` — 4 PHPUnit tests covering: flag-on + `is_modern=false` → legacy; flag-on + `is_modern=true` → React mount; opt-out filter vetoes even when opted in; getter smoke.

### How to test the changes in this Pull Request:

1. Apply this branch and rebuild PHP autoloader entries (`pnpm --filter=@woocommerce/plugin-woocommerce build`).
2. With the `modern-settings` flag off, visit `/wp-admin/admin.php?page=wc-settings&tab=general`. Expect the legacy form — no `[data-wc-modern-settings]` nodes in the DOM.
3. Enable the `modern-settings` flag (Tools → WooCommerce → Beta Tester, or via the `woocommerce_admin_features` filter). Reload. Expect the **same legacy form** — no behavioural change, because no Core page sets `$is_modern = true`.
4. In a sandbox plugin, subclass `WC_Settings_Page` with `protected $is_modern = true;` and a `text` field. With the flag on, expect the React mount div. With the flag off, expect the legacy form.
5. Hook `woocommerce_react_settings_opt_out` to return true for your tab; the page should render legacy even when opted in.

### Testing that has already taken place:

- PHPUnit: `pnpm test:php:env -- --filter SettingsPageOptInTest` — 4/4 passing.
- `phpcs-changed` clean on modified files.
- PHPStan baseline did not grow.
- Manual smoke against a local WP env: flag off → legacy form renders, no `[data-wc-modern-settings]` nodes, save button intact.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message

Gate modernised settings rendering on a per-page `$is_modern` opt-in so Core behaviour is unchanged unless a page explicitly opts in.

</details>
