### PR TITLE
Adopt WP 7.0 form-control sizing on settings inputs and Select2 multi-select

### DIFF
--- a/plugins/woocommerce/changelog/tweak-admin-form-controls-wp7-align
+++ b/plugins/woocommerce/changelog/tweak-admin-form-controls-wp7-align
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Align settings page input padding and Select2 multi-select border-radius with WordPress 7.0 native form-control sizing.
+Align settings page input padding, Select2 single/multi-select text padding and border-radius, and shipping zone name/regions controls with WordPress 7.0 native form-control sizing.

--- a/plugins/woocommerce/changelog/tweak-admin-form-controls-wp7-align
+++ b/plugins/woocommerce/changelog/tweak-admin-form-controls-wp7-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Align settings page input padding and Select2 multi-select border-radius with WordPress 7.0 native form-control sizing.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8358,6 +8358,7 @@ table.bar_chart {
 
 			.select2-selection__rendered {
 				line-height: 38px;
+				padding: 0 12px; // Match WP 7.0 native input padding so text aligns with sibling inputs.
 			}
 
 			.select2-selection__arrow {
@@ -8616,6 +8617,16 @@ table.bar_chart {
 	&.post-type-product #postdivrich.woocommerce-product-description {
 		margin-left: 4px;
 		margin-right: 4px;
+	}
+
+	// Shipping zone name input: ID selector in the base rule outranks the form-table override above.
+	.wc-shipping-zone-settings #zone_name {
+		padding: 0 12px;
+	}
+
+	// Zone regions TreeSelectControl: match WP 7.0 native select border-radius.
+	#wc-shipping-zone-region-picker-root .woocommerce-tree-select-control .components-base-control {
+		border-radius: 2px;
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8325,6 +8325,23 @@ table.bar_chart {
 		padding: 6px 8px;
 	}
 
+	// Adopt WP 7.0 12px horizontal padding on settings inputs.
+	.woocommerce table.form-table {
+		input[type="text"],
+		input[type="email"],
+		input[type="number"],
+		input[type="password"],
+		input[type="datetime-local"],
+		input[type="date"],
+		input[type="time"],
+		input[type="week"],
+		input[type="url"],
+		input[type="tel"],
+		input.regular-input {
+			padding: 0 12px;
+		}
+	}
+
 	// Colour picker swatch: match WP 7.0 input height (40px).
 	.woocommerce table.form-table .colorpickpreview {
 		height: 40px;
@@ -8350,6 +8367,7 @@ table.bar_chart {
 
 		.select2-selection--multiple {
 			min-height: 40px;
+			border-radius: 2px; // Match WP 7.0 native select border-radius.
 
 			.select2-selection__rendered {
 				display: block;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8304,6 +8304,23 @@ table.bar_chart {
 		padding: 6px 8px;
 	}
 
+	// Adopt WP 7.0 12px horizontal padding on settings inputs.
+	.woocommerce table.form-table {
+		input[type="text"],
+		input[type="email"],
+		input[type="number"],
+		input[type="password"],
+		input[type="datetime-local"],
+		input[type="date"],
+		input[type="time"],
+		input[type="week"],
+		input[type="url"],
+		input[type="tel"],
+		input.regular-input {
+			padding: 0 12px;
+		}
+	}
+
 	// Colour picker swatch: match WP 7.0 input height (40px).
 	.woocommerce table.form-table .colorpickpreview {
 		height: 40px;
@@ -8329,6 +8346,7 @@ table.bar_chart {
 
 		.select2-selection--multiple {
 			min-height: 40px;
+			border-radius: 2px; // Match WP 7.0 native select border-radius.
 
 			.select2-selection__rendered {
 				display: block;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8337,6 +8337,7 @@ table.bar_chart {
 
 			.select2-selection__rendered {
 				line-height: 38px;
+				padding: 0 12px; // Match WP 7.0 native input padding so text aligns with sibling inputs.
 			}
 
 			.select2-selection__arrow {
@@ -8558,6 +8559,16 @@ table.bar_chart {
 		width: auto;
 		height: auto;
 		color: #1e1e1e;
+	}
+
+	// Shipping zone name input: ID selector in the base rule outranks the form-table override above.
+	.wc-shipping-zone-settings #zone_name {
+		padding: 0 12px;
+	}
+
+	// Zone regions TreeSelectControl: match WP 7.0 native select border-radius.
+	#wc-shipping-zone-region-picker-root .woocommerce-tree-select-control .components-base-control {
+		border-radius: 2px;
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WP 7.0 bumped native form-control `min-height` to 40px, horizontal padding to 12px, and border-radius to 2px (from 30px / 8px / 4px). Woo's `.wc-wp-version-gte-70` override block already re-centres labels and resizes Select2 single selects, but **five gaps were missed**:

1. **Settings-page text inputs**: the `.wc-wp-version-gte-53` block sets `padding: 0 8px` on text inputs inside `table.form-table`, and the gte-70 block never overrides it. On WP 7.0 those inputs render at 8px when they should be 12px to match native WP.
2. **Select2 multi-select**: the gte-70 block bumps `min-height` to 40px but leaves `border-radius` at the pre-7.0 4px (via the gte-53 rule). WP 7.0 native selects use 2px.
3. **Select2 single-select text**: the rendered selection/placeholder text sits at Select2's default 8px left padding, so it didn't align with the 12px padding now used on sibling inputs (e.g. Store Address → Country/State next to the address inputs). Applied `padding: 0 12px` to the rendered text so the visible start matches.
4. **Shipping zone name input**: the base rule `.wc-shipping-zone-settings #zone_name { padding: 2px 8px }` uses an ID selector, so the gte-70 text-input padding override above never wins. Added a matching-specificity override so it also adopts WP 7.0's 12px horizontal padding.
5. **Shipping zone regions picker**: this is a custom React `TreeSelectControl` (not Select2 — it's a tree-checkbox multi-selector that wraps `.components-base-control`). It renders with a 4px border-radius, which looks inconsistent next to the Select2 multi-selects on the same screen now that they're 2px. Bumped it to 2px purely for visual consistency with WP 7.0 / other form controls — it's not a Select2, so the native form-control sizing doesn't fully apply.

This PR closes all five gaps by adding the missing overrides to the existing `.wc-wp-version-gte-70` block. No existing rules are deleted, so WP < 7.0 behaviour is unchanged.

### Screenshots or screen recordings:

| Before (WP 7.0, unfixed) | After |
| ------ | ----- |
| _Settings → General text inputs at 8px padding_ | _12px padding matching WP native_ |
| _Select2 multi-select at 4px radius_ | _2px radius_ |
| _Select2 single text at 8px left padding, misaligned with sibling inputs_ | _12px left padding, aligned_ |
| _Shipping zones → Zone name at 2px 8px padding_ | _0 12px padding_ |
| _Shipping zones → Zone regions picker at 4px radius_ | _2px radius_ |

<img width="924" height="762" alt="CleanShot 2026-04-22 at 22 08 27@2x" src="https://github.com/user-attachments/assets/1fd7c997-73e6-4a53-9548-530a5db3a356" />

<img width="1554" height="1274" alt="CleanShot 2026-04-22 at 22 09 29@2x" src="https://github.com/user-attachments/assets/2e1ad623-2bda-4742-aeb4-387f506451c4" />


### How to test the changes in this Pull Request:

1. Run WooCommerce on WP 7.0+.
2. Navigate to **WooCommerce → Settings → General**:
   - Inspect a text input (e.g. "Address line 1"). Horizontal padding should be 12px on either side of the text.
   - Inspect the **Country / State** Select2 dropdown. The rendered value/placeholder text should start 12px from the left edge, aligning with the Address inputs below it.
3. Navigate to **WooCommerce → Settings → Shipping → Add zone** (or edit an existing zone):
   - The **Zone name** input should have 12px horizontal padding.
   - The **Zone regions** picker (TreeSelectControl) should have a 2px border-radius on its outer control.
4. On a screen with a Select2 multi-select, confirm the 2px border-radius.
5. On WP ≤ 6.9 (if available): confirm form-control sizing is unchanged (gte-53 rules still apply).

### Testing that has already taken place:

- Local smoke test on WP 7.0 (wp-env). Text inputs on Settings pages now have 12px horizontal padding; `.short` inputs in Product data panels (Dimensions 3-field row) tested with `1234.56` — no clipping.
- Stylelint: no new errors in the edit range.
- Pre-existing stylelint errors in `admin.scss` (file-wide) are unrelated and untouched.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.

### Changelog entry

Changelog entry committed manually in this PR (see `plugins/woocommerce/changelog/tweak-admin-form-controls-wp7-align`).

### Related

- Related issue: #64321 (Product / Coupon Data panel label misalignment — out of scope here, follow-up)
- Part of the WP 7.0 admin alignment effort tracked in the internal design spreadsheet.