### PR TITLE
Let CodeRabbit auto-review feature-branch PRs

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,4 +1,9 @@
 reviews:
+    auto_review:
+        base_branches:
+            - "trunk"
+            - "feature/.*"
+            - "rsm-.*"
     assess_linked_issues: false
     collapse_walkthrough: true
     high_level_summary: false


### PR DESCRIPTION
## Summary

CodeRabbit's default `auto_review.base_branches` only matches the repo's default branch, so PRs targeting feature/* or rsm-* integration branches don't get auto-reviewed. On stacked-PR workflows (e.g. the in-flight back-in-stock-notifications alpha stack — three chained PRs with manual `@coderabbitai review` triggers the only way to get a review) this means no incremental review until a PR is rebased to trunk.

This PR extends `reviews.auto_review.base_branches` to:
- `trunk` (unchanged, now explicit)
- `feature/.*` (long-lived integration branches)
- `rsm-.*` (Radical Speed Month team branches)

## Test plan

- [ ] After merge, open a new PR against `feature/*` or `rsm-*` and confirm CodeRabbit posts an auto-review without needing `@coderabbitai review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)