### PR TITLE
Fix VAT exemption not applying to variable product prices (since 10.4.0)

### DIFF
--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -574,9 +574,12 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			return false;
 		}
 
-		if ( ! empty( WC()->customer ) && WC()->customer->get_is_vat_exempt() ) {
-			return false;
-		}
+		// Taxes influence the price regardless of VAT exempt status. Even when a
+		// customer is VAT exempt, the displayed prices differ from non-exempt
+		// prices, so they need separate cache entries and the opposite_price_hash
+		// optimization should not apply. Returning false here was causing cached
+		// non-exempt prices to be served to VAT exempt customers.
+		// See: https://github.com/woocommerce/woocommerce/issues/63716
 
 		return true;
 	}

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -529,6 +529,9 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		WC()->customer->set_is_vat_exempt( true );
 		$this->assertTrue( $extended_data_store->taxes_influence_price( $product ) );
 
+		// Restore default state to avoid leaking into other tests.
+		WC()->customer->set_is_vat_exempt( false );
+
 		remove_filter( 'wc_tax_enabled', '__return_true' );
 		remove_filter( 'woocommerce_product_is_taxable', '__return_true' );
 		remove_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -629,6 +629,11 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
 	}
 
+	/**
+	 * Get a data store instance with taxes_influence_price() exposed as public.
+	 *
+	 * @return object Data store with public taxes_influence_price method.
+	 */
 	private function get_data_store_with_public_taxes_influence_price(): object {
 		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
 		return new class() extends WC_Product_Variable_Data_Store_CPT {

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -503,6 +503,9 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		sort( $actual_hashes );
 		$this->assertEquals( $expected_hashes, $actual_hashes );
 
+		// Restore default state to avoid leaking into subsequent tests.
+		WC()->customer->set_is_vat_exempt( false );
+
 		remove_filter( 'wc_tax_enabled', $tax_enabled ? '__return_true' : '__return_false' );
 		remove_filter( 'woocommerce_product_is_taxable', $taxable_product ? '__return_true' : '__return_false' );
 		remove_filter( 'woocommerce_matched_rates', $tax_has_rates ? array( $this, '__return_rates' ) : '__return_empty_array' );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -468,7 +468,6 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testWith [false, true, true, false]
 	 *           [false, false, true, false]
 	 *           [true, true, false, false]
-	 *           [true, true, true, true]
 	 *
 	 * @param bool $tax_enabled Taxes enabled shop-wide or not.
 	 * @param bool $taxable_product Product is taxable or not.
@@ -507,6 +506,32 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		remove_filter( 'wc_tax_enabled', $tax_enabled ? '__return_true' : '__return_false' );
 		remove_filter( 'woocommerce_product_is_taxable', $taxable_product ? '__return_true' : '__return_false' );
 		remove_filter( 'woocommerce_matched_rates', $tax_has_rates ? array( $this, '__return_rates' ) : '__return_empty_array' );
+	}
+
+	/**
+	 * @testdox taxes_influence_price returns true even when customer is VAT exempt, because exempt prices differ from non-exempt.
+	 */
+	public function test_taxes_influence_price_returns_true_for_vat_exempt() {
+		add_filter( 'wc_tax_enabled', '__return_true' );
+		add_filter( 'woocommerce_product_is_taxable', '__return_true' );
+		add_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
+
+		$product = WC_Helper_Product::create_variation_product();
+
+		$extended_data_store = $this->get_data_store_with_public_taxes_influence_price();
+
+		// Non-exempt: taxes should influence price.
+		WC()->customer->set_is_vat_exempt( false );
+		$this->assertTrue( $extended_data_store->taxes_influence_price( $product ) );
+
+		// VAT exempt: taxes should STILL influence price because the displayed
+		// prices are different (tax removed), requiring separate cache entries.
+		WC()->customer->set_is_vat_exempt( true );
+		$this->assertTrue( $extended_data_store->taxes_influence_price( $product ) );
+
+		remove_filter( 'wc_tax_enabled', '__return_true' );
+		remove_filter( 'woocommerce_product_is_taxable', '__return_true' );
+		remove_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
 	}
 
 	/**
@@ -599,6 +624,16 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		return new class() extends WC_Product_Variable_Data_Store_CPT {
 			public function get_price_hash( &$product, $for_display = false ) {
 				return parent::get_price_hash( $product, $for_display );
+			}
+		};
+		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
+	}
+
+	private function get_data_store_with_public_taxes_influence_price(): object {
+		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
+		return new class() extends WC_Product_Variable_Data_Store_CPT {
+			public function taxes_influence_price( $product ): bool {
+				return parent::taxes_influence_price( $product );
 			}
 		};
 		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC()->customer->set_is_vat_exempt(true)` correctly removes tax from **simple** product prices on shop/product pages, but NOT from **variable** product prices. The tax is removed correctly in the cart. This is a regression since WooCommerce 10.4.0.

**Root cause**: The `taxes_influence_price()` method, introduced in 10.4.0, returns `false` when the customer is VAT exempt. This triggers the `$opposite_price_hash` optimization in `read_price_data()`, which was designed to avoid redundant cache entries when taxes don't affect the displayed price.

However, VAT exempt prices ARE different from non-exempt prices (tax is removed), so they need separate cache entries. Returning `false` causes the optimization to serve stale non-exempt cached prices to VAT exempt customers.

**Fix**: Remove the VAT exempt check from `taxes_influence_price()`. The `get_price_hash()` method already includes the VAT exempt status in the hash, ensuring separate cache entries. With `taxes_influence_price()` returning `true`, the `$opposite_price_hash` is set to `null`, and the direct hash-based caching works correctly for both exempt and non-exempt customers.

**Impact**: Minimal — this only changes the caching behavior for variable products when a customer is VAT exempt. The price calculation logic (in `wc_get_price_including_tax()` / `wc_get_price_excluding_tax()`) already handles VAT exemption correctly.

Closes #63716

(For Bug Fixes) Bug introduced in 10.4.0 by the `taxes_influence_price()` method addition.

### Screenshots or screen recordings:

N/A — price display change only.

### How to test the changes in this Pull Request:

1. Configure tax settings:
   - WooCommerce → Settings → Tax: Enable taxes
   - Set prices inclusive of tax
   - Display prices in shop: Including Tax
   - Add a standard tax rate (e.g. 20% for all countries)
2. Create a simple product (price: 100) and a variable product (2 variations, both price: 100).
3. Add this code to set VAT exempt:
   ```php
   add_action('template_redirect', function() {
       WC()->customer->set_is_vat_exempt(true);
   });
   ```
4. Visit the shop page.
5. **Before fix**: Simple product shows tax removed (83.33), variable product still shows full price (100.00).
6. **After fix**: Both simple and variable products show tax-removed prices consistently.

### Testing that has already taken place:

- PHP syntax check passed (`php -l`) on both modified files
- Updated existing test data provider to remove the VAT exempt case from "taxes don't influence" test
- Added new test `test_taxes_influence_price_returns_true_for_vat_exempt` verifying the method returns true for both exempt and non-exempt customers
- The existing `test_variation_price_cache_vat_exempt` test should now pass with this fix

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Fix VAT exemption not applying to variable product prices by removing incorrect early return in taxes_influence_price().

</details>