### PR TITLE
fix(analytics): prevent fatal when plain WC_Order passed to customer DataStore

### DIFF
--- a/plugins/woocommerce/changelog/fix-64338-order-customer-name-method-fallback
+++ b/plugins/woocommerce/changelog/fix-64338-order-customer-name-method-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error when DataStore::get_or_create_customer_from_order() receives a plain WC_Order instead of the Overrides\Order subclass, by adding method_exists() fallback for get_customer_first_name/get_customer_last_name.

--- a/plugins/woocommerce/changelog/fix-64338-order-customer-name-method-fallback
+++ b/plugins/woocommerce/changelog/fix-64338-order-customer-name-method-fallback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix fatal error when DataStore::get_or_create_customer_from_order() receives a plain WC_Order instead of the Overrides\Order subclass, by adding method_exists() fallback for get_customer_first_name/get_customer_last_name.
+Fix fatal error in Analytics Customers DataStore when a plain WC_Order (rather than the Overrides\Order subclass) is passed to get_or_create_customer_from_order(), and harden date_last_active against a missing date_created by cascading through date_modified and date_paid before falling back to null.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -48848,12 +48848,6 @@ parameters:
 			path: src/Admin/Overrides/OrderRefund.php
 
 		-
-			message: '#^Property Automattic\\WooCommerce\\Admin\\Overrides\\OrderRefund\:\:\$customer_id \(int\) does not accept false\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Admin/Overrides/OrderRefund.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\Overrides\\ThemeUpgrader\:\:install\(\) has invalid return type Automattic\\WooCommerce\\Admin\\Overrides\\WP_Error\.$#'
 			identifier: class.notFound
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -41955,52 +41955,12 @@ parameters:
 			count: 3
 			path: src/Admin/API/Reports/Customers/DataStore.php
 
-		-
-			message: '#^Call to an undefined method object\:\:get_billing_city\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
 
-		-
-			message: '#^Call to an undefined method object\:\:get_billing_country\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_billing_email\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_billing_postcode\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_billing_state\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_customer_first_name\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_customer_last_name\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
 
 		-
 			message: '#^Call to an undefined method object\:\:get_date_created\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 2
 			path: src/Admin/API/Reports/Customers/DataStore.php
 
 		-
@@ -42015,11 +41975,7 @@ parameters:
 			count: 1
 			path: src/Admin/API/Reports/Customers/DataStore.php
 
-		-
-			message: '#^Call to an undefined method object\:\:get_user_id\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/Admin/API/Reports/Customers/DataStore.php
+
 
 		-
 			message: '#^Call to an undefined method object\:\:get_username\(\)\.$#'
@@ -42160,7 +42116,7 @@ parameters:
 			path: src/Admin/API/Reports/Customers/DataStore.php
 
 		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Customers\\DataStore\:\:get_customer_order_data_and_format\(\) expects object, WC_Order\|WC_Order_Refund\|false given\.$#'
+			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Customers\\DataStore\:\:get_customer_order_data_and_format\(\) expects WC_Order, WC_Order\|WC_Order_Refund\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Admin/API/Reports/Customers/DataStore.php

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -41958,12 +41958,6 @@ parameters:
 
 
 		-
-			message: '#^Call to an undefined method object\:\:get_email\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
 			message: '#^Call to an undefined method object\:\:get_id\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -41972,19 +41966,7 @@ parameters:
 
 
 		-
-			message: '#^Call to an undefined method object\:\:get_username\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
 			message: '#^Cannot call method get_id\(\) on Automattic\\WooCommerce\\Admin\\API\\Reports\\Customers\\WC_Order\|WC_Order\|WC_Order_Refund\|false\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
-			message: '#^Cannot call method get_id\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Admin/API/Reports/Customers/DataStore.php
@@ -42105,12 +42087,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$customer_id of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Customers\\DataStore\:\:get_last_order\(\) expects int, int\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Customers\\DataStore\:\:get_existing_customer_id_from_order\(\) expects object, WC_Order\|WC_Order_Refund\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Admin/API/Reports/Customers/DataStore.php
@@ -48838,12 +48814,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\Overrides\\OrderRefund\:\:add_filters\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Admin/Overrides/OrderRefund.php
-
-		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Customers\\DataStore\:\:get_or_create_customer_from_order\(\) expects object, WC_Order\|WC_Order_Refund\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Admin/Overrides/OrderRefund.php
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -41958,12 +41958,6 @@ parameters:
 
 
 		-
-			message: '#^Call to an undefined method object\:\:get_date_created\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
 			message: '#^Call to an undefined method object\:\:get_email\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -42111,12 +42105,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$customer_id of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Customers\\DataStore\:\:get_last_order\(\) expects int, int\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Customers/DataStore.php
-
-		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Customers\\DataStore\:\:get_customer_order_data_and_format\(\) expects WC_Order, WC_Order\|WC_Order_Refund\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Admin/API/Reports/Customers/DataStore.php

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -193,7 +193,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		$order = wc_get_order( $post_id );
-		if ( ! $order ) {
+		if ( ! $order instanceof \WC_Order ) {
 			return -1;
 		}
 		$customer_id = self::get_existing_customer_id_from_order( $order );
@@ -713,6 +713,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @return array ($data, $format)
 	 */
 	public static function get_customer_order_data_and_format( $order, $customer_user = null ) {
+		if ( ! is_a( $order, 'WC_Order' ) ) {
+			return array( array(), array() );
+		}
+
 		if ( ! $order instanceof OverridesOrder ) {
 			if ( ! $order->get_id() ) {
 				return array( array(), array() );

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -191,7 +191,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		$order       = wc_get_order( $post_id );
+		$order = wc_get_order( $post_id );
+		if ( ! $order instanceof \WC_Order ) {
+			return -1;
+		}
+
 		$customer_id = self::get_existing_customer_id_from_order( $order );
 		if ( false === $customer_id ) {
 			return -1;
@@ -692,11 +696,14 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Returns a data object and format object of the customers data coming from the order.
 	 *
 	 * @param \WC_Order   $order         WC_Order where we get customer info from.
-	 * @param object|null $customer_user WC_Customer registered customer WP user.
+	 * @param \WC_Customer|null $customer_user WC_Customer registered customer WP user.
 	 * @return array ($data, $format)
 	 */
 	public static function get_customer_order_data_and_format( $order, $customer_user = null ) {
-		$data   = array(
+		$order_date = $order->get_date_created( 'edit' )
+			?? $order->get_date_modified( 'edit' )
+			?? $order->get_date_paid( 'edit' );
+		$data       = array(
 			'first_name'       => method_exists( $order, 'get_customer_first_name' )
 				? $order->get_customer_first_name()
 				: $order->get_billing_first_name( 'edit' ),
@@ -708,9 +715,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'state'            => $order->get_billing_state( 'edit' ),
 			'postcode'         => $order->get_billing_postcode( 'edit' ),
 			'country'          => $order->get_billing_country( 'edit' ),
-			'date_last_active' => $order->get_date_created( 'edit' )
-				? gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() )
-				: gmdate( 'Y-m-d H:i:s' ),
+			'date_last_active' => $order_date
+				? gmdate( 'Y-m-d H:i:s', $order_date->getTimestamp() )
+				: null,
 		);
 		$format = array(
 			'%s',

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -691,20 +691,26 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Returns a data object and format object of the customers data coming from the order.
 	 *
-	 * @param object      $order         WC_Order where we get customer info from.
+	 * @param \WC_Order   $order         WC_Order where we get customer info from.
 	 * @param object|null $customer_user WC_Customer registered customer WP user.
 	 * @return array ($data, $format)
 	 */
 	public static function get_customer_order_data_and_format( $order, $customer_user = null ) {
 		$data   = array(
-			'first_name'       => $order->get_customer_first_name(),
-			'last_name'        => $order->get_customer_last_name(),
+			'first_name'       => method_exists( $order, 'get_customer_first_name' )
+				? $order->get_customer_first_name()
+				: $order->get_billing_first_name( 'edit' ),
+			'last_name'        => method_exists( $order, 'get_customer_last_name' )
+				? $order->get_customer_last_name()
+				: $order->get_billing_last_name( 'edit' ),
 			'email'            => $order->get_billing_email( 'edit' ),
 			'city'             => $order->get_billing_city( 'edit' ),
 			'state'            => $order->get_billing_state( 'edit' ),
 			'postcode'         => $order->get_billing_postcode( 'edit' ),
 			'country'          => $order->get_billing_country( 'edit' ),
-			'date_last_active' => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
+			'date_last_active' => $order->get_date_created( 'edit' )
+				? gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() )
+				: gmdate( 'Y-m-d H:i:s' ),
 		);
 		$format = array(
 			'%s',

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -193,10 +193,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		$order = wc_get_order( $post_id );
-		if ( ! $order instanceof \WC_Order ) {
+		if ( ! $order ) {
 			return -1;
 		}
-
 		$customer_id = self::get_existing_customer_id_from_order( $order );
 		if ( false === $customer_id ) {
 			return -1;
@@ -657,7 +656,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Get or create a customer from a given order.
 	 *
-	 * @param object $order WC Order.
+	 * A plain WC_Order will be converted to an Overrides\Order internally
+	 * to ensure consistent name resolution (user meta → billing → shipping fallback).
+	 *
+	 * @param \WC_Order $order WC Order.
 	 * @return int|bool
 	 */
 	public static function get_or_create_customer_from_order( $order ) {
@@ -669,6 +671,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return false;
+		}
+
+		if ( ! $order instanceof OverridesOrder ) {
+			$order = new OverridesOrder( $order->get_id() );
 		}
 
 		$returning_customer_id = self::get_existing_customer_id_from_order( $order );
@@ -696,29 +702,31 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Returns a data object and format object of the customers data coming from the order.
 	 *
-	 * @param \WC_Order   $order         WC_Order where we get customer info from.
+	 * A plain WC_Order will be converted to an Overrides\Order internally
+	 * to ensure consistent name resolution (user meta → billing → shipping fallback).
+	 *
+	 * @param \WC_Order         $order         WC_Order where we get customer info from.
 	 * @param \WC_Customer|null $customer_user WC_Customer registered customer WP user.
 	 * @return array ($data, $format)
 	 */
 	public static function get_customer_order_data_and_format( $order, $customer_user = null ) {
-		$order_date = $order->get_date_created( 'edit' )
+		if ( ! $order instanceof OverridesOrder ) {
+			$order = new OverridesOrder( $order->get_id() );
+		}
+
+		$date_created = $order->get_date_created( 'edit' )
 			?? $order->get_date_modified( 'edit' )
 			?? $order->get_date_paid( 'edit' );
-		$data       = array(
-			'first_name'       => $order instanceof OverridesOrder
-				? $order->get_customer_first_name()
-				: $order->get_billing_first_name( 'edit' ),
-			'last_name'        => $order instanceof OverridesOrder
-				? $order->get_customer_last_name()
-				: $order->get_billing_last_name( 'edit' ),
+
+		$data   = array(
+			'first_name'       => $order->get_customer_first_name(),
+			'last_name'        => $order->get_customer_last_name(),
 			'email'            => $order->get_billing_email( 'edit' ),
 			'city'             => $order->get_billing_city( 'edit' ),
 			'state'            => $order->get_billing_state( 'edit' ),
 			'postcode'         => $order->get_billing_postcode( 'edit' ),
 			'country'          => $order->get_billing_country( 'edit' ),
-			'date_last_active' => $order_date
-				? gmdate( 'Y-m-d H:i:s', $order_date->getTimestamp() )
-				: null,
+			'date_last_active' => $date_created ? gmdate( 'Y-m-d H:i:s', $date_created->getTimestamp() ) : null,
 		);
 		$format = array(
 			'%s',

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -674,6 +674,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		if ( ! $order instanceof OverridesOrder ) {
+			if ( ! $order->get_id() ) {
+				return false;
+			}
 			$order = new OverridesOrder( $order->get_id() );
 		}
 
@@ -711,6 +714,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public static function get_customer_order_data_and_format( $order, $customer_user = null ) {
 		if ( ! $order instanceof OverridesOrder ) {
+			if ( ! $order->get_id() ) {
+				return array( array(), array() );
+			}
 			$order = new OverridesOrder( $order->get_id() );
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Admin\API\Reports\DataStoreInterface;
 use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 use Automattic\WooCommerce\Admin\API\Reports\SqlQuery;
 use Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
+use Automattic\WooCommerce\Admin\Overrides\Order as OverridesOrder;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
@@ -704,10 +705,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			?? $order->get_date_modified( 'edit' )
 			?? $order->get_date_paid( 'edit' );
 		$data       = array(
-			'first_name'       => method_exists( $order, 'get_customer_first_name' )
+			'first_name'       => $order instanceof OverridesOrder
 				? $order->get_customer_first_name()
 				: $order->get_billing_first_name( 'edit' ),
-			'last_name'        => method_exists( $order, 'get_customer_last_name' )
+			'last_name'        => $order instanceof OverridesOrder
 				? $order->get_customer_last_name()
 				: $order->get_billing_last_name( 'edit' ),
 			'email'            => $order->get_billing_email( 'edit' ),

--- a/plugins/woocommerce/src/Admin/Overrides/OrderRefund.php
+++ b/plugins/woocommerce/src/Admin/Overrides/OrderRefund.php
@@ -61,11 +61,9 @@ class OrderRefund extends \WC_Order_Refund {
 		if ( is_null( $this->customer_id ) ) {
 			$parent_order = \wc_get_order( $this->get_parent_id() );
 
-			if ( ! $parent_order ) {
-				$this->customer_id = false;
-			}
-
-			$this->customer_id = CustomersDataStore::get_or_create_customer_from_order( $parent_order );
+			$this->customer_id = $parent_order instanceof \WC_Order
+				? CustomersDataStore::get_or_create_customer_from_order( $parent_order )
+				: false;
 		}
 
 		return $this->customer_id;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
@@ -768,6 +768,186 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that get_or_create_customer_from_order works with a plain WC_Order (not Overrides\Order).
+	 *
+	 * Bug condition: When a plain WC_Order is passed, get_customer_first_name() does not exist,
+	 * causing a fatal error. The fix should convert to Overrides\Order internally.
+	 *
+	 * Validates: Requirements 1.1, 1.2
+	 */
+	public function test_get_or_create_customer_from_plain_wc_order() {
+		// Remove the filter that converts WC_Order to Overrides\Order so we get a plain WC_Order.
+		remove_filter( 'woocommerce_order_class', array( \Automattic\WooCommerce\Admin\Overrides\Order::class, 'order_class_name' ), 10 );
+
+		$order = new \WC_Order();
+		$order->set_billing_first_name( 'Plain' );
+		$order->set_billing_last_name( 'Order' );
+		$order->set_billing_email( 'plain.order@example.com' );
+		$order->set_date_created( time() );
+		$order->save();
+
+		// Restore the filter.
+		add_filter( 'woocommerce_order_class', array( \Automattic\WooCommerce\Admin\Overrides\Order::class, 'order_class_name' ), 10, 3 );
+
+		// This should not fatal — it should return an int customer ID.
+		$customer_id = CustomersDataStore::get_or_create_customer_from_order( $order );
+
+		$this->assertIsInt( $customer_id );
+		$this->assertGreaterThan( 0, $customer_id );
+	}
+
+	/**
+	 * Test that get_customer_order_data_and_format handles null date_created without fatal.
+	 *
+	 * Bug condition: When get_date_created('edit') returns null, calling ->getTimestamp() on null
+	 * causes a fatal error. The fix should handle null dates gracefully.
+	 *
+	 * Validates: Requirements 1.3
+	 */
+	public function test_get_customer_order_data_with_null_date_created() {
+		$order = new \Automattic\WooCommerce\Admin\Overrides\Order();
+		$order->set_billing_first_name( 'NullDate' );
+		$order->set_billing_last_name( 'Test' );
+		$order->set_billing_email( 'nulldate@example.com' );
+		$order->save();
+
+		// Force all date fields to null after save (simulates edge case / corrupted data).
+		// Since the order is already an OverridesOrder, the instanceof check passes
+		// and no re-instantiation from DB occurs.
+		$order->set_date_created( null );
+		$order->set_date_modified( null );
+
+		// This should not fatal — date_last_active should be null when all dates are null.
+		list( $data, $format ) = CustomersDataStore::get_customer_order_data_and_format( $order );
+
+		$this->assertNull( $data['date_last_active'] );
+	}
+
+	/**
+	 * Test that sync_order_customer handles a non-existent order ID without fatal.
+	 *
+	 * Bug condition: When wc_get_order() returns false for a non-existent order,
+	 * the code proceeds to call methods on false, causing a fatal error.
+	 * The fix should return -1 gracefully.
+	 *
+	 * Validates: Requirements 1.2
+	 */
+	public function test_sync_order_customer_with_nonexistent_order() {
+		// Use a very high order ID that doesn't exist.
+		$result = CustomersDataStore::sync_order_customer( 999999 );
+
+		$this->assertEquals( -1, $result );
+	}
+
+	/**
+	 * Test that get_or_create_customer_from_order preserves correct behavior with Overrides\Order.
+	 *
+	 * Preservation: Overrides\Order with billing name and valid date_created produces
+	 * a customer record with correct first_name, last_name, and date_last_active.
+	 *
+	 * Validates: Requirements 3.1, 3.2
+	 */
+	public function test_overrides_order_customer_creation_preserved() {
+		$order = new \Automattic\WooCommerce\Admin\Overrides\Order();
+		$order->set_billing_first_name( 'Preserved' );
+		$order->set_billing_last_name( 'Customer' );
+		$order->set_billing_email( 'preserved.customer@example.com' );
+		$order->set_date_created( time() );
+		$order->save();
+
+		$customer_id = CustomersDataStore::get_or_create_customer_from_order( $order );
+
+		// Returns an int customer ID.
+		$this->assertIsInt( $customer_id );
+		$this->assertGreaterThan( 0, $customer_id );
+
+		// Verify customer record has correct first_name/last_name (from billing since no user_id).
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'wc_customer_lookup';
+		$record     = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$table_name} WHERE customer_id = %d", $customer_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		$this->assertEquals( 'Preserved', $record->first_name );
+		$this->assertEquals( 'Customer', $record->last_name );
+
+		// date_last_active matches the order's date_created formatted as Y-m-d H:i:s.
+		$expected_date = gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() );
+		$this->assertEquals( $expected_date, $record->date_last_active );
+	}
+
+	/**
+	 * Test that get_or_create_customer_from_order preserves correct behavior with a registered user.
+	 *
+	 * Preservation: Overrides\Order with a registered user produces a customer record
+	 * with correct user_id and username from the WC_Customer.
+	 *
+	 * Validates: Requirements 3.3
+	 */
+	public function test_overrides_order_registered_user_preserved() {
+		// Create a WordPress user to associate with the order.
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'preserveduser',
+				'user_pass'  => 'password',
+				'user_email' => 'preserveduser@example.com',
+				'first_name' => 'RegFirst',
+				'last_name'  => 'RegLast',
+				'role'       => 'customer',
+			)
+		);
+
+		$order = new \Automattic\WooCommerce\Admin\Overrides\Order();
+		$order->set_customer_id( $user_id );
+		$order->set_billing_first_name( 'BillingFirst' );
+		$order->set_billing_last_name( 'BillingLast' );
+		$order->set_billing_email( 'preserveduser@example.com' );
+		$order->set_date_created( time() );
+		$order->save();
+
+		$customer_id = CustomersDataStore::get_or_create_customer_from_order( $order );
+
+		// Returns an int customer ID.
+		$this->assertIsInt( $customer_id );
+		$this->assertGreaterThan( 0, $customer_id );
+
+		// Verify customer record has correct user_id and username from WC_Customer.
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'wc_customer_lookup';
+		$record     = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$table_name} WHERE customer_id = %d", $customer_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		$this->assertEquals( $user_id, (int) $record->user_id );
+		$this->assertEquals( 'preserveduser', $record->username );
+	}
+
+	/**
+	 * Test that calling get_or_create_customer_from_order twice for the same order
+	 * returns the same customer_id without creating a duplicate.
+	 *
+	 * Preservation: Existing customer record for same order returns existing customer_id.
+	 *
+	 * Validates: Requirements 3.4
+	 */
+	public function test_existing_customer_not_duplicated() {
+		$order = new \Automattic\WooCommerce\Admin\Overrides\Order();
+		$order->set_billing_first_name( 'NoDupe' );
+		$order->set_billing_last_name( 'Test' );
+		$order->set_billing_email( 'nodupe@example.com' );
+		$order->set_date_created( time() );
+		$order->save();
+
+		$customer_id_first  = CustomersDataStore::get_or_create_customer_from_order( $order );
+		$customer_id_second = CustomersDataStore::get_or_create_customer_from_order( $order );
+
+		// Both calls return the same customer_id (no duplicate created).
+		$this->assertIsInt( $customer_id_first );
+		$this->assertIsInt( $customer_id_second );
+		$this->assertEquals( $customer_id_first, $customer_id_second );
+	}
+
+	/**
 	 * Test get_last_order.
 	 */
 	public function test_get_last_order() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
@@ -789,11 +789,47 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		// Restore the filter.
 		add_filter( 'woocommerce_order_class', array( \Automattic\WooCommerce\Admin\Overrides\Order::class, 'order_class_name' ), 10, 3 );
 
-		// This should not fatal — it should return an int customer ID.
 		$customer_id = CustomersDataStore::get_or_create_customer_from_order( $order );
 
 		$this->assertIsInt( $customer_id );
 		$this->assertGreaterThan( 0, $customer_id );
+
+		// Verify the converted order resolved billing names via Overrides\Order.
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'wc_customer_lookup';
+		$record     = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$table_name} WHERE customer_id = %d", $customer_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		$this->assertEquals( 'Plain', $record->first_name );
+		$this->assertEquals( 'Order', $record->last_name );
+		$this->assertEquals( 'plain.order@example.com', $record->email );
+		$this->assertNotNull( $record->date_last_active );
+	}
+
+	/**
+	 * Test that get_or_create_customer_from_order returns false for unsaved orders.
+	 *
+	 * Bug condition: An unsaved order has get_id() === 0. Constructing
+	 * new OverridesOrder( 0 ) returns an empty order, which would write
+	 * a blank customer row.
+	 */
+	public function test_get_or_create_customer_from_unsaved_order() {
+		// Remove the filter that converts WC_Order to Overrides\Order so we get a plain WC_Order.
+		remove_filter( 'woocommerce_order_class', array( \Automattic\WooCommerce\Admin\Overrides\Order::class, 'order_class_name' ), 10 );
+
+		$order = new \WC_Order();
+		$order->set_billing_first_name( 'Unsaved' );
+		$order->set_billing_last_name( 'Order' );
+		$order->set_billing_email( 'unsaved@example.com' );
+		// Do NOT call save() — order has no ID yet.
+
+		$result = CustomersDataStore::get_or_create_customer_from_order( $order );
+
+		$this->assertFalse( $result );
+
+		// Restore the filter.
+		add_filter( 'woocommerce_order_class', array( \Automattic\WooCommerce\Admin\Overrides\Order::class, 'order_class_name' ), 10, 3 );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
@@ -31,7 +31,8 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		$customer_id = DataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
+		$customer_id = DataStore::get_customer_id_by_user_id( $customer->get_id() );
+		// This is the customer ID from lookup table.
 
 		// Create 3 orders.
 		foreach ( range( 1, 3 ) as $i ) {
@@ -87,7 +88,8 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		$customer_id = DataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
+		$customer_id = DataStore::get_customer_id_by_user_id( $customer->get_id() );
+		// This is the customer ID from lookup table.
 
 		// Customer should remain in lookup table after first order deleted.
 		$order1->delete( true );
@@ -192,6 +194,64 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 		$this->assertCount( 1, $rows, 'Guest row should still exist.' );
 		$this->assertNull( $rows[0]->user_id, 'Guest row user_id should remain NULL for normal registration.' );
 	}
+
+	/**
+	 * Test that get_or_create_customer_from_order() handles a plain WC_Order
+	 * (not the Overrides\Order subclass) without a fatal error.
+	 *
+	 * This is a regression test for the scenario described in issue #64338,
+	 * where get_customer_first_name/get_customer_last_name do not exist on plain WC_Order.
+	 *
+	 * @covers \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_or_create_customer_from_order
+	 */
+	public function test_get_or_create_customer_from_plain_wc_order() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Build a plain WC_Order directly, bypassing the woocommerce_order_class filter
+		// that normally swaps in the Overrides\Order subclass. This is the exact path
+		// that produced the production fatal.
+		$order = new WC_Order();
+		$order->set_billing_first_name( 'Jane' );
+		$order->set_billing_last_name( 'Doe' );
+		$order->set_billing_email( 'jane.doe.plain@example.com' );
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$customer_id = \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_or_create_customer_from_order( $order );
+
+		$this->assertNotFalse( $customer_id, 'Should return a customer ID for a plain WC_Order without fataling.' );
+		$this->assertIsInt( $customer_id, 'Returned customer ID should be an integer.' );
+	}
+
+	/**
+	 * Test that get_customer_order_data_and_format() cascades through date_modified
+	 * and date_paid when date_created is null, and ultimately falls back to null
+	 * rather than stamping an incorrect current timestamp.
+	 *
+	 * @covers \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_customer_order_data_and_format
+	 */
+	public function test_date_last_active_falls_back_when_date_created_is_null() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_date_created' )->willReturn( null );
+		$order->method( 'get_date_modified' )->willReturn( null );
+		$order->method( 'get_date_paid' )->willReturn( null );
+		$order->method( 'get_user_id' )->willReturn( 0 );
+		$order->method( 'get_billing_email' )->willReturn( 'test@example.com' );
+		$order->method( 'get_billing_first_name' )->willReturn( 'Test' );
+		$order->method( 'get_billing_last_name' )->willReturn( 'User' );
+		$order->method( 'get_billing_city' )->willReturn( '' );
+		$order->method( 'get_billing_state' )->willReturn( '' );
+		$order->method( 'get_billing_postcode' )->willReturn( '' );
+		$order->method( 'get_billing_country' )->willReturn( '' );
+
+		list( $data, ) = \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_customer_order_data_and_format( $order );
+
+		$this->assertNull(
+			$data['date_last_active'],
+			'date_last_active must be null (not the current timestamp) when all date fields are null.'
+		);
+	}
+
 
 	/**
 	 * Get a customer's record from the database.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
@@ -231,7 +231,8 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 	 * @covers \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_customer_order_data_and_format
 	 */
 	public function test_date_last_active_falls_back_when_date_created_is_null() {
-		$order = $this->createMock( WC_Order::class );
+		$order = $this->createMock( \Automattic\WooCommerce\Admin\Overrides\Order::class );
+		$order->method( 'get_id' )->willReturn( 0 );
 		$order->method( 'get_date_created' )->willReturn( null );
 		$order->method( 'get_date_modified' )->willReturn( null );
 		$order->method( 'get_date_paid' )->willReturn( null );
@@ -243,6 +244,8 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 		$order->method( 'get_billing_state' )->willReturn( '' );
 		$order->method( 'get_billing_postcode' )->willReturn( '' );
 		$order->method( 'get_billing_country' )->willReturn( '' );
+		$order->method( 'get_customer_first_name' )->willReturn( 'Test' );
+		$order->method( 'get_customer_last_name' )->willReturn( 'User' );
 
 		list( $data, ) = \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_customer_order_data_and_format( $order );
 


### PR DESCRIPTION
## Summary

This PR prevents two fatal errors in the Analytics Customers DataStore:

1. **Plain `WC_Order` passed to `get_or_create_customer_from_order()`** — The original code assumed the order object is always an instance of `Automattic\WooCommerce\Admin\Overrides\Order`, which defines `get_customer_first_name()` and `get_customer_last_name()`. When a plain `WC_Order` is passed (e.g., constructed directly without the `woocommerce_order_class` filter), these methods don't exist, causing a fatal error.

   **Fix**: Both `get_or_create_customer_from_order()` and `get_customer_order_data_and_format()` now convert plain `WC_Order` to `Overrides\Order` at the entry point via `new Overrides\Order( $order->get_id() )`. This ensures all orders go through the same name resolution logic (user meta → billing → shipping fallback) regardless of how they were instantiated.

2. **Null `date_created` passed to `getTimestamp()`** — `get_date_created()` can return `null` for orders with missing or corrupted data. Calling `getTimestamp()` on null causes a fatal error.

   **Fix**: Cascade through available date fields (`date_created → date_modified → date_paid`) and fall back to `null` (not the current timestamp) when all are absent.

3. **`wc_get_order()` returning false in `sync_order_customer()`** — Added a guard that returns `-1` gracefully when the order lookup fails (deleted/corrupt orders).

Fixes #64338

## Testing

### Test 1: Plain WC_Order processing
1. Create a plain `WC_Order` (bypassing the `woocommerce_order_class` filter)
2. Pass it to `DataStore::get_or_create_customer_from_order()`
3. Verify no fatal error; customer record is created with correct billing details

### Test 2: Null date_created handling
1. Create an order with `date_created` set to `null`
2. Pass it to `DataStore::get_customer_order_data_and_format()`
3. Verify `date_last_active` is `null` (not the current timestamp)

### Test 3: Non-existent order ID
1. Call `DataStore::sync_order_customer()` with a non-existent order ID
2. Verify it returns `-1` gracefully

### Test 4: Preservation of existing behavior
1. Pass an `Overrides\Order` with billing name and valid `date_created`
2. Verify customer record has correct `first_name`, `last_name`, and `date_last_active`
3. Pass an `Overrides\Order` with a registered user
4. Verify `user_id` and `username` come from the `WC_Customer`
5. Call `get_or_create_customer_from_order()` twice for the same order
6. Verify same customer ID returned (no duplicate created)

## New unit tests

- `test_get_or_create_customer_from_plain_wc_order` — plain WC_Order doesn't fatal
- `test_get_customer_order_data_with_null_date_created` — null date cascade works
- `test_sync_order_customer_with_nonexistent_order` — false guard works
- `test_overrides_order_customer_creation_preserved` — existing behavior preserved
- `test_overrides_order_registered_user_preserved` — registered user flow preserved
- `test_existing_customer_not_duplicated` — duplicate prevention works
- `test_get_or_create_customer_from_plain_wc_order` (integration test) — plain WC_Order creates customer
- `test_date_last_active_falls_back_when_date_created_is_null` — date cascade in mock test