### PR TITLE
Fix OrdersTableQuery LIMIT for SQLite compatibility

### DIFF
--- a/plugins/woocommerce/changelog/fix-orders-query-sqlite-limit
+++ b/plugins/woocommerce/changelog/fix-orders-query-sqlite-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Omit the LIMIT clause in OrdersTableQuery when an unlimited (-1) row count is requested, matching WP_Query nopaging behavior. Fixes a datatype mismatch error when the orders query runs against a SQLite database.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1444,11 +1444,14 @@ class OrdersTableQuery {
 			return;
 		}
 
+		$offset    = (int) ( $this->limits[0] ?? 0 );
 		$row_count = $this->limits[1] ?? 0;
 
-		if ( $this->limits && $row_count > 0 ) {
+		if ( $this->limits && ( $row_count > 0 || $offset > 0 ) ) {
 			$this->found_orders  = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$this->max_num_pages = (int) ceil( $this->found_orders / $row_count );
+			$this->max_num_pages = $row_count > 0
+				? (int) ceil( $this->found_orders / $row_count )
+				: 0;
 		} else {
 			$this->found_orders = count( $this->orders );
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -32,13 +32,6 @@ class OrdersTableQuery {
 	public const REGEX_SHORTHAND_DATES = '/([^.<>]*)(>=|<=|>|<|\.\.\.)([^.<>]+)/';
 
 	/**
-	 * Highest possible unsigned bigint value (unsigned bigints being the type of the `id` column).
-	 *
-	 * This is deliberately held as a string, rather than a numeric type, for inclusion within queries.
-	 */
-	private const MYSQL_MAX_UNSIGNED_BIGINT = '18446744073709551615';
-
-	/**
 	 * Names of all COT tables (orders, addresses, operational_data, meta) in the form 'table_id' => 'table name'.
 	 *
 	 * @var array
@@ -857,8 +850,19 @@ class OrdersTableQuery {
 
 		if ( ! empty( $this->limits ) && count( $this->limits ) === 2 ) {
 			list( $offset, $row_count ) = $this->limits;
-			$row_count                  = -1 === $row_count ? self::MYSQL_MAX_UNSIGNED_BIGINT : (int) $row_count;
-			$limits                     = 'LIMIT ' . (int) $offset . ', ' . $row_count;
+			$offset                     = (int) $offset;
+
+			if ( -1 === $row_count ) {
+				// For "unlimited" (-1) queries, mirror WP_Query's nopaging behavior and
+				// omit the LIMIT clause. When an offset is specified, MySQL requires a
+				// row count, so emit PHP_INT_MAX — portable across MySQL (well below
+				// its unsigned bigint max) and SQLite (its signed 64-bit max).
+				if ( $offset > 0 ) {
+					$limits = 'LIMIT ' . $offset . ', ' . PHP_INT_MAX;
+				}
+			} else {
+				$limits = 'LIMIT ' . $offset . ', ' . (int) $row_count;
+			}
 		}
 
 		// GROUP BY.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1444,9 +1444,11 @@ class OrdersTableQuery {
 			return;
 		}
 
-		if ( $this->limits ) {
+		$row_count = $this->limits[1] ?? 0;
+
+		if ( $this->limits && $row_count > 0 ) {
 			$this->found_orders  = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
+			$this->max_num_pages = (int) ceil( $this->found_orders / $row_count );
 		} else {
 			$this->found_orders = count( $this->orders );
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -849,8 +849,8 @@ class OrdersTableQuery {
 		$limits = '';
 
 		if ( ! empty( $this->limits ) && count( $this->limits ) === 2 ) {
-			list( $offset, $row_count ) = $this->limits;
-			$offset                     = (int) $offset;
+			$offset    = (int) ( $this->limits[0] ?? 0 );
+			$row_count = (int) ( $this->limits[1] ?? 0 );
 
 			if ( -1 === $row_count ) {
 				// For "unlimited" (-1) queries, mirror WP_Query's nopaging behavior and
@@ -861,7 +861,7 @@ class OrdersTableQuery {
 					$limits = 'LIMIT ' . $offset . ', ' . PHP_INT_MAX;
 				}
 			} else {
-				$limits = 'LIMIT ' . $offset . ', ' . (int) $row_count;
+				$limits = 'LIMIT ' . $offset . ', ' . $row_count;
 			}
 		}
 
@@ -907,9 +907,6 @@ class OrdersTableQuery {
 		// version 10.9, this logic is implemented here as alternative changes above are getting flagged by regression analysis.
 		if ( '' === $join && "{$orders_table}.id" === $fields ) {
 			$groupby = '';
-		}
-		if ( 'LIMIT 0, ' . self::MYSQL_MAX_UNSIGNED_BIGINT === $limits ) {
-			$limits = '';
 		}
 
 		$this->sql = "SELECT $fields FROM $orders_table $join WHERE $where $groupby $orderby $limits";
@@ -1445,9 +1442,9 @@ class OrdersTableQuery {
 		}
 
 		$offset    = (int) ( $this->limits[0] ?? 0 );
-		$row_count = $this->limits[1] ?? 0;
+		$row_count = (int) ( $this->limits[1] ?? 0 );
 
-		if ( $this->limits && ( $row_count > 0 || $offset > 0 ) ) {
+		if ( $row_count > 0 || $offset > 0 ) {
 			$this->found_orders  = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$this->max_num_pages = $row_count > 0
 				? (int) ceil( $this->found_orders / $row_count )

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1296,6 +1296,16 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		);
 		$this->assertCount( 12, $query->orders, 'A limit of -1 can successfully be combined with an offset.' );
 		$this->assertEquals( array_slice( $test_orders, 18 ), $query->orders, 'The expected dataset is supplied when an offset is combined with a limit of -1.' );
+		$this->assertEquals(
+			30,
+			$query->found_orders,
+			'A limit of -1 combined with an offset still calculates all found orders.'
+		);
+		$this->assertEquals(
+			0,
+			$query->max_num_pages,
+			'A limit of -1 combined with an offset is treated as unpaged.'
+		);
 
 		$query = new OrdersTableQuery( array( 'limit' => 5 ) );
 		$this->assertCount( 5, $query->orders, 'Limits are respected when applied.' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When callers pass `limit => -1` (e.g. `WC_Order::get_refunds()`), `OrdersTableQuery` emits `LIMIT 0, 18446744073709551615`. That literal is MySQL's unsigned 64-bit max and overflows SQLite's signed 64-bit `INTEGER` type, producing a `datatype mismatch` error under the WordPress SQLite integration (e.g. on WordPress Playground).

This PR mirrors `WP_Query`'s `nopaging` behavior: when `row_count === -1` and no offset is set, omit the `LIMIT` clause entirely. For the rarer offset-to-end case (`limit: -1` + positive `offset`), MySQL still requires a row count, so `PHP_INT_MAX` is used — it fits within MySQL's unsigned bigint range *and* SQLite's signed 64-bit `INTEGER` range. The `MYSQL_MAX_UNSIGNED_BIGINT` constant is removed.

Bug introduced in PR #34289.

**Relationship to #65413:** This branch predates #65413 (_[Performance] Optimize OrdersTableQuery query generation_), which landed on trunk separately and post-processes the built SQL — stripping a `LIMIT 0, <max>` clause and dropping a redundant `GROUP BY`. After rebasing onto trunk, this PR removes that now-redundant strip-`LIMIT` step: the `nopaging` change above already omits the clause, and the step referenced the `MYSQL_MAX_UNSIGNED_BIGINT` constant this PR deletes (leaving it would be a dangling reference / fatal). #65413's `GROUP BY` optimization is kept. This PR also covers a case #65413's approach missed — `limit: -1` with a positive `offset`, where its logic still emitted the SQLite-incompatible `LIMIT <offset>, 18446744073709551615`.

### How to test the changes in this Pull Request:

1. Spin up a WooCommerce site using the SQLite integration (e.g. WordPress Playground or the `sqlite-database-integration` plugin).
2. Place an order, then partially refund an item in the order from the admin.
3. View the order confirmation page on the front-end (e.g. `/checkout/order-received/<id>/`).
4. **Before this PR:** the page errors with `SQLSTATE[HY000]: General error: 20 datatype mismatch`, originating from `WC_Order::get_refunds()`.
5. **After this PR:** the page renders correctly, showing the refunded quantity on the affected line item.
6. Run the existing unit test to confirm no regression: `pnpm test:php:env -- --filter OrdersTableDataStoreTests::test_cot_query_pagination`. It asserts that `limit: -1` returns all orders, and that `limit: -1 + offset: 18` returns the remaining 12 of 30 orders — both still pass.

### Testing that has already taken place:

-   PHPStan clean on the modified file.
-   PHPCS (via `phpcs-changed`) clean on the diff.
-   Manually reproduced on WordPress Playground (SQLite): refunded order confirmation page errored before, renders after.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually via `pnpm --filter=@woocommerce/plugin-woocommerce changelog add` and is included in this PR at `plugins/woocommerce/changelog/fix-orders-query-sqlite-limit`.

</details>
