### PR TITLE
feat: cover additional native field types in modernised settings SDK

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3487-modern-settings-native-type-coverage
+++ b/plugins/woocommerce/changelog/wooprd-3487-modern-settings-native-type-coverage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Modernised settings SDK: cover password, email, URL, tel, color, date/time family, textarea, searchable page select, and info field types so legacy pages using these types render natively instead of falling back.

--- a/plugins/woocommerce/client/admin/client/settings/field-transformers.tsx
+++ b/plugins/woocommerce/client/admin/client/settings/field-transformers.tsx
@@ -3,6 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
+import {
+	ColorPicker,
+	ComboboxControl,
+	DatePicker,
+	DateTimePicker,
+	TextareaControl,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -35,6 +43,50 @@ type FieldTypeTransformer = (
 type EditComponent = {
 	( props: Record< string, unknown > ): JSX.Element | null;
 	displayName?: string;
+};
+
+type DataFormFieldShape = {
+	id: string;
+	getValue: ( args: { item: Record< string, unknown > } ) => unknown;
+	setValue: ( args: {
+		item: Record< string, unknown >;
+		value: unknown;
+	} ) => Record< string, unknown >;
+};
+
+type DataFormEditProps = {
+	data: Record< string, unknown >;
+	field: DataFormFieldShape;
+	onChange: ( value: Record< string, unknown > ) => void;
+	hideLabelFromVision?: boolean;
+};
+
+const readFieldValue = (
+	data: Record< string, unknown >,
+	field: DataFormFieldShape
+): string => {
+	const raw =
+		typeof field.getValue === 'function'
+			? field.getValue( { item: data } )
+			: data[ field.id ];
+
+	if ( raw === null || raw === undefined ) {
+		return '';
+	}
+
+	return typeof raw === 'string' ? raw : String( raw );
+};
+
+const writeFieldValue = (
+	{ data, field, onChange }: DataFormEditProps,
+	nextValue: string
+): void => {
+	if ( typeof field.setValue === 'function' ) {
+		onChange( field.setValue( { item: data, value: nextValue } ) );
+		return;
+	}
+
+	onChange( { ...data, [ field.id ]: nextValue } );
 };
 
 const coerceString = ( value: unknown ): string | null => {
@@ -365,6 +417,224 @@ export const baseFieldTransformer = (
 						value.every( ( item ) => optionValues.includes( item ) )
 					);
 				},
+			};
+			return applySafeEdit( field );
+		}
+		case 'email': {
+			// DataViews 11.1.0 renders an HTML5 email input natively for `type: 'email'`.
+			const field = {
+				...baseField,
+				type: 'email',
+			};
+			return applySafeEdit( field );
+		}
+		case 'url': {
+			// Reuse the native text input but validate that the value is a URL.
+			const field = {
+				...baseField,
+				type: 'text',
+				isValid: ( value: unknown ) => {
+					if ( typeof value !== 'string' || value === '' ) {
+						return true;
+					}
+
+					if (
+						typeof URL !== 'undefined' &&
+						typeof URL.canParse === 'function'
+					) {
+						return URL.canParse( value );
+					}
+
+					try {
+						// eslint-disable-next-line no-new
+						new URL( value );
+						return true;
+					} catch ( error ) {
+						return false;
+					}
+				},
+			};
+			return applySafeEdit( field );
+		}
+		case 'password': {
+			const PasswordEdit = ( props: DataFormEditProps ) => (
+				<InputControl
+					__next40pxDefaultSize
+					type="password"
+					autoComplete="new-password"
+					label={ baseField.label }
+					hideLabelFromVision={ props.hideLabelFromVision }
+					value={ readFieldValue( props.data, props.field ) }
+					onChange={ ( next?: string ) =>
+						writeFieldValue( props, next ?? '' )
+					}
+				/>
+			);
+			const field = {
+				...baseField,
+				type: 'text',
+				Edit: PasswordEdit,
+			};
+			return applySafeEdit( field );
+		}
+		case 'tel': {
+			const TelEdit = ( props: DataFormEditProps ) => (
+				<InputControl
+					__next40pxDefaultSize
+					type="tel"
+					label={ baseField.label }
+					hideLabelFromVision={ props.hideLabelFromVision }
+					value={ readFieldValue( props.data, props.field ) }
+					onChange={ ( next?: string ) =>
+						writeFieldValue( props, next ?? '' )
+					}
+				/>
+			);
+			const field = {
+				...baseField,
+				type: 'text',
+				Edit: TelEdit,
+			};
+			return applySafeEdit( field );
+		}
+		case 'color': {
+			const ColorEdit = ( props: DataFormEditProps ) => (
+				<ColorPicker
+					enableAlpha={ false }
+					color={ readFieldValue( props.data, props.field ) }
+					onChange={ ( next: string ) =>
+						writeFieldValue( props, next )
+					}
+				/>
+			);
+			const field = {
+				...baseField,
+				type: 'text',
+				Edit: ColorEdit,
+			};
+			return applySafeEdit( field );
+		}
+		case 'date': {
+			const DateEdit = ( props: DataFormEditProps ) => (
+				<DatePicker
+					currentDate={
+						readFieldValue( props.data, props.field ) || null
+					}
+					onChange={ ( next: string ) =>
+						writeFieldValue( props, next )
+					}
+				/>
+			);
+			const field = {
+				...baseField,
+				type: 'text',
+				Edit: DateEdit,
+			};
+			return applySafeEdit( field );
+		}
+		case 'datetime':
+		case 'datetime-local': {
+			const DateTimeEdit = ( props: DataFormEditProps ) => (
+				<DateTimePicker
+					currentDate={
+						readFieldValue( props.data, props.field ) || null
+					}
+					onChange={ ( next: string | null ) =>
+						writeFieldValue( props, next ?? '' )
+					}
+				/>
+			);
+			const field = {
+				...baseField,
+				type: 'text',
+				Edit: DateTimeEdit,
+			};
+			return applySafeEdit( field );
+		}
+		case 'month':
+		case 'week':
+		case 'time': {
+			const inputType = setting.type;
+			const NativeInputEdit = ( props: DataFormEditProps ) => (
+				<input
+					type={ inputType }
+					aria-label={ baseField.label }
+					value={ readFieldValue( props.data, props.field ) }
+					onChange={ ( event ) =>
+						writeFieldValue( props, event.target.value )
+					}
+				/>
+			);
+			const field = {
+				...baseField,
+				type: 'text',
+				Edit: NativeInputEdit,
+			};
+			return applySafeEdit( field );
+		}
+		case 'textarea': {
+			const TextareaEdit = ( props: DataFormEditProps ) => (
+				<TextareaControl
+					__nextHasNoMarginBottom
+					label={ baseField.label }
+					hideLabelFromVision={ props.hideLabelFromVision }
+					value={ readFieldValue( props.data, props.field ) }
+					onChange={ ( next: string ) =>
+						writeFieldValue( props, next )
+					}
+				/>
+			);
+			const field = {
+				...baseField,
+				type: 'text',
+				Edit: TextareaEdit,
+			};
+			return applySafeEdit( field );
+		}
+		case 'single_select_page_with_search': {
+			const elements = parseOptions( setting.options );
+			const comboboxOptions = elements.map( ( option ) => ( {
+				label: option.label,
+				value: option.value,
+			} ) );
+
+			const ComboboxEdit = ( props: DataFormEditProps ) => (
+				<ComboboxControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ baseField.label }
+					hideLabelFromVision={ props.hideLabelFromVision }
+					options={ comboboxOptions }
+					value={ readFieldValue( props.data, props.field ) }
+					onChange={ ( next?: string | null ) =>
+						writeFieldValue( props, next ?? '' )
+					}
+				/>
+			);
+			const field = {
+				...baseField,
+				type: 'text',
+				elements,
+				Edit: ComboboxEdit,
+			};
+			return applySafeEdit( field );
+		}
+		case 'info': {
+			// Description-only row: render the description, no input, no formData mutation.
+			const description = baseField.description;
+			const InfoEdit = () =>
+				description ? (
+					<div className="wc-settings-info-field">
+						{ description }
+					</div>
+				) : null;
+			const field = {
+				...baseField,
+				type: 'text',
+				Edit: InfoEdit,
+				getValue: () => '',
+				setValue: ( { item }: { item: Record< string, unknown > } ) =>
+					item,
 			};
 			return applySafeEdit( field );
 		}

--- a/plugins/woocommerce/client/admin/client/settings/field-transformers.tsx
+++ b/plugins/woocommerce/client/admin/client/settings/field-transformers.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
+	BaseControl,
 	ColorPicker,
 	ComboboxControl,
 	DatePicker,
@@ -499,13 +500,20 @@ export const baseFieldTransformer = (
 		}
 		case 'color': {
 			const ColorEdit = ( props: DataFormEditProps ) => (
-				<ColorPicker
-					enableAlpha={ false }
-					color={ readFieldValue( props.data, props.field ) }
-					onChange={ ( next: string ) =>
-						writeFieldValue( props, next )
-					}
-				/>
+				<BaseControl
+					__nextHasNoMarginBottom
+					id={ baseField.id }
+					label={ baseField.label }
+					hideLabelFromVision={ props.hideLabelFromVision }
+				>
+					<ColorPicker
+						enableAlpha={ false }
+						color={ readFieldValue( props.data, props.field ) }
+						onChange={ ( next: string ) =>
+							writeFieldValue( props, next )
+						}
+					/>
+				</BaseControl>
 			);
 			const field = {
 				...baseField,
@@ -515,16 +523,30 @@ export const baseFieldTransformer = (
 			return applySafeEdit( field );
 		}
 		case 'date': {
-			const DateEdit = ( props: DataFormEditProps ) => (
-				<DatePicker
-					currentDate={
-						readFieldValue( props.data, props.field ) || null
-					}
-					onChange={ ( next: string ) =>
-						writeFieldValue( props, next )
-					}
-				/>
-			);
+			const DateEdit = ( props: DataFormEditProps ) => {
+				const stored = readFieldValue( props.data, props.field );
+				// Guard against unparseable initial values so a single
+				// corrupt option doesn't trigger the form-level ErrorBoundary.
+				const safeDate =
+					stored && ! Number.isNaN( Date.parse( stored ) )
+						? stored
+						: null;
+				return (
+					<BaseControl
+						__nextHasNoMarginBottom
+						id={ baseField.id }
+						label={ baseField.label }
+						hideLabelFromVision={ props.hideLabelFromVision }
+					>
+						<DatePicker
+							currentDate={ safeDate }
+							onChange={ ( next: string ) =>
+								writeFieldValue( props, next )
+							}
+						/>
+					</BaseControl>
+				);
+			};
 			const field = {
 				...baseField,
 				type: 'text',
@@ -534,16 +556,28 @@ export const baseFieldTransformer = (
 		}
 		case 'datetime':
 		case 'datetime-local': {
-			const DateTimeEdit = ( props: DataFormEditProps ) => (
-				<DateTimePicker
-					currentDate={
-						readFieldValue( props.data, props.field ) || null
-					}
-					onChange={ ( next: string | null ) =>
-						writeFieldValue( props, next ?? '' )
-					}
-				/>
-			);
+			const DateTimeEdit = ( props: DataFormEditProps ) => {
+				const stored = readFieldValue( props.data, props.field );
+				const safeDate =
+					stored && ! Number.isNaN( Date.parse( stored ) )
+						? stored
+						: null;
+				return (
+					<BaseControl
+						__nextHasNoMarginBottom
+						id={ baseField.id }
+						label={ baseField.label }
+						hideLabelFromVision={ props.hideLabelFromVision }
+					>
+						<DateTimePicker
+							currentDate={ safeDate }
+							onChange={ ( next: string | null ) =>
+								writeFieldValue( props, next ?? '' )
+							}
+						/>
+					</BaseControl>
+				);
+			};
 			const field = {
 				...baseField,
 				type: 'text',
@@ -556,12 +590,14 @@ export const baseFieldTransformer = (
 		case 'time': {
 			const inputType = setting.type;
 			const NativeInputEdit = ( props: DataFormEditProps ) => (
-				<input
+				<InputControl
+					__next40pxDefaultSize
 					type={ inputType }
-					aria-label={ baseField.label }
+					label={ baseField.label }
+					hideLabelFromVision={ props.hideLabelFromVision }
 					value={ readFieldValue( props.data, props.field ) }
-					onChange={ ( event ) =>
-						writeFieldValue( props, event.target.value )
+					onChange={ ( next?: string ) =>
+						writeFieldValue( props, next ?? '' )
 					}
 				/>
 			);
@@ -593,10 +629,6 @@ export const baseFieldTransformer = (
 		}
 		case 'single_select_page_with_search': {
 			const elements = parseOptions( setting.options );
-			const comboboxOptions = elements.map( ( option ) => ( {
-				label: option.label,
-				value: option.value,
-			} ) );
 
 			const ComboboxEdit = ( props: DataFormEditProps ) => (
 				<ComboboxControl
@@ -604,7 +636,7 @@ export const baseFieldTransformer = (
 					__nextHasNoMarginBottom
 					label={ baseField.label }
 					hideLabelFromVision={ props.hideLabelFromVision }
-					options={ comboboxOptions }
+					options={ elements }
 					value={ readFieldValue( props.data, props.field ) }
 					onChange={ ( next?: string | null ) =>
 						writeFieldValue( props, next ?? '' )
@@ -633,8 +665,12 @@ export const baseFieldTransformer = (
 				type: 'text',
 				Edit: InfoEdit,
 				getValue: () => '',
-				setValue: ( { item }: { item: Record< string, unknown > } ) =>
+				setValue: ( {
 					item,
+				}: {
+					item: Record< string, unknown >;
+					value: unknown;
+				} ) => item,
 			};
 			return applySafeEdit( field );
 		}

--- a/plugins/woocommerce/client/admin/client/settings/test/field-transformers.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings/test/field-transformers.test.tsx
@@ -20,6 +20,11 @@ jest.mock( '@wordpress/components', () => {
 	const TextareaControl = jest.requireActual(
 		'@wordpress/components/build/textarea-control'
 	).default;
+	// Use the real BaseControl so its label/htmlFor wiring is exercised by
+	// `getByLabelText` assertions for the wrapped widget Edits below.
+	const BaseControl = jest.requireActual(
+		'@wordpress/components/build/base-control'
+	).default;
 
 	type StubProps = {
 		value?: string | null;
@@ -85,6 +90,7 @@ jest.mock( '@wordpress/components', () => {
 		// Real components used by passing tests.
 		__experimentalInputControl: InputControl,
 		TextareaControl,
+		BaseControl,
 		// Stubs for components whose interactive behaviour is unreliable in JSDOM.
 		ColorPicker: ColorPickerStub,
 		DatePicker: DatePickerStub,
@@ -371,6 +377,10 @@ describe( 'field transformers', () => {
 			/>
 		);
 
+		// BaseControl renders the label as a heading (no input to associate
+		// with for ColorPicker), so assert via getByText rather than getByLabelText.
+		expect( screen.getByText( 'Brand color' ) ).toBeInTheDocument();
+
 		const stub = screen.getByTestId(
 			'color-picker-stub'
 		) as HTMLInputElement;
@@ -416,7 +426,7 @@ describe( 'field transformers', () => {
 		} );
 	} );
 
-	it( 'renders native input for month/week/time field types', () => {
+	it( 'renders InputControl with associated label for month/week/time field types', () => {
 		const cases: Array< {
 			type: 'month' | 'week' | 'time';
 			initial: string;
@@ -428,9 +438,10 @@ describe( 'field transformers', () => {
 		];
 
 		cases.forEach( ( { type, initial, next } ) => {
+			const label = `${ type } field`;
 			const transformed = baseFieldTransformer( {
 				id: `${ type }_field`,
-				label: `${ type } field`,
+				label,
 				type,
 			} );
 
@@ -439,7 +450,7 @@ describe( 'field transformers', () => {
 			const Edit = transformed.Edit as React.ComponentType< EditProps >;
 			const onChange = jest.fn();
 			const field = buildField( transformed, `${ type }_field` );
-			const { container, unmount } = render(
+			const { unmount } = render(
 				<Edit
 					data={ { [ `${ type }_field` ]: initial } }
 					field={ field }
@@ -447,16 +458,12 @@ describe( 'field transformers', () => {
 				/>
 			);
 
-			const input = container.querySelector(
-				'input'
-			) as HTMLInputElement | null;
-			expect( input ).not.toBeNull();
-			expect( input?.getAttribute( 'type' ) ).toBe( type );
-			expect( input?.value ).toBe( initial );
+			// InputControl wires up the label-to-input htmlFor association.
+			const input = screen.getByLabelText( label ) as HTMLInputElement;
+			expect( input.getAttribute( 'type' ) ).toBe( type );
+			expect( input.value ).toBe( initial );
 
-			if ( input ) {
-				fireEvent.change( input, { target: { value: next } } );
-			}
+			fireEvent.change( input, { target: { value: next } } );
 
 			expect( onChange ).toHaveBeenCalledWith( {
 				[ `${ type }_field` ]: next,
@@ -486,6 +493,9 @@ describe( 'field transformers', () => {
 			/>
 		);
 
+		// The BaseControl wrapper renders a visible label.
+		expect( screen.getByText( 'Date' ) ).toBeInTheDocument();
+
 		const stub = screen.getByTestId(
 			'date-picker-stub'
 		) as HTMLInputElement;
@@ -496,11 +506,41 @@ describe( 'field transformers', () => {
 		expect( onChange ).toHaveBeenCalledWith( { date_field: '2026-05-01' } );
 	} );
 
+	it( 'renders date picker safely when stored value is unparseable', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'date_field',
+			label: 'Date',
+			type: 'date',
+		} );
+
+		const Edit = transformed.Edit as React.ComponentType< EditProps >;
+		const onChange = jest.fn();
+		const field = buildField( transformed, 'date_field' );
+
+		expect( () =>
+			render(
+				<Edit
+					data={ { date_field: 'not-a-date' } }
+					field={ field }
+					onChange={ onChange }
+				/>
+			)
+		).not.toThrow();
+
+		const stub = screen.getByTestId(
+			'date-picker-stub'
+		) as HTMLInputElement;
+		// The guard normalises the unparseable value to an empty string so the
+		// underlying picker doesn't blow up.
+		expect( stub.value ).toBe( '' );
+	} );
+
 	it( 'maps datetime and datetime-local to a DateTimePicker Edit that round-trips values', () => {
 		( [ 'datetime', 'datetime-local' ] as const ).forEach( ( type ) => {
+			const label = `${ type } field`;
 			const transformed = baseFieldTransformer( {
 				id: `${ type }_field`,
-				label: `${ type } field`,
+				label,
 				type,
 			} );
 
@@ -519,6 +559,9 @@ describe( 'field transformers', () => {
 				/>
 			);
 
+			// The BaseControl wrapper renders a visible label.
+			expect( screen.getByText( label ) ).toBeInTheDocument();
+
 			const stub = screen.getByTestId(
 				'date-time-picker-stub'
 			) as HTMLInputElement;
@@ -534,6 +577,33 @@ describe( 'field transformers', () => {
 
 			unmount();
 		} );
+	} );
+
+	it( 'renders datetime picker safely when stored value is unparseable', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'datetime_field',
+			label: 'When',
+			type: 'datetime',
+		} );
+
+		const Edit = transformed.Edit as React.ComponentType< EditProps >;
+		const onChange = jest.fn();
+		const field = buildField( transformed, 'datetime_field' );
+
+		expect( () =>
+			render(
+				<Edit
+					data={ { datetime_field: 'definitely-not-a-date' } }
+					field={ field }
+					onChange={ onChange }
+				/>
+			)
+		).not.toThrow();
+
+		const stub = screen.getByTestId(
+			'date-time-picker-stub'
+		) as HTMLInputElement;
+		expect( stub.value ).toBe( '' );
 	} );
 
 	it( 'renders combobox for single_select_page_with_search and writes selection', () => {

--- a/plugins/woocommerce/client/admin/client/settings/test/field-transformers.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings/test/field-transformers.test.tsx
@@ -1,7 +1,97 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// Mock the @wordpress/components widgets that JSDOM cannot fully exercise.
+// We stub them with deterministic test inputs so we can assert OUR wiring
+// (initial value → render, change → onChange wrapper) without depending on
+// the upstream component's interactive behaviour. We only re-export the
+// specific symbols the transformer actually imports — spreading the real
+// module triggers eager evaluation of unrelated lazy proxies (e.g. v2
+// custom-select internals) and crashes the suite.
+jest.mock( '@wordpress/components', () => {
+	// Pull individual components from their submodules to avoid evaluating
+	// the lazy proxy index which crashes when iterating unrelated exports
+	// in the JSDOM environment.
+	const InputControl = jest.requireActual(
+		'@wordpress/components/build/input-control'
+	).default;
+	const TextareaControl = jest.requireActual(
+		'@wordpress/components/build/textarea-control'
+	).default;
+
+	type StubProps = {
+		value?: string | null;
+		color?: string | null;
+		currentDate?: string | null;
+		onChange?: ( next: string ) => void;
+	};
+
+	const ColorPickerStub = ( props: StubProps ) => (
+		<input
+			data-testid="color-picker-stub"
+			value={ props.color ?? '' }
+			onChange={ ( event ) =>
+				props.onChange && props.onChange( event.target.value )
+			}
+			readOnly={ ! props.onChange }
+		/>
+	);
+
+	const DatePickerStub = ( props: StubProps ) => (
+		<input
+			data-testid="date-picker-stub"
+			value={ props.currentDate ?? '' }
+			onChange={ ( event ) =>
+				props.onChange && props.onChange( event.target.value )
+			}
+			readOnly={ ! props.onChange }
+		/>
+	);
+
+	const DateTimePickerStub = ( props: StubProps ) => (
+		<input
+			data-testid="date-time-picker-stub"
+			value={ props.currentDate ?? '' }
+			onChange={ ( event ) =>
+				props.onChange && props.onChange( event.target.value )
+			}
+			readOnly={ ! props.onChange }
+		/>
+	);
+
+	type ComboboxStubProps = StubProps & {
+		options?: Array< { label: string; value: string } >;
+	};
+
+	const ComboboxControlStub = ( props: ComboboxStubProps ) => (
+		<select
+			data-testid="combobox-stub"
+			value={ props.value ?? '' }
+			onChange={ ( event ) =>
+				props.onChange && props.onChange( event.target.value )
+			}
+		>
+			{ ( props.options ?? [] ).map( ( option ) => (
+				<option key={ option.value } value={ option.value }>
+					{ option.label }
+				</option>
+			) ) }
+		</select>
+	);
+
+	return {
+		// Real components used by passing tests.
+		__experimentalInputControl: InputControl,
+		TextareaControl,
+		// Stubs for components whose interactive behaviour is unreliable in JSDOM.
+		ColorPicker: ColorPickerStub,
+		DatePicker: DatePickerStub,
+		DateTimePicker: DateTimePickerStub,
+		ComboboxControl: ComboboxControlStub,
+	};
+} );
 
 /**
  * Internal dependencies
@@ -14,6 +104,39 @@ import {
 	registerFieldTypeTransformer,
 } from '../field-transformers';
 import type { ReactSettingsField } from '../types';
+
+type EditProps = {
+	data: Record< string, unknown >;
+	field: {
+		id: string;
+		label: string;
+		getValue: ( args: { item: Record< string, unknown > } ) => unknown;
+		setValue: ( args: {
+			item: Record< string, unknown >;
+			value: unknown;
+		} ) => Record< string, unknown >;
+	};
+	onChange: ( value: Record< string, unknown > ) => void;
+};
+
+const buildField = (
+	transformed: Record< string, unknown >,
+	settingId: string
+): EditProps[ 'field' ] => ( {
+	id: settingId,
+	label:
+		typeof transformed.label === 'string'
+			? ( transformed.label as string )
+			: settingId,
+	getValue:
+		typeof transformed.getValue === 'function'
+			? ( transformed.getValue as EditProps[ 'field' ][ 'getValue' ] )
+			: ( { item } ) => item[ settingId ],
+	setValue:
+		typeof transformed.setValue === 'function'
+			? ( transformed.setValue as EditProps[ 'field' ][ 'setValue' ] )
+			: ( { item, value } ) => ( { ...item, [ settingId ]: value } ),
+} );
 
 describe( 'field transformers', () => {
 	it( 'parses options from a record', () => {
@@ -130,5 +253,356 @@ describe( 'field transformers', () => {
 		const { getByText } = render( <Edit /> );
 
 		expect( getByText( 'Custom field' ) ).toBeInTheDocument();
+	} );
+
+	it( 'transforms email fields to native DataForm email type', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'email_field',
+			label: 'Email',
+			type: 'email',
+		} );
+
+		expect( transformed.type ).toBe( 'email' );
+		expect( transformed.Edit ).toBeUndefined();
+	} );
+
+	it( 'validates URL values via isValid on url fields', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'url_field',
+			label: 'URL',
+			type: 'url',
+		} );
+
+		expect( transformed.type ).toBe( 'text' );
+		const isValid = transformed.isValid as ( v: unknown ) => boolean;
+		expect( isValid( '' ) ).toBe( true );
+		expect( isValid( 'https://example.com' ) ).toBe( true );
+		expect( isValid( 'not a url' ) ).toBe( false );
+	} );
+
+	it( 'renders password input and writes back via onChange', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'password_field',
+			label: 'Password',
+			type: 'password',
+		} );
+
+		expect( transformed.type ).toBe( 'text' );
+
+		const Edit = transformed.Edit as React.ComponentType< EditProps >;
+		const onChange = jest.fn();
+		const field = buildField( transformed, 'password_field' );
+		render(
+			<Edit
+				data={ { password_field: 'old-secret' } }
+				field={ field }
+				onChange={ onChange }
+			/>
+		);
+
+		const input = document.querySelector(
+			'input[type="password"]'
+		) as HTMLInputElement | null;
+		expect( input ).not.toBeNull();
+		expect( input?.getAttribute( 'autocomplete' ) ).toBe( 'new-password' );
+		expect( input?.value ).toBe( 'old-secret' );
+
+		if ( input ) {
+			fireEvent.change( input, { target: { value: 'new-secret' } } );
+		}
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			password_field: 'new-secret',
+		} );
+	} );
+
+	it( 'renders telephone input and writes back via onChange', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'phone_field',
+			label: 'Phone',
+			type: 'tel',
+		} );
+
+		expect( transformed.type ).toBe( 'text' );
+
+		const Edit = transformed.Edit as React.ComponentType< EditProps >;
+		const onChange = jest.fn();
+		const field = buildField( transformed, 'phone_field' );
+		render(
+			<Edit
+				data={ { phone_field: '555-1234' } }
+				field={ field }
+				onChange={ onChange }
+			/>
+		);
+
+		const input = document.querySelector(
+			'input[type="tel"]'
+		) as HTMLInputElement | null;
+		expect( input ).not.toBeNull();
+		expect( input?.value ).toBe( '555-1234' );
+
+		if ( input ) {
+			fireEvent.change( input, { target: { value: '555-5555' } } );
+		}
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			phone_field: '555-5555',
+		} );
+	} );
+
+	it( 'renders color picker and writes back via onChange', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'color_field',
+			label: 'Brand color',
+			type: 'color',
+		} );
+
+		expect( transformed.type ).toBe( 'text' );
+
+		const Edit = transformed.Edit as React.ComponentType< EditProps >;
+		const onChange = jest.fn();
+		const field = buildField( transformed, 'color_field' );
+		render(
+			<Edit
+				data={ { color_field: '#ff0000' } }
+				field={ field }
+				onChange={ onChange }
+			/>
+		);
+
+		const stub = screen.getByTestId(
+			'color-picker-stub'
+		) as HTMLInputElement;
+		expect( stub.value ).toBe( '#ff0000' );
+
+		fireEvent.change( stub, { target: { value: '#00ff00' } } );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			color_field: '#00ff00',
+		} );
+	} );
+
+	it( 'renders textarea control and writes back via onChange', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'notes_field',
+			label: 'Notes',
+			type: 'textarea',
+		} );
+
+		expect( transformed.type ).toBe( 'text' );
+
+		const Edit = transformed.Edit as React.ComponentType< EditProps >;
+		const onChange = jest.fn();
+		const field = buildField( transformed, 'notes_field' );
+		render(
+			<Edit
+				data={ { notes_field: 'hello' } }
+				field={ field }
+				onChange={ onChange }
+			/>
+		);
+
+		const textarea = screen.getByLabelText(
+			'Notes'
+		) as HTMLTextAreaElement;
+		expect( textarea.tagName ).toBe( 'TEXTAREA' );
+		expect( textarea.value ).toBe( 'hello' );
+
+		fireEvent.change( textarea, { target: { value: 'updated notes' } } );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			notes_field: 'updated notes',
+		} );
+	} );
+
+	it( 'renders native input for month/week/time field types', () => {
+		const cases: Array< {
+			type: 'month' | 'week' | 'time';
+			initial: string;
+			next: string;
+		} > = [
+			{ type: 'month', initial: '2026-04', next: '2026-05' },
+			{ type: 'week', initial: '2026-W17', next: '2026-W18' },
+			{ type: 'time', initial: '10:30', next: '11:45' },
+		];
+
+		cases.forEach( ( { type, initial, next } ) => {
+			const transformed = baseFieldTransformer( {
+				id: `${ type }_field`,
+				label: `${ type } field`,
+				type,
+			} );
+
+			expect( transformed.type ).toBe( 'text' );
+
+			const Edit = transformed.Edit as React.ComponentType< EditProps >;
+			const onChange = jest.fn();
+			const field = buildField( transformed, `${ type }_field` );
+			const { container, unmount } = render(
+				<Edit
+					data={ { [ `${ type }_field` ]: initial } }
+					field={ field }
+					onChange={ onChange }
+				/>
+			);
+
+			const input = container.querySelector(
+				'input'
+			) as HTMLInputElement | null;
+			expect( input ).not.toBeNull();
+			expect( input?.getAttribute( 'type' ) ).toBe( type );
+			expect( input?.value ).toBe( initial );
+
+			if ( input ) {
+				fireEvent.change( input, { target: { value: next } } );
+			}
+
+			expect( onChange ).toHaveBeenCalledWith( {
+				[ `${ type }_field` ]: next,
+			} );
+
+			unmount();
+		} );
+	} );
+
+	it( 'renders date picker and emits ISO date string on change', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'date_field',
+			label: 'Date',
+			type: 'date',
+		} );
+
+		expect( transformed.type ).toBe( 'text' );
+
+		const Edit = transformed.Edit as React.ComponentType< EditProps >;
+		const onChange = jest.fn();
+		const field = buildField( transformed, 'date_field' );
+		render(
+			<Edit
+				data={ { date_field: '2026-04-21' } }
+				field={ field }
+				onChange={ onChange }
+			/>
+		);
+
+		const stub = screen.getByTestId(
+			'date-picker-stub'
+		) as HTMLInputElement;
+		expect( stub.value ).toBe( '2026-04-21' );
+
+		fireEvent.change( stub, { target: { value: '2026-05-01' } } );
+
+		expect( onChange ).toHaveBeenCalledWith( { date_field: '2026-05-01' } );
+	} );
+
+	it( 'maps datetime and datetime-local to a DateTimePicker Edit that round-trips values', () => {
+		( [ 'datetime', 'datetime-local' ] as const ).forEach( ( type ) => {
+			const transformed = baseFieldTransformer( {
+				id: `${ type }_field`,
+				label: `${ type } field`,
+				type,
+			} );
+
+			expect( transformed.type ).toBe( 'text' );
+
+			const Edit = transformed.Edit as React.ComponentType< EditProps >;
+			const onChange = jest.fn();
+			const field = buildField( transformed, `${ type }_field` );
+			const { unmount } = render(
+				<Edit
+					data={ {
+						[ `${ type }_field` ]: '2026-04-21T10:30:00',
+					} }
+					field={ field }
+					onChange={ onChange }
+				/>
+			);
+
+			const stub = screen.getByTestId(
+				'date-time-picker-stub'
+			) as HTMLInputElement;
+			expect( stub.value ).toBe( '2026-04-21T10:30:00' );
+
+			fireEvent.change( stub, {
+				target: { value: '2026-05-01T12:00:00' },
+			} );
+
+			expect( onChange ).toHaveBeenCalledWith( {
+				[ `${ type }_field` ]: '2026-05-01T12:00:00',
+			} );
+
+			unmount();
+		} );
+	} );
+
+	it( 'renders combobox for single_select_page_with_search and writes selection', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'page_field',
+			label: 'Page',
+			type: 'single_select_page_with_search',
+			options: { '1': 'Home', '2': 'Shop' },
+		} );
+
+		expect( transformed.type ).toBe( 'text' );
+		expect( Array.isArray( transformed.elements ) ).toBe( true );
+		expect( transformed.elements ).toEqual( [
+			{ label: 'Home', value: '1' },
+			{ label: 'Shop', value: '2' },
+		] );
+
+		const Edit = transformed.Edit as React.ComponentType< EditProps >;
+		const onChange = jest.fn();
+		const field = buildField( transformed, 'page_field' );
+		render(
+			<Edit
+				data={ { page_field: '1' } }
+				field={ field }
+				onChange={ onChange }
+			/>
+		);
+
+		const stub = screen.getByTestId( 'combobox-stub' ) as HTMLSelectElement;
+		expect( stub.value ).toBe( '1' );
+		expect( stub.querySelectorAll( 'option' ) ).toHaveLength( 2 );
+
+		fireEvent.change( stub, { target: { value: '2' } } );
+
+		expect( onChange ).toHaveBeenCalledWith( { page_field: '2' } );
+	} );
+
+	it( 'renders info field as a description-only row that does not write to formData', () => {
+		const transformed = baseFieldTransformer( {
+			id: 'info_field',
+			label: 'Heads up',
+			type: 'info',
+			desc: 'Informational text shown to merchants.',
+		} );
+
+		expect( transformed.type ).toBe( 'text' );
+
+		const getValue = transformed.getValue as ( args: {
+			item: Record< string, unknown >;
+		} ) => unknown;
+		expect( getValue( { item: { info_field: 'ignored' } } ) ).toBe( '' );
+
+		const setValue = transformed.setValue as ( args: {
+			item: Record< string, unknown >;
+			value: unknown;
+		} ) => Record< string, unknown >;
+		expect(
+			setValue( { item: { foo: 'bar' }, value: 'anything' } )
+		).toEqual( { foo: 'bar' } );
+
+		const Edit = transformed.Edit as React.ComponentType;
+		const { container, queryByRole } = render( <Edit /> );
+
+		expect( container.textContent ).toContain(
+			'Informational text shown to merchants.'
+		);
+		expect( queryByRole( 'textbox' ) ).toBeNull();
+		expect(
+			container.querySelector( 'input, textarea, select' )
+		).toBeNull();
 	} );
 } );

--- a/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
@@ -45,7 +45,7 @@ class ReactSettingsSchema {
 	 * @since 10.6.0
 	 * @var string[]
 	 */
-	private const OPTION_TYPES = array( 'select', 'multiselect' );
+	private const OPTION_TYPES = array( 'select', 'multiselect', 'single_select_page_with_search' );
 	/**
 	 * Get the payload path for a settings tab/section.
 	 *
@@ -115,7 +115,30 @@ class ReactSettingsSchema {
 	 * @since 10.6.0
 	 */
 	public static function get_supported_types( string $tab, string $section, array $settings_definitions, $settings_page ): array {
-		$default_types = array( 'text', 'number', 'select', 'multiselect', 'checkbox', 'radio', 'toggle' );
+		$default_types = array(
+			'text',
+			'number',
+			'select',
+			'multiselect',
+			'checkbox',
+			'radio',
+			'toggle',
+			// 10.8 SDK additions: native type coverage handled by baseFieldTransformer.
+			'password',
+			'email',
+			'url',
+			'tel',
+			'color',
+			'date',
+			'datetime',
+			'datetime-local',
+			'month',
+			'week',
+			'time',
+			'textarea',
+			'single_select_page_with_search',
+			'info',
+		);
 		/**
 		 * Filter supported React settings field types.
 		 *
@@ -151,11 +174,9 @@ class ReactSettingsSchema {
 	 */
 	public static function get_type_map( string $tab, string $section, array $settings_definitions, $settings_page ): array {
 		$default_map = array(
-			'single_select_country'          => 'select',
-			'multi_select_countries'         => 'multiselect',
-			'single_select_page'             => 'select',
-			'single_select_page_with_search' => 'select',
-			'textarea'                       => 'text',
+			'single_select_country'  => 'select',
+			'multi_select_countries' => 'multiselect',
+			'single_select_page'     => 'select',
 		);
 		/**
 		 * Filter the field type map for React settings.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
@@ -320,6 +320,8 @@ class ReactSettingsSchema {
 				continue;
 			}
 
+			// Opting into the React renderer requires every field (including legacy `info` rows) to declare an
+			// explicit `id`. Array-key-only entries from the legacy renderer are intentionally not coerced.
 			if ( empty( $setting['id'] ) ) {
 				continue;
 			}
@@ -378,11 +380,23 @@ class ReactSettingsSchema {
 		$type_map     = self::get_type_map( $tab, $section, array( $setting ), $settings_page );
 		$field_type   = $type_map[ $setting_type ] ?? $setting_type;
 
+		$desc = $setting['desc'] ?? '';
+
+		// Legacy `info` rows use `setting['text']` as the primary body channel
+		// (see WC_Admin_Settings::output_fields() `case 'info'`). When `desc`
+		// is empty, fall back to `text` so the React `info` Edit has content
+		// to render. Note: the legacy renderer runs `wpautop`/`wp_kses_post`
+		// on this text; the React side renders plain text for now — a Phase 2
+		// channel for HTML payloads is pending.
+		if ( 'info' === $setting_type && '' === $desc ) {
+			$desc = $setting['text'] ?? '';
+		}
+
 		$field = array(
 			'id'    => $setting_id,
 			'label' => $setting['title'] ?? $setting['name'] ?? $setting_id,
 			'type'  => $field_type,
-			'desc'  => $setting['desc'] ?? '',
+			'desc'  => $desc,
 		);
 
 		$options = self::get_field_options( $setting, $field_type );
@@ -431,6 +445,34 @@ class ReactSettingsSchema {
 
 					foreach ( $country_states as $state_code => $state_name ) {
 						$options[ $country_code . ':' . $state_code ] = $country_name . ' — ' . $state_name;
+					}
+				}
+			}
+
+			// Legacy `single_select_page_with_search` consumers (see
+			// class-wc-settings-advanced.php) define no `options` array — they
+			// rely on a server-side AJAX search at the legacy renderer level.
+			// To keep the React combobox honest, synthesise the page list from
+			// `get_pages()` honouring any `args.exclude` value.
+			if ( 'single_select_page_with_search' === $type && function_exists( 'get_pages' ) ) {
+				$query_args = array(
+					'sort_column' => 'menu_order, post_title',
+					'post_status' => 'publish',
+				);
+
+				$exclude = $setting['args']['exclude'] ?? null;
+				if ( is_array( $exclude ) ) {
+					$query_args['exclude'] = array_values( array_filter( array_map( 'absint', $exclude ) ) );
+				}
+
+				$pages = get_pages( $query_args );
+				if ( is_array( $pages ) ) {
+					foreach ( $pages as $page ) {
+						$page_id = (int) $page->ID;
+						if ( $page_id <= 0 ) {
+							continue;
+						}
+						$options[ $page_id ] = html_entity_decode( (string) $page->post_title, ENT_QUOTES, get_bloginfo( 'charset' ) );
 					}
 				}
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/ReactSettingsSchema.php
@@ -123,7 +123,6 @@ class ReactSettingsSchema {
 			'checkbox',
 			'radio',
 			'toggle',
-			// 10.8 SDK additions: native type coverage handled by baseFieldTransformer.
 			'password',
 			'email',
 			'url',

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php
@@ -272,4 +272,205 @@ class ReactSettingsSchemaTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'saved_value', $response['values']['setting_one'] );
 		$this->assertSame( 'saved_value_two', $response['values']['setting_two'] );
 	}
+
+	/**
+	 * @testdox Should pass legacy `info` row `text` content through to the field's `desc` channel.
+	 */
+	public function test_build_response_falls_back_to_info_text_for_desc() {
+		$settings = array(
+			array(
+				'type'  => 'title',
+				'id'    => 'info_group',
+				'title' => 'Info group',
+			),
+			array(
+				'id'    => 'info_field',
+				'type'  => 'info',
+				'title' => 'Heads up',
+				'text'  => 'Hello',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'info_group',
+			),
+		);
+
+		$response = ReactSettingsSchema::build_response( 'general', '', $settings, null );
+
+		$this->assertArrayHasKey( 'info_group', $response['groups'] );
+		$fields = $response['groups']['info_group']['fields'];
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'info_field', $fields[0]['id'] );
+		$this->assertSame( 'Hello', $fields[0]['desc'], "The legacy 'text' channel should be exposed via the field's 'desc'." );
+	}
+
+	/**
+	 * @testdox Should prefer an explicit `desc` over the legacy `text` channel for `info` rows.
+	 */
+	public function test_build_response_prefers_desc_over_info_text() {
+		$settings = array(
+			array(
+				'type' => 'title',
+				'id'   => 'info_group',
+			),
+			array(
+				'id'    => 'info_field',
+				'type'  => 'info',
+				'title' => 'Heads up',
+				'desc'  => 'Primary',
+				'text'  => 'Fallback',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'info_group',
+			),
+		);
+
+		$response = ReactSettingsSchema::build_response( 'general', '', $settings, null );
+
+		$this->assertSame( 'Primary', $response['groups']['info_group']['fields'][0]['desc'] );
+	}
+
+	/**
+	 * @testdox Should synthesise a page list for `single_select_page_with_search` when the consumer omits `options`.
+	 */
+	public function test_build_response_synthesises_pages_for_single_select_page_with_search() {
+		$page_one_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Page One',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$page_two_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Page Two',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$settings = array(
+			array(
+				'type' => 'title',
+				'id'   => 'page_group',
+			),
+			array(
+				'id'    => 'sample_page_field',
+				'type'  => 'single_select_page_with_search',
+				'title' => 'Pick a page',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'page_group',
+			),
+		);
+
+		$response = ReactSettingsSchema::build_response( 'general', '', $settings, null );
+
+		wp_delete_post( $page_one_id, true );
+		wp_delete_post( $page_two_id, true );
+
+		$this->assertArrayHasKey( 'page_group', $response['groups'] );
+		$fields = $response['groups']['page_group']['fields'];
+		$this->assertCount( 1, $fields );
+		$this->assertArrayHasKey( 'options', $fields[0], 'Synthesised options should be emitted to React.' );
+
+		$options = $fields[0]['options'];
+		$this->assertArrayHasKey( (string) $page_one_id, $options );
+		$this->assertArrayHasKey( (string) $page_two_id, $options );
+		$this->assertSame( 'Test Page One', $options[ (string) $page_one_id ] );
+		$this->assertSame( 'Test Page Two', $options[ (string) $page_two_id ] );
+	}
+
+	/**
+	 * @testdox Should preserve consumer-provided `options` for `single_select_page_with_search` instead of synthesising them.
+	 */
+	public function test_build_response_preserves_explicit_options_for_single_select_page_with_search() {
+		// This page would be picked up by the synthesis path; if it appears, we know synthesis ran.
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Should Not Appear',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$settings = array(
+			array(
+				'type' => 'title',
+				'id'   => 'page_group',
+			),
+			array(
+				'id'      => 'sample_page_field',
+				'type'    => 'single_select_page_with_search',
+				'title'   => 'Pick a page',
+				'options' => array(
+					'42' => 'Custom Option A',
+					'99' => 'Custom Option B',
+				),
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'page_group',
+			),
+		);
+
+		$response = ReactSettingsSchema::build_response( 'general', '', $settings, null );
+
+		wp_delete_post( $page_id, true );
+
+		$options = $response['groups']['page_group']['fields'][0]['options'];
+		$this->assertSame( 'Custom Option A', $options['42'] );
+		$this->assertSame( 'Custom Option B', $options['99'] );
+		$this->assertArrayNotHasKey( (string) $page_id, $options, 'Explicit options must not be merged with synthesised pages.' );
+	}
+
+	/**
+	 * @testdox Should honour `args.exclude` when synthesising the page list for `single_select_page_with_search`.
+	 */
+	public function test_build_response_excludes_pages_for_single_select_page_with_search() {
+		$keep_id    = wp_insert_post(
+			array(
+				'post_title'  => 'Keep Me',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$exclude_id = wp_insert_post(
+			array(
+				'post_title'  => 'Exclude Me',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$settings = array(
+			array(
+				'type' => 'title',
+				'id'   => 'page_group',
+			),
+			array(
+				'id'    => 'sample_page_field',
+				'type'  => 'single_select_page_with_search',
+				'title' => 'Pick a page',
+				'args'  => array(
+					'exclude' => array( $exclude_id ),
+				),
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'page_group',
+			),
+		);
+
+		$response = ReactSettingsSchema::build_response( 'general', '', $settings, null );
+
+		wp_delete_post( $keep_id, true );
+		wp_delete_post( $exclude_id, true );
+
+		$options = $response['groups']['page_group']['fields'][0]['options'];
+		$this->assertArrayHasKey( (string) $keep_id, $options );
+		$this->assertArrayNotHasKey( (string) $exclude_id, $options, 'args.exclude entries must be filtered out of the synthesised page list.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ReactSettingsSchemaTest.php
@@ -40,6 +40,47 @@ class ReactSettingsSchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Includes the 10.8 SDK native types in the default supported types list.
+	 *
+	 * @dataProvider provider_sdk_10_8_supported_types
+	 *
+	 * @param string $expected_type Type expected in the defaults.
+	 */
+	public function test_get_supported_types_includes_sdk_10_8_native_types( string $expected_type ) {
+		$types = ReactSettingsSchema::get_supported_types( 'general', '', array(), null );
+
+		$this->assertContains(
+			$expected_type,
+			$types,
+			"Expected '{$expected_type}' to be in the default supported types list."
+		);
+	}
+
+	/**
+	 * Data provider for the 10.8 SDK native type defaults.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provider_sdk_10_8_supported_types(): array {
+		return array(
+			'password'                       => array( 'password' ),
+			'email'                          => array( 'email' ),
+			'url'                            => array( 'url' ),
+			'tel'                            => array( 'tel' ),
+			'color'                          => array( 'color' ),
+			'date'                           => array( 'date' ),
+			'datetime'                       => array( 'datetime' ),
+			'datetime-local'                 => array( 'datetime-local' ),
+			'month'                          => array( 'month' ),
+			'week'                           => array( 'week' ),
+			'time'                           => array( 'time' ),
+			'textarea'                       => array( 'textarea' ),
+			'single_select_page_with_search' => array( 'single_select_page_with_search' ),
+			'info'                           => array( 'info' ),
+		);
+	}
+
+	/**
 	 * @testdox Applies supported types filters.
 	 */
 	public function test_get_supported_types_applies_filter() {
@@ -65,6 +106,45 @@ class ReactSettingsSchemaTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'select', $type_map['single_select_page'] );
 		$this->assertSame( 'multiselect', $type_map['multi_select_countries'] );
+	}
+
+	/**
+	 * @testdox Drops textarea and single_select_page_with_search from the default type map so they reach the JS transformer raw.
+	 */
+	public function test_get_type_map_drops_unmapped_native_types() {
+		$type_map = ReactSettingsSchema::get_type_map( 'general', '', array(), null );
+
+		$this->assertArrayNotHasKey(
+			'textarea',
+			$type_map,
+			'textarea must reach the JS transformer untouched so the custom Edit can render.'
+		);
+		$this->assertArrayNotHasKey(
+			'single_select_page_with_search',
+			$type_map,
+			'single_select_page_with_search must reach the JS transformer untouched so the combobox Edit can render.'
+		);
+	}
+
+	/**
+	 * @testdox Treats every 10.8 SDK native type as renderable.
+	 *
+	 * @dataProvider provider_sdk_10_8_supported_types
+	 *
+	 * @param string $type Setting type to check.
+	 */
+	public function test_has_renderable_fields_returns_true_for_sdk_10_8_native_types( string $type ) {
+		$settings = array(
+			array(
+				'id'   => 'sample_field',
+				'type' => $type,
+			),
+		);
+
+		$this->assertTrue(
+			ReactSettingsSchema::has_renderable_fields( 'general', '', $settings, null ),
+			"Expected '{$type}' to be treated as a renderable field."
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3487.

Adds support for **14 raw WC field types** in the modernised settings renderer: `password`, `email`, `url`, `tel`, `color`, `date`, `datetime`, `datetime-local`, `month`, `week`, `time`, `textarea`, `single_select_page_with_search`, and `info`. Without these in the supported set, any legacy page containing one of them silently falls back to the legacy renderer, which is a poor consumer experience for plugins building modernised settings pages.

**PHP (`ReactSettingsSchema.php`):**
- `get_supported_types()` defaults extended with all 14 new raw types.
- `get_type_map()` defaults trimmed: `textarea` and `single_select_page_with_search` no longer normalise away to `text`/`select`, so the JS layer can render them with custom `Edit` components.
- `OPTION_TYPES` extended with `single_select_page_with_search` so PHP keeps emitting the field's `options` payload to React.
- `transform_setting_to_field()`: `info` rows fall back from `setting['desc']` to `setting['text']` (legacy WC convention).
- `get_field_options()`: when `single_select_page_with_search` ships no `options`, synthesise the page list server-side via `get_pages()`, honouring `setting['args']['exclude']`.
- Inline note documenting that `info` rows must declare an explicit `id` to opt into the React renderer.

**JS (`field-transformers.tsx`):**
- 11 new cases in `baseFieldTransformer` covering the new types.
- Custom `Edit` components built on `@wordpress/components` widgets (`InputControl`, `ColorPicker`, `DatePicker`, `DateTimePicker`, `TextareaControl`, `ComboboxControl`); `email` uses native DataForm `type: 'email'`; `url` uses `type: 'text'` with an `isValid` URL check.
- Every custom Edit goes through the existing `applySafeEdit` ErrorBoundary helper.
- `color`, `date`, `datetime`, `datetime-local` Edits wrap their picker in `<BaseControl label hideLabelFromVision id>` so screen readers get an accessible name (the underlying widgets accept no label prop).
- `month`, `week`, `time` Edits use `<InputControl label hideLabelFromVision type=...>`.
- `date` / `datetime` Edits guard against unparseable stored values (`Number.isNaN(Date.parse(...))`) so a single corrupt option no longer trips the form ErrorBoundary.
- `info` renders the description in a non-interactive row; `getValue`/`setValue` are no-ops so the field never writes to formData.

**Notes for reviewers:**
- **`info` HTML formatting divergence:** the legacy renderer wraps body text in `wpautop`/`wp_kses_post`. React renders plain text for now — HTML support is deferred until a sanitised HTML payload channel is added.
- **`info` rows without `id` are dropped** by `build_response`. Real legacy consumers (e.g. `Internal\Admin\Logging\Settings`) use array keys without an explicit `id` field — opting those rows into the React renderer requires adding an `id`. Documented inline.

### How to test the changes in this Pull Request:

1. Apply this branch and rebuild PHP autoloader entries + the admin bundle (`pnpm --filter=@woocommerce/admin-library build:project:bundle`).
2. In a sandbox plugin, wire a `WC_Settings_Page` subclass to `$is_modern = true` with one section per new field type (e.g. one `password`, one `email`, one `color`, one `datetime`, one `info`, one `single_select_page_with_search` with no `options`).
3. With the `modern-settings` flag on, visit the tab. Expect the React renderer to mount and every new field to render with its appropriate widget — no fallback to legacy.
4. For `single_select_page_with_search` without `options`, expect the page list to be auto-populated from `get_pages()`. Add `'args' => array('exclude' => array($id_to_skip))` and confirm the excluded page is omitted.
5. For `info`, set `'text' => 'Hello world'` (no `desc`) and confirm the body text renders. Confirm the field doesn't appear in `formData` after a save round-trip.
6. For `date`/`datetime`, set the stored option to a non-ISO string via `update_option()` and confirm the picker renders empty rather than tripping the ErrorBoundary.
7. Confirm legacy fallback still works for unsupported types (e.g. `'type' => 'image_width'`) by adding one such field and checking the entire section drops to the legacy form.

### Testing that has already taken place:

- Jest: `pnpm run test:js -- field-transformers.test.tsx` — 20/20 pass.
- PHPUnit: `pnpm test:php:env -- --filter ReactSettingsSchemaTest` — 42/42 pass.
- `pnpm run ts:check` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- PHPStan against `ReactSettingsSchema.php` — no baseline growth.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Modernised settings SDK: cover password, email, URL, tel, color, date/time family, textarea, searchable page select, and info field types so legacy pages using these types render natively instead of falling back.

</details>
