### PR TITLE
[Performance] BFCM stress-test config fo K6

### DIFF
--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -29,7 +29,7 @@
 		"env:destroy": "pnpm wp-env destroy",
 		"env:dev": "pnpm wp-env start --update",
 		"env:down": "pnpm wp-env stop",
-		"env:performance-init": "./tests/performance/bin/init-sample-products.sh",
+		"env:performance-init": "./tests/performance/bin/init-environment.sh",
 		"env:restart": "pnpm wp-env destroy && pnpm wp-env start --update",
 		"env:start": "pnpm wp-env start",
 		"env:start:blocks": "pnpm --filter='@woocommerce/block-library' env:start && pnpm playwright install chromium",

--- a/plugins/woocommerce/tests/performance/README.md
+++ b/plugins/woocommerce/tests/performance/README.md
@@ -50,7 +50,7 @@ Alternatively the k6 docker image can be used to execute tests.
 
 Before using the tests a test environment is needed to run against.
 
-We first spin up an environment using `wp-env` and configure that environment with the necessary plugins and data using the Initialization Script [`init-sample-products.sh`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/performance/bin/init-sample-products.sh) that will set up a shop with sample products imported and the shop settings (payment method, permalinks, address etc) needed for the tests already set. It is recommended using this to just see the tests in action.
+We first spin up an environment using `wp-env` and configure that environment with the necessary plugins and data using the Initialization Script [`init-environment.sh`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/performance/bin/init-environment.sh) that will set up a shop with sample products imported and the shop settings (payment method, permalinks, address etc) needed for the tests already set. It is recommended using this to just see the tests in action.
 
 ```sh
 pnpm env:dev --filter=@woocommerce/plugin-woocommerce

--- a/plugins/woocommerce/tests/performance/bin/init-environment.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-environment.sh
@@ -35,4 +35,14 @@ wp-env run tests-cli wp theme install storefront --activate
 wp-env run tests-cli wp config set DISABLE_WP_CRON true --raw --type=constant
 wp-env run tests-cli wp config set WP_HTTP_BLOCK_EXTERNAL true --raw --type=constant
 
+# Remove container-level strains for cleaner performance metrics: OPcache.
+docker exec -u root "$(docker ps --filter name=tests-wordpress --format '{{.Names}}' | head -1)" bash -c \
+    "printf '[opcache]\nopcache.enable=1\nopcache.memory_consumption=256\nopcache.max_accelerated_files=20000\nopcache.validate_timestamps=1\nopcache.revalidate_freq=0\n' > /usr/local/etc/php/conf.d/perf-opcache.ini"
+docker restart "$(docker ps --filter name=tests-wordpress --format '{{.Names}}' | head -1)"
+
+# Remove container-level strains for cleaner performance metrics: DB buffer and connections pool.
+docker exec -u root "$(docker ps --filter name=tests-mysql --format '{{.Names}}')" bash -c "printf '[mysqld]\ninnodb_buffer_pool_size=1073741824\ninnodb_flush_log_at_trx_commit=2\n' > /etc/mysql/conf.d/perf-tuning.cnf"
+docker restart "$(docker ps --filter name=tests-mysql --format '{{.Names}}')"
+_timeout=30; until docker exec "$(docker ps --filter name=tests-mysql --format '{{.Names}}')" mariadb -u root -ppassword -e "SELECT 1" &>/dev/null || [ $((_timeout--)) -eq 0 ]; do sleep 0.5; done
+
 echo "Success! Your E2E Test Environment is now ready."

--- a/plugins/woocommerce/tests/performance/bin/init-environment.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-environment.sh
@@ -35,14 +35,29 @@ wp-env run tests-cli wp theme install storefront --activate
 wp-env run tests-cli wp config set DISABLE_WP_CRON true --raw --type=constant
 wp-env run tests-cli wp config set WP_HTTP_BLOCK_EXTERNAL true --raw --type=constant
 
+# Resolve container names once; fail loudly if wp-env is not running.
+_wp_container="$(docker ps --filter name=tests-wordpress --format '{{.Names}}' | head -1)"
+_db_container="$(docker ps --filter name=tests-mysql --format '{{.Names}}' | head -1)"
+if [ -z "$_wp_container" ] || [ -z "$_db_container" ]; then
+    echo "Error: wp-env containers not found. Run 'wp-env start' first." >&2
+    exit 1
+fi
+
 # Remove container-level strains for cleaner performance metrics: OPcache.
-docker exec -u root "$(docker ps --filter name=tests-wordpress --format '{{.Names}}' | head -1)" bash -c \
+docker exec -u root "$_wp_container" bash -c \
     "printf '[opcache]\nopcache.enable=1\nopcache.memory_consumption=256\nopcache.max_accelerated_files=20000\nopcache.validate_timestamps=1\nopcache.revalidate_freq=0\n' > /usr/local/etc/php/conf.d/perf-opcache.ini"
-docker restart "$(docker ps --filter name=tests-wordpress --format '{{.Names}}' | head -1)"
+docker restart "$_wp_container"
 
 # Remove container-level strains for cleaner performance metrics: DB buffer and connections pool.
-docker exec -u root "$(docker ps --filter name=tests-mysql --format '{{.Names}}')" bash -c "printf '[mysqld]\ninnodb_buffer_pool_size=1073741824\ninnodb_flush_log_at_trx_commit=2\n' > /etc/mysql/conf.d/perf-tuning.cnf"
-docker restart "$(docker ps --filter name=tests-mysql --format '{{.Names}}')"
-_timeout=30; until docker exec "$(docker ps --filter name=tests-mysql --format '{{.Names}}')" mariadb -u root -ppassword -e "SELECT 1" &>/dev/null || [ $((_timeout--)) -eq 0 ]; do sleep 0.5; done
+docker exec -u root "$_db_container" bash -c "printf '[mysqld]\ninnodb_buffer_pool_size=1073741824\ninnodb_flush_log_at_trx_commit=2\n' > /etc/mysql/conf.d/perf-tuning.cnf"
+docker restart "$_db_container"
+_deadline=$((SECONDS + 30))
+until docker exec "$_db_container" mariadb -u root -ppassword -e "SELECT 1" &>/dev/null; do
+    if [ $SECONDS -ge $_deadline ]; then
+        echo "Error: MariaDB did not become ready within 30 seconds." >&2
+        exit 1
+    fi
+    sleep 0.5
+done
 
 echo "Success! Your E2E Test Environment is now ready."

--- a/plugins/woocommerce/tests/performance/bin/init-environment.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-environment.sh
@@ -39,7 +39,7 @@ wp-env run tests-cli wp config set WP_HTTP_BLOCK_EXTERNAL true --raw --type=cons
 _wp_container="$(docker ps --filter name=tests-wordpress --format '{{.Names}}' | head -1)"
 _db_container="$(docker ps --filter name=tests-mysql --format '{{.Names}}' | head -1)"
 if [ -z "$_wp_container" ] || [ -z "$_db_container" ]; then
-    echo "Error: wp-env containers not found. Run 'wp-env start' first." >&2
+    echo "Error: wp-env containers not found. Run 'pnpm env:perf' first." >&2
     exit 1
 fi
 

--- a/plugins/woocommerce/tests/performance/tests/bfcm.js
+++ b/plugins/woocommerce/tests/performance/tests/bfcm.js
@@ -55,20 +55,33 @@ export const options = {
 	},
 	thresholds: {
 		// Aggregate thresholds across all requests.
-		http_req_duration: [ 'p(50)<200', 'p(90)<1000', 'p(95)<1500', 'p(99.9)<3000' ],
-		http_req_failed:   [ 'rate<0.01' ],
+		http_req_duration: [
+			'p(50)<200',
+			'p(90)<1000',
+			'p(95)<1500',
+			'p(99.9)<3000',
+		],
+		http_req_failed: [ 'rate<0.01' ],
 
 		// Per-request thresholds: cart workflow.
-		'http_req_duration{name:Shopper - wc-ajax=add_to_cart}':             [ 'p(95)<500' ],
-		'http_req_duration{name:Shopper - wc-ajax=get_refreshed_fragments}': [ 'p(95)<200' ],
-		'http_req_duration{name:Shopper - View Cart}':                       [ 'p(95)<500' ],
+		'http_req_duration{name:Shopper - wc-ajax=add_to_cart}': [
+			'p(95)<500',
+		],
+		'http_req_duration{name:Shopper - wc-ajax=get_refreshed_fragments}': [
+			'p(95)<200',
+		],
+		'http_req_duration{name:Shopper - View Cart}': [ 'p(95)<500' ],
 
 		// Per-request thresholds: checkout workflow.
-		'http_req_duration{name:Shopper - View Checkout}':             [ 'p(95)<1000' ],
-		'http_req_duration{name:Shopper - Login to Checkout}':         [ 'p(95)<750' ],
-		'http_req_duration{name:Shopper - Store API update-customer}': [ 'p(95)<500' ],
-		'http_req_duration{name:Shopper - Store API checkout}':        [ 'p(95)<3000' ],
-		'http_req_duration{name:Shopper - Order Received}':            [ 'p(95)<1000' ],
+		'http_req_duration{name:Shopper - View Checkout}': [ 'p(95)<1000' ],
+		'http_req_duration{name:Shopper - Login to Checkout}': [ 'p(95)<750' ],
+		'http_req_duration{name:Shopper - Store API update-customer}': [
+			'p(95)<500',
+		],
+		'http_req_duration{name:Shopper - Store API checkout}': [
+			'p(95)<3000',
+		],
+		'http_req_duration{name:Shopper - Order Received}': [ 'p(95)<1000' ],
 	},
 };
 

--- a/plugins/woocommerce/tests/performance/tests/bfcm.js
+++ b/plugins/woocommerce/tests/performance/tests/bfcm.js
@@ -1,0 +1,83 @@
+/**
+ * Internal dependencies
+ */
+import { cart } from '../requests/shopper/cart.js';
+import { checkoutGuest } from '../requests/shopper/checkout-guest.js';
+import { checkoutCustomerLogin } from '../requests/shopper/checkout-customer-login.js';
+
+// Regression and stabilization indicators (for AI agents comparing runs):
+// This test runs at the environment's saturation ceiling — thresholds will fail by design.
+// Use the following metrics to detect regressions (numbers go up) or improvements (numbers go down):
+//   - http_req_failed rate      — baseline ~4%; target <1%; regressions push this higher.
+//   - dropped_iterations        — baseline ~278; fewer = system handled more load cleanly.
+//   - http_req_duration p(50)   — baseline ~101ms; the fast-path latency; regressions surface here first.
+//   - iteration_duration avg    — baseline ~52s; lower = checkout flow completing faster under load.
+//   - Store API checkout avg    — baseline ~16s; the heaviest per-request operation; most sensitive to checkout optimizations.
+// A PR that reduces DB queries or checkout overhead will move all of the above in the right direction even
+// if the test still "fails" thresholds — less failing is a measurable win. Baseline is as of April 2026.
+
+export const options = {
+	// Saturation profile (M4 Pro, wp-env defaults):
+	// - Bottleneck: Apache prefork MaxRequestWorkers=150 (not DB — MariaDB Threads_running stays at 1).
+	// - At 0.8 checkout/s workers plateau at ~37/150, spike to ~56/150, then self-correct — bounded, no cascade.
+	// - At 1.0/s workers climb unboundedly to ~117/150, causing request queuing and timeouts.
+	// - Requires a clean Apache baseline: restart the WordPress container between runs (init-environment.sh).
+	// - To raise the ceiling: increase MaxRequestWorkers in Apache MPM prefork config and re-profile.
+	scenarios: {
+		// Guest checkout: 60% of checkouts.
+		checkout_guest_bfcm: {
+			executor: 'ramping-arrival-rate',
+			exec: 'checkoutGuestFlow',
+			startRate: 1,
+			timeUnit: '10s',
+			preAllocatedVUs: 6,
+			maxVUs: 15,
+			stages: [
+				{ duration: '4m', target: 5 }, // Ramp to peak.
+				{ duration: '8m', target: 5 }, // Sustain peak.
+				{ duration: '2m', target: 0 }, // Ramp down.
+			],
+		},
+		// Authenticated checkout: 40% of checkouts.
+		checkout_customer_bfcm: {
+			executor: 'ramping-arrival-rate',
+			exec: 'checkoutCustomerLoginFlow',
+			startRate: 1,
+			timeUnit: '10s',
+			preAllocatedVUs: 4,
+			maxVUs: 10,
+			stages: [
+				{ duration: '4m', target: 3 }, // Ramp to peak.
+				{ duration: '8m', target: 3 }, // Sustain peak.
+				{ duration: '2m', target: 0 }, // Ramp down.
+			],
+		},
+	},
+	thresholds: {
+		// Aggregate thresholds across all requests.
+		http_req_duration: [ 'p(50)<200', 'p(90)<1000', 'p(95)<1500', 'p(99.9)<3000' ],
+		http_req_failed:   [ 'rate<0.01' ],
+
+		// Per-request thresholds: cart workflow.
+		'http_req_duration{name:Shopper - wc-ajax=add_to_cart}':             [ 'p(95)<500' ],
+		'http_req_duration{name:Shopper - wc-ajax=get_refreshed_fragments}': [ 'p(95)<200' ],
+		'http_req_duration{name:Shopper - View Cart}':                       [ 'p(95)<500' ],
+
+		// Per-request thresholds: checkout workflow.
+		'http_req_duration{name:Shopper - View Checkout}':             [ 'p(95)<1000' ],
+		'http_req_duration{name:Shopper - Login to Checkout}':         [ 'p(95)<750' ],
+		'http_req_duration{name:Shopper - Store API update-customer}': [ 'p(95)<500' ],
+		'http_req_duration{name:Shopper - Store API checkout}':        [ 'p(95)<3000' ],
+		'http_req_duration{name:Shopper - Order Received}':            [ 'p(95)<1000' ],
+	},
+};
+
+export function checkoutGuestFlow() {
+	cart();
+	checkoutGuest();
+}
+
+export function checkoutCustomerLoginFlow() {
+	cart();
+	checkoutCustomerLogin();
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fully saturate the standard wp-env container and measure checkout workflow, simulating BFCM (tuned for M4 pro, not intended for CI!). Checkout is expected to break and underperform, so with further checkout optimization, we can track if the dynamic improves.

```
█ THRESHOLDS 

    http_req_duration
    ✓ 'p(50)<200' p(50)=101.07ms
    ✗ 'p(90)<1000' p(90)=16.33s
    ✗ 'p(95)<1500' p(95)=37.57s
    ✗ 'p(99.9)<3000' p(99.9)=1m0s

      {name:Shopper - Login to Checkout}
      ✗ 'p(95)<750' p(95)=14.61s

      {name:Shopper - Order Received}
      ✗ 'p(95)<1000' p(95)=8.35s

      {name:Shopper - Store API checkout}
      ✗ 'p(95)<3000' p(95)=1m0s

      {name:Shopper - Store API update-customer}
      ✗ 'p(95)<500' p(95)=9.73s

      {name:Shopper - View Cart}
      ✗ 'p(95)<500' p(95)=33.31s

      {name:Shopper - View Checkout}
      ✗ 'p(95)<1000' p(95)=2.97s

      {name:Shopper - wc-ajax=add_to_cart}
      ✗ 'p(95)<500' p(95)=1m0s

      {name:Shopper - wc-ajax=get_refreshed_fragments}
      ✓ 'p(95)<200' p(95)=0s

    http_req_failed
    ✗ 'rate<0.01' rate=4.05%


  █ TOTAL RESULTS 

    checks_total.......: 4654   5.349608/s
    checks_succeeded...: 95.05% 4424 out of 4654
    checks_failed......: 4.94%  230 out of 4654

    ✓ url query is status 200
    ✓ url query response matches retrieved product data sku
    ✗ is status 200
      ↳  94% — ✓ 1653 / ✗ 105
    ✗ title is: "Cart – WooCommerce Core E2E Test Suite"
      ↳  94% — ✓ 258 / ✗ 14
    ✓ body does not contain: 'your cart is currently empty'
    ✓ footer contains: Built with WooCommerce
    ✗ title is: "Checkout – WooCommerce Core E2E Test Suite"
      ↳  90% — ✓ 232 / ✗ 25
    ✗ body contains: wp-block-woocommerce-checkout
      ↳  90% — ✓ 232 / ✗ 23
    ✗ body contains: order_id
      ↳  73% — ✓ 176 / ✗ 63
    ✓ title is: "Order received – WooCommerce Core E2E Test Suite"
    ✓ body contains: Thank you. Your order has been received.

    HTTP
    http_req_duration......................................: avg=4.8s     min=34.53ms  med=101.07ms max=1m0s   p(90)=16.33s   p(95)=37.57s
      { expected_response:true }...........................: avg=2.81s    min=34.53ms  med=96.23ms  max=57.59s p(90)=6.79s    p(95)=24.14s
      { name:Shopper - Login to Checkout }.................: avg=3.23s    min=56.91ms  med=120.96ms max=1m0s   p(90)=11.25s   p(95)=14.61s
      { name:Shopper - Order Received }....................: avg=1.32s    min=58.56ms  med=104.71ms max=35.93s p(90)=1.19s    p(95)=8.35s 
      { name:Shopper - Store API checkout }................: avg=16.26s   min=134.04ms med=1.03s    max=1m0s   p(90)=1m0s     p(95)=1m0s  
      { name:Shopper - Store API update-customer }.........: avg=1.33s    min=36.98ms  med=66.13ms  max=35.29s p(90)=2.65s    p(95)=9.73s 
      { name:Shopper - View Cart }.........................: avg=4.07s    min=46.53ms  med=107.12ms max=1m0s   p(90)=17.91s   p(95)=33.31s
      { name:Shopper - View Checkout }.....................: avg=997.42ms min=46.72ms  med=92.41ms  max=1m0s   p(90)=322.89ms p(95)=2.97s 
      { name:Shopper - wc-ajax=add_to_cart }...............: avg=10.38s   min=48.15ms  med=83.66ms  max=1m0s   p(90)=54.86s   p(95)=1m0s  
      { name:Shopper - wc-ajax=get_refreshed_fragments }...: avg=0s       min=0s       med=0s       max=0s     p(90)=0s       p(95)=0s    
    http_req_failed........................................: 4.05%  105 out of 2590
    http_reqs..............................................: 2590   2.977113/s

    EXECUTION
    dropped_iterations.....................................: 278    0.319551/s
    iteration_duration.....................................: avg=52.26s   min=2.92s    med=14.31s   max=3m49s  p(90)=2m31s    p(95)=3m15s 
    iterations.............................................: 255    0.293113/s
    vus....................................................: 17     min=0           max=25
    vus_max................................................: 25     min=10          max=25

    NETWORK
    data_received..........................................: 211 MB 242 kB/s
    data_sent..............................................: 2.0 MB 2.3 kB/s




running (14m30.0s), 00/25 VUs, 255 complete and 17 interrupted iterations
checkout_customer_bfcm ✓ [======================================] 05/10 VUs  14m0s  0.04 iters/s
checkout_guest_bfcm    ✓ [======================================] 12/15 VUs  14m0s  0.05 iters/s
ERRO[0870] thresholds on metrics 'http_req_duration, http_req_duration{name:Shopper - Login to Checkout}, http_req_duration{name:Shopper - Order Received}, http_req_duration{name:Shopper - Store API checkout}, http_req_duration{name:Shopper - Store API update-customer}, http_req_duration{name:Shopper - View Cart}, http_req_duration{name:Shopper - View Checkout}, http_req_duration{name:Shopper - wc-ajax=add_to_cart}, http_req_failed' have been crossed 
 
```

### How to test the changes in this Pull Request:

- Modify `"test:perf": "./tests/performance/bin/k6 run ./tests/performance/tests/main.js",` -> `"test:perf": "./tests/performance/bin/k6 run ./tests/performance/tests/bfcm.js",` in `plugins/woocommerce/package.json`
- Spin off the perf-testing container and run benchmarking using available pnpm commands

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
