### PR TITLE
Add per-user push notification preferences

### DIFF
--- a/plugins/woocommerce/changelog/64351-issue-RSM-693
+++ b/plugins/woocommerce/changelog/64351-issue-RSM-693
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add per-user push notification preferences REST endpoint at \`/wc-push-notifications/preferences\`.

--- a/plugins/woocommerce/changelog/64351-issue-RSM-693
+++ b/plugins/woocommerce/changelog/64351-issue-RSM-693
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add per-user push notification preferences REST endpoint at \`/wc-push-notifications/preferences\`.
+Add per-user push notification preferences REST endpoint at `/wc-push-notifications/preferences`.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -9,6 +9,9 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use Exception;
+use WC_Data_Exception;
 use WP_Error;
 use WP_Http;
 use WP_REST_Request;
@@ -111,12 +114,16 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 		$service = wc_get_container()->get( NotificationPreferencesService::class );
 		$input   = array_intersect_key( $request->get_params(), $service->get_defaults() );
 
-		$service->save_preferences( get_current_user_id(), array_map( 'boolval', $input ) );
+		try {
+			$merged = $service->save_preferences(
+				get_current_user_id(),
+				array_map( 'boolval', $input )
+			);
+		} catch ( Exception $e ) {
+			return $this->convert_exception_to_wp_error( $e );
+		}
 
-		return new WP_REST_Response(
-			$service->get_preferences( get_current_user_id() ),
-			WP_Http::OK
-		);
+		return new WP_REST_Response( $merged, WP_Http::OK );
 	}
 
 	/**
@@ -178,5 +185,43 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Convert an exception thrown by the service into a WP_Error suitable for
+	 * the REST response.
+	 *
+	 * Mirrors PushTokenRestController::convert_exception_to_wp_error: surface
+	 * domain-specific WC_Data_Exception details for client-recoverable failures
+	 * (non-500 codes), and log + return a generic internal-error response for
+	 * 500-level / unknown failures.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param Exception $e The exception to convert.
+	 * @return WP_Error
+	 */
+	private function convert_exception_to_wp_error( Exception $e ): WP_Error {
+		if (
+			$e instanceof WC_Data_Exception
+			&& $e->getCode() !== WP_Http::INTERNAL_SERVER_ERROR
+		) {
+			return new WP_Error(
+				$e->getErrorCode(),
+				$e->getMessage(),
+				$e->getErrorData()
+			);
+		}
+
+		wc_get_container()
+			->get( LegacyProxy::class )
+			->call_function( 'wc_get_logger' )
+			->error( (string) $e->getMessage(), array( 'source' => PushNotifications::FEATURE_NAME ) );
+
+		return new WP_Error(
+			'woocommerce_internal_error',
+			'Internal server error',
+			array( 'status' => WP_Http::INTERNAL_SERVER_ERROR )
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -8,10 +8,9 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
+use Automattic\WooCommerce\Internal\PushNotifications\Traits\ConvertsExceptionsToWpError;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
-use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Exception;
-use WC_Data_Exception;
 use WP_Error;
 use WP_Http;
 use WP_REST_Request;
@@ -25,6 +24,8 @@ use WP_REST_Server;
  * @since 10.8.0
  */
 class NotificationPreferencesRestController extends RestApiControllerBase {
+	use ConvertsExceptionsToWpError;
+
 	/**
 	 * The root namespace for the JSON REST API endpoints.
 	 *
@@ -179,41 +180,5 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 		}
 
 		return $args;
-	}
-
-	/**
-	 * Convert an exception thrown by the service into a WP_Error suitable for
-	 * the REST response.
-	 *
-	 * Mirrors PushTokenRestController::convert_exception_to_wp_error: surface
-	 * domain-specific WC_Data_Exception details for client-recoverable failures
-	 * (non-500 codes), and log + return a generic internal-error response for
-	 * 500-level / unknown failures.
-	 *
-	 * @param Exception $e The exception to convert.
-	 * @return WP_Error
-	 */
-	private function convert_exception_to_wp_error( Exception $e ): WP_Error {
-		if (
-			$e instanceof WC_Data_Exception
-			&& $e->getCode() !== WP_Http::INTERNAL_SERVER_ERROR
-		) {
-			return new WP_Error(
-				$e->getErrorCode(),
-				$e->getMessage(),
-				$e->getErrorData()
-			);
-		}
-
-		wc_get_container()
-			->get( LegacyProxy::class )
-			->call_function( 'wc_get_logger' )
-			->error( (string) $e->getMessage(), array( 'source' => PushNotifications::FEATURE_NAME ) );
-
-		return new WP_Error(
-			'woocommerce_internal_error',
-			'Internal server error',
-			array( 'status' => WP_Http::INTERNAL_SERVER_ERROR )
-		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -159,8 +159,6 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	 * Boolean preference keys are derived from the service's defaults map so
 	 * this stays in lock-step with the list of supported notification types.
 	 *
-	 * @since 10.8.0
-	 *
 	 * @return array<string, array<string, mixed>>
 	 */
 	private function get_args(): array {
@@ -191,8 +189,6 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	 * domain-specific WC_Data_Exception details for client-recoverable failures
 	 * (non-500 codes), and log + return a generic internal-error response for
 	 * 500-level / unknown failures.
-	 *
-	 * @since 10.8.0
 	 *
 	 * @param Exception $e The exception to convert.
 	 * @return WP_Error

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -157,7 +157,8 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	/**
 	 * Get the accepted arguments for the POST request.
 	 *
-	 * Boolean preference keys are derived from the service's defaults map so
+	 * Each preference is an object so future sub-fields can be added without
+	 * a schema-version bump. Keys are derived from the service's defaults so
 	 * this stays in lock-step with the list of supported notification types.
 	 *
 	 * @return array<string, array<string, mixed>>
@@ -170,10 +171,16 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 			$args[ $key ] = array(
 				'description'       => sprintf(
 					/* translators: %s: notification preference key (e.g. store_order). */
-					__( 'Enable the %s push notification type.', 'woocommerce' ),
+					__( 'Preferences for the %s push notification type.', 'woocommerce' ),
 					$key
 				),
-				'type'              => 'boolean',
+				'type'              => 'object',
+				'properties'        => array(
+					'enabled' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether this notification type is enabled.', 'woocommerce' ),
+					),
+				),
 				'required'          => false,
 				'validate_callback' => 'rest_validate_request_arg',
 			);

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -111,14 +111,10 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function update_preferences( WP_REST_Request $request ) {
-		$service = wc_get_container()->get( NotificationPreferencesService::class );
-		$input   = array_intersect_key( $request->get_params(), $service->get_defaults() );
-
 		try {
-			$merged = $service->save_preferences(
-				get_current_user_id(),
-				array_map( 'boolval', $input )
-			);
+			$merged = wc_get_container()
+				->get( NotificationPreferencesService::class )
+				->save_preferences( get_current_user_id(), $request->get_params() );
 		} catch ( Exception $e ) {
 			return $this->convert_exception_to_wp_error( $e );
 		}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -1,0 +1,182 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Controllers;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
+use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Controller for the REST endpoints associated with the current user's
+ * push notification preferences.
+ *
+ * @since 10.8.0
+ */
+class NotificationPreferencesRestController extends RestApiControllerBase {
+	/**
+	 * The root namespace for the JSON REST API endpoints.
+	 *
+	 * @var string
+	 */
+	protected string $route_namespace = 'wc-push-notifications';
+
+	/**
+	 * The REST base for the endpoints URL.
+	 *
+	 * @var string
+	 */
+	protected string $rest_base = 'preferences';
+
+	/**
+	 * Class identifier used by `woocommerce_rest_api_get_rest_namespaces`.
+	 *
+	 * Intentionally distinct from the URL `$route_namespace` — the filter keys
+	 * one class per value here, so sharing the value with sibling controllers
+	 * (e.g. `PushTokenRestController`) would overwrite them.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @return string
+	 */
+	protected function get_rest_api_namespace(): string {
+		return 'wc-push-notifications-preferences';
+	}
+
+	/**
+	 * Register the REST API endpoints handled by this controller.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->route_namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => fn ( WP_REST_Request $request ) => $this->run( $request, 'get_preferences' ),
+					'permission_callback' => array( $this, 'authorize_as_authenticated' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => fn ( WP_REST_Request $request ) => $this->run( $request, 'update_preferences' ),
+					'permission_callback' => array( $this, 'authorize_as_authenticated' ),
+					'args'                => $this->get_args(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Return the current user's notification preferences.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_preferences( WP_REST_Request $request ) {
+		unset( $request );
+
+		$preferences = wc_get_container()
+			->get( NotificationPreferencesService::class )
+			->get_preferences( get_current_user_id() );
+
+		return new WP_REST_Response( $preferences, WP_Http::OK );
+	}
+
+	/**
+	 * Partially update the current user's notification preferences and return
+	 * the merged result.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_preferences( WP_REST_Request $request ) {
+		$service = wc_get_container()->get( NotificationPreferencesService::class );
+		$input   = array_intersect_key( $request->get_params(), $service->get_defaults() );
+
+		$service->save_preferences( get_current_user_id(), array_map( 'boolval', $input ) );
+
+		return new WP_REST_Response(
+			$service->get_preferences( get_current_user_id() ),
+			WP_Http::OK
+		);
+	}
+
+	/**
+	 * Checks user is authenticated and authorized to access this endpoint.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return bool|WP_Error
+	 */
+	public function authorize_as_authenticated( WP_REST_Request $request ) {
+		if ( ! get_current_user_id() ) {
+			return new WP_Error(
+				'woocommerce_rest_cannot_view',
+				__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		if ( ! wc_get_container()->get( PushNotifications::class )->should_be_enabled() ) {
+			return false;
+		}
+
+		$has_valid_role = array_reduce(
+			PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED,
+			fn ( $carry, $role ) => $this->check_permission( $request, $role ) === true ? true : $carry,
+			false
+		);
+
+		return $has_valid_role ? true : false;
+	}
+
+	/**
+	 * Get the accepted arguments for the POST request.
+	 *
+	 * Boolean preference keys are derived from the service's defaults map so
+	 * this stays in lock-step with the list of supported notification types.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function get_args(): array {
+		$args     = array();
+		$defaults = wc_get_container()->get( NotificationPreferencesService::class )->get_defaults();
+
+		foreach ( array_keys( $defaults ) as $key ) {
+			$args[ $key ] = array(
+				'description'       => sprintf(
+					/* translators: %s: notification preference key (e.g. store_order). */
+					__( 'Enable the %s push notification type.', 'woocommerce' ),
+					$key
+				),
+				'type'              => 'boolean',
+				'required'          => false,
+				'validate_callback' => 'rest_validate_request_arg',
+			);
+		}
+
+		return $args;
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -41,6 +41,38 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	protected string $rest_base = 'preferences';
 
 	/**
+	 * The notification preferences service.
+	 *
+	 * @var NotificationPreferencesService
+	 */
+	private NotificationPreferencesService $preferences_service;
+
+	/**
+	 * The push notifications module enablement gate.
+	 *
+	 * @var PushNotifications
+	 */
+	private PushNotifications $push_notifications;
+
+	/**
+	 * Initialize injected dependencies.
+	 *
+	 * @internal
+	 *
+	 * @param NotificationPreferencesService $preferences_service The preferences service.
+	 * @param PushNotifications              $push_notifications  The push notifications module.
+	 *
+	 * @since 10.8.0
+	 */
+	final public function init(
+		NotificationPreferencesService $preferences_service,
+		PushNotifications $push_notifications
+	): void {
+		$this->preferences_service = $preferences_service;
+		$this->push_notifications  = $push_notifications;
+	}
+
+	/**
 	 * Class identifier used by `woocommerce_rest_api_get_rest_namespaces`.
 	 *
 	 * Intentionally distinct from the URL `$route_namespace` — the filter keys
@@ -94,9 +126,7 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	public function get_preferences( WP_REST_Request $request ) {
 		unset( $request );
 
-		$preferences = wc_get_container()
-			->get( NotificationPreferencesService::class )
-			->get_preferences( get_current_user_id() );
+		$preferences = $this->preferences_service->get_preferences( get_current_user_id() );
 
 		return new WP_REST_Response( $preferences, WP_Http::OK );
 	}
@@ -113,9 +143,10 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	 */
 	public function update_preferences( WP_REST_Request $request ) {
 		try {
-			$merged = wc_get_container()
-				->get( NotificationPreferencesService::class )
-				->save_preferences( get_current_user_id(), $request->get_params() );
+			$merged = $this->preferences_service->save_preferences(
+				get_current_user_id(),
+				$request->get_params()
+			);
 		} catch ( Exception $e ) {
 			return $this->convert_exception_to_wp_error( $e );
 		}
@@ -141,7 +172,7 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 			);
 		}
 
-		if ( ! wc_get_container()->get( PushNotifications::class )->should_be_enabled() ) {
+		if ( ! $this->push_notifications->should_be_enabled() ) {
 			return false;
 		}
 
@@ -165,7 +196,7 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	 */
 	private function get_args(): array {
 		$args     = array();
-		$defaults = wc_get_container()->get( NotificationPreferencesService::class )->get_defaults();
+		$defaults = $this->preferences_service->get_defaults();
 
 		foreach ( array_keys( $defaults ) as $key ) {
 			$args[ $key ] = array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -11,12 +11,11 @@ use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataS
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenNotFoundException;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Internal\PushNotifications\Traits\ConvertsExceptionsToWpError;
 use Automattic\WooCommerce\Internal\PushNotifications\Validators\PushTokenValidator;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
-use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Exception;
 use WC_Data_Exception;
-use WC_Logger;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -30,6 +29,8 @@ use WP_Http;
  * @since 10.6.0
  */
 class PushTokenRestController extends RestApiControllerBase {
+	use ConvertsExceptionsToWpError;
+
 	/**
 	 * The root namespace for the JSON REST API endpoints.
 	 *
@@ -353,43 +354,6 @@ class PushTokenRestController extends RestApiControllerBase {
 			'woocommerce_rest_cannot_view',
 			__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
 			array( 'status' => rest_authorization_required_code() )
-		);
-	}
-
-	/**
-	 * Converts an exception to an instance of WP_Error.
-	 *
-	 * @since 10.6.0
-	 *
-	 * @param Exception $e The exception to convert.
-	 * @return WP_Error
-	 */
-	private function convert_exception_to_wp_error( Exception $e ): WP_Error {
-		/**
-		 * If the exception is `WC_Data_Exception`, and doesn't represent an
-		 * internal server error (which may contain internal details that should
-		 * be obscured) then format it as a `WP_Error`.
-		 */
-		if (
-			$e instanceof WC_Data_Exception
-			&& $e->getCode() !== WP_Http::INTERNAL_SERVER_ERROR
-		) {
-			return new WP_Error(
-				$e->getErrorCode(),
-				$e->getMessage(),
-				$e->getErrorData()
-			);
-		}
-
-		wc_get_container()
-			->get( LegacyProxy::class )
-			->call_function( 'wc_get_logger' )
-			->error( (string) $e->getMessage(), array( 'source' => PushNotifications::FEATURE_NAME ) );
-
-		return new WP_Error(
-			'woocommerce_internal_error',
-			'Internal server error',
-			array( 'status' => WP_Http::INTERNAL_SERVER_ERROR )
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -45,14 +45,18 @@ class PushTokenRestController extends RestApiControllerBase {
 	protected string $rest_base = 'push-tokens';
 
 	/**
-	 * Get the WooCommerce REST API namespace for the class.
+	 * Class identifier used by `woocommerce_rest_api_get_rest_namespaces`.
+	 *
+	 * Intentionally distinct from the URL `$route_namespace` — the filter keys
+	 * one class per value here, so sharing the value with sibling controllers
+	 * in the same module would overwrite them.
 	 *
 	 * @since 10.6.0
 	 *
 	 * @return string
 	 */
 	protected function get_rest_api_namespace(): string {
-		return $this->route_namespace;
+		return 'wc-push-notifications-push-tokens';
 	}
 
 	/**
@@ -64,7 +68,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	 */
 	public function register_routes(): void {
 		register_rest_route(
-			$this->get_rest_api_namespace(),
+			$this->route_namespace,
 			$this->rest_base,
 			array(
 				array(
@@ -102,7 +106,7 @@ class PushTokenRestController extends RestApiControllerBase {
 		);
 
 		register_rest_route(
-			$this->get_rest_api_namespace(),
+			$this->route_namespace,
 			$this->rest_base . '/(?P<id>[\d]+)',
 			array(
 				array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStore.php
@@ -46,6 +46,8 @@ class NotificationPreferencesDataStore {
 	 *
 	 * @return array|null Envelope with `schema_version` and `preferences` keys, or null if unstored.
 	 *
+	 * @throws WC_Data_Exception When persisting a migrated envelope fails.
+	 *
 	 * @since 10.8.0
 	 */
 	public function read( int $user_id ): ?array {
@@ -59,7 +61,7 @@ class NotificationPreferencesDataStore {
 
 		if ( $stored_version < self::CURRENT_SCHEMA_VERSION ) {
 			$stored = $this->migrate( $stored, $stored_version );
-			Users::update_site_user_meta( $user_id, self::META_KEY, $stored );
+			$this->write( $user_id, $stored );
 		}
 
 		return $stored;

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStore.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\DataStores;
+
+defined( 'ABSPATH' ) || exit;
+
+use WC_Data_Exception;
+use WP_Http;
+
+/**
+ * Persistence layer for per-user push notification preferences.
+ *
+ * Stores a single versioned envelope per user under the `wc_push_notification_preferences`
+ * user meta key. Owns schema migration on read and surfaces real DB write failures via
+ * `WC_Data_Exception`.
+ *
+ * @since 10.8.0
+ */
+class NotificationPreferencesDataStore {
+	/**
+	 * User meta key under which the preferences envelope is stored.
+	 */
+	const META_KEY = 'wc_push_notification_preferences';
+
+	/**
+	 * Current preferences schema version.
+	 *
+	 * Bump when the envelope's `preferences` shape changes, and add a
+	 * corresponding branch to `migrate()`.
+	 */
+	const CURRENT_SCHEMA_VERSION = 1;
+
+	/**
+	 * Read the stored envelope for a user.
+	 *
+	 * Migrates older schema versions on the fly and persists the upgrade so
+	 * callers always receive a current-version envelope. Returns null when
+	 * nothing is stored for the user.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return array|null Envelope with `schema_version` and `preferences` keys, or null if unstored.
+	 *
+	 * @since 10.8.0
+	 */
+	public function read( int $user_id ): ?array {
+		$stored = get_user_meta( $user_id, self::META_KEY, true );
+
+		if ( ! is_array( $stored ) || empty( $stored ) ) {
+			return null;
+		}
+
+		$stored_version = isset( $stored['schema_version'] ) ? (int) $stored['schema_version'] : 0;
+
+		if ( $stored_version < self::CURRENT_SCHEMA_VERSION ) {
+			$stored = $this->migrate( $stored, $stored_version );
+			update_user_meta( $user_id, self::META_KEY, $stored );
+		}
+
+		return $stored;
+	}
+
+	/**
+	 * Persist an envelope for a user.
+	 *
+	 * No-ops when the stored value already matches the supplied envelope.
+	 * Throws `WC_Data_Exception` when the underlying user meta write fails
+	 * for a reason other than the value being unchanged.
+	 *
+	 * @param int   $user_id  The user ID.
+	 * @param array $envelope The envelope to persist (must have `schema_version` and `preferences` keys).
+	 *
+	 * @return void
+	 *
+	 * @throws WC_Data_Exception When the user meta write fails for a non-no-op reason.
+	 *
+	 * @since 10.8.0
+	 */
+	public function write( int $user_id, array $envelope ): void {
+		// Skip the write when the stored envelope already matches. This avoids
+		// the ambiguous `false` return from update_user_meta() that means
+		// either "value unchanged" or "DB write failed" — by short-circuiting
+		// the no-op case, a `false` from the call below unambiguously means
+		// the write itself failed and we can surface it.
+		$stored = get_user_meta( $user_id, self::META_KEY, true );
+		if ( $stored === $envelope ) {
+			return;
+		}
+
+		$result = update_user_meta( $user_id, self::META_KEY, $envelope );
+
+		if ( false === $result ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new WC_Data_Exception(
+				'woocommerce_push_notification_preferences_save_failed',
+				'Failed to save push notification preferences.',
+				WP_Http::INTERNAL_SERVER_ERROR
+			);
+			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+	}
+
+	/**
+	 * Upgrade an envelope to the current schema version.
+	 *
+	 * Pure transformation — does not persist. Missing or malformed
+	 * `preferences` entries are replaced with an empty array; the service
+	 * layer is responsible for filling in defaults from the empty case.
+	 *
+	 * @param array $data         The stored envelope (expected keys: `schema_version`, `preferences`).
+	 * @param int   $from_version The schema version currently on disk.
+	 *
+	 * @return array Envelope upgraded to `self::CURRENT_SCHEMA_VERSION`.
+	 *
+	 * @since 10.8.0
+	 */
+	public function migrate( array $data, int $from_version ): array {
+		// Parameter reserved for future schema migrations.
+		unset( $from_version );
+
+		$preferences = isset( $data['preferences'] ) && is_array( $data['preferences'] )
+			? $data['preferences']
+			: array();
+
+		// For v1 the envelope shape is stable; we only normalize the version tag.
+
+		return array(
+			'schema_version' => self::CURRENT_SCHEMA_VERSION,
+			'preferences'    => $preferences,
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStore.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\DataStores;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use WC_Data_Exception;
 use WP_Http;
 
@@ -13,8 +14,10 @@ use WP_Http;
  * Persistence layer for per-user push notification preferences.
  *
  * Stores a single versioned envelope per user under the `wc_push_notification_preferences`
- * user meta key. Owns schema migration on read and surfaces real DB write failures via
- * `WC_Data_Exception`.
+ * user meta key. The key is automatically scoped to the current site by `Users::*_site_user_meta`,
+ * which prefixes the underlying meta key with the blog ID so preferences set on one site in a
+ * multisite network do not leak to other sites the same user belongs to. Owns schema migration
+ * on read and surfaces real DB write failures via `WC_Data_Exception`.
  *
  * @since 10.8.0
  */
@@ -46,7 +49,7 @@ class NotificationPreferencesDataStore {
 	 * @since 10.8.0
 	 */
 	public function read( int $user_id ): ?array {
-		$stored = get_user_meta( $user_id, self::META_KEY, true );
+		$stored = Users::get_site_user_meta( $user_id, self::META_KEY );
 
 		if ( ! is_array( $stored ) || empty( $stored ) ) {
 			return null;
@@ -56,7 +59,7 @@ class NotificationPreferencesDataStore {
 
 		if ( $stored_version < self::CURRENT_SCHEMA_VERSION ) {
 			$stored = $this->migrate( $stored, $stored_version );
-			update_user_meta( $user_id, self::META_KEY, $stored );
+			Users::update_site_user_meta( $user_id, self::META_KEY, $stored );
 		}
 
 		return $stored;
@@ -84,12 +87,12 @@ class NotificationPreferencesDataStore {
 		// either "value unchanged" or "DB write failed" — by short-circuiting
 		// the no-op case, a `false` from the call below unambiguously means
 		// the write itself failed and we can surface it.
-		$stored = get_user_meta( $user_id, self::META_KEY, true );
+		$stored = Users::get_site_user_meta( $user_id, self::META_KEY );
 		if ( $stored === $envelope ) {
 			return;
 		}
 
-		$result = update_user_meta( $user_id, self::META_KEY, $envelope );
+		$result = Users::update_site_user_meta( $user_id, self::META_KEY, $envelope );
 
 		if ( false === $result ) {
 			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\PushNotifications;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
+use Automattic\WooCommerce\Internal\PushNotifications\Controllers\NotificationPreferencesRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushNotificationRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
@@ -78,6 +79,7 @@ class PushNotifications {
 
 		( new PushTokenRestController() )->register();
 		( new PushNotificationRestController() )->register();
+		( new NotificationPreferencesRestController() )->register();
 		( new NewOrderNotificationTrigger() )->register();
 		( new NewReviewNotificationTrigger() )->register();
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -1,0 +1,151 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages per-user push notification preferences.
+ *
+ * Preferences are stored in user meta under a single versioned envelope,
+ * enabling forward-compatible schema migrations without losing merchant choices.
+ *
+ * @since 10.8.0
+ */
+class NotificationPreferencesService {
+	/**
+	 * User meta key under which the preferences envelope is stored.
+	 */
+	const META_KEY = 'wc_push_notification_preferences';
+
+	/**
+	 * Current preferences schema version.
+	 *
+	 * Bump when the `preferences` shape changes, and add a corresponding
+	 * branch to `migrate()`.
+	 */
+	const CURRENT_SCHEMA_VERSION = 1;
+
+	/**
+	 * Retrieve a user's notification preferences.
+	 *
+	 * Falls back to defaults for users with no stored preferences. If the
+	 * stored envelope is older than the current schema version, it is migrated
+	 * and persisted before being returned.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return array<string, bool> Flat preferences map (preference key => enabled).
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_preferences( int $user_id ): array {
+		$stored = get_user_meta( $user_id, self::META_KEY, true );
+
+		if ( ! is_array( $stored ) || empty( $stored ) ) {
+			return $this->get_defaults();
+		}
+
+		$stored_version = isset( $stored['schema_version'] ) ? (int) $stored['schema_version'] : 0;
+
+		if ( $stored_version < self::CURRENT_SCHEMA_VERSION ) {
+			$stored = $this->migrate( $stored, $stored_version );
+			update_user_meta( $user_id, self::META_KEY, $stored );
+		}
+
+		$preferences = isset( $stored['preferences'] ) && is_array( $stored['preferences'] )
+			? $stored['preferences']
+			: array();
+
+		return $this->sanitize( array_merge( $this->get_defaults(), $preferences ) );
+	}
+
+	/**
+	 * Persist a partial update to a user's notification preferences.
+	 *
+	 * Unknown preference keys are dropped; values are coerced to boolean.
+	 * The merged result is stored inside the current versioned envelope.
+	 *
+	 * @param int                 $user_id     The user ID.
+	 * @param array<string, bool> $preferences Partial preferences to merge over existing values.
+	 *
+	 * @return bool True when the user meta value changed, false otherwise.
+	 *
+	 * @since 10.8.0
+	 */
+	public function save_preferences( int $user_id, array $preferences ): bool {
+		$current = $this->get_preferences( $user_id );
+		$merged  = $this->sanitize( array_merge( $current, $preferences ) );
+
+		$envelope = array(
+			'schema_version' => self::CURRENT_SCHEMA_VERSION,
+			'preferences'    => $merged,
+		);
+
+		return (bool) update_user_meta( $user_id, self::META_KEY, $envelope );
+	}
+
+	/**
+	 * Return the default preferences for a new user.
+	 *
+	 * @return array<string, bool> Flat defaults map.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_defaults(): array {
+		return array(
+			'store_order'  => true,
+			'store_review' => true,
+		);
+	}
+
+	/**
+	 * Migrate a stored preferences envelope up to the current schema version.
+	 *
+	 * Intended to be a pure transformation: callers are responsible for
+	 * persisting the returned envelope if needed. Missing or malformed
+	 * `preferences` entries are replaced with defaults.
+	 *
+	 * @param array $data         The stored envelope (expected keys: `schema_version`, `preferences`).
+	 * @param int   $from_version The schema version currently on disk.
+	 *
+	 * @return array The envelope upgraded to `self::CURRENT_SCHEMA_VERSION`.
+	 *
+	 * @since 10.8.0
+	 */
+	public function migrate( array $data, int $from_version ): array {
+		$preferences = isset( $data['preferences'] ) && is_array( $data['preferences'] )
+			? $data['preferences']
+			: $this->get_defaults();
+
+		// Future schema bumps add cases here (e.g. `if ( $from_version < 2 ) { ... }`).
+		// For v1 the envelope shape is stable; we only normalize the version tag.
+
+		return array(
+			'schema_version' => self::CURRENT_SCHEMA_VERSION,
+			'preferences'    => $preferences,
+		);
+	}
+
+	/**
+	 * Drop unknown keys and coerce values to boolean.
+	 *
+	 * @param array $preferences Arbitrary preferences map.
+	 *
+	 * @return array<string, bool> Sanitized preferences restricted to known default keys.
+	 */
+	private function sanitize( array $preferences ): array {
+		$allowed   = $this->get_defaults();
+		$sanitized = array();
+
+		foreach ( $allowed as $key => $default ) {
+			$sanitized[ $key ] = array_key_exists( $key, $preferences )
+				? (bool) $preferences[ $key ]
+				: $default;
+		}
+
+		return $sanitized;
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -116,11 +116,13 @@ class NotificationPreferencesService {
 	 * @since 10.8.0
 	 */
 	public function migrate( array $data, int $from_version ): array {
+		// Parameter reserved for future schema migrations.
+		unset( $from_version );
+
 		$preferences = isset( $data['preferences'] ) && is_array( $data['preferences'] )
 			? $data['preferences']
 			: $this->get_defaults();
 
-		// Future schema bumps add cases here (e.g. `if ( $from_version < 2 ) { ... }`).
 		// For v1 the envelope shape is stable; we only normalize the version tag.
 
 		return array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -48,7 +48,7 @@ class NotificationPreferencesService {
 	 *
 	 * @param int $user_id The user ID.
 	 *
-	 * @return array<string, bool> Flat preferences map (preference key => enabled).
+	 * @return array<string, array<string, mixed>> Map of preference key => sub-options.
 	 *
 	 * @since 10.8.0
 	 */
@@ -69,14 +69,14 @@ class NotificationPreferencesService {
 	/**
 	 * Persist a partial update to a user's notification preferences.
 	 *
-	 * Unknown preference keys are dropped; values are coerced to boolean.
+	 * Unknown top-level keys and unknown sub-fields per key are dropped.
 	 * The merged result is wrapped in the current versioned envelope and
 	 * handed to the data store.
 	 *
-	 * @param int                 $user_id     The user ID.
-	 * @param array<string, bool> $preferences Partial preferences to merge over existing values.
+	 * @param int                                 $user_id     The user ID.
+	 * @param array<string, array<string, mixed>> $preferences Partial preferences to merge over existing values.
 	 *
-	 * @return array<string, bool> The merged, sanitized preferences map after the save.
+	 * @return array<string, array<string, mixed>> The merged, sanitized preferences map after the save.
 	 *
 	 * @throws \WC_Data_Exception Propagated from the data store on real persistence failure.
 	 *
@@ -101,33 +101,71 @@ class NotificationPreferencesService {
 	/**
 	 * Return the default preferences for a new user.
 	 *
-	 * The keyset is derived from `Notification::NOTIFICATION_CLASSES` so that
-	 * adding a new notification type automatically opts it into preferences
-	 * with `true` as the default — no parallel list to keep in sync.
+	 * Each preference is a small object so future fields (thresholds, sub-toggles)
+	 * can be added without bumping the schema version. The keyset is derived from
+	 * `Notification::NOTIFICATION_CLASSES` so adding a new notification type
+	 * automatically opts it into preferences — no parallel list to keep in sync.
 	 *
-	 * @return array<string, bool> Flat defaults map.
+	 * @return array<string, array<string, mixed>> Map of preference key => default sub-options.
 	 *
 	 * @since 10.8.0
 	 */
 	public function get_defaults(): array {
-		return array_fill_keys( array_keys( Notification::NOTIFICATION_CLASSES ), true );
+		$defaults = array();
+		foreach ( array_keys( Notification::NOTIFICATION_CLASSES ) as $type ) {
+			$defaults[ $type ] = array( 'enabled' => true );
+		}
+		return $defaults;
 	}
 
 	/**
-	 * Drop unknown keys and coerce values to boolean.
+	 * Drop unknown top-level keys and unknown sub-fields per key, coercing
+	 * known sub-fields to their expected types.
 	 *
 	 * @param array $preferences Arbitrary preferences map.
 	 *
-	 * @return array<string, bool> Sanitized preferences restricted to known default keys.
+	 * @return array<string, array<string, mixed>> Sanitized preferences.
 	 */
 	private function sanitize( array $preferences ): array {
 		$allowed   = $this->get_defaults();
 		$sanitized = array();
 
-		foreach ( $allowed as $key => $default ) {
-			$sanitized[ $key ] = array_key_exists( $key, $preferences )
-				? (bool) $preferences[ $key ]
-				: $default;
+		foreach ( $allowed as $key => $default_shape ) {
+			$value             = $preferences[ $key ] ?? array();
+			$value             = is_array( $value ) ? $value : array();
+			$sanitized[ $key ] = $this->sanitize_value( $key, $value, $default_shape );
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Apply per-key sanitization to a single preference's sub-options.
+	 *
+	 * Unknown sub-keys are dropped; missing sub-keys fall back to their default.
+	 * Today only `enabled` is recognized; future preference types extend this method
+	 * (or its dispatch) to validate their additional sub-fields.
+	 *
+	 * @param string               $key           Preference key (e.g. `store_order`).
+	 * @param array                $value         Submitted sub-options for the key.
+	 * @param array<string, mixed> $default_shape Default sub-options for the key.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function sanitize_value( string $key, array $value, array $default_shape ): array {
+		// Reserved for per-key dispatch when sub-fields are added.
+		unset( $key );
+
+		$sanitized = array();
+
+		foreach ( $default_shape as $sub_key => $sub_default ) {
+			if ( 'enabled' === $sub_key ) {
+				$sanitized[ $sub_key ] = array_key_exists( $sub_key, $value )
+					? (bool) $value[ $sub_key ]
+					: (bool) $sub_default;
+				continue;
+			}
+			// Future sub-fields (thresholds, sub-toggles) extend this switch.
 		}
 
 		return $sanitized;

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -6,6 +6,9 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Services;
 
 defined( 'ABSPATH' ) || exit;
 
+use WC_Data_Exception;
+use WP_Http;
+
 /**
  * Manages per-user push notification preferences.
  *
@@ -71,11 +74,13 @@ class NotificationPreferencesService {
 	 * @param int                 $user_id     The user ID.
 	 * @param array<string, bool> $preferences Partial preferences to merge over existing values.
 	 *
-	 * @return bool True when the user meta value changed, false otherwise.
+	 * @return array<string, bool> The merged, sanitized preferences map after the save.
+	 *
+	 * @throws WC_Data_Exception When the user meta write fails for a non-no-op reason.
 	 *
 	 * @since 10.8.0
 	 */
-	public function save_preferences( int $user_id, array $preferences ): bool {
+	public function save_preferences( int $user_id, array $preferences ): array {
 		$current = $this->get_preferences( $user_id );
 		$merged  = $this->sanitize( array_merge( $current, $preferences ) );
 
@@ -84,7 +89,29 @@ class NotificationPreferencesService {
 			'preferences'    => $merged,
 		);
 
-		return (bool) update_user_meta( $user_id, self::META_KEY, $envelope );
+		// Skip the write when the stored envelope already matches. This avoids
+		// the ambiguous `false` return from update_user_meta() that means
+		// either "value unchanged" or "DB write failed" — by short-circuiting
+		// the no-op case, a `false` from the call below unambiguously means
+		// the write itself failed and we can surface it.
+		$stored = get_user_meta( $user_id, self::META_KEY, true );
+		if ( $stored === $envelope ) {
+			return $merged;
+		}
+
+		$result = update_user_meta( $user_id, self::META_KEY, $envelope );
+
+		if ( false === $result ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new WC_Data_Exception(
+				'woocommerce_push_notification_preferences_save_failed',
+				'Failed to save push notification preferences.',
+				WP_Http::INTERNAL_SERVER_ERROR
+			);
+			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		return $merged;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Services;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\PushNotifications\DataStores\NotificationPreferencesDataStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
 
 /**
  * Manages per-user push notification preferences.
@@ -100,15 +101,16 @@ class NotificationPreferencesService {
 	/**
 	 * Return the default preferences for a new user.
 	 *
+	 * The keyset is derived from `Notification::NOTIFICATION_CLASSES` so that
+	 * adding a new notification type automatically opts it into preferences
+	 * with `true` as the default — no parallel list to keep in sync.
+	 *
 	 * @return array<string, bool> Flat defaults map.
 	 *
 	 * @since 10.8.0
 	 */
 	public function get_defaults(): array {
-		return array(
-			'store_order'  => true,
-			'store_review' => true,
-		);
+		return array_fill_keys( array_keys( Notification::NOTIFICATION_CLASSES ), true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -6,37 +6,44 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Services;
 
 defined( 'ABSPATH' ) || exit;
 
-use WC_Data_Exception;
-use WP_Http;
+use Automattic\WooCommerce\Internal\PushNotifications\DataStores\NotificationPreferencesDataStore;
 
 /**
  * Manages per-user push notification preferences.
  *
- * Preferences are stored in user meta under a single versioned envelope,
- * enabling forward-compatible schema migrations without losing merchant choices.
+ * Owns the domain logic — the default preference values and how arbitrary
+ * input is sanitized — and delegates persistence to
+ * `NotificationPreferencesDataStore`.
  *
  * @since 10.8.0
  */
 class NotificationPreferencesService {
 	/**
-	 * User meta key under which the preferences envelope is stored.
+	 * The data store used for persistence.
+	 *
+	 * @var NotificationPreferencesDataStore
 	 */
-	const META_KEY = 'wc_push_notification_preferences';
+	private NotificationPreferencesDataStore $data_store;
 
 	/**
-	 * Current preferences schema version.
+	 * Initialize injected dependencies.
 	 *
-	 * Bump when the `preferences` shape changes, and add a corresponding
-	 * branch to `migrate()`.
+	 * @internal
+	 *
+	 * @param NotificationPreferencesDataStore $data_store The data store.
+	 *
+	 * @since 10.8.0
 	 */
-	const CURRENT_SCHEMA_VERSION = 1;
+	final public function init( NotificationPreferencesDataStore $data_store ): void {
+		$this->data_store = $data_store;
+	}
 
 	/**
 	 * Retrieve a user's notification preferences.
 	 *
-	 * Falls back to defaults for users with no stored preferences. If the
-	 * stored envelope is older than the current schema version, it is migrated
-	 * and persisted before being returned.
+	 * Falls back to defaults for users with no stored preferences. Stored
+	 * preferences are overlaid on top of the defaults so that any newer keys
+	 * not yet on disk are filled in.
 	 *
 	 * @param int $user_id The user ID.
 	 *
@@ -45,38 +52,32 @@ class NotificationPreferencesService {
 	 * @since 10.8.0
 	 */
 	public function get_preferences( int $user_id ): array {
-		$stored = get_user_meta( $user_id, self::META_KEY, true );
+		$envelope = $this->data_store->read( $user_id );
 
-		if ( ! is_array( $stored ) || empty( $stored ) ) {
+		if ( null === $envelope ) {
 			return $this->get_defaults();
 		}
 
-		$stored_version = isset( $stored['schema_version'] ) ? (int) $stored['schema_version'] : 0;
-
-		if ( $stored_version < self::CURRENT_SCHEMA_VERSION ) {
-			$stored = $this->migrate( $stored, $stored_version );
-			update_user_meta( $user_id, self::META_KEY, $stored );
-		}
-
-		$preferences = isset( $stored['preferences'] ) && is_array( $stored['preferences'] )
-			? $stored['preferences']
+		$stored = isset( $envelope['preferences'] ) && is_array( $envelope['preferences'] )
+			? $envelope['preferences']
 			: array();
 
-		return $this->sanitize( array_merge( $this->get_defaults(), $preferences ) );
+		return $this->sanitize( array_merge( $this->get_defaults(), $stored ) );
 	}
 
 	/**
 	 * Persist a partial update to a user's notification preferences.
 	 *
 	 * Unknown preference keys are dropped; values are coerced to boolean.
-	 * The merged result is stored inside the current versioned envelope.
+	 * The merged result is wrapped in the current versioned envelope and
+	 * handed to the data store.
 	 *
 	 * @param int                 $user_id     The user ID.
 	 * @param array<string, bool> $preferences Partial preferences to merge over existing values.
 	 *
 	 * @return array<string, bool> The merged, sanitized preferences map after the save.
 	 *
-	 * @throws WC_Data_Exception When the user meta write fails for a non-no-op reason.
+	 * @throws \WC_Data_Exception Propagated from the data store on real persistence failure.
 	 *
 	 * @since 10.8.0
 	 */
@@ -84,32 +85,14 @@ class NotificationPreferencesService {
 		$current = $this->get_preferences( $user_id );
 		$merged  = $this->sanitize( array_merge( $current, $preferences ) );
 
-		$envelope = array(
-			'schema_version' => self::CURRENT_SCHEMA_VERSION,
-			'preferences'    => $merged,
+		// Data store throws WC_Data_Exception on real failure; let it propagate.
+		$this->data_store->write(
+			$user_id,
+			array(
+				'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+				'preferences'    => $merged,
+			)
 		);
-
-		// Skip the write when the stored envelope already matches. This avoids
-		// the ambiguous `false` return from update_user_meta() that means
-		// either "value unchanged" or "DB write failed" — by short-circuiting
-		// the no-op case, a `false` from the call below unambiguously means
-		// the write itself failed and we can surface it.
-		$stored = get_user_meta( $user_id, self::META_KEY, true );
-		if ( $stored === $envelope ) {
-			return $merged;
-		}
-
-		$result = update_user_meta( $user_id, self::META_KEY, $envelope );
-
-		if ( false === $result ) {
-			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw new WC_Data_Exception(
-				'woocommerce_push_notification_preferences_save_failed',
-				'Failed to save push notification preferences.',
-				WP_Http::INTERNAL_SERVER_ERROR
-			);
-			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
-		}
 
 		return $merged;
 	}
@@ -125,36 +108,6 @@ class NotificationPreferencesService {
 		return array(
 			'store_order'  => true,
 			'store_review' => true,
-		);
-	}
-
-	/**
-	 * Migrate a stored preferences envelope up to the current schema version.
-	 *
-	 * Intended to be a pure transformation: callers are responsible for
-	 * persisting the returned envelope if needed. Missing or malformed
-	 * `preferences` entries are replaced with defaults.
-	 *
-	 * @param array $data         The stored envelope (expected keys: `schema_version`, `preferences`).
-	 * @param int   $from_version The schema version currently on disk.
-	 *
-	 * @return array The envelope upgraded to `self::CURRENT_SCHEMA_VERSION`.
-	 *
-	 * @since 10.8.0
-	 */
-	public function migrate( array $data, int $from_version ): array {
-		// Parameter reserved for future schema migrations.
-		unset( $from_version );
-
-		$preferences = isset( $data['preferences'] ) && is_array( $data['preferences'] )
-			? $data['preferences']
-			: $this->get_defaults();
-
-		// For v1 the envelope shape is stable; we only normalize the version tag.
-
-		return array(
-			'schema_version' => self::CURRENT_SCHEMA_VERSION,
-			'preferences'    => $preferences,
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -63,7 +63,7 @@ class NotificationPreferencesService {
 			? $envelope['preferences']
 			: array();
 
-		return $this->sanitize( array_merge( $this->get_defaults(), $stored ) );
+		return $this->sanitize( array_replace_recursive( $this->get_defaults(), $stored ) );
 	}
 
 	/**
@@ -84,7 +84,7 @@ class NotificationPreferencesService {
 	 */
 	public function save_preferences( int $user_id, array $preferences ): array {
 		$current = $this->get_preferences( $user_id );
-		$merged  = $this->sanitize( array_merge( $current, $preferences ) );
+		$merged  = $this->sanitize( array_replace_recursive( $current, $preferences ) );
 
 		// Data store throws WC_Data_Exception on real failure; let it propagate.
 		$this->data_store->write(
@@ -152,7 +152,7 @@ class NotificationPreferencesService {
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function sanitize_value( string $key, array $value, array $default_shape ): array {
+	protected function sanitize_value( string $key, array $value, array $default_shape ): array {
 		// Reserved for per-key dispatch when sub-fields are added.
 		unset( $key );
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Traits/ConvertsExceptionsToWpError.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Traits/ConvertsExceptionsToWpError.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Traits;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use Exception;
+use WC_Data_Exception;
+use WP_Error;
+use WP_Http;
+
+/**
+ * Shared converter for REST controller catch blocks in the PushNotifications
+ * module.
+ *
+ * Surfaces domain-specific `WC_Data_Exception` details for client-recoverable
+ * failures (non-500 status codes), and logs + returns a generic
+ * internal-error response for 500-level or unrecognized exceptions so that
+ * internal details aren't leaked to API clients.
+ */
+trait ConvertsExceptionsToWpError {
+	/**
+	 * Convert an exception thrown by a service into a WP_Error suitable for
+	 * the REST response.
+	 *
+	 * @param Exception $e The exception to convert.
+	 * @return WP_Error
+	 */
+	protected function convert_exception_to_wp_error( Exception $e ): WP_Error {
+		// Non-500 WC_Data_Exception: client-recoverable, surface details.
+		if (
+			$e instanceof WC_Data_Exception
+			&& $e->getCode() !== WP_Http::INTERNAL_SERVER_ERROR
+		) {
+			return new WP_Error(
+				$e->getErrorCode(),
+				$e->getMessage(),
+				$e->getErrorData()
+			);
+		}
+
+		// Anything else: log and surface a generic 500.
+		wc_get_container()
+			->get( LegacyProxy::class )
+			->call_function( 'wc_get_logger' )
+			->error( $e->getMessage(), array( 'source' => PushNotifications::FEATURE_NAME ) );
+
+		return new WP_Error(
+			'woocommerce_internal_error',
+			__( 'Internal server error', 'woocommerce' ),
+			array( 'status' => WP_Http::INTERNAL_SERVER_ERROR )
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -189,7 +189,13 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		wc_get_container()
 			->get( NotificationPreferencesService::class )
-			->save_preferences( $this->user_id, array( 'store_order' => false, 'store_review' => false ) );
+			->save_preferences(
+				$this->user_id,
+				array(
+					'store_order'  => false,
+					'store_review' => false,
+				)
+			);
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
 		$request->set_param( 'store_review', true );
@@ -217,7 +223,10 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		$preferences_controller->register();
 		$push_token_controller->register();
 
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Triggering an existing filter from RestApiControllerBase, not defining one.
 		$namespaces = apply_filters( 'woocommerce_rest_api_get_rest_namespaces', array( 'wc/v3' => array() ) );
+
+		$this->assertArrayHasKey( 'wc/v3', $namespaces );
 
 		$registered_classes = array_values( $namespaces['wc/v3'] );
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -46,10 +46,17 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->set_up_features_controller_mock();
 		$this->reset_push_notifications_cache();
 
-		( new NotificationPreferencesRestController() )->register_routes();
-
 		$this->user_id       = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
 		$this->subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	/**
+	 * Register the controller's routes using the container so init() auto-wires the service
+	 * and push-notifications dependencies. Tests call this after setting up any container
+	 * mocks they need (e.g. replacing the service) so the resolved controller picks them up.
+	 */
+	private function register_routes(): void {
+		wc_get_container()->get( NotificationPreferencesRestController::class )->register_routes();
 	}
 
 	/**
@@ -73,6 +80,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_preferences_requires_authentication() {
 		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
 
 		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/preferences' );
 		$response = $this->server->dispatch( $request );
@@ -86,6 +94,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function test_get_preferences_rejects_users_without_role() {
 		wp_set_current_user( $this->subscriber_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
 
 		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/preferences' );
 		$response = $this->server->dispatch( $request );
@@ -99,6 +108,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function test_get_preferences_returns_user_preferences() {
 		wp_set_current_user( $this->user_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
 
 		wc_get_container()
 			->get( NotificationPreferencesService::class )
@@ -125,6 +135,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function test_post_preferences_updates_settings() {
 		wp_set_current_user( $this->user_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
 		$request->set_param( 'store_order', array( 'enabled' => false ) );
@@ -146,6 +157,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function test_post_preferences_rejects_non_object_value() {
 		wp_set_current_user( $this->user_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
 		$request->set_param( 'store_order', 'not-an-object' );
@@ -161,6 +173,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function test_post_preferences_rejects_non_boolean_enabled() {
 		wp_set_current_user( $this->user_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
 		$request->set_param( 'store_order', array( 'enabled' => 'not-a-boolean' ) );
@@ -176,6 +189,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function test_patch_preferences_updates_settings() {
 		wp_set_current_user( $this->user_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
 
 		$request = new WP_REST_Request( 'PATCH', '/wc-push-notifications/preferences' );
 		$request->set_param( 'store_order', array( 'enabled' => false ) );
@@ -194,6 +208,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function test_post_preferences_returns_merged_result() {
 		wp_set_current_user( $this->user_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
 
 		wc_get_container()
 			->get( NotificationPreferencesService::class )
@@ -243,6 +258,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		);
 
 		wc_get_container()->replace( NotificationPreferencesService::class, $service_mock );
+		$this->register_routes();
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
 		$request->set_param( 'store_review', array( 'enabled' => false ) );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -4,15 +4,10 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Controllers;
 
-use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\NotificationPreferencesRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
-use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
-use Automattic\WooCommerce\Proxies\LegacyProxy;
-use PHPUnit\Framework\MockObject\MockObject;
-use ReflectionClass;
+use Automattic\WooCommerce\Tests\Internal\PushNotifications\Helpers\PushNotificationsTestTrait;
 use WC_Data_Exception;
 use WC_REST_Unit_Test_Case;
 use WP_Http;
@@ -24,6 +19,8 @@ use WP_REST_Request;
  * @package WooCommerce\Tests\PushNotifications
  */
 class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
+	use PushNotificationsTestTrait;
+
 	/**
 	 * Shop manager user ID for testing.
 	 *
@@ -37,16 +34,6 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * @var int
 	 */
 	private $subscriber_id;
-
-	/**
-	 * @var JetpackConnectionManager|MockObject
-	 */
-	private $jetpack_connection_manager_mock;
-
-	/**
-	 * @var FeaturesController|MockObject
-	 */
-	private $features_controller_mock;
 
 	/**
 	 * Set up test.
@@ -269,62 +256,5 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->assertContains( NotificationPreferencesRestController::class, $registered_classes );
 		$this->assertContains( PushTokenRestController::class, $registered_classes );
-	}
-
-	/**
-	 * Mocks the JetpackConnectionManager class to report whether Jetpack is connected.
-	 *
-	 * @param bool $is_connected Whether the manager should report Jetpack is connected.
-	 */
-	private function mock_jetpack_connection_manager_is_connected( bool $is_connected = true ) {
-		$this->jetpack_connection_manager_mock = $this
-			->getMockBuilder( JetpackConnectionManager::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'is_connected' ) )
-			->getMock();
-
-		wc_get_container()->get( LegacyProxy::class )->register_class_mocks(
-			array( JetpackConnectionManager::class => $this->jetpack_connection_manager_mock )
-		);
-
-		$this->jetpack_connection_manager_mock
-			->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( $is_connected );
-
-		$this->reset_push_notifications_cache();
-	}
-
-	/**
-	 * Sets up the FeaturesController mock to enable the push_notifications feature.
-	 */
-	private function set_up_features_controller_mock() {
-		$this->features_controller_mock = $this
-			->getMockBuilder( FeaturesController::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'feature_is_enabled' ) )
-			->getMock();
-
-		$this->features_controller_mock
-			->method( 'feature_is_enabled' )
-			->willReturnCallback(
-				function ( $feature_id ) {
-					return PushNotifications::FEATURE_NAME === $feature_id;
-				}
-			);
-
-		wc_get_container()->replace( FeaturesController::class, $this->features_controller_mock );
-	}
-
-	/**
-	 * Resets the cached enablement state on the container's PushNotifications instance.
-	 */
-	private function reset_push_notifications_cache() {
-		$push_notifications = wc_get_container()->get( PushNotifications::class );
-		$reflection         = new ReflectionClass( $push_notifications );
-		$property           = $reflection->getProperty( 'enabled' );
-
-		$property->setAccessible( true );
-		$property->setValue( $push_notifications, null );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Controllers;
 
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\NotificationPreferencesRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
+use Automattic\WooCommerce\Internal\PushNotifications\DataStores\NotificationPreferencesDataStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Tests\Internal\PushNotifications\Helpers\PushNotificationsTestTrait;
 use WC_Data_Exception;
@@ -56,7 +57,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function tearDown(): void {
 		wp_set_current_user( 0 );
 
-		delete_user_meta( $this->user_id, NotificationPreferencesService::META_KEY );
+		delete_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		wp_delete_user( $this->user_id );
 		wp_delete_user( $this->subscriber_id );
 
@@ -129,7 +130,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->assertSame( WP_Http::OK, $response->get_status() );
 
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
 		$this->assertIsArray( $stored );
 		$this->assertFalse( $stored['preferences']['store_order'] );
 		$this->assertFalse( $stored['preferences']['store_review'] );
@@ -164,7 +165,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->assertSame( WP_Http::OK, $response->get_status() );
 
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
 		$this->assertFalse( $stored['preferences']['store_order'] );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Controllers;
+
+use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\PushNotifications\Controllers\NotificationPreferencesRestController;
+use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionClass;
+use WC_REST_Unit_Test_Case;
+use WP_Http;
+use WP_REST_Request;
+
+/**
+ * Tests for the NotificationPreferencesRestController class.
+ *
+ * @package WooCommerce\Tests\PushNotifications
+ */
+class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
+	/**
+	 * Shop manager user ID for testing.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Subscriber user ID for testing.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * @var JetpackConnectionManager|MockObject
+	 */
+	private $jetpack_connection_manager_mock;
+
+	/**
+	 * @var FeaturesController|MockObject
+	 */
+	private $features_controller_mock;
+
+	/**
+	 * Set up test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->set_up_features_controller_mock();
+		$this->reset_push_notifications_cache();
+
+		( new NotificationPreferencesRestController() )->register_routes();
+
+		$this->user_id       = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
+		$this->subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	/**
+	 * Tear down test.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		delete_user_meta( $this->user_id, NotificationPreferencesService::META_KEY );
+		wp_delete_user( $this->user_id );
+		wp_delete_user( $this->subscriber_id );
+
+		$this->reset_container_replacements();
+		wc_get_container()->reset_all_resolved();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox GET should reject unauthenticated requests.
+	 */
+	public function test_get_preferences_requires_authentication() {
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/preferences' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( rest_authorization_required_code(), $response->get_status() );
+	}
+
+	/**
+	 * @testdox GET should reject users without a push-notifications role.
+	 */
+	public function test_get_preferences_rejects_users_without_role() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/preferences' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_status() );
+	}
+
+	/**
+	 * @testdox GET should return the current user's preferences merged with defaults.
+	 */
+	public function test_get_preferences_returns_user_preferences() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		wc_get_container()
+			->get( NotificationPreferencesService::class )
+			->save_preferences( $this->user_id, array( 'store_order' => false ) );
+
+		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/preferences' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'store_order', $data );
+		$this->assertFalse( $data['store_order'] );
+		$this->assertArrayHasKey( 'store_review', $data );
+		$this->assertTrue( $data['store_review'] );
+	}
+
+	/**
+	 * @testdox POST should persist new preferences to the authenticated user.
+	 */
+	public function test_post_preferences_updates_settings() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
+		$request->set_param( 'store_order', false );
+		$request->set_param( 'store_review', false );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
+		$this->assertIsArray( $stored );
+		$this->assertFalse( $stored['preferences']['store_order'] );
+		$this->assertFalse( $stored['preferences']['store_review'] );
+	}
+
+	/**
+	 * @testdox POST should reject non-boolean values via the REST validation layer.
+	 */
+	public function test_post_preferences_validates_input() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
+		$request->set_param( 'store_order', 'not-a-boolean' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::BAD_REQUEST, $response->get_status() );
+	}
+
+	/**
+	 * @testdox PATCH should be accepted and update preferences like POST.
+	 */
+	public function test_patch_preferences_updates_settings() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'PATCH', '/wc-push-notifications/preferences' );
+		$request->set_param( 'store_order', false );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
+		$this->assertFalse( $stored['preferences']['store_order'] );
+	}
+
+	/**
+	 * @testdox POST should return the merged preferences after partial update.
+	 */
+	public function test_post_preferences_returns_merged_result() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		wc_get_container()
+			->get( NotificationPreferencesService::class )
+			->save_preferences( $this->user_id, array( 'store_order' => false, 'store_review' => false ) );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
+		$request->set_param( 'store_review', true );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['store_order'] );
+		$this->assertTrue( $data['store_review'] );
+	}
+
+	/**
+	 * @testdox Should not collide with PushTokenRestController on the WC REST namespaces filter.
+	 *
+	 * Both controllers share the URL route namespace `wc-push-notifications`, but they must use
+	 * distinct class identifiers via `get_rest_api_namespace()` so that neither overwrites the
+	 * other in the `woocommerce_rest_api_get_rest_namespaces` filter output.
+	 */
+	public function test_does_not_overwrite_sibling_controller_in_rest_namespaces_filter() {
+		$preferences_controller = new NotificationPreferencesRestController();
+		$push_token_controller  = new PushTokenRestController();
+
+		$preferences_controller->register();
+		$push_token_controller->register();
+
+		$namespaces = apply_filters( 'woocommerce_rest_api_get_rest_namespaces', array( 'wc/v3' => array() ) );
+
+		$registered_classes = array_values( $namespaces['wc/v3'] );
+
+		$this->assertContains( NotificationPreferencesRestController::class, $registered_classes );
+		$this->assertContains( PushTokenRestController::class, $registered_classes );
+	}
+
+	/**
+	 * Mocks the JetpackConnectionManager class to report whether Jetpack is connected.
+	 *
+	 * @param bool $is_connected Whether the manager should report Jetpack is connected.
+	 */
+	private function mock_jetpack_connection_manager_is_connected( bool $is_connected = true ) {
+		$this->jetpack_connection_manager_mock = $this
+			->getMockBuilder( JetpackConnectionManager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'is_connected' ) )
+			->getMock();
+
+		wc_get_container()->get( LegacyProxy::class )->register_class_mocks(
+			array( JetpackConnectionManager::class => $this->jetpack_connection_manager_mock )
+		);
+
+		$this->jetpack_connection_manager_mock
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( $is_connected );
+
+		$this->reset_push_notifications_cache();
+	}
+
+	/**
+	 * Sets up the FeaturesController mock to enable the push_notifications feature.
+	 */
+	private function set_up_features_controller_mock() {
+		$this->features_controller_mock = $this
+			->getMockBuilder( FeaturesController::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'feature_is_enabled' ) )
+			->getMock();
+
+		$this->features_controller_mock
+			->method( 'feature_is_enabled' )
+			->willReturnCallback(
+				function ( $feature_id ) {
+					return PushNotifications::FEATURE_NAME === $feature_id;
+				}
+			);
+
+		wc_get_container()->replace( FeaturesController::class, $this->features_controller_mock );
+	}
+
+	/**
+	 * Resets the cached enablement state on the container's PushNotifications instance.
+	 */
+	private function reset_push_notifications_cache() {
+		$push_notifications = wc_get_container()->get( PushNotifications::class );
+		$reflection         = new ReflectionClass( $push_notifications );
+		$property           = $reflection->getProperty( 'enabled' );
+
+		$property->setAccessible( true );
+		$property->setValue( $push_notifications, null );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Controllers\NotificationPr
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\DataStores\NotificationPreferencesDataStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use Automattic\WooCommerce\Tests\Internal\PushNotifications\Helpers\PushNotificationsTestTrait;
 use WC_Data_Exception;
 use WC_REST_Unit_Test_Case;
@@ -57,7 +58,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function tearDown(): void {
 		wp_set_current_user( 0 );
 
-		delete_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
+		Users::delete_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		wp_delete_user( $this->user_id );
 		wp_delete_user( $this->subscriber_id );
 
@@ -130,7 +131,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->assertSame( WP_Http::OK, $response->get_status() );
 
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
+		$stored = Users::get_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		$this->assertIsArray( $stored );
 		$this->assertFalse( $stored['preferences']['store_order'] );
 		$this->assertFalse( $stored['preferences']['store_review'] );
@@ -165,7 +166,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->assertSame( WP_Http::OK, $response->get_status() );
 
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
+		$stored = Users::get_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		$this->assertFalse( $stored['preferences']['store_order'] );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPrefe
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
+use WC_Data_Exception;
 use WC_REST_Unit_Test_Case;
 use WP_Http;
 use WP_REST_Request;
@@ -207,6 +208,42 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$this->assertFalse( $data['store_order'] );
 		$this->assertTrue( $data['store_review'] );
+	}
+
+	/**
+	 * @testdox POST should return a 500 when the service throws a persistence error.
+	 */
+	public function test_post_preferences_returns_500_when_service_throws() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$service_mock = $this->createMock( NotificationPreferencesService::class );
+		$service_mock->method( 'get_defaults' )->willReturn(
+			array(
+				'store_order'  => true,
+				'store_review' => true,
+			)
+		);
+		$service_mock->method( 'save_preferences' )->willThrowException(
+			new WC_Data_Exception(
+				'woocommerce_push_notification_preferences_save_failed',
+				'Failed to save push notification preferences.',
+				WP_Http::INTERNAL_SERVER_ERROR
+			)
+		);
+
+		wc_get_container()->replace( NotificationPreferencesService::class, $service_mock );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
+		$request->set_param( 'store_review', false );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::INTERNAL_SERVER_ERROR, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertSame( 'woocommerce_internal_error', $data['code'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -102,7 +102,10 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		wc_get_container()
 			->get( NotificationPreferencesService::class )
-			->save_preferences( $this->user_id, array( 'store_order' => false ) );
+			->save_preferences(
+				$this->user_id,
+				array( 'store_order' => array( 'enabled' => false ) )
+			);
 
 		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/preferences' );
 		$response = $this->server->dispatch( $request );
@@ -111,9 +114,9 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'store_order', $data );
-		$this->assertFalse( $data['store_order'] );
+		$this->assertFalse( $data['store_order']['enabled'] );
 		$this->assertArrayHasKey( 'store_review', $data );
-		$this->assertTrue( $data['store_review'] );
+		$this->assertTrue( $data['store_review']['enabled'] );
 	}
 
 	/**
@@ -124,8 +127,8 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_jetpack_connection_manager_is_connected( true );
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
-		$request->set_param( 'store_order', false );
-		$request->set_param( 'store_review', false );
+		$request->set_param( 'store_order', array( 'enabled' => false ) );
+		$request->set_param( 'store_review', array( 'enabled' => false ) );
 
 		$response = $this->server->dispatch( $request );
 
@@ -133,19 +136,34 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$stored = Users::get_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		$this->assertIsArray( $stored );
-		$this->assertFalse( $stored['preferences']['store_order'] );
-		$this->assertFalse( $stored['preferences']['store_review'] );
+		$this->assertFalse( $stored['preferences']['store_order']['enabled'] );
+		$this->assertFalse( $stored['preferences']['store_review']['enabled'] );
 	}
 
 	/**
-	 * @testdox POST should reject non-boolean values via the REST validation layer.
+	 * @testdox POST should reject non-object values via the REST validation layer.
 	 */
-	public function test_post_preferences_validates_input() {
+	public function test_post_preferences_rejects_non_object_value() {
 		wp_set_current_user( $this->user_id );
 		$this->mock_jetpack_connection_manager_is_connected( true );
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
-		$request->set_param( 'store_order', 'not-a-boolean' );
+		$request->set_param( 'store_order', 'not-an-object' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::BAD_REQUEST, $response->get_status() );
+	}
+
+	/**
+	 * @testdox POST should reject non-boolean `enabled` sub-fields via the REST validation layer.
+	 */
+	public function test_post_preferences_rejects_non_boolean_enabled() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
+		$request->set_param( 'store_order', array( 'enabled' => 'not-a-boolean' ) );
 
 		$response = $this->server->dispatch( $request );
 
@@ -160,14 +178,14 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_jetpack_connection_manager_is_connected( true );
 
 		$request = new WP_REST_Request( 'PATCH', '/wc-push-notifications/preferences' );
-		$request->set_param( 'store_order', false );
+		$request->set_param( 'store_order', array( 'enabled' => false ) );
 
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( WP_Http::OK, $response->get_status() );
 
 		$stored = Users::get_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
-		$this->assertFalse( $stored['preferences']['store_order'] );
+		$this->assertFalse( $stored['preferences']['store_order']['enabled'] );
 	}
 
 	/**
@@ -182,21 +200,21 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 			->save_preferences(
 				$this->user_id,
 				array(
-					'store_order'  => false,
-					'store_review' => false,
+					'store_order'  => array( 'enabled' => false ),
+					'store_review' => array( 'enabled' => false ),
 				)
 			);
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
-		$request->set_param( 'store_review', true );
+		$request->set_param( 'store_review', array( 'enabled' => true ) );
 
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( WP_Http::OK, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertFalse( $data['store_order'] );
-		$this->assertTrue( $data['store_review'] );
+		$this->assertFalse( $data['store_order']['enabled'] );
+		$this->assertTrue( $data['store_review']['enabled'] );
 	}
 
 	/**
@@ -209,8 +227,8 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		$service_mock = $this->createMock( NotificationPreferencesService::class );
 		$service_mock->method( 'get_defaults' )->willReturn(
 			array(
-				'store_order'  => true,
-				'store_review' => true,
+				'store_order'  => array( 'enabled' => true ),
+				'store_review' => array( 'enabled' => true ),
 			)
 		);
 		$internal_code    = 'woocommerce_push_notification_preferences_save_failed';
@@ -227,7 +245,7 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		wc_get_container()->replace( NotificationPreferencesService::class, $service_mock );
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
-		$request->set_param( 'store_review', false );
+		$request->set_param( 'store_review', array( 'enabled' => false ) );
 
 		$response = $this->server->dispatch( $request );
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -213,10 +213,13 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 				'store_review' => true,
 			)
 		);
+		$internal_code    = 'woocommerce_push_notification_preferences_save_failed';
+		$internal_message = 'Failed to save push notification preferences.';
+
 		$service_mock->method( 'save_preferences' )->willThrowException(
 			new WC_Data_Exception(
-				'woocommerce_push_notification_preferences_save_failed',
-				'Failed to save push notification preferences.',
+				$internal_code,
+				$internal_message,
 				WP_Http::INTERNAL_SERVER_ERROR
 			)
 		);
@@ -233,6 +236,12 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'code', $data );
 		$this->assertSame( 'woocommerce_internal_error', $data['code'] );
+
+		// Internal exception details must not be leaked to API clients.
+		$this->assertNotSame( $internal_code, $data['code'] );
+		$serialized = wp_json_encode( $data );
+		$this->assertStringNotContainsString( $internal_code, (string) $serialized );
+		$this->assertStringNotContainsString( $internal_message, (string) $serialized );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -4,18 +4,15 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Controllers;
 
-use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenInvalidDataException;
 use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenNotFoundException;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
-use Automattic\WooCommerce\Proxies\LegacyProxy;
+use Automattic\WooCommerce\Tests\Internal\PushNotifications\Helpers\PushNotificationsTestTrait;
 use Exception;
 use RuntimeException;
-use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 use WC_Data_Exception;
 use WC_REST_Unit_Test_Case;
@@ -29,6 +26,8 @@ use WP_REST_Request;
  * @package WooCommerce\Tests\PushNotifications
  */
 class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
+	use PushNotificationsTestTrait;
+
 	/**
 	 * Shop manager user ID for testing.
 	 *
@@ -56,16 +55,6 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * @var int
 	 */
 	private $subscriber_id;
-
-	/**
-	 * @var JetpackConnectionManager|MockObject
-	 */
-	private $jetpack_connection_manager_mock;
-
-	/**
-	 * @var FeaturesController|MockObject
-	 */
-	private $features_controller_mock;
 
 	/**
 	 * Set up test.
@@ -1310,67 +1299,6 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'woocommerce_internal_error', $result->get_error_code() );
 		$this->assertEquals( 'Internal server error', $result->get_error_message() );
 		$this->assertEquals( WP_Http::INTERNAL_SERVER_ERROR, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * Sets up the Jetpack connection manager mocking, and ensures the
-	 * PushNotifications class state is reset so `should_be_enabled` calculates
-	 * this from scratch.
-	 *
-	 * @param bool $is_connected Whether the manager should report Jetpack is
-	 * connected or not.
-	 */
-	private function mock_jetpack_connection_manager_is_connected( bool $is_connected = true ) {
-		$this->jetpack_connection_manager_mock = $this
-			->getMockBuilder( JetpackConnectionManager::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'is_connected' ) )
-			->getMock();
-
-		wc_get_container()->get( LegacyProxy::class )->register_class_mocks(
-			array( JetpackConnectionManager::class => $this->jetpack_connection_manager_mock )
-		);
-
-		$this->jetpack_connection_manager_mock
-			->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( $is_connected );
-
-		$this->reset_push_notifications_cache();
-	}
-
-	/**
-	 * Sets up the FeaturesController mock to enable push_notifications feature.
-	 */
-	private function set_up_features_controller_mock() {
-		$this->features_controller_mock = $this
-			->getMockBuilder( FeaturesController::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'feature_is_enabled' ) )
-			->getMock();
-
-		$this->features_controller_mock
-			->method( 'feature_is_enabled' )
-			->willReturnCallback(
-				function ( $feature_id ) {
-					return PushNotifications::FEATURE_NAME === $feature_id;
-				}
-			);
-
-		wc_get_container()->replace( FeaturesController::class, $this->features_controller_mock );
-	}
-
-	/**
-	 * Resets the cached enablement state on the container's PushNotifications
-	 * instance.
-	 */
-	private function reset_push_notifications_cache() {
-		$push_notifications = wc_get_container()->get( PushNotifications::class );
-		$reflection         = new ReflectionClass( $push_notifications );
-		$property           = $reflection->getProperty( 'enabled' );
-
-		$property->setAccessible( true );
-		$property->setValue( $push_notifications, null );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStoreTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\DataStores;
+
+use Automattic\WooCommerce\Internal\PushNotifications\DataStores\NotificationPreferencesDataStore;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the NotificationPreferencesDataStore class.
+ *
+ * @covers \Automattic\WooCommerce\Internal\PushNotifications\DataStores\NotificationPreferencesDataStore
+ */
+class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var NotificationPreferencesDataStore
+	 */
+	private $sut;
+
+	/**
+	 * A test user ID.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut     = new NotificationPreferencesDataStore();
+		$this->user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Clean up user meta and the test user between tests.
+	 */
+	public function tearDown(): void {
+		delete_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
+		wp_delete_user( $this->user_id );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should return null when nothing is stored for the user.
+	 */
+	public function test_read_returns_null_for_unstored_user(): void {
+		$this->assertNull( $this->sut->read( $this->user_id ) );
+	}
+
+	/**
+	 * @testdox Should return the envelope as stored when it is at the current schema version.
+	 */
+	public function test_read_returns_stored_envelope(): void {
+		$envelope = array(
+			'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+			'preferences'    => array(
+				'store_order'  => false,
+				'store_review' => true,
+			),
+		);
+
+		update_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, $envelope );
+
+		$result = $this->sut->read( $this->user_id );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION, $result['schema_version'] );
+		$this->assertArrayHasKey( 'preferences', $result );
+		$this->assertArrayHasKey( 'store_order', $result['preferences'] );
+		$this->assertFalse( $result['preferences']['store_order'] );
+		$this->assertArrayHasKey( 'store_review', $result['preferences'] );
+		$this->assertTrue( $result['preferences']['store_review'] );
+	}
+
+	/**
+	 * @testdox Should migrate an older envelope on read and persist the upgraded version.
+	 */
+	public function test_read_migrates_old_envelope_and_persists_upgrade(): void {
+		update_user_meta(
+			$this->user_id,
+			NotificationPreferencesDataStore::META_KEY,
+			array(
+				'schema_version' => 0,
+				'preferences'    => array( 'store_order' => false ),
+			)
+		);
+
+		$result = $this->sut->read( $this->user_id );
+
+		// Returned envelope is at current version.
+		$this->assertSame( NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION, $result['schema_version'] );
+		$this->assertArrayHasKey( 'store_order', $result['preferences'] );
+		$this->assertFalse( $result['preferences']['store_order'] );
+
+		// And the upgrade was persisted back to user meta.
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
+		$this->assertSame( NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION, $stored['schema_version'] );
+	}
+
+	/**
+	 * @testdox Should fall back to an empty preferences array when migrating an envelope with malformed preferences.
+	 */
+	public function test_migrate_falls_back_to_empty_preferences_for_malformed_input(): void {
+		$migrated = $this->sut->migrate(
+			array(
+				'schema_version' => 0,
+				'preferences'    => 'corrupted',
+			),
+			0
+		);
+
+		$this->assertSame( NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION, $migrated['schema_version'] );
+		$this->assertArrayHasKey( 'preferences', $migrated );
+		$this->assertSame( array(), $migrated['preferences'] );
+	}
+
+	/**
+	 * @testdox Should persist the supplied envelope to user meta.
+	 */
+	public function test_write_persists_envelope_to_user_meta(): void {
+		$envelope = array(
+			'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+			'preferences'    => array(
+				'store_order'  => false,
+				'store_review' => false,
+			),
+		);
+
+		$this->sut->write( $this->user_id, $envelope );
+
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
+		$this->assertSame( $envelope, $stored );
+	}
+
+	/**
+	 * @testdox Should be a no-op when the supplied envelope already matches what is stored.
+	 *
+	 * Verified indirectly: a second write of an identical envelope does not throw, and the stored
+	 * value remains unchanged. The pre-check inside write() short-circuits before update_user_meta(),
+	 * which would otherwise return false for the unchanged value and trigger a spurious exception.
+	 */
+	public function test_write_is_a_no_op_when_envelope_unchanged(): void {
+		$envelope = array(
+			'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+			'preferences'    => array(
+				'store_order'  => true,
+				'store_review' => true,
+			),
+		);
+
+		$this->sut->write( $this->user_id, $envelope );
+		$this->sut->write( $this->user_id, $envelope );
+
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
+		$this->assertSame( $envelope, $stored );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStoreTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\DataStores;
 
 use Automattic\WooCommerce\Internal\PushNotifications\DataStores\NotificationPreferencesDataStore;
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use WC_Unit_Test_Case;
 
 /**
@@ -42,7 +43,7 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 	 * Clean up user meta and the test user between tests.
 	 */
 	public function tearDown(): void {
-		delete_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
+		Users::delete_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		wp_delete_user( $this->user_id );
 		parent::tearDown();
 	}
@@ -66,7 +67,7 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		update_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, $envelope );
+		Users::update_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, $envelope );
 
 		$result = $this->sut->read( $this->user_id );
 
@@ -83,7 +84,7 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 	 * @testdox Should migrate an older envelope on read and persist the upgraded version.
 	 */
 	public function test_read_migrates_old_envelope_and_persists_upgrade(): void {
-		update_user_meta(
+		Users::update_site_user_meta(
 			$this->user_id,
 			NotificationPreferencesDataStore::META_KEY,
 			array(
@@ -100,7 +101,7 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 		$this->assertFalse( $result['preferences']['store_order'] );
 
 		// And the upgrade was persisted back to user meta.
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
+		$stored = Users::get_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		$this->assertSame( NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION, $stored['schema_version'] );
 	}
 
@@ -135,7 +136,7 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 
 		$this->sut->write( $this->user_id, $envelope );
 
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
+		$stored = Users::get_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		$this->assertSame( $envelope, $stored );
 	}
 
@@ -158,7 +159,7 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 		$this->sut->write( $this->user_id, $envelope );
 		$this->sut->write( $this->user_id, $envelope );
 
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY, true );
+		$stored = Users::get_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
 		$this->assertSame( $envelope, $stored );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/NotificationPreferencesDataStoreTest.php
@@ -62,8 +62,8 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 		$envelope = array(
 			'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
 			'preferences'    => array(
-				'store_order'  => false,
-				'store_review' => true,
+				'store_order'  => array( 'enabled' => false ),
+				'store_review' => array( 'enabled' => true ),
 			),
 		);
 
@@ -75,9 +75,9 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 		$this->assertSame( NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION, $result['schema_version'] );
 		$this->assertArrayHasKey( 'preferences', $result );
 		$this->assertArrayHasKey( 'store_order', $result['preferences'] );
-		$this->assertFalse( $result['preferences']['store_order'] );
+		$this->assertFalse( $result['preferences']['store_order']['enabled'] );
 		$this->assertArrayHasKey( 'store_review', $result['preferences'] );
-		$this->assertTrue( $result['preferences']['store_review'] );
+		$this->assertTrue( $result['preferences']['store_review']['enabled'] );
 	}
 
 	/**
@@ -89,7 +89,9 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 			NotificationPreferencesDataStore::META_KEY,
 			array(
 				'schema_version' => 0,
-				'preferences'    => array( 'store_order' => false ),
+				'preferences'    => array(
+					'store_order' => array( 'enabled' => false ),
+				),
 			)
 		);
 
@@ -98,7 +100,7 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 		// Returned envelope is at current version.
 		$this->assertSame( NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION, $result['schema_version'] );
 		$this->assertArrayHasKey( 'store_order', $result['preferences'] );
-		$this->assertFalse( $result['preferences']['store_order'] );
+		$this->assertFalse( $result['preferences']['store_order']['enabled'] );
 
 		// And the upgrade was persisted back to user meta.
 		$stored = Users::get_site_user_meta( $this->user_id, NotificationPreferencesDataStore::META_KEY );
@@ -129,8 +131,8 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 		$envelope = array(
 			'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
 			'preferences'    => array(
-				'store_order'  => false,
-				'store_review' => false,
+				'store_order'  => array( 'enabled' => false ),
+				'store_review' => array( 'enabled' => false ),
 			),
 		);
 
@@ -151,8 +153,8 @@ class NotificationPreferencesDataStoreTest extends WC_Unit_Test_Case {
 		$envelope = array(
 			'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
 			'preferences'    => array(
-				'store_order'  => true,
-				'store_review' => true,
+				'store_order'  => array( 'enabled' => true ),
+				'store_review' => array( 'enabled' => true ),
 			),
 		);
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Helpers/PushNotificationsTestTrait.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Helpers/PushNotificationsTestTrait.php
@@ -25,12 +25,12 @@ trait PushNotificationsTestTrait {
 	/**
 	 * @var JetpackConnectionManager|MockObject|null
 	 */
-	private $jetpack_connection_manager_mock;
+	protected $jetpack_connection_manager_mock;
 
 	/**
 	 * @var FeaturesController|MockObject|null
 	 */
-	private $features_controller_mock;
+	protected $features_controller_mock;
 
 	/**
 	 * Mocks the JetpackConnectionManager so its `is_connected()` returns the
@@ -39,7 +39,7 @@ trait PushNotificationsTestTrait {
 	 *
 	 * @param bool $is_connected Whether the manager should report Jetpack is connected.
 	 */
-	private function mock_jetpack_connection_manager_is_connected( bool $is_connected = true ) {
+	protected function mock_jetpack_connection_manager_is_connected( bool $is_connected = true ) {
 		$this->jetpack_connection_manager_mock = $this
 			->getMockBuilder( JetpackConnectionManager::class )
 			->disableOriginalConstructor()
@@ -62,7 +62,7 @@ trait PushNotificationsTestTrait {
 	 * Sets up the FeaturesController mock so the `push_notifications` feature
 	 * reports as enabled (and only that feature).
 	 */
-	private function set_up_features_controller_mock() {
+	protected function set_up_features_controller_mock() {
 		$this->features_controller_mock = $this
 			->getMockBuilder( FeaturesController::class )
 			->disableOriginalConstructor()
@@ -84,7 +84,7 @@ trait PushNotificationsTestTrait {
 	 * Resets the cached enablement state on the container's PushNotifications
 	 * instance so subsequent `should_be_enabled()` calls re-evaluate.
 	 */
-	private function reset_push_notifications_cache() {
+	protected function reset_push_notifications_cache() {
 		$push_notifications = wc_get_container()->get( PushNotifications::class );
 		$reflection         = new ReflectionClass( $push_notifications );
 		$property           = $reflection->getProperty( 'enabled' );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Helpers/PushNotificationsTestTrait.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Helpers/PushNotificationsTestTrait.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Helpers;
+
+use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionClass;
+
+/**
+ * Shared test helpers for the PushNotifications module.
+ *
+ * Mocks the Jetpack connection state, the FeaturesController, and resets the
+ * memoized enablement flag on the container's `PushNotifications` instance —
+ * the three things every push-notifications-related controller test needs in
+ * setUp.
+ *
+ * @package WooCommerce\Tests\PushNotifications
+ */
+trait PushNotificationsTestTrait {
+	/**
+	 * @var JetpackConnectionManager|MockObject|null
+	 */
+	private $jetpack_connection_manager_mock;
+
+	/**
+	 * @var FeaturesController|MockObject|null
+	 */
+	private $features_controller_mock;
+
+	/**
+	 * Mocks the JetpackConnectionManager so its `is_connected()` returns the
+	 * supplied value, and resets the PushNotifications enablement cache so
+	 * `should_be_enabled()` re-evaluates against the new mock.
+	 *
+	 * @param bool $is_connected Whether the manager should report Jetpack is connected.
+	 */
+	private function mock_jetpack_connection_manager_is_connected( bool $is_connected = true ) {
+		$this->jetpack_connection_manager_mock = $this
+			->getMockBuilder( JetpackConnectionManager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'is_connected' ) )
+			->getMock();
+
+		wc_get_container()->get( LegacyProxy::class )->register_class_mocks(
+			array( JetpackConnectionManager::class => $this->jetpack_connection_manager_mock )
+		);
+
+		$this->jetpack_connection_manager_mock
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( $is_connected );
+
+		$this->reset_push_notifications_cache();
+	}
+
+	/**
+	 * Sets up the FeaturesController mock so the `push_notifications` feature
+	 * reports as enabled (and only that feature).
+	 */
+	private function set_up_features_controller_mock() {
+		$this->features_controller_mock = $this
+			->getMockBuilder( FeaturesController::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'feature_is_enabled' ) )
+			->getMock();
+
+		$this->features_controller_mock
+			->method( 'feature_is_enabled' )
+			->willReturnCallback(
+				function ( $feature_id ) {
+					return PushNotifications::FEATURE_NAME === $feature_id;
+				}
+			);
+
+		wc_get_container()->replace( FeaturesController::class, $this->features_controller_mock );
+	}
+
+	/**
+	 * Resets the cached enablement state on the container's PushNotifications
+	 * instance so subsequent `should_be_enabled()` calls re-evaluate.
+	 */
+	private function reset_push_notifications_cache() {
+		$push_notifications = wc_get_container()->get( PushNotifications::class );
+		$reflection         = new ReflectionClass( $push_notifications );
+		$property           = $reflection->getProperty( 'enabled' );
+
+		$property->setAccessible( true );
+		$property->setValue( $push_notifications, null );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Services;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the NotificationPreferencesService class.
+ */
+class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var NotificationPreferencesService
+	 */
+	private $sut;
+
+	/**
+	 * A test user ID.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut     = new NotificationPreferencesService();
+		$this->user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Clean up user meta between tests.
+	 */
+	public function tearDown(): void {
+		delete_user_meta( $this->user_id, NotificationPreferencesService::META_KEY );
+		wp_delete_user( $this->user_id );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should return defaults when the user has no stored preferences.
+	 */
+	public function test_get_preferences_returns_defaults_for_new_user(): void {
+		$preferences = $this->sut->get_preferences( $this->user_id );
+
+		$this->assertSame( $this->sut->get_defaults(), $preferences );
+	}
+
+	/**
+	 * @testdox Should return previously saved preferences, overlaid on defaults.
+	 */
+	public function test_get_preferences_returns_saved_preferences(): void {
+		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false ) );
+
+		$preferences = $this->sut->get_preferences( $this->user_id );
+
+		$this->assertArrayHasKey( 'store_order', $preferences );
+		$this->assertFalse( $preferences['store_order'] );
+		$this->assertArrayHasKey( 'store_review', $preferences );
+		$this->assertTrue( $preferences['store_review'] );
+	}
+
+	/**
+	 * @testdox Should write the versioned envelope to user meta on save.
+	 */
+	public function test_save_preferences_updates_user_meta(): void {
+		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false, 'store_review' => false ) );
+
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
+
+		$this->assertIsArray( $stored );
+		$this->assertArrayHasKey( 'schema_version', $stored );
+		$this->assertSame( NotificationPreferencesService::CURRENT_SCHEMA_VERSION, $stored['schema_version'] );
+		$this->assertArrayHasKey( 'preferences', $stored );
+		$this->assertFalse( $stored['preferences']['store_order'] );
+		$this->assertFalse( $stored['preferences']['store_review'] );
+	}
+
+	/**
+	 * @testdox Should merge partial saves with previously stored preferences.
+	 */
+	public function test_save_preferences_merges_with_existing(): void {
+		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false, 'store_review' => false ) );
+
+		$this->sut->save_preferences( $this->user_id, array( 'store_review' => true ) );
+
+		$preferences = $this->sut->get_preferences( $this->user_id );
+
+		$this->assertFalse( $preferences['store_order'] );
+		$this->assertTrue( $preferences['store_review'] );
+	}
+
+	/**
+	 * @testdox Should upgrade an older envelope to the current schema version on read.
+	 */
+	public function test_migration_upgrades_schema_version(): void {
+		update_user_meta(
+			$this->user_id,
+			NotificationPreferencesService::META_KEY,
+			array(
+				'schema_version' => 0,
+				'preferences'    => array( 'store_order' => false ),
+			)
+		);
+
+		$preferences = $this->sut->get_preferences( $this->user_id );
+
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
+		$this->assertSame( NotificationPreferencesService::CURRENT_SCHEMA_VERSION, $stored['schema_version'] );
+		$this->assertFalse( $preferences['store_order'] );
+		$this->assertArrayHasKey( 'store_review', $preferences );
+		$this->assertTrue( $preferences['store_review'] );
+	}
+
+	/**
+	 * @testdox Should drop unknown preference keys on save.
+	 */
+	public function test_save_preferences_drops_unknown_keys(): void {
+		$this->sut->save_preferences(
+			$this->user_id,
+			array(
+				'store_order'          => false,
+				'store_abandoned_cart' => true,
+			)
+		);
+
+		$preferences = $this->sut->get_preferences( $this->user_id );
+		$stored      = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
+
+		$this->assertArrayNotHasKey( 'store_abandoned_cart', $preferences );
+		$this->assertArrayNotHasKey( 'store_abandoned_cart', $stored['preferences'] );
+		$this->assertFalse( $preferences['store_order'] );
+	}
+
+	/**
+	 * @testdox Should fall back to defaults when a migrated envelope has a malformed preferences value.
+	 */
+	public function test_migrate_falls_back_to_defaults_for_malformed_preferences(): void {
+		update_user_meta(
+			$this->user_id,
+			NotificationPreferencesService::META_KEY,
+			array(
+				'schema_version' => 0,
+				'preferences'    => 'corrupted',
+			)
+		);
+
+		$preferences = $this->sut->get_preferences( $this->user_id );
+
+		$this->assertSame( $this->sut->get_defaults(), $preferences );
+	}
+
+	/**
+	 * @testdox Should include every known notification type in the defaults.
+	 */
+	public function test_get_defaults_includes_all_notification_types(): void {
+		$defaults = $this->sut->get_defaults();
+
+		$this->assertIsArray( $defaults );
+		$this->assertArrayHasKey( 'store_order', $defaults );
+		$this->assertArrayHasKey( 'store_review', $defaults );
+
+		foreach ( $defaults as $value ) {
+			$this->assertIsBool( $value );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
@@ -242,6 +242,97 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should perform a deep merge so partial updates preserve unrelated sub-fields.
+	 *
+	 * Locks in the contract for forward-compatible sub-fields. When stored preferences contain
+	 * multiple sub-fields per pref (e.g. RSM-1550's `min_amount` alongside `enabled`), a partial
+	 * update that only sends one sub-field must not clobber the others. With a shallow merge
+	 * (`array_merge`), the entire sub-object is replaced; with a deep merge
+	 * (`array_replace_recursive`), only the specified sub-fields are overridden.
+	 *
+	 * Today's schema only has `enabled` per pref, so the bug is invisible. This test extends
+	 * the schema via an anonymous subclass to exercise the multi-sub-field case the future
+	 * tickets rely on.
+	 */
+	public function test_save_preferences_deep_merges_partial_updates(): void {
+		$service = new class() extends NotificationPreferencesService {
+			/**
+			 * Extended schema for the test: a second sub-field alongside `enabled`.
+			 *
+			 * @return array<string, array<string, mixed>>
+			 */
+			public function get_defaults(): array {
+				return array(
+					'store_order' => array(
+						'enabled'    => true,
+						'min_amount' => 0,
+					),
+				);
+			}
+
+			/**
+			 * Permissive sanitize for the test: preserve every sub-key in the default shape,
+			 * coercing to the type implied by its default value.
+			 *
+			 * @param string               $key           Preference key.
+			 * @param array                $value         Submitted sub-options.
+			 * @param array<string, mixed> $default_shape Default sub-options.
+			 * @return array<string, mixed>
+			 */
+			protected function sanitize_value( string $key, array $value, array $default_shape ): array {
+				$sanitized = array();
+				foreach ( $default_shape as $sub_key => $sub_default ) {
+					if ( ! array_key_exists( $sub_key, $value ) ) {
+						$sanitized[ $sub_key ] = $sub_default;
+						continue;
+					}
+					if ( is_bool( $sub_default ) ) {
+						$sanitized[ $sub_key ] = (bool) $value[ $sub_key ];
+					} elseif ( is_int( $sub_default ) ) {
+						$sanitized[ $sub_key ] = (int) $value[ $sub_key ];
+					} else {
+						$sanitized[ $sub_key ] = $value[ $sub_key ];
+					}
+				}
+				return $sanitized;
+			}
+		};
+		$service->init( $this->data_store );
+
+		// Stored state already has a non-default `min_amount`.
+		$this->data_store->method( 'read' )->willReturn(
+			array(
+				'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+				'preferences'    => array(
+					'store_order' => array(
+						'enabled'    => true,
+						'min_amount' => 500,
+					),
+				),
+			)
+		);
+
+		// Verify that a partial update of just `enabled` preserves `min_amount`.
+		$this->data_store
+			->expects( $this->once() )
+			->method( 'write' )
+			->with(
+				$this->anything(),
+				$this->callback(
+					function ( $envelope ) {
+						$prefs = $envelope['preferences']['store_order'];
+						return false === $prefs['enabled'] && 500 === $prefs['min_amount'];
+					}
+				)
+			);
+
+		$service->save_preferences(
+			$this->user_id,
+			array( 'store_order' => array( 'enabled' => false ) )
+		);
+	}
+
+	/**
 	 * @testdox Should return a nested-object default for every known notification type.
 	 */
 	public function test_get_defaults_includes_all_notification_types(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
@@ -68,24 +68,25 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 		$this->data_store->method( 'read' )->willReturn(
 			array(
 				'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
-				'preferences'    => array( 'store_order' => false ),
+				'preferences'    => array(
+					'store_order' => array( 'enabled' => false ),
+				),
 			)
 		);
 
 		$preferences = $this->sut->get_preferences( $this->user_id );
 
 		$this->assertArrayHasKey( 'store_order', $preferences );
-		$this->assertFalse( $preferences['store_order'] );
+		$this->assertArrayHasKey( 'enabled', $preferences['store_order'] );
+		$this->assertFalse( $preferences['store_order']['enabled'] );
+
 		$this->assertArrayHasKey( 'store_review', $preferences );
-		$this->assertTrue( $preferences['store_review'] );
+		$this->assertArrayHasKey( 'enabled', $preferences['store_review'] );
+		$this->assertTrue( $preferences['store_review']['enabled'] );
 	}
 
 	/**
 	 * @testdox Should fall back to defaults when the stored envelope has empty preferences.
-	 *
-	 * This is the path the data-store hits after a malformed-input migration: the stored envelope
-	 * has `preferences => array()`. The service should fill in defaults rather than return an
-	 * empty preferences map.
 	 */
 	public function test_get_preferences_overlays_defaults_when_stored_preferences_is_empty(): void {
 		$this->data_store->method( 'read' )->willReturn(
@@ -111,16 +112,19 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 			->method( 'write' )
 			->with(
 				$this->user_id,
-				array(
-					'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
-					'preferences'    => array(
-						'store_order'  => false,
-						'store_review' => true,
-					),
+				$this->callback(
+					function ( $envelope ) {
+						return NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION === $envelope['schema_version']
+							&& false === $envelope['preferences']['store_order']['enabled']
+							&& true === $envelope['preferences']['store_review']['enabled'];
+					}
 				)
 			);
 
-		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false ) );
+		$this->sut->save_preferences(
+			$this->user_id,
+			array( 'store_order' => array( 'enabled' => false ) )
+		);
 	}
 
 	/**
@@ -132,15 +136,15 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 		$result = $this->sut->save_preferences(
 			$this->user_id,
 			array(
-				'store_order'  => false,
-				'store_review' => false,
+				'store_order'  => array( 'enabled' => false ),
+				'store_review' => array( 'enabled' => false ),
 			)
 		);
 
 		$this->assertArrayHasKey( 'store_order', $result );
-		$this->assertFalse( $result['store_order'] );
+		$this->assertFalse( $result['store_order']['enabled'] );
 		$this->assertArrayHasKey( 'store_review', $result );
-		$this->assertFalse( $result['store_review'] );
+		$this->assertFalse( $result['store_review']['enabled'] );
 	}
 
 	/**
@@ -151,20 +155,23 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 			array(
 				'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
 				'preferences'    => array(
-					'store_order'  => false,
-					'store_review' => false,
+					'store_order'  => array( 'enabled' => false ),
+					'store_review' => array( 'enabled' => false ),
 				),
 			)
 		);
 
-		$result = $this->sut->save_preferences( $this->user_id, array( 'store_review' => true ) );
+		$result = $this->sut->save_preferences(
+			$this->user_id,
+			array( 'store_review' => array( 'enabled' => true ) )
+		);
 
-		$this->assertFalse( $result['store_order'] );
-		$this->assertTrue( $result['store_review'] );
+		$this->assertFalse( $result['store_order']['enabled'] );
+		$this->assertTrue( $result['store_review']['enabled'] );
 	}
 
 	/**
-	 * @testdox Should drop unknown preference keys before writing.
+	 * @testdox Should drop unknown top-level preference keys before writing.
 	 */
 	public function test_save_preferences_drops_unknown_keys(): void {
 		$this->data_store->method( 'read' )->willReturn( null );
@@ -184,12 +191,33 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 		$result = $this->sut->save_preferences(
 			$this->user_id,
 			array(
-				'store_order'          => false,
-				'store_abandoned_cart' => true,
+				'store_order'          => array( 'enabled' => false ),
+				'store_abandoned_cart' => array( 'enabled' => true ),
 			)
 		);
 
 		$this->assertArrayNotHasKey( 'store_abandoned_cart', $result );
+	}
+
+	/**
+	 * @testdox Should drop unknown sub-fields within a known preference before writing.
+	 */
+	public function test_save_preferences_drops_unknown_sub_fields(): void {
+		$this->data_store->method( 'read' )->willReturn( null );
+
+		$result = $this->sut->save_preferences(
+			$this->user_id,
+			array(
+				'store_order' => array(
+					'enabled'        => true,
+					'future_unknown' => 'should be dropped',
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'store_order', $result );
+		$this->assertArrayHasKey( 'enabled', $result['store_order'] );
+		$this->assertArrayNotHasKey( 'future_unknown', $result['store_order'] );
 	}
 
 	/**
@@ -207,11 +235,14 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 
 		$this->expectException( WC_Data_Exception::class );
 
-		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false ) );
+		$this->sut->save_preferences(
+			$this->user_id,
+			array( 'store_order' => array( 'enabled' => false ) )
+		);
 	}
 
 	/**
-	 * @testdox Should include every known notification type in the defaults.
+	 * @testdox Should return a nested-object default for every known notification type.
 	 */
 	public function test_get_defaults_includes_all_notification_types(): void {
 		$defaults = $this->sut->get_defaults();
@@ -220,8 +251,10 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'store_order', $defaults );
 		$this->assertArrayHasKey( 'store_review', $defaults );
 
-		foreach ( $defaults as $value ) {
-			$this->assertIsBool( $value );
+		foreach ( $defaults as $type => $shape ) {
+			$this->assertIsArray( $shape, "Default for {$type} should be an object/array." );
+			$this->assertArrayHasKey( 'enabled', $shape, "Default for {$type} should have an `enabled` sub-field." );
+			$this->assertIsBool( $shape['enabled'] );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
@@ -4,11 +4,17 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Services;
 
+use Automattic\WooCommerce\Internal\PushNotifications\DataStores\NotificationPreferencesDataStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Data_Exception;
 use WC_Unit_Test_Case;
+use WP_Http;
 
 /**
  * Tests for the NotificationPreferencesService class.
+ *
+ * @covers \Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService
  */
 class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 
@@ -20,11 +26,18 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	private $sut;
 
 	/**
-	 * A test user ID.
+	 * Mocked data store.
+	 *
+	 * @var NotificationPreferencesDataStore|MockObject
+	 */
+	private $data_store;
+
+	/**
+	 * An arbitrary test user ID.
 	 *
 	 * @var int
 	 */
-	private int $user_id;
+	private int $user_id = 42;
 
 	/**
 	 * Set up test fixtures.
@@ -32,33 +45,32 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->sut     = new NotificationPreferencesService();
-		$this->user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->data_store = $this->createMock( NotificationPreferencesDataStore::class );
+		$this->sut        = new NotificationPreferencesService();
+		$this->sut->init( $this->data_store );
 	}
 
 	/**
-	 * Clean up user meta between tests.
+	 * @testdox Should return defaults when the data store has no envelope for the user.
 	 */
-	public function tearDown(): void {
-		delete_user_meta( $this->user_id, NotificationPreferencesService::META_KEY );
-		wp_delete_user( $this->user_id );
-		parent::tearDown();
-	}
+	public function test_get_preferences_returns_defaults_when_data_store_returns_null(): void {
+		$this->data_store->method( 'read' )->willReturn( null );
 
-	/**
-	 * @testdox Should return defaults when the user has no stored preferences.
-	 */
-	public function test_get_preferences_returns_defaults_for_new_user(): void {
 		$preferences = $this->sut->get_preferences( $this->user_id );
 
 		$this->assertSame( $this->sut->get_defaults(), $preferences );
 	}
 
 	/**
-	 * @testdox Should return previously saved preferences, overlaid on defaults.
+	 * @testdox Should overlay stored preferences on top of defaults.
 	 */
-	public function test_get_preferences_returns_saved_preferences(): void {
-		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false ) );
+	public function test_get_preferences_returns_saved_preferences_overlaid_on_defaults(): void {
+		$this->data_store->method( 'read' )->willReturn(
+			array(
+				'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+				'preferences'    => array( 'store_order' => false ),
+			)
+		);
 
 		$preferences = $this->sut->get_preferences( $this->user_id );
 
@@ -69,9 +81,54 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should write the versioned envelope to user meta on save and return the merged map.
+	 * @testdox Should fall back to defaults when the stored envelope has empty preferences.
+	 *
+	 * This is the path the data-store hits after a malformed-input migration: the stored envelope
+	 * has `preferences => array()`. The service should fill in defaults rather than return an
+	 * empty preferences map.
 	 */
-	public function test_save_preferences_updates_user_meta(): void {
+	public function test_get_preferences_overlays_defaults_when_stored_preferences_is_empty(): void {
+		$this->data_store->method( 'read' )->willReturn(
+			array(
+				'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+				'preferences'    => array(),
+			)
+		);
+
+		$preferences = $this->sut->get_preferences( $this->user_id );
+
+		$this->assertSame( $this->sut->get_defaults(), $preferences );
+	}
+
+	/**
+	 * @testdox Should write the merged envelope to the data store on save.
+	 */
+	public function test_save_preferences_calls_data_store_with_correctly_built_envelope(): void {
+		$this->data_store->method( 'read' )->willReturn( null );
+
+		$this->data_store
+			->expects( $this->once() )
+			->method( 'write' )
+			->with(
+				$this->user_id,
+				array(
+					'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+					'preferences'    => array(
+						'store_order'  => false,
+						'store_review' => true,
+					),
+				)
+			);
+
+		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false ) );
+	}
+
+	/**
+	 * @testdox Should return the merged preferences map after save.
+	 */
+	public function test_save_preferences_returns_merged_map(): void {
+		$this->data_store->method( 'read' )->willReturn( null );
+
 		$result = $this->sut->save_preferences(
 			$this->user_id,
 			array(
@@ -80,70 +137,50 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		// Return value: the merged preferences map.
-		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'store_order', $result );
 		$this->assertFalse( $result['store_order'] );
 		$this->assertArrayHasKey( 'store_review', $result );
 		$this->assertFalse( $result['store_review'] );
-
-		// Stored envelope shape on disk.
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
-
-		$this->assertIsArray( $stored );
-		$this->assertArrayHasKey( 'schema_version', $stored );
-		$this->assertSame( NotificationPreferencesService::CURRENT_SCHEMA_VERSION, $stored['schema_version'] );
-		$this->assertArrayHasKey( 'preferences', $stored );
-		$this->assertFalse( $stored['preferences']['store_order'] );
-		$this->assertFalse( $stored['preferences']['store_review'] );
 	}
 
 	/**
-	 * @testdox Should merge partial saves with previously stored preferences and return the merged map.
+	 * @testdox Should merge a partial save with previously stored preferences.
 	 */
-	public function test_save_preferences_merges_with_existing(): void {
-		$this->sut->save_preferences(
-			$this->user_id,
+	public function test_save_preferences_merges_with_existing_preferences(): void {
+		$this->data_store->method( 'read' )->willReturn(
 			array(
-				'store_order'  => false,
-				'store_review' => false,
+				'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+				'preferences'    => array(
+					'store_order'  => false,
+					'store_review' => false,
+				),
 			)
 		);
 
 		$result = $this->sut->save_preferences( $this->user_id, array( 'store_review' => true ) );
 
-		$this->assertArrayHasKey( 'store_order', $result );
 		$this->assertFalse( $result['store_order'] );
-		$this->assertArrayHasKey( 'store_review', $result );
 		$this->assertTrue( $result['store_review'] );
 	}
 
 	/**
-	 * @testdox Should upgrade an older envelope to the current schema version on read.
-	 */
-	public function test_migration_upgrades_schema_version(): void {
-		update_user_meta(
-			$this->user_id,
-			NotificationPreferencesService::META_KEY,
-			array(
-				'schema_version' => 0,
-				'preferences'    => array( 'store_order' => false ),
-			)
-		);
-
-		$preferences = $this->sut->get_preferences( $this->user_id );
-
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
-		$this->assertSame( NotificationPreferencesService::CURRENT_SCHEMA_VERSION, $stored['schema_version'] );
-		$this->assertFalse( $preferences['store_order'] );
-		$this->assertArrayHasKey( 'store_review', $preferences );
-		$this->assertTrue( $preferences['store_review'] );
-	}
-
-	/**
-	 * @testdox Should drop unknown preference keys on save (in both return value and storage).
+	 * @testdox Should drop unknown preference keys before writing.
 	 */
 	public function test_save_preferences_drops_unknown_keys(): void {
+		$this->data_store->method( 'read' )->willReturn( null );
+
+		$this->data_store
+			->expects( $this->once() )
+			->method( 'write' )
+			->with(
+				$this->user_id,
+				$this->callback(
+					function ( $envelope ) {
+						return ! array_key_exists( 'store_abandoned_cart', $envelope['preferences'] );
+					}
+				)
+			);
+
 		$result = $this->sut->save_preferences(
 			$this->user_id,
 			array(
@@ -152,30 +189,25 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
-
 		$this->assertArrayNotHasKey( 'store_abandoned_cart', $result );
-		$this->assertArrayNotHasKey( 'store_abandoned_cart', $stored['preferences'] );
-		$this->assertArrayHasKey( 'store_order', $result );
-		$this->assertFalse( $result['store_order'] );
 	}
 
 	/**
-	 * @testdox Should fall back to defaults when a migrated envelope has a malformed preferences value.
+	 * @testdox Should propagate WC_Data_Exception thrown by the data store.
 	 */
-	public function test_migrate_falls_back_to_defaults_for_malformed_preferences(): void {
-		update_user_meta(
-			$this->user_id,
-			NotificationPreferencesService::META_KEY,
-			array(
-				'schema_version' => 0,
-				'preferences'    => 'corrupted',
+	public function test_save_preferences_propagates_data_store_exception(): void {
+		$this->data_store->method( 'read' )->willReturn( null );
+		$this->data_store->method( 'write' )->willThrowException(
+			new WC_Data_Exception(
+				'woocommerce_push_notification_preferences_save_failed',
+				'Failed to save push notification preferences.',
+				WP_Http::INTERNAL_SERVER_ERROR
 			)
 		);
 
-		$preferences = $this->sut->get_preferences( $this->user_id );
+		$this->expectException( WC_Data_Exception::class );
 
-		$this->assertSame( $this->sut->get_defaults(), $preferences );
+		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
@@ -72,7 +72,13 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	 * @testdox Should write the versioned envelope to user meta on save.
 	 */
 	public function test_save_preferences_updates_user_meta(): void {
-		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false, 'store_review' => false ) );
+		$this->sut->save_preferences(
+			$this->user_id,
+			array(
+				'store_order'  => false,
+				'store_review' => false,
+			)
+		);
 
 		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
 
@@ -88,7 +94,13 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	 * @testdox Should merge partial saves with previously stored preferences.
 	 */
 	public function test_save_preferences_merges_with_existing(): void {
-		$this->sut->save_preferences( $this->user_id, array( 'store_order' => false, 'store_review' => false ) );
+		$this->sut->save_preferences(
+			$this->user_id,
+			array(
+				'store_order'  => false,
+				'store_review' => false,
+			)
+		);
 
 		$this->sut->save_preferences( $this->user_id, array( 'store_review' => true ) );
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
@@ -69,10 +69,10 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should write the versioned envelope to user meta on save.
+	 * @testdox Should write the versioned envelope to user meta on save and return the merged map.
 	 */
 	public function test_save_preferences_updates_user_meta(): void {
-		$this->sut->save_preferences(
+		$result = $this->sut->save_preferences(
 			$this->user_id,
 			array(
 				'store_order'  => false,
@@ -80,6 +80,14 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
+		// Return value: the merged preferences map.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'store_order', $result );
+		$this->assertFalse( $result['store_order'] );
+		$this->assertArrayHasKey( 'store_review', $result );
+		$this->assertFalse( $result['store_review'] );
+
+		// Stored envelope shape on disk.
 		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
 
 		$this->assertIsArray( $stored );
@@ -91,7 +99,7 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should merge partial saves with previously stored preferences.
+	 * @testdox Should merge partial saves with previously stored preferences and return the merged map.
 	 */
 	public function test_save_preferences_merges_with_existing(): void {
 		$this->sut->save_preferences(
@@ -102,12 +110,12 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->sut->save_preferences( $this->user_id, array( 'store_review' => true ) );
+		$result = $this->sut->save_preferences( $this->user_id, array( 'store_review' => true ) );
 
-		$preferences = $this->sut->get_preferences( $this->user_id );
-
-		$this->assertFalse( $preferences['store_order'] );
-		$this->assertTrue( $preferences['store_review'] );
+		$this->assertArrayHasKey( 'store_order', $result );
+		$this->assertFalse( $result['store_order'] );
+		$this->assertArrayHasKey( 'store_review', $result );
+		$this->assertTrue( $result['store_review'] );
 	}
 
 	/**
@@ -133,10 +141,10 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should drop unknown preference keys on save.
+	 * @testdox Should drop unknown preference keys on save (in both return value and storage).
 	 */
 	public function test_save_preferences_drops_unknown_keys(): void {
-		$this->sut->save_preferences(
+		$result = $this->sut->save_preferences(
 			$this->user_id,
 			array(
 				'store_order'          => false,
@@ -144,12 +152,12 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$preferences = $this->sut->get_preferences( $this->user_id );
-		$stored      = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
+		$stored = get_user_meta( $this->user_id, NotificationPreferencesService::META_KEY, true );
 
-		$this->assertArrayNotHasKey( 'store_abandoned_cart', $preferences );
+		$this->assertArrayNotHasKey( 'store_abandoned_cart', $result );
 		$this->assertArrayNotHasKey( 'store_abandoned_cart', $stored['preferences'] );
-		$this->assertFalse( $preferences['store_order'] );
+		$this->assertArrayHasKey( 'store_order', $result );
+		$this->assertFalse( $result['store_order'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes RSM-693, RSM-694

Mobile merchants need to toggle push notification types on a per-user basis. This PR lands the backend surface behind that.

**Layering** (matches the existing `PushTokensDataStore` / `PushTokenRestController` pattern in the same module):

```
NotificationPreferencesRestController     (REST surface, validation, exception → WP_Error)
  └─> NotificationPreferencesService      (defaults, sanitize, orchestration)
        └─> NotificationPreferencesDataStore   (envelope I/O, migration, exception)
              └─> WP user_meta                  (site-scoped via Users::*_site_user_meta)
```

**REST endpoints** at `/wp-json/wc-push-notifications/preferences`:
- `GET` — return current user's preferences (defaults overlaid for missing keys).
- `POST` / `PUT` / `PATCH` — partial update, returns the merged result. Auth: logged-in user with a role in `PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED` (`administrator`, `shop_manager`) and the `push_notifications` feature flag enabled.

**Preference shape** — each preference is an object so future tickets (RSM-1550, RSM-1551, RSM-1552) can add sub-fields like `min_amount`, `max_rating`, or per-event sub-toggles without bumping the schema version:

```json
{
  "store_order":  { "enabled": true },
  "store_review": { "enabled": true }
}
```

**Defaults are derived from `Notification::NOTIFICATION_CLASSES`** so adding a new notification type automatically opts it into preferences — no parallel list to keep in sync.

**Multisite-aware storage**: persistence uses `Users::*_site_user_meta` so preferences are scoped per blog. A merchant who uses the same WPCOM account across two sites in a multisite network gets independent prefs per site.

**Drive-by fix** in `PushTokenRestController`: its `get_rest_api_namespace()` returned the shared URL namespace, which would cause any sibling controller registered after it to overwrite its entry in the `woocommerce_rest_api_get_rest_namespaces` filter. Fixed in [73fe3f5b](https://github.com/woocommerce/woocommerce/pull/64351/commits/73fe3f5b2f116f926bff7afe066f81c7ecc7eb41); a regression test in `NotificationPreferencesRestControllerTest` locks the contract.

**Shared infrastructure extracted**:
- `Internal/PushNotifications/Traits/ConvertsExceptionsToWpError` — used by both REST controllers to map domain exceptions to `WP_Error` responses (and log + return a generic 500 for unrecognized failures so internal details don't leak to clients).
- `tests/.../Helpers/PushNotificationsTestTrait` — shared setUp helpers (Jetpack mock, FeaturesController mock, PushNotifications cache reset) used by both controller test classes.

### How to test the changes in this Pull Request:

1. On a WooCommerce site with the `push_notifications` feature flag enabled and Jetpack connected, authenticate as a user with the `administrator` or `shop_manager` role.
2. `curl -u admin:app-password https://site.test/wp-json/wc-push-notifications/preferences` → expect `{"store_order":{"enabled":true},"store_review":{"enabled":true}}` (defaults for a new user).
3. `curl -u admin:app-password -X PATCH -H 'Content-Type: application/json' -d '{"store_review":{"enabled":false}}' https://site.test/wp-json/wc-push-notifications/preferences` → expect `{"store_order":{"enabled":true},"store_review":{"enabled":false}}` (merged result).
4. POST same value again → still `200`, idempotent. The data store's no-op short-circuit avoids a spurious `WC_Data_Exception` from `update_user_meta` returning `false` on unchanged value.
5. Verify storage: `wp eval "var_dump( get_user_meta( get_current_user_id(), 'wc_push_notification_preferences_wp_' . get_current_blog_id(), true ) );"` returns `['schema_version' => 1, 'preferences' => [...]]` (note the `_wp_<blog_id>` suffix from site-scoping).
6. As a `subscriber` user, `GET /wc-push-notifications/preferences` → expect `403`.
7. Unauthenticated `GET /wc-push-notifications/preferences` → expect `401`.
8. `curl -u admin:app-password -X POST -H 'Content-Type: application/json' -d '{"store_order":"not-an-object"}'` → expect `400` (REST type validation rejects non-object).
9. `curl -u admin:app-password -X POST -H 'Content-Type: application/json' -d '{"store_order":{"enabled":"not-a-boolean"}}'` → expect `400` (REST validates the inner `enabled` is boolean).
10. Forward-compat probe: `curl -u admin:app-password -X POST -H 'Content-Type: application/json' -d '{"store_order":{"enabled":true,"future_field":"x"}}'` → expect `200` with `future_field` silently dropped from the stored value.
11. Sibling route regression: `curl -u admin:app-password -X POST https://site.test/wp-json/wc-push-notifications/push-tokens -d '{"token":"...","platform":"apple","origin":"woocommerce-ios","device_locale":"en_US"}'` → expect normal `201`, not `404`.
12. Multisite scoping (only relevant on a multisite network): set a value on store-A, then read on store-B as the same user → expect store-B's defaults, not store-A's value.

### Testing that has already taken place:

- **PHPUnit**: 249 tests / 580 assertions passing under the `NotificationPreferences|PushToken` filter (PHP 8.1, wp-env). Includes data store CRUD, service mocking pattern, REST integration, namespace-collision regression, multisite-scoping, exception propagation, and a 500-response leak-prevention assertion (verifies that internal exception messages aren't echoed back in the body).
- **PHPStan**: clean across all new and modified `src/` files.
- **PHPCS**: clean on every file touched by this PR (verified in PHP 8.1 wp-env container, matching CI runtime).
- **Manual API verification** on a single-site Jurassic Ninja sandbox via curl (every test step above).
- **Multisite leak verification**: confirmed via direct SQL probe that storage uses the per-site-prefixed meta key (`wc_push_notification_preferences_wp_<blog_id>`) so prefs don't leak across sites in a network.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Minor

#### Type

- [x] Add - Adds functionality

#### Message

Add per-user push notification preferences REST endpoint at `/wc-push-notifications/preferences`.

</details>
