### PR TITLE
[DataViews - All Products] Refactor Product Actions

### DIFF
--- a/packages/js/experimental-products-app/src/dataviews-actions/index.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useMemo } from '@wordpress/element';
 import { edit, external } from '@wordpress/icons';
 import { __, _x } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';

--- a/packages/js/experimental-products-app/src/dataviews-actions/index.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/index.tsx
@@ -6,12 +6,12 @@ import { __, _x } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { getAdminLink } from '@woocommerce/settings';
 import type { Action } from '@wordpress/dataviews';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import type { ProductEntityRecord } from '../fields/types';
-import { useMemo } from 'react';
 
 export const editAction = (): Action< ProductEntityRecord > => ( {
 	id: 'edit-product',

--- a/packages/js/experimental-products-app/src/dataviews-actions/index.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/index.tsx
@@ -11,6 +11,7 @@ import type { Action } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import type { ProductEntityRecord } from '../fields/types';
+import { useMemo } from 'react';
 
 export const editAction = (): Action< ProductEntityRecord > => ( {
 	id: 'edit-product',
@@ -59,4 +60,5 @@ export const viewAction = (): Action< ProductEntityRecord > => ( {
 	},
 } );
 
-export const useProductActions = () => [ editAction(), viewAction() ];
+export const useProductActions = () =>
+	useMemo( () => [ editAction(), viewAction() ], [] );

--- a/packages/js/experimental-products-app/src/dataviews-actions/index.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/index.tsx
@@ -2,44 +2,62 @@
  * External dependencies
  */
 import { useMemo } from '@wordpress/element';
-import { edit } from '@wordpress/icons';
-import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { __ } from '@wordpress/i18n';
-import { Product } from '@woocommerce/data';
+import { edit, external } from '@wordpress/icons';
+import { __, _x } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { getAdminLink } from '@woocommerce/settings';
+import type { Action } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
  */
-import { unlock } from '../lock-unlock';
+import type { ProductEntityRecord } from '../fields/types';
 
-const { useHistory, useLocation } = unlock( routerPrivateApis );
+export const editAction = (): Action< ProductEntityRecord > => ( {
+	id: 'edit-product',
+	label: __( 'Edit', 'woocommerce' ),
+	isPrimary: true,
+	icon: edit,
+	isEligible( product ) {
+		return product.status !== 'trash';
+	},
+	callback( items, { onActionPerformed } ) {
+		const product = items[ 0 ];
 
-export const useEditProductAction = ( { postType }: { postType: string } ) => {
-	const history = useHistory();
-	const location = useLocation();
-	return useMemo(
-		() => ( {
-			id: 'edit-product',
-			label: __( 'Edit', 'woocommerce' ),
-			isPrimary: true,
-			icon: edit,
-			supportsBulk: true,
-			isEligible( product: Product ) {
-				if ( product.status === 'trash' ) {
-					return false;
-				}
-				return true;
-			},
-			callback( items: Product[] ) {
-				const product = items[ 0 ];
-				history.push( {
-					...location.params,
-					postId: product.id,
-					postType,
-					quickEdit: true,
-				} );
-			},
-		} ),
-		[ history, location.params ]
-	);
-};
+		if ( product ) {
+			window.location.href = getAdminLink(
+				addQueryArgs( 'post.php', {
+					post: product.id,
+					action: 'edit',
+				} )
+			);
+		}
+
+		if ( onActionPerformed ) {
+			onActionPerformed( items );
+		}
+	},
+} );
+
+export const viewAction = (): Action< ProductEntityRecord > => ( {
+	id: 'view-product',
+	label: _x( 'View', 'verb', 'woocommerce' ),
+	isPrimary: true,
+	icon: external,
+	isEligible( product ) {
+		return product.status !== 'trash' && !! product.permalink;
+	},
+	callback( items, { onActionPerformed } ) {
+		const product = items[ 0 ];
+
+		if ( product?.permalink ) {
+			window.open( product.permalink, '_blank' );
+		}
+
+		if ( onActionPerformed ) {
+			onActionPerformed( items );
+		}
+	},
+} );
+
+export const useProductActions = () => [ editAction(), viewAction() ];

--- a/packages/js/experimental-products-app/src/fields/utils/currency.ts
+++ b/packages/js/experimental-products-app/src/fields/utils/currency.ts
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	CURRENCY,
-	// @ts-expect-error - The CURRENCY object doesn't have types yet.
-} from '@woocommerce/settings';
+import { CURRENCY } from '@woocommerce/settings';
 
 type CurrencyObject = {
 	code: string;

--- a/packages/js/experimental-products-app/src/product-list/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/index.tsx
@@ -2,22 +2,18 @@
  * External dependencies
  */
 import { DataViews, View } from '@wordpress/dataviews';
-import {
-	useState,
-	useMemo,
-	useCallback,
-	useEffect,
-	Fragment,
-} from '@wordpress/element';
-import { ProductQuery, productsStore } from '@woocommerce/data';
+import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import { ProductQuery } from '@woocommerce/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { store as coreStore } from '@wordpress/core-data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
-import { Button } from '@wordpress/components';
+import { Button, Stack } from '@wordpress/ui';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { Page } from '@wordpress/admin-ui';
+import { addQueryArgs } from '@wordpress/url';
+import { getAdminLink } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -29,7 +25,7 @@ import {
 	DEFAULT_PRODUCT_TABLE_LAYOUT,
 	DEFAULT_PRODUCT_TABLE_VIEW,
 } from './layouts';
-import { useEditProductAction } from '../dataviews-actions';
+import { useProductActions } from '../dataviews-actions';
 
 const { usePostActions } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -79,11 +75,7 @@ function getItemId( item: ProductEntityRecord ) {
 	return item.id.toString();
 }
 
-export default function ProductList( {
-	subTitle,
-	className,
-	hideTitleFromUI = false,
-}: ProductListProps ) {
+export default function ProductList( { className }: ProductListProps ) {
 	const history = useHistory();
 	const location = useLocation();
 	const {
@@ -133,19 +125,14 @@ export default function ProductList( {
 		[ history, location.params ]
 	);
 
-	// TODO: Use the Woo data store to get all the products, as this doesn't contain all the product data.
-	const { records, totalCount, isLoading } = useSelect(
-		( select ) => {
-			// @ts-expect-error - The productsStore doesn't have types yet.
-			const { getProducts, getProductsTotalCount, isResolving } =
-				select( productsStore );
-			return {
-				records: getProducts( queryParams ) as ProductEntityRecord[],
-				totalCount: getProductsTotalCount( queryParams ),
-				isLoading: isResolving( 'getProducts', [ queryParams ] ),
-			};
-		},
-		[ queryParams ]
+	const {
+		records,
+		totalItems: totalCount,
+		isResolving: isLoading,
+	} = useEntityRecords< ProductEntityRecord >(
+		'root',
+		'product',
+		queryParams
 	);
 
 	const paginationInfo = useMemo(
@@ -158,14 +145,10 @@ export default function ProductList( {
 		[ totalCount, view.perPage ]
 	);
 
-	const { labels, canCreateRecord } = useSelect(
+	const { canCreateRecord } = useSelect(
 		( select ) => {
-			const { getPostType, canUser } = select( coreStore );
-			const postTypeData:
-				| { labels: Record< string, string > }
-				| undefined = getPostType( postType );
+			const { canUser } = select( coreStore );
 			return {
-				labels: postTypeData?.labels,
 				canCreateRecord: canUser( 'create', {
 					kind: 'postType',
 					name: postType,
@@ -179,36 +162,74 @@ export default function ProductList( {
 		postType,
 		context: 'list',
 	} );
-	const editAction = useEditProductAction( { postType } );
+	const productActions = useProductActions();
 	const actions = useMemo(
-		() => [ editAction, ...postTypeActions ],
-		[ postTypeActions, editAction ]
+		() => [
+			...productActions,
+			...postTypeActions.filter(
+				( { id }: { id: string } ) => id !== 'view-post'
+			),
+		],
+		[ postTypeActions, productActions ]
 	);
 
 	const classes = clsx( 'edit-site-page', className );
 
-	const pageActions = ! hideTitleFromUI && (
-		<Fragment>
-			{ labels?.add_new_item && canCreateRecord && (
-				<Button
-					variant="primary"
-					disabled={ true }
-					__next40pxDefaultSize
-				>
-					{ labels.add_new_item }
-				</Button>
-			) }
-		</Fragment>
+	const pageActions = (
+		<Stack gap="lg">
+			<Button
+				size="compact"
+				variant="outline"
+				onClick={ () =>
+					( window.location.href = getAdminLink(
+						addQueryArgs( 'edit.php', {
+							post_type: 'product',
+							page: 'product_exporter',
+						} )
+					) )
+				}
+			>
+				{ __( 'Export', 'woocommerce' ) }
+			</Button>
+			<Button
+				size="compact"
+				onClick={ () =>
+					( window.location.href = getAdminLink(
+						addQueryArgs( 'edit.php', {
+							post_type: 'product',
+							page: 'product_importer',
+						} )
+					) )
+				}
+				variant="outline"
+			>
+				{ __( 'Import', 'woocommerce' ) }
+			</Button>
+			<Button
+				size="compact"
+				disabled={ canCreateRecord === false }
+				onClick={ () =>
+					( window.location.href = getAdminLink(
+						addQueryArgs( 'post-new.php', {
+							post_type: 'product',
+						} )
+					) )
+				}
+			>
+				{ __( 'Add new product', 'woocommerce' ) }
+			</Button>
+		</Stack>
 	);
 
 	return (
 		<Page
 			className={ classes }
 			ariaLabel={ __( 'Products', 'woocommerce' ) }
-			title={
-				hideTitleFromUI ? undefined : __( 'Products', 'woocommerce' )
-			}
-			subTitle={ hideTitleFromUI ? undefined : subTitle }
+			subTitle={ __(
+				'Add, edit, and manage the products you sell in your store',
+				'woocommerce'
+			) }
+			title={ __( 'Products', 'woocommerce' ) }
 			actions={ pageActions }
 		>
 			<DataViews

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -1,5 +1,7 @@
+@import "../node_modules/@wordpress/theme/src/prebuilt/css/design-tokens.css";
 @import "@wordpress/components/build-style/style.css";
 @import "@wordpress/dataviews/build-style/style.css";
+@import "@wordpress/admin-ui/build-style/style.css";
 
 .product_page_woocommerce-products-dashboard {
 	background-color: unset;

--- a/packages/js/experimental-products-app/tsconfig.json
+++ b/packages/js/experimental-products-app/tsconfig.json
@@ -10,9 +10,16 @@
 		"resolveJsonModule": true,
 		"jsx": "react-jsx",
 		"jsxFactory": null,
-		"jsxFragmentFactory": null
+		"jsxFragmentFactory": null,
+		"typeRoots": [
+			"./typings",
+			"./node_modules/@types"
+		]
 	},
-	"include": [ "src/**/*" ],
+	"include": [
+		"typings/**/*",
+		"src/**/*"
+	],
 	"exclude": [
 		"**/test/**",
 		"**/stories/**",

--- a/packages/js/experimental-products-app/typings/index.d.ts
+++ b/packages/js/experimental-products-app/typings/index.d.ts
@@ -8,10 +8,9 @@ declare module '@woocommerce/settings' {
 		thousandSeparator?: string;
 	};
 	export declare function getAdminLink( path: string ): string;
-	export declare function getSetting< T >(
+	export function getSetting< T >(
 		name: string,
 		fallback?: unknown,
-		filter = ( val: unknown, fb: unknown ) =>
-			typeof val !== 'undefined' ? val : fb
+		filter?: ( val: unknown, fb: unknown ) => unknown
 	): T;
 }

--- a/packages/js/experimental-products-app/typings/index.d.ts
+++ b/packages/js/experimental-products-app/typings/index.d.ts
@@ -1,0 +1,17 @@
+declare module '@woocommerce/settings' {
+	export declare const CURRENCY: {
+		code: string;
+		precision: number;
+		symbol: string;
+		symbolPosition: string;
+		decimalSeparator?: string;
+		thousandSeparator?: string;
+	};
+	export declare function getAdminLink( path: string ): string;
+	export declare function getSetting< T >(
+		name: string,
+		fallback?: unknown,
+		filter = ( val: unknown, fb: unknown ) =>
+			typeof val !== 'undefined' ? val : fb
+	): T;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR improves the experimental products page layout and aligns product actions.


The main changes are:

- Switch the product list data fetching from the WooCommerce products store to `useEntityRecords`, so the page uses core entity records for loading products and pagination totals.
- Update the products page header to always show the page title/subtitle and add primary page actions for exporting products, importing products, and adding a new product.
- Replace the custom quick-edit row action with direct admin navigation for editing products, and add an explicit View action that opens the product permalink in a new tab.
- Remove the default `view-post` action from the inherited post type actions so the product-specific View action is used instead.


Part of #64414
(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Open the experimental products page in WooCommerce admin.
2. Confirm the page shows the updated Products title/subtitle and the new Export, Import, and Add new product actions.
3. Click Export and verify it opens the product exporter screen.
4. Click Import and verify it opens the product importer screen.
5. Click Add new product and verify it opens the new product creation screen.
6. From the product list, click Edit on a product and verify it opens the wp-admin product edit screen.
7. From the product list, click View on a published product and verify it opens the product permalink in a new tab.
8. Confirm product list loading, pagination, and other DataViews interactions still work as expected after switching to `useEntityRecords`.
9. Verify the performance test suite now contains separate `bfcm-infra-hammered.js` and `bfcm-infra-holdingup.js` scenarios with the updated scenario documentation.

### Testing that has already taken place:

