### PR TITLE
Fix: Use DOM API to set aria-label on tooltip span

### DIFF
--- a/plugins/woocommerce/changelog/pr-64359
+++ b/plugins/woocommerce/changelog/pr-64359
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use DOM API instead of template literal for tooltip aria-label.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1429,9 +1429,10 @@ jQuery( function ( $ ) {
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );
-	const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${
-		woocommerce_admin_meta_boxes.i18n_product_image_tip
-	}"></span>`;
+	const tooltipMarkup = document.createElement( 'span' );
+	tooltipMarkup.className = 'woocommerce-help-tip';
+	tooltipMarkup.tabIndex = 0;
+	tooltipMarkup.ariaLabel = woocommerce_admin_meta_boxes.i18n_product_image_tip;
 	const tooltipData = {
 		attribute: 'data-tip',
 		content: woocommerce_admin_meta_boxes.i18n_product_image_tip,
@@ -1442,7 +1443,7 @@ jQuery( function ( $ ) {
 	};
 
 	if ( setProductImageLink ) {
-		$( tooltipMarkup )
+		$( tooltipMarkup.cloneNode( true ) )
 			.insertAfter( setProductImageLink )
 			.tipTip( tooltipData );
 	}
@@ -1450,7 +1451,7 @@ jQuery( function ( $ ) {
 	const addProductImagesLink = $( '.add_product_images > a' );
 
 	if ( addProductImagesLink ) {
-		$( tooltipMarkup )
+		$( tooltipMarkup.cloneNode( true ) )
 			.insertAfter( addProductImagesLink )
 			.tipTip( tooltipData );
 	}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1432,7 +1432,7 @@ jQuery( function ( $ ) {
 	const tooltipMarkup = document.createElement( 'span' );
 	tooltipMarkup.className = 'woocommerce-help-tip';
 	tooltipMarkup.tabIndex = 0;
-	tooltipMarkup.ariaLabel = woocommerce_admin_meta_boxes.i18n_product_image_tip;
+	tooltipMarkup.setAttribute( 'aria-label', woocommerce_admin_meta_boxes.i18n_product_image_tip );
 	const tooltipData = {
 		attribute: 'data-tip',
 		content: woocommerce_admin_meta_boxes.i18n_product_image_tip,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Replaces direct `.ariaLabel` property assignment with `setAttribute( 'aria-label', ... )` on the tooltip markup in the product image meta box. This improves compatibility with older browsers that do not support the `ariaLabel` IDL attribute on `<span>` elements.

Closes #64282.

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Products** and edit a product
2. Hover over the product image thumbnail in the meta box
3. **Before fix:** `ariaLabel` property may not be set in some older browsers
4. **After fix:** `aria-label` attribute is reliably set via `setAttribute`, tooltip works in all browsers
5. Verify no console errors appear

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix

#### Message

Use setAttribute for aria-label on tooltip span for better browser compatibility

</details>
