### PR TITLE
Log get_order() exception to WC Logger for easier debugging

### DIFF
--- a/plugins/woocommerce/changelog/fix-36979-log-get-order-exception
+++ b/plugins/woocommerce/changelog/fix-36979-log-get-order-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Log get_order() exceptions to WC Logger for easier debugging.

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -55,13 +55,12 @@ class WC_Order_Factory {
 			wc_caught_exception( $e, __FUNCTION__, array( $order_id ) );
 			wc_get_logger()->error(
 				sprintf(
-					/* translators: 1: Function name 2: Error message */
-					__( 'Exception caught in %1$s: %2$s', 'woocommerce' ),
+					'Exception caught in %1$s: %2$s',
 					__FUNCTION__,
 					$e->getMessage()
 				),
 				array(
-					'source' => 'get_order',
+					'source'   => 'get_order',
 					'order_id' => $order_id,
 				)
 			);

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -53,6 +53,18 @@ class WC_Order_Factory {
 			return $order;
 		} catch ( Exception $e ) {
 			wc_caught_exception( $e, __FUNCTION__, array( $order_id ) );
+			wc_get_logger()->error(
+				sprintf(
+					/* translators: %s: Error message. */
+					__( 'Exception caught in %s: %s', 'woocommerce' ),
+					__FUNCTION__,
+					$e->getMessage()
+				),
+				array(
+					'source' => 'get_order',
+					'order_id' => $order_id,
+				)
+			);
 			return false;
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -60,8 +60,9 @@ class WC_Order_Factory {
 					$e->getMessage()
 				),
 				array(
-					'source'   => 'get_order',
-					'order_id' => $order_id,
+					'source'    => 'get_order',
+					'order_id'  => $order_id,
+					'exception' => $e,
 				)
 			);
 			return false;

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -55,7 +55,7 @@ class WC_Order_Factory {
 			wc_caught_exception( $e, __FUNCTION__, array( $order_id ) );
 			wc_get_logger()->error(
 				sprintf(
-					'Exception caught in %1$s: %2$s',
+					'Exception caught in %s: %s',
 					__FUNCTION__,
 					$e->getMessage()
 				),
@@ -65,7 +65,7 @@ class WC_Order_Factory {
 				)
 			);
 			return false;
-		}
+		}//end try
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -55,8 +55,8 @@ class WC_Order_Factory {
 			wc_caught_exception( $e, __FUNCTION__, array( $order_id ) );
 			wc_get_logger()->error(
 				sprintf(
-					/* translators: %s: Error message. */
-					__( 'Exception caught in %s: %s', 'woocommerce' ),
+					/* translators: 1: Function name 2: Error message */
+					__( 'Exception caught in %1$s: %2$s', 'woocommerce' ),
 					__FUNCTION__,
 					$e->getMessage()
 				),


### PR DESCRIPTION
## Summary

When `WC_Order_Factory::get_order()` catches an exception, it currently only calls `wc_caught_exception()` which logs to PHP error logs. This makes it difficult for merchants to discover and troubleshoot order loading failures.

This PR adds a `wc_get_logger()->error()` call so exceptions are also visible in **WooCommerce > Status > Logs**, which is much more accessible.

## Changes

- Added `wc_get_logger()` call in the catch block of `get_order()` method
- Log includes the function name, exception message, and order ID as context

## Testing Instructions

1. Create an order with invalid data that triggers an exception in `get_order()`
2. Check **WooCommerce > Status > Logs** for the `get_order` source
3. Verify the exception message and order ID are logged

Fixes #36979

cc @woocommerce/core