### PR TITLE
Add auto-generation mode to coupon code block

### DIFF
--- a/packages/php/email-editor/changelog/64342-add-coupon-code-block-auto-generation
+++ b/packages/php/email-editor/changelog/64342-add-coupon-code-block-auto-generation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add auto-generation mode to the coupon code email block, allowing users to configure coupon rules that generate unique codes at send time.

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-coupon-code.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-coupon-code.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package.
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Renderer\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
+
+/**
+ * Renders the woocommerce/coupon-code block for email.
+ *
+ * For "existing" source, the block content passes through unchanged.
+ * For "createNew" source, the placeholder (XXXX-XXXXXX-XXXX) is replaced
+ * with a generated coupon code via the woocommerce_coupon_code_block_auto_generate filter.
+ */
+class Coupon_Code extends Abstract_Block_Renderer {
+
+	const COUPON_CODE_PLACEHOLDER = 'XXXX-XXXXXX-XXXX';
+
+	/**
+	 * Render the coupon code block content for email.
+	 *
+	 * @param string            $block_content Block content from the standard WP render.
+	 * @param array             $parsed_block Parsed block data.
+	 * @param Rendering_Context $rendering_context Rendering context with email-specific data.
+	 * @return string
+	 */
+	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$attrs  = $parsed_block['attrs'] ?? array();
+		$source = $attrs['source'] ?? 'createNew';
+
+		if ( 'createNew' === $source ) {
+			/**
+			 * Filters the auto-generated coupon code for the coupon-code block.
+			 *
+			 * Integrators (MailPoet, WooCommerce, third-party plugins) hook into this filter
+			 * to generate a WooCommerce coupon at send time and return its code.
+			 *
+			 * @hook woocommerce_coupon_code_block_auto_generate
+			 * @since 10.6.0
+			 *
+			 * @param string            $coupon_code       The coupon code. Empty by default.
+			 * @param array             $attrs             Block attributes (discountType, amount, expiryDay, etc.).
+			 * @param Rendering_Context $rendering_context The rendering context with email-specific data
+			 *                                             (recipient email, user ID, etc.).
+			 * @return string The generated coupon code. Return empty string to suppress the block output.
+			 */
+			$coupon_code = apply_filters(
+				'woocommerce_coupon_code_block_auto_generate',
+				'',
+				$attrs,
+				$rendering_context
+			);
+
+			if ( empty( $coupon_code ) ) {
+				return '';
+			}
+
+			$block_content = str_replace(
+				self::COUPON_CODE_PLACEHOLDER,
+				esc_html( $coupon_code ),
+				$block_content
+			);
+		}
+
+		$align = $attrs['align'] ?? 'center';
+		if ( ! in_array( $align, array( 'left', 'center', 'right' ), true ) ) {
+			$align = 'center';
+		}
+
+		$table_attrs = array(
+			'style' => 'border-collapse: separate;',
+			'width' => '100%',
+		);
+
+		$cell_attrs = array(
+			'align' => $align,
+			'style' => \WP_Style_Engine::compile_css(
+				array(
+					'text-align' => $align,
+				),
+				''
+			),
+		);
+
+		return Table_Wrapper_Helper::render_table_wrapper( $block_content, $table_attrs, $cell_attrs );
+	}
+}

--- a/packages/php/email-editor/src/Integrations/WooCommerce/class-coupon-code-generator.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/class-coupon-code-generator.php
@@ -64,8 +64,8 @@ class Coupon_Code_Generator {
 
 			$coupon->set_free_shipping( ! empty( $attrs['freeShipping'] ) );
 
-			$coupon->set_minimum_amount( (string) ( $attrs['minimumAmount'] ?? '' ) );
-			$coupon->set_maximum_amount( (string) ( $attrs['maximumAmount'] ?? '' ) );
+			$coupon->set_minimum_amount( (float) ( $attrs['minimumAmount'] ?? 0 ) );
+			$coupon->set_maximum_amount( (float) ( $attrs['maximumAmount'] ?? 0 ) );
 			$coupon->set_individual_use( ! empty( $attrs['individualUse'] ) );
 			$coupon->set_exclude_sale_items( ! empty( $attrs['excludeSaleItems'] ) );
 
@@ -86,8 +86,10 @@ class Coupon_Code_Generator {
 
 			$coupon->set_email_restrictions( array_unique( array_filter( $email_restrictions ) ) );
 
-			$coupon->set_usage_limit( (int) ( $attrs['usageLimit'] ?? 0 ) );
-			$coupon->set_usage_limit_per_user( (int) ( $attrs['usageLimitPerUser'] ?? 0 ) );
+			$usage_limit          = $attrs['usageLimit'] ?? 0;
+			$usage_limit_per_user = $attrs['usageLimitPerUser'] ?? 0;
+			$coupon->set_usage_limit( is_numeric( $usage_limit ) ? (int) $usage_limit : 0 );
+			$coupon->set_usage_limit_per_user( is_numeric( $usage_limit_per_user ) ? (int) $usage_limit_per_user : 0 );
 
 			$coupon->set_description(
 				__( 'Auto-generated coupon by WooCommerce Email Editor', 'woocommerce' )
@@ -146,8 +148,12 @@ class Coupon_Code_Generator {
 	 */
 	private function extract_ids( array $items ): array {
 		return array_map(
-			function ( $item ) {
-				return (int) ( is_array( $item ) ? ( $item['id'] ?? 0 ) : 0 );
+			function ( $item ): int {
+				if ( ! is_array( $item ) ) {
+					return 0;
+				}
+				$id = $item['id'] ?? 0;
+				return is_numeric( $id ) ? (int) $id : 0;
 			},
 			$items
 		);

--- a/packages/php/email-editor/src/Integrations/WooCommerce/class-coupon-code-generator.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/class-coupon-code-generator.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package.
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+
+/**
+ * Generates WooCommerce coupons at email send time for the coupon-code block.
+ *
+ * Hooks into the woocommerce_coupon_code_block_auto_generate filter to create
+ * a WC_Coupon from block attributes. This provides baseline auto-generation
+ * that works without any additional plugins (e.g. MailPoet).
+ *
+ * Integrators like MailPoet can hook the same filter at a higher priority
+ * to add features like per-subscriber restriction or coupon persistence.
+ */
+class Coupon_Code_Generator {
+
+	/**
+	 * Initialize the generator by registering the filter hook.
+	 */
+	public function init(): void {
+		add_filter( 'woocommerce_coupon_code_block_auto_generate', array( $this, 'generate_coupon' ), 10, 3 );
+	}
+
+	/**
+	 * Generate a WooCommerce coupon from block attributes.
+	 *
+	 * @param string            $coupon_code       The coupon code (empty if not yet generated).
+	 * @param array             $attrs             Block attributes.
+	 * @param Rendering_Context $rendering_context The rendering context.
+	 * @return string The generated coupon code, or empty string on failure.
+	 */
+	public function generate_coupon( string $coupon_code, array $attrs, Rendering_Context $rendering_context ): string {
+		if ( ! empty( $coupon_code ) ) {
+			return $coupon_code;
+		}
+
+		if ( ! function_exists( 'wc_get_coupon_types' ) || ! class_exists( 'WC_Coupon' ) ) {
+			return '';
+		}
+
+		try {
+			$coupon = new \WC_Coupon();
+			$coupon->set_code( $this->generate_random_code() );
+
+			$discount_type = $this->validate_discount_type( $attrs['discountType'] ?? 'percent' );
+			$coupon->set_discount_type( $discount_type );
+
+			if ( isset( $attrs['amount'] ) ) {
+				$coupon->set_amount( (float) $attrs['amount'] );
+			}
+
+			if ( ! empty( $attrs['expiryDay'] ) ) {
+				$expiration = time() + ( (int) $attrs['expiryDay'] * DAY_IN_SECONDS );
+				$coupon->set_date_expires( $expiration );
+			}
+
+			$coupon->set_free_shipping( ! empty( $attrs['freeShipping'] ) );
+
+			$coupon->set_minimum_amount( (string) ( $attrs['minimumAmount'] ?? '' ) );
+			$coupon->set_maximum_amount( (string) ( $attrs['maximumAmount'] ?? '' ) );
+			$coupon->set_individual_use( ! empty( $attrs['individualUse'] ) );
+			$coupon->set_exclude_sale_items( ! empty( $attrs['excludeSaleItems'] ) );
+
+			$coupon->set_product_ids( $this->extract_ids( $attrs['productIds'] ?? array() ) );
+			$coupon->set_excluded_product_ids( $this->extract_ids( $attrs['excludedProductIds'] ?? array() ) );
+			$coupon->set_product_categories( $this->extract_ids( $attrs['productCategoryIds'] ?? array() ) );
+			$coupon->set_excluded_product_categories( $this->extract_ids( $attrs['excludedProductCategoryIds'] ?? array() ) );
+
+			$email_restrictions = array();
+			if ( ! empty( $attrs['emailRestrictions'] ) ) {
+				$email_restrictions = array_map( 'trim', explode( ',', $attrs['emailRestrictions'] ) );
+			}
+
+			$recipient = $rendering_context->get_recipient_email();
+			if ( $recipient ) {
+				$email_restrictions[] = $recipient;
+			}
+
+			$coupon->set_email_restrictions( array_unique( array_filter( $email_restrictions ) ) );
+
+			$coupon->set_usage_limit( (int) ( $attrs['usageLimit'] ?? 0 ) );
+			$coupon->set_usage_limit_per_user( (int) ( $attrs['usageLimitPerUser'] ?? 0 ) );
+
+			$coupon->set_description(
+				__( 'Auto-generated coupon by WooCommerce Email Editor', 'woocommerce' )
+			);
+
+			$coupon->save();
+
+			return $coupon->get_code();
+		} catch ( \Exception $e ) {
+			return '';
+		}
+	}
+
+	/**
+	 * Validate discount type against WooCommerce's registered types.
+	 *
+	 * @param string $type The discount type to validate.
+	 * @return string A valid discount type.
+	 */
+	private function validate_discount_type( string $type ): string {
+		$valid_types = array_keys( wc_get_coupon_types() );
+		return in_array( $type, $valid_types, true ) ? $type : 'percent';
+	}
+
+	/**
+	 * Generate a random coupon code in XXXX-XXXXXX-XXXX format.
+	 *
+	 * @return string
+	 */
+	private function generate_random_code(): string {
+		$characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+		$length     = strlen( $characters ) - 1;
+
+		$segment1 = '';
+		$segment2 = '';
+		$segment3 = '';
+
+		for ( $i = 0; $i < 4; $i++ ) {
+			$segment1 .= $characters[ random_int( 0, $length ) ];
+		}
+		for ( $i = 0; $i < 6; $i++ ) {
+			$segment2 .= $characters[ random_int( 0, $length ) ];
+		}
+		for ( $i = 0; $i < 4; $i++ ) {
+			$segment3 .= $characters[ random_int( 0, $length ) ];
+		}
+
+		return $segment1 . '-' . $segment2 . '-' . $segment3;
+	}
+
+	/**
+	 * Extract integer IDs from an array of {id, title} objects.
+	 *
+	 * @param array $items Array of items with 'id' key.
+	 * @return array Array of integer IDs.
+	 */
+	private function extract_ids( array $items ): array {
+		return array_map(
+			function ( $item ) {
+				return (int) ( is_array( $item ) ? ( $item['id'] ?? 0 ) : 0 );
+			},
+			$items
+		);
+	}
+}

--- a/packages/php/email-editor/src/Integrations/WooCommerce/class-coupon-code-generator.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/class-coupon-code-generator.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Renderer\Blocks\Coupon_Code;
 
 /**
  * Generates WooCommerce coupons at email send time for the coupon-code block.
@@ -21,6 +22,11 @@ use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering
  * to add features like per-subscriber restriction or coupon persistence.
  */
 class Coupon_Code_Generator {
+
+	/**
+	 * Maximum number of retries for generating a unique coupon code.
+	 */
+	const MAX_CODE_RETRIES = 5;
 
 	/**
 	 * Initialize the generator by registering the filter hook.
@@ -42,13 +48,17 @@ class Coupon_Code_Generator {
 			return $coupon_code;
 		}
 
+		if ( $rendering_context->get( 'is_user_preview' ) ) {
+			return Coupon_Code::COUPON_CODE_PLACEHOLDER;
+		}
+
 		if ( ! function_exists( 'wc_get_coupon_types' ) || ! class_exists( 'WC_Coupon' ) ) {
 			return '';
 		}
 
 		try {
 			$coupon = new \WC_Coupon();
-			$coupon->set_code( $this->generate_random_code() );
+			$coupon->set_code( $this->generate_unique_code() );
 
 			$discount_type = $this->validate_discount_type( $attrs['discountType'] ?? 'percent' );
 			$coupon->set_discount_type( $discount_type );
@@ -74,17 +84,14 @@ class Coupon_Code_Generator {
 			$coupon->set_product_categories( $this->extract_ids( $attrs['productCategoryIds'] ?? array() ) );
 			$coupon->set_excluded_product_categories( $this->extract_ids( $attrs['excludedProductCategoryIds'] ?? array() ) );
 
-			$email_restrictions = array();
-			if ( ! empty( $attrs['emailRestrictions'] ) ) {
-				$email_restrictions = array_map( 'trim', explode( ',', $attrs['emailRestrictions'] ) );
-			}
+			$email_restrictions = $this->parse_email_restrictions( $attrs['emailRestrictions'] ?? '' );
 
 			$recipient = $rendering_context->get_recipient_email();
-			if ( $recipient ) {
+			if ( $recipient && is_email( $recipient ) ) {
 				$email_restrictions[] = $recipient;
 			}
 
-			$coupon->set_email_restrictions( array_unique( array_filter( $email_restrictions ) ) );
+			$coupon->set_email_restrictions( array_unique( $email_restrictions ) );
 
 			$usage_limit          = $attrs['usageLimit'] ?? 0;
 			$usage_limit_per_user = $attrs['usageLimitPerUser'] ?? 0;
@@ -99,8 +106,35 @@ class Coupon_Code_Generator {
 
 			return $coupon->get_code();
 		} catch ( \Exception $e ) {
+			wc_get_logger()->error(
+				'Coupon auto-generation failed: ' . $e->getMessage(),
+				array( 'source' => 'email-editor-coupon-generator' )
+			);
 			return '';
 		}
+	}
+
+	/**
+	 * Parse and validate email restrictions string.
+	 *
+	 * @param mixed $raw Raw email restrictions value (comma-separated string).
+	 * @return array Array of valid email addresses.
+	 */
+	private function parse_email_restrictions( $raw ): array {
+		if ( ! is_string( $raw ) || '' === $raw ) {
+			return array();
+		}
+
+		$emails = array_map( 'trim', explode( ',', $raw ) );
+
+		return array_values(
+			array_filter(
+				$emails,
+				function ( string $email ): bool {
+					return (bool) is_email( $email );
+				}
+			)
+		);
 	}
 
 	/**
@@ -112,6 +146,24 @@ class Coupon_Code_Generator {
 	private function validate_discount_type( string $type ): string {
 		$valid_types = array_keys( wc_get_coupon_types() );
 		return in_array( $type, $valid_types, true ) ? $type : 'percent';
+	}
+
+	/**
+	 * Generate a unique random coupon code, retrying on collision.
+	 *
+	 * @return string A unique coupon code.
+	 * @throws \RuntimeException When a unique code cannot be generated after max retries.
+	 */
+	private function generate_unique_code(): string {
+		for ( $i = 0; $i < self::MAX_CODE_RETRIES; $i++ ) {
+			$code     = $this->generate_random_code();
+			$existing = wc_get_coupon_id_by_code( $code );
+			if ( ! $existing ) {
+				return $code;
+			}
+		}
+		// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- exception message, not rendered output.
+		throw new \RuntimeException( 'Failed to generate a unique coupon code.' );
 	}
 
 	/**

--- a/packages/php/email-editor/src/Integrations/WooCommerce/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/class-initializer.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Fallback;
+use Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Renderer\Blocks\Coupon_Code;
 use Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Renderer\Blocks\Product_Button;
 use Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Renderer\Blocks\Product_Collection;
 use Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Renderer\Blocks\Product_Image;
@@ -103,6 +104,9 @@ class Initializer {
 				break;
 			case 'woocommerce/product-button':
 				$renderer = new Product_Button();
+				break;
+			case 'woocommerce/coupon-code':
+				$renderer = new Coupon_Code();
 				break;
 			default:
 				$renderer = new Fallback();

--- a/packages/php/email-editor/src/class-bootstrap.php
+++ b/packages/php/email-editor/src/class-bootstrap.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\EmailEditor;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Email_Editor;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Initializer as CoreEmailEditorIntegration;
+use Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Coupon_Code_Generator;
 use Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Initializer as WooCommerceEmailEditorIntegration;
 
 /**
@@ -88,6 +89,9 @@ class Bootstrap {
 				10,
 				1
 			);
+
+			$coupon_generator = new Coupon_Code_Generator();
+			$coupon_generator->init();
 		}
 	}
 

--- a/plugins/woocommerce/changelog/64342-add-coupon-code-block-auto-generation
+++ b/plugins/woocommerce/changelog/64342-add-coupon-code-block-auto-generation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add auto-generation mode to the coupon code email block, allowing users to configure coupon rules that generate unique codes at send time.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/block.json
@@ -32,6 +32,83 @@
 		"couponCode": {
 			"type": "string",
 			"default": ""
+		},
+		"source": {
+			"type": "string",
+			"default": "createNew",
+			"enum": [ "createNew", "existing" ]
+		},
+		"discountType": {
+			"type": "string",
+			"default": "percent"
+		},
+		"amount": {
+			"type": "number",
+			"default": 10
+		},
+		"expiryDay": {
+			"type": "number",
+			"default": 10
+		},
+		"freeShipping": {
+			"type": "boolean",
+			"default": false
+		},
+		"usageLimit": {
+			"type": "number",
+			"default": 0
+		},
+		"usageLimitPerUser": {
+			"type": "number",
+			"default": 0
+		},
+		"minimumAmount": {
+			"type": "string",
+			"default": ""
+		},
+		"maximumAmount": {
+			"type": "string",
+			"default": ""
+		},
+		"individualUse": {
+			"type": "boolean",
+			"default": false
+		},
+		"excludeSaleItems": {
+			"type": "boolean",
+			"default": false
+		},
+		"productIds": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "object"
+			}
+		},
+		"excludedProductIds": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "object"
+			}
+		},
+		"productCategoryIds": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "object"
+			}
+		},
+		"excludedProductCategoryIds": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "object"
+			}
+		},
+		"emailRestrictions": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"textdomain": "woocommerce"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
@@ -26,12 +26,18 @@ interface CouponType {
 	label: string;
 }
 
+const DEFAULT_COUPON_TYPES: Record< string, string > = {
+	percent: 'Percentage discount',
+	fixed_cart: 'Fixed cart discount',
+	fixed_product: 'Fixed product discount',
+};
+
 function getCouponTypeOptions(): CouponType[] {
 	const types =
 		( getSetting< Record< string, string > >(
 			'couponTypes',
 			null
-		) as Record< string, string > | null ) ?? {};
+		) as Record< string, string > | null ) ?? DEFAULT_COUPON_TYPES;
 	return Object.entries( types ).map( ( [ value, label ] ) => ( {
 		value,
 		label,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
@@ -5,15 +5,14 @@ import { __ } from '@wordpress/i18n';
 import {
 	PanelBody,
 	SelectControl,
+	TextControl,
 	ToggleControl,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
-import { getSetting } from '@woocommerce/settings';
 import type { CouponCodeAttributes } from '../types';
 
 interface GeneralSettingsProps {
@@ -60,39 +59,41 @@ export function GeneralSettings( {
 			title={ __( 'General', 'woocommerce' ) }
 			initialOpen={ true }
 		>
-			{ couponTypeOptions.length > 0 && (
-				<SelectControl
-					label={ __( 'Discount type', 'woocommerce' ) }
-					value={ attributes.discountType }
-					options={ couponTypeOptions }
-					onChange={ ( value ) =>
-						setAttributes( { discountType: value } )
-					}
-					__nextHasNoMarginBottom
-				/>
-			) }
-			<NumberControl
+			<SelectControl
+				label={ __( 'Discount type', 'woocommerce' ) }
+				value={ attributes.discountType }
+				options={ couponTypeOptions }
+				onChange={ ( value ) =>
+					setAttributes( { discountType: value } )
+				}
+				__nextHasNoMarginBottom
+			/>
+			<TextControl
 				label={ __( 'Amount', 'woocommerce' ) }
-				value={ attributes.amount }
+				value={ String( attributes.amount ) }
+				type="number"
 				min={ 0 }
 				max={ amountMax }
-				onChange={ ( value: string | undefined ) =>
+				onChange={ ( value ) =>
 					setAttributes( {
 						amount: Math.min( Number( value ) || 0, amountMax ),
 					} )
 				}
+				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			/>
-			<NumberControl
+			<TextControl
 				label={ __( 'Expires (days after send)', 'woocommerce' ) }
 				help={ __( 'Set to 0 for no expiry.', 'woocommerce' ) }
-				value={ attributes.expiryDay }
+				value={ String( attributes.expiryDay ) }
+				type="number"
 				min={ 0 }
-				onChange={ ( value: string | undefined ) =>
+				onChange={ ( value ) =>
 					setAttributes( {
 						expiryDay: Number( value ) || 0,
 					} )
 				}
+				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			/>
 			<ToggleControl

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	PanelBody,
+	SelectControl,
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalNumberControl as NumberControl,
+} from '@wordpress/components';
+import { getSetting } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import type { CouponCodeAttributes } from '../types';
+
+interface GeneralSettingsProps {
+	attributes: CouponCodeAttributes;
+	setAttributes: ( attrs: Partial< CouponCodeAttributes > ) => void;
+}
+
+interface CouponType {
+	value: string;
+	label: string;
+}
+
+function getCouponTypeOptions(): CouponType[] {
+	const types =
+		( getSetting< Record< string, string > >(
+			'couponTypes',
+			null
+		) as Record< string, string > | null ) ?? {};
+	return Object.entries( types ).map( ( [ value, label ] ) => ( {
+		value,
+		label,
+	} ) );
+}
+
+function getAmountMax( discountType: string ): number {
+	return discountType === 'percent' ? 100 : 1000000;
+}
+
+export function GeneralSettings( {
+	attributes,
+	setAttributes,
+}: GeneralSettingsProps ): JSX.Element {
+	const couponTypeOptions = getCouponTypeOptions();
+	const amountMax = getAmountMax( attributes.discountType );
+
+	return (
+		<PanelBody
+			title={ __( 'General', 'woocommerce' ) }
+			initialOpen={ true }
+		>
+			{ couponTypeOptions.length > 0 && (
+				<SelectControl
+					label={ __( 'Discount type', 'woocommerce' ) }
+					value={ attributes.discountType }
+					options={ couponTypeOptions }
+					onChange={ ( value ) =>
+						setAttributes( { discountType: value } )
+					}
+					__nextHasNoMarginBottom
+				/>
+			) }
+			<NumberControl
+				label={ __( 'Amount', 'woocommerce' ) }
+				value={ attributes.amount }
+				min={ 0 }
+				max={ amountMax }
+				onChange={ ( value: string | undefined ) =>
+					setAttributes( {
+						amount: Math.min( Number( value ) || 0, amountMax ),
+					} )
+				}
+				__next40pxDefaultSize
+			/>
+			<NumberControl
+				label={ __( 'Expires (days after send)', 'woocommerce' ) }
+				help={ __( 'Set to 0 for no expiry.', 'woocommerce' ) }
+				value={ attributes.expiryDay }
+				min={ 0 }
+				onChange={ ( value: string | undefined ) =>
+					setAttributes( {
+						expiryDay: Number( value ) || 0,
+					} )
+				}
+				__next40pxDefaultSize
+			/>
+			<ToggleControl
+				label={ __( 'Free shipping', 'woocommerce' ) }
+				checked={ attributes.freeShipping }
+				onChange={ ( value ) =>
+					setAttributes( { freeShipping: value } )
+				}
+				__nextHasNoMarginBottom
+			/>
+		</PanelBody>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
@@ -32,11 +32,10 @@ const DEFAULT_COUPON_TYPES: Record< string, string > = {
 };
 
 function getCouponTypeOptions(): CouponType[] {
-	const types =
-		( getSetting< Record< string, string > >(
-			'couponTypes',
-			null
-		) as Record< string, string > | null ) ?? DEFAULT_COUPON_TYPES;
+	const types = getSetting( 'couponTypes', DEFAULT_COUPON_TYPES ) as Record<
+		string,
+		string
+	>;
 	return Object.entries( types ).map( ( [ value, label ] ) => ( {
 		value,
 		label,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
@@ -9,11 +9,11 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
-import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
+import { getSetting } from '@woocommerce/settings';
 import type { CouponCodeAttributes } from '../types';
 
 interface GeneralSettingsProps {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/general-settings.tsx
@@ -26,9 +26,9 @@ interface CouponType {
 }
 
 const DEFAULT_COUPON_TYPES: Record< string, string > = {
-	percent: 'Percentage discount',
-	fixed_cart: 'Fixed cart discount',
-	fixed_product: 'Fixed product discount',
+	percent: __( 'Percentage discount', 'woocommerce' ),
+	fixed_cart: __( 'Fixed cart discount', 'woocommerce' ),
+	fixed_product: __( 'Fixed product discount', 'woocommerce' ),
 };
 
 function getCouponTypeOptions(): CouponType[] {
@@ -63,9 +63,13 @@ export function GeneralSettings( {
 				label={ __( 'Discount type', 'woocommerce' ) }
 				value={ attributes.discountType }
 				options={ couponTypeOptions }
-				onChange={ ( value ) =>
-					setAttributes( { discountType: value } )
-				}
+				onChange={ ( value ) => {
+					const newMax = getAmountMax( value );
+					setAttributes( {
+						discountType: value,
+						amount: Math.min( attributes.amount, newMax ),
+					} );
+				} }
 				__nextHasNoMarginBottom
 			/>
 			<TextControl

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
@@ -120,7 +120,6 @@ export function ProductSearch( {
 				onChange( items );
 			} }
 			__experimentalExpandOnFocus
-			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 		/>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
@@ -87,40 +87,42 @@ export function ProductSearch( {
 	const tokenValues = value.map( ( item ) => item.title );
 
 	return (
-		<FormTokenField
-			label={ label }
-			value={ tokenValues }
-			suggestions={ suggestions }
-			onInputChange={ ( query ) => {
-				if ( debounceRef.current ) {
-					clearTimeout( debounceRef.current );
-				}
-				debounceRef.current = setTimeout( () => {
-					search( query );
-				}, 300 );
-			} }
-			onChange={ ( tokens ) => {
-				const items: Item[] = tokens
-					.map( ( token ) => {
-						const existing = value.find(
-							( v ) => v.title === token
-						);
-						if ( existing ) {
-							return existing;
-						}
-						const result = searchResults.find(
-							( r ) => r.name === token
-						);
-						if ( result ) {
-							return { id: result.id, title: result.name };
-						}
-						return null;
-					} )
-					.filter( ( item ): item is Item => item !== null );
-				onChange( items );
-			} }
-			__experimentalExpandOnFocus
-			__next40pxDefaultSize
-		/>
+		<div style={ { marginBottom: '24px' } }>
+			<FormTokenField
+				label={ label }
+				value={ tokenValues }
+				suggestions={ suggestions }
+				onInputChange={ ( query ) => {
+					if ( debounceRef.current ) {
+						clearTimeout( debounceRef.current );
+					}
+					debounceRef.current = setTimeout( () => {
+						search( query );
+					}, 300 );
+				} }
+				onChange={ ( tokens ) => {
+					const items: Item[] = tokens
+						.map( ( token ) => {
+							const existing = value.find(
+								( v ) => v.title === token
+							);
+							if ( existing ) {
+								return existing;
+							}
+							const result = searchResults.find(
+								( r ) => r.name === token
+							);
+							if ( result ) {
+								return { id: result.id, title: result.name };
+							}
+							return null;
+						} )
+						.filter( ( item ): item is Item => item !== null );
+					onChange( items );
+				} }
+				__experimentalExpandOnFocus
+				__next40pxDefaultSize
+			/>
+		</div>
 	);
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { FormTokenField } from '@wordpress/components';
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
@@ -75,6 +75,9 @@ export function ProductSearch( {
 
 	useEffect( () => {
 		return () => {
+			if ( debounceRef.current ) {
+				clearTimeout( debounceRef.current );
+			}
 			if ( abortRef.current ) {
 				abortRef.current.abort();
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/product-search.tsx
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { FormTokenField } from '@wordpress/components';
+import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+interface Item {
+	id: number;
+	title: string;
+}
+
+interface ProductSearchProps {
+	label: string;
+	value: Item[];
+	onChange: ( items: Item[] ) => void;
+	endpoint: 'products' | 'products/categories';
+}
+
+interface ApiProduct {
+	id: number;
+	name: string;
+}
+
+export function ProductSearch( {
+	label,
+	value,
+	onChange,
+	endpoint,
+}: ProductSearchProps ): JSX.Element {
+	const [ suggestions, setSuggestions ] = useState< string[] >( [] );
+	const [ searchResults, setSearchResults ] = useState< ApiProduct[] >( [] );
+	const debounceRef = useRef< ReturnType< typeof setTimeout > | null >(
+		null
+	);
+	const abortRef = useRef< AbortController | null >( null );
+
+	const search = useCallback(
+		( query: string ) => {
+			if ( abortRef.current ) {
+				abortRef.current.abort();
+			}
+
+			if ( query.length < 2 ) {
+				setSuggestions( [] );
+				setSearchResults( [] );
+				return;
+			}
+
+			abortRef.current = new AbortController();
+
+			apiFetch< ApiProduct[] >( {
+				path: `/wc/v3/${ endpoint }?search=${ encodeURIComponent(
+					query
+				) }&per_page=20`,
+				signal: abortRef.current.signal,
+			} )
+				.then( ( results ) => {
+					setSearchResults( results );
+					setSuggestions( results.map( ( item ) => item.name ) );
+				} )
+				.catch( ( error ) => {
+					if (
+						error instanceof Error &&
+						error.name === 'AbortError'
+					) {
+						return;
+					}
+					setSuggestions( [] );
+					setSearchResults( [] );
+				} );
+		},
+		[ endpoint ]
+	);
+
+	useEffect( () => {
+		return () => {
+			if ( abortRef.current ) {
+				abortRef.current.abort();
+			}
+		};
+	}, [] );
+
+	const tokenValues = value.map( ( item ) => item.title );
+
+	return (
+		<FormTokenField
+			label={ label }
+			value={ tokenValues }
+			suggestions={ suggestions }
+			onInputChange={ ( query ) => {
+				if ( debounceRef.current ) {
+					clearTimeout( debounceRef.current );
+				}
+				debounceRef.current = setTimeout( () => {
+					search( query );
+				}, 300 );
+			} }
+			onChange={ ( tokens ) => {
+				const items: Item[] = tokens
+					.map( ( token ) => {
+						const existing = value.find(
+							( v ) => v.title === token
+						);
+						if ( existing ) {
+							return existing;
+						}
+						const result = searchResults.find(
+							( r ) => r.name === token
+						);
+						if ( result ) {
+							return { id: result.id, title: result.name };
+						}
+						return null;
+					} )
+					.filter( ( item ): item is Item => item !== null );
+				onChange( items );
+			} }
+			__experimentalExpandOnFocus
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+		/>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/usage-limits.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/usage-limits.tsx
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	PanelBody,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalNumberControl as NumberControl,
-} from '@wordpress/components';
+import { PanelBody, TextControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -27,34 +23,38 @@ export function UsageLimits( {
 			title={ __( 'Usage limits', 'woocommerce' ) }
 			initialOpen={ false }
 		>
-			<NumberControl
+			<TextControl
 				label={ __( 'Usage limit per coupon', 'woocommerce' ) }
 				help={ __(
 					'How many times this coupon can be used before it is void. Set to 0 for unlimited.',
 					'woocommerce'
 				) }
-				value={ attributes.usageLimit }
+				value={ String( attributes.usageLimit ) }
+				type="number"
 				min={ 0 }
-				onChange={ ( value: string | undefined ) =>
+				onChange={ ( value ) =>
 					setAttributes( {
 						usageLimit: Number( value ) || 0,
 					} )
 				}
+				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			/>
-			<NumberControl
+			<TextControl
 				label={ __( 'Usage limit per user', 'woocommerce' ) }
 				help={ __(
 					'How many times this coupon can be used by an individual user. Set to 0 for unlimited.',
 					'woocommerce'
 				) }
-				value={ attributes.usageLimitPerUser }
+				value={ String( attributes.usageLimitPerUser ) }
+				type="number"
 				min={ 0 }
-				onChange={ ( value: string | undefined ) =>
+				onChange={ ( value ) =>
 					setAttributes( {
 						usageLimitPerUser: Number( value ) || 0,
 					} )
 				}
+				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			/>
 		</PanelBody>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/usage-limits.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/usage-limits.tsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	PanelBody,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalNumberControl as NumberControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { CouponCodeAttributes } from '../types';
+
+interface UsageLimitsProps {
+	attributes: CouponCodeAttributes;
+	setAttributes: ( attrs: Partial< CouponCodeAttributes > ) => void;
+}
+
+export function UsageLimits( {
+	attributes,
+	setAttributes,
+}: UsageLimitsProps ): JSX.Element {
+	return (
+		<PanelBody
+			title={ __( 'Usage limits', 'woocommerce' ) }
+			initialOpen={ false }
+		>
+			<NumberControl
+				label={ __( 'Usage limit per coupon', 'woocommerce' ) }
+				help={ __(
+					'How many times this coupon can be used before it is void. Set to 0 for unlimited.',
+					'woocommerce'
+				) }
+				value={ attributes.usageLimit }
+				min={ 0 }
+				onChange={ ( value: string | undefined ) =>
+					setAttributes( {
+						usageLimit: Number( value ) || 0,
+					} )
+				}
+				__next40pxDefaultSize
+			/>
+			<NumberControl
+				label={ __( 'Usage limit per user', 'woocommerce' ) }
+				help={ __(
+					'How many times this coupon can be used by an individual user. Set to 0 for unlimited.',
+					'woocommerce'
+				) }
+				value={ attributes.usageLimitPerUser }
+				min={ 0 }
+				onChange={ ( value: string | undefined ) =>
+					setAttributes( {
+						usageLimitPerUser: Number( value ) || 0,
+					} )
+				}
+				__next40pxDefaultSize
+			/>
+		</PanelBody>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/usage-restrictions.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/components/usage-restrictions.tsx
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { CouponCodeAttributes } from '../types';
+import { ProductSearch } from './product-search';
+
+interface UsageRestrictionsProps {
+	attributes: CouponCodeAttributes;
+	setAttributes: ( attrs: Partial< CouponCodeAttributes > ) => void;
+}
+
+export function UsageRestrictions( {
+	attributes,
+	setAttributes,
+}: UsageRestrictionsProps ): JSX.Element {
+	return (
+		<PanelBody
+			title={ __( 'Usage restrictions', 'woocommerce' ) }
+			initialOpen={ false }
+		>
+			<TextControl
+				label={ __( 'Minimum spend', 'woocommerce' ) }
+				value={ attributes.minimumAmount }
+				onChange={ ( value ) =>
+					setAttributes( { minimumAmount: value } )
+				}
+				type="number"
+				min={ 0 }
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+			/>
+			<TextControl
+				label={ __( 'Maximum spend', 'woocommerce' ) }
+				value={ attributes.maximumAmount }
+				onChange={ ( value ) =>
+					setAttributes( { maximumAmount: value } )
+				}
+				type="number"
+				min={ 0 }
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+			/>
+			<ToggleControl
+				label={ __( 'Individual use only', 'woocommerce' ) }
+				help={ __(
+					'If checked, this coupon cannot be used in conjunction with other coupons.',
+					'woocommerce'
+				) }
+				checked={ attributes.individualUse }
+				onChange={ ( value ) =>
+					setAttributes( { individualUse: value } )
+				}
+				__nextHasNoMarginBottom
+			/>
+			<ToggleControl
+				label={ __( 'Exclude sale items', 'woocommerce' ) }
+				help={ __(
+					'If checked, this coupon will not apply to items on sale.',
+					'woocommerce'
+				) }
+				checked={ attributes.excludeSaleItems }
+				onChange={ ( value ) =>
+					setAttributes( { excludeSaleItems: value } )
+				}
+				__nextHasNoMarginBottom
+			/>
+			<ProductSearch
+				label={ __( 'Products', 'woocommerce' ) }
+				value={ attributes.productIds }
+				onChange={ ( items ) => setAttributes( { productIds: items } ) }
+				endpoint="products"
+			/>
+			<ProductSearch
+				label={ __( 'Excluded products', 'woocommerce' ) }
+				value={ attributes.excludedProductIds }
+				onChange={ ( items ) =>
+					setAttributes( { excludedProductIds: items } )
+				}
+				endpoint="products"
+			/>
+			<ProductSearch
+				label={ __( 'Product categories', 'woocommerce' ) }
+				value={ attributes.productCategoryIds }
+				onChange={ ( items ) =>
+					setAttributes( { productCategoryIds: items } )
+				}
+				endpoint="products/categories"
+			/>
+			<ProductSearch
+				label={ __( 'Excluded product categories', 'woocommerce' ) }
+				value={ attributes.excludedProductCategoryIds }
+				onChange={ ( items ) =>
+					setAttributes( {
+						excludedProductCategoryIds: items,
+					} )
+				}
+				endpoint="products/categories"
+			/>
+			<TextControl
+				label={ __( 'Allowed emails', 'woocommerce' ) }
+				help={ __(
+					"Comma-separated list of allowed emails to check against the customer's billing email.",
+					'woocommerce'
+				) }
+				value={ attributes.emailRestrictions }
+				onChange={ ( value ) =>
+					setAttributes( { emailRestrictions: value } )
+				}
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+			/>
+		</PanelBody>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
@@ -328,7 +328,7 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 								setAttributes( {
 									source: 'existing',
 								} );
-							} else {
+							} else if ( value === 'createNew' ) {
 								setAttributes( {
 									source: 'createNew',
 									couponCode: '',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
@@ -8,16 +8,13 @@ import {
 	Button,
 	ComboboxControl,
 	Spinner,
+	SelectControl,
 } from '@wordpress/components';
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import type { CSSProperties } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { applyFilters } from '@wordpress/hooks';
 import { dispatch } from '@wordpress/data';
-// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { __experimentalToggleGroupControl as ToggleGroupControl } from '@wordpress/components';
-// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { __experimentalToggleGroupControlOption as ToggleGroupControlOption } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -319,35 +316,34 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 					title={ __( 'Coupon source', 'woocommerce' ) }
 					initialOpen={ true }
 				>
-					<ToggleGroupControl
+					<SelectControl
 						label={ __( 'Coupon source', 'woocommerce' ) }
 						hideLabelFromVision
 						value={ source }
-						onChange={ ( value: string | number | undefined ) => {
+						options={ [
+							{
+								value: 'createNew',
+								label: __( 'Create new', 'woocommerce' ),
+							},
+							{
+								value: 'existing',
+								label: __( 'Use existing', 'woocommerce' ),
+							},
+						] }
+						onChange={ ( value ) => {
 							if ( value === 'existing' ) {
 								setAttributes( {
 									source: 'existing',
 								} );
-							} else if ( value === 'createNew' ) {
+							} else {
 								setAttributes( {
 									source: 'createNew',
 									couponCode: '',
 								} );
 							}
 						} }
-						isBlock
 						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					>
-						<ToggleGroupControlOption
-							value="createNew"
-							label={ __( 'Create new', 'woocommerce' ) }
-						/>
-						<ToggleGroupControlOption
-							value="existing"
-							label={ __( 'Use existing', 'woocommerce' ) }
-						/>
-					</ToggleGroupControl>
+					/>
 				</PanelBody>
 
 				{ source === 'createNew' && (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
@@ -8,16 +8,16 @@ import {
 	Button,
 	ComboboxControl,
 	Spinner,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import type { CSSProperties } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { applyFilters } from '@wordpress/hooks';
 import { dispatch } from '@wordpress/data';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalToggleGroupControl as ToggleGroupControl } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalToggleGroupControlOption as ToggleGroupControlOption } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
@@ -8,6 +8,10 @@ import {
 	Button,
 	ComboboxControl,
 	Spinner,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import type { CSSProperties } from 'react';
@@ -18,7 +22,12 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import type { BlockEditProps } from './types';
+import type { BlockEditProps, CouponCodeAttributes } from './types';
+import { GeneralSettings } from './components/general-settings';
+import { UsageLimits } from './components/usage-limits';
+import { UsageRestrictions } from './components/usage-restrictions';
+
+const COUPON_CODE_PLACEHOLDER = 'XXXX-XXXXXX-XXXX';
 
 interface Coupon {
 	id: number;
@@ -33,21 +42,15 @@ const DEFAULT_COUPON_STATUSES = [
 	'publish',
 ] as const;
 
-/**
- * Edit component for the Coupon Code block.
- *
- * @param {BlockEditProps} props - Block properties.
- * @return {JSX.Element} The edit component.
- */
-export default function Edit( props: BlockEditProps ): JSX.Element {
-	const { attributes, setAttributes } = props;
-	const couponCode = attributes.couponCode as string;
+function ExistingCouponSettings( {
+	attributes,
+	setAttributes,
+}: {
+	attributes: CouponCodeAttributes;
+	setAttributes: ( attrs: Partial< CouponCodeAttributes > ) => void;
+} ): JSX.Element {
+	const couponCode = attributes.couponCode;
 
-	const {
-		className: blockClassName = '',
-		style: blockStyle,
-		...wrapperProps
-	} = useBlockProps();
 	const [ searchValue, setSearchValue ] = useState( '' );
 	const [ coupons, setCoupons ] = useState< Coupon[] >( [] );
 	const [ isLoading, setIsLoading ] = useState( false );
@@ -56,19 +59,10 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 	);
 	const abortControllerRef = useRef< AbortController | null >( null );
 
-	// Handler for creating a new coupon - uses a filter so integrators can customize behavior
 	const handleCreateCoupon = () => {
-		// Get the handler from the filter (integrations provide the default handler)
-		// Integrators can customize this filter for SPA routing, custom workflows, etc.
-		// Filter: woocommerce_email_editor_create_coupon_handler
-		// @since 10.5.0
-		// @param {() => void} handler - Function called when user clicks "Create new coupon"
-		// @return {() => void} Modified handler function. The returned function should open the coupon creation UI.
 		const createCouponHandler = applyFilters(
 			'woocommerce_email_editor_create_coupon_handler',
 			() => {
-				// This is the ultimate fallback if no integration provides a handler
-				// May not work correctly in subdirectory installations
 				window.open(
 					'/wp-admin/post-new.php?post_type=shop_coupon',
 					'_blank'
@@ -81,14 +75,11 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 		}
 	};
 
-	// Debounced coupon search function
 	const searchCoupons = useCallback( ( search: string ) => {
-		// Cancel any pending request
 		if ( abortControllerRef.current ) {
 			abortControllerRef.current.abort();
 		}
 
-		// Don't search if search term is too short
 		if ( search.length < 2 ) {
 			setCoupons( [] );
 			setIsLoading( false );
@@ -118,7 +109,6 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 				if ( error instanceof Error && error.name === 'AbortError' ) {
 					return;
 				}
-				// Check if it's a permissions error
 				if ( error.code === 'rest_forbidden' || error.status === 403 ) {
 					dispatch( 'core/notices' ).createErrorNotice(
 						__(
@@ -135,19 +125,15 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 			} );
 	}, [] );
 
-	// Handle search value changes with debouncing
 	useEffect( () => {
-		// Clear any existing timer
 		if ( debounceTimerRef.current ) {
 			clearTimeout( debounceTimerRef.current );
 		}
 
-		// Set new timer for debounced search
 		debounceTimerRef.current = setTimeout( () => {
 			searchCoupons( searchValue );
 		}, 300 );
 
-		// Cleanup function
 		return () => {
 			if ( debounceTimerRef.current ) {
 				clearTimeout( debounceTimerRef.current );
@@ -155,7 +141,6 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 		};
 	}, [ searchValue, searchCoupons ] );
 
-	// Cleanup abort controller on unmount
 	useEffect( () => {
 		return () => {
 			if ( abortControllerRef.current ) {
@@ -164,13 +149,11 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 		};
 	}, [] );
 
-	// Convert coupons to options format
 	const couponOptions = coupons.map( ( coupon ) => ( {
 		value: coupon.code,
 		label: coupon.code,
 	} ) );
 
-	// If there's a selected coupon code that's not in the search results, add it to the options
 	if (
 		couponCode &&
 		! couponOptions.some( ( option ) => option.value === couponCode )
@@ -180,6 +163,85 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 			label: couponCode,
 		} );
 	}
+
+	return (
+		<PanelBody title={ __( 'Coupon', 'woocommerce' ) } initialOpen={ true }>
+			<div style={ { marginBottom: '16px' } }>
+				<div>
+					{ __( 'Search for an existing coupon', 'woocommerce' ) }
+				</div>
+				<ComboboxControl
+					label={ __( 'Search coupons', 'woocommerce' ) }
+					hideLabelFromVision
+					value={ couponCode }
+					onChange={ ( value ) => {
+						setAttributes( {
+							couponCode: value || '',
+						} );
+					} }
+					onFilterValueChange={ ( value ) => {
+						setSearchValue( value );
+					} }
+					options={ couponOptions }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					help={ ( () => {
+						if ( isLoading ) {
+							return __( 'Searching coupons…', 'woocommerce' );
+						}
+						if (
+							searchValue.length > 0 &&
+							searchValue.length < 2
+						) {
+							return __(
+								'Type at least 2 characters to search',
+								'woocommerce'
+							);
+						}
+						return null;
+					} )() }
+				/>
+				{ isLoading && (
+					<div
+						style={ {
+							display: 'flex',
+							alignItems: 'center',
+							marginTop: '8px',
+						} }
+					>
+						<Spinner />
+					</div>
+				) }
+			</div>
+			<div>
+				<Button
+					variant="link"
+					onClick={ handleCreateCoupon }
+					style={ { padding: 0, height: 'auto' } }
+				>
+					{ __( 'Create new coupon', 'woocommerce' ) }
+				</Button>
+			</div>
+		</PanelBody>
+	);
+}
+
+/**
+ * Edit component for the Coupon Code block.
+ */
+export default function Edit( props: BlockEditProps ): JSX.Element {
+	const { attributes, setAttributes } = props;
+	const source = attributes.source ?? 'createNew';
+	const couponCode = attributes.couponCode;
+
+	const {
+		className: blockClassName = '',
+		style: blockStyle,
+		...wrapperProps
+	} = useBlockProps();
+
+	const displayCode =
+		source === 'createNew' ? COUPON_CODE_PLACEHOLDER : couponCode || '';
 
 	// Strip block-level background/border styles off the wrapper so we can
 	// fully control visual presentation on the coupon element itself.
@@ -200,11 +262,9 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 		letterSpacing: '1px',
 	};
 
-	// Merge: defaults first, then baseStyle overrides, then forced values.
 	const couponStyles: CSSProperties = {
 		...defaultStyles,
 		...baseStyle,
-		// These values must always be set regardless of baseStyle.
 		display: 'inline-block',
 		boxSizing: 'border-box',
 		textAlign: 'center',
@@ -218,7 +278,7 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 		'start',
 		'end',
 	];
-	const alignAttribute = attributes.align as string | undefined;
+	const alignAttribute = attributes.align;
 	const wrapperTextAlign = supportedAlignments.includes(
 		alignAttribute as CSSProperties[ 'textAlign' ]
 	)
@@ -228,8 +288,6 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 		textAlign: wrapperTextAlign,
 	};
 
-	// Move color/typography utility classes onto the coupon pill so wrapper
-	// layout classes remain unaffected.
 	const classTokens = blockClassName.split( ' ' ).filter( Boolean );
 	const couponClassTokens: string[] = [];
 	const wrapperClassTokens: string[] = [];
@@ -258,72 +316,63 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 		<>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Settings', 'woocommerce' ) }
+					title={ __( 'Coupon source', 'woocommerce' ) }
 					initialOpen={ true }
 				>
-					<div style={ { marginBottom: '16px' } }>
-						<div>
-							{ __(
-								'Search for an existing coupon',
-								'woocommerce'
-							) }
-						</div>
-						<ComboboxControl
-							label={ __( 'Search coupons', 'woocommerce' ) }
-							hideLabelFromVision
-							value={ couponCode }
-							onChange={ ( value ) => {
+					<ToggleGroupControl
+						label={ __( 'Coupon source', 'woocommerce' ) }
+						hideLabelFromVision
+						value={ source }
+						onChange={ ( value: string | number | undefined ) => {
+							if ( value === 'existing' ) {
 								setAttributes( {
-									couponCode: value || '',
+									source: 'existing',
 								} );
-							} }
-							onFilterValueChange={ ( value ) => {
-								setSearchValue( value );
-							} }
-							options={ couponOptions }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							help={ ( () => {
-								if ( isLoading ) {
-									return __(
-										'Searching coupons…',
-										'woocommerce'
-									);
-								}
-								if (
-									searchValue.length > 0 &&
-									searchValue.length < 2
-								) {
-									return __(
-										'Type at least 2 characters to search',
-										'woocommerce'
-									);
-								}
-								return null;
-							} )() }
+							} else {
+								setAttributes( {
+									source: 'createNew',
+									couponCode: '',
+								} );
+							}
+						} }
+						isBlock
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					>
+						<ToggleGroupControlOption
+							value="createNew"
+							label={ __( 'Create new', 'woocommerce' ) }
 						/>
-						{ isLoading && (
-							<div
-								style={ {
-									display: 'flex',
-									alignItems: 'center',
-									marginTop: '8px',
-								} }
-							>
-								<Spinner />
-							</div>
-						) }
-					</div>
-					<div>
-						<Button
-							variant="link"
-							onClick={ handleCreateCoupon }
-							style={ { padding: 0, height: 'auto' } }
-						>
-							{ __( 'Create new coupon', 'woocommerce' ) }
-						</Button>
-					</div>
+						<ToggleGroupControlOption
+							value="existing"
+							label={ __( 'Use existing', 'woocommerce' ) }
+						/>
+					</ToggleGroupControl>
 				</PanelBody>
+
+				{ source === 'createNew' && (
+					<>
+						<GeneralSettings
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+						/>
+						<UsageLimits
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+						/>
+						<UsageRestrictions
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+						/>
+					</>
+				) }
+
+				{ source === 'existing' && (
+					<ExistingCouponSettings
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+					/>
+				) }
 			</InspectorControls>
 			<div
 				{ ...wrapperProps }
@@ -334,13 +383,26 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 				} }
 			>
 				<span className={ couponClassName } style={ couponStyles }>
-					{ couponCode
-						? couponCode
-						: __(
-								'Coupon Code block – No coupon selected',
-								'woocommerce'
-						  ) }
+					{ displayCode ||
+						__(
+							'Coupon Code block – No coupon selected',
+							'woocommerce'
+						) }
 				</span>
+				{ source === 'createNew' && (
+					<div
+						style={ {
+							fontSize: '12px',
+							color: '#757575',
+							marginTop: '8px',
+						} }
+					>
+						{ __(
+							'A unique code will be generated for each recipient at send time.',
+							'woocommerce'
+						) }
+					</div>
+				) }
 			</div>
 		</>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
@@ -331,16 +331,12 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 							},
 						] }
 						onChange={ ( value ) => {
-							if ( value === 'existing' ) {
-								setAttributes( {
-									source: 'existing',
-								} );
-							} else {
-								setAttributes( {
-									source: 'createNew',
-									couponCode: '',
-								} );
-							}
+							setAttributes( {
+								source:
+									value === 'existing'
+										? 'existing'
+										: 'createNew',
+							} );
 						} }
 						__nextHasNoMarginBottom
 					/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
@@ -390,7 +390,7 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 						} }
 					>
 						{ __(
-							'A unique code will be generated for each recipient at send time.',
+							'A coupon code will be automatically generated at send time.',
 							'woocommerce'
 						) }
 					</div>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
@@ -1,21 +1,28 @@
 /**
  * External dependencies
  */
-import type { BlockConfiguration } from '@wordpress/blocks';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import Edit from './edit';
-import { Save } from './save';
-import type { CouponCodeAttributes } from './types';
+import { Save, DeprecatedSave } from './save';
 import metadata from './block.json';
 
-registerBlockType(
-	metadata as unknown as BlockConfiguration< CouponCodeAttributes >,
-	{
-		edit: Edit,
-		save: Save,
-	}
-);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+registerBlockType( metadata as any, {
+	edit: Edit,
+	save: Save,
+	deprecated: [
+		{
+			attributes: {
+				couponCode: {
+					type: 'string' as const,
+					default: '',
+				},
+			},
+			save: DeprecatedSave,
+		},
+	],
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { BlockConfiguration } from '@wordpress/blocks';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -8,10 +9,13 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import Edit from './edit';
 import { Save } from './save';
+import type { CouponCodeAttributes } from './types';
 import metadata from './block.json';
 
-registerBlockType( metadata.name, {
-	...metadata,
-	edit: Edit,
-	save: Save,
-} );
+registerBlockType(
+	metadata as unknown as BlockConfiguration< CouponCodeAttributes >,
+	{
+		edit: Edit,
+		save: Save,
+	}
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
@@ -23,6 +23,12 @@ registerBlockType( metadata as any, {
 				},
 			},
 			save: DeprecatedSave,
+			migrate( attributes: Record< string, unknown > ) {
+				return {
+					...attributes,
+					source: 'existing' as const,
+				};
+			},
 		},
 	],
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/save.tsx
@@ -8,6 +8,8 @@ import { useBlockProps } from '@wordpress/block-editor';
  */
 import type { BlockSaveProps } from './types';
 
+const COUPON_CODE_PLACEHOLDER = 'XXXX-XXXXXX-XXXX';
+
 /**
  * Save component for the Coupon Code block.
  *
@@ -16,13 +18,17 @@ import type { BlockSaveProps } from './types';
  */
 export function Save( props: BlockSaveProps ): JSX.Element {
 	const { attributes } = props;
-	const couponCode = attributes.couponCode as string;
+	const source = attributes.source ?? 'createNew';
+	const displayCode =
+		source === 'createNew'
+			? COUPON_CODE_PLACEHOLDER
+			: attributes.couponCode;
 
 	const blockProps = useBlockProps.save();
 
 	return (
 		<div { ...blockProps }>
-			{ couponCode && <strong>{ couponCode }</strong> }
+			{ displayCode && <strong>{ displayCode }</strong> }
 		</div>
 	);
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/save.tsx
@@ -40,7 +40,8 @@ export function DeprecatedSave( props: {
 	attributes: Record< string, unknown >;
 } ): JSX.Element {
 	const { attributes } = props;
-	const couponCode = attributes.couponCode as string;
+	const couponCode =
+		typeof attributes.couponCode === 'string' ? attributes.couponCode : '';
 
 	const blockProps = useBlockProps.save();
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/save.tsx
@@ -19,16 +19,34 @@ const COUPON_CODE_PLACEHOLDER = 'XXXX-XXXXXX-XXXX';
 export function Save( props: BlockSaveProps ): JSX.Element {
 	const { attributes } = props;
 	const source = attributes.source ?? 'createNew';
+	const couponCode = attributes.couponCode;
+
 	const displayCode =
-		source === 'createNew'
-			? COUPON_CODE_PLACEHOLDER
-			: attributes.couponCode;
+		source === 'createNew' ? COUPON_CODE_PLACEHOLDER : couponCode;
 
 	const blockProps = useBlockProps.save();
 
 	return (
 		<div { ...blockProps }>
 			{ displayCode && <strong>{ displayCode }</strong> }
+		</div>
+	);
+}
+
+/**
+ * Previous save function for blocks created before the source attribute was added.
+ */
+export function DeprecatedSave( props: {
+	attributes: Record< string, unknown >;
+} ): JSX.Element {
+	const { attributes } = props;
+	const couponCode = attributes.couponCode as string;
+
+	const blockProps = useBlockProps.save();
+
+	return (
+		<div { ...blockProps }>
+			{ couponCode && <strong>{ couponCode }</strong> }
 		</div>
 	);
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/types.ts
@@ -3,14 +3,40 @@
  */
 import type { BlockEditProps as WPBlockEditProps } from '@wordpress/blocks';
 
+interface ProductItem {
+	id: number;
+	title: string;
+}
+
+export interface CouponCodeAttributes {
+	couponCode: string;
+	source: 'createNew' | 'existing';
+	discountType: string;
+	amount: number;
+	expiryDay: number;
+	freeShipping: boolean;
+	usageLimit: number;
+	usageLimitPerUser: number;
+	minimumAmount: string;
+	maximumAmount: string;
+	individualUse: boolean;
+	excludeSaleItems: boolean;
+	productIds: ProductItem[];
+	excludedProductIds: ProductItem[];
+	productCategoryIds: ProductItem[];
+	excludedProductCategoryIds: ProductItem[];
+	emailRestrictions: string;
+	align?: string;
+}
+
 /**
  * Block edit props.
  */
-export type BlockEditProps = WPBlockEditProps< Record< string, unknown > >;
+export type BlockEditProps = WPBlockEditProps< CouponCodeAttributes >;
 
 /**
  * Block save props.
  */
 export type BlockSaveProps = {
-	attributes: Record< string, unknown >;
+	attributes: CouponCodeAttributes;
 };

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CouponCode.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CouponCode.php
@@ -75,7 +75,7 @@ class CouponCode extends AbstractBlock {
 	 *
 	 * @param array $attributes Block attributes.
 	 */
-	protected function enqueue_data( array $attributes = [] ): void {
+	protected function enqueue_data( array $attributes = array() ): void {
 		parent::enqueue_data( $attributes );
 
 		if ( ! $this->asset_data_registry->exists( 'couponTypes' ) && function_exists( 'wc_get_coupon_types' ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CouponCode.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CouponCode.php
@@ -75,7 +75,7 @@ class CouponCode extends AbstractBlock {
 	 *
 	 * @param array $attributes Block attributes.
 	 */
-	protected function enqueue_data( array $attributes = [] ) {
+	protected function enqueue_data( array $attributes = [] ): void {
 		parent::enqueue_data( $attributes );
 
 		if ( ! $this->asset_data_registry->exists( 'couponTypes' ) && function_exists( 'wc_get_coupon_types' ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CouponCode.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CouponCode.php
@@ -25,6 +25,11 @@ class CouponCode extends AbstractBlock {
 	protected $block_name = 'coupon-code';
 
 	/**
+	 * Placeholder displayed in the editor and in non-email rendering for auto-generated coupons.
+	 */
+	const COUPON_CODE_PLACEHOLDER = 'XXXX-XXXXXX-XXXX';
+
+	/**
 	 * Default styles for the coupon code element.
 	 */
 	private const DEFAULT_STYLES = array(
@@ -66,6 +71,19 @@ class CouponCode extends AbstractBlock {
 	}
 
 	/**
+	 * Expose coupon types to the editor JS via AssetDataRegistry.
+	 *
+	 * @param array $attributes Block attributes.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		parent::enqueue_data( $attributes );
+
+		if ( ! $this->asset_data_registry->exists( 'couponTypes' ) && function_exists( 'wc_get_coupon_types' ) ) {
+			$this->asset_data_registry->add( 'couponTypes', wc_get_coupon_types() );
+		}
+	}
+
+	/**
 	 * Render the coupon code block.
 	 *
 	 * @param array         $attributes Block attributes.
@@ -76,7 +94,13 @@ class CouponCode extends AbstractBlock {
 	protected function render( $attributes, $content, $block ) {
 		$parsed_block = $block instanceof WP_Block ? $block->parsed_block : array();
 		$attributes   = $this->get_block_attributes( $parsed_block, $attributes );
-		$coupon_code  = $this->get_coupon_code( $attributes );
+		$source       = $attributes['source'] ?? 'createNew';
+
+		if ( 'createNew' === $source ) {
+			$coupon_code = self::COUPON_CODE_PLACEHOLDER;
+		} else {
+			$coupon_code = $this->get_coupon_code( $attributes );
+		}
 
 		if ( empty( $coupon_code ) ) {
 			return '';

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CouponCodeTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CouponCodeTest.php
@@ -78,7 +78,12 @@ class CouponCodeTest extends \WP_UnitTestCase {
 		$result = $this->mock->call_render( array( 'source' => 'existing' ) );
 		$this->assertSame( '', $result );
 
-		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => '' ) );
+		$result = $this->mock->call_render(
+			array(
+				'source'     => 'existing',
+				'couponCode' => '',
+			)
+		);
 		$this->assertSame( '', $result );
 	}
 
@@ -86,7 +91,12 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	 * Test that render returns HTML when coupon code is provided.
 	 */
 	public function test_render_returns_html_with_coupon_code(): void {
-		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => 'TESTCODE' ) );
+		$result = $this->mock->call_render(
+			array(
+				'source'     => 'existing',
+				'couponCode' => 'TESTCODE',
+			)
+		);
 
 		$this->assertStringContainsString( 'TESTCODE', $result );
 		$this->assertStringContainsString( 'woocommerce-coupon-code', $result );
@@ -97,7 +107,12 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	 * Test that coupon code is properly escaped in output.
 	 */
 	public function test_render_escapes_coupon_code(): void {
-		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => '<script>alert("xss")</script>' ) );
+		$result = $this->mock->call_render(
+			array(
+				'source'     => 'existing',
+				'couponCode' => '<script>alert("xss")</script>',
+			)
+		);
 
 		$this->assertStringNotContainsString( '<script>', $result );
 		$this->assertStringContainsString( '&lt;script&gt;', $result );
@@ -222,7 +237,12 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	 * Test render output contains proper table structure for email compatibility.
 	 */
 	public function test_render_contains_email_table_structure(): void {
-		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => 'TESTCODE' ) );
+		$result = $this->mock->call_render(
+			array(
+				'source'     => 'existing',
+				'couponCode' => 'TESTCODE',
+			)
+		);
 
 		$this->assertStringContainsString( '<table', $result );
 		$this->assertStringContainsString( '</table>', $result );
@@ -253,10 +273,20 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	 * Test that non-string coupon code values are handled.
 	 */
 	public function test_render_handles_non_string_coupon_code(): void {
-		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => 12345 ) );
+		$result = $this->mock->call_render(
+			array(
+				'source'     => 'existing',
+				'couponCode' => 12345,
+			)
+		);
 		$this->assertSame( '', $result );
 
-		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => array( 'code' ) ) );
+		$result = $this->mock->call_render(
+			array(
+				'source'     => 'existing',
+				'couponCode' => array( 'code' ),
+			)
+		);
 		$this->assertSame( '', $result );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CouponCodeTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CouponCodeTest.php
@@ -75,10 +75,10 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	 * Test that render returns empty string when no coupon code is provided.
 	 */
 	public function test_render_returns_empty_when_no_coupon_code(): void {
-		$result = $this->mock->call_render( array() );
+		$result = $this->mock->call_render( array( 'source' => 'existing' ) );
 		$this->assertSame( '', $result );
 
-		$result = $this->mock->call_render( array( 'couponCode' => '' ) );
+		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => '' ) );
 		$this->assertSame( '', $result );
 	}
 
@@ -86,7 +86,7 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	 * Test that render returns HTML when coupon code is provided.
 	 */
 	public function test_render_returns_html_with_coupon_code(): void {
-		$result = $this->mock->call_render( array( 'couponCode' => 'TESTCODE' ) );
+		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => 'TESTCODE' ) );
 
 		$this->assertStringContainsString( 'TESTCODE', $result );
 		$this->assertStringContainsString( 'woocommerce-coupon-code', $result );
@@ -97,7 +97,7 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	 * Test that coupon code is properly escaped in output.
 	 */
 	public function test_render_escapes_coupon_code(): void {
-		$result = $this->mock->call_render( array( 'couponCode' => '<script>alert("xss")</script>' ) );
+		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => '<script>alert("xss")</script>' ) );
 
 		$this->assertStringNotContainsString( '<script>', $result );
 		$this->assertStringContainsString( '&lt;script&gt;', $result );
@@ -222,7 +222,7 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	 * Test render output contains proper table structure for email compatibility.
 	 */
 	public function test_render_contains_email_table_structure(): void {
-		$result = $this->mock->call_render( array( 'couponCode' => 'TESTCODE' ) );
+		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => 'TESTCODE' ) );
 
 		$this->assertStringContainsString( '<table', $result );
 		$this->assertStringContainsString( '</table>', $result );
@@ -231,13 +231,32 @@ class CouponCodeTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that render shows placeholder for createNew source.
+	 */
+	public function test_render_shows_placeholder_for_create_new_source(): void {
+		$result = $this->mock->call_render( array( 'source' => 'createNew' ) );
+
+		$this->assertStringContainsString( 'XXXX-XXXXXX-XXXX', $result );
+		$this->assertStringContainsString( 'woocommerce-coupon-code', $result );
+	}
+
+	/**
+	 * Test that render defaults to createNew when no source specified.
+	 */
+	public function test_render_defaults_to_create_new_source(): void {
+		$result = $this->mock->call_render( array() );
+
+		$this->assertStringContainsString( 'XXXX-XXXXXX-XXXX', $result );
+	}
+
+	/**
 	 * Test that non-string coupon code values are handled.
 	 */
 	public function test_render_handles_non_string_coupon_code(): void {
-		$result = $this->mock->call_render( array( 'couponCode' => 12345 ) );
+		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => 12345 ) );
 		$this->assertSame( '', $result );
 
-		$result = $this->mock->call_render( array( 'couponCode' => array( 'code' ) ) );
+		$result = $this->mock->call_render( array( 'source' => 'existing', 'couponCode' => array( 'code' ) ) );
 		$this->assertSame( '', $result );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `woocommerce/coupon-code` block currently only supports selecting an existing WooCommerce coupon. This PR adds a **"Create new" auto-generation mode** where users configure coupon rules in the sidebar and a unique coupon is generated at email send time.

**Editor UI changes:**
- `ToggleGroupControl` to switch between "Create new" (default) and "Use existing" modes
- "Create new" mode shows three sidebar panels: General (discount type, amount, expiry, free shipping), Usage limits (per coupon, per user), and Usage restrictions (min/max spend, individual use, exclude sale items, products, categories, email restrictions)
- Placeholder `XXXX-XXXXXX-XXXX` displayed in the email body with explanatory text
- "Use existing" mode preserves the current coupon search behavior

**Backend changes:**
- 16 new block attributes for coupon configuration
- `CouponCode::render()` shows placeholder for `source=createNew`
- `CouponCode::enqueue_data()` localizes `wc_get_coupon_types()` for the editor
- New `Coupon_Code` email renderer in the email-editor package with `woocommerce_coupon_code_block_auto_generate` filter hook for integrators to generate coupons at send time

This is part of a cross-repo effort with MailPoet (STOMAIL-7969). MailPoet will hook into the filter to provide the actual coupon generation backend.

Closes [STOMAIL-7969](https://linear.app/a8c/issue/STOMAIL-7969/coupon-auto-generation-block-for-the-gutenberg-email-editor).

## Screenshots or screen recordings:

### Coupon code in the email

<img width="1659" height="1156" alt="Screenshot 2026-04-23 at 12 26 45" src="https://github.com/user-attachments/assets/31ff8254-915f-4e31-bcb4-a90672f99454" />

---

### Usage limits setup

<img width="1670" height="1163" alt="Screenshot 2026-04-23 at 12 26 56" src="https://github.com/user-attachments/assets/610b8c7c-cb5a-4540-8ec6-c9a630a1a3c5" />

---

### Option to use an existing coupon

<img width="1663" height="683" alt="Screenshot 2026-04-23 at 12 27 11" src="https://github.com/user-attachments/assets/0f3615ec-96a2-43f8-9418-a705d4287cbe" />

---

### Final coupon in the email client

<img width="801" height="423" alt="Screenshot 2026-04-23 at 15 19 27" src="https://github.com/user-attachments/assets/8207c341-49ad-45e9-9ada-2c1496e3c428" />


### How to test the changes in this Pull Request:

1. Enable the email editor feature flag: `wp option update woocommerce_feature_email_editor_enabled yes`
2. Go to WooCommerce > Settings > Emails and open any email template in the block editor
3. Insert a "Coupon Code" block from the block inserter
4. Verify the block shows `XXXX-XXXXXX-XXXX` placeholder with "A unique code will be generated for each recipient at send time." text
5. In the sidebar, verify the "Create new" / "Use existing" toggle works
6. In "Create new" mode, verify:
   - General panel: discount type dropdown, amount, expiry days, free shipping toggle
   - Usage limits panel (collapsed by default): per coupon and per user limits
   - Usage restrictions panel (collapsed by default): min/max spend, individual use, exclude sale items, product/category search, allowed emails
7. Switch to "Use existing" mode and verify the coupon search still works as before
8. Switch back to "Create new" and verify settings are preserved

### Testing that has already taken place:

- TypeScript compilation: zero errors in coupon-code files
- PHP syntax check: all modified files pass `php -l`
- Prettier formatting applied to all JS/TS files
- Manual testing in WooCommerce email editor (wp-env)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Add auto-generation mode to the coupon code email block, allowing users to configure coupon rules that generate unique codes at send time.

</details>
