### PR TITLE
[dev] Reduce variability in payment gateway is_available implementations.

### DIFF
--- a/plugins/woocommerce/changelog/performance-available-gateways-population
+++ b/plugins/woocommerce/changelog/performance-available-gateways-population
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Reduce variability in payment gateway is_available implementations.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -344,14 +344,13 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return bool
 	 */
 	public function is_available() {
-		if ( 'yes' !== $this->enabled ) {
-			return false;
-		}
+		$is_available = 'yes' === $this->enabled;
 
-		$is_available = true;
-
-		if ( WC()->cart && 0 < $this->get_order_total() && 0 < $this->max_amount && $this->max_amount < $this->get_order_total() ) {
-			$is_available = false;
+		if ( $is_available && WC()->cart ) {
+			$order_total = $this->get_order_total();
+			if ( 0 < $order_total && 0 < $this->max_amount && $order_total > $this->max_amount ) {
+				$is_available = false;
+			}
 		}
 
 		return $is_available;

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -25,7 +25,7 @@ class WC_Payment_Gateways {
 	/**
 	 * Payment gateway classes.
 	 *
-	 * @var array
+	 * @var WC_Payment_Gateway[]
 	 */
 	public $payment_gateways = array();
 
@@ -319,13 +319,13 @@ class WC_Payment_Gateways {
 	 * may try to rely on the existence of a WC session - a valid thing to do,
 	 * and cause fatal errors when the session is not available.
 	 *
-	 * @return array The available payment gateways.
+	 * @return WC_Payment_Gateway[] The available payment gateways.
 	 */
 	public function get_available_payment_gateways() {
 		$_available_gateways = array();
 
 		foreach ( $this->payment_gateways as $gateway ) {
-			if ( $gateway->is_available() ) {
+			if ( 'yes' === $gateway->enabled && $gateway->is_available() ) {
 				if ( ! is_add_payment_method_page() ) {
 					$_available_gateways[ $gateway->id ] = $gateway;
 				} elseif ( $gateway->supports( PaymentGatewayFeature::ADD_PAYMENT_METHOD ) || $gateway->supports( PaymentGatewayFeature::TOKENIZATION ) ) {

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -325,7 +325,7 @@ class WC_Payment_Gateways {
 		$_available_gateways = array();
 
 		foreach ( $this->payment_gateways as $gateway ) {
-			if ( 'yes' === $gateway->enabled && $gateway->is_available() ) {
+			if ( $gateway->is_available() ) {
 				if ( ! is_add_payment_method_page() ) {
 					$_available_gateways[ $gateway->id ] = $gateway;
 				} elseif ( $gateway->supports( PaymentGatewayFeature::ADD_PAYMENT_METHOD ) || $gateway->supports( PaymentGatewayFeature::TOKENIZATION ) ) {

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -339,6 +339,10 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * @return bool
 	 */
 	public function is_available() {
+		if ( 'yes' !== $this->enabled ) {
+			return false;
+		}
+
 		// For Orders v2, require a valid email address to be set up in the gateway settings.
 		if ( $this->should_use_orders_v2() && $this->needs_setup() ) {
 			return false;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: checkout hot-path verification, https://github.com/woocommerce/woocommerce/pull/64349

Consistently use `'yes' === $gateway->enabled` in bundled payment gateway `is_available` implementations to exit early when the gateway is disabled.

While this change is a micro-optimization, Claude considers it a medium issue for production systems, even though we have not yet benchmarked them. My review of the gateways in WooCommerce core, WooPayments, and Stripe Gateway confirms that the flag is not always checked first.

### How to test the changes in this Pull Request:

- CI-check shall pass (changes has good test coverage)
- Optionally smoke-test checkout with CoD gateway