### PR TITLE
Add woocommerce_edit_account_form_before_password action hook

### DIFF
--- a/plugins/woocommerce/templates/myaccount/form-edit-account.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.5.0
+ * @version 10.8.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -58,6 +58,15 @@ do_action( 'woocommerce_before_edit_account_form' );
 		 * @since 8.7.0
 		 */
 		do_action( 'woocommerce_edit_account_form_fields' );
+	?>
+
+	<?php
+		/**
+		 * Hook before the password change section.
+		 *
+		 * @since 10.8.0
+		 */
+		do_action( 'woocommerce_edit_account_form_before_password' );
 	?>
 
 	<fieldset>


### PR DESCRIPTION
## Summary

Adds a `woocommerce_edit_account_form_before_password` action hook to the Edit Account form template, fired just before the password change fieldset. This allows developers to inject custom fields or content above the password section without needing to override the entire template.

Fixes #32068

## Changes

- Added `do_action( 'woocommerce_edit_account_form_before_password' )` in `templates/myaccount/form-edit-account.php` before the password `<fieldset>`
- Bumped template `@version` to 10.8.0

## Usage

```php
add_action( 'woocommerce_edit_account_form_before_password', function() {
    echo '<p>Custom content before password fields</p>';
});
```

## Testing Instructions

1. Go to My Account > Account Details
2. Verify the page loads normally with no errors
3. Add a callback to the `woocommerce_edit_account_form_before_password` hook
4. Reload the page and verify the callback output appears above the password change section

## CodeRabbit

This PR uses the [CHILL](https://coderabbit.ai/docs/configuration#chill-code-review-profile) review profile.