### PR TITLE
Adopt WP 7.0 notice-dismiss button sizing natively

### DIFF
--- a/plugins/woocommerce/changelog/fix-notice-dismiss-button-wp7-align
+++ b/plugins/woocommerce/changelog/fix-notice-dismiss-button-wp7-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adopt WP 7.0 notice-dismiss button sizing in base styles, removing version-gated override.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -922,6 +922,11 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 	}
 
 	a.woocommerce-message-close {
+		// WP 7.0 changes .notice-dismiss to display:flex, width/height:24px.
+		// Woo notices carry visible text so we keep the float-based layout.
+		display: inline;
+		width: auto;
+		height: auto;
 		position: static;
 		float: right;
 		padding: 0 15px 10px 28px;
@@ -929,6 +934,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 		font-size: 13px;
 		line-height: 1.23076923;
 		text-decoration: none;
+		color: #1e1e1e;
 
 		&::before {
 			position: relative;
@@ -8552,15 +8558,6 @@ table.bar_chart {
 	// Restore WP 7.0's padding so the dismiss button aligns correctly.
 	&.woocommerce-embed-page .notice {
 		padding: 8px 12px;
-	}
-
-	// WP 7.0 sets display:flex, width:24px, height:24px on .notice-dismiss.
-	// Reset these so the floated .woocommerce-message-close layout still works.
-	.woocommerce-message a.woocommerce-message-close {
-		display: inline;
-		width: auto;
-		height: auto;
-		color: #1e1e1e;
 	}
 
 	// Align editor meta box border-radius with WP 7.0's dashboard widgets (8px).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WP 7.0 changed `.notice-dismiss` to use `display: flex`, `width: 24px`, and `height: 24px`. Woo notices use `.woocommerce-message-close.notice-dismiss` with visible text content, which requires a float-based layout incompatible with WP 7.0's new flex sizing.

Previously this was handled with a version-gated override in the `.wc-wp-version-gte-70` block. This PR moves those overrides (`display: inline`, `width: auto`, `height: auto`, `color: #1e1e1e`) into the base `.woocommerce-message-close` styles, making the fix unconditional and removing the version gate.

No visual change — the dismiss button looks and behaves the same.

### Screenshots or screen recordings:

No visual change.

### How to test the changes in this Pull Request:

1. Go to any WooCommerce admin page that shows a dismissible notice (e.g. WooCommerce → Settings).
2. Verify the dismiss link appears correctly floated to the right inside the notice.
3. Click it — verify it dismisses as expected.

### Testing that has already taken place:

CSS compiled and synced locally. Dismiss button layout confirmed unaffected.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry manually created and committed to the branch.