### PR TITLE
WC-Core 4: New standalone wc-admin page for mobile app QR login (WOOMOB-2767)

### DIFF
--- a/plugins/woocommerce/changelog/woomob-2765-modal-polish
+++ b/plugins/woocommerce/changelog/woomob-2765-modal-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Drop the outdated "app version needs to be 15.7" helper text from the mobile-app modal QR view and surface the underlying Jetpack error in the magic-link failure notice so support and merchants can diagnose the problem instead of hitting a generic retry message.

--- a/plugins/woocommerce/changelog/woomob-2765-show-qr-direct-login-for-all-admins
+++ b/plugins/woocommerce/changelog/woomob-2765-show-qr-direct-login-for-all-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Always show the QR direct login as the primary path in the mobile app modal, with the WordPress.com magic link available as a secondary CTA when the user has a linked WordPress.com account.

--- a/plugins/woocommerce/changelog/woomob-2766-application-passwords-disabled-copy
+++ b/plugins/woocommerce/changelog/woomob-2766-application-passwords-disabled-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improve the error shown on the QR mobile-app login screen when application passwords are disabled: drop the "ask a site administrator" copy (the merchant hitting this flow is already an admin or shop manager) and replace it with an inline link to the WordPress application-passwords documentation so they can figure out which constant or plugin disabled them.

--- a/plugins/woocommerce/changelog/woomob-2766-update-useqrlogintoken-error-handling
+++ b/plugins/woocommerce/changelog/woomob-2766-update-useqrlogintoken-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update the useQRLoginToken admin hook to handle the capability-based permission errors surfaced by the mobile-app QR login endpoint.

--- a/plugins/woocommerce/changelog/woomob-2767-standalone-mobile-app-login-page
+++ b/plugins/woocommerce/changelog/woomob-2767-standalone-mobile-app-login-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add a new standalone wc-admin page at /mobile-app-login for merchants who already have the Woo mobile app installed and want to sign in via QR code scan.

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginInfo.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginInfo.tsx
@@ -18,12 +18,6 @@ export const MobileAppLoginInfo = ( {
 			{ loginUrl && (
 				<div>
 					<QRCodeSVG value={ loginUrl } size={ 140 } />
-					<p>
-						{ __(
-							'The app version needs to be 15.7 or above to sign in with this link.',
-							'woocommerce'
-						) }
-					</p>
 				</div>
 			) }
 			<div>

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
@@ -10,10 +10,9 @@ import { Stepper, StepperProps } from '@woocommerce/components';
  * Internal dependencies
  */
 import { SendMagicLinkStates } from './';
-import { getAdminSetting } from '~/utils/admin-settings';
 import { MobileAppInstallationInfo } from '../components/MobileAppInstallationInfo';
-import { MobileAppLoginInfo } from '../components/MobileAppLoginInfo';
 import { QRDirectLoginCode } from '../components/QRDirectLoginCode';
+import { SendMagicLinkButton } from '../components/SendMagicLinkButton';
 
 export const MobileAppLoginStepper = ( {
 	step,
@@ -68,57 +67,47 @@ export const MobileAppLoginStepper = ( {
 				},
 			] );
 		} else if ( step === 'second' ) {
-			if (
+			const hasLinkedWordPressAccount =
 				isJetpackPluginInstalled &&
-				wordpressAccountEmailAddress !== undefined
-			) {
-				setStepsToDisplay( [
-					{
-						key: 'first',
-						label: __( 'App installed', 'woocommerce' ),
-						description: '',
-						content: <></>,
-					},
-					{
-						key: 'second',
-						label: __( 'Sign into the app', 'woocommerce' ),
-						description: __(
-							'Scan the QR code below with your phone to sign in instantly — no password needed.',
-							'woocommerce'
-						),
-						content: <QRDirectLoginCode />,
-					},
-				] );
-			} else {
-				const siteUrl: string = getAdminSetting( 'siteUrl' );
-				const username = getAdminSetting( 'currentUserData' ).username;
-				const loginUrl = `woocommerce://app-login?siteUrl=${ encodeURIComponent(
-					siteUrl
-				) }&username=${ encodeURIComponent( username ) }`;
-				const description = loginUrl
-					? __(
-							'Scan the QR code below and enter the wp-admin password in the app.',
-							'woocommerce'
-					  )
-					: __(
-							'Follow the instructions in the app to sign in.',
-							'woocommerce'
-					  );
-				setStepsToDisplay( [
-					{
-						key: 'first',
-						label: __( 'App installed', 'woocommerce' ),
-						description: '',
-						content: <></>,
-					},
-					{
-						key: 'second',
-						label: 'Sign into the app',
-						description,
-						content: <MobileAppLoginInfo loginUrl={ loginUrl } />,
-					},
-				] );
-			}
+				wordpressAccountEmailAddress !== undefined;
+			setStepsToDisplay( [
+				{
+					key: 'first',
+					label: __( 'App installed', 'woocommerce' ),
+					description: '',
+					content: <></>,
+				},
+				{
+					key: 'second',
+					label: __( 'Sign into the app', 'woocommerce' ),
+					description: __(
+						'Scan the QR code below with your phone to sign in instantly — no password needed.',
+						'woocommerce'
+					),
+					content: (
+						<>
+							<QRDirectLoginCode />
+							{ hasLinkedWordPressAccount && (
+								<div className="mobile-app-login-magic-link-secondary">
+									<p className="mobile-app-login-magic-link-secondary__label">
+										{ __(
+											'Or get a WordPress.com sign-in link by email:',
+											'woocommerce'
+										) }
+									</p>
+									<SendMagicLinkButton
+										onClickHandler={ sendMagicLinkHandler }
+										isFetching={
+											sendMagicLinkStatus ===
+											SendMagicLinkStates.FETCHING
+										}
+									/>
+								</div>
+							) }
+						</>
+					),
+				},
+			] );
 		}
 	}, [
 		step,

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
@@ -4,7 +4,9 @@
 import React, { useState, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Stepper, StepperProps } from '@woocommerce/components';
+import { Stepper, StepperProps, Link } from '@woocommerce/components';
+import interpolateComponents from '@automattic/interpolate-components';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -104,6 +106,28 @@ export const MobileAppLoginStepper = ( {
 									/>
 								</div>
 							) }
+							<div className="mobile-app-login-faq">
+								{ interpolateComponents( {
+									mixedString: __(
+										'Any troubles signing in? Check out the {{link}}FAQ{{/link}}.',
+										'woocommerce'
+									),
+									components: {
+										link: (
+											<Link
+												href="https://woocommerce.com/document/android-ios-apps-login-help-faq/"
+												target="_blank"
+												type="external"
+												onClick={ () => {
+													recordEvent(
+														'onboarding_app_login_faq_click'
+													);
+												} }
+											/>
+										),
+									},
+								} ) }
+							</div>
 						</>
 					),
 				},

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
@@ -124,12 +124,6 @@ export const QRDirectLoginCode = () => {
 						formatTime( secondsRemaining )
 					) }
 				</p>
-				<p className="woocommerce-qr-direct-login__version-note">
-					{ __(
-						'The app version needs to be 15.7 or above to sign in with this link.',
-						'woocommerce'
-					) }
-				</p>
 				<div>
 					{ createInterpolateElement(
 						__(

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
@@ -2,15 +2,10 @@
  * External dependencies
  */
 import { QRCodeSVG } from 'qrcode.react';
-import React, {
-	createInterpolateElement,
-	useEffect,
-	useRef,
-} from '@wordpress/element';
+import React, { useEffect, useRef } from '@wordpress/element';
 import { Button, Spinner } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
-import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -124,28 +119,6 @@ export const QRDirectLoginCode = () => {
 						formatTime( secondsRemaining )
 					) }
 				</p>
-				<div>
-					{ createInterpolateElement(
-						__(
-							'Any troubles signing in? Check out the <link>FAQ</link>.',
-							'woocommerce'
-						),
-						{
-							link: (
-								<Link
-									href="https://woocommerce.com/document/android-ios-apps-login-help-faq/"
-									target="_blank"
-									type="external"
-									onClick={ () => {
-										recordEvent(
-											'onboarding_app_login_faq_click'
-										);
-									} }
-								/>
-							),
-						}
-					) }
-				</div>
 			</div>
 		);
 	}

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/MobileAppLoginStepper.test.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/MobileAppLoginStepper.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { MobileAppLoginStepper } from '../MobileAppLoginStepper';
+import { SendMagicLinkStates } from '../useSendMagicLink';
+import { QRLoginTokenStates, useQRLoginToken } from '../useQRLoginToken';
+
+// Mock the QR login token hook so we can drive each state from the tests.
+jest.mock( '../useQRLoginToken', () => {
+	const actual = jest.requireActual( '../useQRLoginToken' );
+	return {
+		...actual,
+		useQRLoginToken: jest.fn(),
+	};
+} );
+
+// Mock tracks to keep tests isolated from analytics side-effects.
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+const mockedUseQRLoginToken = useQRLoginToken as jest.MockedFunction<
+	typeof useQRLoginToken
+>;
+
+const readyTokenState = {
+	state: QRLoginTokenStates.READY,
+	qrUrl: 'woocommerce://qr-login?token=abc&siteUrl=https%3A%2F%2Fexample.test',
+	secondsRemaining: 300,
+	errorMessage: null,
+	fetchToken: jest.fn(),
+	refreshToken: jest.fn(),
+};
+
+const errorTokenState = {
+	state: QRLoginTokenStates.ERROR,
+	qrUrl: null,
+	secondsRemaining: 0,
+	errorMessage: 'QR login requires an HTTPS connection.',
+	fetchToken: jest.fn(),
+	refreshToken: jest.fn(),
+};
+
+const baseProps = {
+	step: 'second' as const,
+	completeInstallationStepHandler: jest.fn(),
+	sendMagicLinkHandler: jest.fn(),
+	sendMagicLinkStatus: SendMagicLinkStates.INIT,
+};
+
+describe( 'MobileAppLoginStepper', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedUseQRLoginToken.mockReturnValue( readyTokenState );
+	} );
+
+	describe( 'step 2 (sign-in)', () => {
+		it( 'renders the QR direct login for an admin without Jetpack and hides the magic link button', () => {
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ false }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			// The QR direct login is the primary path — its expiry timer copy
+			// is a reliable signal that the component is on screen.
+			expect(
+				screen.getByText( /Code expires in/i )
+			).toBeInTheDocument();
+
+			// The WordPress.com magic link secondary CTA should not show up
+			// for non-Jetpack users.
+			expect(
+				screen.queryByText(
+					/Or get a WordPress\.com sign-in link by email/i
+				)
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Send the sign-in link/i,
+				} )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders both the QR and the magic link button when Jetpack is fully connected and the user has a linked WordPress.com account', () => {
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ true }
+					wordpressAccountEmailAddress="admin@example.test"
+				/>
+			);
+
+			expect(
+				screen.getByText( /Code expires in/i )
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/Or get a WordPress\.com sign-in link by email/i
+				)
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', {
+					name: /Send the sign-in link/i,
+				} )
+			).toBeInTheDocument();
+		} );
+
+		it( 'hides the magic link button for a shop manager without a linked WordPress.com account even if Jetpack is installed', () => {
+			// Shop managers typically don't own the Jetpack connection and
+			// their currentUser.wpcomUser.email is undefined upstream, which
+			// surfaces here as wordpressAccountEmailAddress === undefined.
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ true }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			expect(
+				screen.getByText( /Code expires in/i )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText(
+					/Or get a WordPress\.com sign-in link by email/i
+				)
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'invokes the magic link handler when the secondary button is clicked', () => {
+			const sendMagicLinkHandler = jest.fn();
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					sendMagicLinkHandler={ sendMagicLinkHandler }
+					isJetpackPluginInstalled={ true }
+					wordpressAccountEmailAddress="admin@example.test"
+				/>
+			);
+
+			fireEvent.click(
+				screen.getByRole( 'button', {
+					name: /Send the sign-in link/i,
+				} )
+			);
+
+			expect( sendMagicLinkHandler ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'surfaces the QR error state from useQRLoginToken', () => {
+			mockedUseQRLoginToken.mockReturnValue( errorTokenState );
+
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ false }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			expect(
+				screen.getByText( /QR login requires an HTTPS connection/i )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: /Try again/i } )
+			).toBeInTheDocument();
+			// Error state should never leak the happy-path timer copy.
+			expect(
+				screen.queryByText( /Code expires in/i )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'does not render the old username + site URL fallback when the user lacks a linked WordPress.com account', () => {
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					isJetpackPluginInstalled={ false }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			// The removed MobileAppLoginInfo fallback used to show this copy.
+			expect(
+				screen.queryByText(
+					/Scan the QR code below and enter the wp-admin password/i
+				)
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'step 1 (install)', () => {
+		it( 'renders the install-app CTA and wires it up to the handler', () => {
+			const completeInstallationStepHandler = jest.fn();
+			render(
+				<MobileAppLoginStepper
+					{ ...baseProps }
+					step="first"
+					completeInstallationStepHandler={
+						completeInstallationStepHandler
+					}
+					isJetpackPluginInstalled={ false }
+					wordpressAccountEmailAddress={ undefined }
+				/>
+			);
+
+			const installButton = screen.getByRole( 'button', {
+				name: /App is installed/i,
+			} );
+			fireEvent.click( installButton );
+			expect( completeInstallationStepHandler ).toHaveBeenCalledTimes(
+				1
+			);
+
+			// The QR direct login is rendered for step 2, not step 1.
+			expect(
+				screen.queryByText( /Code expires in/i )
+			).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/useQRLoginToken.test.ts
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/useQRLoginToken.test.ts
@@ -268,16 +268,59 @@ describe( 'useQRLoginToken', () => {
 		expect( mockApiFetch ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	it( 'does not set state after unmount during LOADING', async () => {
+	it( 'failed refetch clears the previous token and keeps the error visible', async () => {
+		const firstResponse = buildResponse( 5 );
+		mockApiFetch.mockResolvedValueOnce( firstResponse );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		await act( async () => {
+			await result.current.fetchToken();
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.READY );
+		expect( result.current.qrUrl ).toBe( firstResponse.qr_url );
+		expect( result.current.secondsRemaining ).toBe( 5 );
+
+		mockApiFetch.mockRejectedValueOnce( {
+			code: 'rate_limit_exceeded',
+			message: 'Too many requests',
+		} );
+
+		let refetchPromise: Promise< void > | undefined;
+		act( () => {
+			refetchPromise = result.current.refreshToken();
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.LOADING );
+		expect( result.current.qrUrl ).toBeNull();
+		expect( result.current.secondsRemaining ).toBe( 0 );
+
+		await act( async () => {
+			await refetchPromise;
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.ERROR );
+		expect( result.current.qrUrl ).toBeNull();
+		expect( result.current.secondsRemaining ).toBe( 0 );
+		expect( result.current.errorMessage ).toMatch(
+			/Too many QR login requests/i
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.ERROR );
+	} );
+
+	it( 'does not start a countdown after unmount during LOADING', async () => {
 		let resolveFetch: ( value: unknown ) => void = () => undefined;
 		const pendingResponse = new Promise( ( resolve ) => {
 			resolveFetch = resolve;
 		} );
 		mockApiFetch.mockReturnValueOnce( pendingResponse );
-
-		const warnSpy = jest
-			.spyOn( console, 'error' )
-			.mockImplementation( () => undefined );
+		const setIntervalSpy = jest.spyOn( global, 'setInterval' );
 
 		const { result, unmount } = renderHook( () => useQRLoginToken() );
 
@@ -297,16 +340,9 @@ describe( 'useQRLoginToken', () => {
 			await pendingResponse;
 		} );
 
-		const unmountedWarnings = warnSpy.mock.calls.filter( ( args ) =>
-			args.some(
-				( arg ) =>
-					typeof arg === 'string' &&
-					arg.includes( 'unmounted component' )
-			)
-		);
-		expect( unmountedWarnings ).toHaveLength( 0 );
+		expect( setIntervalSpy ).not.toHaveBeenCalled();
 
-		warnSpy.mockRestore();
+		setIntervalSpy.mockRestore();
 	} );
 
 	it( 'cleans up the countdown interval on unmount', async () => {

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/useQRLoginToken.test.ts
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/useQRLoginToken.test.ts
@@ -1,0 +1,328 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { QRLoginTokenStates, useQRLoginToken } from '../useQRLoginToken';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as unknown as jest.MockedFunction<
+	( options: { path: string; method: string } ) => Promise< unknown >
+>;
+
+// A fixed "now" keeps the countdown math deterministic across tests.
+const NOW_SECONDS = 1_700_000_000;
+const TTL_SECONDS = 300;
+
+const buildResponse = ( ttl: number = TTL_SECONDS ) => ( {
+	qr_url: `woocommerce://qr-login?token=abc&siteUrl=https%3A%2F%2Fexample.test&ttl=${ ttl }`,
+	expires_at: NOW_SECONDS + ttl,
+	ttl,
+} );
+
+// Mock `wpcom_account_required` is intentionally *not* listed here — the
+// backend no longer returns it after WOOMOB-2764 and the hook no longer
+// branches on it. If it ever shows up again we want it to fall through to
+// the generic message (verified by the `unknown error code` test).
+const expectedErrorMessages: Array< {
+	code: string;
+	message: RegExp;
+} > = [
+	{
+		code: 'woocommerce_rest_cannot_view',
+		message: /do not have permission to generate a QR login code/i,
+	},
+	{
+		code: 'ssl_required',
+		message: /requires an HTTPS connection/i,
+	},
+	{
+		code: 'application_passwords_unavailable',
+		message: /Application passwords are disabled/i,
+	},
+	{
+		code: 'rate_limit_exceeded',
+		message: /Too many QR login requests/i,
+	},
+];
+
+describe( 'useQRLoginToken', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		// Pin Date.now so the countdown math is deterministic.
+		jest.setSystemTime( NOW_SECONDS * 1000 );
+	} );
+
+	afterEach( () => {
+		// Clear rather than run pending timers — otherwise the interval
+		// callback fires against (potentially unmounted) test hooks and
+		// React emits an "update not wrapped in act()" warning.
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	} );
+
+	it( 'starts IDLE with empty state', () => {
+		mockApiFetch.mockResolvedValue( buildResponse() );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.IDLE );
+		expect( result.current.qrUrl ).toBeNull();
+		expect( result.current.secondsRemaining ).toBe( 0 );
+		expect( result.current.errorMessage ).toBeNull();
+	} );
+
+	it( 'transitions IDLE → LOADING → READY on successful fetch', async () => {
+		const response = buildResponse();
+		mockApiFetch.mockResolvedValue( response );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.IDLE );
+
+		let fetchPromise: Promise< void > | undefined;
+		act( () => {
+			fetchPromise = result.current.fetchToken();
+		} );
+
+		// Synchronously after kicking off the fetch we should be LOADING.
+		expect( result.current.state ).toBe( QRLoginTokenStates.LOADING );
+
+		await act( async () => {
+			await fetchPromise;
+		} );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/wc-admin/mobile-app/qr-login-token',
+			method: 'POST',
+		} );
+		expect( result.current.state ).toBe( QRLoginTokenStates.READY );
+		expect( result.current.qrUrl ).toBe( response.qr_url );
+		expect( result.current.errorMessage ).toBeNull();
+		expect( result.current.secondsRemaining ).toBe( TTL_SECONDS );
+	} );
+
+	it( 'decrements secondsRemaining each second and transitions to EXPIRED at 0', async () => {
+		mockApiFetch.mockResolvedValue( buildResponse( 3 ) );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		await act( async () => {
+			await result.current.fetchToken();
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.READY );
+		expect( result.current.secondsRemaining ).toBe( 3 );
+
+		// `advanceTimersByTime` bumps the mocked clock *and* runs any
+		// interval callbacks whose due-time falls inside the advance
+		// window, so we don't need to call `setSystemTime` separately.
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+		expect( result.current.secondsRemaining ).toBe( 2 );
+		expect( result.current.state ).toBe( QRLoginTokenStates.READY );
+
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+		expect( result.current.secondsRemaining ).toBe( 1 );
+		expect( result.current.state ).toBe( QRLoginTokenStates.READY );
+
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+		expect( result.current.secondsRemaining ).toBe( 0 );
+		expect( result.current.state ).toBe( QRLoginTokenStates.EXPIRED );
+		expect( result.current.qrUrl ).toBeNull();
+	} );
+
+	it.each( expectedErrorMessages )(
+		'maps backend error code "$code" to the right user-facing message',
+		async ( { code, message } ) => {
+			mockApiFetch.mockRejectedValue( {
+				code,
+				message: `Backend said ${ code }`,
+			} );
+
+			const { result } = renderHook( () => useQRLoginToken() );
+
+			await act( async () => {
+				await result.current.fetchToken();
+			} );
+
+			expect( result.current.state ).toBe( QRLoginTokenStates.ERROR );
+			expect( result.current.qrUrl ).toBeNull();
+			expect( result.current.errorMessage ).toMatch( message );
+		}
+	);
+
+	it( 'falls back to the backend-provided message for unknown error codes', async () => {
+		mockApiFetch.mockRejectedValue( {
+			code: 'something_unexpected',
+			message: 'Specific backend error text.',
+		} );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		await act( async () => {
+			await result.current.fetchToken();
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.ERROR );
+		expect( result.current.errorMessage ).toBe(
+			'Specific backend error text.'
+		);
+	} );
+
+	it( 'falls back to a generic message when the error has neither a code nor a message', async () => {
+		mockApiFetch.mockRejectedValue( {} );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		await act( async () => {
+			await result.current.fetchToken();
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.ERROR );
+		expect( result.current.errorMessage ).toMatch(
+			/Failed to generate QR login code/i
+		);
+	} );
+
+	it( 'clears the previous error message when starting a new fetch', async () => {
+		mockApiFetch.mockRejectedValueOnce( {
+			code: 'ssl_required',
+			message: 'SSL required',
+		} );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		await act( async () => {
+			await result.current.fetchToken();
+		} );
+		expect( result.current.state ).toBe( QRLoginTokenStates.ERROR );
+		expect( result.current.errorMessage ).not.toBeNull();
+
+		// Refetch with a successful response.
+		mockApiFetch.mockResolvedValueOnce( buildResponse() );
+
+		let retryPromise: Promise< void > | undefined;
+		act( () => {
+			retryPromise = result.current.refreshToken();
+		} );
+		expect( result.current.state ).toBe( QRLoginTokenStates.LOADING );
+		expect( result.current.errorMessage ).toBeNull();
+
+		await act( async () => {
+			await retryPromise;
+		} );
+		expect( result.current.state ).toBe( QRLoginTokenStates.READY );
+	} );
+
+	it( 'refetch after EXPIRED yields a fresh token (EXPIRED → LOADING → READY)', async () => {
+		mockApiFetch.mockResolvedValueOnce( buildResponse( 1 ) );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		await act( async () => {
+			await result.current.fetchToken();
+		} );
+
+		// Expire the current token.
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+		expect( result.current.state ).toBe( QRLoginTokenStates.EXPIRED );
+
+		// Second fetch returns a new token. Build the response relative to
+		// the mocked "now" the hook will see at resolution time so the
+		// countdown math is unambiguous.
+		const freshNowSeconds = Math.floor( Date.now() / 1000 );
+		const secondResponse = {
+			qr_url: 'woocommerce://qr-login?token=second&siteUrl=x',
+			expires_at: freshNowSeconds + TTL_SECONDS,
+			ttl: TTL_SECONDS,
+		};
+		mockApiFetch.mockResolvedValueOnce( secondResponse );
+
+		let refetchPromise: Promise< void > | undefined;
+		act( () => {
+			refetchPromise = result.current.refreshToken();
+		} );
+		expect( result.current.state ).toBe( QRLoginTokenStates.LOADING );
+
+		await act( async () => {
+			await refetchPromise;
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.READY );
+		expect( result.current.qrUrl ).toBe( secondResponse.qr_url );
+		expect( result.current.secondsRemaining ).toBe( TTL_SECONDS );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not set state after unmount during LOADING', async () => {
+		let resolveFetch: ( value: unknown ) => void = () => undefined;
+		const pendingResponse = new Promise( ( resolve ) => {
+			resolveFetch = resolve;
+		} );
+		mockApiFetch.mockReturnValueOnce( pendingResponse );
+
+		const warnSpy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => undefined );
+
+		const { result, unmount } = renderHook( () => useQRLoginToken() );
+
+		act( () => {
+			// Fire off the request but don't await it yet.
+			void result.current.fetchToken();
+		} );
+		expect( result.current.state ).toBe( QRLoginTokenStates.LOADING );
+
+		// Unmount while still LOADING.
+		unmount();
+
+		// Now let the request resolve; the hook should not attempt to
+		// update state on the unmounted component.
+		await act( async () => {
+			resolveFetch( buildResponse() );
+			await pendingResponse;
+		} );
+
+		const unmountedWarnings = warnSpy.mock.calls.filter( ( args ) =>
+			args.some(
+				( arg ) =>
+					typeof arg === 'string' &&
+					arg.includes( 'unmounted component' )
+			)
+		);
+		expect( unmountedWarnings ).toHaveLength( 0 );
+
+		warnSpy.mockRestore();
+	} );
+
+	it( 'cleans up the countdown interval on unmount', async () => {
+		mockApiFetch.mockResolvedValue( buildResponse( 5 ) );
+		const clearIntervalSpy = jest.spyOn( global, 'clearInterval' );
+
+		const { result, unmount } = renderHook( () => useQRLoginToken() );
+
+		await act( async () => {
+			await result.current.fetchToken();
+		} );
+		expect( result.current.state ).toBe( QRLoginTokenStates.READY );
+
+		unmount();
+
+		expect( clearIntervalSpy ).toHaveBeenCalled();
+		clearIntervalSpy.mockRestore();
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/useQRLoginToken.test.ts
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/test/useQRLoginToken.test.ts
@@ -29,6 +29,11 @@ const buildResponse = ( ttl: number = TTL_SECONDS ) => ( {
 // backend no longer returns it after WOOMOB-2764 and the hook no longer
 // branches on it. If it ever shows up again we want it to fall through to
 // the generic message (verified by the `unknown error code` test).
+//
+// `application_passwords_unavailable` is intentionally *not* listed either —
+// its message is a `ReactNode` (it embeds an inline link to the WordPress
+// docs) rather than a plain string, so it has its own dedicated test below
+// that asserts on `errorCode` + structural properties of the message.
 const expectedErrorMessages: Array< {
 	code: string;
 	message: RegExp;
@@ -40,10 +45,6 @@ const expectedErrorMessages: Array< {
 	{
 		code: 'ssl_required',
 		message: /requires an HTTPS connection/i,
-	},
-	{
-		code: 'application_passwords_unavailable',
-		message: /Application passwords are disabled/i,
 	},
 	{
 		code: 'rate_limit_exceeded',
@@ -76,6 +77,7 @@ describe( 'useQRLoginToken', () => {
 		expect( result.current.qrUrl ).toBeNull();
 		expect( result.current.secondsRemaining ).toBe( 0 );
 		expect( result.current.errorMessage ).toBeNull();
+		expect( result.current.errorCode ).toBeNull();
 	} );
 
 	it( 'transitions IDLE → LOADING → READY on successful fetch', async () => {
@@ -159,9 +161,34 @@ describe( 'useQRLoginToken', () => {
 
 			expect( result.current.state ).toBe( QRLoginTokenStates.ERROR );
 			expect( result.current.qrUrl ).toBeNull();
+			expect( result.current.errorCode ).toBe( code );
 			expect( result.current.errorMessage ).toMatch( message );
 		}
 	);
+
+	it( 'surfaces the application_passwords_unavailable case with a ReactNode message + docs link', async () => {
+		mockApiFetch.mockRejectedValue( {
+			code: 'application_passwords_unavailable',
+			message: 'Backend said application_passwords_unavailable',
+		} );
+
+		const { result } = renderHook( () => useQRLoginToken() );
+
+		await act( async () => {
+			await result.current.fetchToken();
+		} );
+
+		expect( result.current.state ).toBe( QRLoginTokenStates.ERROR );
+		expect( result.current.errorCode ).toBe(
+			'application_passwords_unavailable'
+		);
+		// The message is a ReactNode (interpolated with an inline link), so
+		// we can't `toMatch` against a string. Just confirm it's set and not
+		// null — the rendering surface is `<QRDirectLoginCode />` and the
+		// link visibility is covered there.
+		expect( result.current.errorMessage ).not.toBeNull();
+		expect( typeof result.current.errorMessage ).not.toBe( 'string' );
+	} );
 
 	it( 'falls back to the backend-provided message for unknown error codes', async () => {
 		mockApiFetch.mockRejectedValue( {
@@ -219,6 +246,7 @@ describe( 'useQRLoginToken', () => {
 		} );
 		expect( result.current.state ).toBe( QRLoginTokenStates.LOADING );
 		expect( result.current.errorMessage ).toBeNull();
+		expect( result.current.errorCode ).toBeNull();
 
 		await act( async () => {
 			await retryPromise;

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.ts
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.ts
@@ -42,6 +42,8 @@ export const useQRLoginToken = ( {
 	const expiresAtRef = useRef< number >( 0 );
 	const onReadyRef = useRef( onReady );
 	const onErrorRef = useRef( onError );
+	const isMountedRef = useRef( true );
+	const requestIdRef = useRef( 0 );
 
 	onReadyRef.current = onReady;
 	onErrorRef.current = onError;
@@ -59,6 +61,10 @@ export const useQRLoginToken = ( {
 			expiresAtRef.current = expiresAt;
 
 			const updateRemaining = () => {
+				if ( ! isMountedRef.current ) {
+					return;
+				}
+
 				const remaining = Math.max(
 					0,
 					Math.floor( expiresAtRef.current - Date.now() / 1000 )
@@ -79,6 +85,13 @@ export const useQRLoginToken = ( {
 	);
 
 	const fetchToken = useCallback( async () => {
+		const requestId = requestIdRef.current + 1;
+		requestIdRef.current = requestId;
+
+		clearTimer();
+		expiresAtRef.current = 0;
+		setQrUrl( null );
+		setSecondsRemaining( 0 );
 		setState( QRLoginTokenStates.LOADING );
 		setErrorMessage( null );
 
@@ -87,6 +100,13 @@ export const useQRLoginToken = ( {
 				path: `${ WC_ADMIN_NAMESPACE }/mobile-app/qr-login-token`,
 				method: 'POST',
 			} );
+
+			if (
+				! isMountedRef.current ||
+				requestId !== requestIdRef.current
+			) {
+				return;
+			}
 
 			if (
 				! response ||
@@ -108,6 +128,18 @@ export const useQRLoginToken = ( {
 			startCountdown( response.expires_at );
 			onReadyRef.current?.();
 		} catch ( error: unknown ) {
+			if (
+				! isMountedRef.current ||
+				requestId !== requestIdRef.current
+			) {
+				return;
+			}
+
+			clearTimer();
+			expiresAtRef.current = 0;
+			setQrUrl( null );
+			setSecondsRemaining( 0 );
+
 			const err = error as { code?: string; message?: string };
 			const errorCode = err.code || 'unknown_error';
 			let nextErrorMessage: string;
@@ -153,11 +185,17 @@ export const useQRLoginToken = ( {
 			setState( QRLoginTokenStates.ERROR );
 			onErrorRef.current?.( errorCode );
 		}
-	}, [ startCountdown ] );
+	}, [ clearTimer, startCountdown ] );
 
 	// Cleanup timer on unmount.
 	useEffect( () => {
-		return () => clearTimer();
+		isMountedRef.current = true;
+
+		return () => {
+			isMountedRef.current = false;
+			requestIdRef.current += 1;
+			clearTimer();
+		};
 	}, [ clearTimer ] );
 
 	return {

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.ts
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.ts
@@ -112,23 +112,41 @@ export const useQRLoginToken = ( {
 			const errorCode = err.code || 'unknown_error';
 			let nextErrorMessage: string;
 
-			if ( errorCode === 'rate_limit_exceeded' ) {
-				nextErrorMessage = __(
-					'Too many requests. Please try again in a few minutes.',
-					'woocommerce'
-				);
-			} else if ( errorCode === 'ssl_required' ) {
-				nextErrorMessage = __(
-					'QR login requires an HTTPS connection.',
-					'woocommerce'
-				);
-			} else {
-				nextErrorMessage =
-					err.message ||
-					__(
-						'Failed to generate QR login code. Please try again.',
+			switch ( errorCode ) {
+				case 'woocommerce_rest_cannot_view':
+					// The endpoint requires the `manage_woocommerce`
+					// capability; surface a clear, actionable message
+					// rather than the generic REST wording.
+					nextErrorMessage = __(
+						'You do not have permission to generate a QR login code. Ask a site administrator for help.',
 						'woocommerce'
 					);
+					break;
+				case 'ssl_required':
+					nextErrorMessage = __(
+						'QR login requires an HTTPS connection.',
+						'woocommerce'
+					);
+					break;
+				case 'application_passwords_unavailable':
+					nextErrorMessage = __(
+						'Application passwords are disabled on this site, so QR login is unavailable. Ask a site administrator to enable them.',
+						'woocommerce'
+					);
+					break;
+				case 'rate_limit_exceeded':
+					nextErrorMessage = __(
+						'Too many QR login requests. Please try again in a few minutes.',
+						'woocommerce'
+					);
+					break;
+				default:
+					nextErrorMessage =
+						err.message ||
+						__(
+							'Failed to generate QR login code. Please try again.',
+							'woocommerce'
+						);
 			}
 
 			setErrorMessage( nextErrorMessage );

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.tsx
@@ -1,10 +1,26 @@
 /**
  * External dependencies
  */
-import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useState,
+	useCallback,
+	useEffect,
+	useRef,
+} from '@wordpress/element';
+import type { ReactNode } from 'react';
 import { __ } from '@wordpress/i18n';
 import { WC_ADMIN_NAMESPACE } from '@woocommerce/data';
 import apiFetch from '@wordpress/api-fetch';
+import { Link } from '@woocommerce/components';
+
+/**
+ * Documentation URL we link to when application passwords are unavailable.
+ * Centralized so the constant can be reused (e.g. in tests or future
+ * surfaces) and so the link is easy to update when the WP docs URL moves.
+ */
+const APPLICATION_PASSWORDS_DOCS_URL =
+	'https://developer.wordpress.org/advanced-administration/security/application-passwords/';
 
 export const QRLoginTokenStates = {
 	IDLE: 'idle',
@@ -37,7 +53,18 @@ export const useQRLoginToken = ( {
 	);
 	const [ qrUrl, setQrUrl ] = useState< string | null >( null );
 	const [ secondsRemaining, setSecondsRemaining ] = useState< number >( 0 );
-	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
+	// `errorMessage` is rendered directly by `<QRDirectLoginCode />`. It is a
+	// `ReactNode` (not just `string`) so individual cases can inject inline
+	// links, for example the `application_passwords_unavailable` branch wraps a
+	// "Learn more" link in the message itself.
+	const [ errorMessage, setErrorMessage ] = useState< ReactNode | null >(
+		null
+	);
+	// `errorCode` mirrors the REST error code that triggered the message,
+	// exposed alongside `errorMessage` so callers (e.g. analytics) can
+	// reliably reference the failure mode regardless of how the message was
+	// rendered.
+	const [ errorCode, setErrorCode ] = useState< string | null >( null );
 	const timerRef = useRef< ReturnType< typeof setInterval > | null >( null );
 	const expiresAtRef = useRef< number >( 0 );
 	const onReadyRef = useRef( onReady );
@@ -94,6 +121,7 @@ export const useQRLoginToken = ( {
 		setSecondsRemaining( 0 );
 		setState( QRLoginTokenStates.LOADING );
 		setErrorMessage( null );
+		setErrorCode( null );
 
 		try {
 			const response = await apiFetch< QRLoginTokenResponse >( {
@@ -141,10 +169,10 @@ export const useQRLoginToken = ( {
 			setSecondsRemaining( 0 );
 
 			const err = error as { code?: string; message?: string };
-			const errorCode = err.code || 'unknown_error';
-			let nextErrorMessage: string;
+			const nextErrorCode = err.code ?? null;
+			let nextErrorMessage: ReactNode;
 
-			switch ( errorCode ) {
+			switch ( nextErrorCode ) {
 				case 'woocommerce_rest_cannot_view':
 					// The endpoint requires the `manage_woocommerce`
 					// capability; surface a clear, actionable message
@@ -161,9 +189,20 @@ export const useQRLoginToken = ( {
 					);
 					break;
 				case 'application_passwords_unavailable':
-					nextErrorMessage = __(
-						'Application passwords are disabled on this site, so QR login is unavailable. Ask a site administrator to enable them.',
-						'woocommerce'
+					nextErrorMessage = createInterpolateElement(
+						__(
+							'Application passwords are disabled on this site, so QR login is unavailable. Find more about application passwords <link>here</link>.',
+							'woocommerce'
+						),
+						{
+							link: (
+								<Link
+									href={ APPLICATION_PASSWORDS_DOCS_URL }
+									target="_blank"
+									type="external"
+								/>
+							),
+						}
 					);
 					break;
 				case 'rate_limit_exceeded':
@@ -181,9 +220,10 @@ export const useQRLoginToken = ( {
 						);
 			}
 
+			setErrorCode( nextErrorCode );
 			setErrorMessage( nextErrorMessage );
 			setState( QRLoginTokenStates.ERROR );
-			onErrorRef.current?.( errorCode );
+			onErrorRef.current?.( nextErrorCode ?? 'unknown_error' );
 		}
 	}, [ clearTimer, startCountdown ] );
 
@@ -203,6 +243,7 @@ export const useQRLoginToken = ( {
 		qrUrl,
 		secondsRemaining,
 		errorMessage,
+		errorCode,
 		fetchToken,
 		refreshToken: fetchToken,
 	};

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useSendMagicLink.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useSendMagicLink.tsx
@@ -57,14 +57,27 @@ export const useSendMagicLink = () => {
 					error: response.message,
 					code: response.code,
 				} );
+				// Log the full response so the actual Jetpack / backend error
+				// is visible in the browser console for debugging. The
+				// user-facing notice is intentionally friendlier below.
+				// eslint-disable-next-line no-console
+				console.error( 'Send magic link failed:', response );
+
+				const genericRetry = __(
+					'We couldn’t send the link. Try again in a few seconds.',
+					'woocommerce'
+				);
+
 				if ( response.code === 'error_sending_mobile_magic_link' ) {
-					createNotice(
-						'error',
-						__(
-							'We couldn’t send the link. Try again in a few seconds.',
-							'woocommerce'
-						)
-					);
+					// The backend embeds the Jetpack error as
+					// "<code>: <message>" in response.message. Surface it
+					// alongside the retry guidance so merchants and support
+					// can distinguish a transient hiccup from a real
+					// configuration problem.
+					const detail = response.message
+						? ` (${ response.message })`
+						: '';
+					createNotice( 'error', `${ genericRetry }${ detail }` );
 				} else if (
 					response.code === 'invalid_user_permission_view_admin'
 				) {
@@ -78,10 +91,7 @@ export const useSendMagicLink = () => {
 				} else if ( response.code === 'jetpack_not_connected' ) {
 					createNotice( 'error', response.message );
 				} else {
-					createNotice(
-						'error',
-						'We couldn’t send the link. Try again in a few seconds.'
-					);
+					createNotice( 'error', genericRetry );
 				}
 			} );
 	}, [ createNotice ] );

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
@@ -206,15 +206,12 @@
 }
 
 button.components-button.send-magic-link-button {
-	background: #7f54b3;
+	background: #007cba;
 	color: #fff;
 	position: relative;
 	margin-bottom: 1em;
-	transition: background-color 0.15s ease-in-out;
-
-	&:hover,
-	&:focus {
-		background: #674399;
+	:hover {
+		// the hover state makes the text invisible so we need to override it
 		color: #fff;
 	}
 
@@ -288,7 +285,7 @@ button.components-button.send-magic-link-button {
 		}
 		.email-sent-footer-text {
 			.email-sent-send-another-link {
-				color: #7f54b3;
+				color: #007cba;
 				text-decoration: none;
 				padding: 0;
 				cursor: pointer;

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
@@ -206,15 +206,15 @@
 }
 
 button.components-button.send-magic-link-button {
-	background: var(--wp-admin-theme-color, #007cba);
+	background: #7f54b3;
 	color: #fff;
 	position: relative;
 	margin-bottom: 1em;
-	&:hover {
-		background: var(--wp-admin-theme-color-darker-20, #005a87);
-	}
-	:hover {
-		// the hover state makes the text invisible so we need to override it
+	transition: background-color 0.15s ease-in-out;
+
+	&:hover,
+	&:focus {
+		background: #674399;
 		color: #fff;
 	}
 
@@ -288,7 +288,7 @@ button.components-button.send-magic-link-button {
 		}
 		.email-sent-footer-text {
 			.email-sent-send-another-link {
-				color: #007cba;
+				color: #7f54b3;
 				text-decoration: none;
 				padding: 0;
 				cursor: pointer;
@@ -322,4 +322,3 @@ button.components-button.send-magic-link-button {
 		}
 	}
 }
-

--- a/plugins/woocommerce/client/admin/client/layout/controller.js
+++ b/plugins/woocommerce/client/admin/client/layout/controller.js
@@ -76,6 +76,10 @@ const LaunchStore = lazy( () =>
 	import( /* webpackChunkName: "launch-store" */ '../launch-your-store/hub' )
 );
 
+const MobileAppLoginPage = lazy( () =>
+	import( /* webpackChunkName: "mobile-app-login" */ '../mobile-app-login' )
+);
+
 export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
 export const getPages = ( reports = [] ) => {
@@ -328,6 +332,20 @@ export const getPages = ( reports = [] ) => {
 			capability: 'manage_woocommerce',
 		} );
 	}
+
+	pages.push( {
+		container: MobileAppLoginPage,
+		path: '/mobile-app-login',
+		breadcrumbs: [
+			...initialBreadcrumbs,
+			__( 'Mobile app login', 'woocommerce' ),
+		],
+		wpOpenMenu: 'toplevel_page_woocommerce',
+		navArgs: {
+			id: 'woocommerce-mobile-app-login',
+		},
+		capability: 'manage_woocommerce',
+	} );
 
 	/**
 	 * List of WooCommerce Admin pages.

--- a/plugins/woocommerce/client/admin/client/mobile-app-login/README.md
+++ b/plugins/woocommerce/client/admin/client/mobile-app-login/README.md
@@ -29,13 +29,13 @@ structural rewrite.
   `client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx`
   renders the QR, countdown, and in-QR FAQ link.
 - `useQRLoginToken` from
-  `client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.ts`
+  `client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.tsx`
   owns the token lifecycle — it is consumed indirectly by
   `<QRDirectLoginCode />`.
 
-Neither file is modified by this page. The "Refresh code" button forces a
-remount of `<QRDirectLoginCode />` via a `key` prop, which triggers a fresh
-token fetch without forking the component.
+Neither file is modified by this page. The shared QR component only allows a
+manual retry after it reaches an error or expired state, so the page does not
+mint parallel valid login tokens while a QR code is still live.
 
 ## What this page does not do
 

--- a/plugins/woocommerce/client/admin/client/mobile-app-login/README.md
+++ b/plugins/woocommerce/client/admin/client/mobile-app-login/README.md
@@ -1,0 +1,51 @@
+# Mobile app login
+
+Standalone wc-admin page that lets a logged-in merchant sign in to the Woo
+mobile app on their phone by scanning a QR code.
+
+## Audience
+
+Merchants who already have the Woo mobile app installed on their phone and
+want a direct, one-shot way to sign in — without going through the onboarding
+modal on the wc-admin home screen.
+
+## Route
+
+`/wp-admin/admin.php?page=wc-admin&path=/mobile-app-login`
+
+Registered in `client/admin/client/layout/controller.js` with capability
+`manage_woocommerce`, so admins and shop managers can reach it.
+
+## Scope
+
+Application Password flow only. The WordPress.com multi-store flow is deferred
+to a future task. The page's single-column layout leaves room below the QR for
+a future secondary CTA, so adding that flow later does not require a
+structural rewrite.
+
+## Reused components
+
+- `<QRDirectLoginCode />` from
+  `client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx`
+  renders the QR, countdown, and in-QR FAQ link.
+- `useQRLoginToken` from
+  `client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.ts`
+  owns the token lifecycle — it is consumed indirectly by
+  `<QRDirectLoginCode />`.
+
+Neither file is modified by this page. The "Refresh code" button forces a
+remount of `<QRDirectLoginCode />` via a `key` prop, which triggers a fresh
+token fetch without forking the component.
+
+## What this page does not do
+
+- No Jetpack / WordPress.com detection branching.
+- No `<SendMagicLinkButton />` — the email magic-link CTA stays in the
+  onboarding modal only.
+- No URL input field — the page is only reachable inside the merchant's own
+  wp-admin, so the site URL is already known.
+- No "install the app" wizard step — the audience is "app already installed."
+
+## Tests
+
+See `test/index.test.tsx`.

--- a/plugins/woocommerce/client/admin/client/mobile-app-login/index.tsx
+++ b/plugins/woocommerce/client/admin/client/mobile-app-login/index.tsx
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Card, CardBody } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import interpolateComponents from '@automattic/interpolate-components';
+import { Link } from '@woocommerce/components';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { QRDirectLoginCode } from '~/homescreen/mobile-app-modal/components/QRDirectLoginCode';
+import './style.scss';
+
+/**
+ * URL to the mobile app login help article.
+ *
+ * Kept in sync with the FAQ link rendered inside `<QRDirectLoginCode />` —
+ * both point at the same canonical help page so merchants land in the same
+ * place regardless of which troubleshooting affordance they tap.
+ */
+const FAQ_URL =
+	'https://woocommerce.com/document/android-ios-apps-login-help-faq/';
+
+/**
+ * Standalone wc-admin page for signing in to the Woo mobile app via QR code.
+ *
+ * Audience: merchants who already have the Woo mobile app installed on their
+ * phone and want a quick, one-shot way to sign in without going through the
+ * onboarding modal.
+ *
+ * This page only builds the Application Password flow. The WordPress.com
+ * multi-store flow is intentionally deferred — the single-column layout
+ * leaves room below the QR for a future secondary CTA without needing a
+ * structural rewrite.
+ */
+export const MobileAppLoginPage = () => {
+	// Forces `<QRDirectLoginCode />` to remount when the merchant clicks
+	// "Refresh code". Because the QR component owns its own token lifecycle
+	// via `useQRLoginToken`, a fresh mount is the simplest way to trigger a
+	// new token fetch without forking the component or reaching into its
+	// internals.
+	const [ refreshKey, setRefreshKey ] = useState( 0 );
+
+	useEffect( () => {
+		recordEvent( 'mobile_app_qr_login_page_viewed' );
+	}, [] );
+
+	const handleRefreshClick = () => {
+		recordEvent( 'mobile_app_qr_login_page_refresh_clicked' );
+		setRefreshKey( ( value ) => value + 1 );
+	};
+
+	return (
+		<div className="woocommerce-mobile-app-login">
+			<Card className="woocommerce-mobile-app-login__card">
+				<CardBody className="woocommerce-mobile-app-login__body">
+					<h1 className="woocommerce-mobile-app-login__heading">
+						{ __( 'Sign in to the Woo mobile app', 'woocommerce' ) }
+					</h1>
+					<p className="woocommerce-mobile-app-login__intro">
+						{ interpolateComponents( {
+							mixedString: __(
+								'Open the Woo mobile app on your phone, tap {{strong}}Scan QR code{{/strong}}, then point your camera at the code below.',
+								'woocommerce'
+							),
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</p>
+
+					<div className="woocommerce-mobile-app-login__qr">
+						<QRDirectLoginCode key={ refreshKey } />
+					</div>
+
+					<div className="woocommerce-mobile-app-login__actions">
+						<Button
+							variant="secondary"
+							onClick={ handleRefreshClick }
+						>
+							{ __( 'Refresh code', 'woocommerce' ) }
+						</Button>
+					</div>
+
+					{ /*
+					 * Leave room below the actions for a future "Log in with
+					 * WordPress.com for multi-store access" secondary CTA
+					 * (see WOOMOB-2767 plan). Do not add the UI here — a
+					 * separate task owns that flow.
+					 */ }
+
+					<p className="woocommerce-mobile-app-login__faq">
+						{ interpolateComponents( {
+							mixedString: __(
+								'Having trouble? Check our {{link}}troubleshooting guide{{/link}}.',
+								'woocommerce'
+							),
+							components: {
+								link: (
+									<Link
+										href={ FAQ_URL }
+										target="_blank"
+										type="external"
+										onClick={ () => {
+											recordEvent(
+												'mobile_app_qr_login_page_faq_click'
+											);
+										} }
+									/>
+								),
+							},
+						} ) }
+					</p>
+				</CardBody>
+			</Card>
+		</div>
+	);
+};
+
+export default MobileAppLoginPage;

--- a/plugins/woocommerce/client/admin/client/mobile-app-login/index.tsx
+++ b/plugins/woocommerce/client/admin/client/mobile-app-login/index.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Card, CardBody } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { Card, CardBody } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
@@ -37,21 +37,9 @@ const FAQ_URL =
  * structural rewrite.
  */
 export const MobileAppLoginPage = () => {
-	// Forces `<QRDirectLoginCode />` to remount when the merchant clicks
-	// "Refresh code". Because the QR component owns its own token lifecycle
-	// via `useQRLoginToken`, a fresh mount is the simplest way to trigger a
-	// new token fetch without forking the component or reaching into its
-	// internals.
-	const [ refreshKey, setRefreshKey ] = useState( 0 );
-
 	useEffect( () => {
 		recordEvent( 'mobile_app_qr_login_page_viewed' );
 	}, [] );
-
-	const handleRefreshClick = () => {
-		recordEvent( 'mobile_app_qr_login_page_refresh_clicked' );
-		setRefreshKey( ( value ) => value + 1 );
-	};
 
 	return (
 		<div className="woocommerce-mobile-app-login">
@@ -73,16 +61,7 @@ export const MobileAppLoginPage = () => {
 					</p>
 
 					<div className="woocommerce-mobile-app-login__qr">
-						<QRDirectLoginCode key={ refreshKey } />
-					</div>
-
-					<div className="woocommerce-mobile-app-login__actions">
-						<Button
-							variant="secondary"
-							onClick={ handleRefreshClick }
-						>
-							{ __( 'Refresh code', 'woocommerce' ) }
-						</Button>
+						<QRDirectLoginCode />
 					</div>
 
 					{ /*

--- a/plugins/woocommerce/client/admin/client/mobile-app-login/style.scss
+++ b/plugins/woocommerce/client/admin/client/mobile-app-login/style.scss
@@ -1,0 +1,58 @@
+.woocommerce-mobile-app-login {
+	display: flex;
+	justify-content: center;
+	padding: $gap-large;
+
+	&__card {
+		width: 100%;
+		max-width: 560px;
+	}
+
+	&__body {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		padding: $gap-largest;
+	}
+
+	&__heading {
+		font-size: 24px;
+		font-weight: 400;
+		line-height: 1.3;
+		margin: 0 0 $gap;
+	}
+
+	&__intro {
+		color: $gray-700;
+		font-size: 14px;
+		line-height: 1.5;
+		margin: 0 0 $gap-large;
+		max-width: 420px;
+	}
+
+	&__qr {
+		margin-bottom: $gap;
+
+		// Centre the internal QR layout — `<QRDirectLoginCode />` is wrapped
+		// in a `.qr-direct-login` div with default left-aligned children,
+		// so we re-align them for this standalone single-column page.
+		.qr-direct-login {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			text-align: center;
+		}
+	}
+
+	&__actions {
+		margin-bottom: $gap-large;
+	}
+
+	&__faq {
+		color: $gray-700;
+		font-size: 13px;
+		line-height: 1.5;
+		margin: 0;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/mobile-app-login/test/index.test.tsx
+++ b/plugins/woocommerce/client/admin/client/mobile-app-login/test/index.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { MobileAppLoginPage } from '../index';
+import {
+	QRLoginTokenStates,
+	useQRLoginToken,
+} from '~/homescreen/mobile-app-modal/components/useQRLoginToken';
+
+// Drive `<QRDirectLoginCode />` from the tests by mocking its shared token
+// hook. The real component is rendered so we exercise the integration
+// surface of this page against the component we claim to reuse.
+jest.mock( '~/homescreen/mobile-app-modal/components/useQRLoginToken', () => {
+	const actual = jest.requireActual(
+		'~/homescreen/mobile-app-modal/components/useQRLoginToken'
+	);
+	return {
+		...actual,
+		useQRLoginToken: jest.fn(),
+	};
+} );
+
+// Keep tests isolated from analytics side-effects.
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+const mockedUseQRLoginToken = useQRLoginToken as jest.MockedFunction<
+	typeof useQRLoginToken
+>;
+
+const makeReadyState = () => ( {
+	state: QRLoginTokenStates.READY,
+	qrUrl: 'woocommerce://qr-login?token=abc&siteUrl=https%3A%2F%2Fexample.test',
+	secondsRemaining: 300,
+	errorMessage: null,
+	fetchToken: jest.fn(),
+	refreshToken: jest.fn(),
+} );
+
+describe( 'MobileAppLoginPage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedUseQRLoginToken.mockReturnValue( makeReadyState() );
+	} );
+
+	it( 'renders the heading, scan-first intro, and the QR code', () => {
+		render( <MobileAppLoginPage /> );
+
+		expect(
+			screen.getByRole( 'heading', {
+				name: /Sign in to the Woo mobile app/i,
+				level: 1,
+			} )
+		).toBeInTheDocument();
+
+		// The scan-first intro mentions the in-app action merchants have to
+		// tap — the exact phrasing is what engineering Happiness reads back
+		// to users on support tickets, so we assert on it literally.
+		expect( screen.getByText( /Scan QR code/ ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /Open the Woo mobile app on your phone/i )
+		).toBeInTheDocument();
+
+		// `<QRDirectLoginCode />` in READY state renders its countdown copy.
+		// That copy is the load-bearing signal that the QR is on screen
+		// because the SVG payload itself is not easily queryable.
+		expect( screen.getByText( /Code expires in/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the troubleshooting FAQ link pointing at the help doc', () => {
+		render( <MobileAppLoginPage /> );
+
+		const faqLink = screen.getByRole( 'link', {
+			name: /troubleshooting guide/i,
+		} );
+		expect( faqLink ).toHaveAttribute(
+			'href',
+			'https://woocommerce.com/document/android-ios-apps-login-help-faq/'
+		);
+	} );
+
+	it( 'remounts the QR component on refresh to force a new token fetch', () => {
+		// Tracks `fetchToken` calls across all hook instances — every mount
+		// of `<QRDirectLoginCode />` runs its own `fetchToken` on mount.
+		const fetchToken = jest.fn();
+		mockedUseQRLoginToken.mockReturnValue( {
+			...makeReadyState(),
+			fetchToken,
+		} );
+
+		render( <MobileAppLoginPage /> );
+
+		// First mount fires exactly one fetch (from QRDirectLoginCode's
+		// initial `useEffect`).
+		expect( fetchToken ).toHaveBeenCalledTimes( 1 );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: /Refresh code/i } )
+		);
+
+		// Clicking refresh should remount the QR component, which runs its
+		// initial-fetch effect again. Two total calls is the behavioural
+		// signal that the refresh actually triggers a new token.
+		expect( fetchToken ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not render the magic-link button (regression guard — modal-only feature)', () => {
+		render( <MobileAppLoginPage /> );
+
+		// The onboarding modal ships a "Send the sign-in link" button when
+		// a WordPress.com account is linked. That button must never appear
+		// on this standalone page — the audience here is app-install-ready
+		// merchants who just need to scan, not magic-link recipients.
+		expect(
+			screen.queryByRole( 'button', {
+				name: /Send the sign-in link/i,
+			} )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				/Or get a WordPress\.com sign-in link by email/i
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'surfaces the QR error state from useQRLoginToken without breaking the page shell', () => {
+		mockedUseQRLoginToken.mockReturnValue( {
+			state: QRLoginTokenStates.ERROR,
+			qrUrl: null,
+			secondsRemaining: 0,
+			errorMessage: 'QR login requires an HTTPS connection.',
+			fetchToken: jest.fn(),
+			refreshToken: jest.fn(),
+		} );
+
+		render( <MobileAppLoginPage /> );
+
+		// The heading and the refresh button are static shell — they must
+		// still render even when the QR surfaces an error from the backend.
+		expect(
+			screen.getByRole( 'heading', {
+				name: /Sign in to the Woo mobile app/i,
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: /Refresh code/i } )
+		).toBeInTheDocument();
+
+		// Error text from the hook leaks through the shared component.
+		expect(
+			screen.getByText( /QR login requires an HTTPS connection/i )
+		).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/mobile-app-login/test/index.test.tsx
+++ b/plugins/woocommerce/client/admin/client/mobile-app-login/test/index.test.tsx
@@ -85,9 +85,7 @@ describe( 'MobileAppLoginPage', () => {
 		);
 	} );
 
-	it( 'remounts the QR component on refresh to force a new token fetch', () => {
-		// Tracks `fetchToken` calls across all hook instances — every mount
-		// of `<QRDirectLoginCode />` runs its own `fetchToken` on mount.
+	it( 'does not offer a manual refresh while a QR code is still valid', () => {
 		const fetchToken = jest.fn();
 		mockedUseQRLoginToken.mockReturnValue( {
 			...makeReadyState(),
@@ -100,14 +98,29 @@ describe( 'MobileAppLoginPage', () => {
 		// initial `useEffect`).
 		expect( fetchToken ).toHaveBeenCalledTimes( 1 );
 
+		expect(
+			screen.queryByRole( 'button', { name: /Refresh code/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'lets the shared QR component generate a new code after expiry', () => {
+		const refreshToken = jest.fn();
+		mockedUseQRLoginToken.mockReturnValue( {
+			state: QRLoginTokenStates.EXPIRED,
+			qrUrl: null,
+			secondsRemaining: 0,
+			errorMessage: null,
+			fetchToken: jest.fn(),
+			refreshToken,
+		} );
+
+		render( <MobileAppLoginPage /> );
+
 		fireEvent.click(
-			screen.getByRole( 'button', { name: /Refresh code/i } )
+			screen.getByRole( 'button', { name: /Generate new code/i } )
 		);
 
-		// Clicking refresh should remount the QR component, which runs its
-		// initial-fetch effect again. Two total calls is the behavioural
-		// signal that the refresh actually triggers a new token.
-		expect( fetchToken ).toHaveBeenCalledTimes( 2 );
+		expect( refreshToken ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'does not render the magic-link button (regression guard — modal-only feature)', () => {
@@ -141,15 +154,15 @@ describe( 'MobileAppLoginPage', () => {
 
 		render( <MobileAppLoginPage /> );
 
-		// The heading and the refresh button are static shell — they must
-		// still render even when the QR surfaces an error from the backend.
+		// The heading and FAQ link are static shell — they must still render
+		// even when the QR surfaces an error from the backend.
 		expect(
 			screen.getByRole( 'heading', {
 				name: /Sign in to the Woo mobile app/i,
 			} )
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole( 'button', { name: /Refresh code/i } )
+			screen.getByRole( 'link', { name: /troubleshooting guide/i } )
 		).toBeInTheDocument();
 
 		// Error text from the hook leaks through the shared component.


### PR DESCRIPTION
> **📚 Stack navigation**
> ⬅ Previous: [#64319 — WC-Core 3 — error handling](https://github.com/woocommerce/woocommerce/pull/64319)
> ➡ Next: [#64456 — WC-Core 5 — confirmation/revoke/renew](https://github.com/woocommerce/woocommerce/pull/64456)

## Summary

Adds a standalone wc-admin page at `/mobile-app-login` that hosts the same `<QRDirectLoginCode />` surface used in the homescreen modal. Mobile apps that need to redirect a user back to wc-admin after install (or merchants who want a deep-linkable URL to share) need a stable destination — the modal alone is not addressable, and embedding the QR in a homescreen widget is overloaded with the rest of that surface.

## Changes

- New page registered in `client/admin/client/mobile-app-login/`, gated on `manage_woocommerce` (same gate as the REST endpoint, so the URL won't render for users who couldn't generate a token anyway).
- The page renders `<QRDirectLoginCode />` directly — no duplicated component logic. The modal and the standalone page are visually distinct (Woo wordmark, full-card chrome) but share state-machine behavior.
- Refresh debounce — the page's `useEffect` for `fetchToken` only fires once per mount; visibility-change re-renders don't re-mint a token.

## Diagram

```mermaid
flowchart LR
    A[Browser nav to<br/>/admin.php?page=wc-admin&path=/mobile-app-login] --> B{manage_woocommerce?}
    B -- no --> C[Redirect to wc-admin home]
    B -- yes --> D[Render &lt;QRDirectLoginCode /&gt;]
    D --> E[POST /qr-login-token]
    E --> F[QR + countdown rendered]
    F --> G[App scans → exchange flow]
```

## Testing

**Automated:** new Jest tests under `client/admin/client/mobile-app-login/test/index.test.tsx` covering capability gate, render, and the FAQ link.

**Manual:** visit `/wp-admin/admin.php?page=wc-admin&path=/mobile-app-login` as an admin — page renders the QR with the same UX as the modal. Visit as a subscriber — page redirects. Full sign-in end-to-end with the mobile app is exercised in #64503 (the final number-matching PR ships the production-ready protocol); at this stage the page can be smoke-tested by running through the curl flow from #64302's manual section.

### Linear

[WOOMOB-2767](https://linear.app/a8c/issue/WOOMOB-2767).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Changelog entry created manually (committed in the branch).
