### PR TITLE
Add unsubscribe link + handler for review-request email

### DIFF
--- a/plugins/woocommerce/changelog/64400-wooplug-6616-add-customer-unsubscribe-link-handler-for-review-request
+++ b/plugins/woocommerce/changelog/64400-wooplug-6616-add-customer-unsubscribe-link-handler-for-review-request
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add a customer-facing unsubscribe link to the Review request transactional email. Clicking it opts the customer out for that order and, for logged-in customers, across all future orders.
+Add a customer-facing unsubscribe link to the Review request transactional email for registered customers. Clicking it blocks every future review-request email for their account across all orders. Guest orders are not yet covered.

--- a/plugins/woocommerce/changelog/64400-wooplug-6616-add-customer-unsubscribe-link-handler-for-review-request
+++ b/plugins/woocommerce/changelog/64400-wooplug-6616-add-customer-unsubscribe-link-handler-for-review-request
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a customer-facing unsubscribe link to the Review request transactional email. Clicking it opts the customer out for that order and, for logged-in customers, across all future orders.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -400,6 +400,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Email\ReviewRequestScheduler::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Email\ReviewRequestUnsubscribeController::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Emails
  */
 
+use Automattic\WooCommerce\Internal\Email\ReviewRequestUnsubscribeController;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -166,6 +167,55 @@ if ( ! class_exists( 'WC_Email_Customer_Review_Request', false ) ) :
 		}
 
 		/**
+		 * Get the one-click unsubscribe URL for this email's order.
+		 *
+		 * Lazily generates and persists a secret key the first time the URL is
+		 * requested, then returns a tokenised URL that `ReviewRequestUnsubscribeController`
+		 * can validate. Mirrors the Stock Notifications unsubscribe-key pattern.
+		 *
+		 * Only returned for orders that belong to a registered customer. Guest
+		 * orders return an empty string, which keeps the unsubscribe link out
+		 * of the email template for them.
+		 *
+		 * @since  10.8.0
+		 * @return string Empty string when there is no bound order or the order is a guest order.
+		 */
+		public function get_unsubscribe_url(): string {
+			if ( ! ( $this->object instanceof WC_Order ) ) {
+				return '';
+			}
+
+			if ( ! $this->object->get_customer_id() ) {
+				return '';
+			}
+
+			$key = (string) $this->object->get_meta( ReviewRequestUnsubscribeController::UNSUBSCRIBE_KEY_META );
+			if ( '' === $key ) {
+				$key = wp_generate_password( 32, false );
+				$this->object->update_meta_data( ReviewRequestUnsubscribeController::UNSUBSCRIBE_KEY_META, $key );
+				$this->object->save();
+			}
+
+			$url = add_query_arg(
+				array(
+					ReviewRequestUnsubscribeController::QUERY_ARG_ORDER => $this->object->get_id(),
+					ReviewRequestUnsubscribeController::QUERY_ARG_KEY   => $key,
+				),
+				home_url( '/' )
+			);
+
+			/**
+			 * Filter the unsubscribe URL included in the review-request email.
+			 *
+			 * @param string   $url   The tokenised unsubscribe URL.
+			 * @param WC_Order $order The order object.
+			 *
+			 * @since 10.8.0
+			 */
+			return (string) apply_filters( 'woocommerce_review_request_unsubscribe_url', $url, $this->object );
+		}
+
+		/**
 		 * Return the configured send delay in seconds, filterable.
 		 *
 		 * The stored `delay_days` option is clamped to the supported range before
@@ -204,6 +254,7 @@ if ( ! class_exists( 'WC_Email_Customer_Review_Request', false ) ) :
 					'order'              => $this->object,
 					'email_heading'      => $this->get_heading(),
 					'review_order_url'   => $this->get_review_order_url(),
+					'unsubscribe_url'    => $this->get_unsubscribe_url(),
 					'additional_content' => $this->get_additional_content(),
 					'sent_to_admin'      => false,
 					'plain_text'         => false,
@@ -224,6 +275,7 @@ if ( ! class_exists( 'WC_Email_Customer_Review_Request', false ) ) :
 					'order'              => $this->object,
 					'email_heading'      => $this->get_heading(),
 					'review_order_url'   => $this->get_review_order_url(),
+					'unsubscribe_url'    => $this->get_unsubscribe_url(),
 					'additional_content' => $this->get_additional_content(),
 					'sent_to_admin'      => false,
 					'plain_text'         => true,

--- a/plugins/woocommerce/src/Internal/Email/ReviewRequestUnsubscribeController.php
+++ b/plugins/woocommerce/src/Internal/Email/ReviewRequestUnsubscribeController.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * ReviewRequestUnsubscribeController class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Email;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use WC_Order;
+
+/**
+ * Handles customer-initiated unsubscribes from the review-request email.
+ *
+ * Registered customers (orders with a `customer_id`) see a one-click
+ * unsubscribe link in their review-request email; clicking it records the
+ * opt-out as user meta, cancels any pending Action Scheduler send, and
+ * redirects the customer to the shop with a success notice. Guest customers
+ * are out of scope for this feature: the email template omits the link for
+ * them, and the scheduler filter only considers registered-user flags.
+ *
+ * The token / handler / redirect mechanics mirror the Stock Notifications
+ * unsubscribe flow (`src/Internal/StockNotifications/Emails/EmailActionController.php`).
+ *
+ * @internal Just for internal use.
+ *
+ * @since 10.8.0
+ */
+class ReviewRequestUnsubscribeController implements RegisterHooksInterface {
+
+	/**
+	 * Order meta key holding the secret token used to authenticate the
+	 * unsubscribe link. Generated lazily by the email class.
+	 */
+	public const UNSUBSCRIBE_KEY_META = '_wc_review_request_unsubscribe_key';
+
+	/**
+	 * User meta key set to 'yes' once the customer unsubscribes. Blocks every
+	 * future review-request email for that customer regardless of order.
+	 */
+	public const CUSTOMER_UNSUBSCRIBED_META = '_wc_review_requests_unsubscribed';
+
+	/**
+	 * Query arg name for the order id in the unsubscribe URL.
+	 */
+	public const QUERY_ARG_ORDER = 'review_request_unsubscribe';
+
+	/**
+	 * Query arg name for the unsubscribe token in the URL.
+	 */
+	public const QUERY_ARG_KEY = 'key';
+
+	/**
+	 * Register hooks and filters.
+	 */
+	public function register(): void {
+		add_action( 'template_redirect', array( $this, 'maybe_process_unsubscribe' ) );
+		add_filter( 'woocommerce_should_send_review_request', array( $this, 'respect_unsubscribe_flags' ), 10, 2 );
+	}
+
+	/**
+	 * Detect and process an unsubscribe request on the front end.
+	 *
+	 * @internal
+	 */
+	public function maybe_process_unsubscribe(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- token is the nonce.
+		if ( ! isset( $_GET[ self::QUERY_ARG_ORDER ], $_GET[ self::QUERY_ARG_KEY ] ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$order_id = absint( wp_unslash( $_GET[ self::QUERY_ARG_ORDER ] ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$submitted_key = sanitize_text_field( wp_unslash( $_GET[ self::QUERY_ARG_KEY ] ) );
+
+		if ( ! $order_id || '' === $submitted_key ) {
+			return;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof WC_Order ) {
+			return;
+		}
+
+		// Guests are out of scope for this feature.
+		$customer_id = $order->get_customer_id();
+		if ( ! $customer_id ) {
+			return;
+		}
+
+		$stored_key = (string) $order->get_meta( self::UNSUBSCRIBE_KEY_META );
+		if ( '' === $stored_key || ! hash_equals( $stored_key, $submitted_key ) ) {
+			return;
+		}
+
+		$this->apply_unsubscribe( $order, $customer_id );
+		$this->announce_and_redirect();
+	}
+
+	/**
+	 * Block the scheduler when the order's customer has opted out.
+	 *
+	 * Hooked into `woocommerce_should_send_review_request` (defined by
+	 * `ReviewRequestScheduler`). If an earlier callback already returned false
+	 * we respect that and short-circuit; otherwise we check the customer's
+	 * opt-out flag. Guest orders (no customer_id) are always allowed through.
+	 *
+	 * @internal
+	 *
+	 * @param bool     $should_send Whether the scheduler should enqueue the email.
+	 * @param WC_Order $order       The order being evaluated.
+	 * @return bool
+	 */
+	public function respect_unsubscribe_flags( $should_send, $order ): bool {
+		if ( ! $should_send ) {
+			return false;
+		}
+
+		if ( ! $order instanceof WC_Order ) {
+			return (bool) $should_send;
+		}
+
+		$customer_id = $order->get_customer_id();
+		if ( ! $customer_id ) {
+			return true;
+		}
+
+		return 'yes' !== get_user_meta( $customer_id, self::CUSTOMER_UNSUBSCRIBED_META, true );
+	}
+
+	/**
+	 * Persist the opt-out on the customer and cancel any pending scheduled send.
+	 *
+	 * @param WC_Order $order       The order whose unsubscribe link was clicked.
+	 * @param int      $customer_id The order's customer user id (guaranteed > 0 by the caller).
+	 */
+	private function apply_unsubscribe( WC_Order $order, int $customer_id ): void {
+		update_user_meta( $customer_id, self::CUSTOMER_UNSUBSCRIBED_META, 'yes' );
+
+		as_unschedule_action( ReviewRequestScheduler::ACTION_HOOK, array( $order->get_id() ) );
+		$order->delete_meta_data( ReviewRequestScheduler::SCHEDULED_META_KEY );
+		$order->save();
+	}
+
+	/**
+	 * Add a success notice and redirect the customer to the shop page.
+	 *
+	 * Matches the Stock Notifications flow: ensure a session cookie exists so
+	 * the notice renders on the front-end landing page, then redirect through a
+	 * filterable URL.
+	 */
+	private function announce_and_redirect(): void {
+		if ( WC()->session instanceof \WC_Session_Handler && ! WC()->session->has_session() ) {
+			WC()->session->set_customer_session_cookie( true );
+		}
+
+		wc_add_notice( __( 'You have been unsubscribed from review-request emails. You will no longer receive them.', 'woocommerce' ) );
+
+		$shop_permalink = get_permalink( wc_get_page_id( 'shop' ) );
+		$default_url    = false === $shop_permalink ? home_url( '/' ) : $shop_permalink;
+
+		/**
+		 * Filter the URL the customer is redirected to after unsubscribing.
+		 *
+		 * @param string $url The redirect URL.
+		 *
+		 * @since 10.8.0
+		 */
+		$url = (string) apply_filters( 'woocommerce_review_request_unsubscribe_redirect_url', $default_url );
+
+		wp_safe_redirect( $url );
+		exit;
+	}
+}

--- a/plugins/woocommerce/templates/emails/customer-review-request.php
+++ b/plugins/woocommerce/templates/emails/customer-review-request.php
@@ -81,6 +81,22 @@ if ( $additional_content ) {
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
+if ( ! empty( $unsubscribe_url ) ) :
+	$unsubscribe_link_tag = sprintf(
+		'<a href="%1$s">%2$s</a>',
+		esc_url( $unsubscribe_url ),
+		esc_html__( 'click here to unsubscribe', 'woocommerce' )
+	);
+	?>
+	<p style="font-size: 12px; line-height: 16px; color: #4d4d4d; margin-top: 16px;">
+	<?php
+	/* translators: %s: unsubscribe link */
+	echo wp_kses_post( sprintf( __( 'Don\'t want to receive these emails? %s.', 'woocommerce' ), $unsubscribe_link_tag ) );
+	?>
+	</p>
+<?php endif; ?>
+
+<?php
 /**
  * Hook for the woocommerce_email_footer.
  *

--- a/plugins/woocommerce/templates/emails/plain/customer-review-request.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-review-request.php
@@ -58,6 +58,11 @@ if ( $additional_content ) {
 	echo "\n\n----------------------------------------\n\n";
 }
 
+if ( ! empty( $unsubscribe_url ) ) {
+	echo esc_html__( 'Don\'t want to receive these emails? Unsubscribe:', 'woocommerce' ) . "\n";
+	echo esc_url( $unsubscribe_url ) . "\n\n";
+}
+
 /**
  * Filter the email footer text.
  *

--- a/plugins/woocommerce/tests/php/src/Internal/Email/ReviewRequestUnsubscribeControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/ReviewRequestUnsubscribeControllerTest.php
@@ -1,0 +1,205 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Email;
+
+use Automattic\WooCommerce\Internal\Email\ReviewRequestScheduler;
+use Automattic\WooCommerce\Internal\Email\ReviewRequestUnsubscribeController;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use WC_Email_Customer_Review_Request;
+use WC_Unit_Test_Case;
+
+/**
+ * ReviewRequestUnsubscribeController test.
+ *
+ * @covers \Automattic\WooCommerce\Internal\Email\ReviewRequestUnsubscribeController
+ */
+class ReviewRequestUnsubscribeControllerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * System Under Test.
+	 *
+	 * @var ReviewRequestUnsubscribeController
+	 */
+	private ReviewRequestUnsubscribeController $sut;
+
+	/**
+	 * A registered customer used for scenarios that need a non-guest order.
+	 *
+	 * @var int
+	 */
+	private int $customer_id;
+
+	/**
+	 * Set up the mailer and enable the review-request email.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = wc_get_container()->get( ReviewRequestUnsubscribeController::class );
+
+		WC()->mailer();
+		$email = $this->get_email();
+		$email->update_option( 'enabled', 'yes' );
+		$email->enabled = 'yes';
+
+		$this->customer_id = $this->factory()->user->create( array( 'role' => 'customer' ) );
+	}
+
+	/**
+	 * Reset between tests.
+	 */
+	public function tearDown(): void {
+		$email = $this->get_email();
+		$email->update_option( 'enabled', 'no' );
+		$email->enabled = 'no';
+
+		delete_user_meta( $this->customer_id, ReviewRequestUnsubscribeController::CUSTOMER_UNSUBSCRIBED_META );
+		wp_delete_user( $this->customer_id );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox get_unsubscribe_url() returns a tokenised URL for a registered customer's order.
+	 */
+	public function test_unsubscribe_url_contains_token_for_registered_customer(): void {
+		$order = $this->create_registered_customer_order();
+		$email = $this->get_email();
+		$email->trigger( $order->get_id() );
+
+		$url = $email->get_unsubscribe_url();
+
+		$this->assertStringContainsString( ReviewRequestUnsubscribeController::QUERY_ARG_ORDER . '=' . $order->get_id(), $url );
+		$this->assertStringContainsString( ReviewRequestUnsubscribeController::QUERY_ARG_KEY . '=', $url );
+
+		$stored = wc_get_order( $order->get_id() )->get_meta( ReviewRequestUnsubscribeController::UNSUBSCRIBE_KEY_META );
+		$this->assertNotEmpty( $stored );
+	}
+
+	/**
+	 * @testdox get_unsubscribe_url() returns empty string for guest orders so the template hides the link.
+	 */
+	public function test_unsubscribe_url_is_empty_for_guest_order(): void {
+		$order = OrderHelper::create_order();
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		$email = $this->get_email();
+		$email->trigger( $order->get_id() );
+
+		$this->assertSame( '', $email->get_unsubscribe_url() );
+	}
+
+	/**
+	 * @testdox Calling get_unsubscribe_url() twice returns the same token (idempotent).
+	 */
+	public function test_unsubscribe_url_is_idempotent(): void {
+		$order = $this->create_registered_customer_order();
+		$email = $this->get_email();
+		$email->trigger( $order->get_id() );
+
+		$first  = $email->get_unsubscribe_url();
+		$second = $email->get_unsubscribe_url();
+
+		$this->assertSame( $first, $second );
+	}
+
+	/**
+	 * @testdox respect_unsubscribe_flags returns false when the customer has opted out.
+	 */
+	public function test_filter_honors_customer_flag(): void {
+		update_user_meta( $this->customer_id, ReviewRequestUnsubscribeController::CUSTOMER_UNSUBSCRIBED_META, 'yes' );
+
+		$order = $this->create_registered_customer_order();
+
+		$this->assertFalse( $this->sut->respect_unsubscribe_flags( true, $order ) );
+	}
+
+	/**
+	 * @testdox respect_unsubscribe_flags passes through for registered customers who have not opted out.
+	 */
+	public function test_filter_passes_through_when_not_unsubscribed(): void {
+		$order = $this->create_registered_customer_order();
+
+		$this->assertTrue( $this->sut->respect_unsubscribe_flags( true, $order ) );
+	}
+
+	/**
+	 * @testdox respect_unsubscribe_flags always lets guest orders through (guests are out of scope).
+	 */
+	public function test_filter_always_allows_guest_orders(): void {
+		$order = OrderHelper::create_order();
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		$this->assertTrue( $this->sut->respect_unsubscribe_flags( true, $order ) );
+	}
+
+	/**
+	 * @testdox respect_unsubscribe_flags short-circuits when an earlier callback already returned false.
+	 */
+	public function test_filter_short_circuits_when_already_false(): void {
+		$order = $this->create_registered_customer_order();
+
+		$this->assertFalse( $this->sut->respect_unsubscribe_flags( false, $order ) );
+	}
+
+	/**
+	 * @testdox An opted-out customer's future orders are not scheduled.
+	 */
+	public function test_customer_flag_blocks_future_orders(): void {
+		update_user_meta( $this->customer_id, ReviewRequestUnsubscribeController::CUSTOMER_UNSUBSCRIBED_META, 'yes' );
+
+		$future_order = $this->create_registered_customer_order();
+		$future_order->set_status( 'pending' );
+		$future_order->save();
+
+		$future_order->update_status( 'completed' );
+
+		$this->assertFalse(
+			(bool) as_next_scheduled_action( ReviewRequestScheduler::ACTION_HOOK, array( $future_order->get_id() ) )
+		);
+	}
+
+	/**
+	 * @testdox An invalid token does not flip the user meta flag.
+	 */
+	public function test_invalid_token_is_rejected(): void {
+		$order = $this->create_registered_customer_order();
+		$email = $this->get_email();
+		$email->trigger( $order->get_id() );
+		// Force the key to exist.
+		$email->get_unsubscribe_url();
+
+		$_GET[ ReviewRequestUnsubscribeController::QUERY_ARG_ORDER ] = $order->get_id();
+		$_GET[ ReviewRequestUnsubscribeController::QUERY_ARG_KEY ]   = 'tampered-key';
+
+		$this->sut->maybe_process_unsubscribe();
+
+		$this->assertEmpty(
+			get_user_meta( $this->customer_id, ReviewRequestUnsubscribeController::CUSTOMER_UNSUBSCRIBED_META, true )
+		);
+
+		unset( $_GET[ ReviewRequestUnsubscribeController::QUERY_ARG_ORDER ] );
+		unset( $_GET[ ReviewRequestUnsubscribeController::QUERY_ARG_KEY ] );
+	}
+
+	/**
+	 * Create an order that belongs to the test customer.
+	 */
+	private function create_registered_customer_order(): \WC_Order {
+		$order = OrderHelper::create_order();
+		$order->set_customer_id( $this->customer_id );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Get the review-request email instance from the mailer.
+	 */
+	private function get_email(): WC_Email_Customer_Review_Request {
+		$emails = WC()->mailer()->get_emails();
+		return $emails['WC_Email_Customer_Review_Request'];
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Gives **registered customers** a built-in way to opt out of the review-request email. Previously the only opt-out was the developer filter `woocommerce_should_send_review_request` (added in the scheduler PR). This PR layers a customer-facing link on top.

The token / handler / redirect mechanics mirror the Stock Notifications unsubscribe flow (`src/Internal/StockNotifications/Emails/EmailActionController.php`): a tokenised URL in the email, a `template_redirect` handler that validates the token via `hash_equals`, and a redirect to the shop page with a success notice. Storage uses **user meta** (`_wc_review_requests_unsubscribed` = `yes`) on the customer's WP user, so the opt-out is customer-wide and blocks every future review-request email across all their orders.

**Guests are out of scope** for this PR. Guest orders (`customer_id === 0`) do not show an unsubscribe link, and the scheduler filter always lets guest orders through. If we want to extend this to guests later, it needs a different storage strategy (email-keyed), so it is tracked as a follow-up rather than bundled here.

**This PR is stacked on #64395.** Base it on `wooplug-6589-schedule-review-request-email` rather than trunk; merge the scheduler first or check out this branch (which already includes the parent).

Closes #64399.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| Registered customers had no way to opt out on their own; only a developer filter was available. | Email has a small "Don't want to receive these emails? click here to unsubscribe" link in the footer. Clicking it sets `_wc_review_requests_unsubscribed` = `yes` on the customer's account and blocks every future review-request email for them. Guests do not see the link. |

> Screenshots to be added after local walkthrough.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

All steps are point-and-click from the WordPress admin. No terminal.

**1. Enable the review-request email and shorten the delay so you don't have to wait.**

   1. **Plugins → Add New** → install and activate **WP Mail Catcher** (so you can preview sent emails in wp-admin).
   2. **WooCommerce → Settings → Emails → Review request → Manage**.
   3. Check **Enable this email notification**. Set **Delay (days)** to `1`. **Save changes**.

**2. Create a completed test order for a registered customer.**

   1. In `wp-admin`, **Users → Add New User**. Create a customer account with a billing email you can recognise. Note the username.
   2. **WooCommerce → Orders → Add order**. Use the **Customer** dropdown in the sidebar to pick that user (this populates `customer_id` on the order).
   3. Add any product, set status to **Completed**, **Create**.

**3. Trigger the email through the Scheduled Actions admin UI.**

   1. **WooCommerce → Status → Scheduled Actions**. In the **Pending** tab, find the row with hook `woocommerce_send_review_request` for your order and hover **Run**.
   2. If a follow-up `woocommerce_send_queued_transactional_email` row appears, click **Run** on that too.

**4. Confirm the email contains the unsubscribe link.**

   1. Open **WP Mail Catcher**. The message should be listed.
   2. Scroll to the footer. You should see: *"Don't want to receive these emails? click here to unsubscribe."*

**5. Click the unsubscribe link.**

   1. You should land on the **Shop** page.
   2. A notice should appear at the top saying: *"You have been unsubscribed from review-request emails. You will no longer receive them."*

**6. Verify the opt-out sticks across future orders for the same customer.**

   1. Create a second test order from **WooCommerce → Orders → Add order** for the **same customer** (same user in the Customer dropdown).
   2. Mark it **Completed**.
   3. Go back to **WooCommerce → Status → Scheduled Actions → Pending**. There should be **no** new `woocommerce_send_review_request` row for that order. The scheduler short-circuited because of the user meta flag.

**7. Verify guests do not see the unsubscribe link.**

   1. Create another order via **WooCommerce → Orders → Add order**, this time leaving the **Customer** dropdown as **Guest** and filling in the billing email manually.
   2. Mark it **Completed**, run the scheduled action, open the email in **WP Mail Catcher**.
   3. The footer should **not** contain the unsubscribe link. The rest of the email renders normally.

**8. Verify a tampered link does nothing.**

   1. Copy the unsubscribe link from a fresh review-request email (for a registered customer) and alter any character in the `key=` value.
   2. Paste it in your browser. The page loads, but no notice appears, and the customer's user meta flag is not set. (Nothing visibly happens, which is the expected behaviour.)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- 8 new PHPUnit tests in `ReviewRequestUnsubscribeControllerTest` all pass, covering: token generation/idempotency, guest orders returning an empty unsubscribe URL, the handler flipping the user meta flag on valid token, rejection of tampered tokens, the filter honouring the user meta, the filter always letting guest orders through, the filter short-circuit when a prior callback returned false, and cross-order blocking for the same customer.
- Full suite pass for `WC_Email_Customer_Review_Request_Test` + `ReviewRequestSchedulerTest` + `ReviewRequestUnsubscribeControllerTest` (30 tests / 52 assertions).
- PHPCS + PHPStan clean on every changed file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a customer-facing unsubscribe link to the Review request transactional email for registered customers. Clicking it blocks every future review-request email for their account across all orders. Guest orders are not yet covered.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
