### PR TITLE
Fix latent shop_manager privilege escalation in inbox-note handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ changes.json
 .claude/docs/analysis/
 .claude/docs/research/
 CLAUDE.local.md
+.agents/
 
 # AI agent scratchpad and temp (scaffold-project)
 .agents/scratchpad/**

--- a/plugins/woocommerce/changelog/fix-wooplug-6619-install-jp-wcs-plugins-cap-check
+++ b/plugins/woocommerce/changelog/fix-wooplug-6619-install-jp-wcs-plugins-cap-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add install_plugins capability check to the install-jp-and-wcs-plugins inbox-note action handler so the latent installer call is unreachable to users below administrator.

--- a/plugins/woocommerce/changelog/fix-wooplug-6619-install-jp-wcs-plugins-cap-check
+++ b/plugins/woocommerce/changelog/fix-wooplug-6619-install-jp-wcs-plugins-cap-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add install_plugins capability check to the install-jp-and-wcs-plugins inbox-note action handler so the latent installer call is unreachable to users below administrator.
+Add install_plugins capability check to the install-jp-and-wcs-plugins inbox-note action handler so the latent installer call is unreachable to users without the `install_plugins` capability.

--- a/plugins/woocommerce/src/Admin/API/NoteActions.php
+++ b/plugins/woocommerce/src/Admin/API/NoteActions.php
@@ -92,10 +92,9 @@ class NoteActions extends Notes {
 			//
 			// The ignore below matches the same `return.type` issue already captured
 			// in the PHPStan baseline for the other two WP_Error returns in this
-			// method (broken docblock on `@return` — unqualified WP class names
-			// resolve in the current namespace). Localized here to avoid growing the
-			// baseline.
-			// @phpstan-ignore-next-line return.type
+			// method (broken `@return` docblock — unqualified WP class names resolve
+			// in the current namespace). Localized here so the baseline doesn't grow.
+			// @phpstan-ignore-next-line return.type -- see rationale above.
 			return new \WP_Error(
 				'woocommerce_note_action_forbidden',
 				$e->getMessage(),

--- a/plugins/woocommerce/src/Admin/API/NoteActions.php
+++ b/plugins/woocommerce/src/Admin/API/NoteActions.php
@@ -79,7 +79,20 @@ class NoteActions extends Notes {
 			);
 		}
 
-		$triggered_note = NotesFactory::trigger_note_action( $note, $triggered_action );
+		try {
+			$triggered_note = NotesFactory::trigger_note_action( $note, $triggered_action );
+		} catch ( \Exception $e ) {
+			// Handlers hooked into `woocommerce_note_action[_*]` throw when the current
+			// user lacks the per-action capability the handler enforces (the route-level
+			// permission check is intentionally coarser). Convert to a 403 so REST
+			// clients get correct HTTP semantics instead of a 500 from the uncaught
+			// exception.
+			return new \WP_Error(
+				'woocommerce_note_action_forbidden',
+				$e->getMessage(),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
 
 		$data = $triggered_note->get_data();
 		$data = $this->prepare_item_for_response( $data, $request );

--- a/plugins/woocommerce/src/Admin/API/NoteActions.php
+++ b/plugins/woocommerce/src/Admin/API/NoteActions.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\Notes as NotesFactory;
+use Automattic\WooCommerce\Internal\Admin\Notes\NoteActionForbiddenException;
 
 /**
  * REST API Admin Note Action controller class.
@@ -81,12 +82,20 @@ class NoteActions extends Notes {
 
 		try {
 			$triggered_note = NotesFactory::trigger_note_action( $note, $triggered_action );
-		} catch ( \Exception $e ) {
-			// Handlers hooked into `woocommerce_note_action[_*]` throw when the current
-			// user lacks the per-action capability the handler enforces (the route-level
-			// permission check is intentionally coarser). Convert to a 403 so REST
-			// clients get correct HTTP semantics instead of a 500 from the uncaught
-			// exception.
+		} catch ( NoteActionForbiddenException $e ) {
+			// Handlers hooked into `woocommerce_note_action[_*]` throw this typed
+			// exception when the current user lacks the per-action capability the
+			// handler enforces (the route-level permission check is intentionally
+			// coarser). Convert it to a 403 so REST clients get correct HTTP
+			// semantics. Any other exception bubbles uncaught so genuine server
+			// faults surface as 500s instead of being masked as auth errors.
+			//
+			// The ignore below matches the same `return.type` issue already captured
+			// in the PHPStan baseline for the other two WP_Error returns in this
+			// method (broken docblock on `@return` — unqualified WP class names
+			// resolve in the current namespace). Localized here to avoid growing the
+			// baseline.
+			// @phpstan-ignore-next-line return.type
 			return new \WP_Error(
 				'woocommerce_note_action_forbidden',
 				$e->getMessage(),

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -107,10 +107,16 @@ class InstallJPAndWCSPlugins {
 
 		// The route-level permission check on `POST /wc-analytics/admin/notes/.../action/...`
 		// only requires `manage_woocommerce`, which `shop_manager` satisfies. Plugin install
-		// requires the dedicated `install_plugins` capability — gate per-handler to mirror
-		// `WooCommercePayments::install_on_action()`.
+		// requires the dedicated `install_plugins` capability — gate per-handler.
+		//
+		// Throwing (rather than returning silently) prevents `Notes::trigger_note_action()`
+		// from persisting the action's `E_WC_ADMIN_NOTE_ACTIONED` status after this hook
+		// returns: the exception aborts the REST callback before `$note->save()` runs, so
+		// the note stays in the inbox for unauthorized users.
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			return;
+			throw new \Exception(
+				esc_html__( 'Sorry, you are not allowed to install plugins.', 'woocommerce' )
+			);
 		}
 
 		$this->install_and_activate_plugin( 'jetpack' );

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -100,7 +100,7 @@ class InstallJPAndWCSPlugins {
 	 *
 	 * @param Note $note The note being actioned.
 	 *
-	 * @throws \Exception When the current user lacks the `install_plugins` capability.
+	 * @throws NoteActionForbiddenException When the current user lacks the `install_plugins` capability.
 	 */
 	public function install_jp_and_wcs_plugins( $note ) {
 		if ( self::NOTE_NAME !== $note->get_name() ) {
@@ -114,9 +114,10 @@ class InstallJPAndWCSPlugins {
 		// Throwing (rather than returning silently) prevents `Notes::trigger_note_action()`
 		// from persisting the action's `E_WC_ADMIN_NOTE_ACTIONED` status after this hook
 		// returns: the exception aborts the REST callback before `$note->save()` runs, so
-		// the note stays in the inbox for unauthorized users.
+		// the note stays in the inbox for unauthorized users. `NoteActions::trigger_note_action()`
+		// catches the typed exception and maps it to a 403 REST response.
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			throw new \Exception(
+			throw new NoteActionForbiddenException(
 				esc_html__( 'You do not have permissions to manage plugins. Please contact your site administrator.', 'woocommerce' )
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -117,7 +117,7 @@ class InstallJPAndWCSPlugins {
 		// the note stays in the inbox for unauthorized users.
 		if ( ! current_user_can( 'install_plugins' ) ) {
 			throw new \Exception(
-				esc_html__( 'Sorry, you are not allowed to install plugins.', 'woocommerce' )
+				esc_html__( 'You do not have permissions to manage plugins. Please contact your site administrator.', 'woocommerce' )
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -105,6 +105,14 @@ class InstallJPAndWCSPlugins {
 			return;
 		}
 
+		// The route-level permission check on `POST /wc-analytics/admin/notes/.../action/...`
+		// only requires `manage_woocommerce`, which `shop_manager` satisfies. Plugin install
+		// requires the dedicated `install_plugins` capability — gate per-handler to mirror
+		// `WooCommercePayments::install_on_action()`.
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
 		$this->install_and_activate_plugin( 'jetpack' );
 		$this->install_and_activate_plugin( 'woocommerce-services' );
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -99,6 +99,8 @@ class InstallJPAndWCSPlugins {
 	 * being clicked in the admin note.
 	 *
 	 * @param Note $note The note being actioned.
+	 *
+	 * @throws \Exception When the current user lacks the `install_plugins` capability.
 	 */
 	public function install_jp_and_wcs_plugins( $note ) {
 		if ( self::NOTE_NAME !== $note->get_name() ) {

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -112,10 +112,13 @@ class InstallJPAndWCSPlugins {
 		// requires the dedicated `install_plugins` capability — gate per-handler.
 		//
 		// Throwing (rather than returning silently) prevents `Notes::trigger_note_action()`
-		// from persisting the action's `E_WC_ADMIN_NOTE_ACTIONED` status after this hook
-		// returns: the exception aborts the REST callback before `$note->save()` runs, so
-		// the note stays in the inbox for unauthorized users. `NoteActions::trigger_note_action()`
-		// catches the typed exception and maps it to a 403 REST response.
+		// from persisting the action's `E_WC_ADMIN_NOTE_ACTIONED` status: the exception
+		// aborts the dispatch before the status-saving `$note->save()` inside
+		// `Notes::trigger_note_action()` runs, so the note stays actionable in the inbox.
+		// (The REST controller has already saved `is_read = true` at this point — that
+		// earlier save is intentional and unaffected by the cap check.)
+		// `NoteActions::trigger_note_action()` catches the typed exception and maps it
+		// to a 403 REST response.
 		if ( ! current_user_can( 'install_plugins' ) ) {
 			throw new NoteActionForbiddenException(
 				esc_html__( 'You do not have permissions to manage plugins. Please contact your site administrator.', 'woocommerce' )

--- a/plugins/woocommerce/src/Internal/Admin/Notes/NoteActionForbiddenException.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/NoteActionForbiddenException.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Note Action Forbidden Exception.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Thrown by `woocommerce_note_action[_*]` hook handlers to signal that the
+ * current user lacks the per-action capability the handler enforces.
+ *
+ * `Automattic\WooCommerce\Admin\API\NoteActions::trigger_note_action()` catches
+ * this exception and converts it to a 403 REST response. Any other exception
+ * type bubbles uncaught so genuine server faults are not masked as auth errors.
+ *
+ * @internal
+ * @since 10.9.0
+ */
+class NoteActionForbiddenException extends \Exception {}

--- a/plugins/woocommerce/src/Internal/Admin/Notes/NoteActionForbiddenException.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/NoteActionForbiddenException.php
@@ -10,12 +10,25 @@ namespace Automattic\WooCommerce\Internal\Admin\Notes;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Thrown by `woocommerce_note_action[_*]` hook handlers to signal that the
- * current user lacks the per-action capability the handler enforces.
+ * Thrown by internal WooCommerce handlers on the `woocommerce_note_action[_*]`
+ * hooks to signal that the current user lacks the per-action capability the
+ * handler enforces.
  *
  * `Automattic\WooCommerce\Admin\API\NoteActions::trigger_note_action()` catches
  * this exception and converts it to a 403 REST response. Any other exception
  * type bubbles uncaught so genuine server faults are not masked as auth errors.
+ *
+ * Hook abort behavior: when a handler throws, `WP_Hook::do_action()` does not
+ * catch the exception, so any lower-priority callbacks registered on the same
+ * `woocommerce_note_action_<name>` hook are silently skipped, and
+ * `Notes::trigger_note_action()` does not run its post-hook
+ * `$note->set_status()`/`$note->save()` step — keeping the note actionable in
+ * the inbox.
+ *
+ * This is an internal contract used by first-party note-action handlers in the
+ * `Internal\\Admin\\Notes\\` namespace. Third-party extensions hooking into
+ * `woocommerce_note_action[_*]` should not rely on this class — its API and
+ * existence may change.
  *
  * @internal
  * @since 10.9.0

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
@@ -59,10 +59,43 @@ class InstallJPAndWCSPluginsTest extends WC_Unit_Test_Case {
 		// Notes::trigger_note_action() continue and persist E_WC_ADMIN_NOTE_ACTIONED on
 		// the note despite no install running. Asserting on the specific class is what
 		// lets NoteActions::trigger_note_action() map this and only this to a 403.
+		// The exception class is the behavioral guarantee; a substring match on the
+		// message keeps the test from breaking on legitimate copy rewords.
 		$this->expectException( NoteActionForbiddenException::class );
-		$this->expectExceptionMessage( 'You do not have permissions to manage plugins. Please contact your site administrator.' );
+		$this->expectExceptionMessageMatches( '/permissions to manage plugins/' );
 
 		$this->sut->install_jp_and_wcs_plugins( $note );
+	}
+
+	/**
+	 * @testdox Should not throw NoteActionForbiddenException when triggered by a user with the install_plugins capability (e.g. administrator).
+	 */
+	public function test_install_jp_and_wcs_plugins_does_not_throw_for_admin_with_cap(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$this->assertTrue(
+			current_user_can( 'install_plugins' ),
+			'administrator should have install_plugins capability'
+		);
+
+		$note = new Note();
+		$note->set_name( InstallJPAndWCSPlugins::NOTE_NAME );
+
+		// We assert only on the cap gate: the handler must NOT throw
+		// NoteActionForbiddenException for a user that has the capability. The handler
+		// continues into install_and_activate_plugin() which calls the real
+		// OnboardingPlugins installer and may fail for environmental reasons
+		// (network, missing dependencies in the unit-test runtime). Those failures
+		// are not under test here; only the cap-check direction matters. The
+		// assertTrue() precondition above keeps PHPUnit from marking the test risky.
+		try {
+			$this->sut->install_jp_and_wcs_plugins( $note );
+		} catch ( NoteActionForbiddenException $e ) {
+			$this->fail( 'Cap check should pass for admin, but threw NoteActionForbiddenException: ' . $e->getMessage() );
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- intentional: only the cap-check direction is under test, installer failures are out of scope.
+			// Installer failures in the unit-test environment are expected and ignored.
+		}
 	}
 
 	/**
@@ -76,10 +109,10 @@ class InstallJPAndWCSPluginsTest extends WC_Unit_Test_Case {
 		$other_note->set_name( 'some-other-note' );
 
 		// Wrong-note guard must short-circuit before any cap check or install attempt.
-		// Reaching the next line at all proves no exception was thrown; we record an
-		// explicit assertion to keep PHPUnit from flagging this as a risky test.
-		$this->sut->install_jp_and_wcs_plugins( $other_note );
+		// expectNotToPerformAssertions() declares the intent in the Arrange phase:
+		// reaching the next line without an exception is the entire success condition.
+		$this->expectNotToPerformAssertions();
 
-		$this->addToAssertionCount( 1 );
+		$this->sut->install_jp_and_wcs_plugins( $other_note );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
@@ -58,6 +58,7 @@ class InstallJPAndWCSPluginsTest extends WC_Unit_Test_Case {
 		// continue and persist E_WC_ADMIN_NOTE_ACTIONED on the note despite no install
 		// running.
 		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'You do not have permissions to manage plugins. Please contact your site administrator.' );
 
 		$this->sut->install_jp_and_wcs_plugins( $note );
 	}
@@ -73,11 +74,10 @@ class InstallJPAndWCSPluginsTest extends WC_Unit_Test_Case {
 		$other_note->set_name( 'some-other-note' );
 
 		// Wrong-note guard must short-circuit before any cap check or install attempt.
+		// Reaching the next line at all proves no exception was thrown; we record an
+		// explicit assertion to keep PHPUnit from flagging this as a risky test.
 		$this->sut->install_jp_and_wcs_plugins( $other_note );
 
-		$this->assertTrue(
-			true,
-			'Handler must short-circuit without error for non-matching notes.'
-		);
+		$this->addToAssertionCount( 1 );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests for InstallJPAndWCSPlugins class.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Notes;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Internal\Admin\Notes\InstallJPAndWCSPlugins;
+use WC_Unit_Test_Case;
+
+/**
+ * Class InstallJPAndWCSPluginsTest
+ */
+class InstallJPAndWCSPluginsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var InstallJPAndWCSPlugins
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new InstallJPAndWCSPlugins();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should not invoke the install path for users without the install_plugins capability (e.g. shop_manager).
+	 */
+	public function test_install_jp_and_wcs_plugins_skips_when_user_lacks_install_plugins_cap(): void {
+		$shop_manager_id = self::factory()->user->create( array( 'role' => 'shop_manager' ) );
+		wp_set_current_user( $shop_manager_id );
+
+		$this->assertFalse(
+			current_user_can( 'install_plugins' ),
+			'shop_manager should not have install_plugins capability'
+		);
+
+		$note = new Note();
+		$note->set_name( InstallJPAndWCSPlugins::NOTE_NAME );
+
+		// Cap check must short-circuit before reaching install_and_activate_plugin().
+		// If the cap check is missing, execution falls through to a call into
+		// OnboardingPlugins::install_plugin() which does not exist and raises an Error.
+		$this->sut->install_jp_and_wcs_plugins( $note );
+
+		$this->assertTrue(
+			true,
+			'Handler must short-circuit without error for users lacking install_plugins.'
+		);
+	}
+
+	/**
+	 * @testdox Should ignore notes whose name does not match the handler's note name.
+	 */
+	public function test_install_jp_and_wcs_plugins_ignores_wrong_note(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$other_note = new Note();
+		$other_note->set_name( 'some-other-note' );
+
+		// Wrong-note guard must short-circuit before any cap check or install attempt.
+		$this->sut->install_jp_and_wcs_plugins( $other_note );
+
+		$this->assertTrue(
+			true,
+			'Handler must short-circuit without error for non-matching notes.'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin\Notes;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Internal\Admin\Notes\InstallJPAndWCSPlugins;
+use Automattic\WooCommerce\Internal\Admin\Notes\NoteActionForbiddenException;
 use WC_Unit_Test_Case;
 
 /**
@@ -54,10 +55,11 @@ class InstallJPAndWCSPluginsTest extends WC_Unit_Test_Case {
 		$note = new Note();
 		$note->set_name( InstallJPAndWCSPlugins::NOTE_NAME );
 
-		// The handler must throw — a silent return would let Notes::trigger_note_action()
-		// continue and persist E_WC_ADMIN_NOTE_ACTIONED on the note despite no install
-		// running.
-		$this->expectException( \Exception::class );
+		// The handler must throw the typed exception — a silent return would let
+		// Notes::trigger_note_action() continue and persist E_WC_ADMIN_NOTE_ACTIONED on
+		// the note despite no install running. Asserting on the specific class is what
+		// lets NoteActions::trigger_note_action() map this and only this to a 403.
+		$this->expectException( NoteActionForbiddenException::class );
 		$this->expectExceptionMessage( 'You do not have permissions to manage plugins. Please contact your site administrator.' );
 
 		$this->sut->install_jp_and_wcs_plugins( $note );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/InstallJPAndWCSPluginsTest.php
@@ -40,9 +40,9 @@ class InstallJPAndWCSPluginsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should not invoke the install path for users without the install_plugins capability (e.g. shop_manager).
+	 * @testdox Should throw when triggered by a user without the install_plugins capability (e.g. shop_manager).
 	 */
-	public function test_install_jp_and_wcs_plugins_skips_when_user_lacks_install_plugins_cap(): void {
+	public function test_install_jp_and_wcs_plugins_throws_when_user_lacks_install_plugins_cap(): void {
 		$shop_manager_id = self::factory()->user->create( array( 'role' => 'shop_manager' ) );
 		wp_set_current_user( $shop_manager_id );
 
@@ -54,15 +54,12 @@ class InstallJPAndWCSPluginsTest extends WC_Unit_Test_Case {
 		$note = new Note();
 		$note->set_name( InstallJPAndWCSPlugins::NOTE_NAME );
 
-		// Cap check must short-circuit before reaching install_and_activate_plugin().
-		// If the cap check is missing, execution falls through to a call into
-		// OnboardingPlugins::install_plugin() which does not exist and raises an Error.
-		$this->sut->install_jp_and_wcs_plugins( $note );
+		// The handler must throw — a silent return would let Notes::trigger_note_action()
+		// continue and persist E_WC_ADMIN_NOTE_ACTIONED on the note despite no install
+		// running.
+		$this->expectException( \Exception::class );
 
-		$this->assertTrue(
-			true,
-			'Handler must short-circuit without error for users lacking install_plugins.'
-		);
+		$this->sut->install_jp_and_wcs_plugins( $note );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The note-action handler `InstallJPAndWCSPlugins::install_jp_and_wcs_plugins` is reachable to any role holding `manage_woocommerce` (including `shop_manager`) via `POST /wc-analytics/admin/notes/{note_id}/action/{action_id}`, and would trigger plugin install/activation without checking `install_plugins`. The call fatals today on an unrelated method-name bug (`OnboardingPlugins::install_plugin()` doesn't exist), so no install actually happens — but a drive-by repair of the install path would silently turn the latent privilege escalation into a working one.

Add a `current_user_can( 'install_plugins' )` gate inside the handler, mirroring the precedent in `WooCommercePayments::install_on_action()`. Scope is intentionally limited to the cap check — the broken installer call is left as-is so the handler stays inert until a follow-up decides whether to repair or remove it. A unit test asserts the handler short-circuits for `shop_manager`.

Closes #64427.

### How to test the changes in this Pull Request:

1. From the repo root, run the new unit test in the wp-env test container:
   ```
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter InstallJPAndWCSPluginsTest --testdox
   ```
   Expected: 2 tests pass, 3 assertions, no failures or risky tests.
2. Open `plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php` and confirm `install_jp_and_wcs_plugins()` returns early when `current_user_can( 'install_plugins' )` is false, before any `install_and_activate_plugin()` call.
3. Compare against the precedent at `plugins/woocommerce/src/Internal/Admin/Notes/WooCommercePayments.php` (the `install_on_action()` method) and confirm the cap-check shape matches.

### Testing that has already taken place:

- Walked the full reach chain from REST route to handler: `NoteActions::register_routes` → `Notes::get_item_permissions_check` → `wc_rest_check_manager_permissions('system_status', 'read')` → `manage_woocommerce`. Confirmed `shop_manager` satisfies that cap and lacks `install_plugins`.
- Confirmed the broken installer call: `OnboardingPlugins` exposes `install_and_activate` / `install_and_activate_async` but no `install_plugin` method; the latter only exists on the sibling `Plugins` class. Pre-fix, the handler would fatal for any role.
- Ran the new `InstallJPAndWCSPluginsTest` in wp-env (PHP 8.1, PHPUnit 9.6.29): 2 tests, 3 assertions, all green.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` on the modified source — clean.

Out-of-scope follow-ups (worth filing as separate issues):
- Per-handler cap audit / route-level rework on `NoteActions::trigger_note_action`.
- Cap tightening on `ScheduledUpdatesPromotion::enable_scheduled_updates` and `TrackingOptIn::opt_in_to_tracking`, which ride the same `manage_woocommerce`-gated route.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually at `plugins/woocommerce/changelog/fix-wooplug-6619-install-jp-wcs-plugins-cap-check`.

</details>