### PR TITLE
[RSM-1334] Control deprecated Woo MCP ability exposure

### DIFF
--- a/docs/features/mcp/README.md
+++ b/docs/features/mcp/README.md
@@ -100,7 +100,7 @@ WooCommerce Core
 
 - Manages MCP server initialization and configuration
 - Handles feature flag checking (`mcp_integration`)
-- Provides ability filtering and namespace management
+- Provides deprecated endpoint exposure filtering
 
 **Abilities Registry** ([`AbilitiesRegistry.php`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Abilities/AbilitiesRegistry.php))
 
@@ -281,7 +281,26 @@ add_action( 'abilities_api_init', function() {
 
 ### Including Custom Abilities in WooCommerce MCP Server
 
-By default, only abilities with the `woocommerce/` namespace are included. To include abilities from other namespaces:
+REST-derived WooCommerce abilities include `expose_in_deprecated_woocommerce_mcp` metadata automatically. Custom abilities are not included by namespace alone; set this metadata to boolean `true` when registering the ability to include it in the deprecated WooCommerce MCP server by default:
+
+```php
+wp_register_ability(
+    'your-plugin/custom-operation',
+    array(
+        'label'               => __( 'Custom Store Operation', 'your-plugin' ),
+        'description'         => __( 'Performs a custom store operation.', 'your-plugin' ),
+        'execute_callback'    => 'your_custom_ability_handler',
+        'permission_callback' => function () {
+            return current_user_can( 'manage_woocommerce' );
+        },
+        'meta'                => array(
+            'expose_in_deprecated_woocommerce_mcp' => true,
+        ),
+    )
+);
+```
+
+To override the default metadata decision at runtime, use the `woocommerce_mcp_include_ability` filter:
 
 ```php
 add_filter( 'woocommerce_mcp_include_ability', function( $include, $ability_id ) {
@@ -322,7 +341,7 @@ The demo plugin creates a `woocommerce-demo/store-info` ability that retrieves s
 ## Ability Not Found
 
 - Confirm abilities are registered during `abilities_api_init`
-- Check namespace inclusion using the `woocommerce_mcp_include_ability` filter
+- Check the ability's `expose_in_deprecated_woocommerce_mcp` metadata or override inclusion using the `woocommerce_mcp_include_ability` filter
 - Verify ability callbacks are accessible
 
 Check **WooCommerce → Status → Logs** for entries with source `woocommerce-mcp`.

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesCategories.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesCategories.php
@@ -40,12 +40,14 @@ class AbilitiesCategories {
 			return;
 		}
 
-		wp_register_ability_category(
-			'woocommerce-rest',
-			array(
-				'label'       => __( 'WooCommerce REST API', 'woocommerce' ),
-				'description' => __( 'REST API operations for WooCommerce resources including products, orders, and other store data.', 'woocommerce' ),
-			)
-		);
+		if ( ! function_exists( 'wp_has_ability_category' ) || ! wp_has_ability_category( 'woocommerce-rest' ) ) {
+			wp_register_ability_category(
+				'woocommerce-rest',
+				array(
+					'label'       => __( 'WooCommerce REST API', 'woocommerce' ),
+					'description' => __( 'REST API operations for WooCommerce resources including products, orders, and other store data.', 'woocommerce' ),
+				)
+			);
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -71,7 +71,7 @@ class RestAbilityFactory {
 				},
 				'ability_class'       => RestAbility::class,
 				'meta'                => array(
-					'show_in_rest'                         => true,
+					'show_in_rest' => true,
 					self::EXPOSE_IN_DEPRECATED_MCP_META_KEY => true,
 				),
 			);

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -20,6 +20,11 @@ defined( 'ABSPATH' ) || exit;
 class RestAbilityFactory {
 
 	/**
+	 * Metadata key that marks REST-derived abilities for deprecated WooCommerce MCP exposure.
+	 */
+	public const EXPOSE_IN_DEPRECATED_MCP_META_KEY = 'expose_in_deprecated_woocommerce_mcp';
+
+	/**
 	 * Register abilities for a REST controller based on configuration.
 	 *
 	 * @param array $config Controller configuration containing controller class and abilities array.
@@ -67,7 +72,7 @@ class RestAbilityFactory {
 				'ability_class'       => RestAbility::class,
 				'meta'                => array(
 					'show_in_rest'                         => true,
-					'expose_in_deprecated_woocommerce_mcp' => true,
+					self::EXPOSE_IN_DEPRECATED_MCP_META_KEY => true,
 				),
 			);
 

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -66,7 +66,11 @@ class RestAbilityFactory {
 				},
 				'ability_class'       => RestAbility::class,
 				'meta'                => array(
-					'show_in_rest' => true,
+					'show_in_rest'                 => true,
+					'woocommerce_mcp_expose'       => true,
+					'woocommerce_mcp_projection'   => 'legacy-rest',
+					'woocommerce_ability_source'   => 'rest-controller',
+					'woocommerce_ability_operation' => $ability_config['operation'],
 				),
 			);
 

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -66,11 +66,8 @@ class RestAbilityFactory {
 				},
 				'ability_class'       => RestAbility::class,
 				'meta'                => array(
-					'show_in_rest'                  => true,
-					'woocommerce_mcp_expose'        => true,
-					'woocommerce_mcp_projection'    => 'legacy-rest',
-					'woocommerce_ability_source'    => 'rest-controller',
-					'woocommerce_ability_operation' => $ability_config['operation'],
+					'show_in_rest'                     => true,
+					'woocommerce_expose_in_legacy_mcp' => true,
 				),
 			);
 
@@ -90,7 +87,7 @@ class RestAbilityFactory {
 					array( 'source' => 'woocommerce-rest-abilities' )
 				);
 			}
-		}
+		}//end try
 	}
 
 	/**
@@ -154,7 +151,7 @@ class RestAbilityFactory {
 					),
 					'required'   => array( 'id' ),
 				);
-		}
+		}//end switch
 
 		// Fallback.
 		return array( 'type' => 'object' );
@@ -229,7 +226,7 @@ class RestAbilityFactory {
 			}
 
 			$properties[ $key ] = $property;
-		}
+		}//end foreach
 
 		$schema = array(
 			'type'       => 'object',
@@ -359,7 +356,7 @@ class RestAbilityFactory {
 				$schema['type'] = $normalized;
 			}
 			return $schema;
-		}
+		}//end if
 
 		// Non-string, non-array type — remove it.
 		unset( $schema['type'] );
@@ -421,11 +418,11 @@ class RestAbilityFactory {
 						'previous' => $schema,
 					),
 				);
-			}
+			}//end if
 
 			// For get, create, update operations.
 			return $schema;
-		}
+		}//end if
 
 		return array( 'type' => 'object' );
 	}

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -87,7 +87,7 @@ class RestAbilityFactory {
 					array( 'source' => 'woocommerce-rest-abilities' )
 				);
 			}
-		}//end try
+		}
 	}
 
 	/**
@@ -151,7 +151,7 @@ class RestAbilityFactory {
 					),
 					'required'   => array( 'id' ),
 				);
-		}//end switch
+		}
 
 		// Fallback.
 		return array( 'type' => 'object' );
@@ -226,7 +226,7 @@ class RestAbilityFactory {
 			}
 
 			$properties[ $key ] = $property;
-		}//end foreach
+		}
 
 		$schema = array(
 			'type'       => 'object',
@@ -356,7 +356,7 @@ class RestAbilityFactory {
 				$schema['type'] = $normalized;
 			}
 			return $schema;
-		}//end if
+		}
 
 		// Non-string, non-array type — remove it.
 		unset( $schema['type'] );
@@ -418,11 +418,11 @@ class RestAbilityFactory {
 						'previous' => $schema,
 					),
 				);
-			}//end if
+			}
 
 			// For get, create, update operations.
 			return $schema;
-		}//end if
+		}
 
 		return array( 'type' => 'object' );
 	}

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -66,8 +66,8 @@ class RestAbilityFactory {
 				},
 				'ability_class'       => RestAbility::class,
 				'meta'                => array(
-					'show_in_rest'                     => true,
-					'woocommerce_expose_in_legacy_mcp' => true,
+					'show_in_rest'                         => true,
+					'expose_in_deprecated_woocommerce_mcp' => true,
 				),
 			);
 

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -66,10 +66,10 @@ class RestAbilityFactory {
 				},
 				'ability_class'       => RestAbility::class,
 				'meta'                => array(
-					'show_in_rest'                 => true,
-					'woocommerce_mcp_expose'       => true,
-					'woocommerce_mcp_projection'   => 'legacy-rest',
-					'woocommerce_ability_source'   => 'rest-controller',
+					'show_in_rest'                  => true,
+					'woocommerce_mcp_expose'        => true,
+					'woocommerce_mcp_projection'    => 'legacy-rest',
+					'woocommerce_ability_source'    => 'rest-controller',
 					'woocommerce_ability_operation' => $ability_config['operation'],
 				),
 			);

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -203,9 +203,9 @@ class MCPAdapterProvider {
 			return false;
 		}
 
-		if ( function_exists( 'wp_get_ability' ) ) {
+		if ( function_exists( 'wp_get_ability' ) && function_exists( 'wp_has_ability' ) && wp_has_ability( $ability_id ) ) {
 			$ability = wp_get_ability( $ability_id );
-			if ( $ability && method_exists( $ability, 'get_meta_item' ) ) {
+			if ( $ability ) {
 				$explicit_exposure = $ability->get_meta_item( 'woocommerce_mcp_expose', null );
 				if ( null !== $explicit_exposure ) {
 					return (bool) $explicit_exposure;

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -187,11 +187,11 @@ class MCPAdapterProvider {
 	}
 
 	/**
-	 * Check if an ability should be included in the default WooCommerce MCP surface.
+	 * Check if an ability should be included in the deprecated WooCommerce MCP endpoint.
 	 *
-	 * Existing WooCommerce MCP consumers expect the REST-derived ability surface on the
-	 * default endpoint. Require abilities to explicitly opt in so semantic/domain
-	 * abilities can coexist without changing the legacy MCP tool list.
+	 * REST-derived abilities can opt in to the deprecated WooCommerce MCP endpoint.
+	 * Require explicit metadata so semantic/domain abilities can use WooCommerce
+	 * namespaces without expanding the deprecated MCP tool list.
 	 *
 	 * @param string $ability_id Ability ID.
 	 * @return bool Whether to include the ability by default.
@@ -200,7 +200,7 @@ class MCPAdapterProvider {
 		if ( function_exists( 'wp_get_ability' ) && function_exists( 'wp_has_ability' ) && wp_has_ability( $ability_id ) ) {
 			$ability = wp_get_ability( $ability_id );
 			if ( $ability ) {
-				return true === $ability->get_meta_item( 'woocommerce_expose_in_legacy_mcp', false );
+				return true === $ability->get_meta_item( 'expose_in_deprecated_woocommerce_mcp', false );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -153,8 +153,8 @@ class MCPAdapterProvider {
 	/**
 	 * Get WooCommerce abilities for MCP server.
 	 *
-	 * Filters abilities to include only those with 'woocommerce/' namespace by default,
-	 * with a filter to allow inclusion of abilities from other namespaces.
+	 * Filters abilities to include only those explicitly exposed to the deprecated
+	 * WooCommerce MCP endpoint, with a filter to override inclusion decisions.
 	 *
 	 * @return array Array of ability IDs for MCP server.
 	 */
@@ -163,7 +163,7 @@ class MCPAdapterProvider {
 		$abilities_registry = wc_get_container()->get( AbilitiesRegistry::class );
 		$all_abilities_ids  = $abilities_registry->get_abilities_ids();
 
-		// Filter abilities based on namespace and custom filter.
+		// Filter abilities based on deprecated endpoint exposure metadata and custom filter.
 		$mcp_abilities = array_filter(
 			$all_abilities_ids,
 			static function ( $ability_id ) {

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -147,7 +147,7 @@ class MCPAdapterProvider {
 		} finally {
 			// Re-enable MCP validation immediately after server creation.
 			remove_filter( 'mcp_validation_enabled', array( __CLASS__, 'disable_mcp_validation' ), 999 );
-		}
+		}//end try
 	}
 
 	/**
@@ -189,36 +189,22 @@ class MCPAdapterProvider {
 	/**
 	 * Check if an ability should be included in the default WooCommerce MCP surface.
 	 *
-	 * Existing WooCommerce MCP consumers expect the REST-derived ability surface on
-	 * the default endpoint. Keep the historical namespace fallback for abilities
-	 * that do not carry projection metadata, but require projected abilities to
-	 * target the legacy REST surface explicitly so semantic/domain abilities can
-	 * coexist without changing the legacy MCP tool list.
+	 * Existing WooCommerce MCP consumers expect the REST-derived ability surface on the
+	 * default endpoint. Require abilities to explicitly opt in so semantic/domain
+	 * abilities can coexist without changing the legacy MCP tool list.
 	 *
 	 * @param string $ability_id Ability ID.
 	 * @return bool Whether to include the ability by default.
 	 */
 	private static function should_include_ability_by_default( string $ability_id ): bool {
-		if ( ! str_starts_with( $ability_id, 'woocommerce/' ) ) {
-			return false;
-		}
-
 		if ( function_exists( 'wp_get_ability' ) && function_exists( 'wp_has_ability' ) && wp_has_ability( $ability_id ) ) {
 			$ability = wp_get_ability( $ability_id );
 			if ( $ability ) {
-				$explicit_exposure = $ability->get_meta_item( 'woocommerce_mcp_expose', null );
-				if ( null !== $explicit_exposure ) {
-					return true === $explicit_exposure;
-				}
-
-				$projection = $ability->get_meta_item( 'woocommerce_mcp_projection', null );
-				if ( null !== $projection ) {
-					return 'legacy-rest' === $projection;
-				}
+				return true === $ability->get_meta_item( 'woocommerce_expose_in_legacy_mcp', false );
 			}
 		}
 
-		return true;
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Internal\MCP;
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Internal\Abilities\AbilitiesRegistry;
+use Automattic\WooCommerce\Internal\Abilities\REST\RestAbilityFactory;
 use Automattic\WooCommerce\Internal\MCP\Transport\WooCommerceRestTransport;
 
 defined( 'ABSPATH' ) || exit;
@@ -175,7 +176,10 @@ class MCPAdapterProvider {
 				 *
 				 * @since 10.3.0
 				 *
-				 * @param bool   $include    Whether to include the ability.
+				 * @param bool   $include    Whether to include the ability by default. True when the ability has
+				 *                            `expose_in_deprecated_woocommerce_mcp => true` in its metadata
+				 *                            (set automatically on REST-derived abilities by RestAbilityFactory).
+				 *                            Return unchanged to keep the default, or return true/false to override.
 				 * @param string $ability_id The ability ID.
 				 */
 				return apply_filters( 'woocommerce_mcp_include_ability', $include, $ability_id );
@@ -192,15 +196,22 @@ class MCPAdapterProvider {
 	 * REST-derived abilities can opt in to the deprecated WooCommerce MCP endpoint.
 	 * Require explicit metadata so semantic/domain abilities can use WooCommerce
 	 * namespaces without expanding the deprecated MCP tool list.
+	 * This intentionally allows abilities from any namespace to opt in to the
+	 * deprecated endpoint while keeping namespace and transport exposure separate.
 	 *
 	 * @param string $ability_id Ability ID.
 	 * @return bool Whether to include the ability by default.
 	 */
 	private static function should_include_ability_by_default( string $ability_id ): bool {
+		// Keep the pre-check to avoid triggering _doing_it_wrong() for stale or mocked registry IDs.
 		if ( function_exists( 'wp_get_ability' ) && function_exists( 'wp_has_ability' ) && wp_has_ability( $ability_id ) ) {
 			$ability = wp_get_ability( $ability_id );
 			if ( $ability ) {
-				return true === $ability->get_meta_item( 'expose_in_deprecated_woocommerce_mcp', false );
+				// Strict boolean required: truthy values like 1 or "true" are intentionally excluded.
+				return true === $ability->get_meta_item(
+					RestAbilityFactory::EXPOSE_IN_DEPRECATED_MCP_META_KEY,
+					false
+				);
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -167,8 +167,7 @@ class MCPAdapterProvider {
 		$mcp_abilities = array_filter(
 			$all_abilities_ids,
 			static function ( $ability_id ) {
-				// Include WooCommerce abilities by default.
-				$include = str_starts_with( $ability_id, 'woocommerce/' );
+				$include = self::should_include_ability_by_default( $ability_id );
 
 				// Allow filter to override inclusion decision.
 				/**
@@ -185,6 +184,36 @@ class MCPAdapterProvider {
 
 		// Re-index array.
 		return array_values( $mcp_abilities );
+	}
+
+	/**
+	 * Check if an ability should be included in the default WooCommerce MCP surface.
+	 *
+	 * Existing WooCommerce MCP consumers expect the REST-derived ability surface on
+	 * the default endpoint. Keep the historical namespace fallback for abilities
+	 * that do not carry projection metadata, but allow new ability registrations to
+	 * opt out explicitly so semantic/domain abilities can coexist without changing
+	 * the legacy MCP tool list.
+	 *
+	 * @param string $ability_id Ability ID.
+	 * @return bool Whether to include the ability by default.
+	 */
+	private static function should_include_ability_by_default( string $ability_id ): bool {
+		if ( ! str_starts_with( $ability_id, 'woocommerce/' ) ) {
+			return false;
+		}
+
+		if ( function_exists( 'wp_get_ability' ) ) {
+			$ability = wp_get_ability( $ability_id );
+			if ( $ability && method_exists( $ability, 'get_meta_item' ) ) {
+				$explicit_exposure = $ability->get_meta_item( 'woocommerce_mcp_expose', null );
+				if ( null !== $explicit_exposure ) {
+					return (bool) $explicit_exposure;
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -191,9 +191,9 @@ class MCPAdapterProvider {
 	 *
 	 * Existing WooCommerce MCP consumers expect the REST-derived ability surface on
 	 * the default endpoint. Keep the historical namespace fallback for abilities
-	 * that do not carry projection metadata, but allow new ability registrations to
-	 * opt out explicitly so semantic/domain abilities can coexist without changing
-	 * the legacy MCP tool list.
+	 * that do not carry projection metadata, but require projected abilities to
+	 * target the legacy REST surface explicitly so semantic/domain abilities can
+	 * coexist without changing the legacy MCP tool list.
 	 *
 	 * @param string $ability_id Ability ID.
 	 * @return bool Whether to include the ability by default.
@@ -208,7 +208,12 @@ class MCPAdapterProvider {
 			if ( $ability ) {
 				$explicit_exposure = $ability->get_meta_item( 'woocommerce_mcp_expose', null );
 				if ( null !== $explicit_exposure ) {
-					return (bool) $explicit_exposure;
+					return true === $explicit_exposure;
+				}
+
+				$projection = $ability->get_meta_item( 'woocommerce_mcp_projection', null );
+				if ( null !== $projection ) {
+					return 'legacy-rest' === $projection;
 				}
 			}
 		}

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -179,6 +179,8 @@ class MCPAdapterProvider {
 				 * @param bool   $include    Whether to include the ability by default. True when the ability has
 				 *                            `expose_in_deprecated_woocommerce_mcp => true` in its metadata
 				 *                            (set automatically on REST-derived abilities by RestAbilityFactory).
+				 *                            Migration note: this value no longer represents whether the ability uses
+				 *                            the `woocommerce/` namespace.
 				 *                            Return unchanged to keep the default, or return true/false to override.
 				 * @param string $ability_id The ability ID.
 				 */

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -147,7 +147,7 @@ class MCPAdapterProvider {
 		} finally {
 			// Re-enable MCP validation immediately after server creation.
 			remove_filter( 'mcp_validation_enabled', array( __CLASS__, 'disable_mcp_validation' ), 999 );
-		}//end try
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Abilities/REST/RestAbilityFactoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Abilities/REST/RestAbilityFactoryTest.php
@@ -279,7 +279,7 @@ class RestAbilityFactoryTest extends WC_Unit_Test_Case {
 		$this->assertNotNull( $ability, 'REST-derived test ability should register successfully.' );
 		$this->registered_ability_ids[] = $ability_id;
 		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ), 'REST-derived abilities should remain exposed through the Abilities REST API.' );
-		$this->assertTrue( $ability->get_meta_item( 'expose_in_deprecated_woocommerce_mcp', false ), 'REST-derived abilities should opt in to the deprecated WooCommerce MCP endpoint.' );
+		$this->assertTrue( $ability->get_meta_item( RestAbilityFactory::EXPOSE_IN_DEPRECATED_MCP_META_KEY, false ), 'REST-derived abilities should opt in to the deprecated WooCommerce MCP endpoint.' );
 	}
 
 	// ── Bug 1: date-time type conversion (issue #62764) ──

--- a/plugins/woocommerce/tests/php/src/Internal/Abilities/REST/RestAbilityFactoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Abilities/REST/RestAbilityFactoryTest.php
@@ -19,6 +19,88 @@ class RestAbilityFactoryTest extends WC_Unit_Test_Case {
 	private const VALID_JSON_SCHEMA_TYPES = array( 'string', 'number', 'integer', 'boolean', 'object', 'array', 'null' );
 
 	/**
+	 * Ability IDs registered by these tests.
+	 *
+	 * @var array
+	 */
+	private $registered_ability_ids = array();
+
+	/**
+	 * Ability category IDs registered by these tests.
+	 *
+	 * @var array
+	 */
+	private $registered_ability_category_ids = array();
+
+	/**
+	 * Original value of $wp_actions['wp_abilities_api_init'] to restore in tearDown.
+	 *
+	 * @var int|null
+	 */
+	private $original_wp_abilities_api_init_action_count;
+
+	/**
+	 * Original value of $wp_actions['wp_abilities_api_categories_init'] to restore in tearDown.
+	 *
+	 * @var int|null
+	 */
+	private $original_wp_abilities_api_categories_init_action_count;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		global $wp_actions;
+
+		parent::setUp();
+
+		$this->original_wp_abilities_api_init_action_count            = $wp_actions['wp_abilities_api_init'] ?? null;
+		$this->original_wp_abilities_api_categories_init_action_count = $wp_actions['wp_abilities_api_categories_init'] ?? null;
+
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			$abilities_bootstrap = WP_PLUGIN_DIR . '/woocommerce/vendor/wordpress/abilities-api/includes/bootstrap.php';
+			if ( file_exists( $abilities_bootstrap ) ) {
+				require_once $abilities_bootstrap;
+			}
+		}
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		global $wp_actions;
+
+		foreach ( $this->registered_ability_ids as $ability_id ) {
+			if ( function_exists( 'wp_unregister_ability' ) ) {
+				wp_unregister_ability( $ability_id );
+			}
+		}
+		$this->registered_ability_ids = array();
+
+		foreach ( $this->registered_ability_category_ids as $category_id ) {
+			if ( function_exists( 'wp_unregister_ability_category' ) ) {
+				wp_unregister_ability_category( $category_id );
+			}
+		}
+		$this->registered_ability_category_ids = array();
+
+		if ( null !== $this->original_wp_abilities_api_init_action_count ) {
+			$wp_actions['wp_abilities_api_init'] = $this->original_wp_abilities_api_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $wp_actions['wp_abilities_api_init'] ) ) {
+			unset( $wp_actions['wp_abilities_api_init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		if ( null !== $this->original_wp_abilities_api_categories_init_action_count ) {
+			$wp_actions['wp_abilities_api_categories_init'] = $this->original_wp_abilities_api_categories_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $wp_actions['wp_abilities_api_categories_init'] ) ) {
+			unset( $wp_actions['wp_abilities_api_categories_init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Helper to invoke the private sanitize_args_to_schema method.
 	 *
 	 * @param array $args WordPress REST API arguments array.
@@ -45,6 +127,51 @@ class RestAbilityFactoryTest extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		return $method->invoke( null, $controller, $operation );
+	}
+
+	/**
+	 * Register the test ability category if the suite has not already registered it.
+	 *
+	 * @param string $category_id Ability category ID.
+	 */
+	private function ensure_test_ability_category( string $category_id ): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
+			return;
+		}
+
+		if ( wp_has_ability_category( $category_id ) ) {
+			return;
+		}
+
+		$category = null;
+		$callback = null;
+		$callback = function () use ( &$category, $category_id, &$callback ) {
+			remove_action( 'wp_abilities_api_categories_init', $callback );
+
+			if ( wp_has_ability_category( $category_id ) ) {
+				return;
+			}
+
+			$category = wp_register_ability_category(
+				$category_id,
+				array(
+					'label'       => 'WooCommerce REST API',
+					'description' => 'REST API operations for WooCommerce resources.',
+				)
+			);
+		};
+
+		add_action( 'wp_abilities_api_categories_init', $callback );
+		do_action( 'wp_abilities_api_categories_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		remove_action( 'wp_abilities_api_categories_init', $callback );
+
+		if ( null !== $category ) {
+			$this->assertNotWPError( $category, 'Test ability category should register successfully.' );
+			$this->assertNotNull( $category, 'Test ability category should register successfully.' );
+			$this->registered_ability_category_ids[] = $category_id;
+		}
+
+		$this->assertTrue( wp_has_ability_category( $category_id ), 'Test ability category should be available.' );
 	}
 
 	/**
@@ -112,6 +239,47 @@ class RestAbilityFactoryTest extends WC_Unit_Test_Case {
 				return $this->schema;
 			}
 		};
+	}
+
+	/**
+	 * @testdox Should mark REST-derived abilities for the deprecated WooCommerce MCP endpoint.
+	 */
+	public function test_register_controller_abilities_marks_rest_abilities_for_deprecated_mcp(): void {
+		$this->assertTrue( function_exists( 'wp_register_ability' ), 'Abilities API should be available.' );
+		$this->assertTrue( class_exists( \WC_REST_Products_Controller::class ), 'Products REST controller should be available.' );
+		$this->ensure_test_ability_category( 'woocommerce-rest' );
+
+		$ability_id = 'woocommerce/rest-factory-metadata-test';
+		$config     = array(
+			'controller' => \WC_REST_Products_Controller::class,
+			'route'      => '/wc/v3/products',
+			'abilities'  => array(
+				array(
+					'id'          => $ability_id,
+					'operation'   => 'list',
+					'label'       => 'List REST factory test products',
+					'description' => 'Retrieve REST factory test products.',
+				),
+			),
+		);
+
+		$callback = null;
+		$callback = static function () use ( $config, &$callback ) {
+			remove_action( 'wp_abilities_api_init', $callback );
+
+			RestAbilityFactory::register_controller_abilities( $config );
+		};
+
+		add_action( 'wp_abilities_api_init', $callback );
+		do_action( 'wp_abilities_api_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		remove_action( 'wp_abilities_api_init', $callback );
+
+		$ability = wp_get_ability( $ability_id );
+
+		$this->assertNotNull( $ability, 'REST-derived test ability should register successfully.' );
+		$this->registered_ability_ids[] = $ability_id;
+		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ), 'REST-derived abilities should remain exposed through the Abilities REST API.' );
+		$this->assertTrue( $ability->get_meta_item( 'expose_in_deprecated_woocommerce_mcp', false ), 'REST-derived abilities should opt in to the deprecated WooCommerce MCP endpoint.' );
 	}
 
 	// ── Bug 1: date-time type conversion (issue #62764) ──

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -285,6 +285,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	public function test_get_woocommerce_mcp_abilities_respects_explicit_exposure_metadata() {
 		$legacy_ability   = 'woocommerce/test-legacy-rest';
 		$semantic_ability = 'woocommerce/test-semantic';
+		$invalid_ability  = 'woocommerce/test-invalid-exposure';
 
 		$this->register_test_ability(
 			$legacy_ability,
@@ -300,6 +301,13 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 				'woocommerce_mcp_projection' => 'semantic-flat-experimental',
 			)
 		);
+		$this->register_test_ability(
+			$invalid_ability,
+			array(
+				'woocommerce_mcp_expose'     => 'false',
+				'woocommerce_mcp_projection' => 'legacy-rest',
+			)
+		);
 
 		$this->mock_abilities_registry
 			->method( 'get_abilities_ids' )
@@ -307,6 +315,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 				array(
 					$legacy_ability,
 					$semantic_ability,
+					$invalid_ability,
 				)
 			);
 
@@ -317,6 +326,50 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		$result = $method->invoke( $this->sut );
 
 		$this->assertEquals( array( $legacy_ability ), $result, 'Should include legacy projection abilities and exclude semantic abilities from the default MCP surface.' );
+	}
+
+	/**
+	 * Test projection metadata controls the default MCP surface when exposure metadata is absent.
+	 */
+	public function test_get_woocommerce_mcp_abilities_respects_projection_metadata_without_explicit_exposure() {
+		$legacy_ability      = 'woocommerce/test-projected-legacy-rest';
+		$semantic_ability    = 'woocommerce/test-projected-semantic';
+		$unprojected_ability = 'woocommerce/test-unprojected';
+
+		$this->register_test_ability(
+			$legacy_ability,
+			array(
+				'woocommerce_mcp_projection' => 'legacy-rest',
+			)
+		);
+		$this->register_test_ability(
+			$semantic_ability,
+			array(
+				'woocommerce_mcp_projection' => 'semantic-flat-experimental',
+			)
+		);
+		$this->register_test_ability(
+			$unprojected_ability,
+			array()
+		);
+
+		$this->mock_abilities_registry
+			->method( 'get_abilities_ids' )
+			->willReturn(
+				array(
+					$legacy_ability,
+					$semantic_ability,
+					$unprojected_ability,
+				)
+			);
+
+		$reflection = new \ReflectionClass( $this->sut );
+		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->sut );
+
+		$this->assertEquals( array( $legacy_ability, $unprojected_ability ), $result, 'Should include legacy and unprojected WooCommerce abilities while excluding non-legacy projections.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -206,18 +206,38 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test ability filtering by namespace.
+	 * Test ability filtering by legacy WooCommerce MCP exposure metadata.
 	 */
-	public function test_get_woocommerce_mcp_abilities_filters_by_namespace() {
+	public function test_get_woocommerce_mcp_abilities_filters_by_legacy_exposure_metadata() {
+		$legacy_products_ability = 'woocommerce/test-legacy-products-a';
+		$legacy_orders_ability   = 'woocommerce/test-legacy-orders-a';
+		$canonical_ability       = 'woocommerce/test-canonical-products-a';
+
+		$this->register_test_ability(
+			$legacy_products_ability,
+			array(
+				'woocommerce_expose_in_legacy_mcp' => true,
+			)
+		);
+		$this->register_test_ability(
+			$legacy_orders_ability,
+			array(
+				'woocommerce_expose_in_legacy_mcp' => true,
+			)
+		);
+		$this->register_test_ability(
+			$canonical_ability,
+			array()
+		);
+
 		// Mock abilities registry to return test abilities.
 		$this->mock_abilities_registry
 			->method( 'get_abilities_ids' )
 			->willReturn(
 				array(
-					'woocommerce/products-list',
-					'woocommerce/orders-get',
-					'other-plugin/custom-action',
-					'another/namespace/action',
+					$legacy_products_ability,
+					$legacy_orders_ability,
+					$canonical_ability,
 				)
 			);
 
@@ -229,23 +249,32 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		$result = $method->invoke( $this->sut );
 
 		$expected = array(
-			'woocommerce/products-list',
-			'woocommerce/orders-get',
+			$legacy_products_ability,
+			$legacy_orders_ability,
 		);
 
-		$this->assertEquals( $expected, $result, 'Should only return woocommerce namespaced abilities' );
+		$this->assertEquals( $expected, $result, 'Should only return abilities explicitly exposed in the legacy WooCommerce MCP surface.' );
 	}
 
 	/**
 	 * Test ability filtering with custom filter.
 	 */
 	public function test_get_woocommerce_mcp_abilities_respects_custom_filter() {
+		$legacy_ability = 'woocommerce/test-custom-filter-legacy';
+
+		$this->register_test_ability(
+			$legacy_ability,
+			array(
+				'woocommerce_expose_in_legacy_mcp' => true,
+			)
+		);
+
 		// Mock abilities registry to return test abilities.
 		$this->mock_abilities_registry
 			->method( 'get_abilities_ids' )
 			->willReturn(
 				array(
-					'woocommerce/products-list',
+					$legacy_ability,
 					'custom-plugin/special-action',
 					'other-plugin/normal-action',
 				)
@@ -272,7 +301,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		$result = $method->invoke( $this->sut );
 
 		$expected = array(
-			'woocommerce/products-list',
+			$legacy_ability,
 			'custom-plugin/special-action',
 		);
 
@@ -290,22 +319,19 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		$this->register_test_ability(
 			$legacy_ability,
 			array(
-				'woocommerce_mcp_expose'     => true,
-				'woocommerce_mcp_projection' => 'legacy-rest',
+				'woocommerce_expose_in_legacy_mcp' => true,
 			)
 		);
 		$this->register_test_ability(
 			$semantic_ability,
 			array(
-				'woocommerce_mcp_expose'     => false,
-				'woocommerce_mcp_projection' => 'semantic-flat-experimental',
+				'woocommerce_expose_in_legacy_mcp' => false,
 			)
 		);
 		$this->register_test_ability(
 			$invalid_ability,
 			array(
-				'woocommerce_mcp_expose'     => 'false',
-				'woocommerce_mcp_projection' => 'legacy-rest',
+				'woocommerce_expose_in_legacy_mcp' => 'true',
 			)
 		);
 
@@ -325,31 +351,17 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$result = $method->invoke( $this->sut );
 
-		$this->assertEquals( array( $legacy_ability ), $result, 'Should include legacy projection abilities and exclude semantic abilities from the default MCP surface.' );
+		$this->assertEquals( array( $legacy_ability ), $result, 'Should include only abilities explicitly exposed in the legacy WooCommerce MCP surface.' );
 	}
 
 	/**
-	 * Test projection metadata controls the default MCP surface when exposure metadata is absent.
+	 * Test abilities without legacy exposure metadata are excluded by default.
 	 */
-	public function test_get_woocommerce_mcp_abilities_respects_projection_metadata_without_explicit_exposure() {
-		$legacy_ability      = 'woocommerce/test-projected-legacy-rest';
-		$semantic_ability    = 'woocommerce/test-projected-semantic';
-		$unprojected_ability = 'woocommerce/test-unprojected';
+	public function test_get_woocommerce_mcp_abilities_excludes_unmarked_abilities_by_default() {
+		$unmarked_ability = 'woocommerce/test-unmarked';
 
 		$this->register_test_ability(
-			$legacy_ability,
-			array(
-				'woocommerce_mcp_projection' => 'legacy-rest',
-			)
-		);
-		$this->register_test_ability(
-			$semantic_ability,
-			array(
-				'woocommerce_mcp_projection' => 'semantic-flat-experimental',
-			)
-		);
-		$this->register_test_ability(
-			$unprojected_ability,
+			$unmarked_ability,
 			array()
 		);
 
@@ -357,9 +369,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			->method( 'get_abilities_ids' )
 			->willReturn(
 				array(
-					$legacy_ability,
-					$semantic_ability,
-					$unprojected_ability,
+					$unmarked_ability,
 				)
 			);
 
@@ -369,7 +379,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$result = $method->invoke( $this->sut );
 
-		$this->assertEquals( array( $legacy_ability, $unprojected_ability ), $result, 'Should include legacy and unprojected WooCommerce abilities while excluding non-legacy projections.' );
+		$this->assertEquals( array(), $result, 'Should exclude abilities that are not explicitly exposed in the legacy WooCommerce MCP surface.' );
 	}
 
 	/**
@@ -442,15 +452,31 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	 * Test array re-indexing after filtering.
 	 */
 	public function test_reindexes_array_after_filtering() {
+		$legacy_products_ability = 'woocommerce/test-reindex-products-list';
+		$legacy_orders_ability   = 'woocommerce/test-reindex-orders-get';
+
+		$this->register_test_ability(
+			$legacy_products_ability,
+			array(
+				'woocommerce_expose_in_legacy_mcp' => true,
+			)
+		);
+		$this->register_test_ability(
+			$legacy_orders_ability,
+			array(
+				'woocommerce_expose_in_legacy_mcp' => true,
+			)
+		);
+
 		// Mock abilities registry to return mixed abilities.
 		$this->mock_abilities_registry
 			->method( 'get_abilities_ids' )
 			->willReturn(
 				array(
 					'other-plugin/action-1',
-					'woocommerce/products-list',
+					$legacy_products_ability,
 					'another-namespace/action-2',
-					'woocommerce/orders-get',
+					$legacy_orders_ability,
 				)
 			);
 
@@ -465,8 +491,8 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( array( 0, 1 ), array_keys( $result ), 'Should re-index array after filtering' );
 		$this->assertEquals(
 			array(
-				'woocommerce/products-list',
-				'woocommerce/orders-get',
+				$legacy_products_ability,
+				$legacy_orders_ability,
 			),
 			array_values( $result ),
 			'Should maintain correct values after re-indexing'
@@ -480,35 +506,42 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	 * @param array  $meta Ability meta.
 	 */
 	private function register_test_ability( string $ability_id, array $meta ): void {
-		global $wp_actions;
-
-		$wp_actions['wp_abilities_api_init'] = 1; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
 		$this->ensure_test_ability_category( 'woocommerce-rest' );
 
-		$ability = wp_register_ability(
-			$ability_id,
-			array(
-				'label'               => 'Test ability',
-				'description'         => 'Test ability.',
-				'category'            => 'woocommerce-rest',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array( 'type' => 'object' ),
-				'execute_callback'    => static function () {
-					return array();
-				},
-				'permission_callback' => static function () {
-					return true;
-				},
-				'meta'                => array_merge(
-					array(
-						'show_in_rest' => true,
-					),
-					$meta
-				),
-			)
-		);
+		$ability  = null;
+		$callback = null;
+		$callback = function () use ( &$ability, $ability_id, $meta, &$callback ) {
+			remove_action( 'wp_abilities_api_init', $callback );
 
+			$ability = wp_register_ability(
+				$ability_id,
+				array(
+					'label'               => 'Test ability',
+					'description'         => 'Test ability.',
+					'category'            => 'woocommerce-rest',
+					'input_schema'        => array( 'type' => 'object' ),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => static function () {
+						return array();
+					},
+					'permission_callback' => static function () {
+						return true;
+					},
+					'meta'                => array_merge(
+						array(
+							'show_in_rest' => true,
+						),
+						$meta
+					),
+				)
+			);
+		};
+
+		add_action( 'wp_abilities_api_init', $callback );
+		do_action( 'wp_abilities_api_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		remove_action( 'wp_abilities_api_init', $callback );
+
+		$this->assertNotWPError( $ability, 'Test ability should register successfully.' );
 		$this->assertNotNull( $ability, 'Test ability should register successfully.' );
 		$this->registered_ability_ids[] = $ability_id;
 	}
@@ -519,8 +552,6 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	 * @param string $category_id Ability category ID.
 	 */
 	private function ensure_test_ability_category( string $category_id ): void {
-		global $wp_actions;
-
 		if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
 			return;
 		}
@@ -529,16 +560,34 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			return;
 		}
 
-		$wp_actions['wp_abilities_api_categories_init'] = 1; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$category = null;
+		$callback = null;
+		$callback = function () use ( &$category, $category_id, &$callback ) {
+			remove_action( 'wp_abilities_api_categories_init', $callback );
 
-		wp_register_ability_category(
-			$category_id,
-			array(
-				'label'       => 'WooCommerce REST API',
-				'description' => 'REST API operations for WooCommerce resources.',
-			)
-		);
+			if ( wp_has_ability_category( $category_id ) ) {
+				return;
+			}
 
-		$this->registered_ability_category_ids[] = $category_id;
+			$category = wp_register_ability_category(
+				$category_id,
+				array(
+					'label'       => 'WooCommerce REST API',
+					'description' => 'REST API operations for WooCommerce resources.',
+				)
+			);
+		};
+
+		add_action( 'wp_abilities_api_categories_init', $callback );
+		do_action( 'wp_abilities_api_categories_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		remove_action( 'wp_abilities_api_categories_init', $callback );
+
+		if ( null !== $category ) {
+			$this->assertNotWPError( $category, 'Test ability category should register successfully.' );
+			$this->assertNotNull( $category, 'Test ability category should register successfully.' );
+			$this->registered_ability_category_ids[] = $category_id;
+		}
+
+		$this->assertTrue( wp_has_ability_category( $category_id ), 'Test ability category should be available.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -433,7 +433,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$this->ensure_test_ability_category( 'woocommerce-rest' );
 
-		wp_register_ability(
+		$ability = wp_register_ability(
 			$ability_id,
 			array(
 				'label'               => 'Test ability',
@@ -456,6 +456,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			)
 		);
 
+		$this->assertNotNull( $ability, 'Test ability should register successfully.' );
 		$this->registered_ability_ids[] = $ability_id;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -206,23 +206,23 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test ability filtering by legacy WooCommerce MCP exposure metadata.
+	 * Test ability filtering by deprecated WooCommerce MCP exposure metadata.
 	 */
-	public function test_get_woocommerce_mcp_abilities_filters_by_legacy_exposure_metadata() {
-		$legacy_products_ability = 'woocommerce/test-legacy-products-a';
-		$legacy_orders_ability   = 'woocommerce/test-legacy-orders-a';
-		$canonical_ability       = 'woocommerce/test-canonical-products-a';
+	public function test_get_woocommerce_mcp_abilities_filters_by_deprecated_endpoint_exposure_metadata() {
+		$deprecated_products_ability = 'woocommerce/test-deprecated-products-a';
+		$deprecated_orders_ability   = 'woocommerce/test-deprecated-orders-a';
+		$canonical_ability           = 'woocommerce/test-canonical-products-a';
 
 		$this->register_test_ability(
-			$legacy_products_ability,
+			$deprecated_products_ability,
 			array(
-				'woocommerce_expose_in_legacy_mcp' => true,
+				'expose_in_deprecated_woocommerce_mcp' => true,
 			)
 		);
 		$this->register_test_ability(
-			$legacy_orders_ability,
+			$deprecated_orders_ability,
 			array(
-				'woocommerce_expose_in_legacy_mcp' => true,
+				'expose_in_deprecated_woocommerce_mcp' => true,
 			)
 		);
 		$this->register_test_ability(
@@ -235,8 +235,8 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			->method( 'get_abilities_ids' )
 			->willReturn(
 				array(
-					$legacy_products_ability,
-					$legacy_orders_ability,
+					$deprecated_products_ability,
+					$deprecated_orders_ability,
 					$canonical_ability,
 				)
 			);
@@ -249,23 +249,23 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		$result = $method->invoke( $this->sut );
 
 		$expected = array(
-			$legacy_products_ability,
-			$legacy_orders_ability,
+			$deprecated_products_ability,
+			$deprecated_orders_ability,
 		);
 
-		$this->assertEquals( $expected, $result, 'Should only return abilities explicitly exposed in the legacy WooCommerce MCP surface.' );
+		$this->assertEquals( $expected, $result, 'Should only return abilities explicitly exposed in the deprecated WooCommerce MCP endpoint.' );
 	}
 
 	/**
 	 * Test ability filtering with custom filter.
 	 */
 	public function test_get_woocommerce_mcp_abilities_respects_custom_filter() {
-		$legacy_ability = 'woocommerce/test-custom-filter-legacy';
+		$deprecated_ability = 'woocommerce/test-custom-filter-deprecated';
 
 		$this->register_test_ability(
-			$legacy_ability,
+			$deprecated_ability,
 			array(
-				'woocommerce_expose_in_legacy_mcp' => true,
+				'expose_in_deprecated_woocommerce_mcp' => true,
 			)
 		);
 
@@ -274,7 +274,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			->method( 'get_abilities_ids' )
 			->willReturn(
 				array(
-					$legacy_ability,
+					$deprecated_ability,
 					'custom-plugin/special-action',
 					'other-plugin/normal-action',
 				)
@@ -301,7 +301,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		$result = $method->invoke( $this->sut );
 
 		$expected = array(
-			$legacy_ability,
+			$deprecated_ability,
 			'custom-plugin/special-action',
 		);
 
@@ -309,29 +309,29 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test ability exposure metadata controls the default MCP surface.
+	 * Test ability exposure metadata controls the deprecated WooCommerce MCP endpoint.
 	 */
 	public function test_get_woocommerce_mcp_abilities_respects_explicit_exposure_metadata() {
-		$legacy_ability   = 'woocommerce/test-legacy-rest';
-		$semantic_ability = 'woocommerce/test-semantic';
-		$invalid_ability  = 'woocommerce/test-invalid-exposure';
+		$deprecated_ability = 'woocommerce/test-deprecated-rest';
+		$semantic_ability   = 'woocommerce/test-semantic';
+		$invalid_ability    = 'woocommerce/test-invalid-exposure';
 
 		$this->register_test_ability(
-			$legacy_ability,
+			$deprecated_ability,
 			array(
-				'woocommerce_expose_in_legacy_mcp' => true,
+				'expose_in_deprecated_woocommerce_mcp' => true,
 			)
 		);
 		$this->register_test_ability(
 			$semantic_ability,
 			array(
-				'woocommerce_expose_in_legacy_mcp' => false,
+				'expose_in_deprecated_woocommerce_mcp' => false,
 			)
 		);
 		$this->register_test_ability(
 			$invalid_ability,
 			array(
-				'woocommerce_expose_in_legacy_mcp' => 'true',
+				'expose_in_deprecated_woocommerce_mcp' => 'true',
 			)
 		);
 
@@ -339,7 +339,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			->method( 'get_abilities_ids' )
 			->willReturn(
 				array(
-					$legacy_ability,
+					$deprecated_ability,
 					$semantic_ability,
 					$invalid_ability,
 				)
@@ -351,11 +351,11 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$result = $method->invoke( $this->sut );
 
-		$this->assertEquals( array( $legacy_ability ), $result, 'Should include only abilities explicitly exposed in the legacy WooCommerce MCP surface.' );
+		$this->assertEquals( array( $deprecated_ability ), $result, 'Should include only abilities explicitly exposed in the deprecated WooCommerce MCP endpoint.' );
 	}
 
 	/**
-	 * Test abilities without legacy exposure metadata are excluded by default.
+	 * Test abilities without deprecated endpoint exposure metadata are excluded by default.
 	 */
 	public function test_get_woocommerce_mcp_abilities_excludes_unmarked_abilities_by_default() {
 		$unmarked_ability = 'woocommerce/test-unmarked';
@@ -379,7 +379,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$result = $method->invoke( $this->sut );
 
-		$this->assertEquals( array(), $result, 'Should exclude abilities that are not explicitly exposed in the legacy WooCommerce MCP surface.' );
+		$this->assertEquals( array(), $result, 'Should exclude abilities that are not explicitly exposed in the deprecated WooCommerce MCP endpoint.' );
 	}
 
 	/**
@@ -452,19 +452,19 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	 * Test array re-indexing after filtering.
 	 */
 	public function test_reindexes_array_after_filtering() {
-		$legacy_products_ability = 'woocommerce/test-reindex-products-list';
-		$legacy_orders_ability   = 'woocommerce/test-reindex-orders-get';
+		$deprecated_products_ability = 'woocommerce/test-reindex-products-list';
+		$deprecated_orders_ability   = 'woocommerce/test-reindex-orders-get';
 
 		$this->register_test_ability(
-			$legacy_products_ability,
+			$deprecated_products_ability,
 			array(
-				'woocommerce_expose_in_legacy_mcp' => true,
+				'expose_in_deprecated_woocommerce_mcp' => true,
 			)
 		);
 		$this->register_test_ability(
-			$legacy_orders_ability,
+			$deprecated_orders_ability,
 			array(
-				'woocommerce_expose_in_legacy_mcp' => true,
+				'expose_in_deprecated_woocommerce_mcp' => true,
 			)
 		);
 
@@ -474,9 +474,9 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			->willReturn(
 				array(
 					'other-plugin/action-1',
-					$legacy_products_ability,
+					$deprecated_products_ability,
 					'another-namespace/action-2',
-					$legacy_orders_ability,
+					$deprecated_orders_ability,
 				)
 			);
 
@@ -491,8 +491,8 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( array( 0, 1 ), array_keys( $result ), 'Should re-index array after filtering' );
 		$this->assertEquals(
 			array(
-				$legacy_products_ability,
-				$legacy_orders_ability,
+				$deprecated_products_ability,
+				$deprecated_orders_ability,
 			),
 			array_values( $result ),
 			'Should maintain correct values after re-indexing'

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -38,10 +38,43 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	private $original_abilities_registry;
 
 	/**
+	 * Ability IDs registered by these tests.
+	 *
+	 * @var array
+	 */
+	private $registered_ability_ids = array();
+
+	/**
+	 * Ability category IDs registered by these tests.
+	 *
+	 * @var array
+	 */
+	private $registered_ability_category_ids = array();
+
+	/**
+	 * Original value of $wp_actions['wp_abilities_api_init'] to restore in tearDown.
+	 *
+	 * @var int|null
+	 */
+	private $original_wp_abilities_api_init_action_count;
+
+	/**
+	 * Original value of $wp_actions['wp_abilities_api_categories_init'] to restore in tearDown.
+	 *
+	 * @var int|null
+	 */
+	private $original_wp_abilities_api_categories_init_action_count;
+
+	/**
 	 * Set up before each test.
 	 */
 	public function setUp(): void {
+		global $wp_actions;
+
 		parent::setUp();
+
+		$this->original_wp_abilities_api_init_action_count            = $wp_actions['wp_abilities_api_init'] ?? null;
+		$this->original_wp_abilities_api_categories_init_action_count = $wp_actions['wp_abilities_api_categories_init'] ?? null;
 
 		// Bootstrap the WordPress Abilities API for tests.
 		if ( ! function_exists( 'wp_register_ability' ) ) {
@@ -80,6 +113,8 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	 * Clean up after each test.
 	 */
 	public function tearDown(): void {
+		global $wp_actions;
+
 		// Restore original abilities registry if it was captured.
 		if ( $this->original_abilities_registry ) {
 			$container = wc_get_container();
@@ -92,12 +127,38 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		remove_all_filters( 'woocommerce_mcp_allow_insecure_transport' );
 		remove_all_filters( 'mcp_validation_enabled' );
 
+		foreach ( $this->registered_ability_ids as $ability_id ) {
+			if ( function_exists( 'wp_unregister_ability' ) ) {
+				wp_unregister_ability( $ability_id );
+			}
+		}
+		$this->registered_ability_ids = array();
+
+		foreach ( $this->registered_ability_category_ids as $category_id ) {
+			if ( function_exists( 'wp_unregister_ability_category' ) ) {
+				wp_unregister_ability_category( $category_id );
+			}
+		}
+		$this->registered_ability_category_ids = array();
+
 		// Remove actions registered by the system under test.
 		remove_action( 'rest_api_init', array( $this->sut, 'maybe_initialize' ), 10 );
 		remove_action( 'mcp_adapter_init', array( $this->sut, 'initialize_mcp_server' ), 10 );
 
 		// Clean up feature flag options.
 		delete_option( 'woocommerce_feature_mcp_integration_enabled' );
+
+		if ( null !== $this->original_wp_abilities_api_init_action_count ) {
+			$wp_actions['wp_abilities_api_init'] = $this->original_wp_abilities_api_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $wp_actions['wp_abilities_api_init'] ) ) {
+			unset( $wp_actions['wp_abilities_api_init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		if ( null !== $this->original_wp_abilities_api_categories_init_action_count ) {
+			$wp_actions['wp_abilities_api_categories_init'] = $this->original_wp_abilities_api_categories_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $wp_actions['wp_abilities_api_categories_init'] ) ) {
+			unset( $wp_actions['wp_abilities_api_categories_init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
 
 		parent::tearDown();
 	}
@@ -219,6 +280,46 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test ability exposure metadata controls the default MCP surface.
+	 */
+	public function test_get_woocommerce_mcp_abilities_respects_explicit_exposure_metadata() {
+		$legacy_ability   = 'woocommerce/test-legacy-rest';
+		$semantic_ability = 'woocommerce/test-semantic';
+
+		$this->register_test_ability(
+			$legacy_ability,
+			array(
+				'woocommerce_mcp_expose'     => true,
+				'woocommerce_mcp_projection' => 'legacy-rest',
+			)
+		);
+		$this->register_test_ability(
+			$semantic_ability,
+			array(
+				'woocommerce_mcp_expose'     => false,
+				'woocommerce_mcp_projection' => 'semantic-flat-experimental',
+			)
+		);
+
+		$this->mock_abilities_registry
+			->method( 'get_abilities_ids' )
+			->willReturn(
+				array(
+					$legacy_ability,
+					$semantic_ability,
+				)
+			);
+
+		$reflection = new \ReflectionClass( $this->sut );
+		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->sut );
+
+		$this->assertEquals( array( $legacy_ability ), $result, 'Should include legacy projection abilities and exclude semantic abilities from the default MCP surface.' );
+	}
+
+	/**
 	 * Test MCP validation disable workaround.
 	 */
 	public function test_disable_mcp_validation_returns_false() {
@@ -317,5 +418,73 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			array_values( $result ),
 			'Should maintain correct values after re-indexing'
 		);
+	}
+
+	/**
+	 * Register a minimal ability for provider tests.
+	 *
+	 * @param string $ability_id Ability ID.
+	 * @param array  $meta Ability meta.
+	 */
+	private function register_test_ability( string $ability_id, array $meta ): void {
+		global $wp_actions;
+
+		$wp_actions['wp_abilities_api_init'] = 1; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->ensure_test_ability_category( 'woocommerce-rest' );
+
+		wp_register_ability(
+			$ability_id,
+			array(
+				'label'               => 'Test ability',
+				'description'         => 'Test ability.',
+				'category'            => 'woocommerce-rest',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array();
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array_merge(
+					array(
+						'show_in_rest' => true,
+					),
+					$meta
+				),
+			)
+		);
+
+		$this->registered_ability_ids[] = $ability_id;
+	}
+
+	/**
+	 * Register the test ability category if the suite has not already registered it.
+	 *
+	 * @param string $category_id Ability category ID.
+	 */
+	private function ensure_test_ability_category( string $category_id ): void {
+		global $wp_actions;
+
+		if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
+			return;
+		}
+
+		if ( wp_has_ability_category( $category_id ) ) {
+			return;
+		}
+
+		$wp_actions['wp_abilities_api_categories_init'] = 1; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		wp_register_ability_category(
+			$category_id,
+			array(
+				'label'       => 'WooCommerce REST API',
+				'description' => 'REST API operations for WooCommerce resources.',
+			)
+		);
+
+		$this->registered_ability_category_ids[] = $category_id;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -7,8 +7,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\MCP;
 
-use Automattic\WooCommerce\Internal\MCP\MCPAdapterProvider;
 use Automattic\WooCommerce\Internal\Abilities\AbilitiesRegistry;
+use Automattic\WooCommerce\Internal\Abilities\REST\RestAbilityFactory;
+use Automattic\WooCommerce\Internal\MCP\MCPAdapterProvider;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
@@ -164,9 +165,9 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that maybe_initialize respects feature flag when disabled.
+	 * @testdox Should not initialize when the MCP feature flag is disabled.
 	 */
-	public function test_maybe_initialize_respects_feature_flag_disabled() {
+	public function test_maybe_initialize_respects_feature_flag_disabled(): void {
 		// Ensure MCP feature is disabled via option.
 		update_option( 'woocommerce_feature_mcp_integration_enabled', 'no' );
 
@@ -176,9 +177,9 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that maybe_initialize respects feature flag when enabled.
+	 * @testdox Should initialize when the MCP feature flag is enabled.
 	 */
-	public function test_maybe_initialize_respects_feature_flag_enabled() {
+	public function test_maybe_initialize_respects_feature_flag_enabled(): void {
 
 		// Enable MCP feature via option.
 		update_option( 'woocommerce_feature_mcp_integration_enabled', 'yes' );
@@ -189,9 +190,9 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that double initialization is prevented.
+	 * @testdox Should prevent double initialization.
 	 */
-	public function test_prevents_double_initialization() {
+	public function test_prevents_double_initialization(): void {
 		// Enable MCP feature via option.
 		update_option( 'woocommerce_feature_mcp_integration_enabled', 'yes' );
 
@@ -206,41 +207,22 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test ability filtering by deprecated WooCommerce MCP exposure metadata.
+	 * @testdox Should include marked deprecated WooCommerce MCP abilities across namespaces.
 	 */
-	public function test_get_woocommerce_mcp_abilities_filters_by_deprecated_endpoint_exposure_metadata() {
+	public function test_get_woocommerce_mcp_abilities_includes_marked_abilities_across_namespaces(): void {
 		$exposed_woocommerce_ability = 'woocommerce/test-deprecated-products-a';
 		$exposed_external_ability    = 'custom-plugin/test-deprecated-orders-a';
-		$unmarked_ability            = 'woocommerce/test-unmarked';
-		$opted_out_ability           = 'woocommerce/test-opted-out';
-		$invalid_exposure_ability    = 'woocommerce/test-invalid-exposure';
 
 		$this->register_test_ability(
 			$exposed_woocommerce_ability,
 			array(
-				'expose_in_deprecated_woocommerce_mcp' => true,
+				RestAbilityFactory::EXPOSE_IN_DEPRECATED_MCP_META_KEY => true,
 			)
 		);
 		$this->register_test_ability(
 			$exposed_external_ability,
 			array(
-				'expose_in_deprecated_woocommerce_mcp' => true,
-			)
-		);
-		$this->register_test_ability(
-			$unmarked_ability,
-			array()
-		);
-		$this->register_test_ability(
-			$opted_out_ability,
-			array(
-				'expose_in_deprecated_woocommerce_mcp' => false,
-			)
-		);
-		$this->register_test_ability(
-			$invalid_exposure_ability,
-			array(
-				'expose_in_deprecated_woocommerce_mcp' => 'true',
+				RestAbilityFactory::EXPOSE_IN_DEPRECATED_MCP_META_KEY => true,
 			)
 		);
 
@@ -250,8 +232,66 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 				array(
 					'unregistered-plugin/not-available',
 					$exposed_woocommerce_ability,
-					$unmarked_ability,
 					$exposed_external_ability,
+				)
+			);
+
+		$result = $this->get_woocommerce_mcp_abilities();
+
+		$this->assertCount( 2, $result, 'Should only return abilities explicitly exposed in the deprecated WooCommerce MCP endpoint.' );
+		$this->assertContains( $exposed_woocommerce_ability, $result, 'Should include marked WooCommerce abilities.' );
+		$this->assertContains( $exposed_external_ability, $result, 'Should include marked abilities from other namespaces.' );
+		$this->assertSame( array( 0, 1 ), array_keys( $result ), 'Should re-index array after filtering.' );
+	}
+
+	/**
+	 * @testdox Should exclude unmarked WooCommerce abilities from the deprecated MCP endpoint.
+	 */
+	public function test_get_woocommerce_mcp_abilities_excludes_unmarked_woocommerce_abilities(): void {
+		$unmarked_ability = 'woocommerce/test-unmarked';
+
+		$this->register_test_ability(
+			$unmarked_ability,
+			array()
+		);
+
+		$this->mock_abilities_registry
+			->method( 'get_abilities_ids' )
+			->willReturn(
+				array(
+					$unmarked_ability,
+				)
+			);
+
+		$result = $this->get_woocommerce_mcp_abilities();
+
+		$this->assertEmpty( $result, 'Should exclude unmarked WooCommerce abilities.' );
+	}
+
+	/**
+	 * @testdox Should require strict boolean metadata for deprecated MCP endpoint exposure.
+	 */
+	public function test_get_woocommerce_mcp_abilities_excludes_false_or_non_boolean_exposure_metadata(): void {
+		$opted_out_ability        = 'woocommerce/test-opted-out';
+		$invalid_exposure_ability = 'woocommerce/test-invalid-exposure';
+
+		$this->register_test_ability(
+			$opted_out_ability,
+			array(
+				RestAbilityFactory::EXPOSE_IN_DEPRECATED_MCP_META_KEY => false,
+			)
+		);
+		$this->register_test_ability(
+			$invalid_exposure_ability,
+			array(
+				RestAbilityFactory::EXPOSE_IN_DEPRECATED_MCP_META_KEY => 'true',
+			)
+		);
+
+		$this->mock_abilities_registry
+			->method( 'get_abilities_ids' )
+			->willReturn(
+				array(
 					$opted_out_ability,
 					$invalid_exposure_ability,
 				)
@@ -259,25 +299,19 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$result = $this->get_woocommerce_mcp_abilities();
 
-		$expected = array(
-			$exposed_woocommerce_ability,
-			$exposed_external_ability,
-		);
-
-		$this->assertEquals( $expected, $result, 'Should only return abilities explicitly exposed in the deprecated WooCommerce MCP endpoint.' );
-		$this->assertSame( array( 0, 1 ), array_keys( $result ), 'Should re-index array after filtering.' );
+		$this->assertEmpty( $result, 'Should exclude false and non-boolean exposure metadata.' );
 	}
 
 	/**
-	 * Test ability filtering with custom filter.
+	 * @testdox Should respect custom filters for deprecated WooCommerce MCP ability inclusion.
 	 */
-	public function test_get_woocommerce_mcp_abilities_respects_custom_filter() {
+	public function test_get_woocommerce_mcp_abilities_respects_custom_filter(): void {
 		$deprecated_ability = 'woocommerce/test-custom-filter-deprecated';
 
 		$this->register_test_ability(
 			$deprecated_ability,
 			array(
-				'expose_in_deprecated_woocommerce_mcp' => true,
+				RestAbilityFactory::EXPOSE_IN_DEPRECATED_MCP_META_KEY => true,
 			)
 		);
 
@@ -310,26 +344,25 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$result = $this->get_woocommerce_mcp_abilities();
 
-		$expected = array(
-			'custom-plugin/special-action',
-		);
-
-		$this->assertEquals( $expected, $result, 'Should respect custom filter for including abilities' );
+		$this->assertCount( 1, $result, 'Should only return abilities included by the custom filter.' );
+		$this->assertContains( 'custom-plugin/special-action', $result, 'Should include abilities opted in by filter.' );
+		$this->assertNotContains( $deprecated_ability, $result, 'Should exclude abilities opted out by filter.' );
+		$this->assertSame( array( 0 ), array_keys( $result ), 'Should re-index array after filter override.' );
 	}
 
 	/**
-	 * Test MCP validation disable workaround.
+	 * @testdox Should disable MCP validation.
 	 */
-	public function test_disable_mcp_validation_returns_false() {
+	public function test_disable_mcp_validation_returns_false(): void {
 		$result = MCPAdapterProvider::disable_mcp_validation();
 
 		$this->assertFalse( $result, 'disable_mcp_validation should always return false' );
 	}
 
 	/**
-	 * Test initialization state tracking.
+	 * @testdox Should track initialization state.
 	 */
-	public function test_is_initialized_tracks_state() {
+	public function test_is_initialized_tracks_state(): void {
 		$this->assertFalse( $this->sut->is_initialized(), 'Should start as not initialized' );
 
 		// Enable MCP feature via option.
@@ -340,9 +373,9 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that abilities with empty array are handled correctly.
+	 * @testdox Should handle an empty abilities array.
 	 */
-	public function test_handles_empty_abilities_array() {
+	public function test_handles_empty_abilities_array(): void {
 		// Mock abilities registry to return empty array.
 		$this->mock_abilities_registry
 			->method( 'get_abilities_ids' )
@@ -350,13 +383,13 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$result = $this->get_woocommerce_mcp_abilities();
 
-		$this->assertEquals( array(), $result, 'Should handle empty abilities array correctly' );
+		$this->assertEmpty( $result, 'Should handle empty abilities array correctly' );
 	}
 
 	/**
-	 * Test that unregistered abilities are filtered out.
+	 * @testdox Should filter out unregistered abilities.
 	 */
-	public function test_filters_out_unregistered_abilities() {
+	public function test_filters_out_unregistered_abilities(): void {
 		$this->mock_abilities_registry
 			->method( 'get_abilities_ids' )
 			->willReturn(
@@ -369,7 +402,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		$result = $this->get_woocommerce_mcp_abilities();
 
-		$this->assertEquals( array(), $result, 'Should filter out all unregistered abilities.' );
+		$this->assertEmpty( $result, 'Should filter out all unregistered abilities.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -209,51 +209,63 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	 * Test ability filtering by deprecated WooCommerce MCP exposure metadata.
 	 */
 	public function test_get_woocommerce_mcp_abilities_filters_by_deprecated_endpoint_exposure_metadata() {
-		$deprecated_products_ability = 'woocommerce/test-deprecated-products-a';
-		$deprecated_orders_ability   = 'woocommerce/test-deprecated-orders-a';
-		$canonical_ability           = 'woocommerce/test-canonical-products-a';
+		$exposed_woocommerce_ability = 'woocommerce/test-deprecated-products-a';
+		$exposed_external_ability    = 'custom-plugin/test-deprecated-orders-a';
+		$unmarked_ability            = 'woocommerce/test-unmarked';
+		$opted_out_ability           = 'woocommerce/test-opted-out';
+		$invalid_exposure_ability    = 'woocommerce/test-invalid-exposure';
 
 		$this->register_test_ability(
-			$deprecated_products_ability,
+			$exposed_woocommerce_ability,
 			array(
 				'expose_in_deprecated_woocommerce_mcp' => true,
 			)
 		);
 		$this->register_test_ability(
-			$deprecated_orders_ability,
+			$exposed_external_ability,
 			array(
 				'expose_in_deprecated_woocommerce_mcp' => true,
 			)
 		);
 		$this->register_test_ability(
-			$canonical_ability,
+			$unmarked_ability,
 			array()
 		);
+		$this->register_test_ability(
+			$opted_out_ability,
+			array(
+				'expose_in_deprecated_woocommerce_mcp' => false,
+			)
+		);
+		$this->register_test_ability(
+			$invalid_exposure_ability,
+			array(
+				'expose_in_deprecated_woocommerce_mcp' => 'true',
+			)
+		);
 
-		// Mock abilities registry to return test abilities.
 		$this->mock_abilities_registry
 			->method( 'get_abilities_ids' )
 			->willReturn(
 				array(
-					$deprecated_products_ability,
-					$deprecated_orders_ability,
-					$canonical_ability,
+					'unregistered-plugin/not-available',
+					$exposed_woocommerce_ability,
+					$unmarked_ability,
+					$exposed_external_ability,
+					$opted_out_ability,
+					$invalid_exposure_ability,
 				)
 			);
 
-		// Use reflection to test the private method.
-		$reflection = new \ReflectionClass( $this->sut );
-		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $this->sut );
+		$result = $this->get_woocommerce_mcp_abilities();
 
 		$expected = array(
-			$deprecated_products_ability,
-			$deprecated_orders_ability,
+			$exposed_woocommerce_ability,
+			$exposed_external_ability,
 		);
 
 		$this->assertEquals( $expected, $result, 'Should only return abilities explicitly exposed in the deprecated WooCommerce MCP endpoint.' );
+		$this->assertSame( array( 0, 1 ), array_keys( $result ), 'Should re-index array after filtering.' );
 	}
 
 	/**
@@ -284,6 +296,9 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		add_filter(
 			'woocommerce_mcp_include_ability',
 			function ( $should_include, $ability_id ) {
+				if ( 'woocommerce/test-custom-filter-deprecated' === $ability_id ) {
+					return false;
+				}
 				if ( str_starts_with( $ability_id, 'custom-plugin/' ) ) {
 					return true;
 				}
@@ -293,93 +308,13 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			2
 		);
 
-		// Use reflection to test the private method.
-		$reflection = new \ReflectionClass( $this->sut );
-		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $this->sut );
+		$result = $this->get_woocommerce_mcp_abilities();
 
 		$expected = array(
-			$deprecated_ability,
 			'custom-plugin/special-action',
 		);
 
 		$this->assertEquals( $expected, $result, 'Should respect custom filter for including abilities' );
-	}
-
-	/**
-	 * Test ability exposure metadata controls the deprecated WooCommerce MCP endpoint.
-	 */
-	public function test_get_woocommerce_mcp_abilities_respects_explicit_exposure_metadata() {
-		$deprecated_ability = 'woocommerce/test-deprecated-rest';
-		$semantic_ability   = 'woocommerce/test-semantic';
-		$invalid_ability    = 'woocommerce/test-invalid-exposure';
-
-		$this->register_test_ability(
-			$deprecated_ability,
-			array(
-				'expose_in_deprecated_woocommerce_mcp' => true,
-			)
-		);
-		$this->register_test_ability(
-			$semantic_ability,
-			array(
-				'expose_in_deprecated_woocommerce_mcp' => false,
-			)
-		);
-		$this->register_test_ability(
-			$invalid_ability,
-			array(
-				'expose_in_deprecated_woocommerce_mcp' => 'true',
-			)
-		);
-
-		$this->mock_abilities_registry
-			->method( 'get_abilities_ids' )
-			->willReturn(
-				array(
-					$deprecated_ability,
-					$semantic_ability,
-					$invalid_ability,
-				)
-			);
-
-		$reflection = new \ReflectionClass( $this->sut );
-		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $this->sut );
-
-		$this->assertEquals( array( $deprecated_ability ), $result, 'Should include only abilities explicitly exposed in the deprecated WooCommerce MCP endpoint.' );
-	}
-
-	/**
-	 * Test abilities without deprecated endpoint exposure metadata are excluded by default.
-	 */
-	public function test_get_woocommerce_mcp_abilities_excludes_unmarked_abilities_by_default() {
-		$unmarked_ability = 'woocommerce/test-unmarked';
-
-		$this->register_test_ability(
-			$unmarked_ability,
-			array()
-		);
-
-		$this->mock_abilities_registry
-			->method( 'get_abilities_ids' )
-			->willReturn(
-				array(
-					$unmarked_ability,
-				)
-			);
-
-		$reflection = new \ReflectionClass( $this->sut );
-		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $this->sut );
-
-		$this->assertEquals( array(), $result, 'Should exclude abilities that are not explicitly exposed in the deprecated WooCommerce MCP endpoint.' );
 	}
 
 	/**
@@ -413,21 +348,15 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			->method( 'get_abilities_ids' )
 			->willReturn( array() );
 
-		// Use reflection to test the private method.
-		$reflection = new \ReflectionClass( $this->sut );
-		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $this->sut );
+		$result = $this->get_woocommerce_mcp_abilities();
 
 		$this->assertEquals( array(), $result, 'Should handle empty abilities array correctly' );
 	}
 
 	/**
-	 * Test that non-woocommerce abilities are filtered out.
+	 * Test that unregistered abilities are filtered out.
 	 */
-	public function test_filters_out_non_woocommerce_abilities() {
-		// Mock abilities registry to return only non-woocommerce abilities.
+	public function test_filters_out_unregistered_abilities() {
 		$this->mock_abilities_registry
 			->method( 'get_abilities_ids' )
 			->willReturn(
@@ -438,65 +367,22 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 				)
 			);
 
-		// Use reflection to test the private method.
-		$reflection = new \ReflectionClass( $this->sut );
-		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
-		$method->setAccessible( true );
+		$result = $this->get_woocommerce_mcp_abilities();
 
-		$result = $method->invoke( $this->sut );
-
-		$this->assertEquals( array(), $result, 'Should filter out all non-woocommerce abilities' );
+		$this->assertEquals( array(), $result, 'Should filter out all unregistered abilities.' );
 	}
 
 	/**
-	 * Test array re-indexing after filtering.
+	 * Get WooCommerce MCP abilities through the private provider method.
+	 *
+	 * @return array
 	 */
-	public function test_reindexes_array_after_filtering() {
-		$deprecated_products_ability = 'woocommerce/test-reindex-products-list';
-		$deprecated_orders_ability   = 'woocommerce/test-reindex-orders-get';
-
-		$this->register_test_ability(
-			$deprecated_products_ability,
-			array(
-				'expose_in_deprecated_woocommerce_mcp' => true,
-			)
-		);
-		$this->register_test_ability(
-			$deprecated_orders_ability,
-			array(
-				'expose_in_deprecated_woocommerce_mcp' => true,
-			)
-		);
-
-		// Mock abilities registry to return mixed abilities.
-		$this->mock_abilities_registry
-			->method( 'get_abilities_ids' )
-			->willReturn(
-				array(
-					'other-plugin/action-1',
-					$deprecated_products_ability,
-					'another-namespace/action-2',
-					$deprecated_orders_ability,
-				)
-			);
-
-		// Use reflection to test the private method.
+	private function get_woocommerce_mcp_abilities(): array {
 		$reflection = new \ReflectionClass( $this->sut );
 		$method     = $reflection->getMethod( 'get_woocommerce_mcp_abilities' );
 		$method->setAccessible( true );
 
-		$result = $method->invoke( $this->sut );
-
-		// Check that array is properly re-indexed (keys should be 0, 1).
-		$this->assertEquals( array( 0, 1 ), array_keys( $result ), 'Should re-index array after filtering' );
-		$this->assertEquals(
-			array(
-				$deprecated_products_ability,
-				$deprecated_orders_ability,
-			),
-			array_values( $result ),
-			'Should maintain correct values after re-indexing'
-		);
+		return $method->invoke( $this->sut );
 	}
 
 	/**


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WooCommerce's deprecated `/wp-json/woocommerce/mcp` endpoint includes abilities by explicit deprecated-endpoint exposure metadata, not by `woocommerce/*` namespace matching.

REST-derived WooCommerce abilities produced by `RestAbilityFactory` are marked automatically with:

```php
'expose_in_deprecated_woocommerce_mcp' => true,
```

`MCPAdapterProvider` includes an ability by default only when that metadata value is the boolean `true`. The metadata is namespace-agnostic, so abilities from any namespace can opt in to the deprecated WooCommerce MCP endpoint with the same flag. Unmarked abilities, including unmarked `woocommerce/*` domain abilities, stay out of the deprecated endpoint by default.

The `woocommerce_mcp_include_ability` filter remains the final override. Extensions can return `true` or `false` to include or exclude an ability regardless of the metadata default.

The `woocommerce-rest` ability category registration is guarded so repeated bootstrap paths do not register the category twice.

The compatibility boundary is:

- WordPress Abilities API registration remains independent of MCP exposure.
- Shared WordPress MCP adapter exposure uses the adapter's own MCP metadata.
- Deprecated WooCommerce MCP endpoint exposure uses `expose_in_deprecated_woocommerce_mcp => true` or the `woocommerce_mcp_include_ability` filter.

Existing REST-derived Woo MCP tools remain available for compatibility, while follow-up canonical/domain ability work in [RSM-1335](https://linear.app/a8c/issue/RSM-1335/woo-core-add-canonical-domain-abilities-backed-by-woo-crud-apis) can use WooCommerce namespaces without automatically expanding the deprecated MCP tool list.

Supersedes the RSM-1334-relevant part of experimental Pattern B draft PR #64330 with a clean branch against `trunk`.

### How to test the changes in this Pull Request:

1. Check out this branch in a WooCommerce development environment.
2. Run the focused MCP adapter tests:

   ```sh
   pnpm test:php:env -- --filter MCPAdapterProviderTest
   ```

3. Optionally test manually with the Woo MCP feature enabled:

   ```sh
   pnpm wp-env run cli wp option update woocommerce_feature_mcp_integration_enabled yes
   ```

4. Confirm REST-derived Woo abilities still appear on `/wp-json/woocommerce/mcp`.
5. Register a `woocommerce/*` ability without `expose_in_deprecated_woocommerce_mcp` and confirm it is not included in the default Woo MCP ability list.
6. Add `expose_in_deprecated_woocommerce_mcp => true` to that ability's metadata, or include it through `woocommerce_mcp_include_ability`, and confirm it is included.

### Testing that has already taken place:

- `php -l plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php`
- `php -l plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php`
- `php -l plugins/woocommerce/tests/php/src/Internal/Abilities/REST/RestAbilityFactoryTest.php`
- `php -l plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php`
- `git diff --check`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch:php`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- `WP_ENV_PORT=8890 WP_ENV_TESTS_PORT=8891 pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "MCPAdapterProviderTest|RestAbilityFactoryTest"`
  - `OK (36 tests, 91 assertions)`
- CI `Lint - @woocommerce/plugin-woocommerce` passes on latest head.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

#### Type

#### Message

#### Comment

Internal MCP/Abilities compatibility metadata and inclusion behavior. No user-facing merchant change.

</details>
