### PR TITLE
Fix JS TypeError when product excerpt metabox is removed

### DIFF
--- a/plugins/woocommerce/changelog/pr-64346
+++ b/plugins/woocommerce/changelog/pr-64346
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix JS TypeError when product excerpt metabox is removed.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -237,7 +237,7 @@ class WC_Products_Tracking {
 							product_type_options_string: productTypeOptionsString,
 							purchase_note:			     $( '#_purchase_note' ).val().length ? 'yes' : 'no',
 							sale_price:				     $( '#_sale_price' ).val() ? 'yes' : 'no',
-							short_description:		     $( '#excerpt' ).val().length ? 'yes' : 'no',
+							short_description:		     ( $( '#excerpt' ).length && $( '#excerpt' ).val() ) ? ( $( '#excerpt' ).val().length ? 'yes' : 'no' ) : 'no',
 							stock_quantity_update:	     ( initialStockValue != currentStockValue ) ? 'Yes' : 'No',
 							tags:					     tagsText.length > 0 ? tagsText.split( ',' ).length : 0,
 							upsells:				     $( '#upsell_ids option' ).length ? 'Yes' : 'No',

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -237,7 +237,7 @@ class WC_Products_Tracking {
 							product_type_options_string: productTypeOptionsString,
 							purchase_note:			     $( '#_purchase_note' ).val().length ? 'yes' : 'no',
 							sale_price:				     $( '#_sale_price' ).val() ? 'yes' : 'no',
-							short_description:		     ( $( '#excerpt' ).length && $( '#excerpt' ).val() ) ? ( $( '#excerpt' ).val().length ? 'yes' : 'no' ) : 'no',
+							short_description:		     $( '#excerpt' ).val() ? 'yes' : 'no',
 							stock_quantity_update:	     ( initialStockValue != currentStockValue ) ? 'Yes' : 'No',
 							tags:					     tagsText.length > 0 ? tagsText.split( ',' ).length : 0,
 							upsells:				     $( '#upsell_ids option' ).length ? 'Yes' : 'No',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes a JavaScript TypeError that prevents saving products when the excerpt metabox has been removed via `remove_meta_box( 'postexcerpt', 'product', 'normal' )`.

The tracking code in `class-wc-products-tracking.php` calls `$( '#excerpt' ).val()` which throws a TypeError when the `#excerpt` element does not exist in the DOM. This PR simplifies the check to match the existing `sale_price` pattern — `$( '#excerpt' ).val()` returns undefined (falsy) when the element does not exist, so the ternary safely returns `'no'`.

Closes #34987.

### How to test the changes in this Pull Request:

1. Add `remove_meta_box( 'postexcerpt', 'product', 'normal' );` to your theme's `functions.php`
2. Edit and save a product
3. **Before fix:** JS TypeError in console, form may not submit properly
4. **After fix:** Product saves normally with no JS errors
5. Remove the `remove_meta_box` call and verify the excerpt tracking still works correctly (returns `'yes'` when excerpt has content, `'no'` when empty)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix

#### Message

Fix JS TypeError when product excerpt metabox is removed

</details>
