### PR TITLE
Add configurable maximum query complexity to GraphQL settings

### DIFF
--- a/plugins/woocommerce/changelog/64337-graphql-settings-query-complexity
+++ b/plugins/woocommerce/changelog/64337-graphql-settings-query-complexity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a configurable maximum query complexity to the GraphQL settings section.

--- a/plugins/woocommerce/src/Internal/Api/GraphQLController.php
+++ b/plugins/woocommerce/src/Internal/Api/GraphQLController.php
@@ -18,7 +18,6 @@ use Automattic\WooCommerce\Vendor\GraphQL\Type\Schema;
 use Automattic\WooCommerce\Vendor\GraphQL\Error\DebugFlag;
 use Automattic\WooCommerce\Vendor\GraphQL\Validator\DocumentValidator;
 use Automattic\WooCommerce\Vendor\GraphQL\Validator\Rules\DisableIntrospection;
-use Automattic\WooCommerce\Vendor\GraphQL\Validator\Rules\QueryComplexity;
 use Automattic\WooCommerce\Vendor\GraphQL\Validator\Rules\QueryDepth;
 
 /**
@@ -172,9 +171,9 @@ class GraphQLController {
 		$schema = $this->get_schema();
 
 		// 6. Build validation rules.
-		// A single QueryComplexity instance is kept so its computed score can
+		// A single complexity-rule instance is kept so its computed score can
 		// be surfaced in the debug extensions after execution.
-		$complexity_rule    = new QueryComplexity( self::get_max_query_complexity() );
+		$complexity_rule    = new QueryComplexityRule( self::get_max_query_complexity() );
 		$validation_rules   = array_values( DocumentValidator::allRules() );
 		$validation_rules[] = new QueryDepth( self::get_max_query_depth() );
 		$validation_rules[] = $complexity_rule;

--- a/plugins/woocommerce/src/Internal/Api/GraphQLController.php
+++ b/plugins/woocommerce/src/Internal/Api/GraphQLController.php
@@ -34,13 +34,14 @@ class GraphQLController {
 	public const DEFAULT_MAX_QUERY_DEPTH = 15;
 
 	/**
-	 * Maximum computed complexity score allowed for a GraphQL query.
+	 * Default complexity-score limit applied when the option is unset or non-positive.
 	 *
 	 * Complexity is the sum of per-field scores; connection fields multiply
-	 * their child score by the requested page size. Queries exceeding this
-	 * score are rejected during validation. See {@see self::get_max_query_complexity()}.
+	 * their child score by the requested page size. Queries exceeding the
+	 * configured limit are rejected during validation. See
+	 * {@see self::get_max_query_complexity()} for the accessor.
 	 */
-	private const MAX_QUERY_COMPLEXITY = 1000;
+	public const DEFAULT_MAX_QUERY_COMPLEXITY = 1000;
 
 	/**
 	 * Cached GraphQL schema instance.
@@ -81,11 +82,13 @@ class GraphQLController {
 	/**
 	 * The maximum computed complexity score allowed for a GraphQL query.
 	 *
-	 * Exposed as a method so the limit can become configurable — e.g. via a
-	 * filter or store option — without requiring call-site changes.
+	 * Reads the {@see Main::OPTION_MAX_QUERY_COMPLEXITY} store option; falls
+	 * back to {@see self::DEFAULT_MAX_QUERY_COMPLEXITY} when the option is
+	 * unset, empty, or non-positive.
 	 */
 	public static function get_max_query_complexity(): int {
-		return self::MAX_QUERY_COMPLEXITY;
+		$value = (int) get_option( Main::OPTION_MAX_QUERY_COMPLEXITY, self::DEFAULT_MAX_QUERY_COMPLEXITY );
+		return $value > 0 ? $value : self::DEFAULT_MAX_QUERY_COMPLEXITY;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/Main.php
+++ b/plugins/woocommerce/src/Internal/Api/Main.php
@@ -35,6 +35,14 @@ class Main {
 	public const OPTION_MAX_QUERY_DEPTH = 'woocommerce_graphql_max_query_depth';
 
 	/**
+	 * Option name for the "Maximum query complexity" setting.
+	 *
+	 * Caps the computed complexity score of a GraphQL query — connection
+	 * fields multiply their children's cost by the requested page size.
+	 */
+	public const OPTION_MAX_QUERY_COMPLEXITY = 'woocommerce_graphql_max_query_complexity';
+
+	/**
 	 * Cached result of the feature-enabled check, null until first evaluated.
 	 *
 	 * @var ?bool

--- a/plugins/woocommerce/src/Internal/Api/QueryComplexityRule.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryComplexityRule.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\Api;
+
+use Automattic\WooCommerce\Vendor\GraphQL\Validator\Rules\QueryComplexity;
+
+/**
+ * QueryComplexity validation rule that returns a generic error message when the complexity is exceeded.
+ *
+ * Admins can still read both values via debug mode; see
+ * {@see GraphQLController} step 8.
+ */
+class QueryComplexityRule extends QueryComplexity {
+	/**
+	 * Override webonyx's default ("Max query complexity should be {max} but
+	 * got {count}.").
+	 *
+	 * @param int $max   The configured maximum complexity (unused).
+	 * @param int $count The computed query complexity (unused).
+	 */
+	public static function maxQueryComplexityErrorMessage( int $max, int $count ): string {
+		return 'Maximum query complexity exceeded.';
+	}
+}

--- a/plugins/woocommerce/src/Internal/Api/Settings.php
+++ b/plugins/woocommerce/src/Internal/Api/Settings.php
@@ -71,6 +71,14 @@ class Settings {
 				'custom_attributes' => array( 'min' => '1' ),
 			),
 			array(
+				'title'             => __( 'Maximum query complexity', 'woocommerce' ),
+				'desc'              => __( 'Reject queries whose computed complexity score exceeds this value.', 'woocommerce' ),
+				'id'                => Main::OPTION_MAX_QUERY_COMPLEXITY,
+				'default'           => (string) GraphQLController::DEFAULT_MAX_QUERY_COMPLEXITY,
+				'type'              => 'number',
+				'custom_attributes' => array( 'min' => '1' ),
+			),
+			array(
 				'type' => 'sectionend',
 				'id'   => 'woocommerce_graphql_options',
 			),

--- a/plugins/woocommerce/tests/php/src/Internal/Api/GraphQLControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/GraphQLControllerTest.php
@@ -43,6 +43,7 @@ class GraphQLControllerTest extends WC_REST_Unit_Test_Case {
 	public function tearDown(): void {
 		delete_option( Main::OPTION_GET_ENDPOINT_ENABLED );
 		delete_option( Main::OPTION_MAX_QUERY_DEPTH );
+		delete_option( Main::OPTION_MAX_QUERY_COMPLEXITY );
 		parent::tearDown();
 	}
 
@@ -110,7 +111,40 @@ class GraphQLControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Non-positive values that the getter should replace with the default.
+	 * @testdox get_max_query_complexity returns the default when the option is unset.
+	 */
+	public function test_get_max_query_complexity_returns_default_when_option_unset(): void {
+		delete_option( Main::OPTION_MAX_QUERY_COMPLEXITY );
+		$this->assertSame(
+			GraphQLController::DEFAULT_MAX_QUERY_COMPLEXITY,
+			GraphQLController::get_max_query_complexity()
+		);
+	}
+
+	/**
+	 * @testdox get_max_query_complexity returns the option value when it is a positive integer.
+	 */
+	public function test_get_max_query_complexity_returns_option_value_when_positive(): void {
+		update_option( Main::OPTION_MAX_QUERY_COMPLEXITY, '500' );
+		$this->assertSame( 500, GraphQLController::get_max_query_complexity() );
+	}
+
+	/**
+	 * @testdox get_max_query_complexity falls back to the default when the option is empty, zero, or negative.
+	 * @dataProvider provider_non_positive_option_values
+	 *
+	 * @param string $value The non-positive option value.
+	 */
+	public function test_get_max_query_complexity_falls_back_on_non_positive( string $value ): void {
+		update_option( Main::OPTION_MAX_QUERY_COMPLEXITY, $value );
+		$this->assertSame(
+			GraphQLController::DEFAULT_MAX_QUERY_COMPLEXITY,
+			GraphQLController::get_max_query_complexity()
+		);
+	}
+
+	/**
+	 * Non-positive values that the getters should replace with the default.
 	 *
 	 * @return array<string, array{string}>
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
@@ -100,4 +100,20 @@ class SettingsTest extends WC_Unit_Test_Case {
 		);
 		$this->assertSame( '1', $by_id[ Main::OPTION_MAX_QUERY_DEPTH ]['custom_attributes']['min'] );
 	}
+
+	/**
+	 * @testdox add_settings defines the max query complexity field with min=1 and the default constant as default.
+	 */
+	public function test_add_settings_defines_max_query_complexity_field(): void {
+		$fields = $this->sut->add_settings( array(), Settings::SECTION_ID );
+		$by_id  = array_column( $fields, null, 'id' );
+
+		$this->assertArrayHasKey( Main::OPTION_MAX_QUERY_COMPLEXITY, $by_id );
+		$this->assertSame( 'number', $by_id[ Main::OPTION_MAX_QUERY_COMPLEXITY ]['type'] );
+		$this->assertSame(
+			(string) GraphQLController::DEFAULT_MAX_QUERY_COMPLEXITY,
+			$by_id[ Main::OPTION_MAX_QUERY_COMPLEXITY ]['default']
+		);
+		$this->assertSame( '1', $by_id[ Main::OPTION_MAX_QUERY_COMPLEXITY ]['custom_attributes']['min'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [ ] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [ ] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds the **Maximum query complexity** setting under **WooCommerce → Settings → Advanced → GraphQL**. The previously hardcoded 1000-point limit (enforced via webonyx's `QueryComplexity` validation rule) now reads from a store option, defaulting to 1000 when unset or set to a non-positive value.

Mirrors the pattern established by the maximum query depth setting — same option-name convention, same `public const DEFAULT_*` as the UI default, same `> 0` guard in the getter so a cleared or invalid option value falls back to the default instead of silently disabling the check.

Part of #64165. Closes #64300.

### How to test the changes in this Pull Request:

1. Enable the feature flag: `wp option update woocommerce_feature_dual_code_graphql_api_enabled yes`.
2. Visit **WooCommerce → Settings → Advanced → GraphQL**. A new **Maximum query complexity** field should be visible below the depth field, pre-filled with `1000`, with `min=1` enforced by the browser.
3. Set the field to `50` and save. Run a query whose computed complexity exceeds 50, e.g. `{ products(first: 100) { nodes { id } } }`. Expect HTTP 400 with an error message along the lines of `"Max query complexity should be 50 but got …"`.
4. Run the same query with `?_debug=1` appended. The response should include `"extensions.debug.complexity"` showing the computed score — confirming the rejection number.
5. Set the field back to `1000`, save, re-run step 3's query. Expect HTTP 200.



### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Add - Adds functionality

#### Message

Add a configurable maximum query complexity to the GraphQL settings section.

</details>
