### PR TITLE
Fix: use home_url() instead of get_site_url() for transient file public URL

### DIFF
--- a/plugins/woocommerce/changelog/64242-fix-transient-file-url-uses-home-url
+++ b/plugins/woocommerce/changelog/64242-fix-transient-file-url-uses-home-url
@@ -1,4 +1,3 @@
 Significance: patch
 Type: fix
-
-Fix transient file public URL to use home_url() instead of get_site_url(), resolving 404s on subdirectory WordPress installs
+Comment: Fix transient file public URL to use home_url() instead of get_site_url(), resolving 404s on subdirectory WordPress installs

--- a/plugins/woocommerce/changelog/64242-fix-transient-file-url-uses-home-url
+++ b/plugins/woocommerce/changelog/64242-fix-transient-file-url-uses-home-url
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Fix transient file public URL to use home_url() instead of get_site_url(), resolving 404s on subdirectory WordPress installs

--- a/plugins/woocommerce/changelog/64242-fix-transient-file-url-uses-home-url
+++ b/plugins/woocommerce/changelog/64242-fix-transient-file-url-uses-home-url
@@ -1,3 +1,4 @@
 Significance: patch
 Type: fix
+
 Fix transient file public URL to use home_url() instead of get_site_url(), resolving 404s on subdirectory WordPress installs

--- a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
+++ b/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
@@ -219,7 +219,7 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	 * @return string The public URL of the file.
 	 */
 	public function get_public_url( string $filename ) {
-		return $this->legacy_proxy->call_function( 'get_site_url', null, '/wc/file/transient/' . $filename );
+		return $this->legacy_proxy->call_function( 'home_url', '/wc/file/transient/' . $filename );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
@@ -348,12 +348,13 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_public_url returns the full public URL of a transient file given its name.
+	 * @testdox get_public_url uses the frontend URL for subdirectory WordPress installs.
 	 */
 	public function test_get_public_url() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'home_url' => fn( $path = '' ) => 'http://example.com' . $path,
+				'home_url'     => fn( $path = '' ) => 'http://example.com' . $path,
+				'get_site_url' => fn( $blog_id = null, $path = '' ) => 'http://example.com/wp' . $path,
 			)
 		);
 

--- a/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
@@ -353,7 +353,7 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 	public function test_get_public_url() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_site_url' => fn( $blog_id, $path) => 'http://example.com' . $path,
+				'home_url' => fn( $path = '' ) => 'http://example.com' . $path,
 			)
 		);
 


### PR DESCRIPTION
 ### Changes proposed in this Pull Request:

Fixes `TransientFilesEngine::get_public_url()` which was using `get_site_url()` to build the public URL for transient files. On WordPress installs where core is installed in a subdirectory (e.g. Bedrock-style setups where `site_url() = https://example.com/wp` but `home_url() = https://example.com`), this generates an incorrect URL that returns 404.

Since `wc/file/transient` is a frontend rewrite endpoint registered via `add_rewrite_rule()`, it resolves relative to `home_url()`, not `site_url()`.

Closes #64242.

### How to test the changes in this Pull Request:

1. Set up WordPress with core installed in a subdirectory so that `home_url() ≠ site_url()` (e.g. `site_url = https://example.test/wp`, `home_url = https://example.test`)
2. Install and activate WooCommerce
3. Create a WooCommerce order
4. Generate a printable receipt via `POST /wp-json/wc/v3/orders/{order_id}/receipt`
5. Confirm the returned `receipt_url` uses `home_url` base (no `/wp/` in path)
6. Open the `receipt_url` and confirm it returns 200, not 404

### Testing that has already taken place:

Reproduced locally using Local WP with `WP_SITEURL = http://subdirtest.local/wp` and `WP_HOME = http://subdirtest.local`. Confirmed `receipt_url` returned `/wp/wc/file/transient/...` before fix and `/wc/file/transient/...` after fix.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- Significance: Patch
- Type: Fix
- Message: Fix transient file public URL to use home_url() instead of get_site_url(), resolving 404s on subdirectory WordPress installs
