### PR TITLE
Align Product / Coupon Data panel labels and help-tips with 40px inputs (WP 7.0)

### DIFF
--- a/plugins/woocommerce/changelog/tweak-product-coupon-data-label-align-wp7
+++ b/plugins/woocommerce/changelog/tweak-product-coupon-data-label-align-wp7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Vertically centre Product / Coupon Data panel labels and help-tip icons with 40px inputs on WordPress 7.0.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8627,6 +8627,26 @@ table.bar_chart {
 	#wc-shipping-zone-region-picker-root .woocommerce-tree-select-control .components-base-control {
 		border-radius: 2px;
 	}
+
+	// Product / Coupon Data panel labels: vertically centre with 40px inputs.
+	// Skip checkbox and radio rows — their controls are ~16px, so the taller
+	// line-height pushes the label below them instead of aligning with it.
+	.woocommerce_options_panel .form-field:not(:has(input[type="checkbox"], input[type="radio"])) label,
+	.woocommerce_options_panel .form-field:not(:has(input[type="checkbox"], input[type="radio"])) legend {
+		line-height: 40px;
+	}
+
+	// Help-tip icon: vertical-align middle aligns to text baseline, not line-box middle,
+	// so it lands near the top of the 40px row. Push down to visual centre — but
+	// skip checkbox/radio rows, whose inputs are still ~16px and don't need the offset.
+	.woocommerce_options_panel .form-field:not(:has(input[type="checkbox"], input[type="radio"])) .woocommerce-help-tip {
+		margin-top: 12px;
+	}
+
+	// Checkbox/radio rows: small nudge so the help-tip visually centres with the control.
+	.woocommerce_options_panel .form-field:has(input[type="checkbox"], input[type="radio"]) .woocommerce-help-tip {
+		margin-bottom: 3px;
+	}
 }
 
 /**

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8562,6 +8562,26 @@ table.bar_chart {
 		height: auto;
 		color: #1e1e1e;
 	}
+
+	// Product / Coupon Data panel labels: vertically centre with 40px inputs.
+	// Skip checkbox rows — their control is ~16px, so the taller line-height
+	// pushes the label text below the checkbox instead of aligning with it.
+	.woocommerce_options_panel .form-field:not(:has(input[type="checkbox"])) label,
+	.woocommerce_options_panel .form-field:not(:has(input[type="checkbox"])) legend {
+		line-height: 40px;
+	}
+
+	// Help-tip icon: vertical-align middle aligns to text baseline, not line-box middle,
+	// so it lands near the top of the 40px row. Push down to visual centre — but
+	// skip checkbox rows, whose input is still ~16px and doesn't need the offset.
+	.woocommerce_options_panel .form-field:not(:has(input[type="checkbox"])) .woocommerce-help-tip {
+		margin-top: 12px;
+	}
+
+	// Checkbox rows: small nudge so the help-tip visually centres with the checkbox.
+	.woocommerce_options_panel .form-field:has(input[type="checkbox"]) .woocommerce-help-tip {
+		margin-bottom: 3px;
+	}
 }
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WP 7.0 bumped native form-control `min-height` from 30px to 40px. The Settings-page label alignment was already patched in the existing `.wc-wp-version-gte-70` block, but the **Product Data** and **Coupon Data** meta boxes (which render via `.woocommerce_options_panel` + `.form-field`, not `table.form-table`) were missed. On WP 7.0 their labels sat ~8px above the input midline, and the `?` help-tip icons sat near the top of the 40px row.

Three narrowly-scoped rules added to the existing `.wc-wp-version-gte-70` block in `client/legacy/css/admin.scss`:

1. **Labels for non-checkbox rows**: `line-height: 40px` so the floated label's visual midline matches the 40px input midline. Checkbox rows are excluded because their control is ~16px — applying 40px line-height there would push the label below the checkbox.
2. **Help-tip icon on non-checkbox rows**: `margin-top: 12px` so `vertical-align: middle` (which aligns to the text baseline, not the line-box middle) lands the icon at the 40px input's centre.
3. **Help-tip icon on checkbox rows**: `margin-bottom: 3px` — small nudge so the icon visually centres with the 16px checkbox (verified via live DevTools testing).

### Screenshots or screen recordings:

| Before (WP 7.0, unfixed) | After |
| ------ | ----- |
| _Product Data → Shipping: labels above input midline, `?` icon near top of row_ | _Labels and help-tip centred with 40px inputs_ |
| _Product Data → Advanced → Available for POS: `?` icon misaligned with checkbox_ | _`?` icon centred with checkbox_ |

<img width="1034" height="306" alt="CleanShot 2026-04-22 at 22 57 17@2x" src="https://github.com/user-attachments/assets/f7c39645-2266-4ce9-8d4b-29401dc8d907" />

<img width="1146" height="508" alt="CleanShot 2026-04-22 at 23 01 36@2x" src="https://github.com/user-attachments/assets/0e082e01-055d-4939-8dd5-91834a18fc47" />

<img width="904" height="328" alt="CleanShot 2026-04-22 at 23 01 57@2x" src="https://github.com/user-attachments/assets/2ed3365b-6faa-47b3-9ce8-41f8bce1e178" />

<img width="874" height="564" alt="CleanShot 2026-04-22 at 23 44 19@2x" src="https://github.com/user-attachments/assets/2502e098-52f0-4afe-b636-b53d27a67813" />

<img width="892" height="488" alt="CleanShot 2026-04-22 at 23 50 50@2x" src="https://github.com/user-attachments/assets/410c79e2-2569-474d-8e24-83b53d1c0d58" />
(Note: Purchase note is a textarea; it's not within the scope of this issue)

### How to test the changes in this Pull Request:

1. Run WooCommerce on WP 7.0+.
2. Navigate to **Products → Add / Edit → Product data**:
   - **General** tab: Regular price / Sale price labels should vertically centre with the inputs; their `?` icons should centre on the input row.
   - **Inventory** tab: SKU, Stock status — same.
   - **Shipping** tab: Weight, Dimensions, Shipping class — same (Shipping class includes a Select2 single-select, verify the row as a whole).
   - **Advanced** tab:
     - Text fields (Purchase note, Menu order) — labels and help-tip centred.
     - Checkbox rows (Enable reviews, Available for POS) — label text aligns with the checkbox; `?` icon centres with the checkbox.
   - **General** tab checkbox row (Sold individually → "Limit purchases to 1 item per order") — same checkbox-row behaviour.
3. Navigate to **Marketing → Coupons → Add / Edit → Coupon data** and verify the same label/help-tip alignment across tabs.
4. On WP ≤ 6.9 (if available): confirm nothing changed (gte-53 rules still apply).

### Testing that has already taken place:

- Local smoke test on WP 7.0 (wp-env) with a simple product and a coupon. All Product/Coupon Data tabs visually verified.
- Edge case iterated in DevTools: checkbox-row `?` was initially pushed too far down with `margin-top: 12px`; scoped the rule to non-checkbox rows via `:has()` and added a `margin-bottom: 3px` nudge for checkbox rows specifically.
- No existing rules removed, so no regression risk on WP < 7.0.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.

### Changelog entry

Changelog entry committed manually in this PR (see `plugins/woocommerce/changelog/tweak-product-coupon-data-label-align-wp7`).

### Related

- Follow-up to #64322 (settings-page + shipping-zone alignment on WP 7.0).
- Part of the WP 7.0 admin alignment effort tracked in the internal design spreadsheet.