### PR TITLE
Fix fatal TypeError in filter_raw_meta_data when HPOS Data Caching is enabled

### DIFF
--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -108,6 +108,16 @@ class WC_Data_Store_WP {
 	 * @return mixed|void
 	 */
 	public function filter_raw_meta_data( &$object, $raw_meta_data ) {
+		// Ensure $raw_meta_data is always an array. With HPOS data caching enabled,
+		// cache cross-contamination between orders, refunds, and subscriptions can
+		// cause a single stdClass to be passed instead of the expected array of stdClass.
+		// See: https://github.com/woocommerce/woocommerce/issues/64219
+		if ( $raw_meta_data instanceof stdClass ) {
+			$raw_meta_data = array( $raw_meta_data );
+		} elseif ( ! is_array( $raw_meta_data ) ) {
+			$raw_meta_data = array();
+		}
+
 		$this->internal_meta_keys = array_unique(
 			array_merge(
 				array_map(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1488,10 +1488,16 @@ WHERE
 			'_billing_address_index',
 			'_shipping_address_index',
 		);
+
+		// Ensure $raw_meta_data is iterable before filtering.
+		if ( ! is_array( $raw_meta_data ) ) {
+			$raw_meta_data = array();
+		}
+
 		$allowed_meta       = array_filter(
 			$raw_meta_data,
 			function ( $meta ) use ( $allowed_keys ) {
-				return in_array( $meta->meta_key, $allowed_keys, true );
+				return is_object( $meta ) && isset( $meta->meta_key ) && in_array( $meta->meta_key, $allowed_keys, true );
 			}
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

After upgrading to WooCommerce 10.7.0, loading the HPOS Orders admin page (`wp-admin/admin.php?page=wc-orders`) triggers a fatal TypeError:

```
Fatal error: Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, stdClass given
in class-wc-data-store-wp.php:120
```

**Root cause**: When HPOS Data Caching is enabled with a persistent object cache (Redis, Memcached), the `orders_meta` cache group can cross-contaminate between orders, refunds, and subscriptions. This causes `$order_data->meta_data` to be a single `stdClass` instead of the expected `array<stdClass>`, and `filter_raw_meta_data()` passes this directly to `array_filter()` which expects an array.

**Fix**: Add type normalization at the entry point of both `WC_Data_Store_WP::filter_raw_meta_data()` and its override in `OrdersTableDataStore`:

1. **Parent class**: If `$raw_meta_data` is a `stdClass`, wrap it in an array. If it's not an array at all, use an empty array.
2. **OrdersTableDataStore override**: Add `is_array()` check before its own `array_filter()` call, and add an `is_object()` guard in the callback.

This is a **10.7.0 regression** that completely breaks the HPOS Orders admin list for stores with refunds and persistent caching.

Closes #64219

(For Bug Fixes) Bug introduced in PR # (unknown — cache shape mismatch introduced with HPOS caching changes).

### How to test the changes in this Pull Request:

1. Install WooCommerce 10.7.0+ with HPOS enabled and **HPOS Data Caching turned on** (WooCommerce → Settings → Advanced → Features).
2. Use a persistent object cache (Redis via Object Cache Pro, or Memcached).
3. Have a store with a mix of orders and refunds.
4. Visit `wp-admin/admin.php?page=wc-orders`.
5. **Before fix**: Fatal TypeError — the Orders admin page is completely broken.
6. **After fix**: Orders page loads normally without errors.

### Testing that has already taken place:

- PHP syntax check passed (`php -l`) on both modified files
- Code review confirming the normalization is safe and backward-compatible (arrays pass through unchanged, only non-array values are normalized)
- The fix is defensive and does not change behavior for correctly-typed inputs

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Fix fatal TypeError in filter_raw_meta_data when HPOS Data Caching cache cross-contamination passes stdClass instead of array.

</details>