### PR TITLE
Add GraphQL settings section with GET endpoint toggle

### DIFF
--- a/plugins/woocommerce/changelog/64279-64165-graphql-settings-page
+++ b/plugins/woocommerce/changelog/64279-64165-graphql-settings-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a GraphQL settings section under Advanced with a toggle for the GET endpoint.

--- a/plugins/woocommerce/changelog/64279-64165-graphql-settings-page
+++ b/plugins/woocommerce/changelog/64279-64165-graphql-settings-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a GraphQL settings section under Advanced with a toggle for the GET endpoint. Only visible when the Dual Code & GraphQL API feature is enabled.

--- a/plugins/woocommerce/changelog/64279-64165-graphql-settings-page
+++ b/plugins/woocommerce/changelog/64279-64165-graphql-settings-page
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add a GraphQL settings section under Advanced with a toggle for the GET endpoint. Only visible when the Dual Code & GraphQL API feature is enabled.
+Add a GraphQL settings section under Advanced with a toggle for the GET endpoint.

--- a/plugins/woocommerce/changelog/64293-add-graphql-settings-toggle
+++ b/plugins/woocommerce/changelog/64293-add-graphql-settings-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a GraphQL settings section under Advanced with a toggle for the GET endpoint.

--- a/plugins/woocommerce/src/Internal/Api/GraphQLController.php
+++ b/plugins/woocommerce/src/Internal/Api/GraphQLController.php
@@ -90,11 +90,13 @@ class GraphQLController {
 	 * Register the GraphQL REST route.
 	 */
 	public function register(): void {
+		$methods = Main::is_get_endpoint_enabled() ? array( 'GET', 'POST' ) : array( 'POST' );
+
 		register_rest_route(
 			'wc',
 			'/graphql',
 			array(
-				'methods'             => array( 'GET', 'POST' ),
+				'methods'             => $methods,
 				'callback'            => array( $this, 'handle_request' ),
 				// Auth is handled per-query/mutation.
 				'permission_callback' => '__return_true',

--- a/plugins/woocommerce/src/Internal/Api/Main.php
+++ b/plugins/woocommerce/src/Internal/Api/Main.php
@@ -57,7 +57,7 @@ class Main {
 	 * HTTP methods to accept.
 	 */
 	public static function is_get_endpoint_enabled(): bool {
-		return wc_string_to_bool( get_option( self::OPTION_GET_ENDPOINT_ENABLED, 'no' ) );
+		return wc_string_to_bool( get_option( self::OPTION_GET_ENDPOINT_ENABLED, 'yes' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/Main.php
+++ b/plugins/woocommerce/src/Internal/Api/Main.php
@@ -21,6 +21,13 @@ class Main {
 	private const FEATURE_SLUG = 'dual_code_graphql_api';
 
 	/**
+	 * Option name for the "Enable GET endpoint" setting.
+	 *
+	 * When disabled, the GraphQL route only accepts POST requests.
+	 */
+	public const OPTION_GET_ENDPOINT_ENABLED = 'woocommerce_graphql_get_endpoint_enabled';
+
+	/**
 	 * Cached result of the feature-enabled check, null until first evaluated.
 	 *
 	 * @var ?bool
@@ -40,6 +47,17 @@ class Main {
 			self::$enabled = PHP_VERSION_ID >= 80100 && FeaturesUtil::feature_is_enabled( self::FEATURE_SLUG );
 		}
 		return self::$enabled;
+	}
+
+	/**
+	 * Whether the GraphQL endpoint accepts GET requests.
+	 *
+	 * Defaults to false. Reads from the option written by the GraphQL
+	 * settings section so the REST route registration can decide which
+	 * HTTP methods to accept.
+	 */
+	public static function is_get_endpoint_enabled(): bool {
+		return wc_string_to_bool( get_option( self::OPTION_GET_ENDPOINT_ENABLED, 'no' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/Main.php
+++ b/plugins/woocommerce/src/Internal/Api/Main.php
@@ -62,5 +62,8 @@ class Main {
 				wc_get_container()->get( GraphQLController::class )->register();
 			}
 		);
+
+		$settings = wc_get_container()->get( Settings::class );
+		$settings->register();
 	}
 }

--- a/plugins/woocommerce/src/Internal/Api/Settings.php
+++ b/plugins/woocommerce/src/Internal/Api/Settings.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\Api;
+
+/**
+ * Settings handling for the GraphQL API.
+ *
+ * Registers the "GraphQL" section under WooCommerce - Settings - Advanced.
+ * Only active when Main::is_enabled() returns true (feature flag on and
+ * PHP 8.1+), so the section is hidden when the feature is disabled.
+ */
+class Settings {
+	/**
+	 * Identifier for the GraphQL section under the Advanced settings tab.
+	 */
+	public const SECTION_ID = 'graphql';
+
+	/**
+	 * Register the filter hooks that expose the GraphQL settings section.
+	 */
+	public function register(): void {
+		add_filter( 'woocommerce_get_sections_advanced', array( $this, 'add_section' ) );
+		add_filter( 'woocommerce_get_settings_advanced', array( $this, 'add_settings' ), 10, 2 );
+	}
+
+	/**
+	 * Append the GraphQL section to the Advanced settings tab.
+	 *
+	 * @param array $sections Existing sections keyed by id.
+	 * @return array
+	 */
+	public function add_section( array $sections ): array {
+		$sections[ self::SECTION_ID ] = __( 'GraphQL', 'woocommerce' );
+		return $sections;
+	}
+
+	/**
+	 * Provide the settings fields for the GraphQL section.
+	 *
+	 * @param array  $settings   Existing settings for the current section.
+	 * @param string $section_id Current section id.
+	 * @return array
+	 */
+	public function add_settings( array $settings, string $section_id ): array {
+		if ( self::SECTION_ID !== $section_id ) {
+			return $settings;
+		}
+
+		return array();
+	}
+}

--- a/plugins/woocommerce/src/Internal/Api/Settings.php
+++ b/plugins/woocommerce/src/Internal/Api/Settings.php
@@ -57,9 +57,9 @@ class Settings {
 			),
 			array(
 				'title'   => __( 'Enable GET endpoint', 'woocommerce' ),
-				'desc'    => __( 'Allow GraphQL queries over GET in addition to POST.', 'woocommerce' ),
+				'desc'    => __( 'Allow GraphQL queries over GET in addition to POST', 'woocommerce' ),
 				'id'      => Main::OPTION_GET_ENDPOINT_ENABLED,
-				'default' => 'no',
+				'default' => 'yes',
 				'type'    => 'checkbox',
 			),
 			array(

--- a/plugins/woocommerce/src/Internal/Api/Settings.php
+++ b/plugins/woocommerce/src/Internal/Api/Settings.php
@@ -48,6 +48,24 @@ class Settings {
 			return $settings;
 		}
 
-		return array();
+		return array(
+			array(
+				'title' => __( 'GraphQL', 'woocommerce' ),
+				'desc'  => __( 'Configure the WooCommerce GraphQL API.', 'woocommerce' ),
+				'type'  => 'title',
+				'id'    => 'woocommerce_graphql_options',
+			),
+			array(
+				'title'   => __( 'Enable GET endpoint', 'woocommerce' ),
+				'desc'    => __( 'Allow GraphQL queries over GET in addition to POST.', 'woocommerce' ),
+				'id'      => Main::OPTION_GET_ENDPOINT_ENABLED,
+				'default' => 'no',
+				'type'    => 'checkbox',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'woocommerce_graphql_options',
+			),
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Api/GraphQLControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/GraphQLControllerTest.php
@@ -43,7 +43,9 @@ class GraphQLControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->sut->register();
 
-		$methods = rest_get_server()->get_routes()['/wc/graphql'][0]['methods'];
+		$handlers = rest_get_server()->get_routes()['/wc/graphql'];
+		$this->assertCount( 1, $handlers, 'Exactly one handler should be registered for /wc/graphql.' );
+		$methods = $handlers[0]['methods'];
 		$this->assertTrue( $methods['POST'] ?? false );
 		$this->assertFalse( $methods['GET'] ?? false );
 	}
@@ -56,7 +58,9 @@ class GraphQLControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->sut->register();
 
-		$methods = rest_get_server()->get_routes()['/wc/graphql'][0]['methods'];
+		$handlers = rest_get_server()->get_routes()['/wc/graphql'];
+		$this->assertCount( 1, $handlers, 'Exactly one handler should be registered for /wc/graphql.' );
+		$methods = $handlers[0]['methods'];
 		$this->assertTrue( $methods['GET'] ?? false );
 		$this->assertTrue( $methods['POST'] ?? false );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Api/GraphQLControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/GraphQLControllerTest.php
@@ -21,9 +21,19 @@ class GraphQLControllerTest extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Set up before each test.
+	 *
+	 * Skips on PHP < 8.1 because GraphQLController uses PHP 8.0+ syntax in its
+	 * source file (named arguments). In production the class is only loaded
+	 * after {@see Main::is_enabled()} gates on PHP 8.1+; these tests bypass
+	 * that gate by hitting the DI container directly, so we replicate it here.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			$this->markTestSkipped( 'GraphQLController requires PHP 8.1+.' );
+		}
+
 		$this->sut = wc_get_container()->get( GraphQLController::class );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Api/GraphQLControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/GraphQLControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Api;
+
+use Automattic\WooCommerce\Internal\Api\GraphQLController;
+use Automattic\WooCommerce\Internal\Api\Main;
+use WC_REST_Unit_Test_Case;
+
+/**
+ * Tests for the GraphQLController class — specifically the HTTP methods
+ * registered on the /wc/graphql route based on the GET endpoint option.
+ */
+class GraphQLControllerTest extends WC_REST_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var GraphQLController
+	 */
+	private $sut;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = wc_get_container()->get( GraphQLController::class );
+	}
+
+	/**
+	 * Clean up the GET endpoint option between tests.
+	 */
+	public function tearDown(): void {
+		delete_option( Main::OPTION_GET_ENDPOINT_ENABLED );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox register exposes POST only when the GET endpoint option is disabled.
+	 */
+	public function test_register_exposes_post_only_when_get_disabled(): void {
+		update_option( Main::OPTION_GET_ENDPOINT_ENABLED, 'no' );
+
+		$this->sut->register();
+
+		$methods = rest_get_server()->get_routes()['/wc/graphql'][0]['methods'];
+		$this->assertTrue( $methods['POST'] ?? false );
+		$this->assertFalse( $methods['GET'] ?? false );
+	}
+
+	/**
+	 * @testdox register exposes GET and POST when the GET endpoint option is enabled.
+	 */
+	public function test_register_exposes_get_and_post_when_get_enabled(): void {
+		update_option( Main::OPTION_GET_ENDPOINT_ENABLED, 'yes' );
+
+		$this->sut->register();
+
+		$methods = rest_get_server()->get_routes()['/wc/graphql'][0]['methods'];
+		$this->assertTrue( $methods['GET'] ?? false );
+		$this->assertTrue( $methods['POST'] ?? false );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
@@ -27,6 +27,15 @@ class SettingsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Clean up filters registered by tests so global state doesn't leak.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'woocommerce_get_sections_advanced', array( $this->sut, 'add_section' ) );
+		remove_filter( 'woocommerce_get_settings_advanced', array( $this->sut, 'add_settings' ), 10 );
+		parent::tearDown();
+	}
+
+	/**
 	 * @testdox register hooks add_section and add_settings into WooCommerce's advanced settings filters.
 	 */
 	public function test_register_hooks_both_advanced_filters(): void {
@@ -53,7 +62,7 @@ class SettingsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox add_settings defines the GET endpoint checkbox with a 'no' default.
+	 * @testdox add_settings defines the GET endpoint checkbox with a 'yes' default.
 	 */
 	public function test_add_settings_defines_get_endpoint_checkbox(): void {
 		$fields = $this->sut->add_settings( array(), Settings::SECTION_ID );

--- a/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
@@ -27,6 +27,22 @@ class SettingsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox register hooks add_section and add_settings into WooCommerce's advanced settings filters.
+	 */
+	public function test_register_hooks_both_advanced_filters(): void {
+		$this->sut->register();
+
+		$this->assertNotFalse(
+			has_filter( 'woocommerce_get_sections_advanced', array( $this->sut, 'add_section' ) ),
+			'add_section should be hooked to woocommerce_get_sections_advanced.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'woocommerce_get_settings_advanced', array( $this->sut, 'add_settings' ) ),
+			'add_settings should be hooked to woocommerce_get_settings_advanced.'
+		);
+	}
+
+	/**
 	 * @testdox add_section appends the graphql section while preserving existing ones.
 	 */
 	public function test_add_section_appends_graphql_section(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
@@ -61,6 +61,6 @@ class SettingsTest extends WC_Unit_Test_Case {
 
 		$this->assertArrayHasKey( Main::OPTION_GET_ENDPOINT_ENABLED, $by_id );
 		$this->assertSame( 'checkbox', $by_id[ Main::OPTION_GET_ENDPOINT_ENABLED ]['type'] );
-		$this->assertSame( 'no', $by_id[ Main::OPTION_GET_ENDPOINT_ENABLED ]['default'] );
+		$this->assertSame( 'yes', $by_id[ Main::OPTION_GET_ENDPOINT_ENABLED ]['default'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
@@ -1,0 +1,50 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Api;
+
+use Automattic\WooCommerce\Internal\Api\Main;
+use Automattic\WooCommerce\Internal\Api\Settings;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the GraphQL API Settings class.
+ */
+class SettingsTest extends WC_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var Settings
+	 */
+	private $sut;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new Settings();
+	}
+
+	/**
+	 * @testdox add_section appends the graphql section while preserving existing ones.
+	 */
+	public function test_add_section_appends_graphql_section(): void {
+		$result = $this->sut->add_section( array( 'features' => 'Features' ) );
+
+		$this->assertArrayHasKey( Settings::SECTION_ID, $result );
+		$this->assertArrayHasKey( 'features', $result );
+	}
+
+	/**
+	 * @testdox add_settings defines the GET endpoint checkbox with a 'no' default.
+	 */
+	public function test_add_settings_defines_get_endpoint_checkbox(): void {
+		$fields = $this->sut->add_settings( array(), Settings::SECTION_ID );
+		$by_id  = array_column( $fields, null, 'id' );
+
+		$this->assertArrayHasKey( Main::OPTION_GET_ENDPOINT_ENABLED, $by_id );
+		$this->assertSame( 'checkbox', $by_id[ Main::OPTION_GET_ENDPOINT_ENABLED ]['type'] );
+		$this->assertSame( 'no', $by_id[ Main::OPTION_GET_ENDPOINT_ENABLED ]['default'] );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [ ] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [ ] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds a **GraphQL** section under **WooCommerce → Settings → Advanced** with the option to enable/disable the GET endpoint.

When off, `/wc/graphql` accepts POST only; when on, it accepts GET + POST. The section is hidden unless the `dual_code_graphql_api` feature flag is on.

Closes https://github.com/woocommerce/woocommerce/issues/64295

### How to test the changes in this Pull Request:

1. Enable the feature flag on a dev environment running PHP 8.1+: `wp option update woocommerce_feature_dual_code_graphql_api_enabled yes`.
2. Visit **WooCommerce → Settings → Advanced**. A new **GraphQL** tab should be present at the end of the section list.
3. Click the tab. The page shows a **GraphQL** header with a short description and one **Enable GET endpoint** checkbox, unchecked by default.
4. With the checkbox **unchecked**, run any query to the GET endpoint, you should get a 404.
5. Run a POST query against the same URL, you should get a response this time.
6. Check the **Enable GET endpoint** box, save, and re-run the GET request from step 4. Expect a 200 response.
7. Flip the feature flag off (`wp option update woocommerce_feature_dual_code_graphql_api_enabled no`). The **GraphQL** tab should disappear from the Advanced settings.

### Testing that has already taken place:

- Automated: added `SettingsTest` (section registration, checkbox default) and `GraphQLControllerTest` (route methods when GET is enabled/disabled). All 4 tests + 9 assertions pass under `wp-env` / PHPUnit 9.6.29 / PHP 8.1.34.
- Manual: verified the tab appears only when the feature flag is on; verified GET/POST behavior on `/wc/graphql` after toggling the checkbox.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Add - Adds functionality

#### Message

Add a GraphQL settings section under Advanced with a toggle for the GET endpoint.

</details>

