### PR TITLE
feat(reviews): detect and render already-reviewed order items as locked row

### DIFF
--- a/plugins/woocommerce/changelog/64312-add-already-reviewed-locked-row
+++ b/plugins/woocommerce/changelog/64312-add-already-reviewed-locked-row
@@ -1,0 +1,5 @@
+Significance: minor
+Type: add
+Comment: Add detection and locked-row rendering for already-reviewed order items.
+
+

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4723,3 +4723,137 @@ function wc_get_quantity_input_args( $args, $product = null ) {
 
 	return $args;
 }
+
+/**
+ * Get the most recent existing review for a product by a given email address.
+ *
+ * Queries WordPress comments of type 'review' matching the product and author
+ * email. Returns the most recent match (any approval status) or null.
+ *
+ * @since 10.8.0
+ *
+ * @param int    $product_id   Product ID.
+ * @param string $author_email Reviewer email address.
+ * @return WP_Comment|null The most recent review comment, or null if none found.
+ */
+function wc_get_order_product_existing_review( int $product_id, string $author_email ): ?WP_Comment {
+	if ( ! $product_id || '' === $author_email ) {
+		return null;
+	}
+
+	$reviews = get_comments(
+		array(
+			'post_id'      => $product_id,
+			'author_email' => $author_email,
+			'type'         => 'review',
+			'status'       => 'all',
+			'number'       => 1,
+			'orderby'      => 'comment_date_gmt',
+			'order'        => 'DESC',
+		)
+	);
+
+	if ( ! empty( $reviews ) && $reviews[0] instanceof WP_Comment ) {
+		return $reviews[0];
+	}
+
+	return null;
+}
+
+/**
+ * Determine whether a product has already been reviewed by the order's customer.
+ *
+ * Wraps wc_get_order_product_existing_review() with a filterable boolean result
+ * so third-party code can override the detection logic.
+ *
+ * @since 10.8.0
+ *
+ * @param int      $product_id     Product ID.
+ * @param WC_Order $order          Order object.
+ * @param string   $customer_email Customer email address.
+ * @return bool True if the product has an existing review from this customer.
+ */
+function wc_order_item_is_already_reviewed( int $product_id, WC_Order $order, string $customer_email ): bool {
+	$existing = wc_get_order_product_existing_review( $product_id, $customer_email );
+
+	$is_reviewed = null !== $existing;
+
+	/**
+	 * Filters whether an order item's product has already been reviewed by this customer.
+	 *
+	 * Return true to render the locked "Reviewed" row instead of the review form,
+	 * or false to show the form even if a review exists.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param bool     $is_reviewed    Whether a review already exists.
+	 * @param int      $product_id     Product ID.
+	 * @param WC_Order $order          Order object.
+	 * @param string   $customer_email Customer email address.
+	 */
+	return (bool) apply_filters( 'woocommerce_review_order_item_already_reviewed', $is_reviewed, $product_id, $order, $customer_email );
+}
+
+/**
+ * Build enriched review item data for each line item in an order.
+ *
+ * For each product line item, determines:
+ * - Whether reviews are open on the product (comments_open).
+ * - Whether the customer has already reviewed this product.
+ * - The existing review object (if any).
+ *
+ * Items where reviews are disabled (comments_open is false) are excluded.
+ *
+ * @since 10.8.0
+ *
+ * @param WC_Order $order          Order object.
+ * @param string   $customer_email Customer email address.
+ * @return array<int, array{
+ *     product_id:   int,
+ *     product:      WC_Product|null,
+ *     is_reviewed:  bool,
+ *     review:       WP_Comment|null,
+ *     rating:       int,
+ *     review_body:  string,
+ *     product_url:  string,
+ *     product_name: string,
+ * }> Array of review item data, keyed by product ID.
+ */
+function wc_get_order_review_items_data( WC_Order $order, string $customer_email ): array {
+	$items = array();
+
+	foreach ( $order->get_items() as $item ) {
+		if ( ! $item instanceof WC_Order_Item_Product ) {
+			continue;
+		}
+
+		$product_id = $item->get_product_id();
+
+		// Skip products that already have an entry (avoid duplicates from quantity > 1).
+		if ( isset( $items[ $product_id ] ) ) {
+			continue;
+		}
+
+		// Skip products where reviews are disabled.
+		if ( ! comments_open( $product_id ) ) {
+			continue;
+		}
+
+		$product     = $item->get_product();
+		$is_reviewed = wc_order_item_is_already_reviewed( $product_id, $order, $customer_email );
+		$review      = $is_reviewed ? wc_get_order_product_existing_review( $product_id, $customer_email ) : null;
+
+		$items[ $product_id ] = array(
+			'product_id'   => $product_id,
+			'product'      => $product instanceof WC_Product ? $product : null,
+			'is_reviewed'  => $is_reviewed,
+			'review'       => $review,
+			'rating'       => $review ? (int) get_comment_meta( $review->comment_ID, 'rating', true ) : 0,
+			'review_body'  => $review ? $review->comment_content : '',
+			'product_url'  => $product instanceof WC_Product ? $product->get_permalink() : '',
+			'product_name' => $item->get_name(),
+		);
+	}//end foreach
+
+	return $items;
+}

--- a/plugins/woocommerce/templates/order/order-review-item-reviewed.php
+++ b/plugins/woocommerce/templates/order/order-review-item-reviewed.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Order Review Item — Already Reviewed (locked row)
+ *
+ * Renders a read-only "Reviewed" row for a product that the customer has
+ * already reviewed. Displays the stored star rating, a truncated excerpt
+ * of the review body, a "Reviewed" badge, and an optional link to the
+ * product page.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-review-item-reviewed.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 10.8.0
+ *
+ * @var int         $product_id   Product ID.
+ * @var string      $product_name Product name.
+ * @var string      $product_url  Product permalink (may be empty).
+ * @var int         $rating       Stored star rating (1–5).
+ * @var string      $review_body  Full review text.
+ * @var WP_Comment  $review       The review comment object.
+ * @var WC_Product|null $product  Product object (may be null if deleted).
+ * @var WC_Order    $order        Order object.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$max_excerpt_length = 120;
+$excerpt            = wp_strip_all_tags( $review_body );
+$is_truncated       = mb_strlen( $excerpt ) > $max_excerpt_length;
+$excerpt_display    = $is_truncated ? mb_substr( $excerpt, 0, $max_excerpt_length ) . '&hellip;' : $excerpt;
+?>
+
+<tr class="wc-order-review-item wc-order-review-item--reviewed">
+	<td class="wc-order-review-item__product">
+		<span class="wc-order-review-item__name">
+			<?php if ( $product_url ) : ?>
+				<a href="<?php echo esc_url( $product_url ); ?>"><?php echo esc_html( $product_name ); ?></a>
+			<?php else : ?>
+				<?php echo esc_html( $product_name ); ?>
+			<?php endif; ?>
+		</span>
+	</td>
+
+	<td class="wc-order-review-item__rating">
+		<?php if ( $rating > 0 ) : ?>
+			<div class="wc-order-review-item__stars" aria-label="<?php echo esc_attr( sprintf( __( 'Rated %d out of 5', 'woocommerce' ), $rating ) ); ?>">
+				<?php echo wc_get_rating_html( $rating ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			</div>
+		<?php endif; ?>
+	</td>
+
+	<td class="wc-order-review-item__body">
+		<?php if ( $excerpt_display ) : ?>
+			<p class="wc-order-review-item__excerpt"><?php echo esc_html( $excerpt_display ); ?></p>
+		<?php endif; ?>
+	</td>
+
+	<td class="wc-order-review-item__status">
+		<span class="wc-order-review-item__badge wc-order-review-item__badge--reviewed">
+			<?php esc_html_e( 'Reviewed', 'woocommerce' ); ?>
+		</span>
+
+		<?php if ( $product_url ) : ?>
+			<a href="<?php echo esc_url( $product_url . '#reviews' ); ?>" class="wc-order-review-item__view-link">
+				<?php esc_html_e( 'View on product page', 'woocommerce' ); ?>
+			</a>
+		<?php endif; ?>
+	</td>
+</tr>

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-review-detection-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-review-detection-test.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * Tests for the order review detection functions.
+ *
+ * @package WooCommerce\Tests
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+
+/**
+ * Tests for wc_get_order_product_existing_review(),
+ * wc_order_item_is_already_reviewed(), and wc_get_order_review_items_data().
+ */
+class WC_Order_Review_Detection_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Helper: create a simple product.
+	 *
+	 * @return WC_Product
+	 */
+	private function create_product(): WC_Product {
+		$product = WC_Helper_Product::create_simple_product();
+		// Ensure comments/reviews are open.
+		wp_update_post(
+			array(
+				'ID'             => $product->get_id(),
+				'comment_status' => 'open',
+			)
+		);
+		return $product;
+	}
+
+	/**
+	 * Helper: create a product with reviews closed.
+	 *
+	 * @return WC_Product
+	 */
+	private function create_product_reviews_closed(): WC_Product {
+		$product = WC_Helper_Product::create_simple_product();
+		wp_update_post(
+			array(
+				'ID'             => $product->get_id(),
+				'comment_status' => 'closed',
+			)
+		);
+		return $product;
+	}
+
+	/**
+	 * Helper: create an order with given products.
+	 *
+	 * @param WC_Product[] $products Products to add to the order.
+	 * @return WC_Order
+	 */
+	private function create_order( array $products ): WC_Order {
+		$order = wc_create_order(
+			array(
+				'status' => OrderStatus::COMPLETED,
+			)
+		);
+
+		$order->set_billing_first_name( 'Jane' );
+		$order->set_billing_last_name( 'Smith' );
+		$order->set_billing_email( 'jane@example.com' );
+
+		foreach ( $products as $product ) {
+			$order->add_product( $product, 1 );
+		}
+
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Helper: insert a product review comment.
+	 *
+	 * @param int    $product_id Product ID.
+	 * @param string $email      Author email.
+	 * @param int    $rating     Star rating.
+	 * @param string $content    Review text.
+	 * @param string $approved   Comment approved status.
+	 * @return int Comment ID.
+	 */
+	private function insert_review( int $product_id, string $email, int $rating = 5, string $content = 'Great product!', string $approved = '1' ): int {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $product_id,
+				'comment_author'       => 'Jane Smith',
+				'comment_author_email' => $email,
+				'comment_content'      => $content,
+				'comment_type'         => 'review',
+				'comment_approved'     => $approved,
+			)
+		);
+
+		update_comment_meta( $comment_id, 'rating', $rating );
+
+		return $comment_id;
+	}
+
+	// ---------------------------------------------------------------
+	// wc_get_order_product_existing_review()
+	// ---------------------------------------------------------------
+
+	/**
+	 * @testdox Returns null when no review exists for the product/email pair.
+	 */
+	public function test_get_existing_review_returns_null_when_none_exists(): void {
+		$product = $this->create_product();
+
+		$result = wc_get_order_product_existing_review( $product->get_id(), 'nobody@example.com' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @testdox Returns the review comment when one exists.
+	 */
+	public function test_get_existing_review_returns_comment_when_exists(): void {
+		$product    = $this->create_product();
+		$comment_id = $this->insert_review( $product->get_id(), 'jane@example.com' );
+
+		$result = wc_get_order_product_existing_review( $product->get_id(), 'jane@example.com' );
+
+		$this->assertInstanceOf( WP_Comment::class, $result );
+		$this->assertEquals( $comment_id, $result->comment_ID );
+	}
+
+	/**
+	 * @testdox Returns the most recent review when multiple exist.
+	 */
+	public function test_get_existing_review_returns_most_recent(): void {
+		$product = $this->create_product();
+
+		$this->insert_review( $product->get_id(), 'jane@example.com', 3, 'Old review' );
+		// Advance time to ensure ordering.
+		sleep( 1 );
+		$newer_id = $this->insert_review( $product->get_id(), 'jane@example.com', 5, 'New review' );
+
+		$result = wc_get_order_product_existing_review( $product->get_id(), 'jane@example.com' );
+
+		$this->assertNotNull( $result );
+		$this->assertEquals( $newer_id, $result->comment_ID );
+		$this->assertEquals( 'New review', $result->comment_content );
+	}
+
+	/**
+	 * @testdox Returns null for invalid product ID.
+	 */
+	public function test_get_existing_review_returns_null_for_invalid_product(): void {
+		$result = wc_get_order_product_existing_review( 0, 'jane@example.com' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @testdox Returns null for empty email.
+	 */
+	public function test_get_existing_review_returns_null_for_empty_email(): void {
+		$product = $this->create_product();
+
+		$result = wc_get_order_product_existing_review( $product->get_id(), '' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @testdox Includes pending/unapproved reviews.
+	 */
+	public function test_get_existing_review_includes_unapproved(): void {
+		$product    = $this->create_product();
+		$comment_id = $this->insert_review( $product->get_id(), 'jane@example.com', 4, 'Pending review', '0' );
+
+		$result = wc_get_order_product_existing_review( $product->get_id(), 'jane@example.com' );
+
+		$this->assertNotNull( $result );
+		$this->assertEquals( $comment_id, $result->comment_ID );
+	}
+
+	/**
+	 * @testdox Does not match reviews from a different email.
+	 */
+	public function test_get_existing_review_different_email_returns_null(): void {
+		$product = $this->create_product();
+		$this->insert_review( $product->get_id(), 'other@example.com' );
+
+		$result = wc_get_order_product_existing_review( $product->get_id(), 'jane@example.com' );
+
+		$this->assertNull( $result );
+	}
+
+	// ---------------------------------------------------------------
+	// wc_order_item_is_already_reviewed()
+	// ---------------------------------------------------------------
+
+	/**
+	 * @testdox Returns true when a review exists.
+	 */
+	public function test_is_already_reviewed_returns_true(): void {
+		$product = $this->create_product();
+		$order   = $this->create_order( array( $product ) );
+		$this->insert_review( $product->get_id(), 'jane@example.com' );
+
+		$this->assertTrue(
+			wc_order_item_is_already_reviewed( $product->get_id(), $order, 'jane@example.com' )
+		);
+	}
+
+	/**
+	 * @testdox Returns false when no review exists.
+	 */
+	public function test_is_already_reviewed_returns_false(): void {
+		$product = $this->create_product();
+		$order   = $this->create_order( array( $product ) );
+
+		$this->assertFalse(
+			wc_order_item_is_already_reviewed( $product->get_id(), $order, 'jane@example.com' )
+		);
+	}
+
+	/**
+	 * @testdox Filter can override the detection result to false.
+	 */
+	public function test_filter_can_override_to_false(): void {
+		$product = $this->create_product();
+		$order   = $this->create_order( array( $product ) );
+		$this->insert_review( $product->get_id(), 'jane@example.com' );
+
+		$callback = function () {
+			return false;
+		};
+		add_filter( 'woocommerce_review_order_item_already_reviewed', $callback );
+
+		$this->assertFalse(
+			wc_order_item_is_already_reviewed( $product->get_id(), $order, 'jane@example.com' )
+		);
+
+		remove_filter( 'woocommerce_review_order_item_already_reviewed', $callback );
+	}
+
+	/**
+	 * @testdox Filter can override the detection result to true.
+	 */
+	public function test_filter_can_override_to_true(): void {
+		$product = $this->create_product();
+		$order   = $this->create_order( array( $product ) );
+
+		$callback = function () {
+			return true;
+		};
+		add_filter( 'woocommerce_review_order_item_already_reviewed', $callback );
+
+		$this->assertTrue(
+			wc_order_item_is_already_reviewed( $product->get_id(), $order, 'jane@example.com' )
+		);
+
+		remove_filter( 'woocommerce_review_order_item_already_reviewed', $callback );
+	}
+
+	/**
+	 * @testdox Filter receives the correct arguments.
+	 */
+	public function test_filter_receives_correct_args(): void {
+		$product = $this->create_product();
+		$order   = $this->create_order( array( $product ) );
+
+		$captured = array();
+		$callback = function ( $is_reviewed, $pid, $ord, $email ) use ( &$captured ) {
+			$captured = array(
+				'is_reviewed' => $is_reviewed,
+				'product_id'  => $pid,
+				'order'       => $ord,
+				'email'       => $email,
+			);
+			return $is_reviewed;
+		};
+		add_filter( 'woocommerce_review_order_item_already_reviewed', $callback, 10, 4 );
+
+		wc_order_item_is_already_reviewed( $product->get_id(), $order, 'jane@example.com' );
+
+		$this->assertFalse( $captured['is_reviewed'] );
+		$this->assertEquals( $product->get_id(), $captured['product_id'] );
+		$this->assertInstanceOf( WC_Order::class, $captured['order'] );
+		$this->assertEquals( 'jane@example.com', $captured['email'] );
+
+		remove_filter( 'woocommerce_review_order_item_already_reviewed', $callback );
+	}
+
+	// ---------------------------------------------------------------
+	// wc_get_order_review_items_data()
+	// ---------------------------------------------------------------
+
+	/**
+	 * @testdox Returns enriched data for each order item with reviews open.
+	 */
+	public function test_get_review_items_data_basic(): void {
+		$product = $this->create_product();
+		$order   = $this->create_order( array( $product ) );
+
+		$data = wc_get_order_review_items_data( $order, 'jane@example.com' );
+
+		$this->assertCount( 1, $data );
+		$this->assertArrayHasKey( $product->get_id(), $data );
+
+		$item = $data[ $product->get_id() ];
+		$this->assertEquals( $product->get_id(), $item['product_id'] );
+		$this->assertFalse( $item['is_reviewed'] );
+		$this->assertNull( $item['review'] );
+		$this->assertEquals( 0, $item['rating'] );
+		$this->assertEquals( '', $item['review_body'] );
+	}
+
+	/**
+	 * @testdox Items with reviews closed are excluded.
+	 */
+	public function test_get_review_items_data_excludes_closed(): void {
+		$open   = $this->create_product();
+		$closed = $this->create_product_reviews_closed();
+		$order  = $this->create_order( array( $open, $closed ) );
+
+		$data = wc_get_order_review_items_data( $order, 'jane@example.com' );
+
+		$this->assertCount( 1, $data );
+		$this->assertArrayHasKey( $open->get_id(), $data );
+		$this->assertArrayNotHasKey( $closed->get_id(), $data );
+	}
+
+	/**
+	 * @testdox Already-reviewed items include the review data.
+	 */
+	public function test_get_review_items_data_includes_review(): void {
+		$product = $this->create_product();
+		$order   = $this->create_order( array( $product ) );
+
+		$comment_id = $this->insert_review( $product->get_id(), 'jane@example.com', 4, 'Nice!' );
+
+		$data = wc_get_order_review_items_data( $order, 'jane@example.com' );
+
+		$item = $data[ $product->get_id() ];
+		$this->assertTrue( $item['is_reviewed'] );
+		$this->assertInstanceOf( WP_Comment::class, $item['review'] );
+		$this->assertEquals( $comment_id, $item['review']->comment_ID );
+		$this->assertEquals( 4, $item['rating'] );
+		$this->assertEquals( 'Nice!', $item['review_body'] );
+	}
+
+	/**
+	 * @testdox Duplicate product IDs (same product, qty > 1) produce only one entry.
+	 */
+	public function test_get_review_items_data_deduplicates(): void {
+		$product = $this->create_product();
+		$order   = wc_create_order(
+			array(
+				'status' => OrderStatus::COMPLETED,
+			)
+		);
+		$order->set_billing_email( 'jane@example.com' );
+		$order->add_product( $product, 3 );
+		$order->save();
+
+		$data = wc_get_order_review_items_data( $order, 'jane@example.com' );
+
+		$this->assertCount( 1, $data );
+	}
+
+	/**
+	 * @testdox Mixed reviewed and unreviewed items return correct flags.
+	 */
+	public function test_get_review_items_data_mixed(): void {
+		$reviewed   = $this->create_product();
+		$unreviewed = $this->create_product();
+		$order      = $this->create_order( array( $reviewed, $unreviewed ) );
+
+		$this->insert_review( $reviewed->get_id(), 'jane@example.com', 5, 'Awesome!' );
+
+		$data = wc_get_order_review_items_data( $order, 'jane@example.com' );
+
+		$this->assertCount( 2, $data );
+		$this->assertTrue( $data[ $reviewed->get_id() ]['is_reviewed'] );
+		$this->assertFalse( $data[ $unreviewed->get_id() ]['is_reviewed'] );
+	}
+}


### PR DESCRIPTION
## Summary

Adds detection logic and a theme-overridable template for order items that the customer has already reviewed. When the review form is rendered, previously-reviewed products display a locked row with the stored rating, truncated excerpt, "Reviewed" badge, and a product page link — instead of an empty form.

Fixes #64312

## Changes

### `includes/wc-template-functions.php`

Three new functions appended:

**`wc_get_order_product_existing_review( $product_id, $author_email )`**
Queries `get_comments()` with `type => 'review'`, `status => 'all'`, returns the most recent `WP_Comment` or `null`.

**`wc_order_item_is_already_reviewed( $product_id, $order, $customer_email )`**
Boolean wrapper with the filterable hook:
```php
apply_filters( 'woocommerce_review_order_item_already_reviewed', $is_reviewed, $product_id, $order, $customer_email );
```

**`wc_get_order_review_items_data( $order, $customer_email )`**
Iterates order line items and returns enriched data (product, is_reviewed, rating, review_body, etc.). Skips products where `comments_open()` is false and deduplicates by product ID.

---

### `templates/order/order-review-item-reviewed.php` [NEW]

Theme-overridable template rendering:
- Read-only star rating via `wc_get_rating_html()`
- Truncated review excerpt (120 chars)
- "Reviewed" badge
- "View on product page" link (if product exists)

---

### `tests/php/includes/class-wc-order-review-detection-test.php` [NEW]

17 test methods covering:
- Positive/negative review lookup
- Most-recent-wins ordering
- Edge cases (empty email, invalid product ID, unapproved reviews)
- Filter override in both directions
- Filter argument verification
- `comments_open` gating
- Deduplication of same-product line items
- Mixed reviewed/unreviewed items

## Testing

**Unit tests:**
```bash
pnpm test:php:env -- --filter WC_Order_Review_Detection_Test
```

**Manual verification:**
1. Create an order with 2+ products
2. Submit a review for one product via the product page
3. Call `wc_get_order_review_items_data( $order, $billing_email )` — verified product shows `is_reviewed => true` with rating and body populated
4. Render `order-review-item-reviewed.php` template — displays locked stars, excerpt, badge, and product link

## Changelog

```
Significance: minor
Type: add
```