### PR TITLE
fix: update BYN currency symbol to official sign fallback

### DIFF
--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -558,7 +558,7 @@ function get_woocommerce_currency_symbols() {
 			'BTN' => 'Nu.',
 			'BWP' => 'P',
 			'BYR' => 'Br',
-			'BYN' => 'Br',
+			'BYN' => '&#x411;',
 			'BZD' => '&#36;',
 			'CAD' => '&#36;',
 			'CDF' => 'Fr',


### PR DESCRIPTION
## Summary

Updates the Belarusian ruble (BYN) currency symbol to the new official graphical symbol adopted in 2026. Uses a Cyrillic 'Б' fallback to ensure reliable rendering across all systems.

Fixes #64200

## Problem

The previous 'Br' symbol is outdated for the Belarusian ruble (BYN). While a new Unicode point (U+20C5) was assigned in early 2026, it currently lacks widespread font support, leading to broken "tofu" character boxes in the currency selection UI and frontend.

## Solution

Updated the `BYN` mapping in `wc_get_woocommerce_currency_symbols()` to use `&#x411;` (the Cyrillic letter 'Б'). This approach aligns with the base of the new official graphical symbol while guaranteeing that the character renders correctly on all user devices today, regardless of their Unicode font support.

## Changes

### plugins/woocommerce/includes/wc-core-functions.php

**Before:**
```php
'BYN' => 'Br',
```

**After:**
```php
'BYN' => '&#x411;',
```

**Why:** Replaces the deprecated 'Br' abbreviation with the base of the new official symbol. Using a standard Cyrillic character fallback prevents the rendering issues observed when using the newly assigned (but poorly supported) `U+20C5` code point.

## Testing

**Test 1: Currency Selection**
Steps: 
1) Navigate to WooCommerce > Settings > General 
2) Select "Belarusian ruble (BYN)" from the currency dropdown 
3) Save changes.

Result: The 'Б' symbol appears correctly in the dropdown list and in the settings field.

**Test 2: Frontend Display**
Steps: 
1) Add a product to cart 
2) View cart/checkout with BYN currency active.

Result: Prices display with the 'Б' symbol prefix/suffix as expected.

## Screenshot
<img width="740" height="311" alt="image" src="https://github.com/user-attachments/assets/7d0339c3-5faa-4ef8-b74b-e3ab973ec599" />
