### PR TITLE
WC-Core 2: Always show QR direct login in mobile app modal (WOOMOB-2765)

### DIFF
--- a/plugins/woocommerce/changelog/woomob-2765-modal-polish
+++ b/plugins/woocommerce/changelog/woomob-2765-modal-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Drop the outdated "app version needs to be 15.7" helper text from the mobile-app modal QR view and surface the underlying Jetpack error in the magic-link failure notice so support and merchants can diagnose the problem instead of hitting a generic retry message.

--- a/plugins/woocommerce/changelog/woomob-2765-show-qr-direct-login-for-all-admins
+++ b/plugins/woocommerce/changelog/woomob-2765-show-qr-direct-login-for-all-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Always show the QR direct login as the primary path in the mobile app modal, with the WordPress.com magic link available as a secondary CTA when the user has a linked WordPress.com account.

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginInfo.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginInfo.tsx
@@ -18,12 +18,6 @@ export const MobileAppLoginInfo = ( {
 			{ loginUrl && (
 				<div>
 					<QRCodeSVG value={ loginUrl } size={ 140 } />
-					<p>
-						{ __(
-							'The app version needs to be 15.7 or above to sign in with this link.',
-							'woocommerce'
-						) }
-					</p>
 				</div>
 			) }
 			<div>

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
@@ -10,10 +10,9 @@ import { Stepper, StepperProps } from '@woocommerce/components';
  * Internal dependencies
  */
 import { SendMagicLinkStates } from './';
-import { getAdminSetting } from '~/utils/admin-settings';
 import { MobileAppInstallationInfo } from '../components/MobileAppInstallationInfo';
-import { MobileAppLoginInfo } from '../components/MobileAppLoginInfo';
 import { QRDirectLoginCode } from '../components/QRDirectLoginCode';
+import { SendMagicLinkButton } from '../components/SendMagicLinkButton';
 
 export const MobileAppLoginStepper = ( {
 	step,
@@ -68,57 +67,47 @@ export const MobileAppLoginStepper = ( {
 				},
 			] );
 		} else if ( step === 'second' ) {
-			if (
+			const hasLinkedWordPressAccount =
 				isJetpackPluginInstalled &&
-				wordpressAccountEmailAddress !== undefined
-			) {
-				setStepsToDisplay( [
-					{
-						key: 'first',
-						label: __( 'App installed', 'woocommerce' ),
-						description: '',
-						content: <></>,
-					},
-					{
-						key: 'second',
-						label: __( 'Sign into the app', 'woocommerce' ),
-						description: __(
-							'Scan the QR code below with your phone to sign in instantly — no password needed.',
-							'woocommerce'
-						),
-						content: <QRDirectLoginCode />,
-					},
-				] );
-			} else {
-				const siteUrl: string = getAdminSetting( 'siteUrl' );
-				const username = getAdminSetting( 'currentUserData' ).username;
-				const loginUrl = `woocommerce://app-login?siteUrl=${ encodeURIComponent(
-					siteUrl
-				) }&username=${ encodeURIComponent( username ) }`;
-				const description = loginUrl
-					? __(
-							'Scan the QR code below and enter the wp-admin password in the app.',
-							'woocommerce'
-					  )
-					: __(
-							'Follow the instructions in the app to sign in.',
-							'woocommerce'
-					  );
-				setStepsToDisplay( [
-					{
-						key: 'first',
-						label: __( 'App installed', 'woocommerce' ),
-						description: '',
-						content: <></>,
-					},
-					{
-						key: 'second',
-						label: 'Sign into the app',
-						description,
-						content: <MobileAppLoginInfo loginUrl={ loginUrl } />,
-					},
-				] );
-			}
+				wordpressAccountEmailAddress !== undefined;
+			setStepsToDisplay( [
+				{
+					key: 'first',
+					label: __( 'App installed', 'woocommerce' ),
+					description: '',
+					content: <></>,
+				},
+				{
+					key: 'second',
+					label: __( 'Sign into the app', 'woocommerce' ),
+					description: __(
+						'Scan the QR code below with your phone to sign in instantly — no password needed.',
+						'woocommerce'
+					),
+					content: (
+						<>
+							<QRDirectLoginCode />
+							{ hasLinkedWordPressAccount && (
+								<div className="mobile-app-login-magic-link-secondary">
+									<p className="mobile-app-login-magic-link-secondary__label">
+										{ __(
+											'Or get a WordPress.com sign-in link by email:',
+											'woocommerce'
+										) }
+									</p>
+									<SendMagicLinkButton
+										onClickHandler={ sendMagicLinkHandler }
+										isFetching={
+											sendMagicLinkStatus ===
+											SendMagicLinkStates.FETCHING
+										}
+									/>
+								</div>
+							) }
+						</>
+					),
+				},
+			] );
 		}
 	}, [
 		step,

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
@@ -4,7 +4,9 @@
 import React, { useState, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Stepper, StepperProps } from '@woocommerce/components';
+import { Stepper, StepperProps, Link } from '@woocommerce/components';
+import interpolateComponents from '@automattic/interpolate-components';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -104,6 +106,28 @@ export const MobileAppLoginStepper = ( {
 									/>
 								</div>
 							) }
+							<div className="mobile-app-login-faq">
+								{ interpolateComponents( {
+									mixedString: __(
+										'Any troubles signing in? Check out the {{link}}FAQ{{/link}}.',
+										'woocommerce'
+									),
+									components: {
+										link: (
+											<Link
+												href="https://woocommerce.com/document/android-ios-apps-login-help-faq/"
+												target="_blank"
+												type="external"
+												onClick={ () => {
+													recordEvent(
+														'onboarding_app_login_faq_click'
+													);
+												} }
+											/>
+										),
+									},
+								} ) }
+							</div>
 						</>
 					),
 				},

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
@@ -124,12 +124,6 @@ export const QRDirectLoginCode = () => {
 						formatTime( secondsRemaining )
 					) }
 				</p>
-				<p className="woocommerce-qr-direct-login__version-note">
-					{ __(
-						'The app version needs to be 15.7 or above to sign in with this link.',
-						'woocommerce'
-					) }
-				</p>
 				<div>
 					{ createInterpolateElement(
 						__(

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
@@ -2,15 +2,10 @@
  * External dependencies
  */
 import { QRCodeSVG } from 'qrcode.react';
-import React, {
-	createInterpolateElement,
-	useEffect,
-	useRef,
-} from '@wordpress/element';
+import React, { useEffect, useRef } from '@wordpress/element';
 import { Button, Spinner } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
-import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -124,28 +119,6 @@ export const QRDirectLoginCode = () => {
 						formatTime( secondsRemaining )
 					) }
 				</p>
-				<div>
-					{ createInterpolateElement(
-						__(
-							'Any troubles signing in? Check out the <link>FAQ</link>.',
-							'woocommerce'
-						),
-						{
-							link: (
-								<Link
-									href="https://woocommerce.com/document/android-ios-apps-login-help-faq/"
-									target="_blank"
-									type="external"
-									onClick={ () => {
-										recordEvent(
-											'onboarding_app_login_faq_click'
-										);
-									} }
-								/>
-							),
-						}
-					) }
-				</div>
 			</div>
 		);
 	}

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/MobileAppLoginStepper.test.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/MobileAppLoginStepper.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { MobileAppLoginStepper } from '../MobileAppLoginStepper';
+import { SendMagicLinkStates } from '../useSendMagicLink';
+import { QRLoginTokenStates, useQRLoginToken } from '../useQRLoginToken';
+
+// Mock the QR login token hook so we can drive each state from the tests.
+jest.mock( '../useQRLoginToken', () => {
+	const actual = jest.requireActual( '../useQRLoginToken' );
+	return {
+		...actual,
+		useQRLoginToken: jest.fn(),
+	};
+} );
+
+// Mock tracks to keep tests isolated from analytics side-effects.
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+const mockedUseQRLoginToken = useQRLoginToken as jest.MockedFunction<
+	typeof useQRLoginToken
+>;
+
+const readyTokenState = {
+	state: QRLoginTokenStates.READY,
+	qrUrl: 'woocommerce://qr-login?token=abc&siteUrl=https%3A%2F%2Fexample.test',
+	secondsRemaining: 300,
+	errorMessage: null,
+	fetchToken: jest.fn(),
+	refreshToken: jest.fn(),
+};
+
+const errorTokenState = {
+	state: QRLoginTokenStates.ERROR,
+	qrUrl: null,
+	secondsRemaining: 0,
+	errorMessage: 'QR login requires an HTTPS connection.',
+	fetchToken: jest.fn(),
+	refreshToken: jest.fn(),
+};
+
+const baseProps = {
+	step: 'second' as const,
+	completeInstallationStepHandler: jest.fn(),
+	sendMagicLinkHandler: jest.fn(),
+	sendMagicLinkStatus: SendMagicLinkStates.INIT,
+};
+
+describe( 'MobileAppLoginStepper', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedUseQRLoginToken.mockReturnValue( readyTokenState );
+	} );
+
+	describe( 'step 2 (sign-in)', () => {
+		it( 'renders the QR direct login for an admin without Jetpack and hides the magic link button', () => {
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ false }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			// The QR direct login is the primary path — its expiry timer copy
+			// is a reliable signal that the component is on screen.
+			expect(
+				screen.getByText( /Code expires in/i )
+			).toBeInTheDocument();
+
+			// The WordPress.com magic link secondary CTA should not show up
+			// for non-Jetpack users.
+			expect(
+				screen.queryByText(
+					/Or get a WordPress\.com sign-in link by email/i
+				)
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Send the sign-in link/i,
+				} )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders both the QR and the magic link button when Jetpack is fully connected and the user has a linked WordPress.com account', () => {
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ true }
+					wordpressAccountEmailAddress="admin@example.test"
+				/>
+			);
+
+			expect(
+				screen.getByText( /Code expires in/i )
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/Or get a WordPress\.com sign-in link by email/i
+				)
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', {
+					name: /Send the sign-in link/i,
+				} )
+			).toBeInTheDocument();
+		} );
+
+		it( 'hides the magic link button for a shop manager without a linked WordPress.com account even if Jetpack is installed', () => {
+			// Shop managers typically don't own the Jetpack connection and
+			// their currentUser.wpcomUser.email is undefined upstream, which
+			// surfaces here as wordpressAccountEmailAddress === undefined.
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ true }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			expect(
+				screen.getByText( /Code expires in/i )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText(
+					/Or get a WordPress\.com sign-in link by email/i
+				)
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'invokes the magic link handler when the secondary button is clicked', () => {
+			const sendMagicLinkHandler = jest.fn();
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					sendMagicLinkHandler={ sendMagicLinkHandler }
+					isJetpackPluginInstalled={ true }
+					wordpressAccountEmailAddress="admin@example.test"
+				/>
+			);
+
+			fireEvent.click(
+				screen.getByRole( 'button', {
+					name: /Send the sign-in link/i,
+				} )
+			);
+
+			expect( sendMagicLinkHandler ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'surfaces the QR error state from useQRLoginToken', () => {
+			mockedUseQRLoginToken.mockReturnValue( errorTokenState );
+
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ false }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			expect(
+				screen.getByText( /QR login requires an HTTPS connection/i )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: /Try again/i } )
+			).toBeInTheDocument();
+			// Error state should never leak the happy-path timer copy.
+			expect(
+				screen.queryByText( /Code expires in/i )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'does not render the old username + site URL fallback when the user lacks a linked WordPress.com account', () => {
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ false }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			// The removed MobileAppLoginInfo fallback used to show this copy.
+			expect(
+				screen.queryByText(
+					/Scan the QR code below and enter the wp-admin password/i
+				)
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'step 1 (install)', () => {
+		it( 'renders the install-app CTA and wires it up to the handler', () => {
+			const completeInstallationStepHandler = jest.fn();
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					step="first"
+					completeInstallationStepHandler={
+						completeInstallationStepHandler
+					}
+					isJetpackPluginInstalled={ false }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			const installButton = screen.getByRole( 'button', {
+				name: /App is installed/i,
+			} );
+			fireEvent.click( installButton );
+			expect( completeInstallationStepHandler ).toHaveBeenCalledTimes(
+				1
+			);
+
+			// The QR direct login is rendered for step 2, not step 1.
+			expect(
+				screen.queryByText( /Code expires in/i )
+			).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useSendMagicLink.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useSendMagicLink.tsx
@@ -57,14 +57,27 @@ export const useSendMagicLink = () => {
 					error: response.message,
 					code: response.code,
 				} );
+				// Log the full response so the actual Jetpack / backend error
+				// is visible in the browser console for debugging. The
+				// user-facing notice is intentionally friendlier below.
+				// eslint-disable-next-line no-console
+				console.error( 'Send magic link failed:', response );
+
+				const genericRetry = __(
+					'We couldn’t send the link. Try again in a few seconds.',
+					'woocommerce'
+				);
+
 				if ( response.code === 'error_sending_mobile_magic_link' ) {
-					createNotice(
-						'error',
-						__(
-							'We couldn’t send the link. Try again in a few seconds.',
-							'woocommerce'
-						)
-					);
+					// The backend embeds the Jetpack error as
+					// "<code>: <message>" in response.message. Surface it
+					// alongside the retry guidance so merchants and support
+					// can distinguish a transient hiccup from a real
+					// configuration problem.
+					const detail = response.message
+						? ` (${ response.message })`
+						: '';
+					createNotice( 'error', `${ genericRetry }${ detail }` );
 				} else if (
 					response.code === 'invalid_user_permission_view_admin'
 				) {
@@ -78,10 +91,7 @@ export const useSendMagicLink = () => {
 				} else if ( response.code === 'jetpack_not_connected' ) {
 					createNotice( 'error', response.message );
 				} else {
-					createNotice(
-						'error',
-						'We couldn’t send the link. Try again in a few seconds.'
-					);
+					createNotice( 'error', genericRetry );
 				}
 			} );
 	}, [ createNotice ] );

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
@@ -206,15 +206,12 @@
 }
 
 button.components-button.send-magic-link-button {
-	background: #7f54b3;
+	background: #007cba;
 	color: #fff;
 	position: relative;
 	margin-bottom: 1em;
-	transition: background-color 0.15s ease-in-out;
-
-	&:hover,
-	&:focus {
-		background: #674399;
+	:hover {
+		// the hover state makes the text invisible so we need to override it
 		color: #fff;
 	}
 
@@ -288,7 +285,7 @@ button.components-button.send-magic-link-button {
 		}
 		.email-sent-footer-text {
 			.email-sent-send-another-link {
-				color: #7f54b3;
+				color: #007cba;
 				text-decoration: none;
 				padding: 0;
 				cursor: pointer;

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
@@ -206,15 +206,15 @@
 }
 
 button.components-button.send-magic-link-button {
-	background: var(--wp-admin-theme-color, #007cba);
+	background: #7f54b3;
 	color: #fff;
 	position: relative;
 	margin-bottom: 1em;
-	&:hover {
-		background: var(--wp-admin-theme-color-darker-20, #005a87);
-	}
-	:hover {
-		// the hover state makes the text invisible so we need to override it
+	transition: background-color 0.15s ease-in-out;
+
+	&:hover,
+	&:focus {
+		background: #674399;
 		color: #fff;
 	}
 
@@ -288,7 +288,7 @@ button.components-button.send-magic-link-button {
 		}
 		.email-sent-footer-text {
 			.email-sent-send-another-link {
-				color: #007cba;
+				color: #7f54b3;
 				text-decoration: none;
 				padding: 0;
 				cursor: pointer;
@@ -322,4 +322,3 @@ button.components-button.send-magic-link-button {
 		}
 	}
 }
-


### PR DESCRIPTION
> **📚 Stack navigation**
> ⬅ Previous: [#64302 — WC-Core 1 — capability gate](https://github.com/woocommerce/woocommerce/pull/64302)
> ➡ Next: [#64319 — WC-Core 3 — error handling](https://github.com/woocommerce/woocommerce/pull/64319)

## Summary

The "Get the WooCommerce mobile app" modal previously hid the **QR sign-in** option behind a WordPress.com-linked-account gate; with #64302 lifting that gate at the REST layer, this surface should always show it. This PR rewires `MobileAppLoginStepper` so the QR step renders for every admin who can open the modal.

The **magic-link** button keeps its existing, narrower gating — it stays hidden unless the current admin user is the Jetpack connection owner with a linked WP.com email — because that's the only case where there is actually a WP.com email to send the link to.

## Gating after this PR

| Site state for the current admin user | QR sign-in | Magic-link button |
|---|---|---|
| No Jetpack / not activated / no WP.com connection | ✅ shown | ❌ hidden |
| Jetpack connected, current user is **not** the connection owner (`NOT_OWNER_OF_CONNECTION`) | ✅ shown | ❌ hidden |
| Jetpack connected, current user **is** the connection owner with a WP.com email (`FULL_CONNECTION`) | ✅ shown | ✅ shown |

The "connection owner" check is the existing `jetpackConnectionData.currentUser.isMaster` flag from Jetpack — see `useJetpackPluginState.tsx`. We don't introduce any new gating; we just stop conditionally hiding `<QRDirectLoginCode />`.

## Changes

- `MobileAppLoginStepper.tsx` — render `<QRDirectLoginCode />` unconditionally inside the second stepper step. The magic-link block stays wrapped in `hasLinkedWordPressAccount && …` so it only renders when `isJetpackPluginInstalled && wordpressAccountEmailAddress !== undefined` (i.e. the connection-owner case above).
- The "Sign in with QR code" button is restyled to match the magic-link button (Woo purple primary). FAQ link relocated below the magic-link block.
- Removed the "version 15.7+ required" subtitle — once #64503 lands, all production builds support number-matching, and a hard-coded version string here would rot fast.
- New Jest tests covering the stepper rendering all three Jetpack/WPCOM combinations independently.

## Testing

**Automated:** `pnpm run test:js -- MobileAppLoginStepper`.

**Manual:** open the homescreen and click "Get the WooCommerce mobile app". The QR option should appear in **every** scenario below; only the third should also surface the magic-link option.

1. **No Jetpack** (or Jetpack installed but not connected to WP.com): QR ✅, magic-link ❌.
2. **Jetpack connected, current admin is _not_ the connection owner** — easiest repro: connect Jetpack as user A, then log in as user B (who has admin but never linked their WP.com account). Open the modal. QR ✅, magic-link ❌.
3. **Jetpack connected, current admin _is_ the connection owner**, with a linked WP.com email: QR ✅, magic-link ✅.

End-to-end QR sign-in (rendered code → scan from the app → land in the store) is exercised by the later PRs in this stack — see [#64335](https://github.com/woocommerce/woocommerce/pull/64335) (standalone-page surface) and [#64503](https://github.com/woocommerce/woocommerce/pull/64503) (number-matching approval, the production-ready protocol). At this PR there's nothing app-side to scan against because the schema isn't number-match-aware yet.

### Linear

Closes [WOOMOB-2765](https://linear.app/a8c/issue/WOOMOB-2765).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Changelog entry created manually (committed in the branch).
