### PR TITLE
Fix: De-duplicate tfoot in order-details.php template

### DIFF
--- a/plugins/woocommerce/changelog/pr-64358
+++ b/plugins/woocommerce/changelog/pr-64358
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-De-duplicate tfoot blocks in order/order-details email templates.
+Remove duplicate tfoot elements in the My Account order details template.

--- a/plugins/woocommerce/changelog/pr-64358
+++ b/plugins/woocommerce/changelog/pr-64358
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+De-duplicate tfoot blocks in order/order-details email templates.

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -89,10 +89,10 @@ if ( $show_downloads ) {
 			?>
 		</tbody>
 
-		<?php
-		if ( ! empty( $actions ) ) :
-			?>
 		<tfoot>
+			<?php
+			if ( ! empty( $actions ) ) :
+				?>
 			<tr>
 				<th class="order-actions--heading"><?php esc_html_e( 'Actions', 'woocommerce' ); ?>:</th>
 				<td>
@@ -112,9 +112,7 @@ if ( $show_downloads ) {
 						?>
 					</td>
 				</tr>
-			</tfoot>
-			<?php endif ?>
-		<tfoot>
+			<?php endif; ?>
 			<?php
 			foreach ( $order->get_order_item_totals() as $key => $total ) {
 				?>

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.8.0
+ * @version 10.9.0
  *
  * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */
@@ -91,6 +91,27 @@ if ( $show_downloads ) {
 
 		<tfoot>
 			<?php
+			foreach ( $order->get_order_item_totals() as $key => $total ) {
+				?>
+					<tr>
+						<th scope="row"><?php echo esc_html( $total['label'] ); ?></th>
+						<td><?php echo wp_kses_post( $total['value'] ); ?></td>
+					</tr>
+					<?php
+			}
+			?>
+			<?php if ( $order->get_customer_note() ) : ?>
+				<tr>
+					<th><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
+					<td>
+					<?php
+					$customer_note = wc_wptexturize_order_note( $order->get_customer_note() );
+					echo wp_kses( nl2br( $customer_note ), array( 'br' => array() ) );
+					?>
+					</td>
+				</tr>
+			<?php endif; ?>
+			<?php
 			if ( ! empty( $actions ) ) :
 				?>
 			<tr>
@@ -110,27 +131,6 @@ if ( $show_downloads ) {
 								unset( $action_aria_label );
 						}
 						?>
-					</td>
-				</tr>
-			<?php endif; ?>
-			<?php
-			foreach ( $order->get_order_item_totals() as $key => $total ) {
-				?>
-					<tr>
-						<th scope="row"><?php echo esc_html( $total['label'] ); ?></th>
-						<td><?php echo wp_kses_post( $total['value'] ); ?></td>
-					</tr>
-					<?php
-			}
-			?>
-			<?php if ( $order->get_customer_note() ) : ?>
-				<tr>
-					<th><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
-					<td>
-					<?php
-					$customer_note = wc_wptexturize_order_note( $order->get_customer_note() );
-					echo wp_kses( nl2br( $customer_note ), array( 'br' => array() ) );
-					?>
 					</td>
 				</tr>
 			<?php endif; ?>

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.1.0
+ * @version 10.8.0
  *
  * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */


### PR DESCRIPTION
## Summary

Merges two separate `<tfoot>` elements in `order-details.php` into a single valid `<tfoot>` block.

Per the HTML spec, only one `<tfoot>` element is allowed per `<table>`:
> Contexts in which this element can be used: As a child of a table element, but only if there are no other tfoot elements that are children of the table element.
> — https://html.spec.what.whatwg.org/multipage/tables.html#the-tfoot-element

## Changes

- Removes the first standalone `<tfoot>` block (containing order actions)
- Moves the conditional actions row inside the main `<tfoot>`, before order item totals
- Result: one `<tfoot>` with actions (conditional) + order totals + customer note

## Testing Instructions

1. Place an order and view the order details page (My Account > Orders > View)
2. Verify the order details table renders correctly with totals
3. Test with and without order actions available
4. Verify HTML validates (only one `<tfoot>` per table)

Fixes #60086

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->