### PR TITLE
Add stock and product status indicators to admin order product selector

### DIFF
--- a/plugins/woocommerce/changelog/64426-add-stock-status-admin-order-selector
+++ b/plugins/woocommerce/changelog/64426-add-stock-status-admin-order-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add stock status and product status indicators to the admin order product selector so admins can see which variations are out of stock, on backorder, or disabled.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1827,8 +1827,8 @@ class WC_AJAX {
 
 				if ( $managing_stock ) {
 					$stock_amount = $product_object->get_stock_quantity();
-					/* Translators: %d stock amount */
-					$stock_parts[] = sprintf( __( 'Stock: %d', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_amount, $product_object ) );
+					/* Translators: %s stock amount */
+					$stock_parts[] = sprintf( __( 'Stock: %s', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_amount, $product_object ) );
 				}
 
 				$stock_status = $product_object->get_stock_status();

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1811,7 +1811,7 @@ class WC_AJAX {
 		foreach ( $ids as $id ) {
 			$product_object = wc_get_product( $id );
 
-			if ( ! wc_products_array_filter_readable( $product_object ) ) {
+			if ( ! $product_object || ! wc_products_array_filter_readable( $product_object ) ) {
 				continue;
 			}
 
@@ -1822,11 +1822,33 @@ class WC_AJAX {
 				continue;
 			}
 
-			if ( $managing_stock && ! empty( $_GET['display_stock'] ) ) {
-				$stock_amount = $product_object->get_stock_quantity();
-				/* Translators: %d stock amount */
-				$formatted_name .= ' &ndash; ' . sprintf( __( 'Stock: %d', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_amount, $product_object ) );
-			}
+			if ( ! empty( $_GET['display_stock'] ) ) {
+				$stock_parts = array();
+
+				if ( $managing_stock ) {
+					$stock_amount = $product_object->get_stock_quantity();
+					/* Translators: %d stock amount */
+					$stock_parts[] = sprintf( __( 'Stock: %d', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_amount, $product_object ) );
+				}
+
+				$stock_status = $product_object->get_stock_status();
+				if ( ProductStockStatus::OUT_OF_STOCK === $stock_status ) {
+					$stock_parts[] = __( 'Out of stock', 'woocommerce' );
+				} elseif ( ProductStockStatus::ON_BACKORDER === $stock_status ) {
+					$stock_parts[] = __( 'On backorder', 'woocommerce' );
+				}
+
+				if ( ! empty( $stock_parts ) ) {
+					$formatted_name .= ' (' . implode( ' &ndash; ', $stock_parts ) . ')';
+				}
+
+				$product_status = $product_object->get_status();
+				if ( ProductStatus::PRIVATE === $product_status ) {
+					$formatted_name .= ' (' . __( 'Disabled', 'woocommerce' ) . ')';
+				} elseif ( ProductStatus::DRAFT === $product_status ) {
+					$formatted_name .= ' (' . __( 'Draft', 'woocommerce' ) . ')';
+				}
+			}//end if
 
 			$products[ $product_object->get_id() ] = rawurldecode( wp_strip_all_tags( $formatted_name ) );
 		}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -8767,12 +8767,6 @@ parameters:
 			path: includes/class-wc-ajax.php
 
 		-
-			message: '#^Cannot call method get_stock_quantity\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
 			message: '#^Cannot call method get_total\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -8782,12 +8776,6 @@ parameters:
 			message: '#^Cannot call method get_total_refunded\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
 			identifier: method.nonObject
 			count: 2
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Cannot call method get_type\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
 			path: includes/class-wc-ajax.php
 
 		-
@@ -8995,12 +8983,6 @@ parameters:
 			path: includes/class-wc-ajax.php
 
 		-
-			message: '#^Parameter \#1 \$product of function wc_products_array_filter_readable expects WC_Product, WC_Product\|false\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
 			message: '#^Parameter \#1 \$product_object of function wc_render_invalid_variation_notice expects WC_Product, WC_Product\|false\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -9140,12 +9122,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$postcodes of static method WC_Tax\:\:_update_tax_rate_postcodes\(\) expects string, array\<string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Parameter \#2 \$product of function wc_format_stock_quantity_for_display expects WC_Product, WC_Product\|false\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/class-wc-ajax.php

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -8721,13 +8721,13 @@ parameters:
 		-
 			message: '#^Cannot call method get_formatted_name\(\) on WC_Product\|false\|null\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 1
 			path: includes/class-wc-ajax.php
 
 		-
 			message: '#^Cannot call method get_id\(\) on WC_Product\|false\|null\.$#'
 			identifier: method.nonObject
-			count: 5
+			count: 4
 			path: includes/class-wc-ajax.php
 
 		-
@@ -8805,7 +8805,7 @@ parameters:
 		-
 			message: '#^Cannot call method managing_stock\(\) on WC_Product\|false\|null\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 2
 			path: includes/class-wc-ajax.php
 
 		-


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When adding products to an admin order, the variation/product selector now shows stock status and product status indicators. Out-of-stock products show "(Out of stock)", on-backorder products show "(On backorder)", disabled variations show "(Disabled)", and draft products show "(Draft)". Products remain selectable regardless of status, as admins need the ability to add them for backorders and phone orders.

Also adds an explicit null guard for `$product_object` in `json_search_products()`, which shrinks 3 PHPStan baseline entries.

Closes #64022.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1088" height="884" alt="CleanShot 2026-04-27 at 16 53 35@2x" src="https://github.com/user-attachments/assets/b26a93e3-3ff4-4d54-b55d-5a038c746563" /> | <img width="1084" height="886" alt="CleanShot 2026-04-27 at 16 52 35@2x" src="https://github.com/user-attachments/assets/d1ca4d51-684b-4fea-9d94-8362003e7717" /> |
| <img width="1090" height="706" alt="CleanShot 2026-04-27 at 16 53 59@2x" src="https://github.com/user-attachments/assets/a11c3135-66fc-4c09-8be1-7c3a9801d88c" /> | <img width="1104" height="702" alt="CleanShot 2026-04-27 at 16 54 55@2x" src="https://github.com/user-attachments/assets/5f8c4e45-e8b0-409e-a9a3-857087419762" /> |

### How to test the changes in this Pull Request:

1. Create a variable product with several variations.
2. Set one variation to "Out of stock" and disable another (uncheck "Enabled").
3. Create a simple product and set its stock status to "On backorder".
4. Go to **WP Admin → Orders → Add New Order**.
5. Click **Add item(s)** → **Add product(s)**.
6. Search for the products created above.
7. Verify out-of-stock products show "(Out of stock)" after the name.
8. Verify on-backorder products show "(On backorder)" after the name.
9. Verify disabled variations show "(Disabled)" after the name.
10. Verify in-stock products show no extra status label (just stock quantity if managing stock).
11. Verify all products remain selectable regardless of status.

### Testing that has already taken place:

Tested manually on a local WordPress environment with variable products containing disabled and out-of-stock variations, and simple products with various stock statuses. Verified all indicators display correctly and all products remain selectable. PHP linting and PHPStan pass clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Add stock status and product status indicators to the admin order product selector so admins can see which variations are out of stock, on backorder, or disabled.

</details>