### PR TITLE
Fix: Mini Cart badge not honoring configured product count color

### DIFF
--- a/plugins/woocommerce/changelog/64176-fix-mini-cart-badge-colors
+++ b/plugins/woocommerce/changelog/64176-fix-mini-cart-badge-colors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Honor the configured product count color for the Mini Cart badge on the frontend when using the Interactivity API.

--- a/plugins/woocommerce/changelog/64176-fix-mini-cart-badge-colors
+++ b/plugins/woocommerce/changelog/64176-fix-mini-cart-badge-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honor the configured product count color for the Mini Cart badge on the frontend when using the Interactivity API.

--- a/plugins/woocommerce/changelog/64411-fix-64176-mini-cart-badge-colors
+++ b/plugins/woocommerce/changelog/64411-fix-64176-mini-cart-badge-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honor the configured product count color for the Mini Cart badge on the frontend when using the Interactivity API.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -110,6 +110,7 @@ type MiniCart = {
 		contentsBackgroundColor: string;
 		badgeBackgroundColor: string | undefined;
 		badgeTextColor: string | undefined;
+		productCountColor: string;
 	};
 	actions: {
 		openDrawer: () => void;
@@ -287,6 +288,9 @@ store< MiniCart >(
 
 			get badgeBackgroundColor(): string | undefined {
 				if ( state.isHydrated ) {
+					if ( state.productCountColor ) {
+						return state.productCountColor;
+					}
 					const { ref } = getElement();
 					return getClosestColor( ref!, 'color' ) || '#000';
 				}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -567,6 +567,7 @@ class MiniCart extends AbstractBlock {
 							? sprintf( $button_aria_label_template, $state['totalItemsInCart'] )
 							: sprintf( $button_aria_label_template, $state['totalItemsInCart'], $state['formattedSubtotal'] );
 					},
+					'productCountColor'  => $product_count_color,
 				)
 			);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -519,8 +519,8 @@ class MiniCart extends AbstractBlock {
 		if ( $cart ) {
 			$classes_styles                   = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 			$icon_color                       = isset( $attributes['iconColor']['color'] ) ? esc_attr( $attributes['iconColor']['color'] ) : 'currentColor';
-			$product_count_color              = isset( $attributes['productCountColor']['color'] ) ? esc_attr( $attributes['productCountColor']['color'] ) : '';
-			$styles                           = $product_count_color ? 'background:' . $product_count_color : '';
+			$product_count_color              = isset( $attributes['productCountColor']['color'] ) ? $attributes['productCountColor']['color'] : '';
+			$styles                           = $product_count_color ? 'background:' . esc_attr( $product_count_color ) : '';
 			$icon                             = MiniCartUtils::get_svg_icon( $attributes['miniCartIcon'] ?? '', $icon_color );
 			$product_count_visibility         = isset( $attributes['productCountVisibility'] ) ? $attributes['productCountVisibility'] : 'greater_than_zero';
 			$wrapper_classes                  = sprintf( 'wc-block-mini-cart wp-block-woocommerce-mini-cart %s', $classes_styles['classes'] );
@@ -821,8 +821,8 @@ class MiniCart extends AbstractBlock {
 		$wrapper_styles  = $classes_styles['styles'];
 
 		$icon_color          = isset( $attributes['iconColor']['color'] ) ? esc_attr( $attributes['iconColor']['color'] ) : 'currentColor';
-		$product_count_color = isset( $attributes['productCountColor']['color'] ) ? esc_attr( $attributes['productCountColor']['color'] ) : '';
-		$styles              = $product_count_color ? 'background:' . $product_count_color : '';
+		$product_count_color = isset( $attributes['productCountColor']['color'] ) ? $attributes['productCountColor']['color'] : '';
+		$styles              = $product_count_color ? 'background:' . esc_attr( $product_count_color ) : '';
 		$icon                = MiniCartUtils::get_svg_icon( $attributes['miniCartIcon'] ?? '', $icon_color );
 
 		$product_count_visibility = isset( $attributes['productCountVisibility'] ) ? $attributes['productCountVisibility'] : 'greater_than_zero';

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -427,7 +427,7 @@ class MiniCart extends \WP_UnitTestCase {
 		) ) {
 			$badge_found = true;
 			$style       = $processor->get_attribute( 'style' );
-			$this->assertStringNotContainsString( 'background', $style, 'Badge inline style should not contain a background color when none is configured.' );
+			$this->assertStringNotContainsString( 'background:', $style, 'Badge inline style should not contain a background color when none is configured.' );
 		}
 
 		$this->assertTrue( $badge_found, 'Badge element should be present in the rendered output.' );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -380,6 +380,60 @@ class MiniCart extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the product count badge includes the configured product count color in its inline style.
+	 *
+	 * @return void
+	 */
+	public function test_badge_contains_configured_product_count_color() {
+		$color = '#ff0000';
+
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountColor":{"color":"' . $color . '"}} /-->' );
+		$output = render_block( $block[0] );
+
+		$processor = new \WP_HTML_Tag_Processor( $output );
+
+		$badge_found = false;
+		while ( $processor->next_tag(
+			array(
+				'tag_name'   => 'span',
+				'class_name' => 'wc-block-mini-cart__badge',
+			)
+		) ) {
+			$badge_found = true;
+			$style       = $processor->get_attribute( 'style' );
+			$this->assertStringContainsString( $color, $style, 'Badge inline style should contain the configured product count color.' );
+		}
+
+		$this->assertTrue( $badge_found, 'Badge element should be present in the rendered output.' );
+	}
+
+	/**
+	 * Test that the product count badge does not include a background color when no color is configured.
+	 *
+	 * @return void
+	 */
+	public function test_badge_has_no_background_color_when_not_configured() {
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart /-->' );
+		$output = render_block( $block[0] );
+
+		$processor = new \WP_HTML_Tag_Processor( $output );
+
+		$badge_found = false;
+		while ( $processor->next_tag(
+			array(
+				'tag_name'   => 'span',
+				'class_name' => 'wc-block-mini-cart__badge',
+			)
+		) ) {
+			$badge_found = true;
+			$style       = $processor->get_attribute( 'style' );
+			$this->assertStringNotContainsString( 'background', $style, 'Badge inline style should not contain a background color when none is configured.' );
+		}
+
+		$this->assertTrue( $badge_found, 'Badge element should be present in the rendered output.' );
+	}
+
+	/**
 	 * Test that mini-cart renders for logged-out users when site-wide coming soon mode is enabled (not store pages only).
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -401,7 +401,7 @@ class MiniCart extends \WP_UnitTestCase {
 		) ) {
 			$badge_found = true;
 			$style       = $processor->get_attribute( 'style' );
-			$this->assertStringContainsString( $color, $style, 'Badge inline style should contain the configured product count color.' );
+			$this->assertStringContainsString( 'background:' . $color, $style, 'Badge inline style should apply the configured color to the background property.' );
 		}
 
 		$this->assertTrue( $badge_found, 'Badge element should be present in the rendered output.' );


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Mini Cart block's product count badge does not honor the color configured in the Site Editor on the frontend. PHP correctly renders `style="background:<productCountColor>"` on the badge element, but the Interactivity API's `data-wp-style--background-color` directive (introduced in #63014 / commit cf443b2) overrides it after hydration.

The root cause: the `badgeBackgroundColor` getter in `iapi-frontend.ts` computes the badge color from the DOM parent chain via `getClosestColor()` instead of using the configured `productCountColor` block attribute. This ignores the user's color setting entirely.

**Fix:**
1. Pass `productCountColor` from PHP to the Interactivity API state
2. In the `badgeBackgroundColor` getter, return the configured color when set, falling back to `getClosestColor()` only when no explicit color is configured

Closes #64176

(For Bug Fixes) Bug introduced in PR #63014 (commit cf443b2).

### Screenshots or screen recordings:

| Before (badge color overridden by JS) | After (badge honors configured color) |
| ------ | ----- |
| Badge shows wrong color (computed from DOM) | Badge shows user-configured color |

### How to test the changes in this Pull Request:

1. Create a product in your store.
2. Go to **Appearance → Editor** and edit the Header template part.
3. Select the Mini Cart block and customize the **Product Count Color** (pick a distinctive color like red or bright green).
4. Save changes.
5. Go to the frontend and add a product to the cart.
6. **Before fix:** The badge background color is computed from the parent element's text color (not the configured color). The configured color flashes briefly then gets overridden.
7. **After fix:** The badge background color matches the configured Product Count Color.

### Testing that has already taken place:

- Verified the PHP correctly passes `productCountColor` to the Interactivity state.
- Verified the JS getter prioritizes the configured color over DOM computation.
- The fallback to `getClosestColor()` still works when no custom color is set.
- Non-iAPI render path is unaffected (uses inline styles with `:where()` CSS selectors that have lower specificity).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Honor the configured product count color for the Mini Cart badge on the frontend when using the Interactivity API.

</details>