### PR TITLE
docs: add modernised settings SDK developer guide and example plugin

### DIFF
--- a/docs/extensions/settings-and-config/modernised-settings-sdk.md
+++ b/docs/extensions/settings-and-config/modernised-settings-sdk.md
@@ -64,7 +64,7 @@ class My_Plugin_Settings_Tab extends WC_Settings_Page {
         parent::__construct();
     }
 
-    public function get_settings_for_default_section() {
+    protected function get_settings_for_default_section(): array {
         return array(
             array(
                 'title' => __( 'My Plugin settings', 'my-plugin' ),
@@ -264,7 +264,12 @@ The renderer falls back to the legacy `WC_Admin_Settings::output_fields()` path 
 3. `ReactSettingsSchema::get_unsupported_fields()` returns at least one entry.
 4. `ReactSettingsSchema::has_renderable_fields()` returns `false` (e.g. the section only contains `title`/`sectionend` markers).
 
-When the fallback is triggered by an unsupported field type — i.e. the page would otherwise have rendered via React but for a single offending field — a `wc_doing_it_wrong` notice is logged. In the browser console you will see a message identifying the tab, section, and the offending field ids and types. This is intended as a developer signal, not a user-facing warning, and only fires when `WP_DEBUG` is enabled.
+When the fallback is triggered by an unsupported field type — i.e. the page would otherwise have rendered via React but for a single offending field — two developer signals fire:
+
+1. A browser-console message identifying the tab, section, and the offending field ids and types. This always fires when the fallback runs and is intended as the primary developer signal.
+2. A server-side `wc_doing_it_wrong` notice naming the same fields. As with all `wc_doing_it_wrong` calls, this is gated by `WP_DEBUG` and surfaces in the PHP error log when enabled.
+
+Both signals are intended for developers, not end users. They do not surface anywhere a merchant would see them.
 
 ## Migration walkthrough
 
@@ -273,7 +278,7 @@ You have an existing `WC_Settings_Page` subclass. Here is how to adopt the moder
 1. **Audit your field types.** Compare the `type` keys in your `get_settings_for_*_section()` arrays against the supported list and the default type map. Anything outside both will trigger a fallback.
 2. **Set `$is_modern = true`** on your subclass. This is a no-op as long as the `modern-settings` flag is off, so it is safe to ship.
 3. **Enable the `modern-settings` flag** in your dev environment (see [Enabling the feature flag for development](#enabling-the-feature-flag-for-development)).
-4. **Visit your settings tab in `wp-admin`.** If a fallback fires, the browser console will print a `wc_doing_it_wrong` notice naming the field types that caused it.
+4. **Visit your settings tab in `wp-admin`.** If a fallback fires, the browser console will print a message naming the offending field types (with a matching `wc_doing_it_wrong` notice in the PHP error log when `WP_DEBUG` is on).
 5. **Resolve unsupported types.** You have three options:
     - Change the field's raw `type` to one already in the supported list.
     - Map your raw type to a primitive via the `woocommerce_react_settings_type_map` filter.

--- a/docs/extensions/settings-and-config/modernised-settings-sdk.md
+++ b/docs/extensions/settings-and-config/modernised-settings-sdk.md
@@ -13,9 +13,9 @@ This guide covers everything an extension author needs to opt a settings page in
 ## Status in 10.8
 
 - The SDK is **experimental** and ships behind the `modern-settings` feature flag, which is **off by default**.
-- No Core settings page is opted in to the modern path in 10.8. The flag is intentionally a tool for extensions and integrators to experiment with against their own pages.
+- The flag is intentionally a tool for extensions and integrators to experiment with against their own pages while the SDK matures.
 - The legacy save POST handler still runs for every settings page, regardless of the flag. Saves continue to flow through `WC_Admin_Settings::save_fields()` and the existing `woocommerce_update_options_*` hooks. The only thing the modern path replaces in 10.8 is the **render** of the form.
-- With the flag off, no behaviour changes anywhere — even on pages that have already set `$is_modern = true`.
+- With the flag off, no behaviour changes anywhere.
 
 ## Enabling the feature flag for development
 
@@ -44,20 +44,21 @@ add_filter(
 
 This is useful in CI or when scripting a wp-env environment.
 
-## Opting a settings page in (`$is_modern`)
+## When the modern path runs
 
-A `WC_Settings_Page` subclass opts in to the modern path by setting the `$is_modern` property to `true`:
+There is **no per-page opt-in flag** on `WC_Settings_Page` for this SDK. When the `modern-settings` feature flag is on, every section of every `WC_Settings_Page` subclass is a candidate for the modern renderer. Whether it actually renders modern is determined by three checks at render time:
+
+1. The `modern-settings` feature flag is enabled.
+2. None of the section's fields use a raw `type` outside the supported set (and not in the default type map). If any unsupported field is present, the entire section falls back to the legacy renderer. See [Native field type coverage](#native-field-type-coverage) and [Fallback signals](#fallback-signals).
+3. The `woocommerce_react_settings_opt_out` filter has not vetoed the section. Use this filter when you want to keep a specific tab/section on the legacy renderer even though it would otherwise qualify.
+
+A minimal `WC_Settings_Page` subclass that the modern renderer will pick up when the flag is on:
 
 ```php
 <?php
 defined( 'ABSPATH' ) || exit;
 
 class My_Plugin_Settings_Tab extends WC_Settings_Page {
-    /**
-     * @var bool
-     */
-    protected $is_modern = true;
-
     public function __construct() {
         $this->id    = 'my_plugin';
         $this->label = __( 'My Plugin', 'my-plugin' );
@@ -86,12 +87,25 @@ class My_Plugin_Settings_Tab extends WC_Settings_Page {
 }
 ```
 
-Two independent things happen when `$is_modern` is `true`:
-
-1. The full React **settings shell** (rolled out behind the separate `settings` feature flag) treats the tab as a first-class React surface rather than embedding the legacy form.
-2. The per-page **render path** in `WC_Settings_Page::output()` checks the `modern-settings` flag and, if it is on, attempts to mount the React renderer instead of calling `WC_Admin_Settings::output_fields()`.
-
 You do not need to change the `save_*` methods on your subclass. The existing `woocommerce_settings_save_{tab}` action still fires and the legacy save handler is authoritative in 10.8.
+
+### Vetoing the modern renderer for a specific section
+
+If you have a tab whose fields are all supported but you still want to keep it on the legacy renderer (for example because you have CSS or JS coupled to legacy DOM), hook the opt-out filter:
+
+```php
+add_filter(
+    'woocommerce_react_settings_opt_out',
+    static function ( bool $opt_out, string $tab, string $section ): bool {
+        if ( 'my_plugin' === $tab ) {
+            return true;
+        }
+        return $opt_out;
+    },
+    10,
+    3
+);
+```
 
 ## Public PHP API
 
@@ -276,14 +290,14 @@ Both signals are intended for developers, not end users. They do not surface any
 You have an existing `WC_Settings_Page` subclass. Here is how to adopt the modern path.
 
 1. **Audit your field types.** Compare the `type` keys in your `get_settings_for_*_section()` arrays against the supported list and the default type map. Anything outside both will trigger a fallback.
-2. **Set `$is_modern = true`** on your subclass. This is a no-op as long as the `modern-settings` flag is off, so it is safe to ship.
-3. **Enable the `modern-settings` flag** in your dev environment (see [Enabling the feature flag for development](#enabling-the-feature-flag-for-development)).
-4. **Visit your settings tab in `wp-admin`.** If a fallback fires, the browser console will print a message naming the offending field types (with a matching `wc_doing_it_wrong` notice in the PHP error log when `WP_DEBUG` is on).
-5. **Resolve unsupported types.** You have three options:
+2. **Enable the `modern-settings` flag** in your dev environment (see [Enabling the feature flag for development](#enabling-the-feature-flag-for-development)).
+3. **Visit your settings tab in `wp-admin`.** If a fallback fires, the browser console will print a message naming the offending field types (with a matching `wc_doing_it_wrong` notice in the PHP error log when `WP_DEBUG` is on).
+4. **Resolve unsupported types.** You have three options:
     - Change the field's raw `type` to one already in the supported list.
     - Map your raw type to a primitive via the `woocommerce_react_settings_type_map` filter.
     - Register a custom field type via the JS extension point. See [Registering custom field types](./registering-custom-field-types.md).
-6. **Smoke-test the save path.** The legacy save POST handler is still authoritative in 10.8, so saving should behave identically. Confirm the values you submit round-trip through `WC_Admin_Settings::get_option()`.
+5. **Smoke-test the save path.** The legacy save POST handler is still authoritative in 10.8, so saving should behave identically. Confirm the values you submit round-trip through `WC_Admin_Settings::get_option()`.
+6. **(Optional) Veto specific sections.** If you have a tab whose fields are all supported but you do not want it on the modern renderer yet — for example because of CSS or JS coupled to legacy DOM — hook `woocommerce_react_settings_opt_out` and return `true` for that tab/section.
 
 ## Flag-off zero-change guarantee
 
@@ -292,13 +306,12 @@ When the `modern-settings` flag is off, the SDK is invisible:
 - `WC_Settings_Page::output()` runs the legacy renderer unconditionally.
 - No mount markup is emitted.
 - No payload is published on `window.wcSettings`.
-- Setting `$is_modern = true` on a subclass has no observable effect on the rendered page.
 
 This guarantee is enforced by an automated end-to-end test that asserts the rendered DOM with the flag off matches the legacy output exactly.
 
 ## Example plugin
 
-A complete, installable example lives under [`plugins/woocommerce/sample-plugins/modern-settings-example/`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/sample-plugins/modern-settings-example). It registers a `Modern Example` tab under **WooCommerce → Settings**, opts in via `$is_modern = true`, and uses only natively-supported field types so it renders end-to-end with no JS bundle.
+A complete, installable example lives under [`plugins/woocommerce/sample-plugins/modern-settings-example/`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/sample-plugins/modern-settings-example). It registers a `Modern Example` tab under **WooCommerce → Settings** using only natively-supported field types, so it renders via the modern renderer end-to-end with no JS bundle when the `modern-settings` flag is on, and via the legacy renderer when it is off.
 
 To try it locally:
 
@@ -314,6 +327,6 @@ Toggling the flag off and reloading the same tab gives you the legacy form with 
 The following are explicitly **not** part of the 10.8 SDK and are tracked for follow-up phases:
 
 - **REST-driven save.** The save path remains the legacy POST handler in 10.8.
-- **Opting Core settings pages in.** No Core page sets `$is_modern = true` in 10.8. Phase 2 will pick a small surface (likely the General tab) once the SDK has been validated against extension pages.
+- **Auto-rendering Core settings pages on the modern path.** With the flag off, Core renders entirely via the legacy form. Phase 2 will validate the SDK against a small Core surface (likely the General tab) and consider whether to flip the default for selected tabs.
 - **Custom-component coverage** for `image_width`, `relative_date_selector`, and `slotfill_placeholder`. These raw types fall back today; native Edit components are planned.
 - **`DataForm.Fields.extend()`** as an upstream WordPress SPI. The interim runtime registry on `window.wcReactSettings` will be deprecated once an upstream extension point is available.

--- a/docs/extensions/settings-and-config/modernised-settings-sdk.md
+++ b/docs/extensions/settings-and-config/modernised-settings-sdk.md
@@ -1,0 +1,314 @@
+---
+post_title: Modernised settings SDK (10.8)
+sidebar_label: Modernised settings SDK
+sidebar_position: 5
+---
+
+# Modernised settings SDK
+
+The Modernised Settings SDK is an experimental, opt-in path that renders existing `WC_Settings_Page` subclasses with the React-based `DataForm` component instead of the legacy PHP `WC_Admin_Settings::output_fields()` renderer. It is shipped in WooCommerce 10.8 as the first user-facing slice of a longer-term effort to bring WooCommerce settings onto the same component model used elsewhere in `wp-admin`.
+
+This guide covers everything an extension author needs to opt a settings page in, register custom field types, and understand the fallback behaviour.
+
+## Status in 10.8
+
+- The SDK is **experimental** and ships behind the `modern-settings` feature flag, which is **off by default**.
+- No Core settings page is opted in to the modern path in 10.8. The flag is intentionally a tool for extensions and integrators to experiment with against their own pages.
+- The legacy save POST handler still runs for every settings page, regardless of the flag. Saves continue to flow through `WC_Admin_Settings::save_fields()` and the existing `woocommerce_update_options_*` hooks. The only thing the modern path replaces in 10.8 is the **render** of the form.
+- With the flag off, no behaviour changes anywhere — even on pages that have already set `$is_modern = true`.
+
+## Enabling the feature flag for development
+
+There are two ways to turn the flag on while you develop or test against the modern path.
+
+### Via the WooCommerce Beta Tester plugin
+
+1. Install and activate the [WooCommerce Beta Tester](https://github.com/woocommerce/woocommerce-beta-tester) plugin.
+2. Navigate to **Tools → WooCommerce → Beta tester → Features**.
+3. Toggle **Modern Settings** on.
+
+### Programmatically
+
+Add a small mu-plugin or snippet to your development site:
+
+```php
+<?php
+add_filter(
+    'woocommerce_admin_features',
+    static function ( array $features ): array {
+        $features[] = 'modern-settings';
+        return $features;
+    }
+);
+```
+
+This is useful in CI or when scripting a wp-env environment.
+
+## Opting a settings page in (`$is_modern`)
+
+A `WC_Settings_Page` subclass opts in to the modern path by setting the `$is_modern` property to `true`:
+
+```php
+<?php
+defined( 'ABSPATH' ) || exit;
+
+class My_Plugin_Settings_Tab extends WC_Settings_Page {
+    /**
+     * @var bool
+     */
+    protected $is_modern = true;
+
+    public function __construct() {
+        $this->id    = 'my_plugin';
+        $this->label = __( 'My Plugin', 'my-plugin' );
+        parent::__construct();
+    }
+
+    public function get_settings_for_default_section() {
+        return array(
+            array(
+                'title' => __( 'My Plugin settings', 'my-plugin' ),
+                'type'  => 'title',
+                'id'    => 'my_plugin_options',
+            ),
+            array(
+                'title'   => __( 'API key', 'my-plugin' ),
+                'id'      => 'my_plugin_api_key',
+                'type'    => 'text',
+                'default' => '',
+            ),
+            array(
+                'type' => 'sectionend',
+                'id'   => 'my_plugin_options',
+            ),
+        );
+    }
+}
+```
+
+Two independent things happen when `$is_modern` is `true`:
+
+1. The full React **settings shell** (rolled out behind the separate `settings` feature flag) treats the tab as a first-class React surface rather than embedding the legacy form.
+2. The per-page **render path** in `WC_Settings_Page::output()` checks the `modern-settings` flag and, if it is on, attempts to mount the React renderer instead of calling `WC_Admin_Settings::output_fields()`.
+
+You do not need to change the `save_*` methods on your subclass. The existing `woocommerce_settings_save_{tab}` action still fires and the legacy save handler is authoritative in 10.8.
+
+## Public PHP API
+
+The PHP surface for the modern path is the `ReactSettingsSchema` class plus three extension filters.
+
+### `ReactSettingsSchema`
+
+`Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema` exposes the following static methods. They are intended for use by extensions, even though the namespace is currently `Internal\*` — moving the class to a non-`Internal` namespace is tracked as a Phase 2 refactor and the method signatures will be preserved.
+
+| Method | Purpose |
+|--------|---------|
+| `is_opted_out( $tab, $section, $settings, $page )` | Returns `true` if the `woocommerce_react_settings_opt_out` filter has opted the tab/section out. |
+| `get_supported_types( $tab, $section, $settings, $page )` | Returns the normalized list of field types the React renderer can handle for the given tab/section. |
+| `get_type_map( $tab, $section, $settings, $page )` | Returns the map of raw WooCommerce field types to the normalized types in the supported list. |
+| `get_unsupported_fields( $tab, $section, $settings, $page )` | Returns an array of `{ id, type, normalized_type }` entries for any field that cannot be rendered. Empty when the page is fully supported. |
+| `has_renderable_fields( $tab, $section, $settings, $page )` | Returns `true` if at least one field would render under the React path. |
+| `build_response( $tab, $section, $settings, $page )` | Transforms the legacy settings-definition array into the payload the React renderer consumes (`{ id, title, description, values, groups }`). |
+| `get_payload_path( $tab, $section )` | Returns the dot-path under `window.wcSettings.admin` where the payload is published, e.g. `[ 'settings', 'general', 'default' ]`. |
+| `get_mount_id( $tab, $section )` | Returns the DOM id of the mount element, e.g. `wc_settings_react_general_default`. |
+
+All methods accept the empty string `''` for `$section` to mean "default section" and normalize it internally to `default`.
+
+### Filters
+
+#### `woocommerce_react_settings_opt_out`
+
+Force a specific tab/section to fall back to the legacy renderer even when the flag is on.
+
+```php
+add_filter(
+    'woocommerce_react_settings_opt_out',
+    static function ( bool $opt_out, string $tab, string $section, array $settings, $settings_page ): bool {
+        if ( 'my_plugin' === $tab && 'advanced' === $section ) {
+            return true;
+        }
+        return $opt_out;
+    },
+    10,
+    5
+);
+```
+
+#### `woocommerce_react_settings_supported_types`
+
+Add to (or remove from) the list of normalized field types the renderer accepts. Use this when you have registered a custom JS Edit component and want a raw type to be considered renderable.
+
+```php
+add_filter(
+    'woocommerce_react_settings_supported_types',
+    static function ( array $types, string $tab, string $section ): array {
+        if ( 'my_plugin' === $tab ) {
+            $types[] = 'currency';
+        }
+        return $types;
+    },
+    10,
+    3
+);
+```
+
+#### `woocommerce_react_settings_type_map`
+
+Map a raw WooCommerce field type to a normalized type the renderer already supports. This is the simplest extension point for custom types that can be rendered as a primitive.
+
+```php
+add_filter(
+    'woocommerce_react_settings_type_map',
+    static function ( array $map, string $tab, string $section ): array {
+        $map['currency'] = 'text';
+        return $map;
+    },
+    10,
+    3
+);
+```
+
+For the trade-offs between these two filters and the JS-side registration, see [Registering custom field types](./registering-custom-field-types.md).
+
+## Mount protocol
+
+When a page resolves to the modern path, `WC_Settings_Page::output()` emits a single `<div>` and returns:
+
+```html
+<div id="wc_settings_react_my_plugin_default"
+     data-wc-modern-settings="1"
+     data-wc-settings-tab="my_plugin"
+     data-wc-settings-section=""></div>
+```
+
+- The `id` attribute is the value returned by `ReactSettingsSchema::get_mount_id( $tab, $section )` and follows the format `wc_settings_react_{tab}_{section}`. The empty section is normalized to `default`.
+- `data-wc-modern-settings="1"` is the marker the JS bootstrapper scans for.
+- `data-wc-settings-tab` and `data-wc-settings-section` carry the tab and section ids verbatim (the section attribute is empty for the default section).
+
+The settings payload itself is published on the page via `wp_add_inline_script`/`wp_localize_script` under a deterministic path:
+
+```js
+window.wcSettings.admin.settings[ tab ][ section || 'default' ] = {
+    id: 'my_plugin',
+    title: 'My Plugin',
+    description: '',
+    values: { my_plugin_api_key: '' },
+    groups: {
+        my_plugin_options: {
+            title: 'My Plugin settings',
+            description: '',
+            order: 0,
+            fields: [
+                { id: 'my_plugin_api_key', label: 'API key', type: 'text', desc: '' },
+            ],
+        },
+    },
+};
+```
+
+The exact payload shape is what `ReactSettingsSchema::build_response()` returns. Treat the structure as the contract; the renderer reads only those keys.
+
+## JS extension points
+
+The runtime registry is exposed on `window.wcReactSettings`:
+
+```js
+window.wcReactSettings.registerFieldTypeTransformer(
+    'currency',
+    ( setting, baseField ) => ( {
+        ...baseField,
+        type: 'text',
+    } )
+);
+```
+
+- `setting` is the raw WooCommerce settings array entry (the same shape your `get_settings_for_*_section()` method returns).
+- `baseField` is the partially-normalized field shape `{ id, label, type, description? }` produced by the schema layer.
+- The function must return a [DataForm field](https://developer.wordpress.org/block-editor/reference-guides/data/data-core/) shape: at minimum `{ ...baseField, type }`, optionally with `Edit`, `getValue`, `setValue`, `isValid`, or `elements`.
+
+Registrations are global and persist for the lifetime of the page. There is no deregister API in 10.8.
+
+A typed npm package, `@woocommerce/modern-settings-sdk`, is planned to ship alongside the SDK. It will provide TypeScript types and helper utilities (`baseFieldTransformer`, `parseOptions`, `createChildrenWithRows`, `reorderGroupFields`). In 10.8 the registry is consumed via the `window.wcReactSettings` global; a dedicated `wc-modern-settings-sdk` script handle is planned for a follow-up release.
+
+## Native field type coverage
+
+Out of the box in 10.8, the renderer recognises the following raw WooCommerce field types and renders each one with a matching DataForm primitive or a custom Edit component:
+
+| Type family | Raw type(s) | How it renders |
+|-------------|-------------|----------------|
+| Text-like | `text`, `password`, `email`, `url`, `tel` | Single-line input. `password` uses a masked input; `url` validates with `URL.canParse`; `tel` uses an `InputControl` with `type="tel"`. |
+| Number | `number` | Integer input. |
+| Choice | `select`, `radio`, `multiselect`, `single_select_page_with_search` | Standard select / radio / multi-select. The searchable variant uses `ComboboxControl`, with the page list synthesised via `get_pages()` when no `options` are provided. |
+| Boolean | `checkbox`, `toggle` | Checkbox or toggle, persisted as `'yes'` / `'no'`. |
+| Long text | `textarea` | `TextareaControl`. |
+| Colour | `color` | `ColorPicker`. |
+| Date / time | `date`, `datetime`, `datetime-local`, `month`, `week`, `time` | `DatePicker` / `DateTimePicker` for the first three; `InputControl` with the matching HTML5 `type` for the others. |
+| Description | `info` | Read-only description row. The body comes from `setting['text']` (or `setting['desc']` if `text` is absent). The row never writes to `formData` — `info` rows must declare an explicit `id` to opt into the React renderer. |
+
+The default type map normalizes a small set of WooCommerce-specific raw types onto the primitives above:
+
+| Raw type | Normalized to |
+|----------|---------------|
+| `single_select_country` | `select` (options synthesised from `WC()->countries`) |
+| `multi_select_countries` | `multiselect` (options synthesised from `WC()->countries`) |
+| `single_select_page` | `select` |
+
+Any raw type that is neither in the supported list nor present in the type map is reported as unsupported and triggers the fallback (see below).
+
+## Fallback signals
+
+The renderer falls back to the legacy `WC_Admin_Settings::output_fields()` path when any of the following are true:
+
+1. The `modern-settings` feature flag is off (the React mount is never emitted).
+2. The `woocommerce_react_settings_opt_out` filter returns `true`.
+3. `ReactSettingsSchema::get_unsupported_fields()` returns at least one entry.
+4. `ReactSettingsSchema::has_renderable_fields()` returns `false` (e.g. the section only contains `title`/`sectionend` markers).
+
+When the fallback is triggered by an unsupported field type — i.e. the page would otherwise have rendered via React but for a single offending field — a `wc_doing_it_wrong` notice is logged. In the browser console you will see a message identifying the tab, section, and the offending field ids and types. This is intended as a developer signal, not a user-facing warning, and only fires when `WP_DEBUG` is enabled.
+
+## Migration walkthrough
+
+You have an existing `WC_Settings_Page` subclass. Here is how to adopt the modern path.
+
+1. **Audit your field types.** Compare the `type` keys in your `get_settings_for_*_section()` arrays against the supported list and the default type map. Anything outside both will trigger a fallback.
+2. **Set `$is_modern = true`** on your subclass. This is a no-op as long as the `modern-settings` flag is off, so it is safe to ship.
+3. **Enable the `modern-settings` flag** in your dev environment (see [Enabling the feature flag for development](#enabling-the-feature-flag-for-development)).
+4. **Visit your settings tab in `wp-admin`.** If a fallback fires, the browser console will print a `wc_doing_it_wrong` notice naming the field types that caused it.
+5. **Resolve unsupported types.** You have three options:
+    - Change the field's raw `type` to one already in the supported list.
+    - Map your raw type to a primitive via the `woocommerce_react_settings_type_map` filter.
+    - Register a custom field type via the JS extension point. See [Registering custom field types](./registering-custom-field-types.md).
+6. **Smoke-test the save path.** The legacy save POST handler is still authoritative in 10.8, so saving should behave identically. Confirm the values you submit round-trip through `WC_Admin_Settings::get_option()`.
+
+## Flag-off zero-change guarantee
+
+When the `modern-settings` flag is off, the SDK is invisible:
+
+- `WC_Settings_Page::output()` runs the legacy renderer unconditionally.
+- No mount markup is emitted.
+- No payload is published on `window.wcSettings`.
+- Setting `$is_modern = true` on a subclass has no observable effect on the rendered page.
+
+This guarantee is enforced by an automated end-to-end test that asserts the rendered DOM with the flag off matches the legacy output exactly.
+
+## Example plugin
+
+A complete, installable example lives under [`plugins/woocommerce/sample-plugins/modern-settings-example/`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/sample-plugins/modern-settings-example). It registers a `Modern Example` tab under **WooCommerce → Settings**, opts in via `$is_modern = true`, and uses only natively-supported field types so it renders end-to-end with no JS bundle.
+
+To try it locally:
+
+1. Copy the `modern-settings-example/` directory into `wp-content/plugins/`.
+2. Activate **WooCommerce Modernised Settings Example** from the Plugins screen.
+3. Enable the `modern-settings` feature flag (see above).
+4. Visit **WooCommerce → Settings → Modern Example**.
+
+Toggling the flag off and reloading the same tab gives you the legacy form with no other change. That is the zero-change guarantee in action.
+
+## Out of scope for 10.8
+
+The following are explicitly **not** part of the 10.8 SDK and are tracked for follow-up phases:
+
+- **REST-driven save.** The save path remains the legacy POST handler in 10.8.
+- **Opting Core settings pages in.** No Core page sets `$is_modern = true` in 10.8. Phase 2 will pick a small surface (likely the General tab) once the SDK has been validated against extension pages.
+- **Custom-component coverage** for `image_width`, `relative_date_selector`, and `slotfill_placeholder`. These raw types fall back today; native Edit components are planned.
+- **`DataForm.Fields.extend()`** as an upstream WordPress SPI. The interim runtime registry on `window.wcReactSettings` will be deprecated once an upstream extension point is available.

--- a/docs/extensions/settings-and-config/registering-custom-field-types.md
+++ b/docs/extensions/settings-and-config/registering-custom-field-types.md
@@ -1,0 +1,263 @@
+---
+post_title: Registering custom field types (modern settings SDK)
+sidebar_label: Custom field types
+sidebar_position: 6
+---
+
+# Registering custom field types
+
+This guide is a focused walkthrough for the case where your `WC_Settings_Page` subclass uses a setting `type` that is not in the [native supported set](./modernised-settings-sdk.md#native-field-type-coverage), but you want it to render on the modern path rather than fall back to the legacy renderer.
+
+If you have not already, read the [Modernised settings SDK overview](./modernised-settings-sdk.md) first.
+
+## When to register a custom field type
+
+When you set `$is_modern = true` on a settings page and enable the `modern-settings` flag, every field is checked against the supported types. A field whose normalized type is not supported triggers a fallback to the legacy renderer for the entire section.
+
+You have three ways out of the fallback:
+
+1. **Use a supported type.** If your field can be expressed as `text`, `select`, `checkbox`, etc., changing the raw `type` is the simplest fix.
+2. **Wait for native support.** The list of native types is expected to grow each release. If your field is reasonably common, [open an issue](https://github.com/woocommerce/woocommerce/issues) before reaching for a custom registration.
+3. **Register a custom field type.** Recommended when your setting needs a bespoke input (a currency picker, a code editor, a coordinate map, etc.) that the renderer cannot model with a primitive.
+
+This document covers option 3.
+
+## The PHP side
+
+You need to tell the renderer that your raw field type is renderable. There are three options, in increasing order of customization.
+
+### Option A — Map to a primitive
+
+If your custom type is conceptually a primitive — for example, a currency input is just a `text` input with formatting — register it in the type map. No JS is required.
+
+```php
+add_filter(
+    'woocommerce_react_settings_type_map',
+    static function ( array $map, string $tab, string $section ): array {
+        $map['currency'] = 'text';
+        return $map;
+    },
+    10,
+    3
+);
+```
+
+The renderer will treat `currency` fields as `text` fields end-to-end.
+
+### Option B — Mark as supported and ship a JS Edit
+
+If your field genuinely needs custom UI, declare the raw type as supported so it is not normalized away, and register a JS transformer to provide an `Edit` component.
+
+```php
+add_filter(
+    'woocommerce_react_settings_supported_types',
+    static function ( array $types, string $tab, string $section ): array {
+        $types[] = 'currency';
+        return $types;
+    },
+    10,
+    3
+);
+```
+
+### Option C — Both filters
+
+For complete control, declare the raw type as supported AND map it to itself in the type map. This stops the schema from defaulting to the raw type fallback path and makes your transformer the only place that decides the rendered shape.
+
+```php
+add_filter(
+    'woocommerce_react_settings_supported_types',
+    static function ( array $types ): array {
+        $types[] = 'currency';
+        return $types;
+    }
+);
+
+add_filter(
+    'woocommerce_react_settings_type_map',
+    static function ( array $map ): array {
+        $map['currency'] = 'currency';
+        return $map;
+    }
+);
+```
+
+Use Option A unless you have a reason not to.
+
+## The JS side
+
+The runtime registry on `window.wcReactSettings` is the extension point for custom Edit components.
+
+```js
+window.wcReactSettings.registerFieldTypeTransformer(
+    'currency',
+    ( setting, baseField ) => ( {
+        ...baseField,
+        type: 'text',
+        Edit: CurrencyEdit,
+    } )
+);
+```
+
+The transformer receives:
+
+- `setting` — the raw WooCommerce settings array entry: `{ id, title, type, default, desc, options? ... }`. This is exactly what your `get_settings_for_*_section()` returns for that field.
+- `baseField` — a partially-normalized DataForm field shape: `{ id, label, type, description? }`. The `id` and `label` are derived from the raw setting's `id` and `title`/`name`; the `type` is the result of running the type map.
+
+The transformer must return a [DataForm field](https://developer.wordpress.org/block-editor/reference-guides/data/data-core/) shape. At minimum: `{ ...baseField, type }`. Optionally: `Edit`, `getValue`, `setValue`, `isValid`, `elements`.
+
+A custom `Edit` component receives:
+
+```ts
+type EditProps< Value > = {
+    data: Record< string, unknown >;
+    field: { id: string; label: string };
+    onChange: ( next: Record< string, unknown > ) => void;
+    hideLabelFromVision?: boolean;
+};
+```
+
+`data` is the form-wide values object; the current field's value is `data[ field.id ]`. `onChange` is called with a partial values object — the renderer merges it into `data`.
+
+## End-to-end walkthrough — a `currency` field
+
+Let's wire a `currency` field type that renders as a text input with a `$` prefix.
+
+### 1. Register the field on the PHP side
+
+In your settings tab subclass:
+
+```php
+public function get_settings_for_default_section() {
+    return array(
+        array(
+            'title' => __( 'Pricing', 'my-plugin' ),
+            'type'  => 'title',
+            'id'    => 'my_plugin_pricing',
+        ),
+        array(
+            'title'   => __( 'Default price', 'my-plugin' ),
+            'id'      => 'my_plugin_default_price',
+            'type'    => 'currency',
+            'default' => '0.00',
+        ),
+        array(
+            'type' => 'sectionend',
+            'id'   => 'my_plugin_pricing',
+        ),
+    );
+}
+```
+
+Map the raw type to `text` so the schema treats it as renderable; the JS transformer will swap in the custom Edit:
+
+```php
+add_filter(
+    'woocommerce_react_settings_type_map',
+    static function ( array $map ): array {
+        $map['currency'] = 'text';
+        return $map;
+    }
+);
+```
+
+### 2. Enqueue and register the transformer
+
+Ship a small JS file that reads from `window.wcReactSettings`:
+
+```js
+( function () {
+    if ( ! window.wcReactSettings || ! window.wcReactSettings.registerFieldTypeTransformer ) {
+        return;
+    }
+
+    var el = window.wp.element.createElement;
+
+    function CurrencyEdit( props ) {
+        var value = props.data[ props.field.id ] || '';
+        return el( 'label', { className: 'my-plugin-currency' },
+            el( 'span', null, '$' ),
+            el( 'input', {
+                type: 'text',
+                inputMode: 'decimal',
+                value: value,
+                onChange: function ( event ) {
+                    var next = {};
+                    next[ props.field.id ] = event.target.value;
+                    props.onChange( next );
+                },
+            } )
+        );
+    }
+
+    window.wcReactSettings.registerFieldTypeTransformer(
+        'currency',
+        function ( setting, baseField ) {
+            return Object.assign( {}, baseField, {
+                type: 'text',
+                Edit: CurrencyEdit,
+            } );
+        }
+    );
+} )();
+```
+
+Register it on the settings page only:
+
+```php
+add_action(
+    'admin_enqueue_scripts',
+    static function ( string $hook ): void {
+        if ( 'woocommerce_page_wc-settings' !== $hook ) {
+            return;
+        }
+        wp_enqueue_script(
+            'my-plugin-currency-field',
+            plugins_url( 'assets/currency-field.js', __FILE__ ),
+            array( 'wp-element' ),
+            '1.0.0',
+            true
+        );
+    }
+);
+```
+
+The `wp-element` dependency guarantees `window.wp.element` is available before your script runs. If you ship a real React/JSX bundle via `@wordpress/scripts`, depend on whatever your build emits — but for a one-file inline transformer this is enough.
+
+### 3. Verify
+
+1. Activate the plugin and enable the `modern-settings` flag.
+2. Visit the settings tab. The currency field should render with a `$` prefix and accept input.
+3. Save the form. The value should round-trip through the legacy save handler.
+4. Disable the `modern-settings` flag. The same field should render via the legacy renderer with no change to your code.
+
+## Testing your custom field type
+
+There are two layers worth testing.
+
+**Unit-test the transformer in isolation.** It is a pure function from `( setting, baseField ) → fieldShape`. You can call it directly in a Jest test and assert the returned shape, without rendering React.
+
+```js
+import { transformer } from './currency-field';
+
+test( 'returns a text-typed field with a custom Edit', () => {
+    const setting = { id: 'price', title: 'Price', type: 'currency' };
+    const baseField = { id: 'price', label: 'Price', type: 'text' };
+
+    const field = transformer( setting, baseField );
+
+    expect( field.type ).toBe( 'text' );
+    expect( field.Edit ).toBeDefined();
+} );
+```
+
+**Smoke-test the rendered Edit.** Mount the Edit component with a controlled `data`/`onChange` pair and assert the input renders, accepts a value, and propagates a change. The standard `@testing-library/react` patterns apply.
+
+For end-to-end, the [example plugin](./modernised-settings-sdk.md#example-plugin) is a good template — clone its directory layout and swap in your custom field type.
+
+## Limits
+
+- **No automatic label.** The renderer does not wrap your custom `Edit` in a `<label>`. If your input does not have its own `<label htmlFor="...">` or an `aria-label`, wrap it in `<BaseControl>` from `@wordpress/components` for accessibility.
+- **No deregister API.** Transformers persist for the lifetime of the page. If you re-register the same type, the later registration wins.
+- **Global namespace.** The registry is keyed by raw type string. If two plugins register the same type, the one whose script runs last wins. Pick a type name with a plugin-specific prefix (e.g. `my_plugin_currency`, not `currency`).
+- **No type guarantees today.** TypeScript types for the registry will ship with the upcoming `@woocommerce/modern-settings-sdk` package. Until then, treat the field shape as documented above and validate in tests.

--- a/docs/extensions/settings-and-config/registering-custom-field-types.md
+++ b/docs/extensions/settings-and-config/registering-custom-field-types.md
@@ -12,7 +12,7 @@ If you have not already, read the [Modernised settings SDK overview](./modernise
 
 ## When to register a custom field type
 
-When you set `$is_modern = true` on a settings page and enable the `modern-settings` flag, every field is checked against the supported types. A field whose normalized type is not supported triggers a fallback to the legacy renderer for the entire section.
+When the `modern-settings` flag is on, every field on every `WC_Settings_Page` subclass is checked against the supported types. A field whose normalized type is not supported triggers a fallback to the legacy renderer for the entire section.
 
 You have three ways out of the fallback:
 

--- a/plugins/woocommerce/changelog/wooprd-3490-modern-settings-sdk-docs
+++ b/plugins/woocommerce/changelog/wooprd-3490-modern-settings-sdk-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Modernised settings SDK: add developer documentation and example plugin.

--- a/plugins/woocommerce/sample-plugins/modern-settings-example/README.md
+++ b/plugins/woocommerce/sample-plugins/modern-settings-example/README.md
@@ -1,0 +1,54 @@
+# Modernised Settings SDK — Example Plugin
+
+A minimal, installable demonstration of the [WooCommerce Modernised Settings SDK](../../../../docs/extensions/settings-and-config/modernised-settings-sdk.md) introduced in WooCommerce 10.8.
+
+## What it does
+
+- Registers a **Modern Example** tab under **WooCommerce → Settings**.
+- Opts the tab in to the React renderer via `protected $is_modern = true`.
+- Ships only natively-supported field types (`text`, `select`, `toggle`, `checkbox`) so it renders end-to-end with no JavaScript bundle.
+- Doubles as the reference fixture for the SDK's flag-off zero-change guarantee: with the `modern-settings` flag off, the same tab renders via the legacy form with no behavioural difference.
+
+## Install
+
+1. Copy this directory to `wp-content/plugins/modern-settings-example/`.
+2. Activate **WooCommerce Modernised Settings Example** from **Plugins** in `wp-admin`.
+3. Enable the `modern-settings` feature flag. Two ways:
+
+    - **WooCommerce Beta Tester** (recommended): install the plugin, then go to **Tools → WooCommerce → Beta tester → Features** and toggle **Modern Settings** on.
+    - **Programmatically**: drop the snippet below into a mu-plugin.
+
+      ```php
+      <?php
+      add_filter(
+          'woocommerce_admin_features',
+          static function ( array $features ): array {
+              $features[] = 'modern-settings';
+              return $features;
+          }
+      );
+      ```
+
+4. Visit **WooCommerce → Settings → Modern Example**.
+
+With the flag on, the tab renders via the React `DataForm` path. Toggle the flag off and reload to see the same tab fall back to the legacy form.
+
+## Layout
+
+```text
+modern-settings-example/
+├── README.md
+├── modern-settings-example.php
+└── includes/
+    └── class-modern-settings-example-tab.php
+```
+
+## Extending the example
+
+To add a custom field type to this plugin, follow the [Registering custom field types](../../../../docs/extensions/settings-and-config/registering-custom-field-types.md) walkthrough. The end-to-end `currency` field example in that document is designed to drop into this plugin layout.
+
+## Reference
+
+- [Modernised settings SDK](../../../../docs/extensions/settings-and-config/modernised-settings-sdk.md) — full developer guide.
+- [Registering custom field types](../../../../docs/extensions/settings-and-config/registering-custom-field-types.md) — when the native field set isn't enough.
+- [`plugins/woocommerce/src/Internal/Admin/Settings/README.md`](../../src/Internal/Admin/Settings/README.md) — in-repo quick reference for engineers working on the SDK itself.

--- a/plugins/woocommerce/sample-plugins/modern-settings-example/README.md
+++ b/plugins/woocommerce/sample-plugins/modern-settings-example/README.md
@@ -5,7 +5,6 @@ A minimal, installable demonstration of the [WooCommerce Modernised Settings SDK
 ## What it does
 
 - Registers a **Modern Example** tab under **WooCommerce → Settings**.
-- Opts the tab in to the React renderer via `protected $is_modern = true`.
 - Ships only natively-supported field types (`text`, `select`, `toggle`, `checkbox`) so it renders end-to-end with no JavaScript bundle.
 - Doubles as the reference fixture for the SDK's flag-off zero-change guarantee: with the `modern-settings` flag off, the same tab renders via the legacy form with no behavioural difference.
 

--- a/plugins/woocommerce/sample-plugins/modern-settings-example/includes/class-modern-settings-example-tab.php
+++ b/plugins/woocommerce/sample-plugins/modern-settings-example/includes/class-modern-settings-example-tab.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Modern Settings Example tab.
+ *
+ * @package ModernSettingsExample
+ */
+
+declare( strict_types=1 );
+
+namespace Modern_Settings_Example;
+
+use WC_Settings_Page;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds a "Modern Example" tab under WooCommerce → Settings.
+ *
+ * The tab opts in to the modernised settings SDK by setting `$is_modern = true`.
+ * It only uses field types that the React renderer supports natively, so no
+ * accompanying JavaScript bundle is required.
+ *
+ * With the `modern-settings` feature flag on, this tab renders via the React
+ * `DataForm` path. With the flag off, it renders via the legacy
+ * `WC_Admin_Settings::output_fields()` path with no behavioural change.
+ */
+class Modern_Settings_Example_Tab extends WC_Settings_Page {
+
+	/**
+	 * Opt this settings tab in to the modernised settings SDK.
+	 *
+	 * @var bool
+	 */
+	protected $is_modern = true;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->id    = 'modern_example';
+		$this->label = __( 'Modern Example', 'modern-settings-example' );
+
+		parent::__construct();
+	}
+
+	/**
+	 * Get settings for the default section.
+	 *
+	 * @return array
+	 */
+	protected function get_settings_for_default_section(): array {
+		return array(
+			array(
+				'title' => __( 'Modern settings example', 'modern-settings-example' ),
+				'type'  => 'title',
+				'desc'  => __( 'A minimal demonstration of the modernised settings SDK. All fields here use natively-supported field types.', 'modern-settings-example' ),
+				'id'    => 'mse_general_options',
+			),
+			array(
+				'title'    => __( 'Display name', 'modern-settings-example' ),
+				'desc'     => __( 'A short label shown next to your example feature.', 'modern-settings-example' ),
+				'id'       => 'mse_display_name',
+				'type'     => 'text',
+				'default'  => __( 'Modern Example', 'modern-settings-example' ),
+				'desc_tip' => true,
+			),
+			array(
+				'title'    => __( 'Theme', 'modern-settings-example' ),
+				'desc'     => __( 'Choose how the example feature is presented.', 'modern-settings-example' ),
+				'id'       => 'mse_theme',
+				'type'     => 'select',
+				'default'  => 'auto',
+				'options'  => array(
+					'auto'  => __( 'Match site theme', 'modern-settings-example' ),
+					'light' => __( 'Light', 'modern-settings-example' ),
+					'dark'  => __( 'Dark', 'modern-settings-example' ),
+				),
+				'desc_tip' => true,
+			),
+			array(
+				'title'    => __( 'Enable example', 'modern-settings-example' ),
+				'desc'     => __( 'Turn the example feature on or off.', 'modern-settings-example' ),
+				'id'       => 'mse_enabled',
+				'type'     => 'toggle',
+				'default'  => 'no',
+				'desc_tip' => false,
+			),
+			array(
+				'title'         => __( 'Show in admin bar', 'modern-settings-example' ),
+				'desc'          => __( 'Add a quick-access entry for the example feature to the WordPress admin bar.', 'modern-settings-example' ),
+				'id'            => 'mse_show_in_admin_bar',
+				'type'          => 'checkbox',
+				'default'       => 'no',
+				'checkboxgroup' => 'start',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'mse_general_options',
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/sample-plugins/modern-settings-example/includes/class-modern-settings-example-tab.php
+++ b/plugins/woocommerce/sample-plugins/modern-settings-example/includes/class-modern-settings-example-tab.php
@@ -16,8 +16,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Adds a "Modern Example" tab under WooCommerce → Settings.
  *
- * The tab opts in to the modernised settings SDK by setting `$is_modern = true`.
- * It only uses field types that the React renderer supports natively, so no
+ * The tab uses only field types that the React renderer supports natively, so no
  * accompanying JavaScript bundle is required.
  *
  * With the `modern-settings` feature flag on, this tab renders via the React
@@ -25,13 +24,6 @@ defined( 'ABSPATH' ) || exit;
  * `WC_Admin_Settings::output_fields()` path with no behavioural change.
  */
 class Modern_Settings_Example_Tab extends WC_Settings_Page {
-
-	/**
-	 * Opt this settings tab in to the modernised settings SDK.
-	 *
-	 * @var bool
-	 */
-	protected $is_modern = true;
 
 	/**
 	 * Constructor.

--- a/plugins/woocommerce/sample-plugins/modern-settings-example/modern-settings-example.php
+++ b/plugins/woocommerce/sample-plugins/modern-settings-example/modern-settings-example.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Modernised Settings Example
+ * Description: Demonstrates the modernised settings SDK introduced in WooCommerce 10.8. Adds a "Modern Example" tab under WooCommerce → Settings that opts in to the React renderer via $is_modern.
+ * Version: 1.0.0
+ * Author: WooCommerce
+ * Requires Plugins: woocommerce
+ * Requires at least: 6.5
+ * Requires PHP: 8.1
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package ModernSettingsExample
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		if ( ! class_exists( 'WC_Settings_Page' ) ) {
+			return;
+		}
+
+		require_once __DIR__ . '/includes/class-modern-settings-example-tab.php';
+
+		add_filter(
+			'woocommerce_get_settings_pages',
+			static function ( array $pages ): array {
+				$pages[] = new \Modern_Settings_Example\Modern_Settings_Example_Tab();
+				return $pages;
+			}
+		);
+	}
+);

--- a/plugins/woocommerce/sample-plugins/modern-settings-example/modern-settings-example.php
+++ b/plugins/woocommerce/sample-plugins/modern-settings-example/modern-settings-example.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WooCommerce Modernised Settings Example
- * Description: Demonstrates the modernised settings SDK introduced in WooCommerce 10.8. Adds a "Modern Example" tab under WooCommerce → Settings that opts in to the React renderer via $is_modern.
+ * Description: Demonstrates the modernised settings SDK introduced in WooCommerce 10.8. Adds a "Modern Example" tab under WooCommerce → Settings that renders via the React path when the `modern-settings` feature flag is on, and via the legacy form when it is off.
  * Version: 1.0.0
  * Author: WooCommerce
  * Requires Plugins: woocommerce

--- a/plugins/woocommerce/src/Internal/Admin/Settings/README.md
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/README.md
@@ -11,7 +11,7 @@ This document explains how the React settings system renders settings pages by d
 
 ## Overview
 
-React settings render for a `WC_Settings_Page` subclass when (a) the `modern-settings` feature flag is enabled AND (b) the page has opted in via `protected $is_modern = true`. Rendering falls back to legacy settings when unsupported field types are detected or when a page opts out via the filter below.
+React settings render for a `WC_Settings_Page` subclass when the `modern-settings` feature flag is enabled. Rendering falls back to legacy settings when unsupported field types are detected or when a page opts out via the filter below.
 
 ## Server-side hooks
 
@@ -96,4 +96,4 @@ Use `default` for the empty section, e.g. `wc_settings_react_products_default`.
 
 ## Example plugin
 
-A minimal installable example lives in [`plugins/woocommerce/sample-plugins/modern-settings-example/`](../../../../sample-plugins/modern-settings-example/). It registers a settings tab opted in via `$is_modern = true` and uses only natively-supported field types, so it renders end-to-end with no JavaScript bundle.
+A minimal installable example lives in [`plugins/woocommerce/sample-plugins/modern-settings-example/`](../../../../sample-plugins/modern-settings-example/). It uses only natively-supported field types, so it renders end-to-end with no JavaScript bundle.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/README.md
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/README.md
@@ -1,10 +1,17 @@
 # React Settings Screens
 
+> **For published developer documentation, see:**
+>
+> - [Modernised settings SDK](../../../../../../docs/extensions/settings-and-config/modernised-settings-sdk.md)
+> - [Registering custom field types](../../../../../../docs/extensions/settings-and-config/registering-custom-field-types.md)
+>
+> The remainder of this README is the in-repo quick reference for engineers working in this directory.
+
 This document explains how the React settings system renders settings pages by default, how to opt out, and how to extend supported field types.
 
 ## Overview
 
-React settings render automatically for all WooCommerce settings pages when the `modern-settings` feature flag is enabled. Rendering falls back to legacy settings when unsupported field types are detected or when a page opts out.
+React settings render for a `WC_Settings_Page` subclass when (a) the `modern-settings` feature flag is enabled AND (b) the page has opted in via `protected $is_modern = true`. Rendering falls back to legacy settings when unsupported field types are detected or when a page opts out via the filter below.
 
 ## Server-side hooks
 
@@ -86,3 +93,7 @@ wc_settings_react_{tab}_{section}
 ```
 
 Use `default` for the empty section, e.g. `wc_settings_react_products_default`.
+
+## Example plugin
+
+A minimal installable example lives in [`plugins/woocommerce/sample-plugins/modern-settings-example/`](../../../../sample-plugins/modern-settings-example/). It registers a settings tab opted in via `$is_modern = true` and uses only natively-supported field types, so it renders end-to-end with no JavaScript bundle.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3490.

Adds the canonical published developer documentation for the modernised settings SDK plus a minimal installable example plugin. Extension authors who want to build on the React renderer have no canonical reference for the public PHP/JS API surface, the mount protocol, the supported field types, or the fallback signals; the in-tree `src/Internal/Admin/Settings/README.md` is a quick reference for engineers working in that directory but is too thin and too "internal" in tone for downstream extension authors.

**Published docs** (Docusaurus, ship to the WooCommerce developer docs site):
- `docs/extensions/settings-and-config/modernised-settings-sdk.md` — main guide. Covers experimental status, feature flag, `$is_modern` opt-in, public PHP API (`ReactSettingsSchema` + 3 filters), mount protocol, JS extension point (`window.wcReactSettings.registerFieldTypeTransformer`), native field type table, fallback signals (browser console + `wc_doing_it_wrong`), 6-step migration walkthrough, flag-off zero-change guarantee, and what's intentionally out of scope for the initial release.
- `docs/extensions/settings-and-config/registering-custom-field-types.md` — focused walkthrough for the custom-field-type case. Three PHP options (`supported_types` only, `type_map` only, both), JS transformer signature + `Edit` prop contract, end-to-end "currency" field example, testing tips, known limits.

**Example plugin** at `plugins/woocommerce/sample-plugins/modern-settings-example/`:
- `modern-settings-example.php` — plugin header + `plugins_loaded` hook that registers the tab via `woocommerce_get_settings_pages`.
- `includes/class-modern-settings-example-tab.php` — `WC_Settings_Page` subclass with `$is_modern = true` and four natively-supported fields (text, select, toggle, checkbox).
- `README.md` — install instructions and what to expect with the flag on vs off.

**In-repo Settings README** (`plugins/woocommerce/src/Internal/Admin/Settings/README.md`):
- Top-of-file pointer to the published docs.
- Footer link to the example plugin.
- Fixed a stale overview line that pre-dated the `$is_modern` opt-in.

**Notes for reviewers:**
- **No production code modified.** Pure docs + sample-plugin + Settings README + changelog.
- **Scope cut:** the example plugin uses only natively-supported field types so it ships zero JS — no custom field type, no React bundle, zero build step. The custom-field-type story is covered separately in the second docs file with copy-pasteable code blocks.

### How to test the changes in this Pull Request:

1. Apply this branch.
2. Sanity-read `docs/extensions/settings-and-config/modernised-settings-sdk.md` and `registering-custom-field-types.md` end-to-end. Flag any wording that's misleading or any code blocks that wouldn't compile.
3. Verify all relative path links in the docs and READMEs resolve (`ls` each one).
4. Copy the example plugin into `wp-content/plugins/modern-settings-example/`, activate it in WP Admin → Plugins, enable the `modern-settings` flag, and visit **WooCommerce → Settings → Modern Example**. With the flag on, expect the React mount div in the DOM. With the flag off, expect zero behavioural change from a legacy tab.
5. `php -l` both example-plugin PHP files; expect no syntax errors.

### Testing that has already taken place:

- `php -l` on both example-plugin PHP files — clean.
- No production code changed.
- markdownlint not available locally; CI will validate.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Modernised settings SDK: add developer documentation and example plugin.

</details>
