### PR TITLE
Fix cache poisoning in add_to_cart_url() for simple products

### DIFF
--- a/plugins/woocommerce/includes/class-wc-product-simple.php
+++ b/plugins/woocommerce/includes/class-wc-product-simple.php
@@ -47,7 +47,7 @@ class WC_Product_Simple extends WC_Product {
 				array(
 					'add-to-cart' => $this->get_id(),
 				),
-				( function_exists( 'is_feed' ) && is_feed() ) || ( function_exists( 'is_404' ) && is_404() ) ? $this->get_permalink() : false
+				$this->get_permalink()
 			)
 		) : $this->get_permalink();
 		return apply_filters( 'woocommerce_product_add_to_cart_url', $url, $this );

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-simple.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-simple.php
@@ -182,8 +182,10 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( wp_parse_url( $permalink, PHP_URL_PATH ), $url );
 
 		// URL should NOT contain arbitrary query params from the current request.
-		$_SERVER['REQUEST_URI'] = '/shop/?utm_source=google&gclid=123';;
+		$original_request_uri = $_SERVER['REQUEST_URI'];
+		$_SERVER['REQUEST_URI'] = '/shop/?utm_source=google&gclid=123';
 		$url2 = $this->product->add_to_cart_url();
+		$_SERVER['REQUEST_URI'] = $original_request_uri;
 		$this->assertStringNotContainsString( 'utm_source', $url2 );
 		$this->assertStringNotContainsString( 'gclid', $url2 );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-simple.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-simple.php
@@ -169,6 +169,26 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test add_to_cart_url() always returns product permalink based URL.
+	 *
+	 * @since 9.9.0
+	 */
+	public function test_add_to_cart_url_returns_product_permalink() {
+		$permalink = $this->product->get_permalink();
+		$url       = $this->product->add_to_cart_url();
+
+		// URL should contain the product permalink as base, not the current request URI.
+		$this->assertStringContainsString( 'add-to-cart=' . $this->product->get_id(), $url );
+		$this->assertStringContainsString( wp_parse_url( $permalink, PHP_URL_PATH ), $url );
+
+		// URL should NOT contain arbitrary query params from the current request.
+		$_SERVER['REQUEST_URI'] = '/shop/?utm_source=google&gclid=123';;
+		$url2 = $this->product->add_to_cart_url();
+		$this->assertStringNotContainsString( 'utm_source', $url2 );
+		$this->assertStringNotContainsString( 'gclid', $url2 );
+	}
+
+	/**
 	 * Test backorders_require_notification().
 	 *
 	 * @since 2.3


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `add_to_cart_url()` method in `WC_Product_Simple` passes `false` as the second argument to `add_query_arg()`, which causes WordPress to use `$_SERVER["REQUEST_URI"]` as the base URL. This means arbitrary query parameters from the current page request get injected into the add-to-cart links rendered in product loops and related products sections.

This has two impacts:
1. **Cache poisoning**: Every unique URL parameter combination produces a different page output, defeating page caching (Redis, Varnish, CDN). SEO tools flag this as duplicate content with different URLs.
2. **Security**: Unvalidated URL parameters appear in the HTML source of product links, creating a potential injection vector.

**Fix**: Replace `false` with `$this->get_permalink()` so the add-to-cart URL is always based on the product's own permalink, regardless of what URL parameters are present on the current page.

The ternary condition checking for `is_feed()` / `is_404()` was originally added to use permalink in those contexts, but the else branch (`false`) is the problematic path for all normal page loads. Using `$this->get_permalink()` unconditionally is correct for all contexts — feeds and 404 pages also correctly get the product permalink.

Closes #64107

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

1. Create a simple product that is purchasable and in stock.
2. Visit any product page that shows related products (or a shop page).
3. Add a query parameter to the URL, e.g. `?utm_source=google&gclid=123`
4. View the HTML source and inspect the `add-to-cart` link for the simple product in the related products section.
5. **Before fix**: The link contains `utm_source=google&gclid=123` in the URL.
6. **After fix**: The link only contains `?add-to-cart={product_id}` based on the product permalink — no leaked query parameters.

### Testing that has already taken place:

- PHP syntax check passed (`php -l`)
- Unit test added to `tests/legacy/unit-tests/product/product-simple.php` verifying the URL is permalink-based and does not contain arbitrary query parameters
- Manual code review confirming the change is minimal (1 line changed) and only affects the base URL used for `add_query_arg()`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Fix add_to_cart_url() to use product permalink instead of current request URI, preventing cache poisoning and URL parameter injection.

</details>