### PR TITLE
Map email test-send errors to merchant-friendly copy

### DIFF
--- a/plugins/woocommerce/changelog/tweak-email-test-send-friendly-errors
+++ b/plugins/woocommerce/changelog/tweak-email-test-send-friendly-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Show clearer errors when a test email fails to send.

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-preview-send.test.ts
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-preview-send.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Internal dependencies
+ */
+import {
+	friendlyEmailSendError,
+	WPError,
+} from '../settings-email-preview-send';
+
+const makeError = ( overrides: Partial< WPError > = {} ): WPError => ( {
+	code: '',
+	message: '',
+	data: { status: 0 },
+	...overrides,
+} );
+
+describe( 'friendlyEmailSendError', () => {
+	it( 'maps the WP core nonce error code to the session-expired message', () => {
+		const result = friendlyEmailSendError(
+			makeError( { code: 'rest_cookie_invalid_nonce' } )
+		);
+
+		expect( result ).toBe(
+			'Your session expired. Refresh the page and try again.'
+		);
+	} );
+
+	it( 'maps the Woo invalid_nonce code to the session-expired message', () => {
+		const result = friendlyEmailSendError(
+			makeError( { code: 'invalid_nonce' } )
+		);
+
+		expect( result ).toBe(
+			'Your session expired. Refresh the page and try again.'
+		);
+	} );
+
+	it( 'maps rest_invalid_json to the unexpected-output message', () => {
+		const result = friendlyEmailSendError(
+			makeError( { code: 'rest_invalid_json' } )
+		);
+
+		expect( result ).toBe(
+			'The server returned unexpected output. Check your error log, or disable recently added plugins.'
+		);
+	} );
+
+	it( 'maps a WSOD "critical error" message to the PHP-error message', () => {
+		const result = friendlyEmailSendError(
+			makeError( {
+				code: 'some_other_code',
+				message: 'There has been a critical error on this website.',
+			} )
+		);
+
+		expect( result ).toBe(
+			'A PHP error stopped the send. Check your error log or contact your host.'
+		);
+	} );
+
+	it( 'maps woocommerce_rest_email_preview_not_rendered to the render-failed message', () => {
+		const result = friendlyEmailSendError(
+			makeError( {
+				code: 'woocommerce_rest_email_preview_not_rendered',
+			} )
+		);
+
+		expect( result ).toBe(
+			"The email couldn't be rendered. Try resetting the template in Settings → Emails."
+		);
+	} );
+
+	it( 'maps the no-valid-response message to the timeout message', () => {
+		const result = friendlyEmailSendError(
+			makeError( {
+				message: 'Could not get a valid response from the server.',
+			} )
+		);
+
+		expect( result ).toBe(
+			'Your server timed out. If it keeps happening, ask your host to check PHP execution limits.'
+		);
+	} );
+
+	it( 'falls back to the generic message for unknown errors', () => {
+		const result = friendlyEmailSendError(
+			makeError( {
+				code: 'something_unexpected',
+				message: 'Something random went wrong.',
+			} )
+		);
+
+		expect( result ).toBe(
+			"Couldn't send the test email. Check your email settings and try again."
+		);
+	} );
+
+	it( 'still resolves by code when the message is localized (regression: locale fragility)', () => {
+		// Simulates a translated site where the backend error message has
+		// been run through __(). The mapping must still work because we
+		// match on the stable code, not the English message.
+		const result = friendlyEmailSendError(
+			makeError( {
+				code: 'woocommerce_rest_email_preview_not_rendered',
+				message:
+					"Une erreur s'est produite lors du rendu de l'aperçu de l'e-mail.",
+			} )
+		);
+
+		expect( result ).toBe(
+			"The email couldn't be rendered. Try resetting the template in Settings → Emails."
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -22,7 +22,7 @@ type EmailPreviewSendResponse = {
 	message: string;
 };
 
-type WPError = {
+export type WPError = {
 	message: string;
 	code: string;
 	data: {
@@ -30,31 +30,36 @@ type WPError = {
 	};
 };
 
-// TODO: No sibling test file exists for this module yet. When one is added,
-// cover each branch of friendlyEmailSendError plus the fallback.
-function friendlyEmailSendError( wpError: WPError ): string {
+/**
+ * Maps an apiFetch error into merchant-friendly copy.
+ *
+ * Where possible we match on stable backend error codes rather than English
+ * message strings, so the mapping still works on localized sites. The two
+ * branches that still rely on message matches are flagged inline — they don't
+ * have stable codes to match against.
+ */
+export function friendlyEmailSendError( wpError: WPError ): string {
 	const { code, message } = wpError;
 
-	if (
-		code === 'rest_cookie_invalid_nonce' ||
-		message === 'Invalid nonce.'
-	) {
+	// Covers both WP core (rest_cookie_invalid_nonce) and Woo's own
+	// EmailPreviewRestController check (invalid_nonce).
+	if ( code === 'rest_cookie_invalid_nonce' || code === 'invalid_nonce' ) {
 		return __(
 			'Your session expired. Refresh the page and try again.',
 			'woocommerce'
 		);
 	}
 
-	if (
-		code === 'rest_invalid_json' ||
-		message === 'The response is not a valid JSON response.'
-	) {
+	// Stable WP core code for a non-JSON response body.
+	if ( code === 'rest_invalid_json' ) {
 		return __(
 			'The server returned unexpected output. Check your error log, or disable recently added plugins.',
 			'woocommerce'
 		);
 	}
 
+	// Locale-fragile: WSOD responses don't carry a structured error code,
+	// so we fall back to matching the English phrase PHP prints.
 	if ( message.includes( 'critical error' ) ) {
 		return __(
 			'A PHP error stopped the send. Check your error log or contact your host.',
@@ -62,13 +67,17 @@ function friendlyEmailSendError( wpError: WPError ): string {
 		);
 	}
 
-	if ( message === 'There was an error rendering an email preview.' ) {
+	// Stable Woo code emitted by EmailPreviewRestController when the preview
+	// template fails to render.
+	if ( code === 'woocommerce_rest_email_preview_not_rendered' ) {
 		return __(
 			"The email couldn't be rendered. Try resetting the template in Settings → Emails.",
 			'woocommerce'
 		);
 	}
 
+	// Locale-fragile: this apiFetch client fallback has no stable code, so
+	// we compare against the English message directly.
 	if ( message === 'Could not get a valid response from the server.' ) {
 		return __(
 			'Your server timed out. If it keeps happening, ask your host to check PHP execution limits.',
@@ -88,32 +97,39 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 	const [ isSending, setIsSending ] = useState( false );
 	const [ notice, setNotice ] = useState( '' );
 	const [ noticeType, setNoticeType ] = useState( '' );
+
 	const nonce = emailPreviewNonce();
 
 	const handleSendEmail = async () => {
 		setIsSending( true );
 		setNotice( '' );
+
 		try {
 			const response: EmailPreviewSendResponse = await apiFetch( {
 				path: `wc-admin-email/settings/email/send-preview?nonce=${ nonce }`,
 				method: 'POST',
 				data: { email, type },
 			} );
+
 			setNotice( response.message );
 			setNoticeType( 'success' );
+
 			recordEvent( 'settings_emails_preview_test_sent_successful', {
 				email_type: type,
 			} );
 		} catch ( e ) {
 			const wpError = e as WPError;
+
 			setNotice( friendlyEmailSendError( wpError ) );
 			setNoticeType( 'error' );
+
 			recordEvent( 'settings_emails_preview_test_sent_failed', {
 				email_type: type,
 				error: wpError.message,
 				error_code: wpError.code,
 			} );
 		}
+
 		setIsSending( false );
 	};
 
@@ -149,6 +165,7 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 						placeholder={ __( 'Enter an email', 'woocommerce' ) }
 						onChange={ setEmail }
 					/>
+
 					{ notice && (
 						<div
 							className={ `wc-settings-email-preview-send-modal-notice wc-settings-email-preview-send-modal-notice-${ noticeType }` }
@@ -169,6 +186,7 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 						>
 							{ __( 'Cancel', 'woocommerce' ) }
 						</Button>
+
 						<Button
 							variant="primary"
 							onClick={ handleSendEmail }

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -5,7 +5,7 @@ import { Button, Modal, TextControl } from '@wordpress/components';
 import { Icon, check, warning } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import { isValidEmail } from '@woocommerce/product-editor/build/utils/validate-email'; // Import from the build directory so we don't load the entire product editor since we only need this one function.
 
@@ -40,7 +40,7 @@ function friendlyEmailSendError( wpError: WPError ): string {
 		message === 'Invalid nonce.'
 	) {
 		return __(
-			'Your session expired. Refresh the page, then try sending again.',
+			'Your session expired. Refresh the page and try again.',
 			'woocommerce'
 		);
 	}
@@ -50,40 +50,35 @@ function friendlyEmailSendError( wpError: WPError ): string {
 		message === 'The response is not a valid JSON response.'
 	) {
 		return __(
-			'The server sent an unexpected response. A plugin on your site is probably printing PHP warnings. Check your error log, or try disabling recently added plugins.',
+			'The server returned unexpected output. Check your error log, or disable recently added plugins.',
 			'woocommerce'
 		);
 	}
 
 	if ( message.includes( 'critical error' ) ) {
 		return __(
-			"A PHP error stopped the test email. Check your site's error log, or contact your host. A recently added plugin is often the cause.",
+			'A PHP error stopped the send. Check your error log or contact your host.',
 			'woocommerce'
 		);
 	}
 
 	if ( message === 'There was an error rendering an email preview.' ) {
 		return __(
-			"The email couldn't be rendered. A customization or plugin may be interfering with this template. Try resetting it to default in Settings → Emails.",
+			"The email couldn't be rendered. Try resetting the template in Settings → Emails.",
 			'woocommerce'
 		);
 	}
 
 	if ( message === 'Could not get a valid response from the server.' ) {
 		return __(
-			"Your server didn't respond in time. Try again in a moment. If it keeps happening, ask your host to check your PHP execution limits.",
+			'Your server timed out. If it keeps happening, ask your host to check PHP execution limits.',
 			'woocommerce'
 		);
 	}
 
-	const cleanMessage = message.replace( /\.$/, '' );
-	return sprintf(
-		// translators: %s is the raw error message from the server.
-		__(
-			"We couldn't send the test email: %s. Try again, or review your email settings if the problem continues.",
-			'woocommerce'
-		),
-		cleanMessage
+	return __(
+		"Couldn't send the test email. Check your email settings and try again.",
+		'woocommerce'
 	);
 }
 

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -5,7 +5,7 @@ import { Button, Modal, TextControl } from '@wordpress/components';
 import { Icon, check, warning } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import { isValidEmail } from '@woocommerce/product-editor/build/utils/validate-email'; // Import from the build directory so we don't load the entire product editor since we only need this one function.
 
@@ -29,6 +29,63 @@ type WPError = {
 		status: number;
 	};
 };
+
+// TODO: No sibling test file exists for this module yet. When one is added,
+// cover each branch of friendlyEmailSendError plus the fallback.
+function friendlyEmailSendError( wpError: WPError ): string {
+	const { code, message } = wpError;
+
+	if (
+		code === 'rest_cookie_invalid_nonce' ||
+		message === 'Invalid nonce.'
+	) {
+		return __(
+			'Your session expired. Refresh the page, then try sending again.',
+			'woocommerce'
+		);
+	}
+
+	if (
+		code === 'rest_invalid_json' ||
+		message === 'The response is not a valid JSON response.'
+	) {
+		return __(
+			'The server sent an unexpected response. A plugin on your site is probably printing PHP warnings. Check your error log, or try disabling recently added plugins.',
+			'woocommerce'
+		);
+	}
+
+	if ( message.includes( 'critical error' ) ) {
+		return __(
+			"A PHP error stopped the test email. Check your site's error log, or contact your host. A recently added plugin is often the cause.",
+			'woocommerce'
+		);
+	}
+
+	if ( message === 'There was an error rendering an email preview.' ) {
+		return __(
+			"The email couldn't be rendered. A customization or plugin may be interfering with this template. Try resetting it to default in Settings → Emails.",
+			'woocommerce'
+		);
+	}
+
+	if ( message === 'Could not get a valid response from the server.' ) {
+		return __(
+			"Your server didn't respond in time. Try again in a moment. If it keeps happening, ask your host to check your PHP execution limits.",
+			'woocommerce'
+		);
+	}
+
+	const cleanMessage = message.replace( /\.$/, '' );
+	return sprintf(
+		// translators: %s is the raw error message from the server.
+		__(
+			"We couldn't send the test email: %s. Try again, or review your email settings if the problem continues.",
+			'woocommerce'
+		),
+		cleanMessage
+	);
+}
 
 export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -54,11 +111,12 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 			} );
 		} catch ( e ) {
 			const wpError = e as WPError;
-			setNotice( wpError.message );
+			setNotice( friendlyEmailSendError( wpError ) );
 			setNoticeType( 'error' );
 			recordEvent( 'settings_emails_preview_test_sent_failed', {
 				email_type: type,
 				error: wpError.message,
+				error_code: wpError.code,
 			} );
 		}
 		setIsSending( false );

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -39,7 +39,9 @@ export type WPError = {
  * have stable codes to match against.
  */
 export function friendlyEmailSendError( wpError: WPError ): string {
-	const { code, message } = wpError;
+	// apiFetch can reject with non-WPError shapes (native TypeError, wrapped middleware errors); unshaped errors fall through to the generic fallback.
+	const code = wpError?.code ?? '';
+	const message = wpError?.message ?? '';
 
 	// Covers both WP core (rest_cookie_invalid_nonce) and Woo's own
 	// EmailPreviewRestController check (invalid_nonce).

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email.spec.ts
@@ -201,9 +201,10 @@ test.describe( 'WooCommerce Email Settings', () => {
 		await expect( sendButton ).toBeEnabled();
 		await sendButton.click();
 
-		// Wait for the message, because sending will fail in test environment
+		// Sending fails in the test env (no mail server); the backend returns
+		// `woocommerce_rest_email_preview_not_sent`, which hits the generic fallback in friendlyEmailSendError.
 		const message = modal.locator(
-			'text=Error sending test email. Please try again.'
+			"text=Couldn't send the test email. Check your email settings and try again."
 		);
 		await expect( message ).toBeVisible();
 	} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a "Send a test email" attempt fails, the modal currently surfaces whatever raw message WordPress returns ("Invalid nonce.", "There was an error rendering an email preview.", etc.) — strings that are opaque to merchants. This PR adds a `friendlyEmailSendError()` helper that maps known error codes and message patterns to concise merchant-friendly copy, plus a generic fallback for unknown errors. The `settings_emails_preview_test_sent_failed` tracks event now also records `error_code` so we can see which branches fire in the wild.

#### Copy map

| When it fires | Merchant sees |
| --- | --- |
| Session/nonce expired (`rest_cookie_invalid_nonce`, or `"Invalid nonce."`) | Your session expired. Refresh the page and try again. |
| Invalid JSON response (`rest_invalid_json`, or `"The response is not a valid JSON response."`) | The server returned unexpected output. Check your error log, or disable recently added plugins. |
| PHP critical error (message contains `"critical error"`) | A PHP error stopped the send. Check your error log or contact your host. |
| Preview render failed (`"There was an error rendering an email preview."`) | The email couldn't be rendered. Try resetting the template in Settings → Emails. |
| Server didn't respond in time (`"Could not get a valid response from the server."`) | Your server timed out. If it keeps happening, ask your host to check PHP execution limits. |
| Anything else (unknown error) | Couldn't send the test email. Check your email settings and try again. |

### Screenshots or screen recordings:

_To be added before marking ready for review._

| Before | After |
| ------ | ----- |

Before
<img width="1014" height="688" alt="CleanShot 2026-04-21 at 22 45 38@2x" src="https://github.com/user-attachments/assets/27fce90b-866c-4569-a2c3-aae1467d253a" />

After
<img width="1264" height="860" alt="CleanShot 2026-04-21 at 23 26 34@2x" src="https://github.com/user-attachments/assets/f49f35a6-e3e6-4045-ba70-ff36eb77cba6" />


### How to test the changes in this Pull Request:

1. Go to **WooCommerce → Settings → Emails** and open any email (e.g., "Processing order").
2. Click **Send a test email**, enter a valid address, and confirm the happy path — "Test email sent to …" should still appear.
3. Trigger a nonce failure: in DevTools, intercept the `send-preview` request and strip the `nonce` query param. Expect the "session expired" copy from the table above.
4. Trigger a preview-render failure: in an mu-plugin, throw from any hook the preview invokes (e.g., `woocommerce_mail_content`). Expect the "couldn't be rendered" copy.
5. Trigger the unknown-error fallback: force `WC_Emails::send()` to fail with an unmapped message. Expect the fallback copy.

### Testing that has already taken place:

Manual smoke test pending on localhost. Screenshots to follow.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

Changelog entry committed manually in this PR (see `plugins/woocommerce/changelog/tweak-email-test-send-friendly-errors`).
