### PR TITLE
Surface legacy settings fallback via wc_doing_it_wrong; mark v4 update_item @internal

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3488-doing-it-wrong-fallback-internal-marker
+++ b/plugins/woocommerce/changelog/wooprd-3488-doing-it-wrong-fallback-internal-marker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Surface legacy-settings-fallback signal via wc_doing_it_wrong so it appears in debug.log and Query Monitor; mark the v4 REST settings update endpoint as @internal until filter fidelity is restored.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -528,7 +528,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 							return;
 						}
 
-						$this->log_legacy_settings_fallback( $tab, $section_id, $unsupported_fields );
+						$this->warn_legacy_settings_fallback( $tab, $section_id, $unsupported_fields );
 					}
 				}
 			}
@@ -541,26 +541,54 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		}
 
 		/**
-		 * Log a legacy settings fallback in the console to ease debugging.
+		 * Warn that the modernised settings SDK fell back to legacy rendering.
 		 *
-		 * @since 10.6.0
+		 * Surfaces via `wc_doing_it_wrong()` so the nudge appears in `debug.log`,
+		 * Query Monitor, and any other handler listening on `doing_it_wrong_trigger`
+		 * — unlike the previous inline `console.log()` signal, which was easy to miss.
 		 *
-		 * @param string $tab Tab id.
-		 * @param string $section Section id.
-		 * @param array  $unsupported_fields Unsupported fields list.
+		 * The message lists the tab id, section id (with empty normalised to `default`),
+		 * and each unsupported field's id plus its (normalised) type so plugin authors
+		 * know exactly which fields to register via
+		 * `wcReactSettings.registerFieldTypeTransformer()` or add to
+		 * `get_supported_types()` via the `woocommerce_react_settings_supported_types`
+		 * filter to unlock modern rendering.
+		 *
+		 * @since 10.8.0
+		 *
+		 * @param string $tab                Tab id.
+		 * @param string $section            Section id. Empty string is normalised to `default`.
+		 * @param array  $unsupported_fields Unsupported fields list. Each entry is an
+		 *                                   associative array with `id`, `type`, and
+		 *                                   `normalized_type` keys (see
+		 *                                   `ReactSettingsSchema::get_unsupported_fields()`).
 		 */
-		protected function log_legacy_settings_fallback( string $tab, string $section, array $unsupported_fields ) {
-			$payload = array(
-				'tab'               => $tab,
-				'section'           => $section,
-				'unsupportedFields' => $unsupported_fields,
+		protected function warn_legacy_settings_fallback( string $tab, string $section, array $unsupported_fields ): void {
+			if ( empty( $unsupported_fields ) ) {
+				return;
+			}
+
+			$normalized_section = '' === $section ? 'default' : $section;
+
+			$field_descriptions = array();
+			foreach ( $unsupported_fields as $field ) {
+				$field_id        = isset( $field['id'] ) && '' !== $field['id'] ? (string) $field['id'] : '(no id)';
+				$field_type      = isset( $field['type'] ) && '' !== $field['type'] ? (string) $field['type'] : '(no type)';
+				$normalized_type = isset( $field['normalized_type'] ) ? (string) $field['normalized_type'] : $field_type;
+
+				$field_descriptions[] = $normalized_type === $field_type
+					? sprintf( '%s (%s)', $field_id, $field_type )
+					: sprintf( '%s (%s → %s)', $field_id, $field_type, $normalized_type );
+			}
+
+			$message = sprintf(
+				'WooCommerce modernised settings fell back to legacy rendering on tab "%1$s", section "%2$s" because these fields are not supported: %3$s. Register a transformer via wcReactSettings.registerFieldTypeTransformer() or add the type via the woocommerce_react_settings_supported_types filter to enable modern rendering.',
+				$tab,
+				$normalized_section,
+				implode( ', ', $field_descriptions )
 			);
-			echo '<script>console.log(' . wp_json_encode(
-				array(
-					'message' => 'WooCommerce settings fallback to legacy',
-					'details' => $payload,
-				)
-			) . ');</script>';
+
+			wc_doing_it_wrong( __METHOD__, $message, '10.8.0' );
 		}
 
 		/**

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
@@ -26,13 +26,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @internal
  *
- * This controller is MVP-scope for the modernised settings SDK and is not yet
- * safe for public consumption. The writable endpoint bypasses the
- * `woocommerce_admin_settings_sanitize_option_*` and `pre_update_option_*`
- * filter chains that the legacy settings save path fires, so plugins hooked
- * into those filters will not see settings submitted via this endpoint.
- * Filter fidelity is tracked for Phase 2 in
- * {@link https://linear.app/a8c/issue/WOOPRD-3494 WOOPRD-3494}.
+ * The writable endpoint bypasses the `woocommerce_admin_settings_sanitize_option_*`
+ * and `pre_update_option_*` filter chains that the legacy settings save path fires,
+ * so plugins hooked into those filters will not see settings submitted via this
+ * endpoint. Not safe for public consumption until filter fidelity is restored.
  */
 class Controller extends AbstractController {
 	/**
@@ -164,10 +161,9 @@ class Controller extends AbstractController {
 	 *
 	 * This endpoint does not fire `woocommerce_admin_settings_sanitize_option_*`
 	 * or `pre_update_option_*` filters during save. It is not safe for public
-	 * consumption until {@link https://linear.app/a8c/issue/WOOPRD-3494 WOOPRD-3494}
-	 * restores filter fidelity. React-based settings pages currently submit via
-	 * the legacy form POST path which does fire these filters; use that path
-	 * until the REST endpoint is safe.
+	 * consumption until filter fidelity is restored. React-based settings pages
+	 * currently submit via the legacy form POST path which does fire these
+	 * filters; use that path until the REST endpoint is safe.
 	 *
 	 * @since 10.8.0
 	 *

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
@@ -23,6 +23,16 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * REST API General Settings Controller Class.
+ *
+ * @internal
+ *
+ * This controller is MVP-scope for the modernised settings SDK and is not yet
+ * safe for public consumption. The writable endpoint bypasses the
+ * `woocommerce_admin_settings_sanitize_option_*` and `pre_update_option_*`
+ * filter chains that the legacy settings save path fires, so plugins hooked
+ * into those filters will not see settings submitted via this endpoint.
+ * Filter fidelity is tracked for Phase 2 in
+ * {@link https://linear.app/a8c/issue/WOOPRD-3494 WOOPRD-3494}.
  */
 class Controller extends AbstractController {
 	/**
@@ -149,6 +159,17 @@ class Controller extends AbstractController {
 
 	/**
 	 * Update general settings.
+	 *
+	 * @internal
+	 *
+	 * This endpoint does not fire `woocommerce_admin_settings_sanitize_option_*`
+	 * or `pre_update_option_*` filters during save. It is not safe for public
+	 * consumption until {@link https://linear.app/a8c/issue/WOOPRD-3494 WOOPRD-3494}
+	 * restores filter fidelity. React-based settings pages currently submit via
+	 * the legacy form POST path which does fire these filters; use that path
+	 * until the REST endpoint is safe.
+	 *
+	 * @since 10.8.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsPageFallbackNoticeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsPageFallbackNoticeTest.php
@@ -1,0 +1,188 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings;
+
+use ReflectionMethod;
+use WC_Settings_Page;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the legacy-settings-fallback developer notice emitted by
+ * WC_Settings_Page::warn_legacy_settings_fallback().
+ */
+class SettingsPageFallbackNoticeTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Settings_Page
+	 */
+	private $sut;
+
+	/**
+	 * Captured `wc_doing_it_wrong` messages keyed by function name.
+	 *
+	 * @var array<string, string[]>
+	 */
+	private array $captured_messages = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new class() extends WC_Settings_Page {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id    = 'test-tab';
+				$this->label = 'Test';
+				// Intentionally skip parent::__construct() so this bare subclass
+				// does not register hooks against the global settings pipeline.
+			}
+		};
+
+		$this->captured_messages = array();
+		add_action( 'doing_it_wrong_run', array( $this, 'capture_doing_it_wrong' ), 10, 3 );
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_action( 'doing_it_wrong_run', array( $this, 'capture_doing_it_wrong' ), 10 );
+		remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Capture the arguments passed to wc_doing_it_wrong() for later assertions.
+	 *
+	 * @param string $function Function name that triggered the notice.
+	 * @param string $message  Notice message.
+	 * @param string $version  Version in which the notice was introduced.
+	 */
+	public function capture_doing_it_wrong( $function, $message, $version ): void {
+		unset( $version ); // Avoid parameter not used PHPCS errors.
+		$this->captured_messages[ (string) $function ][] = (string) $message;
+	}
+
+	/**
+	 * Invoke the protected warn_legacy_settings_fallback() via reflection.
+	 *
+	 * @param string $tab                Tab id.
+	 * @param string $section            Section id.
+	 * @param array  $unsupported_fields Unsupported field payloads.
+	 */
+	private function invoke_warn( string $tab, string $section, array $unsupported_fields ): void {
+		$method = new ReflectionMethod( WC_Settings_Page::class, 'warn_legacy_settings_fallback' );
+		$method->setAccessible( true );
+		$method->invoke( $this->sut, $tab, $section, $unsupported_fields );
+	}
+
+	/**
+	 * @testdox Should raise wc_doing_it_wrong naming the method when unsupported fields are present.
+	 */
+	public function test_raises_doing_it_wrong_for_unsupported_fields(): void {
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::warn_legacy_settings_fallback' );
+
+		$this->invoke_warn(
+			'general',
+			'',
+			array(
+				array(
+					'id'              => 'my_field',
+					'type'            => 'custom_type',
+					'normalized_type' => 'custom_type',
+				),
+			)
+		);
+
+		$this->assertArrayHasKey(
+			'WC_Settings_Page::warn_legacy_settings_fallback',
+			$this->captured_messages,
+			'Fallback notice should be attributed to warn_legacy_settings_fallback().'
+		);
+	}
+
+	/**
+	 * @testdox Should include tab, section (with default normalisation), and unsupported field details in the message.
+	 */
+	public function test_message_includes_tab_section_and_field_details(): void {
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::warn_legacy_settings_fallback' );
+
+		$this->invoke_warn(
+			'general',
+			'',
+			array(
+				array(
+					'id'              => 'my_field',
+					'type'            => 'custom_type',
+					'normalized_type' => 'custom_type',
+				),
+				array(
+					'id'              => 'other_field',
+					'type'            => 'legacy_alias',
+					'normalized_type' => 'text',
+				),
+			)
+		);
+
+		$messages = $this->captured_messages['WC_Settings_Page::warn_legacy_settings_fallback'] ?? array();
+		$this->assertNotEmpty( $messages, 'Expected at least one captured doing_it_wrong message.' );
+
+		$message = $messages[0];
+
+		$this->assertStringContainsString( 'tab "general"', $message, 'Message should name the tab.' );
+		$this->assertStringContainsString( 'section "default"', $message, 'Empty section should be normalised to "default".' );
+		$this->assertStringContainsString( 'my_field', $message, 'Message should name the first unsupported field id.' );
+		$this->assertStringContainsString( 'custom_type', $message, 'Message should name the first unsupported field type.' );
+		$this->assertStringContainsString( 'other_field', $message, 'Message should name the second unsupported field id.' );
+		$this->assertStringContainsString( 'legacy_alias', $message, 'Message should name the second unsupported field original type.' );
+		$this->assertStringContainsString( 'text', $message, 'Message should name the second unsupported field normalized type.' );
+		$this->assertStringContainsString( 'registerFieldTypeTransformer', $message, 'Message should guide authors towards the transformer API.' );
+		$this->assertStringContainsString( 'woocommerce_react_settings_supported_types', $message, 'Message should mention the supported-types filter.' );
+	}
+
+	/**
+	 * @testdox Should preserve the explicit section id in the message when it is non-empty.
+	 */
+	public function test_message_preserves_non_default_section(): void {
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::warn_legacy_settings_fallback' );
+
+		$this->invoke_warn(
+			'products',
+			'inventory',
+			array(
+				array(
+					'id'              => 'stock_threshold',
+					'type'            => 'mystery',
+					'normalized_type' => 'mystery',
+				),
+			)
+		);
+
+		$messages = $this->captured_messages['WC_Settings_Page::warn_legacy_settings_fallback'] ?? array();
+		$this->assertNotEmpty( $messages, 'Expected at least one captured doing_it_wrong message.' );
+
+		$this->assertStringContainsString( 'tab "products"', $messages[0], 'Message should name the tab.' );
+		$this->assertStringContainsString( 'section "inventory"', $messages[0], 'Message should preserve a non-empty section id verbatim.' );
+	}
+
+	/**
+	 * @testdox Should not raise wc_doing_it_wrong when the unsupported fields list is empty.
+	 */
+	public function test_no_notice_when_no_unsupported_fields(): void {
+		$this->invoke_warn( 'general', '', array() );
+
+		$this->assertArrayNotHasKey(
+			'WC_Settings_Page::warn_legacy_settings_fallback',
+			$this->captured_messages,
+			'No notice should be raised when there are no unsupported fields.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3488.

Replaces the inline `<script>console.log(...)</script>` fallback signal in `WC_Settings_Page` with `wc_doing_it_wrong()` so the nudge surfaces in `debug.log`, Query Monitor, `WP_DEBUG_DISPLAY`, and any `doing_it_wrong` handler. The message lists the specific unsupported field ids and types so plugin authors know exactly what to register.

Marks `V4\Settings\General\Controller::update_item()` `@internal` with a clear warning that the endpoint bypasses `woocommerce_admin_settings_sanitize_option_*` and `pre_update_option_*` filters until filter fidelity is restored. Method renamed `log_legacy_settings_fallback` → `warn_legacy_settings_fallback` to match the new semantics.

The previous inline `console.log` was only visible to developers who open DevTools and invisible to CLI / log-aggregation workflows. `wc_doing_it_wrong()` routes the signal through the standard `_doing_it_wrong` handler and — for AJAX/REST paths — to `error_log()` as a fallback, so debug-log workflows, Query Monitor, and CI assertion helpers all see it.

**Files changed:**
- `includes/admin/settings/class-wc-settings-page.php` — method renamed; `wc_doing_it_wrong()` call; docblock improved.
- `src/Internal/RestApi/Routes/V4/Settings/General/Controller.php` — `@internal` on class + `update_item()` docblock.
- `tests/php/src/Internal/Admin/Settings/SettingsPageFallbackNoticeTest.php` — 4 tests / 18 assertions covering function-name contract, tab/section/field-id/type substrings, default-section normalisation, named-section pass-through, empty-payload no-fire.

### How to test the changes in this Pull Request:

1. Apply this branch and rebuild PHP autoloader entries.
2. Enable `WP_DEBUG` and `WP_DEBUG_LOG` in `wp-config.php`.
3. In a sandbox plugin, subclass `WC_Settings_Page` with `protected $is_modern = true;` and at least one unsupported field type (e.g. `'type' => 'image_width'`). Enable the `modern-settings` flag.
4. Visit your settings tab; expect a `wc_doing_it_wrong` notice in `debug.log` listing the offending field ids and types. Install Query Monitor and verify it appears there too.
5. Confirm the legacy form still renders (fallback path unchanged in behaviour, only the signal mechanism changed).
6. Hit `POST /wp-json/wc/v4/settings/general` and confirm `update_item` still works but the controller class now carries the `@internal` notice in its docblock.

### Testing that has already taken place:

- PHPUnit: `pnpm test:php:env -- --filter SettingsPageFallbackNoticeTest` — 4/4 passing (18 assertions).
- `phpcs-changed` clean.
- PHPStan baseline unchanged.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message

Surface legacy-settings-fallback signal via wc_doing_it_wrong so it appears in debug.log and Query Monitor; mark the v4 REST settings update endpoint as @internal until filter fidelity is restored.

</details>
