### PR TITLE
[Email Editor] Stamp sync meta on generated block email posts

### DIFF
--- a/plugins/woocommerce/changelog/add-email-template-sync-meta
+++ b/plugins/woocommerce/changelog/add-email-template-sync-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stamp sync meta on generated block email posts (version, source hash, synced-at) for emails whose templates expose a parseable @version header. No runtime behaviour change for emails outside the sync registry.

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
@@ -339,6 +339,17 @@ class WCTransactionalEmailPostsGenerator {
 		 */
 		$post_data = apply_filters( 'woocommerce_email_content_post_data', $post_data, $email_type, $email_data );
 
+		// Sync meta stamp for emails participating in template update propagation.
+		$sync_config = WCEmailTemplateSyncRegistry::get_email_sync_config( (string) $email_data->id );
+		if ( null !== $sync_config ) {
+			if ( ! isset( $post_data['meta_input'] ) || ! is_array( $post_data['meta_input'] ) ) {
+				$post_data['meta_input'] = array();
+			}
+			$post_data['meta_input']['_wc_email_template_version']     = (string) $sync_config['version'];
+			$post_data['meta_input']['_wc_email_template_source_hash'] = sha1( (string) ( $post_data['post_content'] ?? '' ) );
+			$post_data['meta_input']['_wc_email_last_synced_at']       = gmdate( 'Y-m-d H:i:s' );
+		}
+
 		$post_id = wp_insert_post( $post_data, true );
 
 		if ( is_wp_error( $post_id ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateSyncRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateSyncRegistryTest.php
@@ -40,7 +40,7 @@ class WCEmailTemplateSyncRegistryTest extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		add_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
+		update_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
 
 		$this->fixtures_base = __DIR__ . '/fixtures/';
 

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGeneratorTest.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\EmailEditor\WCTransactionalEmails;
 
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncRegistry;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
 
@@ -22,6 +24,20 @@ class WCTransactionalEmailPostsGeneratorTest extends \WC_Unit_Test_Case {
 	private WCTransactionalEmailPostsManager $template_manager;
 
 	/**
+	 * Absolute path to the fixtures directory used for sync-stamping tests.
+	 *
+	 * @var string
+	 */
+	private string $fixtures_base;
+
+	/**
+	 * Keys of WC_Emails::$emails entries injected during the current test.
+	 *
+	 * @var string[]
+	 */
+	private array $injected_email_keys = array();
+
+	/**
 	 * Setup test case.
 	 */
 	public function setUp(): void {
@@ -29,6 +45,15 @@ class WCTransactionalEmailPostsGeneratorTest extends \WC_Unit_Test_Case {
 		add_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
 		$this->email_generator  = new WCTransactionalEmailPostsGenerator();
 		$this->template_manager = WCTransactionalEmailPostsManager::get_instance();
+		$this->fixtures_base    = __DIR__ . '/fixtures/';
+
+		// WCTransactionalEmailPostsManager is a process-wide singleton; its in-memory
+		// post_id <-> email_type cache survives DB transaction rollback between tests
+		// and would otherwise make generate_email_template_if_not_exists() return a
+		// stale post ID whose backing post was rolled back.
+		$this->template_manager->clear_caches();
+
+		WCEmailTemplateSyncRegistry::reset_cache();
 	}
 
 	/**
@@ -139,9 +164,167 @@ class WCTransactionalEmailPostsGeneratorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Core email is stamped with all three sync meta keys, and the hash is self-consistent with post_content.
+	 */
+	public function test_core_email_is_stamped_with_all_three_meta_keys(): void {
+		$email_type = 'customer_new_account';
+
+		$this->email_generator->init_default_transactional_emails();
+		$this->template_manager->delete_email_template( $email_type );
+
+		$post_id = $this->email_generator->generate_email_template_if_not_exists( $email_type );
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		$version   = (string) get_post_meta( $post_id, '_wc_email_template_version', true );
+		$hash      = (string) get_post_meta( $post_id, '_wc_email_template_source_hash', true );
+		$synced_at = (string) get_post_meta( $post_id, '_wc_email_last_synced_at', true );
+
+		$this->assertNotSame( '', $version, '_wc_email_template_version should be populated for a core email.' );
+		$this->assertMatchesRegularExpression( '/^\d+\.\d+(?:\.\d+)?/', $version, 'Version should be semver-ish.' );
+
+		$post_content = (string) get_post( $post_id )->post_content;
+		$this->assertSame(
+			sha1( $post_content ),
+			$hash,
+			'_wc_email_template_source_hash must equal sha1() of the stored post_content.'
+		);
+
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+			$synced_at,
+			'_wc_email_last_synced_at should be a GMT MySQL-format timestamp.'
+		);
+	}
+
+	/**
+	 * Emails that are opted in for the block editor but whose templates lack a parseable @version
+	 * header are absent from the sync registry and must not be stamped.
+	 */
+	public function test_email_absent_from_registry_is_not_stamped(): void {
+		$email_id = 'wc_test_email_no_version';
+		$this->register_third_party_email_without_version( $email_id );
+
+		WCEmailTemplateSyncRegistry::reset_cache();
+
+		$this->email_generator->init_default_transactional_emails();
+		$this->template_manager->delete_email_template( $email_id );
+
+		$post_id = $this->email_generator->generate_email_template_if_not_exists( $email_id );
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		$this->assertSame( '', (string) get_post_meta( $post_id, '_wc_email_template_version', true ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, '_wc_email_template_source_hash', true ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, '_wc_email_last_synced_at', true ) );
+	}
+
+	/**
+	 * Regression guard: every core transactional email that is actually loaded by WC_Emails
+	 * must expose a parseable @version header through the sync registry.
+	 *
+	 * This replaces a runtime throw in the registry and catches template drift (missing or
+	 * malformed @version) at CI time. Feature-gated emails may not be loaded in the test
+	 * process, so we intersect against the actually-registered email IDs.
+	 */
+	public function test_every_loaded_core_template_has_parseable_version(): void {
+		WCEmailTemplateSyncRegistry::reset_cache();
+
+		$registered_email_ids = array_map(
+			static fn ( \WC_Email $email ): string => (string) $email->id,
+			array_values( \WC_Emails::instance()->get_emails() )
+		);
+
+		$core_emails_to_check = array_intersect(
+			WCTransactionalEmails::get_core_transactional_emails(),
+			$registered_email_ids
+		);
+
+		$this->assertNotEmpty(
+			$core_emails_to_check,
+			'Expected at least one core transactional email to be registered with WC_Emails during the test run.'
+		);
+
+		foreach ( $core_emails_to_check as $email_id ) {
+			$config = WCEmailTemplateSyncRegistry::get_email_sync_config( (string) $email_id );
+
+			$this->assertNotNull(
+				$config,
+				sprintf( 'Core email "%s" must be resolvable through the sync registry.', $email_id )
+			);
+			$this->assertIsArray( $config );
+			$this->assertArrayHasKey( 'version', $config );
+			$this->assertMatchesRegularExpression(
+				'/^\d+\.\d+(?:\.\d+)?/',
+				(string) $config['version'],
+				sprintf( 'Core email "%s" must expose a semver-ish @version header.', $email_id )
+			);
+		}
+	}
+
+	/**
+	 * Inject a WC_Email stub whose block template has no parseable @version header into
+	 * WC_Emails::$emails and opt it in via the block-editor filter.
+	 *
+	 * @param string $email_id Email ID to inject.
+	 */
+	private function register_third_party_email_without_version( string $email_id ): void {
+		$stub = $this->getMockBuilder( \WC_Email::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$stub->method( 'get_title' )->willReturn( 'Third-party test email' );
+		$stub->method( 'get_description' )->willReturn( 'Fixture email without a parseable @version header.' );
+		$stub->id             = $email_id;
+		$stub->template_base  = $this->fixtures_base;
+		$stub->template_block = 'block/third-party-without-version.php';
+		$stub->template_plain = 'plain/test-fallback.php';
+
+		$class_key = 'WC_Test_Email_' . $email_id;
+
+		$emails_container = \WC_Emails::instance();
+		$reflection       = new \ReflectionClass( $emails_container );
+		$property         = $reflection->getProperty( 'emails' );
+		$property->setAccessible( true );
+		$current               = $property->getValue( $emails_container );
+		$current[ $class_key ] = $stub;
+		$property->setValue( $emails_container, $current );
+
+		$this->injected_email_keys[] = $class_key;
+
+		add_filter(
+			'woocommerce_transactional_emails_for_block_editor',
+			static function ( array $emails ) use ( $email_id ): array {
+				if ( ! in_array( $email_id, $emails, true ) ) {
+					$emails[] = $email_id;
+				}
+				return $emails;
+			}
+		);
+	}
+
+	/**
 	 * Cleanup after test.
 	 */
 	public function tearDown(): void {
+		if ( ! empty( $this->injected_email_keys ) ) {
+			$emails_container = \WC_Emails::instance();
+			$reflection       = new \ReflectionClass( $emails_container );
+			$property         = $reflection->getProperty( 'emails' );
+			$property->setAccessible( true );
+			$current = $property->getValue( $emails_container );
+			foreach ( $this->injected_email_keys as $key ) {
+				unset( $current[ $key ] );
+			}
+			$property->setValue( $emails_container, $current );
+			$this->injected_email_keys = array();
+		}
+
+		remove_all_filters( 'woocommerce_transactional_emails_for_block_editor' );
+
+		WCEmailTemplateSyncRegistry::reset_cache();
+
 		parent::tearDown();
 		update_option( 'woocommerce_feature_block_email_editor_enabled', 'no' );
 		delete_transient( 'wc_email_editor_initial_templates_generated' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes RSM-137
Follow-up to https://github.com/woocommerce/woocommerce/pull/64261

When WooCommerce generates a block-editor email post, we don't currently record which template version it came from. Without that, we can't later tell whether the merchant has edited their copy or whether the source template has moved on. This PR stamps three meta keys on each generated post — template version, content hash, and timestamp — for emails whose block template exposes a parseable `@version` header. Emails outside this set are unchanged.

### How to test the changes in this Pull Request:

1. Enable the block email editor feature.
2. Confirm the email posts exist (for example, open `WooCommerce → Settings → Emails → New order` in the editor).
3. In the database, find the post ID stored in `wp_options` under `woocommerce_email_templates_customer_new_account_post_id`.
4. Query `wp_postmeta` for that post ID and confirm three keys exist: `_wc_email_template_version` (semver-ish string), `_wc_email_template_source_hash` (40-char sha1), and `_wc_email_last_synced_at` (UTC \`YYYY-MM-DD HH:MM:SS\`).
5. Confirm \`sha1( post_content ) === _wc_email_template_source_hash\` for that post.

Note: If the email post already exists in your environment, you need to delete it and regenerate it.

### Testing that has already taken place:

- Added PHPUnit coverage on the generator: happy path, no-\`@version\` skip path, and a regression guard that every loaded core template still exposes a parseable \`@version\`.
- Local \`pnpm lint:php\`, \`pnpm phpstan\`, and filtered PHPUnit on the changed files — all clean.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry already included in the PR at \`plugins/woocommerce/changelog/add-email-template-sync-meta\`.

</details>
