### PR TITLE
Fix missing height attribute on category images when uncropped

### DIFF
--- a/plugins/woocommerce/changelog/64345-fix-38153-clean-category-image-height
+++ b/plugins/woocommerce/changelog/64345-fix-38153-clean-category-image-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix the missing height attribute on category images when uncropped
+

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3013,6 +3013,12 @@ if ( ! function_exists( 'woocommerce_subcategory_thumbnail' ) ) {
 				$image        = $image_data[0];
 				$image_srcset = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $thumbnail_id, $small_thumbnail_size ) : false;
 				$image_sizes  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $thumbnail_id, $small_thumbnail_size ) : false;
+
+				// Use actual image dimensions when uncropped (height is empty).
+				if ( empty( $dimensions['height'] ) && isset( $image_data[1] ) && isset( $image_data[2] ) ) {
+					$dimensions['width']  = $image_data[1];
+					$dimensions['height'] = $image_data[2];
+				}
 			} else {
 				$image        = wc_placeholder_img_src();
 				$image_srcset = false;

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3014,8 +3014,8 @@ if ( ! function_exists( 'woocommerce_subcategory_thumbnail' ) ) {
 				$image_srcset = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $thumbnail_id, $small_thumbnail_size ) : false;
 				$image_sizes  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $thumbnail_id, $small_thumbnail_size ) : false;
 
-				// Use actual image dimensions when uncropped (height is empty).
-				if ( empty( $dimensions['height'] ) && isset( $image_data[1] ) && isset( $image_data[2] ) ) {
+				$uncropped = 0 === ( $dimensions['crop'] ?? 0 ) && '' === ( $dimensions['height'] ?? '' );
+				if ( $uncropped && isset( $image_data[1], $image_data[2] ) ) {
 					$dimensions['width']  = $image_data[1];
 					$dimensions['height'] = $image_data[2];
 				}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes missing height attribute on category thumbnail images when the image size is configured as uncropped. When WooCommerce's image size settings have `crop` set to `0` (uncropped), the height dimension is empty, causing layout shifts since the browser cannot calculate the aspect ratio.

The fix checks if the image is uncropped (crop is `0` and height is empty) and uses the actual image dimensions from `wp_get_attachment_image_src()` instead.

Closes #38153.

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Settings > Products** and set product image cropping to "Uncropped" (1:1)
2. Add a category thumbnail image (non-square image recommended)
3. View the product category page with subcategories
4. **Before fix:** Image has no height attribute, causing layout shift
5. **After fix:** Image has proper width and height attributes from actual image dimensions
6. Test with cropped setting too — ensure no regression

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix the missing height attribute on category images when uncropped

</details>
