### PR TITLE
test: lock flag-off zero-change guarantee for modernised settings SDK

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3489-flag-off-audit-test
+++ b/plugins/woocommerce/changelog/wooprd-3489-flag-off-audit-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Modernised settings SDK: lock the "flag off = zero change" guarantee with PHP unit + Playwright coverage.

--- a/plugins/woocommerce/tests/e2e-pw/tests/settings/modern-settings-flag-off.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/settings/modern-settings-flag-off.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { expect, test, tags } from '../../fixtures/fixtures';
+import { ADMIN_STATE_PATH } from '../../playwright.config';
+
+/**
+ * Locks the "modern-settings flag off = zero change" guarantee for the modernised
+ * settings SDK.
+ *
+ * The `modern-settings` feature flag is disabled by default in the e2e
+ * environment (see plugins/woocommerce/includes/react-admin/feature-config.php),
+ * so no extra setup is needed for the flag-off state. These tests fail loudly
+ * if any code path mounts the React renderer un-gated from the flag, or breaks
+ * the legacy save form.
+ */
+test.describe(
+	'Modernised Settings SDK > flag off',
+	{ tag: tags.SERVICES },
+	() => {
+		test.use( { storageState: ADMIN_STATE_PATH } );
+
+		const ORIGINAL_POSTCODE = '94107';
+		const NEW_POSTCODE = '94016';
+
+		test.afterAll( async ( { restApi } ) => {
+			await restApi.put(
+				`${ WC_API_PATH }/settings/general/woocommerce_store_postcode`,
+				{
+					value: ORIGINAL_POSTCODE,
+				}
+			);
+		} );
+
+		test( 'WooCommerce General settings does not render the modern React mount div when modern-settings flag is off', async ( {
+			page,
+		} ) => {
+			await page.goto(
+				'wp-admin/admin.php?page=wc-settings&tab=general'
+			);
+
+			// The General tab should be active and rendering the legacy form.
+			await expect( page.locator( 'a.nav-tab-active' ) ).toContainText(
+				'General'
+			);
+
+			// Zero React mount nodes should be present anywhere in the page.
+			await expect(
+				page.locator( '[data-wc-modern-settings]' )
+			).toHaveCount( 0 );
+
+			// The legacy form should still be rendered (sanity: at least one
+			// known general-settings input must be present).
+			await expect(
+				page.locator( '#woocommerce_store_postcode' )
+			).toBeVisible();
+		} );
+
+		test( 'WooCommerce General settings still saves changes via the legacy form when flag is off', async ( {
+			page,
+			restApi,
+		} ) => {
+			// Reset to the known baseline before mutating, so the test is
+			// independent of state left by earlier runs.
+			await restApi.put(
+				`${ WC_API_PATH }/settings/general/woocommerce_store_postcode`,
+				{
+					value: ORIGINAL_POSTCODE,
+				}
+			);
+
+			await page.goto(
+				'wp-admin/admin.php?page=wc-settings&tab=general'
+			);
+
+			await page
+				.locator( '#woocommerce_store_postcode' )
+				.fill( NEW_POSTCODE );
+
+			await page.getByRole( 'button', { name: 'Save changes' } ).click();
+
+			await expect( page.locator( 'div.updated.inline' ) ).toContainText(
+				'Your settings have been saved.'
+			);
+
+			// The new value should be persisted across a reload.
+			await page.reload();
+			await expect(
+				page.locator( '#woocommerce_store_postcode' )
+			).toHaveValue( NEW_POSTCODE );
+		} );
+	}
+);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ModernSettingsFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ModernSettingsFeatureFlagTest.php
@@ -1,0 +1,278 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings;
+
+use Automattic\WooCommerce\Internal\Admin\Settings;
+use ReflectionMethod;
+use WC_Settings_Page;
+use WC_Unit_Test_Case;
+
+/**
+ * Locks the "modern-settings flag off = zero change" guarantee for the modernised
+ * settings SDK. These tests are intentionally paired (no-op + teeth) so that
+ * removing the flag check at either site fails the suite.
+ */
+class ModernSettingsFeatureFlagTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Settings page id used by the anonymous modern test page.
+	 */
+	private const TEST_PAGE_ID = 'wcprd_3489_test';
+
+	/**
+	 * Snapshot of $_GET so we can restore it in tearDown.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_get = array();
+
+	/**
+	 * Snapshot of $GLOBALS['hide_save_button'] so we can restore it in tearDown.
+	 *
+	 * @var mixed
+	 */
+	private $original_hide_save_button;
+
+	/**
+	 * Whether $GLOBALS['hide_save_button'] existed before the test ran.
+	 *
+	 * @var bool
+	 */
+	private $hide_save_button_existed = false;
+
+	/**
+	 * Filter callback used to enable the modern-settings feature.
+	 *
+	 * Stored on the instance so we can remove the exact same callable in tearDown.
+	 *
+	 * @var callable|null
+	 */
+	private $enable_filter;
+
+	/**
+	 * Filter callback used to disable the modern-settings feature.
+	 *
+	 * @var callable|null
+	 */
+	private $disable_filter;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Test setup mutates $_GET to simulate the WooCommerce settings page; no form submission involved.
+		$this->original_get              = $_GET;
+		$this->hide_save_button_existed  = array_key_exists( 'hide_save_button', $GLOBALS );
+		$this->original_hide_save_button = $this->hide_save_button_existed
+			? $GLOBALS['hide_save_button']
+			: null;
+
+		// Simulate being on the WooCommerce settings page so that
+		// PageController::is_settings_page() returns true.
+		$_GET['page'] = 'wc-settings';
+		$_GET['tab']  = 'general';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		$this->enable_filter = function ( $features ) {
+			return array_values( array_unique( array_merge( (array) $features, array( 'modern-settings' ) ) ) );
+		};
+
+		$this->disable_filter = function ( $features ) {
+			return array_values( array_diff( (array) $features, array( 'modern-settings' ) ) );
+		};
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		if ( null !== $this->enable_filter ) {
+			remove_filter( 'woocommerce_admin_features', $this->enable_filter );
+		}
+		if ( null !== $this->disable_filter ) {
+			remove_filter( 'woocommerce_admin_features', $this->disable_filter );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restoring $_GET that we mutated in setUp.
+		$_GET = $this->original_get;
+
+		if ( $this->hide_save_button_existed ) {
+			$GLOBALS['hide_save_button'] = $this->original_hide_save_button;
+		} else {
+			unset( $GLOBALS['hide_save_button'] );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Settings::add_react_settings_data is a no-op when the modern-settings flag is disabled.
+	 */
+	public function test_add_react_settings_data_is_noop_when_flag_disabled(): void {
+		add_filter( 'woocommerce_admin_features', $this->disable_filter );
+
+		$input  = array( 'existing' => 'value' );
+		$result = $this->invoke_add_react_settings_data( $input );
+
+		$this->assertSame(
+			$input,
+			$result,
+			'With modern-settings disabled, add_react_settings_data() must not modify the settings array.'
+		);
+		$this->assertArrayNotHasKey(
+			'settings',
+			$result,
+			'With modern-settings disabled, no nested settings payload should be written.'
+		);
+	}
+
+	/**
+	 * @testdox Settings::add_react_settings_data writes the React payload when the modern-settings flag is enabled.
+	 */
+	public function test_add_react_settings_data_writes_payload_when_flag_enabled(): void {
+		add_filter( 'woocommerce_admin_features', $this->enable_filter );
+
+		$input  = array( 'existing' => 'value' );
+		$result = $this->invoke_add_react_settings_data( $input );
+
+		$this->assertSame(
+			'value',
+			$result['existing'] ?? null,
+			'Pre-existing keys should be preserved on the settings array.'
+		);
+		$this->assertArrayHasKey( 'settings', $result, 'A "settings" payload key should be written when the flag is enabled.' );
+		$this->assertArrayHasKey( 'general', $result['settings'], 'The current tab payload should be written.' );
+		$this->assertArrayHasKey( 'default', $result['settings']['general'], 'The default section payload should be written.' );
+
+		$payload = $result['settings']['general']['default'];
+		$this->assertArrayHasKey( 'id', $payload );
+		$this->assertArrayHasKey( 'title', $payload );
+		$this->assertArrayHasKey( 'groups', $payload );
+		$this->assertArrayHasKey( 'values', $payload );
+		$this->assertSame( 'general', $payload['id'], 'Payload id should reflect the current tab.' );
+	}
+
+	/**
+	 * @testdox WC_Settings_Page::output omits the React mount div when the modern-settings flag is disabled.
+	 */
+	public function test_settings_page_output_omits_react_mount_div_when_flag_disabled(): void {
+		add_filter( 'woocommerce_admin_features', $this->disable_filter );
+
+		$page = $this->create_modern_settings_page();
+
+		ob_start();
+		$page->output();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'data-wc-modern-settings',
+			$html,
+			'With modern-settings disabled, the React mount div must NOT be emitted, even on a page where $is_modern is true.'
+		);
+		$this->assertStringNotContainsString(
+			'data-wc-settings-tab',
+			$html,
+			'No React mount markers should leak into the legacy form output.'
+		);
+	}
+
+	/**
+	 * @testdox WC_Settings_Page::output emits the React mount div when the modern-settings flag is enabled.
+	 */
+	public function test_settings_page_output_emits_react_mount_div_when_flag_enabled(): void {
+		add_filter( 'woocommerce_admin_features', $this->enable_filter );
+
+		$page = $this->create_modern_settings_page();
+
+		ob_start();
+		$page->output();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringContainsString(
+			'data-wc-modern-settings="1"',
+			$html,
+			'With modern-settings enabled and an opted-in page, the React mount div must be emitted (teeth).'
+		);
+		$this->assertStringContainsString(
+			'data-wc-settings-tab="' . self::TEST_PAGE_ID . '"',
+			$html,
+			'The mount div must carry the tab id attribute.'
+		);
+		$this->assertStringContainsString(
+			'data-wc-settings-section=""',
+			$html,
+			'The mount div must carry the (default, empty) section attribute.'
+		);
+	}
+
+	/**
+	 * Invoke Settings::add_react_settings_data() via reflection.
+	 *
+	 * The method is private, so we bypass visibility rather than driving it through
+	 * the public filter callback (which has many incidental side effects).
+	 *
+	 * @param array<string, mixed> $settings Input settings array.
+	 * @return array<string, mixed>
+	 */
+	private function invoke_add_react_settings_data( array $settings ): array {
+		$instance = new Settings();
+		$method   = new ReflectionMethod( Settings::class, 'add_react_settings_data' );
+		$method->setAccessible( true );
+
+		/** @var array<string, mixed> $result */
+		$result = $method->invoke( $instance, $settings );
+		return $result;
+	}
+
+	/**
+	 * Build an anonymous WC_Settings_Page subclass that opts in to the modern
+	 * React renderer and exposes one supported (text) field.
+	 *
+	 * @return WC_Settings_Page
+	 */
+	private function create_modern_settings_page(): WC_Settings_Page {
+		$page_id = self::TEST_PAGE_ID;
+
+		return new class( $page_id ) extends WC_Settings_Page {
+			/**
+			 * Constructor — declare an opted-in modern page with one supported field.
+			 *
+			 * @param string $page_id Settings page id.
+			 */
+			public function __construct( string $page_id ) {
+				$this->id        = $page_id;
+				$this->label     = 'Modern Settings Flag Test';
+				$this->is_modern = true;
+				// Intentionally skip parent::__construct() — we don't want to register
+				// hooks for this throw-away page in the unit-test process.
+			}
+
+			/**
+			 * Provide one supported field so the React branch can render.
+			 *
+			 * @return array<int, array<string, mixed>>
+			 */
+			public function get_settings_for_default_section() {
+				return array(
+					array(
+						'type' => 'title',
+						'id'   => 'wcprd_3489_group',
+					),
+					array(
+						'id'      => 'wcprd_3489_setting',
+						'type'    => 'text',
+						'title'   => 'Field',
+						'default' => '',
+					),
+					array(
+						'type' => 'sectionend',
+						'id'   => 'wcprd_3489_group',
+					),
+				);
+			}
+		};
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ModernSettingsFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/ModernSettingsFeatureFlagTest.php
@@ -170,7 +170,7 @@ class ModernSettingsFeatureFlagTest extends WC_Unit_Test_Case {
 		$this->assertStringNotContainsString(
 			'data-wc-modern-settings',
 			$html,
-			'With modern-settings disabled, the React mount div must NOT be emitted, even on a page where $is_modern is true.'
+			'With modern-settings disabled, the React mount div must NOT be emitted on any settings page.'
 		);
 		$this->assertStringNotContainsString(
 			'data-wc-settings-tab',
@@ -194,7 +194,7 @@ class ModernSettingsFeatureFlagTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString(
 			'data-wc-modern-settings="1"',
 			$html,
-			'With modern-settings enabled and an opted-in page, the React mount div must be emitted (teeth).'
+			'With modern-settings enabled and a page exposing supported field types, the React mount div must be emitted (teeth).'
 		);
 		$this->assertStringContainsString(
 			'data-wc-settings-tab="' . self::TEST_PAGE_ID . '"',
@@ -228,8 +228,9 @@ class ModernSettingsFeatureFlagTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Build an anonymous WC_Settings_Page subclass that opts in to the modern
-	 * React renderer and exposes one supported (text) field.
+	 * Build an anonymous WC_Settings_Page subclass exposing one supported (text)
+	 * field — sufficient to make the React renderer fire when the modern-settings
+	 * flag is on (and stay silent when it isn't).
 	 *
 	 * @return WC_Settings_Page
 	 */
@@ -238,14 +239,13 @@ class ModernSettingsFeatureFlagTest extends WC_Unit_Test_Case {
 
 		return new class( $page_id ) extends WC_Settings_Page {
 			/**
-			 * Constructor — declare an opted-in modern page with one supported field.
+			 * Constructor — declare a page with one supported field.
 			 *
 			 * @param string $page_id Settings page id.
 			 */
 			public function __construct( string $page_id ) {
-				$this->id        = $page_id;
-				$this->label     = 'Modern Settings Flag Test';
-				$this->is_modern = true;
+				$this->id    = $page_id;
+				$this->label = 'Modern Settings Flag Test';
 				// Intentionally skip parent::__construct() — we don't want to register
 				// hooks for this throw-away page in the unit-test process.
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3489.

Locks the **"`modern-settings` flag off = zero change"** guarantee in CI with paired PHP unit tests (no-op + teeth at both gate sites) and a Playwright smoke test. Tests-only PR. No production code modified.

The modernised settings renderer is gated in two places: `Settings::add_react_settings_data()` decides whether to inject the React payload into `wcSettings`, and `WC_Settings_Page::output()` decides whether to emit the `[data-wc-modern-settings]` mount div in place of the legacy form. Both gates rely on a single `Features::is_enabled('modern-settings')` check; nothing in CI proves they stay that way. An accidental refactor — e.g. a pre-flight call to `ReactSettingsSchema::build_response()` outside the conditional — would leak the React payload to every store that has the flag off.

**PHP unit (`ModernSettingsFeatureFlagTest`):** four paired tests.
1. `add_react_settings_data` is a no-op when the flag is disabled (input array unchanged, no `settings` top-level key written).
2. `add_react_settings_data` writes the React payload at `settings.{tab}.{section}` when the flag is enabled — **teeth** assertion that proves the no-op test isn't vacuous.
3. `WC_Settings_Page::output()` does NOT emit `[data-wc-modern-settings]` when the flag is disabled, even on a page where `$is_modern = true`.
4. `WC_Settings_Page::output()` DOES emit the mount div with correct `data-wc-settings-tab` / `data-wc-settings-section` attributes when the flag is enabled — **teeth**.

The private `add_react_settings_data` is reached via `ReflectionMethod` to isolate it from `add_component_settings()`'s many incidental side effects. The flag is toggled via the `woocommerce_admin_features` filter (matching the pattern from `ScheduledUpdatesPromotionTest`). Global state (`$_GET`, `$GLOBALS['hide_save_button']`, filter callbacks) is snapshotted in `setUp` and restored in `tearDown`.

**Playwright (`modern-settings-flag-off.spec.ts`):** two tests.
1. Loading `wp-admin/admin.php?page=wc-settings&tab=general` produces zero `[data-wc-modern-settings]` nodes.
2. Submitting the legacy save form still persists changes (postcode round-trip), proving no regression in the legacy path.

`afterAll` restores `woocommerce_store_postcode` to the existing baseline (`94107`, matching `settings-general.spec.ts`) via the WC REST API.

**Notes for reviewers:**
- The `modern-settings` flag is **off by default** in `feature-config.php`, so the Playwright flag-off premise holds without any extra setup.
- The PHP teeth tests rely on the real `WC_Settings_General` page being instantiable for the `add_react_settings_data` test. If a future change makes the General tab emit an unsupported field type, that teeth test would fail with a less-clear message — flagging as known implicit coupling. The `output()` teeth test uses an anonymous `WC_Settings_Page` subclass and is not exposed to that risk.

### How to test the changes in this Pull Request:

1. Apply this branch.
2. Run the new PHP test class: `pnpm test:php:env -- --filter ModernSettingsFeatureFlagTest`. Expect 4/4 pass.
3. Verify the spec is picked up by Playwright: `cd plugins/woocommerce/tests/e2e-pw && npx playwright test --list tests/settings/modern-settings-flag-off.spec.ts`. Expect both tests listed under the `[e2e]` project.
4. Run the spec end-to-end in CI or a local e2e env to confirm the legacy save round-trip works.
5. **Verify the teeth tests have teeth:** locally remove the `Features::is_enabled('modern-settings')` check at `Settings.php` line 280 (return as if flag were always on) and re-run the PHP test class. Expect tests 1 and 3 to fail. Restore the gate. Then remove the check at `class-wc-settings-page.php` line 512 and re-run. Expect tests 3 and 4 to fail. (Don't commit the removals.)

### Testing that has already taken place:

- PHPUnit: `pnpm test:php:env -- --filter ModernSettingsFeatureFlagTest` — **OK (4 tests, 16 assertions)**.
- Playwright: `npx playwright test --list tests/settings/modern-settings-flag-off.spec.ts` — both tests listed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- ESLint on the new spec — clean.
- No production code modified (verified with `git diff --stat`).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Modernised settings SDK: lock the "flag off = zero change" guarantee with PHP unit + Playwright coverage.

</details>
