### PR TITLE
Fix: Replace hardcoded /wp-content path with WP_CONTENT_DIR constant

### DIFF
--- a/plugins/woocommerce/changelog/pr-64376
+++ b/plugins/woocommerce/changelog/pr-64376
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace hardcoded /wp-content path with WP_CONTENT_DIR constant.

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -310,7 +310,7 @@ class WC_Download_Handler {
 			);
 		}
 
-		$wp_content_dir_relative = str_replace( ABSPATH, '', WP_CONTENT_DIR );
+		$wp_content_dir_relative = ( 0 === strpos( WP_CONTENT_DIR, ABSPATH ) ) ? substr( WP_CONTENT_DIR, strlen( ABSPATH ) ) : WP_CONTENT_DIR;
 		$wp_content_dirname     = ( $wp_content_dir_relative !== WP_CONTENT_DIR ) ? '/' . $wp_content_dir_relative : null;
 
 		// See if path needs an abspath prepended to work.

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -310,14 +310,16 @@ class WC_Download_Handler {
 			);
 		}
 
+		$wp_content_dirname = '/' . str_replace( ABSPATH, '', WP_CONTENT_DIR );
+
 		// See if path needs an abspath prepended to work.
 		if ( file_exists( ABSPATH . $file_path ) ) {
 			$remote_file = false;
 			$file_path   = ABSPATH . $file_path;
 
-		} elseif ( '/wp-content' === substr( $file_path, 0, 11 ) ) {
+		} elseif ( 0 === strpos( $file_path, $wp_content_dirname ) ) {
 			$remote_file = false;
-			$file_path   = realpath( WP_CONTENT_DIR . substr( $file_path, 11 ) );
+			$file_path   = realpath( WP_CONTENT_DIR . substr( $file_path, strlen( $wp_content_dirname ) ) );
 
 			// Check if we have an absolute path.
 		} elseif ( ( ! isset( $parsed_file_path['scheme'] ) || ! in_array( $parsed_file_path['scheme'], array( 'http', 'https', 'ftp' ), true ) ) && isset( $parsed_file_path['path'] ) ) {

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -310,14 +310,15 @@ class WC_Download_Handler {
 			);
 		}
 
-		$wp_content_dirname = '/' . str_replace( ABSPATH, '', WP_CONTENT_DIR );
+		$wp_content_dir_relative = str_replace( ABSPATH, '', WP_CONTENT_DIR );
+		$wp_content_dirname     = ( $wp_content_dir_relative !== WP_CONTENT_DIR ) ? '/' . $wp_content_dir_relative : null;
 
 		// See if path needs an abspath prepended to work.
 		if ( file_exists( ABSPATH . $file_path ) ) {
 			$remote_file = false;
 			$file_path   = ABSPATH . $file_path;
 
-		} elseif ( 0 === strpos( $file_path, $wp_content_dirname ) ) {
+		} elseif ( null !== $wp_content_dirname && 0 === strpos( $file_path, $wp_content_dirname ) ) {
 			$remote_file = false;
 			$file_path   = realpath( WP_CONTENT_DIR . substr( $file_path, strlen( $wp_content_dirname ) ) );
 

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -310,15 +310,16 @@ class WC_Download_Handler {
 			);
 		}
 
-		$wp_content_dir_relative = ( 0 === strpos( WP_CONTENT_DIR, ABSPATH ) ) ? substr( WP_CONTENT_DIR, strlen( ABSPATH ) ) : WP_CONTENT_DIR;
-		$wp_content_dirname     = ( $wp_content_dir_relative !== WP_CONTENT_DIR ) ? '/' . $wp_content_dir_relative : null;
+		$wp_content_dirname = ( 0 === strpos( WP_CONTENT_DIR, ABSPATH ) )
+			? '/' . substr( WP_CONTENT_DIR, strlen( ABSPATH ) )
+			: '/wp-content';
 
 		// See if path needs an abspath prepended to work.
 		if ( file_exists( ABSPATH . $file_path ) ) {
 			$remote_file = false;
 			$file_path   = ABSPATH . $file_path;
 
-		} elseif ( null !== $wp_content_dirname && 0 === strpos( $file_path, $wp_content_dirname ) ) {
+		} elseif ( 0 === strpos( $file_path, $wp_content_dirname ) ) {
 			$remote_file = false;
 			$file_path   = realpath( WP_CONTENT_DIR . substr( $file_path, strlen( $wp_content_dirname ) ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Replaces the hardcoded `/wp-content` path in `WC_Download_Handler::parse_file_path()` with a dynamic check derived from the `WP_CONTENT_DIR` constant. This ensures downloads work correctly when the content directory has been renamed or moved from the default location.

The fix uses `strpos()` to check if `WP_CONTENT_DIR` is inside `ABSPATH`:
- If inside: derives the relative path (e.g., `/custom-content`)
- If outside: falls back to `/wp-content` for backward compatibility

Closes #30898.

### How to test the changes in this Pull Request:

1. Create a downloadable product and add a downloadable file
2. Purchase the product and verify the download works with default WordPress configuration
3. (Advanced) Rename `wp-content` to `custom-content` and define `WP_CONTENT_DIR` and `WP_CONTENT_URL` in `wp-config.php`
4. Verify downloads still resolve correctly with the custom content directory
5. Verify no regressions with remote file downloads (URLs)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix

#### Message

Replace hardcoded /wp-content path with dynamic WP_CONTENT_DIR check in download handler

</details>
