### PR TITLE
Stabilise ReactSettingsSchema as the canonical settings transformer

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3484-stabilise-reactsettingsschema
+++ b/plugins/woocommerce/changelog/wooprd-3484-stabilise-reactsettingsschema
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Consolidate v4 REST settings transformers through ReactSettingsSchema; remove the hardcoded settings-page-class dictionary in Settings.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -69451,27 +69451,9 @@ parameters:
 			path: src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
 
 		-
-			message: '#^Call to function in_array\(\) with arguments mixed, array\{''title'', ''sectionend''\} and true will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\RestApi\\Routes\\V4\\Settings\\General\\Schema\\GeneralSettingsSchema\:\:get_item_response\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
-			path: src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\RestApi\\Routes\\V4\\Settings\\General\\Schema\\GeneralSettingsSchema\:\:transform_setting_to_field\(\) never returns null so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php
-
-		-
-			message: '#^Offset ''order'' on array\{title\: mixed, description\: mixed, order\: int, fields\: list\<non\-empty\-array\>\} on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.offset
-			count: 2
 			path: src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php
 
 		-
@@ -69637,27 +69619,9 @@ parameters:
 			path: src/Internal/RestApi/Routes/V4/Settings/Products/Controller.php
 
 		-
-			message: '#^Call to function in_array\(\) with arguments mixed, array\{''title'', ''sectionend''\} and true will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\RestApi\\Routes\\V4\\Settings\\Products\\Schema\\ProductSettingsSchema\:\:get_item_response\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
-			path: src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\RestApi\\Routes\\V4\\Settings\\Products\\Schema\\ProductSettingsSchema\:\:transform_setting_to_field\(\) never returns null so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
-
-		-
-			message: '#^Offset ''order'' on array\{title\: mixed, description\: mixed, order\: int, fields\: list\<non\-empty\-array\>\} on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.offset
-			count: 2
 			path: src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
 
 		-

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -354,29 +354,22 @@ class Settings {
 	}
 
 	/**
-	 * Get settings page instance by id.
+	 * Get a settings page instance by id.
+	 *
+	 * @since 10.8.0
 	 *
 	 * @param string $settings_page_id Settings page id.
-	 * @return WC_Settings_Page|null
+	 * @return \WC_Settings_Page|null
 	 */
 	private function get_settings_page_instance( string $settings_page_id ) {
-		if ( class_exists( 'WC_Admin_Settings', false ) ) {
-			$setting_pages = \WC_Admin_Settings::get_settings_pages();
-			foreach ( $setting_pages as $setting_page ) {
-				if ( method_exists( $setting_page, 'get_id' ) && $settings_page_id === $setting_page->get_id() ) {
-					return $setting_page;
-				}
-			}
+		if ( ! class_exists( 'WC_Admin_Settings', false ) ) {
+			return null;
 		}
 
-		$page_class_map = array(
-			'general'  => 'WC_Settings_General',
-			'products' => 'WC_Settings_Products',
-		);
-
-		if ( isset( $page_class_map[ $settings_page_id ] ) && class_exists( $page_class_map[ $settings_page_id ], false ) ) {
-			$page_class = $page_class_map[ $settings_page_id ];
-			return new $page_class();
+		foreach ( \WC_Admin_Settings::get_settings_pages() as $settings_page ) {
+			if ( method_exists( $settings_page, 'get_id' ) && $settings_page_id === $settings_page->get_id() ) {
+				return $settings_page;
+			}
 		}
 
 		return null;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
@@ -19,6 +19,11 @@ defined( 'ABSPATH' ) || exit;
  * directly with a `$settings_definitions` array and a `$settings_page` instance.
  *
  * @since 10.8.0
+ *
+ * @filter woocommerce_react_settings_opt_out
+ * @filter woocommerce_react_settings_supported_types
+ * @filter woocommerce_react_settings_type_map
+ * @filter woocommerce_react_settings_field_options
  */
 class ReactSettingsSchema {
 	/**
@@ -394,32 +399,6 @@ class ReactSettingsSchema {
 		$options = isset( $setting['options'] ) && is_array( $setting['options'] )
 			? $setting['options']
 			: array();
-
-		if ( empty( $options ) ) {
-			$type = $setting['type'] ?? '';
-
-			if ( 'multi_select_countries' === $type && function_exists( 'WC' ) ) {
-				$options = WC()->countries->get_countries();
-			}
-
-			if ( 'single_select_country' === $type && function_exists( 'WC' ) ) {
-				$countries = WC()->countries->get_countries();
-				$states    = WC()->countries->get_states();
-
-				foreach ( $countries as $country_code => $country_name ) {
-					$country_states = $states[ $country_code ] ?? array();
-
-					if ( empty( $country_states ) ) {
-						$options[ $country_code ] = $country_name;
-						continue;
-					}
-
-					foreach ( $country_states as $state_code => $state_name ) {
-						$options[ $country_code . ':' . $state_code ] = $country_name . ' — ' . $state_name;
-					}
-				}
-			}
-		}
 
 		$setting_id = isset( $setting['id'] ) && is_scalar( $setting['id'] ) ? (string) $setting['id'] : '';
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
@@ -10,15 +10,21 @@ namespace Automattic\WooCommerce\Internal\Admin\Settings;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Transforms legacy settings definitions into React settings responses.
+ * Transforms legacy WC_Settings_Page definitions into React-shaped settings responses.
  *
- * @since 10.6.0
+ * This class is the public transform contract used both for preloading data into
+ * `window.wcSettings.admin.settings.{tab}.{section}` on settings pages that have
+ * opted in to modernised rendering, and for the v4 REST API endpoints that
+ * surface the same shape. Third-party callers MAY call `build_response()`
+ * directly with a `$settings_definitions` array and a `$settings_page` instance.
+ *
+ * @since 10.8.0
  */
 class ReactSettingsSchema {
 	/**
 	 * Settings definition marker types that don't render fields.
 	 *
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 * @var string[]
 	 */
 	private const MARKER_TYPES = array( 'title', 'sectionend' );
@@ -26,7 +32,7 @@ class ReactSettingsSchema {
 	/**
 	 * Default group ID used when settings are not grouped.
 	 *
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 * @var string
 	 */
 	private const DEFAULT_GROUP_ID = 'default';
@@ -34,7 +40,7 @@ class ReactSettingsSchema {
 	/**
 	 * Default order for ungrouped settings.
 	 *
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 * @var int
 	 */
 	private const DEFAULT_GROUP_ORDER = 999;
@@ -42,7 +48,7 @@ class ReactSettingsSchema {
 	/**
 	 * Normalized field types that accept options.
 	 *
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 * @var string[]
 	 */
 	private const OPTION_TYPES = array( 'select', 'multiselect' );
@@ -52,7 +58,7 @@ class ReactSettingsSchema {
 	 * @param string $tab Tab id.
 	 * @param string $section Section id.
 	 * @return array
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	public static function get_payload_path( string $tab, string $section ): array {
 		$section_key = '' === $section ? 'default' : $section;
@@ -65,7 +71,7 @@ class ReactSettingsSchema {
 	 * @param string $tab Tab id.
 	 * @param string $section Section id.
 	 * @return string
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	public static function get_mount_id( string $tab, string $section ): string {
 		$section_key = '' === $section ? 'default' : $section;
@@ -80,13 +86,13 @@ class ReactSettingsSchema {
 	 * @param array  $settings_definitions Settings definitions.
 	 * @param mixed  $settings_page Settings page instance.
 	 * @return bool
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	public static function is_opted_out( string $tab, string $section, array $settings_definitions, $settings_page ): bool {
 		/**
 		 * Filter whether the settings page should opt out of React rendering.
 		 *
-		 * @since 10.6.0
+		 * @since 10.8.0
 		 *
 		 * @param bool   $opt_out Whether to opt out of React rendering.
 		 * @param string $tab Tab id.
@@ -112,14 +118,14 @@ class ReactSettingsSchema {
 	 * @param array  $settings_definitions Settings definitions.
 	 * @param mixed  $settings_page Settings page instance.
 	 * @return array
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	public static function get_supported_types( string $tab, string $section, array $settings_definitions, $settings_page ): array {
 		$default_types = array( 'text', 'number', 'select', 'multiselect', 'checkbox', 'radio', 'toggle' );
 		/**
 		 * Filter supported React settings field types.
 		 *
-		 * @since 10.6.0
+		 * @since 10.8.0
 		 *
 		 * @param array  $supported_types Supported normalized field types.
 		 * @param string $tab Tab id.
@@ -147,7 +153,7 @@ class ReactSettingsSchema {
 	 * @param array  $settings_definitions Settings definitions.
 	 * @param mixed  $settings_page Settings page instance.
 	 * @return array
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	public static function get_type_map( string $tab, string $section, array $settings_definitions, $settings_page ): array {
 		$default_map = array(
@@ -160,7 +166,7 @@ class ReactSettingsSchema {
 		/**
 		 * Filter the field type map for React settings.
 		 *
-		 * @since 10.6.0
+		 * @since 10.8.0
 		 *
 		 * @param array  $type_map Map of WooCommerce field types to normalized types.
 		 * @param string $tab Tab id.
@@ -188,7 +194,7 @@ class ReactSettingsSchema {
 	 * @param array  $settings_definitions Settings definitions.
 	 * @param mixed  $settings_page Settings page instance.
 	 * @return array
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	public static function get_unsupported_fields( string $tab, string $section, array $settings_definitions, $settings_page ): array {
 		$type_map        = self::get_type_map( $tab, $section, $settings_definitions, $settings_page );
@@ -223,7 +229,7 @@ class ReactSettingsSchema {
 	 * @param array  $settings_definitions Settings definitions.
 	 * @param mixed  $settings_page Settings page instance.
 	 * @return bool
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	public static function has_renderable_fields( string $tab, string $section, array $settings_definitions, $settings_page ): bool {
 		$type_map        = self::get_type_map( $tab, $section, $settings_definitions, $settings_page );
@@ -262,7 +268,7 @@ class ReactSettingsSchema {
 	 *     values: array<string, mixed>,
 	 *     groups: array<string, array{title: string, description: string, order: int, fields: array<int, array<string, mixed>>}>
 	 * }
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	public static function build_response( string $tab, string $section, array $settings_definitions, $settings_page ): array {
 		$groups        = array();
@@ -349,7 +355,7 @@ class ReactSettingsSchema {
 	 * @param array  $setting WooCommerce setting array.
 	 * @param mixed  $settings_page Settings page instance.
 	 * @return array|null
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function transform_setting_to_field( string $tab, string $section, array $setting, $settings_page ): ?array {
 		$setting_id   = $setting['id'] ?? '';
@@ -378,7 +384,7 @@ class ReactSettingsSchema {
 	 * @param array  $setting Setting definition.
 	 * @param string $normalized_type Normalized field type.
 	 * @return array
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function get_field_options( array $setting, string $normalized_type ): array {
 		if ( ! in_array( $normalized_type, self::OPTION_TYPES, true ) ) {
@@ -415,7 +421,31 @@ class ReactSettingsSchema {
 			}
 		}
 
-		return self::normalize_options( $options );
+		$setting_id = isset( $setting['id'] ) && is_scalar( $setting['id'] ) ? (string) $setting['id'] : '';
+
+		/**
+		 * Filter field options for a specific field.
+		 *
+		 * Allows tab-specific callers to inject options at response time for
+		 * fields that don't embed a static options array in their definition
+		 * (for example, currency lists, country lists, or dynamic page lists).
+		 *
+		 * @since 10.8.0
+		 *
+		 * @param array  $options         Current options array (associative label map or list of option arrays).
+		 * @param string $field_id        Setting field ID.
+		 * @param array  $setting         Raw setting definition.
+		 * @param string $normalized_type Normalized field type (e.g. 'select', 'multiselect').
+		 */
+		$options = apply_filters(
+			'woocommerce_react_settings_field_options',
+			$options,
+			$setting_id,
+			$setting,
+			$normalized_type
+		);
+
+		return self::normalize_options( is_array( $options ) ? $options : array() );
 	}
 
 	/**
@@ -424,7 +454,7 @@ class ReactSettingsSchema {
 	 * @param array  $setting Setting definition.
 	 * @param string $type Normalized field type.
 	 * @return mixed
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function get_field_value( array $setting, string $type ) {
 		if ( array_key_exists( 'fixed_value', $setting ) && null !== $setting['fixed_value'] ) {
@@ -449,7 +479,7 @@ class ReactSettingsSchema {
 	 * @param mixed  $value Field value.
 	 * @param string $type Normalized field type.
 	 * @return mixed
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function normalize_value( $value, string $type ) {
 		switch ( $type ) {
@@ -475,7 +505,7 @@ class ReactSettingsSchema {
 	 * @param string $type Original type.
 	 * @param string $normalized_type Normalized type.
 	 * @return array
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function get_unsupported_field_payload( array $setting, string $type, string $normalized_type ): array {
 		return array(
@@ -489,7 +519,7 @@ class ReactSettingsSchema {
 	 * Get default group metadata for ungrouped fields.
 	 *
 	 * @return array
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function get_default_group(): array {
 		return array(
@@ -505,7 +535,7 @@ class ReactSettingsSchema {
 	 *
 	 * @param array $options Raw options array.
 	 * @return array
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function normalize_options( array $options ): array {
 		if ( self::is_list_of_option_arrays( $options ) ) {
@@ -549,7 +579,7 @@ class ReactSettingsSchema {
 	 *
 	 * @param array $options Raw options array.
 	 * @return bool
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function is_list_of_option_arrays( array $options ): bool {
 		if ( empty( $options ) ) {
@@ -578,7 +608,7 @@ class ReactSettingsSchema {
 	 *
 	 * @param array $options Raw options array.
 	 * @return bool
-	 * @since 10.6.0
+	 * @since 10.8.0
 	 */
 	private static function is_sequential_keys( array $options ): bool {
 		$expected = 0;

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php
@@ -18,6 +18,13 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * GeneralSettingsSchema class.
+ *
+ * The constructor performs hook registration for the
+ * `woocommerce_react_settings_field_options` filter so that consuming code
+ * gets the tab-specific option generation behaviour simply by instantiating
+ * the schema. This is atypical for the `src/Internal/*` codebase — see the
+ * follow-up note on the constructor docblock about moving registration into
+ * the V4 Settings REST controller's init path.
  */
 class GeneralSettingsSchema extends AbstractSchema {
 	/**
@@ -28,29 +35,25 @@ class GeneralSettingsSchema extends AbstractSchema {
 	const IDENTIFIER = 'general_settings';
 
 	/**
-	 * Whether the tab-specific field options filter callback has been registered.
-	 *
-	 * @var bool
-	 */
-	private static $field_options_filter_registered = false;
-
-	/**
 	 * Constructor.
 	 *
 	 * Registers the tab-specific field options callback on the shared
 	 * `woocommerce_react_settings_field_options` filter exposed by
 	 * ReactSettingsSchema. The callback only injects options for field IDs
 	 * owned by the general settings tab, so it is safe to register globally.
+	 *
+	 * `has_filter()` is used to avoid double-registration under DI container
+	 * instantiation or test re-instantiation.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @todo Move the filter registration into the V4 Settings REST
+	 *       controller's init path so schema classes don't perform global
+	 *       hook side effects at construction time.
 	 */
 	public function __construct() {
-		if ( ! self::$field_options_filter_registered ) {
-			add_filter(
-				'woocommerce_react_settings_field_options',
-				array( self::class, 'inject_field_options' ),
-				10,
-				4
-			);
-			self::$field_options_filter_registered = true;
+		if ( ! has_filter( 'woocommerce_react_settings_field_options', array( self::class, 'inject_field_options' ) ) ) {
+			add_filter( 'woocommerce_react_settings_field_options', array( self::class, 'inject_field_options' ), 10, 4 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php
@@ -9,7 +9,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\General\Schema;
 
+use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractSchema;
+use WC_Settings_General;
 use WP_REST_Request;
 
 defined( 'ABSPATH' ) || exit;
@@ -24,6 +26,33 @@ class GeneralSettingsSchema extends AbstractSchema {
 	 * @var string
 	 */
 	const IDENTIFIER = 'general_settings';
+
+	/**
+	 * Whether the tab-specific field options filter callback has been registered.
+	 *
+	 * @var bool
+	 */
+	private static $field_options_filter_registered = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * Registers the tab-specific field options callback on the shared
+	 * `woocommerce_react_settings_field_options` filter exposed by
+	 * ReactSettingsSchema. The callback only injects options for field IDs
+	 * owned by the general settings tab, so it is safe to register globally.
+	 */
+	public function __construct() {
+		if ( ! self::$field_options_filter_registered ) {
+			add_filter(
+				'woocommerce_react_settings_field_options',
+				array( self::class, 'inject_field_options' ),
+				10,
+				4
+			);
+			self::$field_options_filter_registered = true;
+		}
+	}
 
 	/**
 	 * Return all properties for the item schema.
@@ -137,79 +166,31 @@ class GeneralSettingsSchema extends AbstractSchema {
 	/**
 	 * Get general settings data by transforming raw settings into REST API format.
 	 *
+	 * Delegates the actual transform to ReactSettingsSchema::build_response() so
+	 * there's one canonical transformer shared with the modernised admin UI
+	 * preloader.
+	 *
 	 * @param mixed           $item             Raw settings array.
 	 * @param WP_REST_Request $request          Request object.
 	 * @param array           $include_fields   Fields to include.
 	 * @return array
 	 */
 	public function get_item_response( $item, WP_REST_Request $request, array $include_fields = array() ): array {
-		$raw_settings = $item;
+		$raw_settings = is_array( $item ) ? $item : array();
 
-		// Transform raw settings into grouped format based on title/sectionend markers.
-		$groups           = array();
-		$values           = array();
-		$current_group    = null;
-		$current_group_id = null;
-
-		foreach ( $raw_settings as $setting ) {
-			$setting_type = $setting['type'] ?? '';
-
-			// Handle section titles - start of a new group.
-			if ( 'title' === $setting_type ) {
-				$current_group_id = $setting['id'] ?? '';
-				$current_group    = array(
-					'title'       => $setting['title'] ?? '',
-					'description' => $setting['desc'] ?? '',
-					'order'       => isset( $setting['order'] ) ? (int) $setting['order'] : 999,
-					'fields'      => array(),
-				);
-				continue;
-			}
-
-			// Handle section ends - save the current group.
-			if ( 'sectionend' === $setting_type ) {
-				if ( $current_group && $current_group_id ) {
-					$groups[ $current_group_id ] = $current_group;
-				}
-				$current_group    = null;
-				$current_group_id = null;
-				continue;
-			}
-
-			// Skip title and sectionend types.
-			if ( in_array( $setting_type, array( 'title', 'sectionend' ), true ) ) {
-				continue;
-			}
-
-			// Convert setting to field format.
-			if ( isset( $setting['id'] ) && $current_group ) {
-				$field = $this->transform_setting_to_field( $setting );
-				if ( $field ) {
-					$current_group['fields'][] = $field;
-					// Add field value to the flat values array.
-					$raw_value              = get_option( $field['id'], $setting['default'] ?? '' );
-					$values[ $field['id'] ] = $this->validate_field_value( $raw_value, $field['type'] );
-				}
-			}
-		}
-
-		// Sort groups by their order if available.
-		uasort(
-			$groups,
-			function ( $a, $b ) {
-				$a_order = $a['order'] ?? 999;
-				$b_order = $b['order'] ?? 999;
-				return $a_order - $b_order;
-			}
+		$response = ReactSettingsSchema::build_response(
+			'general',
+			'',
+			$raw_settings,
+			new WC_Settings_General()
 		);
 
-		$response = array(
-			'id'          => 'general',
-			'title'       => __( 'General', 'woocommerce' ),
-			'description' => __( 'Set your store\'s address, visibility, currency, language, and timezone.', 'woocommerce' ),
-			'values'      => $values,
-			'groups'      => $groups,
-		);
+		// Preserve the REST-specific title/description. ReactSettingsSchema
+		// derives title from the page label, which is fine for the admin
+		// preloader but the REST endpoint exposes richer copy.
+		$response['id']          = 'general';
+		$response['title']       = __( 'General', 'woocommerce' );
+		$response['description'] = __( 'Set your store\'s address, visibility, currency, language, and timezone.', 'woocommerce' );
 
 		if ( ! empty( $include_fields ) ) {
 			$response = array_intersect_key( $response, array_flip( $include_fields ) );
@@ -219,40 +200,31 @@ class GeneralSettingsSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Transform a WooCommerce setting into REST API field format.
+	 * Inject tab-specific field options for general settings fields.
 	 *
-	 * @param array $setting WooCommerce setting array.
-	 * @return array|null Transformed field or null if should be skipped.
+	 * Callback registered against `woocommerce_react_settings_field_options`.
+	 * Only overrides options when the existing array is empty, so authors can
+	 * still supply an explicit options list via the settings definition.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param array  $options         Current options array.
+	 * @param string $field_id        Setting field ID.
+	 * @param array  $setting         Raw setting definition.
+	 * @param string $normalized_type Normalized field type.
+	 * @return array
 	 */
-	private function transform_setting_to_field( array $setting ): ?array {
-		$setting_id   = $setting['id'] ?? '';
-		$setting_type = $setting['type'] ?? 'text';
+	public static function inject_field_options( $options, string $field_id, array $setting, string $normalized_type ): array {
+		unset( $setting, $normalized_type ); // Not needed for this callback.
 
-		$field = array(
-			'id'    => $setting_id,
-			'label' => $setting['title'] ?? $setting_id,
-			'type'  => $this->normalize_field_type( $setting_type ),
-			'desc'  => $setting['desc'] ?? '',
-		);
-
-		// Add options for select fields.
-		if ( isset( $setting['options'] ) && is_array( $setting['options'] ) ) {
-			$field['options'] = $setting['options'];
-		} else {
-			// Generate options for special field types.
-			$field['options'] = $this->get_field_options( $setting_id );
+		if ( ! is_array( $options ) ) {
+			$options = array();
 		}
 
-		return $field;
-	}
+		if ( ! empty( $options ) ) {
+			return $options;
+		}
 
-	/**
-	 * Get options for specific field types.
-	 *
-	 * @param string $field_id Field ID.
-	 * @return array Field options.
-	 */
-	private function get_field_options( string $field_id ): array {
 		switch ( $field_id ) {
 			case 'woocommerce_currency':
 				if ( ! function_exists( 'get_woocommerce_currencies' ) || ! function_exists( 'get_woocommerce_currency_symbol' ) ) {
@@ -260,15 +232,15 @@ class GeneralSettingsSchema extends AbstractSchema {
 				}
 
 				$currencies = get_woocommerce_currencies();
-				$options    = array();
+				$generated  = array();
 
 				foreach ( $currencies as $code => $name ) {
-					$label            = wp_specialchars_decode( (string) $name );
-					$symbol           = wp_specialchars_decode( (string) get_woocommerce_currency_symbol( $code ) );
-					$options[ $code ] = $label . ' (' . $symbol . ') — ' . $code;
+					$label               = wp_specialchars_decode( (string) $name );
+					$symbol              = wp_specialchars_decode( (string) get_woocommerce_currency_symbol( $code ) );
+					$generated[ $code ] = $label . ' (' . $symbol . ') — ' . $code;
 				}
 
-				return $options;
+				return $generated;
 
 			case 'woocommerce_default_country':
 				if ( ! function_exists( 'WC' ) ) {
@@ -277,21 +249,22 @@ class GeneralSettingsSchema extends AbstractSchema {
 
 				$countries = WC()->countries->get_countries();
 				$states    = WC()->countries->get_states();
-				$options   = array();
+				$generated = array();
 
 				foreach ( $countries as $country_code => $country_name ) {
 					$country_states = $states[ $country_code ] ?? array();
 
 					if ( empty( $country_states ) ) {
-						$options[ $country_code ] = $country_name;
-					} else {
-						foreach ( $country_states as $state_code => $state_name ) {
-							$options[ $country_code . ':' . $state_code ] = $country_name . ' — ' . $state_name;
-						}
+						$generated[ $country_code ] = $country_name;
+						continue;
+					}
+
+					foreach ( $country_states as $state_code => $state_name ) {
+						$generated[ $country_code . ':' . $state_code ] = $country_name . ' — ' . $state_name;
 					}
 				}
 
-				return $options;
+				return $generated;
 
 			case 'woocommerce_all_except_countries':
 			case 'woocommerce_specific_allowed_countries':
@@ -299,57 +272,9 @@ class GeneralSettingsSchema extends AbstractSchema {
 				if ( ! function_exists( 'WC' ) ) {
 					return array();
 				}
-
-				// For multiselect country fields, return simple country list (no states).
 				return WC()->countries->get_countries();
 		}
 
-		return array();
-	}
-
-	/**
-	 * Normalize WooCommerce field types to REST API field types.
-	 *
-	 * @param string $wc_type WooCommerce field type.
-	 * @return string Normalized field type.
-	 */
-	private function normalize_field_type( string $wc_type ): string {
-		$type_map = array(
-			'single_select_country'  => 'select',
-			'multi_select_countries' => 'multiselect',
-		);
-
-		return $type_map[ $wc_type ] ?? $wc_type;
-	}
-
-	/**
-	 * Validate and sanitize field value based on its type.
-	 *
-	 * @param mixed  $value Field value.
-	 * @param string $type  Field type.
-	 * @return mixed Validated value.
-	 */
-	private function validate_field_value( $value, string $type ) {
-		switch ( $type ) {
-			case 'number':
-				return is_numeric( $value ) ? (float) $value : 0;
-			case 'checkbox':
-				if ( function_exists( 'wc_string_to_bool' ) ) {
-					return wc_string_to_bool( $value );
-				}
-				if ( is_bool( $value ) ) {
-					return $value;
-				}
-				return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
-			case 'multiselect':
-				if ( ! is_array( $value ) ) {
-					return array();
-				}
-				return array_map( 'sanitize_text_field', $value );
-			case 'text':
-			case 'select':
-			default:
-				return is_string( $value ) ? $value : (string) $value;
-		}
+		return $options;
 	}
 }

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -20,6 +20,13 @@ use WP_REST_Request;
 
 /**
  * Product Settings Schema Class.
+ *
+ * The constructor performs hook registration for the
+ * `woocommerce_react_settings_field_options` filter so that consuming code
+ * gets the tab-specific option generation behaviour simply by instantiating
+ * the schema. This is atypical for the `src/Internal/*` codebase — see the
+ * follow-up note on the constructor docblock about moving registration into
+ * the V4 Settings REST controller's init path.
  */
 class ProductSettingsSchema extends AbstractSchema {
 	/**
@@ -30,29 +37,25 @@ class ProductSettingsSchema extends AbstractSchema {
 	const IDENTIFIER = 'product_settings';
 
 	/**
-	 * Whether the tab-specific field options filter callback has been registered.
-	 *
-	 * @var bool
-	 */
-	private static $field_options_filter_registered = false;
-
-	/**
 	 * Constructor.
 	 *
 	 * Registers the tab-specific field options callback on the shared
 	 * `woocommerce_react_settings_field_options` filter exposed by
 	 * ReactSettingsSchema. The callback only injects options for field IDs
 	 * owned by the products settings tab, so it is safe to register globally.
+	 *
+	 * `has_filter()` is used to avoid double-registration under DI container
+	 * instantiation or test re-instantiation.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @todo Move the filter registration into the V4 Settings REST
+	 *       controller's init path so schema classes don't perform global
+	 *       hook side effects at construction time.
 	 */
 	public function __construct() {
-		if ( ! self::$field_options_filter_registered ) {
-			add_filter(
-				'woocommerce_react_settings_field_options',
-				array( self::class, 'inject_field_options' ),
-				10,
-				4
-			);
-			self::$field_options_filter_registered = true;
+		if ( ! has_filter( 'woocommerce_react_settings_field_options', array( self::class, 'inject_field_options' ) ) ) {
+			add_filter( 'woocommerce_react_settings_field_options', array( self::class, 'inject_field_options' ), 10, 4 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -13,7 +13,9 @@ namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Products\Sc
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractSchema;
+use WC_Settings_Products;
 use WP_REST_Request;
 
 /**
@@ -26,6 +28,33 @@ class ProductSettingsSchema extends AbstractSchema {
 	 * @var string
 	 */
 	const IDENTIFIER = 'product_settings';
+
+	/**
+	 * Whether the tab-specific field options filter callback has been registered.
+	 *
+	 * @var bool
+	 */
+	private static $field_options_filter_registered = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * Registers the tab-specific field options callback on the shared
+	 * `woocommerce_react_settings_field_options` filter exposed by
+	 * ReactSettingsSchema. The callback only injects options for field IDs
+	 * owned by the products settings tab, so it is safe to register globally.
+	 */
+	public function __construct() {
+		if ( ! self::$field_options_filter_registered ) {
+			add_filter(
+				'woocommerce_react_settings_field_options',
+				array( self::class, 'inject_field_options' ),
+				10,
+				4
+			);
+			self::$field_options_filter_registered = true;
+		}
+	}
 
 	/**
 	 * Return all properties for the item schema.
@@ -139,116 +168,63 @@ class ProductSettingsSchema extends AbstractSchema {
 	/**
 	 * Get product settings data by transforming WC_Settings_Products data into REST API format.
 	 *
+	 * Delegates the actual transform to ReactSettingsSchema::build_response() so
+	 * there's one canonical transformer shared with the modernised admin UI
+	 * preloader.
+	 *
 	 * @param mixed           $item             Settings products instance.
 	 * @param WP_REST_Request $request          Request object.
 	 * @param array           $include_fields   Fields to include.
 	 * @return array
 	 */
 	public function get_item_response( $item, WP_REST_Request $request, array $include_fields = array() ): array {
-		$raw_settings = $item;
+		$raw_settings = is_array( $item ) ? $item : array();
 
-		// Transform raw settings into grouped format based on title/sectionend markers.
-		$groups           = array();
-		$values           = array();
-		$current_group    = null;
-		$current_group_id = null;
+		$response = ReactSettingsSchema::build_response(
+			'products',
+			'',
+			$raw_settings,
+			new WC_Settings_Products()
+		);
 
-		foreach ( $raw_settings as $setting ) {
-			$setting_type = $setting['type'] ?? '';
+		// Preserve the REST-specific title/description.
+		$response['id']          = 'products';
+		$response['title']       = __( 'Products', 'woocommerce' );
+		$response['description'] = __( 'Manage product settings including dimensions, weight units, and display options.', 'woocommerce' );
 
-			// Handle section titles - start of a new group.
-			if ( 'title' === $setting_type ) {
-				$current_group_id = $setting['id'] ?? '';
-				$current_group    = array(
-					'title'       => $setting['title'] ?? '',
-					'description' => $setting['desc'] ?? '',
-					'order'       => isset( $setting['order'] ) ? (int) $setting['order'] : 999,
-					'fields'      => array(),
-				);
-				continue;
-			}
-
-			// Handle section ends - save the current group.
-			if ( 'sectionend' === $setting_type ) {
-				if ( $current_group && $current_group_id ) {
-					$groups[ $current_group_id ] = $current_group;
-				}
-				$current_group    = null;
-				$current_group_id = null;
-				continue;
-			}
-
-			// Skip title and sectionend types.
-			if ( in_array( $setting_type, array( 'title', 'sectionend' ), true ) ) {
-				continue;
-			}
-
-			// Convert setting to field format.
-			if ( isset( $setting['id'] ) && $current_group ) {
-				$field = $this->transform_setting_to_field( $setting );
-				if ( $field ) {
-					$current_group['fields'][] = $field;
-					// Add field value to the flat values array.
-					$raw_value              = get_option( $field['id'], $setting['default'] ?? '' );
-					$values[ $field['id'] ] = $this->validate_field_value( $raw_value, $field['type'] );
-				}
-			}
+		if ( ! empty( $include_fields ) ) {
+			$response = array_intersect_key( $response, array_flip( $include_fields ) );
 		}
 
-		// Sort groups by their order if available.
-		uasort(
-			$groups,
-			function ( $a, $b ) {
-				$a_order = $a['order'] ?? 999;
-				$b_order = $b['order'] ?? 999;
-				return $a_order - $b_order;
-			}
-		);
-
-		return array(
-			'id'          => 'products',
-			'title'       => __( 'Products', 'woocommerce' ),
-			'description' => __( 'Manage product settings including dimensions, weight units, and display options.', 'woocommerce' ),
-			'values'      => $values,
-			'groups'      => $groups,
-		);
+		return $response;
 	}
 
 	/**
-	 * Transform a WooCommerce setting into REST API field format.
+	 * Inject tab-specific field options for product settings fields.
 	 *
-	 * @param array $setting WooCommerce setting array.
-	 * @return array|null Transformed field or null if should be skipped.
+	 * Callback registered against `woocommerce_react_settings_field_options`.
+	 * Only overrides options when the existing array is empty, so authors can
+	 * still supply an explicit options list via the settings definition.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param array  $options         Current options array.
+	 * @param string $field_id        Setting field ID.
+	 * @param array  $setting         Raw setting definition.
+	 * @param string $normalized_type Normalized field type.
+	 * @return array
 	 */
-	private function transform_setting_to_field( array $setting ): ?array {
-		$setting_id   = $setting['id'] ?? '';
-		$setting_type = $setting['type'] ?? 'text';
+	public static function inject_field_options( $options, string $field_id, array $setting, string $normalized_type ): array {
+		unset( $setting, $normalized_type ); // Not needed for this callback.
 
-		$field = array(
-			'id'    => $setting_id,
-			'label' => $setting['title'] ?? $setting_id,
-			'type'  => $this->normalize_field_type( $setting_type ),
-			'desc'  => $setting['desc'] ?? '',
-		);
-
-		// Add options for select fields.
-		if ( isset( $setting['options'] ) && is_array( $setting['options'] ) ) {
-			$field['options'] = $setting['options'];
-		} else {
-			// Generate options for special field types.
-			$field['options'] = $this->get_field_options( $setting_id );
+		if ( ! is_array( $options ) ) {
+			$options = array();
 		}
 
-		return $field;
-	}
+		if ( ! empty( $options ) ) {
+			return $options;
+		}
 
-	/**
-	 * Get options for specific field types.
-	 *
-	 * @param string $field_id Field ID.
-	 * @return array Field options.
-	 */
-	private function get_field_options( string $field_id ): array {
 		switch ( $field_id ) {
 			case 'woocommerce_weight_unit':
 				return array(
@@ -271,23 +247,24 @@ class ProductSettingsSchema extends AbstractSchema {
 				if ( ! function_exists( 'wc_get_product_types' ) ) {
 					return array();
 				}
-
 				$product_types = wc_get_product_types();
 				return is_array( $product_types ) ? $product_types : array();
+
 			case 'woocommerce_shop_page_id':
-				return $this->get_page_options();
+				return self::get_page_options();
 		}
 
-		return array();
+		return $options;
 	}
 
 	/**
 	 * Get options for page selection fields.
 	 *
+	 * @since 10.8.0
+	 *
 	 * @return array
-	 * @since 10.6.0
 	 */
-	private function get_page_options(): array {
+	private static function get_page_options(): array {
 		if ( ! function_exists( 'get_pages' ) ) {
 			return array();
 		}
@@ -303,54 +280,14 @@ class ProductSettingsSchema extends AbstractSchema {
 			'' => __( 'Select a page…', 'woocommerce' ),
 		);
 
+		if ( ! is_array( $pages ) ) {
+			return $options;
+		}
+
 		foreach ( $pages as $page ) {
 			$options[ (string) $page->ID ] = wp_strip_all_tags( $page->post_title );
 		}
 
 		return $options;
-	}
-
-	/**
-	 * Normalize WooCommerce field types to REST API field types.
-	 *
-	 * @param string $wc_type WooCommerce field type.
-	 * @return string Normalized field type.
-	 */
-	private function normalize_field_type( string $wc_type ): string {
-		$type_map = array(
-			'single_select_product' => 'select',
-			'multi_select_product'  => 'multiselect',
-			'single_select_page'    => 'select',
-		);
-
-		return $type_map[ $wc_type ] ?? $wc_type;
-	}
-
-	/**
-	 * Validate and sanitize field value based on its type.
-	 *
-	 * @param mixed  $value Field value.
-	 * @param string $type  Field type.
-	 * @return mixed Validated value.
-	 */
-	private function validate_field_value( $value, string $type ) {
-		switch ( $type ) {
-			case 'number':
-				return is_numeric( $value ) ? (float) $value : 0;
-			case 'checkbox':
-				if ( function_exists( 'wc_string_to_bool' ) ) {
-					return wc_string_to_bool( $value );
-				}
-				if ( is_bool( $value ) ) {
-					return $value;
-				}
-				return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
-			case 'multiselect':
-				return is_array( $value ) ? $value : array();
-			case 'text':
-			case 'select':
-			default:
-				return is_string( $value ) ? $value : (string) $value;
-		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php
@@ -3,8 +3,11 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings;
 
+use Automattic\WooCommerce\Internal\Admin\Settings;
 use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\General\Schema\GeneralSettingsSchema;
 use WC_Unit_Test_Case;
+use WP_REST_Request;
 
 /**
  * React settings schema test.
@@ -191,5 +194,140 @@ class ReactSettingsSchemaTest extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'default', $response['groups'] );
 		$this->assertSame( 'saved_value', $response['values']['setting_one'] );
 		$this->assertSame( 'saved_value_two', $response['values']['setting_two'] );
+	}
+
+	/**
+	 * @testdox Injects field options via the tab-specific filter hook.
+	 */
+	public function test_build_response_applies_field_options_filter() {
+		$filter = static function ( $options, $field_id ) {
+			if ( 'tab_specific_field' === $field_id ) {
+				return array(
+					'alpha' => 'Alpha',
+					'beta'  => 'Beta',
+				);
+			}
+			return $options;
+		};
+
+		add_filter( 'woocommerce_react_settings_field_options', $filter, 10, 2 );
+
+		$settings = array(
+			array(
+				'type'  => 'title',
+				'id'    => 'group_one',
+				'title' => 'Group one',
+			),
+			array(
+				'id'   => 'tab_specific_field',
+				'type' => 'select',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'group_one',
+			),
+		);
+
+		$response = ReactSettingsSchema::build_response( 'custom_tab', '', $settings, null );
+
+		remove_filter( 'woocommerce_react_settings_field_options', $filter, 10 );
+
+		$fields = $response['groups']['group_one']['fields'];
+		$this->assertNotEmpty( $fields );
+		$this->assertArrayHasKey( 'options', $fields[0] );
+		$this->assertSame( 'Alpha', $fields[0]['options']['alpha'] );
+		$this->assertSame( 'Beta', $fields[0]['options']['beta'] );
+	}
+
+	/**
+	 * @testdox Resolves settings pages registered via WC_Admin_Settings without relying on the legacy hardcoded map.
+	 *
+	 * Regression guard: prior to 10.8.0 `get_settings_page_instance()` fell back
+	 * to a hardcoded `general`/`products` class map. The shipping tab was never
+	 * in that map, so resolving it proves we're now going through the generic
+	 * `WC_Admin_Settings::get_settings_pages()` iteration.
+	 */
+	public function test_settings_page_instance_resolves_non_hardcoded_page() {
+		// Ensure admin-side settings classes are loaded so WC_Admin_Settings::get_settings_pages() is populated.
+		if ( ! class_exists( 'WC_Admin_Settings', false ) ) {
+			include_once WC_ABSPATH . 'includes/admin/class-wc-admin-settings.php';
+		}
+
+		$sut        = Settings::get_instance();
+		$reflection = new \ReflectionClass( $sut );
+		$method     = $reflection->getMethod( 'get_settings_page_instance' );
+		$method->setAccessible( true );
+
+		$instance = $method->invoke( $sut, 'shipping' );
+
+		$this->assertInstanceOf( \WC_Settings_Shipping::class, $instance );
+		$this->assertSame( 'shipping', $instance->get_id() );
+	}
+
+	/**
+	 * @testdox Returns null for unknown settings page ids.
+	 */
+	public function test_settings_page_instance_returns_null_for_unknown_page() {
+		if ( ! class_exists( 'WC_Admin_Settings', false ) ) {
+			include_once WC_ABSPATH . 'includes/admin/class-wc-admin-settings.php';
+		}
+
+		$sut        = Settings::get_instance();
+		$reflection = new \ReflectionClass( $sut );
+		$method     = $reflection->getMethod( 'get_settings_page_instance' );
+		$method->setAccessible( true );
+
+		$instance = $method->invoke( $sut, 'this_tab_does_not_exist' );
+
+		$this->assertNull( $instance );
+	}
+
+	/**
+	 * @testdox GeneralSettingsSchema::get_item_response returns the same core shape as ReactSettingsSchema::build_response.
+	 *
+	 * This guards the "one canonical transformer" contract introduced in 10.8.0
+	 * — the v4 REST response must share groups/values/field shape with the
+	 * admin preloader payload.
+	 */
+	public function test_general_settings_schema_shares_shape_with_build_response() {
+		update_option( 'setting_one', 'saved' );
+
+		$raw_settings = array(
+			array(
+				'type'  => 'title',
+				'id'    => 'group_one',
+				'title' => 'Group one',
+			),
+			array(
+				'id'      => 'setting_one',
+				'type'    => 'text',
+				'default' => 'default_value',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'group_one',
+			),
+		);
+
+		$sut     = new GeneralSettingsSchema();
+		$request = new WP_REST_Request( 'GET', '/wc/v4/settings/general' );
+
+		$schema_response = $sut->get_item_response( $raw_settings, $request );
+		$canonical       = ReactSettingsSchema::build_response( 'general', '', $raw_settings, null );
+
+		delete_option( 'setting_one' );
+
+		// Structural parity — the transform contract.
+		$this->assertSame( $canonical['values'], $schema_response['values'] );
+		$this->assertSame( array_keys( $canonical['groups'] ), array_keys( $schema_response['groups'] ) );
+		$this->assertSame(
+			$canonical['groups']['group_one']['fields'],
+			$schema_response['groups']['group_one']['fields']
+		);
+
+		// Tab-specific copy is preserved on the REST response.
+		$this->assertSame( 'general', $schema_response['id'] );
+		$this->assertSame( 'General', $schema_response['title'] );
+		$this->assertNotEmpty( $schema_response['description'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php
@@ -240,6 +240,47 @@ class ReactSettingsSchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Does not generate country options without a registered field options filter.
+	 *
+	 * Regression guard: prior to this change, `ReactSettingsSchema::get_field_options()`
+	 * had a hardcoded dispatch for `single_select_country` / `multi_select_countries`
+	 * that duplicated the logic now owned by `GeneralSettingsSchema::inject_field_options()`.
+	 * The base class should trust the filter to fill `$options` for types that need
+	 * external data, producing an empty options array when no callback is registered.
+	 */
+	public function test_build_response_does_not_generate_country_options_without_filter() {
+		// Ensure no general-tab callback is registered for this test (it might have been
+		// registered by a previous test that instantiated GeneralSettingsSchema).
+		remove_filter(
+			'woocommerce_react_settings_field_options',
+			array( GeneralSettingsSchema::class, 'inject_field_options' ),
+			10
+		);
+
+		$settings = array(
+			array(
+				'type'  => 'title',
+				'id'    => 'group_one',
+				'title' => 'Group one',
+			),
+			array(
+				'id'   => 'some_country_field',
+				'type' => 'single_select_country',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'group_one',
+			),
+		);
+
+		$response = ReactSettingsSchema::build_response( 'custom_tab', '', $settings, null );
+
+		$fields = $response['groups']['group_one']['fields'];
+		$this->assertNotEmpty( $fields );
+		$this->assertArrayNotHasKey( 'options', $fields[0] );
+	}
+
+	/**
 	 * @testdox Resolves settings pages registered via WC_Admin_Settings without relying on the legacy hardcoded map.
 	 *
 	 * Regression guard: prior to 10.8.0 `get_settings_page_instance()` fell back


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3484.

Promotes `ReactSettingsSchema` to the stable public transform contract for modernised settings (`@since 10.8.0` on every public method + class docblock). Both v4 REST schemas (`GeneralSettingsSchema`, `ProductSettingsSchema`) now delegate `get_item_response()` to `ReactSettingsSchema::build_response()` — one canonical transformer instead of three.

Tab-specific option generation (currency, country/state, page list, weight/dimension units, product types) moves to a new `woocommerce_react_settings_field_options` filter; callbacks register from each schema's constructor, guarded by `has_filter()`. Also simplifies `Settings::get_settings_page_instance()` by dropping the hardcoded general/products class dictionary — now resolves every registered settings page via `WC_Admin_Settings::get_settings_pages()` alone.

Before this change there were three near-identical transformers, each with its own `transform_setting_to_field` / `normalize_field_type` / `validate_field_value` / `get_field_options`. That drifts. Consolidating into one canonical transformer means external plugins building their own modernised settings page can rely on `ReactSettingsSchema::build_response()` as the stable entry point.

**Files changed:**
- `src/Internal/Admin/Settings/ReactSettingsSchema.php` — class-level docblock declares stable public API; `@since` tags updated to 10.8.0; new `woocommerce_react_settings_field_options` filter applied in `get_field_options()`; country/state dispatch removed (moved to filter in `GeneralSettingsSchema`).
- `src/Internal/RestApi/Routes/V4/Settings/General/Schema/GeneralSettingsSchema.php` — delegates to `ReactSettingsSchema::build_response()`; registers `inject_field_options` for currency / default country / multi-country fields; removed 4 duplicate helpers.
- `src/Internal/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php` — same delegation; handles weight/dimension units, product types, shop page ID; removed 4 duplicate helpers.
- `src/Internal/Admin/Settings.php` — `get_settings_page_instance()` reduced to pure iteration.
- `tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php` — 5 new tests covering filter-hook injection, non-dictionary page resolution regression (uses `shipping`), unknown-page null, parity with General's REST response, base-class no-country-options guard.
- `phpstan-baseline.neon` — removed 6 stale entries; baseline did not grow.

### How to test the changes in this Pull Request:

1. Apply this branch and rebuild PHP autoloader entries.
2. Hit `GET /wp-json/wc/v4/settings/general` (with admin nonce). Expect 200 with the same shape as before — currency / default-country options populated, state-merged country entries (e.g. `US:AL` → "United States (US) — Alabama").
3. Hit `GET /wp-json/wc/v4/settings/products`. Expect weight/dimension units and product-type options populated.
4. Resolve a settings tab that wasn't in the old hardcoded dictionary (e.g. `shipping` or `advanced`); the page should resolve to a real `WC_Settings_Page` subclass without falling back.
5. Visual diff `?page=wc-settings&tab=general` between this branch and trunk to confirm no regression in legacy field rendering.

### Testing that has already taken place:

- PHPUnit: `pnpm test:php:env -- --filter ReactSettingsSchemaTest` — 13/13 passing (33 assertions).
- `phpcs-changed` clean on every modified file.
- PHPStan baseline shrank by 6 stale entries; no growth.
- Manual smoke against `/wp-json/wc/v4/settings/general` with admin session: 200, 163 currency options, 2211 default-country options including state-merged entries.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message

Consolidate v4 REST settings transformers through ReactSettingsSchema; remove the hardcoded settings-page-class dictionary in Settings.

</details>
