### PR TITLE
Fix: adopt $radius-s (2px) border-radius for Woo custom inputs and buttons (WP 7.0)

### DIFF
--- a/plugins/woocommerce/changelog/fix-border-radius-inputs-buttons-wp7-align
+++ b/plugins/woocommerce/changelog/fix-border-radius-inputs-buttons-wp7-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adopt 2px border-radius on Woo custom inputs and buttons to align with WP 7.0

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -24,6 +24,9 @@ $highlightext:      desaturate(lighten($highlight, 80%), 18%) !default;  // Text
 $contentbg:         #fff !default;                                     // Content BG - Tabs (active state)
 $subtext:           #767676 !default;                                  // small, breadcrumbs etc
 
+// Border radius tokens — mirrors WP Design System naming.
+$radius-s:          2px !default;                                      // Small radius: inputs, buttons, selects.
+
 // export vars as CSS vars
 :root {
 	--woocommerce: #{$woocommerce};

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5399,6 +5399,7 @@ img.help_tip {
 			display: inline-block;
 			width: 26px;
 			border: 1px solid #ddd;
+			border-radius: $radius-s;
 			font-size: 14px;
 		}
 
@@ -5502,7 +5503,6 @@ img.help_tip {
 				height: 30px;
 				box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 				font-size: 16px;
-				border-radius: $radius-s;
 				margin-right: 3px;
 
 				@media only screen and (max-width: 782px) {
@@ -6403,11 +6403,11 @@ img.help_tip {
 	.dimensions_field .wrap {
 		display: block;
 		width: 50%;
-		border-radius: $radius-s;
 
 		input {
 			width: 30.75%;
 			margin-right: 3.8%;
+			border-radius: $radius-s;
 		}
 
 		.last {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -246,7 +246,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 	}
 
 	.addons-button {
-		border-radius: 3px;
+		border-radius: $radius-s;
 		cursor: pointer;
 		display: block;
 		height: 37px;
@@ -5502,7 +5502,7 @@ img.help_tip {
 				height: 30px;
 				box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 				font-size: 16px;
-				border-radius: 4px;
+				border-radius: $radius-s;
 				margin-right: 3px;
 
 				@media only screen and (max-width: 782px) {
@@ -6403,6 +6403,7 @@ img.help_tip {
 	.dimensions_field .wrap {
 		display: block;
 		width: 50%;
+		border-radius: $radius-s;
 
 		input {
 			width: 30.75%;
@@ -8227,6 +8228,7 @@ table.bar_chart {
 		.select2-selection--single {
 			height: 30px;
 			border-color: #7e8993;
+			border-radius: $radius-s;
 
 			@media only screen and (max-width: 782px) {
 				height: 40px;
@@ -8276,7 +8278,7 @@ table.bar_chart {
 		.select2-selection--multiple {
 			min-height: 30px;
 			border-color: #7e8993;
-			border-radius: 4px;
+			border-radius: $radius-s;
 		}
 
 		.select2-search--inline .select2-search__field {
@@ -8329,7 +8331,6 @@ table.bar_chart {
 	.woocommerce table.form-table .colorpickpreview {
 		height: 40px;
 		width: 40px;
-		border-radius: 2px;
 		box-sizing: border-box;
 	}
 
@@ -8337,7 +8338,6 @@ table.bar_chart {
 	.select2-container {
 		.select2-selection--single {
 			height: 40px; // Match WP 7.0 native select height.
-			border-radius: 2px; // Match WP 7.0 native select border-radius.
 
 			.select2-selection__rendered {
 				line-height: 38px;
@@ -8458,7 +8458,6 @@ table.bar_chart {
 
 		.dimensions_field .wrap {
 			width: 55%; // Wider to compensate for increased padding.
-			border-radius: 2px; // Match WP 7.0 input border-radius.
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Part of the WP 7.0 admin UI alignment series.

WP 7.0 standardised border-radius on form elements to 2px (`$radius-s`). Woo's custom elements (Select2 controls, colour picker swatch, dimensions field wrap, addons button) had hardcoded 3–4px values that were partially patched under a `.wc-wp-version-gte-70` gate.

This PR:
- Introduces `$radius-s: 2px` in `_variables.scss`, mirroring WP's design token naming
- Applies `$radius-s` to all Woo-owned elements unconditionally (no version gate needed)
- Removes now-redundant `border-radius` overrides from the `.wc-wp-version-gte-70` block for `select2-selection--single`, `.colorpickpreview`, and `.dimensions_field .wrap`

Elements updated:
- `.addons-button` — 3px → `$radius-s`
- `.colorpickpreview` (colour picker swatch) — 4px → `$radius-s`
- `.select2-selection--single` (base) — added `$radius-s`
- `.select2-selection--multiple` — 4px → `$radius-s`
- `.dimensions_field .wrap` (product data panel) — added `$radius-s`

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |

After
.addons-button
<img width="912" height="654" alt="CleanShot 2026-04-27 at 18 12 18@2x" src="https://github.com/user-attachments/assets/bed60e8d-d7bb-42ea-a888-dea006ac428e" />

.dimensions_field .wrap
<img width="1328" height="644" alt="CleanShot 2026-04-27 at 18 09 55@2x" src="https://github.com/user-attachments/assets/6c0176cd-e8fe-41f0-8d0e-a67e486273ca" />

.select2-selection
<img width="1364" height="468" alt="CleanShot 2026-04-27 at 17 57 36@2x" src="https://github.com/user-attachments/assets/c84c8847-3863-4a29-b0ce-2606386f06b0" />


### How to test the changes in this Pull Request:

1. Install WP 7.0 or later with WooCommerce active.
2. Go to **WooCommerce → Settings** — verify select dropdowns and the colour picker swatch have 2px corner radius.
3. Go to **Products → Add/Edit product** — open the Product Data panel and check the Dimensions fields and the linked variation selects have 2px corners.
4. Go to **WooCommerce → Extensions** — verify the `.addons-button` has 2px corners.
5. Confirm no visual regressions on other admin screens with form elements.

### Testing that has already taken place:

- SCSS compiled cleanly with no errors.
- Verified compiled output in `client/legacy/build/css/admin.css` resolved `$radius-s` to `2px` for all targeted selectors.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog created manually in branch (`changelog/fix-border-radius-inputs-buttons-wp7-align`).

- [ ] This Pull Request does not require a changelog entry. (Comment required below)