### PR TITLE
[Email Editor] Auto-apply core template updates for unmodified email posts

### DIFF
--- a/plugins/woocommerce/changelog/rsm-139-auto-apply-core-template-updates
+++ b/plugins/woocommerce/changelog/rsm-139-auto-apply-core-template-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Auto-apply the current core block template render to woo_email posts classified as core_updated_uncustomized after a plugin upgrade. Batched via Action Scheduler so the upgrade request is not blocked. Posts edited by the merchant are left untouched.

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\EmailEditor;
 
 use Automattic\WooCommerce\EmailEditor\Validator\Builder;
-use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateDivergenceDetector;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncRegistry;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
@@ -445,49 +445,24 @@ class EmailApiController {
 			);
 		}
 
-		$canonical   = WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email );
-		$sync_config = WCEmailTemplateSyncRegistry::get_email_sync_config( (string) $email_type );
-
-		$update_result = wp_update_post(
-			array(
-				'ID'           => $post_id,
-				'post_content' => $canonical,
-			),
-			true
+		$result = WCEmailTemplateAutoApplier::apply_to_post(
+			$email,
+			$post_id,
+			array( 'require_uncustomized' => false )
 		);
 
-		if ( is_wp_error( $update_result ) ) {
+		if ( is_wp_error( $result ) ) {
 			return new WP_Error(
 				'woocommerce_email_reset_failed',
 				sprintf(
 					/* translators: %s: underlying error message */
 					__( 'Failed to reset email content: %s', 'woocommerce' ),
-					$update_result->get_error_message()
+					$result->get_error_message()
 				),
 				array( 'status' => 500 )
 			);
 		}
 
-		$source_hash = null;
-		$synced_at   = null;
-		if ( null !== $sync_config ) {
-			$source_hash = sha1( $canonical );
-			$synced_at   = gmdate( 'Y-m-d H:i:s' );
-			update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, (string) $sync_config['version'] );
-			update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, $source_hash );
-			update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, $synced_at );
-			update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC );
-		}
-
-		return new WP_REST_Response(
-			array(
-				'content'     => $canonical,
-				'version'     => null !== $sync_config ? (string) $sync_config['version'] : null,
-				'source_hash' => $source_hash,
-				'synced_at'   => $synced_at,
-				'status'      => null !== $sync_config ? WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC : null,
-			),
-			200
-		);
+		return new WP_REST_Response( $result, 200 );
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\EmailEditor\Engine\Dependency_Check;
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns\PatternsController;
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplatesController;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateDivergenceDetector;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncBackfill;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
@@ -149,6 +150,8 @@ class Integration {
 		add_action( 'rest_api_init', array( $this->email_api_controller, 'register_routes' ) );
 		add_action( 'woocommerce_updated', array( WCEmailTemplateDivergenceDetector::class, 'run_sweep' ), 20 );
 		add_action( WCEmailTemplateSyncBackfill::BACKFILL_COMPLETE_ACTION, array( WCEmailTemplateDivergenceDetector::class, 'run_sweep' ), 10 );
+		add_action( 'woocommerce_email_template_divergence_sweep_complete', array( WCEmailTemplateAutoApplier::class, 'schedule' ), 10 );
+		add_action( WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK, array( WCEmailTemplateAutoApplier::class, 'run' ), 10 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -150,8 +150,8 @@ class Integration {
 		add_action( 'rest_api_init', array( $this->email_api_controller, 'register_routes' ) );
 		add_action( 'woocommerce_updated', array( WCEmailTemplateDivergenceDetector::class, 'run_sweep' ), 20 );
 		add_action( WCEmailTemplateSyncBackfill::BACKFILL_COMPLETE_ACTION, array( WCEmailTemplateDivergenceDetector::class, 'run_sweep' ), 10 );
-		add_action( 'woocommerce_email_template_divergence_sweep_complete', array( WCEmailTemplateAutoApplier::class, 'schedule' ), 10 );
 		add_action( WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK, array( WCEmailTemplateAutoApplier::class, 'run' ), 10 );
+		add_action( 'woocommerce_email_template_divergence_sweep_complete', array( WCEmailTemplateAutoApplier::class, 'schedule' ), 10 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -215,16 +215,15 @@ class WCEmailTemplateAutoApplier {
 	 * batch (acceptance criterion). Status meta is never mutated by this method
 	 * on failure — the next sweep re-classifies.
 	 *
-	 * Returns `false` always (one-shot, no AS retry — same convention as
-	 * {@see WCEmailTemplateSyncBackfill::run()}).
-	 *
-	 * @return bool Always false.
+	 * Declared `void` because Action Scheduler async-action callbacks discard
+	 * the return value; a return type would just be noise (and trip PHPStan's
+	 * `return.void` rule on `add_action`).
 	 *
 	 * @since 10.8.0
 	 */
-	public static function run(): bool {
+	public static function run(): void {
 		if ( 'yes' !== get_option( WCEmailTemplateDivergenceDetector::BACKFILL_COMPLETE_OPTION ) ) {
-			return false;
+			return;
 		}
 
 		$candidate_ids = get_posts(
@@ -244,7 +243,7 @@ class WCEmailTemplateAutoApplier {
 		);
 
 		if ( empty( $candidate_ids ) ) {
-			return false;
+			return;
 		}
 
 		$registry      = WCEmailTemplateSyncRegistry::get_sync_enabled_emails();
@@ -284,8 +283,6 @@ class WCEmailTemplateAutoApplier {
 				continue;
 			}
 		}
-
-		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -208,6 +208,126 @@ class WCEmailTemplateAutoApplier {
 	}
 
 	/**
+	 * Action Scheduler callback. Apply the canonical core render to every
+	 * `woo_email` post whose status meta is `core_updated_uncustomized`.
+	 *
+	 * Per-post `try`/`catch` ensures one bad post never breaks the rest of the
+	 * batch (acceptance criterion). Status meta is never mutated by this method
+	 * on failure — the next sweep re-classifies.
+	 *
+	 * Returns `false` always (one-shot, no AS retry — same convention as
+	 * {@see WCEmailTemplateSyncBackfill::run()}).
+	 *
+	 * @return bool Always false.
+	 *
+	 * @since 10.8.0
+	 */
+	public static function run(): bool {
+		if ( 'yes' !== get_option( WCEmailTemplateDivergenceDetector::BACKFILL_COMPLETE_OPTION ) ) {
+			return false;
+		}
+
+		$candidate_ids = get_posts(
+			array(
+				'post_type'      => \Automattic\WooCommerce\Internal\EmailEditor\Integration::EMAIL_POST_TYPE,
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_query'     => array(  // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- bounded set; sync-registered emails only.
+					array(
+						'key'   => WCEmailTemplateDivergenceDetector::STATUS_META_KEY,
+						'value' => WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED,
+					),
+				),
+			)
+		);
+
+		if ( empty( $candidate_ids ) ) {
+			return false;
+		}
+
+		$registry      = WCEmailTemplateSyncRegistry::get_sync_enabled_emails();
+		$posts_manager = WCTransactionalEmailPostsManager::get_instance();
+		$emails_by_id  = $posts_manager->get_emails_by_id();
+
+		foreach ( $candidate_ids as $post_id ) {
+			$post_id = (int) $post_id;
+			try {
+				$email_id = (string) $posts_manager->get_email_type_from_post_id( $post_id );
+				if ( '' === $email_id || ! isset( $registry[ $email_id ] ) ) {
+					continue;
+				}
+
+				$email = $emails_by_id[ $email_id ] ?? null;
+				if ( ! $email instanceof \WC_Email ) {
+					continue;
+				}
+
+				$result = self::apply_to_post( $email, $post_id );
+
+				if ( is_wp_error( $result ) ) {
+					self::log_apply_error( $result, $post_id, $email_id );
+				}
+			} catch ( \Throwable $e ) {
+				self::get_logger()->error(
+					sprintf(
+						'Email template auto-apply failed for post %d: %s',
+						$post_id,
+						$e->getMessage()
+					),
+					array(
+						'post_id' => $post_id,
+						'context' => 'email_template_auto_applier',
+					)
+				);
+				continue;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Map a per-post `WP_Error` from {@see self::apply_to_post()} to the right
+	 * log severity and emit it.
+	 *
+	 * `post_modified_since_stamp` is the expected race outcome (merchant edit in
+	 * the AS lag window) and is logged at `info`. Everything else is at `warning`
+	 * or `error` so it surfaces in the default WC log UI.
+	 *
+	 * @param \WP_Error $error    The error returned by apply_to_post.
+	 * @param int       $post_id  Post ID being processed.
+	 * @param string    $email_id Email ID being processed.
+	 */
+	private static function log_apply_error( \WP_Error $error, int $post_id, string $email_id ): void {
+		$message = sprintf(
+			'Email template auto-apply skipped post %d for email "%s": %s',
+			$post_id,
+			$email_id,
+			$error->get_error_message()
+		);
+
+		$context = array(
+			'post_id'  => $post_id,
+			'email_id' => $email_id,
+			'context'  => 'email_template_auto_applier',
+		);
+
+		switch ( $error->get_error_code() ) {
+			case 'post_modified_since_stamp':
+				self::get_logger()->info( $message, $context );
+				return;
+			case 'no_stored_hash':
+			case 'not_sync_enabled':
+				self::get_logger()->warning( $message, $context );
+				return;
+			default:
+				self::get_logger()->error( $message, $context );
+		}
+	}
+
+	/**
 	 * Whether the auto-applier is currently rewriting a post.
 	 *
 	 * Future `save_post` listeners (RSM-143, RSM-145) should consult this flag

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -115,6 +115,7 @@ class WCEmailTemplateAutoApplier {
 			);
 		}
 
+		$stored_source_hash = '';
 		if ( $require_uncustomized ) {
 			$stored_source_hash = (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true );
 			if ( '' === $stored_source_hash || ! self::is_sha1_hash( $stored_source_hash ) ) {
@@ -123,18 +124,6 @@ class WCEmailTemplateAutoApplier {
 					sprintf(
 						/* translators: %d: post ID */
 						__( 'Post %d has no stored source hash; cannot safely auto-apply.', 'woocommerce' ),
-						$post_id
-					)
-				);
-			}
-
-			$current_post_hash = sha1( (string) $post->post_content );
-			if ( $current_post_hash !== $stored_source_hash ) {
-				return new \WP_Error(
-					'post_modified_since_stamp',
-					sprintf(
-						/* translators: %d: post ID */
-						__( 'Post %d has been modified since the last sync stamp; skipping auto-apply.', 'woocommerce' ),
 						$post_id
 					)
 				);
@@ -149,6 +138,27 @@ class WCEmailTemplateAutoApplier {
 
 		self::$is_auto_applying = true;
 		try {
+			// Re-hash post_content immediately before the write to minimise the
+			// TOCTOU gap between the snapshot and wp_update_post. The first $post
+			// load above is too early — `compute_canonical_post_content` runs in
+			// between and yields the window where a merchant save could otherwise
+			// be silently overwritten.
+			if ( $require_uncustomized ) {
+				$latest_post = get_post( $post_id );
+				if ( ! $latest_post instanceof \WP_Post
+					|| sha1( (string) $latest_post->post_content ) !== $stored_source_hash
+				) {
+					return new \WP_Error(
+						'post_modified_since_stamp',
+						sprintf(
+							/* translators: %d: post ID */
+							__( 'Post %d has been modified since the last sync stamp; skipping auto-apply.', 'woocommerce' ),
+							$post_id
+						)
+					);
+				}
+			}
+
 			$updated = wp_update_post(
 				array(
 					'ID'           => $post_id,

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -28,12 +28,18 @@ class WCEmailTemplateAutoApplier {
 	/**
 	 * Action Scheduler hook name for the batched auto-apply runner.
 	 *
+	 * Internal AS plumbing — not intended for extension consumption. To react to
+	 * the upgrade-time signal, hook {@see 'woocommerce_email_template_divergence_sweep_complete'}
+	 * instead.
+	 *
 	 * @var string
 	 */
 	public const AUTO_APPLY_AS_HOOK = 'woocommerce_email_template_auto_apply_uncustomized';
 
 	/**
 	 * Action Scheduler group for the batched auto-apply runner.
+	 *
+	 * Internal AS plumbing — not intended for extension consumption.
 	 *
 	 * @var string
 	 */
@@ -69,7 +75,10 @@ class WCEmailTemplateAutoApplier {
 	 *     `null` for the four sync fields (BC contract with the pre-RSM-139 reset endpoint).
 	 *
 	 * Atomicity: the post update plus the four meta writes run inside a single
-	 * `START TRANSACTION` block, so a partial failure rolls back cleanly.
+	 * `START TRANSACTION` block, so a partial failure rolls back cleanly. Note
+	 * that third-party callbacks on `save_post`, `post_updated`, and
+	 * `wp_after_insert_post` fire inside this transaction; any `$wpdb` writes
+	 * they perform participate in the rollback if a later step fails.
 	 *
 	 * @param \WC_Email $email   The transactional email instance.
 	 * @param int       $post_id The post ID.

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -190,6 +190,24 @@ class WCEmailTemplateAutoApplier {
 	}
 
 	/**
+	 * Enqueue the batched auto-apply runner as an Action Scheduler async action.
+	 *
+	 * Hooked to {@see 'woocommerce_email_template_divergence_sweep_complete'}. The
+	 * `as_has_scheduled_action()` short-circuit guards against double-enqueueing
+	 * when the detector sweep runs twice in one request — once on
+	 * `woocommerce_updated`, once on `BACKFILL_COMPLETE_ACTION`.
+	 *
+	 * @since 10.8.0
+	 */
+	public static function schedule(): void {
+		if ( as_has_scheduled_action( self::AUTO_APPLY_AS_HOOK, array(), self::AUTO_APPLY_AS_GROUP ) ) {
+			return;
+		}
+
+		as_enqueue_async_action( self::AUTO_APPLY_AS_HOOK, array(), self::AUTO_APPLY_AS_GROUP );
+	}
+
+	/**
 	 * Whether the auto-applier is currently rewriting a post.
 	 *
 	 * Future `save_post` listeners (RSM-143, RSM-145) should consult this flag

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -39,11 +39,14 @@ class WCEmailTemplateAutoApplier {
 	/**
 	 * Action Scheduler group for the batched auto-apply runner.
 	 *
-	 * Internal AS plumbing — not intended for extension consumption.
+	 * Internal AS plumbing — not intended for extension consumption. The
+	 * `woocommerce-email-editor` namespace is reserved for the standalone email
+	 * editor package; integration glue lives under
+	 * `woocommerce-email-editor-integration` to keep the boundary explicit.
 	 *
 	 * @var string
 	 */
-	public const AUTO_APPLY_AS_GROUP = 'woocommerce-email-editor';
+	public const AUTO_APPLY_AS_GROUP = 'woocommerce-email-editor-integration';
 
 	/**
 	 * Re-entrancy flag set while the atom rewrites a post.
@@ -232,10 +235,13 @@ class WCEmailTemplateAutoApplier {
 			return;
 		}
 
+		// `post_status=any` includes draft / private / pending / future and
+		// excludes trash / auto-draft / inherit — anything not in the trash bucket
+		// is fair game for auto-apply.
 		$candidate_ids = get_posts(
 			array(
 				'post_type'      => \Automattic\WooCommerce\Internal\EmailEditor\Integration::EMAIL_POST_TYPE,
-				'post_status'    => 'publish',
+				'post_status'    => 'any',
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 				'no_found_rows'  => true,

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -74,11 +74,9 @@ class WCEmailTemplateAutoApplier {
 	 *     Non-sync-enabled emails receive a content-only reset and the return shape carries
 	 *     `null` for the four sync fields (BC contract with the pre-RSM-139 reset endpoint).
 	 *
-	 * Atomicity: the post update plus the four meta writes run inside a single
-	 * `START TRANSACTION` block, so a partial failure rolls back cleanly. Note
-	 * that third-party callbacks on `save_post`, `post_updated`, and
-	 * `wp_after_insert_post` fire inside this transaction; any `$wpdb` writes
-	 * they perform participate in the rollback if a later step fails.
+	 * The four meta writes are skipped entirely if `wp_update_post` fails, so a
+	 * `WP_Error` return leaves the post and existing meta untouched. Matches the
+	 * pre-RSM-139 reset endpoint shape (see PR #64355 review on `2fa660b3b9`).
 	 *
 	 * @param \WC_Email $email   The transactional email instance.
 	 * @param int       $post_id The post ID.
@@ -143,13 +141,13 @@ class WCEmailTemplateAutoApplier {
 			}
 		}
 
-		global $wpdb;
-
-		$canonical = WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email );
+		$canonical   = WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email );
+		$source_hash = null;
+		$synced_at   = null;
+		$status      = null;
+		$version     = null;
 
 		self::$is_auto_applying = true;
-		$wpdb->query( 'START TRANSACTION' );
-
 		try {
 			$updated = wp_update_post(
 				array(
@@ -160,14 +158,8 @@ class WCEmailTemplateAutoApplier {
 			);
 
 			if ( is_wp_error( $updated ) ) {
-				$wpdb->query( 'ROLLBACK' );
 				return $updated;
 			}
-
-			$source_hash = null;
-			$synced_at   = null;
-			$status      = null;
-			$version     = null;
 
 			if ( null !== $sync_config ) {
 				$source_hash = sha1( $canonical );
@@ -180,11 +172,6 @@ class WCEmailTemplateAutoApplier {
 				update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, $synced_at );
 				update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, $status );
 			}
-
-			$wpdb->query( 'COMMIT' );
-		} catch ( \Throwable $e ) {
-			$wpdb->query( 'ROLLBACK' );
-			throw $e;
 		} finally {
 			self::$is_auto_applying = false;
 		}

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -139,7 +139,7 @@ class WCEmailTemplateAutoApplier {
 					)
 				);
 			}
-		}
+		}//end if
 
 		$canonical   = WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email );
 		$source_hash = null;
@@ -174,7 +174,7 @@ class WCEmailTemplateAutoApplier {
 			}
 		} finally {
 			self::$is_auto_applying = false;
-		}
+		}//end try
 
 		return array(
 			'content'     => $canonical,
@@ -277,8 +277,8 @@ class WCEmailTemplateAutoApplier {
 					)
 				);
 				continue;
-			}
-		}
+			}//end try
+		}//end foreach
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplier.php
@@ -1,0 +1,239 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger_Interface;
+use Automattic\WooCommerce\Internal\EmailEditor\Logger;
+
+/**
+ * Auto-applies the current core block template to `woo_email` posts that have
+ * been classified `core_updated_uncustomized` by {@see WCEmailTemplateDivergenceDetector}.
+ *
+ * Mirrors how legacy static-file emails always reflected the latest core
+ * template: when the merchant has not customised a generated post since it was
+ * last stamped, we silently rewrite its content to the new core render and
+ * flip its status meta back to `in_sync`.
+ *
+ * The per-post atom ({@see self::apply_to_post()}) is shared with the
+ * `POST /woocommerce-email-editor/v1/emails/{id}/reset` endpoint
+ * (see {@see \Automattic\WooCommerce\Internal\EmailEditor\EmailApiController::reset_response()})
+ * so reset and auto-apply share one canonical-write code path.
+ *
+ * @package Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails
+ * @since 10.8.0
+ */
+class WCEmailTemplateAutoApplier {
+	/**
+	 * Action Scheduler hook name for the batched auto-apply runner.
+	 *
+	 * @var string
+	 */
+	public const AUTO_APPLY_AS_HOOK = 'woocommerce_email_template_auto_apply_uncustomized';
+
+	/**
+	 * Action Scheduler group for the batched auto-apply runner.
+	 *
+	 * @var string
+	 */
+	public const AUTO_APPLY_AS_GROUP = 'woocommerce-email-editor';
+
+	/**
+	 * Re-entrancy flag set while the atom rewrites a post.
+	 *
+	 * Future `save_post` listeners (e.g. RSM-143's customised-post detector,
+	 * RSM-145's Tracks event firing) should consult {@see self::is_auto_applying()}
+	 * before interpreting a write as a merchant edit.
+	 *
+	 * @var bool
+	 */
+	private static bool $is_auto_applying = false;
+
+	/**
+	 * Logger instance. Lazily instantiated on first use; overridable for tests.
+	 *
+	 * @var Email_Editor_Logger_Interface|null
+	 */
+	private static ?Email_Editor_Logger_Interface $logger = null;
+
+	/**
+	 * Apply the current core template render to a single `woo_email` post and stamp sync meta.
+	 *
+	 * Two callers, two modes:
+	 *   - Auto-applier (default): `$opts['require_uncustomized'] === true`. Rejects with
+	 *     `WP_Error` when the post has no stored hash, has been edited since stamping,
+	 *     or belongs to a non-sync-enabled email.
+	 *   - Reset endpoint: `$opts['require_uncustomized'] === false`. Unconditional rewrite.
+	 *     Non-sync-enabled emails receive a content-only reset and the return shape carries
+	 *     `null` for the four sync fields (BC contract with the pre-RSM-139 reset endpoint).
+	 *
+	 * Atomicity: the post update plus the four meta writes run inside a single
+	 * `START TRANSACTION` block, so a partial failure rolls back cleanly.
+	 *
+	 * @param \WC_Email $email   The transactional email instance.
+	 * @param int       $post_id The post ID.
+	 * @param array     $opts    Options. Recognised keys:
+	 *                           - `require_uncustomized` (bool, default true): see above.
+	 * @return array|\WP_Error On success, an array with keys `content`, `version`,
+	 *                         `source_hash`, `synced_at`, `status`. On failure, a `WP_Error`.
+	 *
+	 * @since 10.8.0
+	 */
+	public static function apply_to_post( \WC_Email $email, int $post_id, array $opts = array() ) {
+		$require_uncustomized = ! isset( $opts['require_uncustomized'] ) || (bool) $opts['require_uncustomized'];
+
+		$sync_config = WCEmailTemplateSyncRegistry::get_email_sync_config( (string) $email->id );
+
+		if ( $require_uncustomized && null === $sync_config ) {
+			return new \WP_Error(
+				'not_sync_enabled',
+				sprintf(
+					/* translators: %s: email ID */
+					__( 'Email "%s" is not registered for template sync.', 'woocommerce' ),
+					(string) $email->id
+				)
+			);
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post || \Automattic\WooCommerce\Internal\EmailEditor\Integration::EMAIL_POST_TYPE !== $post->post_type ) {
+			return new \WP_Error(
+				'post_not_found',
+				sprintf(
+					/* translators: %d: post ID */
+					__( 'No woo_email post found for ID %d.', 'woocommerce' ),
+					$post_id
+				)
+			);
+		}
+
+		if ( $require_uncustomized ) {
+			$stored_source_hash = (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true );
+			if ( '' === $stored_source_hash || ! self::is_sha1_hash( $stored_source_hash ) ) {
+				return new \WP_Error(
+					'no_stored_hash',
+					sprintf(
+						/* translators: %d: post ID */
+						__( 'Post %d has no stored source hash; cannot safely auto-apply.', 'woocommerce' ),
+						$post_id
+					)
+				);
+			}
+
+			$current_post_hash = sha1( (string) $post->post_content );
+			if ( $current_post_hash !== $stored_source_hash ) {
+				return new \WP_Error(
+					'post_modified_since_stamp',
+					sprintf(
+						/* translators: %d: post ID */
+						__( 'Post %d has been modified since the last sync stamp; skipping auto-apply.', 'woocommerce' ),
+						$post_id
+					)
+				);
+			}
+		}
+
+		global $wpdb;
+
+		$canonical = WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email );
+
+		self::$is_auto_applying = true;
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+			$updated = wp_update_post(
+				array(
+					'ID'           => $post_id,
+					'post_content' => $canonical,
+				),
+				true
+			);
+
+			if ( is_wp_error( $updated ) ) {
+				$wpdb->query( 'ROLLBACK' );
+				return $updated;
+			}
+
+			$source_hash = null;
+			$synced_at   = null;
+			$status      = null;
+			$version     = null;
+
+			if ( null !== $sync_config ) {
+				$source_hash = sha1( $canonical );
+				$synced_at   = gmdate( 'Y-m-d H:i:s' );
+				$status      = WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC;
+				$version     = (string) $sync_config['version'];
+
+				update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, $version );
+				update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, $source_hash );
+				update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, $synced_at );
+				update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, $status );
+			}
+
+			$wpdb->query( 'COMMIT' );
+		} catch ( \Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+			throw $e;
+		} finally {
+			self::$is_auto_applying = false;
+		}
+
+		return array(
+			'content'     => $canonical,
+			'version'     => $version,
+			'source_hash' => $source_hash,
+			'synced_at'   => $synced_at,
+			'status'      => $status,
+		);
+	}
+
+	/**
+	 * Whether the auto-applier is currently rewriting a post.
+	 *
+	 * Future `save_post` listeners (RSM-143, RSM-145) should consult this flag
+	 * to differentiate merchant edits from system-initiated writes.
+	 *
+	 * @return bool
+	 *
+	 * @since 10.8.0
+	 */
+	public static function is_auto_applying(): bool {
+		return self::$is_auto_applying;
+	}
+
+	/**
+	 * Override the logger implementation. Intended for tests only.
+	 *
+	 * @internal
+	 *
+	 * @param Email_Editor_Logger_Interface|null $logger The logger implementation, or null to restore the default.
+	 */
+	public static function set_logger( ?Email_Editor_Logger_Interface $logger ): void {
+		self::$logger = $logger;
+	}
+
+	/**
+	 * Return the logger instance, lazily creating it the first time.
+	 *
+	 * @return Email_Editor_Logger_Interface
+	 */
+	private static function get_logger(): Email_Editor_Logger_Interface {
+		if ( null === self::$logger ) {
+			self::$logger = new Logger( wc_get_logger() );
+		}
+
+		return self::$logger;
+	}
+
+	/**
+	 * Validate that a string is shaped like a SHA-1 hex digest.
+	 *
+	 * @param string $hash Candidate hash value.
+	 * @return bool True when the value is a 40-character hex string.
+	 */
+	private static function is_sha1_hash( string $hash ): bool {
+		return 40 === strlen( $hash ) && ctype_xdigit( $hash );
+	}
+}

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetector.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetector.php
@@ -181,6 +181,19 @@ class WCEmailTemplateDivergenceDetector {
 				continue;
 			}//end try
 		}//end foreach
+
+		/**
+		 * Fires once after the post-upgrade divergence sweep finishes classifying
+		 * every sync-registered email post.
+		 *
+		 * Hooked by {@see \Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier::schedule()}
+		 * to enqueue the batched auto-apply job for posts classified as
+		 * `core_updated_uncustomized`. Fires unconditionally — auto-applier
+		 * short-circuits when no candidates exist.
+		 *
+		 * @since 10.8.0
+		 */
+		do_action( 'woocommerce_email_template_divergence_sweep_complete' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
@@ -527,6 +527,52 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should leave post and sync meta untouched when wp_update_post fails (transaction rollback BC).
+	 */
+	public function test_reset_response_rolls_back_when_wp_update_post_fails(): void {
+		$email_type = 'customer_new_account';
+
+		$generator = new WCTransactionalEmailPostsGenerator();
+		$generator->init_default_transactional_emails();
+
+		$post_manager = WCTransactionalEmailPostsManager::get_instance();
+		$post_manager->clear_caches();
+		$post_manager->delete_email_template( $email_type );
+		WCEmailTemplateSyncRegistry::reset_cache();
+
+		$post_id = $generator->generate_email_template_if_not_exists( $email_type );
+		$this->assertIsInt( $post_id );
+
+		$pre_call_content = (string) get_post( $post_id )->post_content;
+		$pre_call_meta    = array(
+			'version'        => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, true ),
+			'source_hash'    => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ),
+			'last_synced_at' => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, true ),
+			'status'         => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+		);
+
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$request = new \WP_REST_Request( 'POST', '/woocommerce-email-editor/v1/emails/' . $post_id . '/reset' );
+		$request->set_param( 'id', $post_id );
+
+		$result = $this->email_api_controller->reset_response( $request );
+
+		remove_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'woocommerce_email_reset_failed', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+
+		clean_post_cache( $post_id );
+		$this->assertSame( $pre_call_content, (string) get_post( $post_id )->post_content, 'post_content must be untouched after wp_update_post failure.' );
+		$this->assertSame( $pre_call_meta['version'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, true ) );
+		$this->assertSame( $pre_call_meta['source_hash'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ) );
+		$this->assertSame( $pre_call_meta['last_synced_at'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, true ) );
+		$this->assertSame( $pre_call_meta['status'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ) );
+	}
+
+	/**
 	 * @testdox Should return 500 when controller has not been initialized.
 	 */
 	public function test_reset_response_returns_500_when_uninitialized(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
@@ -527,9 +527,9 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should leave post and sync meta untouched when wp_update_post fails (transaction rollback BC).
+	 * @testdox Should leave post and sync meta untouched when wp_update_post fails.
 	 */
-	public function test_reset_response_rolls_back_when_wp_update_post_fails(): void {
+	public function test_reset_response_returns_wp_error_when_wp_update_post_fails(): void {
 		$email_type = 'customer_new_account';
 
 		$generator = new WCTransactionalEmailPostsGenerator();

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -375,6 +375,40 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * is_auto_applying() must read true while wp_update_post is running inside the
+	 * atom and false again once apply_to_post returns. Verified by hooking save_post
+	 * (which fires from inside wp_update_post) and capturing the flag value there.
+	 */
+	public function test_apply_to_post_sets_is_auto_applying_flag_during_write(): void {
+		$email_id = 'wc_test_auto_apply_reentrancy_flag';
+		$post_id  = $this->generate_stamped_post( $email_id );
+
+		$emails_by_id = $this->posts_manager->get_emails_by_id();
+		$email        = $emails_by_id[ $email_id ];
+
+		$captured_during_save = null;
+		$listener             = static function () use ( &$captured_during_save ): void {
+			$captured_during_save = WCEmailTemplateAutoApplier::is_auto_applying();
+		};
+		add_action( 'save_post', $listener );
+
+		// Drive the auto-applier path via the require_uncustomized=false branch so
+		// we don't have to manufacture a core-template change here.
+		try {
+			WCEmailTemplateAutoApplier::apply_to_post(
+				$email,
+				$post_id,
+				array( 'require_uncustomized' => false )
+			);
+		} finally {
+			remove_action( 'save_post', $listener );
+		}
+
+		$this->assertTrue( $captured_during_save, 'is_auto_applying() must read true inside the write block.' );
+		$this->assertFalse( WCEmailTemplateAutoApplier::is_auto_applying(), 'is_auto_applying() must read false after apply_to_post returns.' );
+	}
+
+	/**
 	 * Build a WC_Email stub backed by the third-party-with-version.php fixture, inject it
 	 * into WC_Emails::$emails, and opt the email ID into the block-editor filter so the
 	 * sync registry picks it up.

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -721,6 +721,82 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * The candidate query must accept any non-trash post status — generated
+	 * woo_email posts default to `publish` but third-party flows may move them
+	 * to `draft` / `private` / `pending` / `future` and those must not be
+	 * silently skipped.
+	 *
+	 * @dataProvider provider_non_trash_post_statuses
+	 *
+	 * @param string $post_status Post status to stamp on the candidate.
+	 */
+	public function test_run_applies_to_candidate_regardless_of_non_trash_post_status( string $post_status ): void {
+		global $wpdb;
+
+		$post_id = $this->generate_stamped_post( 'wc_test_run_status_' . $post_status );
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED );
+
+		// Flip status via a direct UPDATE: wp_update_post calls map_meta_cap, which
+		// emits a _doing_it_wrong notice in the unit-test bootstrap because the
+		// woo_email post type is not registered there (Integration::initialize() is
+		// not run). The candidate query is the surface under test; status flipping
+		// is incidental.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $post_status ), array( 'ID' => $post_id ) );
+		clean_post_cache( $post_id );
+
+		WCEmailTemplateAutoApplier::run();
+
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC,
+			(string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+			"Auto-applier must process candidates whose post_status is {$post_status}."
+		);
+	}
+
+	/**
+	 * Data provider for {@see self::test_run_applies_to_candidate_regardless_of_non_trash_post_status()}.
+	 *
+	 * `pending` is intentionally omitted: WP's `wp_update_post` invokes
+	 * `map_meta_cap('publish_post', ...)` for any write touching a pending post,
+	 * which emits a _doing_it_wrong notice in the unit-test bootstrap because the
+	 * `woo_email` post type is not registered there. Pending isn't a realistic
+	 * status for transactional email templates anyway.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public function provider_non_trash_post_statuses(): array {
+		return array(
+			'draft'   => array( 'draft' ),
+			'private' => array( 'private' ),
+			'future'  => array( 'future' ),
+		);
+	}
+
+	/**
+	 * Trashed posts must NOT be picked up by the candidate query — the WP_Query
+	 * `post_status=any` clause already excludes the trash bucket and we want to
+	 * lock that in.
+	 */
+	public function test_run_skips_trashed_posts(): void {
+		$post_id = $this->generate_stamped_post( 'wc_test_run_trashed' );
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED );
+
+		wp_trash_post( $post_id );
+		clean_post_cache( $post_id );
+
+		$content_before = (string) get_post( $post_id )->post_content;
+
+		WCEmailTemplateAutoApplier::run();
+
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED,
+			(string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+			'Trashed posts must not have their status flipped by the auto-applier.'
+		);
+		$this->assertSame( $content_before, (string) get_post( $post_id )->post_content );
+	}
+
+	/**
 	 * Firing the divergence-sweep completion action must trigger the auto-applier
 	 * to enqueue an AS job. This locks in the wiring that lives in
 	 * Integration::register_hooks().

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -334,12 +334,11 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * When wp_update_post() fails the atom must roll back so neither post_content
-	 * nor any of the four sync meta keys are modified. The current behaviour of
-	 * the pre-refactor reset endpoint short-circuits before the meta writes; the
-	 * transaction makes the all-or-nothing guarantee explicit.
+	 * When wp_update_post() fails the atom must short-circuit before the meta
+	 * writes, so neither post_content nor any of the four sync meta keys are
+	 * modified. Matches the pre-RSM-139 reset endpoint contract.
 	 */
-	public function test_apply_to_post_rolls_back_on_wp_update_post_failure(): void {
+	public function test_apply_to_post_returns_wp_error_when_wp_update_post_fails(): void {
 		$email_id = 'wc_test_auto_apply_rollback';
 		$post_id  = $this->generate_stamped_post( $email_id );
 

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -409,6 +409,69 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * schedule() must enqueue an async Action Scheduler action under the
+	 * dedicated email-editor group.
+	 */
+	public function test_schedule_enqueues_action_scheduler_job(): void {
+		// Make sure no leftover action exists from a previous test or session.
+		as_unschedule_all_actions(
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+			array(),
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
+		);
+
+		WCEmailTemplateAutoApplier::schedule();
+
+		$this->assertTrue(
+			(bool) as_has_scheduled_action(
+				WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+				array(),
+				WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
+			)
+		);
+
+		// Cleanup so subsequent tests start with a clean queue.
+		as_unschedule_all_actions(
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+			array(),
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
+		);
+	}
+
+	/**
+	 * Calling schedule() twice in the same request (e.g. once from
+	 * woocommerce_updated and once from BACKFILL_COMPLETE_ACTION) must not
+	 * enqueue two pending actions.
+	 */
+	public function test_schedule_does_not_double_enqueue(): void {
+		as_unschedule_all_actions(
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+			array(),
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
+		);
+
+		WCEmailTemplateAutoApplier::schedule();
+		WCEmailTemplateAutoApplier::schedule();
+
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'   => WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+				'group'  => WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP,
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			),
+			'ids'
+		);
+
+		$this->assertCount( 1, $pending, 'schedule() must guard against double-enqueueing.' );
+
+		as_unschedule_all_actions(
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+			array(),
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
+		);
+	}
+
+	/**
 	 * Build a WC_Email stub backed by the third-party-with-version.php fixture, inject it
 	 * into WC_Emails::$emails, and opt the email ID into the block-editor filter so the
 	 * sync registry picks it up.

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -333,6 +333,48 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * When wp_update_post() fails the atom must roll back so neither post_content
+	 * nor any of the four sync meta keys are modified. The current behaviour of
+	 * the pre-refactor reset endpoint short-circuits before the meta writes; the
+	 * transaction makes the all-or-nothing guarantee explicit.
+	 */
+	public function test_apply_to_post_rolls_back_on_wp_update_post_failure(): void {
+		$email_id = 'wc_test_auto_apply_rollback';
+		$post_id  = $this->generate_stamped_post( $email_id );
+
+		$emails_by_id = $this->posts_manager->get_emails_by_id();
+		$email        = $emails_by_id[ $email_id ];
+
+		$pre_call_content = (string) get_post( $post_id )->post_content;
+		$pre_call_meta    = array(
+			'source_hash'    => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ),
+			'version'        => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, true ),
+			'last_synced_at' => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, true ),
+			'status'         => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+		);
+
+		// Force wp_update_post to fail by short-circuiting it through the
+		// 'wp_insert_post_empty_content' filter — when this returns true,
+		// wp_update_post returns WP_Error('empty_content').
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		try {
+			$result = WCEmailTemplateAutoApplier::apply_to_post( $email, $post_id );
+		} finally {
+			remove_filter( 'wp_insert_post_empty_content', '__return_true' );
+		}
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+
+		clean_post_cache( $post_id );
+		$this->assertSame( $pre_call_content, (string) get_post( $post_id )->post_content );
+		$this->assertSame( $pre_call_meta['source_hash'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ) );
+		$this->assertSame( $pre_call_meta['version'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, true ) );
+		$this->assertSame( $pre_call_meta['last_synced_at'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, true ) );
+		$this->assertSame( $pre_call_meta['status'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ) );
+	}
+
+	/**
 	 * Build a WC_Email stub backed by the third-party-with-version.php fixture, inject it
 	 * into WC_Emails::$emails, and opt the email ID into the block-editor filter so the
 	 * sync registry picks it up.

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\EmailEditor\WCTransactionalEmails;
 
+use Automattic\WooCommerce\Internal\EmailEditor\Integration;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateDivergenceDetector;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncRegistry;
@@ -718,6 +719,41 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 			(string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true )
 		);
 		$this->assertSame( array(), $captured, 'Deactivated-plugin skip must be silent (no log emission).' );
+	}
+
+	/**
+	 * Firing the divergence-sweep completion action must trigger the auto-applier
+	 * to enqueue an AS job. This locks in the wiring that lives in
+	 * Integration::register_hooks().
+	 */
+	public function test_detector_sweep_complete_action_triggers_schedule(): void {
+		// The unit-test bootstrap does not run Integration::initialize() (which calls
+		// register_hooks()). Force it for this single test so the wiring under test
+		// is actually present on the global hook table.
+		wc_get_container()->get( Integration::class )->initialize();
+
+		as_unschedule_all_actions(
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+			array(),
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
+		);
+
+		do_action( 'woocommerce_email_template_divergence_sweep_complete' );
+
+		$this->assertTrue(
+			(bool) as_has_scheduled_action(
+				WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+				array(),
+				WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
+			),
+			'Integration::register_hooks() must wire schedule() to the divergence-sweep completion action.'
+		);
+
+		as_unschedule_all_actions(
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_HOOK,
+			array(),
+			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -472,6 +472,309 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * run() must apply only to posts whose status meta is core_updated_uncustomized,
+	 * leaving in_sync and core_updated_customized posts untouched.
+	 */
+	public function test_run_applies_to_every_uncustomized_post(): void {
+		// 3 posts, each with a distinct fixture email so each registers in the registry.
+		$uncustomized_post_id = $this->generate_stamped_post( 'wc_test_run_uncustomized' );
+		$customized_post_id   = $this->generate_stamped_post( 'wc_test_run_customized' );
+		$in_sync_post_id      = $this->generate_stamped_post( 'wc_test_run_in_sync' );
+
+		update_post_meta(
+			$uncustomized_post_id,
+			WCEmailTemplateDivergenceDetector::STATUS_META_KEY,
+			WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED
+		);
+		update_post_meta(
+			$customized_post_id,
+			WCEmailTemplateDivergenceDetector::STATUS_META_KEY,
+			WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_CUSTOMIZED
+		);
+		update_post_meta(
+			$in_sync_post_id,
+			WCEmailTemplateDivergenceDetector::STATUS_META_KEY,
+			WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC
+		);
+
+		$content_before_customized = (string) get_post( $customized_post_id )->post_content;
+		$content_before_in_sync    = (string) get_post( $in_sync_post_id )->post_content;
+
+		WCEmailTemplateAutoApplier::run();
+
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC,
+			(string) get_post_meta( $uncustomized_post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+			'Uncustomized post must flip to in_sync after run().'
+		);
+
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_CUSTOMIZED,
+			(string) get_post_meta( $customized_post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+			'Customized post status must be untouched.'
+		);
+		$this->assertSame( $content_before_customized, (string) get_post( $customized_post_id )->post_content );
+
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC,
+			(string) get_post_meta( $in_sync_post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true )
+		);
+		$this->assertSame( $content_before_in_sync, (string) get_post( $in_sync_post_id )->post_content );
+	}
+
+	/**
+	 * One bad post must not break the rest of the batch. The atom failure is
+	 * logged at error severity with context=email_template_auto_applier.
+	 */
+	public function test_run_logs_and_continues_when_one_post_fails(): void {
+		$failing_post_id = $this->generate_stamped_post( 'wc_test_run_failure_isolation_fail' );
+		$good_post_id    = $this->generate_stamped_post( 'wc_test_run_failure_isolation_good' );
+
+		update_post_meta( $failing_post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED );
+		update_post_meta( $good_post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED );
+
+		// Force wp_update_post to fail for the FIRST post only by toggling the filter
+		// on/off based on which post ID is being saved.
+		add_filter(
+			'wp_insert_post_empty_content',
+			static function ( $maybe_empty, $postarr ) use ( $failing_post_id ) {
+				return ( ( (int) ( $postarr['ID'] ?? 0 ) ) === $failing_post_id ) ? true : $maybe_empty;
+			},
+			10,
+			2
+		);
+
+		$captured = array();
+		WCEmailTemplateAutoApplier::set_logger( $this->build_recording_logger( $captured ) );
+
+		try {
+			WCEmailTemplateAutoApplier::run();
+		} finally {
+			remove_all_filters( 'wp_insert_post_empty_content' );
+		}
+
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED,
+			(string) get_post_meta( $failing_post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+			'Failing post status must be untouched (no rewrite happened).'
+		);
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC,
+			(string) get_post_meta( $good_post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+			'Good post must still be applied despite the prior failure.'
+		);
+
+		$error_logs = array_filter(
+			$captured,
+			static fn( array $entry ) => 'error' === $entry['level']
+				&& ( $entry['context']['context'] ?? '' ) === 'email_template_auto_applier'
+		);
+		$this->assertCount( 1, $error_logs, 'Exactly one error log entry must be emitted for the failing post.' );
+	}
+
+	/**
+	 * If the post was modified since stamping (race window between sweep and AS job),
+	 * run() must skip it at info severity, leave content/meta untouched, and not
+	 * roll the status meta back.
+	 */
+	public function test_run_skips_post_with_post_modified_since_stamp_at_info_severity(): void {
+		$post_id = $this->generate_stamped_post( 'wc_test_run_race_safety' );
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED );
+
+		// Simulate merchant edit during the AS lag window.
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => '<p>Merchant-edited content during AS lag</p>',
+			)
+		);
+
+		$captured = array();
+		WCEmailTemplateAutoApplier::set_logger( $this->build_recording_logger( $captured ) );
+
+		WCEmailTemplateAutoApplier::run();
+
+		$this->assertSame( '<p>Merchant-edited content during AS lag</p>', (string) get_post( $post_id )->post_content );
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED,
+			(string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ),
+			'Status must remain core_updated_uncustomized so the next sweep can re-classify.'
+		);
+
+		$info_logs = array_filter(
+			$captured,
+			static fn( array $entry ) => 'info' === $entry['level']
+				&& ( $entry['context']['context'] ?? '' ) === 'email_template_auto_applier'
+		);
+		$this->assertCount( 1, $info_logs, 'Race outcome must be logged at info severity.' );
+
+		$error_logs = array_filter( $captured, static fn( array $entry ) => 'error' === $entry['level'] );
+		$this->assertCount( 0, $error_logs, 'Race outcome must NOT log at error severity.' );
+	}
+
+	/**
+	 * run() with no candidates must be a no-op.
+	 */
+	public function test_run_is_a_no_op_when_no_uncustomized_posts_exist(): void {
+		$post_id = $this->generate_stamped_post( 'wc_test_run_no_op' );
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC );
+
+		$content_before = (string) get_post( $post_id )->post_content;
+
+		$write_count = 0;
+		$counter     = static function ( $check, int $object_id, string $meta_key ) use ( &$write_count ) {
+			unset( $object_id, $meta_key );
+			++$write_count;
+			return $check;
+		};
+		add_filter( 'update_post_metadata', $counter, 10, 3 );
+
+		try {
+			WCEmailTemplateAutoApplier::run();
+		} finally {
+			remove_filter( 'update_post_metadata', $counter, 10 );
+		}
+
+		$this->assertSame( 0, $write_count, 'No meta writes must occur when there are no candidates.' );
+		$this->assertSame( $content_before, (string) get_post( $post_id )->post_content );
+	}
+
+	/**
+	 * Two consecutive run() calls on the same state — the first applies and flips
+	 * status to in_sync, the second writes zero rows. (Acceptance criterion.)
+	 */
+	public function test_run_is_idempotent_across_repeat_invocations(): void {
+		$post_id = $this->generate_stamped_post( 'wc_test_run_idempotency' );
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED );
+
+		WCEmailTemplateAutoApplier::run();
+
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC,
+			(string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true )
+		);
+
+		$write_count = 0;
+		$counter     = static function ( $check ) use ( &$write_count ) {
+			++$write_count;
+			return $check;
+		};
+		add_filter( 'update_post_metadata', $counter, 10, 1 );
+		add_filter( 'wp_insert_post_data', $counter, 10, 1 );
+
+		try {
+			WCEmailTemplateAutoApplier::run();
+		} finally {
+			remove_filter( 'update_post_metadata', $counter, 10 );
+			remove_filter( 'wp_insert_post_data', $counter, 10 );
+		}
+
+		$this->assertSame( 0, $write_count, 'Second run must write zero rows.' );
+	}
+
+	/**
+	 * run() must short-circuit when BACKFILL_COMPLETE_OPTION is not 'yes', even if
+	 * core_updated_uncustomized posts exist in the DB.
+	 */
+	public function test_run_respects_backfill_complete_option_gate(): void {
+		$post_id = $this->generate_stamped_post( 'wc_test_run_backfill_gate' );
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED );
+
+		update_option( WCEmailTemplateDivergenceDetector::BACKFILL_COMPLETE_OPTION, 'no' );
+
+		$content_before = (string) get_post( $post_id )->post_content;
+
+		WCEmailTemplateAutoApplier::run();
+
+		$this->assertSame( $content_before, (string) get_post( $post_id )->post_content );
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED,
+			(string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true )
+		);
+	}
+
+	/**
+	 * Posts whose registered email is no longer in the sync registry at run time
+	 * must be skipped silently — no log, no write. (Plugin deactivated mid-cycle.)
+	 */
+	public function test_run_skips_posts_for_deactivated_email_plugins(): void {
+		$post_id = $this->generate_stamped_post( 'wc_test_run_deactivated' );
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED );
+
+		$content_before = (string) get_post( $post_id )->post_content;
+
+		// Drop the email out of the registry.
+		remove_all_filters( 'woocommerce_transactional_emails_for_block_editor' );
+		WCEmailTemplateSyncRegistry::reset_cache();
+
+		$captured = array();
+		WCEmailTemplateAutoApplier::set_logger( $this->build_recording_logger( $captured ) );
+
+		WCEmailTemplateAutoApplier::run();
+
+		$this->assertSame( $content_before, (string) get_post( $post_id )->post_content );
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_CORE_UPDATED_UNCUSTOMIZED,
+			(string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true )
+		);
+		$this->assertSame( array(), $captured, 'Deactivated-plugin skip must be silent (no log emission).' );
+	}
+
+	/**
+	 * Build a recording logger that captures every call into a flat array. Each entry
+	 * is shaped: [ 'level' => 'info'|'warning'|'error', 'message' => string, 'context' => array ].
+	 *
+	 * @param array<int, array<string, mixed>> $sink Reference to the array that will receive entries.
+	 * @return \Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger_Interface
+	 */
+	private function build_recording_logger( array &$sink ): \Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger_Interface {
+		return new class( $sink ) implements \Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger_Interface {
+			/** @var array<int, array<string, mixed>> */
+			private array $sink;
+
+			public function __construct( array &$sink ) {
+				$this->sink = &$sink;
+			}
+
+			public function emergency( string $message, array $context = array() ): void {
+				$this->capture( 'emergency', $message, $context );
+			}
+			public function alert( string $message, array $context = array() ): void {
+				$this->capture( 'alert', $message, $context );
+			}
+			public function critical( string $message, array $context = array() ): void {
+				$this->capture( 'critical', $message, $context );
+			}
+			public function error( string $message, array $context = array() ): void {
+				$this->capture( 'error', $message, $context );
+			}
+			public function warning( string $message, array $context = array() ): void {
+				$this->capture( 'warning', $message, $context );
+			}
+			public function notice( string $message, array $context = array() ): void {
+				$this->capture( 'notice', $message, $context );
+			}
+			public function info( string $message, array $context = array() ): void {
+				$this->capture( 'info', $message, $context );
+			}
+			public function debug( string $message, array $context = array() ): void {
+				$this->capture( 'debug', $message, $context );
+			}
+			public function log( string $level, string $message, array $context = array() ): void {
+				$this->capture( $level, $message, $context );
+			}
+
+			private function capture( string $level, string $message, array $context ): void {
+				$this->sink[] = array(
+					'level'   => $level,
+					'message' => $message,
+					'context' => $context,
+				);
+			}
+		};
+	}
+
+	/**
 	 * Build a WC_Email stub backed by the third-party-with-version.php fixture, inject it
 	 * into WC_Emails::$emails, and opt the email ID into the block-editor filter so the
 	 * sync registry picks it up.

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -252,6 +252,87 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * apply_to_post() with require_uncustomized=false must overwrite a modified
+	 * post unconditionally — no hash gate. This is the reset-endpoint contract.
+	 */
+	public function test_apply_to_post_without_require_uncustomized_overwrites_modified_post(): void {
+		$email_id = 'wc_test_auto_apply_reset_overwrites_modified';
+		$post_id  = $this->generate_stamped_post( $email_id );
+
+		$emails_by_id = $this->posts_manager->get_emails_by_id();
+		$email        = $emails_by_id[ $email_id ];
+
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => '<p>Merchant-edited content that the reset must overwrite</p>',
+			)
+		);
+
+		$expected_canonical = WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email );
+
+		$result = WCEmailTemplateAutoApplier::apply_to_post(
+			$email,
+			$post_id,
+			array( 'require_uncustomized' => false )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $expected_canonical, $result['content'] );
+		$this->assertSame( WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC, $result['status'] );
+
+		$this->assertSame( $expected_canonical, (string) get_post( $post_id )->post_content );
+	}
+
+	/**
+	 * apply_to_post() with require_uncustomized=false on a non-sync-enabled email
+	 * must rewrite content but stamp NO meta. Return shape carries null for the
+	 * four sync fields. BC contract from the pre-RSM-139 reset endpoint.
+	 */
+	public function test_apply_to_post_for_non_sync_enabled_email_with_require_uncustomized_false(): void {
+		$email_id = 'wc_test_auto_apply_reset_non_sync_enabled';
+		$email    = $this->register_fixture_email( $email_id );
+
+		// Generate a post via direct post insert (bypass the generator's RSM-137 stamping)
+		// so the post has no sync meta to begin with — closest analogue to a non-sync-enabled
+		// email's persisted state.
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => \Automattic\WooCommerce\Internal\EmailEditor\Integration::EMAIL_POST_TYPE,
+				'post_status'  => 'publish',
+				'post_name'    => $email_id,
+				'post_title'   => 'Non-sync-enabled fixture',
+				'post_content' => '<p>Initial non-canonical content</p>',
+			)
+		);
+		$this->assertIsInt( $post_id );
+
+		// Drop the email out of the registry so apply_to_post sees null sync_config.
+		remove_all_filters( 'woocommerce_transactional_emails_for_block_editor' );
+		WCEmailTemplateSyncRegistry::reset_cache();
+
+		$expected_canonical = WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email );
+
+		$result = WCEmailTemplateAutoApplier::apply_to_post(
+			$email,
+			$post_id,
+			array( 'require_uncustomized' => false )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'content', $result );
+		$this->assertSame( $expected_canonical, $result['content'] );
+		$this->assertNull( $result['version'] );
+		$this->assertNull( $result['source_hash'] );
+		$this->assertNull( $result['synced_at'] );
+		$this->assertNull( $result['status'] );
+
+		$this->assertSame( $expected_canonical, (string) get_post( $post_id )->post_content );
+		$this->assertSame( '', (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ) );
+	}
+
+	/**
 	 * Build a WC_Email stub backed by the third-party-with-version.php fixture, inject it
 	 * into WC_Emails::$emails, and opt the email ID into the block-editor filter so the
 	 * sync registry picks it up.

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -89,8 +89,8 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	 * @return array
 	 */
 	public function whitelist_email_page_template( $templates ): array {
-		$templates                       = is_array( $templates ) ? $templates : array();
-		$templates['wooemailtemplate']   = 'Woo Email Template';
+		$templates                     = is_array( $templates ) ? $templates : array();
+		$templates['wooemailtemplate'] = 'Woo Email Template';
 		return $templates;
 	}
 
@@ -737,6 +737,12 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 			WCEmailTemplateAutoApplier::AUTO_APPLY_AS_GROUP
 		);
 
+		/**
+		 * Trigger the production hook the auto-applier listens to; the assertions
+		 * below confirm `Integration::register_hooks()` routes it to `schedule()`.
+		 *
+		 * @since 10.8.0
+		 */
 		do_action( 'woocommerce_email_template_divergence_sweep_complete' );
 
 		$this->assertTrue(
@@ -767,38 +773,93 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 			/** @var array<int, array<string, mixed>> */
 			private array $sink;
 
+			/**
+			 * @param array<int, array<string, mixed>> $sink Reference to the array that will receive entries.
+			 */
 			public function __construct( array &$sink ) {
 				$this->sink = &$sink;
 			}
 
+			/**
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function emergency( string $message, array $context = array() ): void {
 				$this->capture( 'emergency', $message, $context );
 			}
+
+			/**
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function alert( string $message, array $context = array() ): void {
 				$this->capture( 'alert', $message, $context );
 			}
+
+			/**
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function critical( string $message, array $context = array() ): void {
 				$this->capture( 'critical', $message, $context );
 			}
+
+			/**
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function error( string $message, array $context = array() ): void {
 				$this->capture( 'error', $message, $context );
 			}
+
+			/**
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function warning( string $message, array $context = array() ): void {
 				$this->capture( 'warning', $message, $context );
 			}
+
+			/**
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function notice( string $message, array $context = array() ): void {
 				$this->capture( 'notice', $message, $context );
 			}
+
+			/**
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function info( string $message, array $context = array() ): void {
 				$this->capture( 'info', $message, $context );
 			}
+
+			/**
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function debug( string $message, array $context = array() ): void {
 				$this->capture( 'debug', $message, $context );
 			}
+
+			/**
+			 * @param string               $level   The log level.
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			public function log( string $level, string $message, array $context = array() ): void {
 				$this->capture( $level, $message, $context );
 			}
 
+			/**
+			 * Append a captured log call to the sink.
+			 *
+			 * @param string               $level   The log level.
+			 * @param string               $message The log message.
+			 * @param array<string, mixed> $context The log context.
+			 */
 			private function capture( string $level, string $message, array $context ): void {
 				$this->sink[] = array(
 					'level'   => $level,

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\EmailEditor\WCTransactionalEmails;
+
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateDivergenceDetector;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncRegistry;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+
+/**
+ * Tests for the WCEmailTemplateAutoApplier class.
+ */
+class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
+	/**
+	 * Absolute path to the fixtures directory shared with the divergence detector tests.
+	 *
+	 * @var string
+	 */
+	private string $fixtures_base;
+
+	/**
+	 * Keys injected into \WC_Emails::$emails during the current test.
+	 *
+	 * @var string[]
+	 */
+	private array $injected_email_keys = array();
+
+	/**
+	 * Transactional email post manager singleton.
+	 *
+	 * @var WCTransactionalEmailPostsManager
+	 */
+	private WCTransactionalEmailPostsManager $posts_manager;
+
+	/**
+	 * Setup test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
+		update_option( WCEmailTemplateDivergenceDetector::BACKFILL_COMPLETE_OPTION, 'yes' );
+
+		// Reuse the divergence-detector fixture file — same shape, same @version header.
+		$this->fixtures_base = dirname( __DIR__ ) . '/WCTransactionalEmails/fixtures/';
+		$this->posts_manager = WCTransactionalEmailPostsManager::get_instance();
+
+		$this->posts_manager->clear_caches();
+		WCEmailTemplateSyncRegistry::reset_cache();
+
+		// In integration runtime the email editor's Templates_Registry registers
+		// the `wooemailtemplate` slug via register_block_template() during admin
+		// bootstrap. Unit tests skip that bootstrap, so wp_update_post( $wp_error = true )
+		// would reject the slug as `invalid_page_template`. Whitelist it via the
+		// theme_{post_type}_templates filter for the duration of the test.
+		add_filter( 'theme_woo_email_templates', array( $this, 'whitelist_email_page_template' ) );
+		add_filter( 'theme_templates', array( $this, 'whitelist_email_page_template' ) );
+	}
+
+	/**
+	 * Cleanup after test.
+	 */
+	public function tearDown(): void {
+		$this->cleanup_injected_emails();
+
+		remove_filter( 'theme_woo_email_templates', array( $this, 'whitelist_email_page_template' ) );
+		remove_filter( 'theme_templates', array( $this, 'whitelist_email_page_template' ) );
+		remove_all_filters( 'woocommerce_transactional_emails_for_block_editor' );
+		remove_all_filters( 'woocommerce_email_content_post_data' );
+
+		WCEmailTemplateSyncRegistry::reset_cache();
+		WCEmailTemplateAutoApplier::set_logger( null );
+
+		delete_option( WCEmailTemplateDivergenceDetector::BACKFILL_COMPLETE_OPTION );
+		update_option( 'woocommerce_feature_block_email_editor_enabled', 'no' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Filter callback — register the `wooemailtemplate` slug so wp_update_post
+	 * with `$wp_error = true` does not bail with `invalid_page_template`.
+	 *
+	 * @param array $templates Existing page templates keyed by slug.
+	 * @return array
+	 */
+	public function whitelist_email_page_template( $templates ): array {
+		$templates                       = is_array( $templates ) ? $templates : array();
+		$templates['wooemailtemplate']   = 'Woo Email Template';
+		return $templates;
+	}
+
+	/**
+	 * apply_to_post() on a sync-enabled post that still matches its stamp must
+	 * rewrite content to the canonical render and stamp all four sync meta keys.
+	 */
+	public function test_apply_to_post_writes_canonical_content_and_stamps_meta(): void {
+		$email_id = 'wc_test_auto_apply_happy_path';
+		$post_id  = $this->generate_stamped_post( $email_id );
+
+		$emails_by_id = $this->posts_manager->get_emails_by_id();
+		$email        = $emails_by_id[ $email_id ];
+
+		// Simulate a core-template change by mutating the canonical content via the
+		// woocommerce_email_content_post_data filter for the duration of this test —
+		// keeps the stored hash from RSM-137 stamping intact while making the
+		// auto-applier's recomputed canonical hash differ.
+		add_filter(
+			'woocommerce_email_content_post_data',
+			static function ( array $post_data ) use ( $email_id ): array {
+				if ( ( $post_data['post_name'] ?? '' ) === $email_id ) {
+					$post_data['post_content'] = (string) ( $post_data['post_content'] ?? '' ) . "\n<!-- new core release -->";
+				}
+				return $post_data;
+			}
+		);
+
+		$expected_canonical = WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email );
+		$expected_hash      = sha1( $expected_canonical );
+		$expected_version   = (string) WCEmailTemplateSyncRegistry::get_email_sync_config( $email_id )['version'];
+
+		$result = WCEmailTemplateAutoApplier::apply_to_post( $email, $post_id );
+
+		$this->assertIsArray( $result, 'Atom must return an array on success.' );
+		$this->assertArrayHasKey( 'content', $result );
+		$this->assertSame( $expected_canonical, $result['content'] );
+		$this->assertSame( $expected_version, $result['version'] );
+		$this->assertSame( $expected_hash, $result['source_hash'] );
+		$this->assertSame( WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC, $result['status'] );
+		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', (string) $result['synced_at'] );
+
+		$post = get_post( $post_id );
+		$this->assertSame( $expected_canonical, (string) $post->post_content, 'Post content must be the new canonical render.' );
+
+		$this->assertSame( $expected_hash, (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ) );
+		$this->assertSame( $expected_version, (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, true ) );
+		$this->assertNotSame( '', (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, true ) );
+		$this->assertSame(
+			WCEmailTemplateDivergenceDetector::STATUS_IN_SYNC,
+			(string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true )
+		);
+	}
+
+	/**
+	 * Build a WC_Email stub backed by the third-party-with-version.php fixture, inject it
+	 * into WC_Emails::$emails, and opt the email ID into the block-editor filter so the
+	 * sync registry picks it up.
+	 *
+	 * @param string $email_id Email ID to assign to the stub.
+	 * @return \WC_Email Registered fixture email instance.
+	 */
+	private function register_fixture_email( string $email_id ): \WC_Email {
+		$stub = $this->getMockBuilder( \WC_Email::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$stub->method( 'get_title' )->willReturn( 'Fixture email for auto-applier tests' );
+		$stub->method( 'get_description' )->willReturn( 'Fixture email used to cover auto-apply scenarios.' );
+		$stub->id             = $email_id;
+		$stub->template_base  = $this->fixtures_base;
+		$stub->template_block = 'block/third-party-with-version.php';
+		$stub->template_plain = null;
+
+		$class_key = 'WC_Test_Email_' . $email_id;
+
+		$emails_container = \WC_Emails::instance();
+		$reflection       = new \ReflectionClass( $emails_container );
+		$property         = $reflection->getProperty( 'emails' );
+		$property->setAccessible( true );
+		$current               = $property->getValue( $emails_container );
+		$current[ $class_key ] = $stub;
+		$property->setValue( $emails_container, $current );
+
+		$this->injected_email_keys[] = $class_key;
+
+		add_filter(
+			'woocommerce_transactional_emails_for_block_editor',
+			static function ( array $emails ) use ( $email_id ): array {
+				if ( ! in_array( $email_id, $emails, true ) ) {
+					$emails[] = $email_id;
+				}
+				return $emails;
+			}
+		);
+
+		WCEmailTemplateSyncRegistry::reset_cache();
+
+		return $stub;
+	}
+
+	/**
+	 * Drive the real generator flow to produce a stamped woo_email post for the given fixture.
+	 *
+	 * @param string $email_id Email ID to generate a post for.
+	 * @return int The generated post ID.
+	 */
+	private function generate_stamped_post( string $email_id ): int {
+		$this->register_fixture_email( $email_id );
+
+		$generator = new WCTransactionalEmailPostsGenerator();
+		$generator->init_default_transactional_emails();
+		$this->posts_manager->delete_email_template( $email_id );
+
+		$post_id = $generator->generate_email_template_if_not_exists( $email_id );
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		return $post_id;
+	}
+
+	/**
+	 * Remove any stubs we injected into WC_Emails::$emails during the test.
+	 */
+	private function cleanup_injected_emails(): void {
+		if ( empty( $this->injected_email_keys ) ) {
+			return;
+		}
+
+		$emails_container = \WC_Emails::instance();
+		$reflection       = new \ReflectionClass( $emails_container );
+		$property         = $reflection->getProperty( 'emails' );
+		$property->setAccessible( true );
+		$current = $property->getValue( $emails_container );
+		foreach ( $this->injected_email_keys as $key ) {
+			unset( $current[ $key ] );
+		}
+		$property->setValue( $emails_container, $current );
+		$this->injected_email_keys = array();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateAutoApplierTest.php
@@ -145,6 +145,113 @@ class WCEmailTemplateAutoApplierTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * apply_to_post() with require_uncustomized=true must return a WP_Error and
+	 * leave the post untouched when the merchant has edited it since stamping.
+	 */
+	public function test_apply_to_post_with_require_uncustomized_returns_wp_error_when_post_modified(): void {
+		$email_id = 'wc_test_auto_apply_modified_since_stamp';
+		$post_id  = $this->generate_stamped_post( $email_id );
+
+		$emails_by_id = $this->posts_manager->get_emails_by_id();
+		$email        = $emails_by_id[ $email_id ];
+
+		// Simulate a merchant edit: rewrite post_content directly so its hash no longer
+		// matches the stored stamp, but leave the meta keys in place.
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => '<p>Merchant-edited content</p>',
+			)
+		);
+
+		$pre_call_meta = array(
+			'source_hash'    => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ),
+			'version'        => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, true ),
+			'last_synced_at' => (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, true ),
+		);
+
+		$result = WCEmailTemplateAutoApplier::apply_to_post( $email, $post_id );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'post_modified_since_stamp', $result->get_error_code() );
+
+		$post = get_post( $post_id );
+		$this->assertSame( '<p>Merchant-edited content</p>', (string) $post->post_content, 'Atom must not rewrite content when hash gate fails.' );
+
+		$this->assertSame( $pre_call_meta['source_hash'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ) );
+		$this->assertSame( $pre_call_meta['version'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, true ) );
+		$this->assertSame( $pre_call_meta['last_synced_at'], (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, true ) );
+	}
+
+	/**
+	 * apply_to_post() must return WP_Error('no_stored_hash') when the source-hash
+	 * meta is missing, even if the post itself looks valid.
+	 */
+	public function test_apply_to_post_returns_wp_error_when_no_stored_hash(): void {
+		$email_id = 'wc_test_auto_apply_no_stored_hash';
+		$post_id  = $this->generate_stamped_post( $email_id );
+
+		$emails_by_id = $this->posts_manager->get_emails_by_id();
+		$email        = $emails_by_id[ $email_id ];
+
+		delete_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY );
+		$pre_call_content = (string) get_post( $post_id )->post_content;
+
+		$result = WCEmailTemplateAutoApplier::apply_to_post( $email, $post_id );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'no_stored_hash', $result->get_error_code() );
+
+		$this->assertSame( $pre_call_content, (string) get_post( $post_id )->post_content );
+	}
+
+	/**
+	 * apply_to_post() with require_uncustomized=true on a non-sync-enabled email
+	 * must return WP_Error('not_sync_enabled') and not write anything.
+	 */
+	public function test_apply_to_post_for_non_sync_enabled_email_with_require_uncustomized_true(): void {
+		$email_id = 'wc_test_auto_apply_non_sync_enabled_strict';
+
+		// Generate a stamped post, then nuke its registry membership so the email is
+		// no longer sync-enabled at apply time. Using a registry-cache reset keeps the
+		// post itself intact (with all four meta keys) so we can assert no writes.
+		$post_id = $this->generate_stamped_post( $email_id );
+
+		$emails_by_id = $this->posts_manager->get_emails_by_id();
+		$email        = $emails_by_id[ $email_id ];
+
+		// Drop the email out of the block-editor opt-in filter for the rest of the test.
+		remove_all_filters( 'woocommerce_transactional_emails_for_block_editor' );
+		WCEmailTemplateSyncRegistry::reset_cache();
+
+		$pre_call_content = (string) get_post( $post_id )->post_content;
+		$pre_call_status  = (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true );
+
+		$result = WCEmailTemplateAutoApplier::apply_to_post( $email, $post_id );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_sync_enabled', $result->get_error_code() );
+
+		$this->assertSame( $pre_call_content, (string) get_post( $post_id )->post_content );
+		$this->assertSame( $pre_call_status, (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, true ) );
+	}
+
+	/**
+	 * apply_to_post() must return WP_Error('post_not_found') when the post ID
+	 * doesn't resolve to a woo_email post.
+	 */
+	public function test_apply_to_post_returns_wp_error_when_post_not_found(): void {
+		// Register a sync-enabled fixture email but do NOT generate a post for it.
+		$email_id = 'wc_test_auto_apply_post_not_found';
+		$email    = $this->register_fixture_email( $email_id );
+
+		$result = WCEmailTemplateAutoApplier::apply_to_post( $email, 999999999 );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'post_not_found', $result->get_error_code() );
+	}
+
+	/**
 	 * Build a WC_Email stub backed by the third-party-with-version.php fixture, inject it
 	 * into WC_Emails::$emails, and opt the email ID into the block-editor filter so the
 	 * sync registry picks it up.

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetectorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetectorTest.php
@@ -223,7 +223,7 @@ class WCEmailTemplateDivergenceDetectorTest extends \WC_Unit_Test_Case {
 		$email_id = 'wc_test_divergence_completion_action';
 		$this->generate_stamped_post( $email_id );
 
-		$fired = 0;
+		$fired    = 0;
 		$listener = static function () use ( &$fired ): void {
 			++$fired;
 		};

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetectorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetectorTest.php
@@ -215,6 +215,30 @@ class WCEmailTemplateDivergenceDetectorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * The sweep must fire `woocommerce_email_template_divergence_sweep_complete`
+	 * unconditionally at end of run, so downstream listeners (RSM-139 auto-applier)
+	 * can hook the completion event without inspecting detector internals.
+	 */
+	public function test_run_sweep_fires_completion_action(): void {
+		$email_id = 'wc_test_divergence_completion_action';
+		$this->generate_stamped_post( $email_id );
+
+		$fired = 0;
+		$listener = static function () use ( &$fired ): void {
+			++$fired;
+		};
+		add_action( 'woocommerce_email_template_divergence_sweep_complete', $listener );
+
+		try {
+			WCEmailTemplateDivergenceDetector::run_sweep();
+		} finally {
+			remove_action( 'woocommerce_email_template_divergence_sweep_complete', $listener );
+		}
+
+		$this->assertSame( 1, $fired, 'Completion action must fire exactly once per sweep.' );
+	}
+
+	/**
 	 * Build a WC_Email stub backed by the third-party-with-version.php fixture, inject it
 	 * into WC_Emails::$emails, and opt the email ID into the block-editor filter so the
 	 * sync registry picks it up. Resets the registry cache so subsequent reads see the


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes RSM-139
Builds on https://github.com/woocommerce/woocommerce/pull/64328 (RSM-138, divergence detector) and https://github.com/woocommerce/woocommerce/pull/64355 (RSM-148, server-authoritative reset endpoint).

When the divergence detector classifies a `woo_email` post as `core_updated_uncustomized` after a plugin upgrade, this PR silently rewrites the post content to the new core canonical render and stamps it `in_sync`. No UI, no merchant interaction. Mirrors how legacy static-file emails always reflected the latest core template render.

#### What this PR does

1. Adds `WCEmailTemplateAutoApplier` in `Internal/EmailEditor/WCTransactionalEmails/`.
   - **Per-post atom** (`apply_to_post`): rewrites a single post's content via `WCTransactionalEmailPostsGenerator::compute_canonical_post_content( $email )`, then stamps the four sync meta keys (`_wc_email_template_version`, `_wc_email_template_source_hash`, `_wc_email_last_synced_at`, `_wc_email_template_status = in_sync`). If `wp_update_post` fails the meta writes never run — matches the no-transaction shape RSM-148 shipped after the [#64355 review on the original transaction wrap](https://github.com/woocommerce/woocommerce/pull/64355#discussion_r3146434306).
   - Two-mode contract via `$opts['require_uncustomized']`:
     - **Auto-applier mode (default true)**: hash-gates against `sha1( $post->post_content ) === stored_source_hash`. Race-safe against merchant edits in the gap between the synchronous sweep and the async AS job — returns `WP_Error('post_modified_since_stamp')` and skips when the gate fails.
     - **Reset endpoint mode (false)**: skips the gate. Used by `EmailApiController::reset_response()` for explicit merchant-initiated resets.
   - Re-entrancy flag (`is_auto_applying()`) for future RSM-143/RSM-145 `save_post` listeners that need to distinguish merchant edits from system-initiated writes.
2. **Action Scheduler runner** (`schedule()` + `run()`).
   - `schedule()` enqueues a one-shot async AS action under group `woocommerce-email-editor-integration`, with `as_has_scheduled_action()` short-circuit so a sweep firing twice in one request (`woocommerce_updated` then `BACKFILL_COMPLETE_ACTION`) does not double-enqueue.
   - `run()` queries posts whose status meta is `core_updated_uncustomized` and applies the atom per post inside `try`/`catch(\Throwable)` so a single failure never aborts the batch. Per-post errors route to `WC_Logger` via the email-editor `Logger` adapter at appropriate severity:
     - `post_modified_since_stamp` (race outcome) → `info`
     - `no_stored_hash` / `not_sync_enabled` → `warning`
     - `WP_Error` from `wp_update_post` / `\Throwable` → `error`
     - Email plugin deactivated mid-cycle → silent `continue`
3. **Detector wiring**: `WCEmailTemplateDivergenceDetector::run_sweep()` fires a new `woocommerce_email_template_divergence_sweep_complete` action unconditionally at end of method. `Integration::register_hooks()` listens to that and routes to `WCEmailTemplateAutoApplier::schedule()`. Trigger chain: `woocommerce_updated → run_sweep → completion action → schedule → AS job → run → apply_to_post per post`.
4. **Reset endpoint refactor**: `EmailApiController::reset_response()` now delegates per-post work to `WCEmailTemplateAutoApplier::apply_to_post( $email, $post_id, [ 'require_uncustomized' => false ] )`, so reset and auto-apply share one canonical-write code path. Wire-level BC preserved verbatim — same URL, same `get_reset_schema()` response shape, same error codes (`woocommerce_email_editor_not_initialized` / `woocommerce_email_not_found` / `woocommerce_email_reset_failed`), same null semantics for non-sync-enabled emails. The four pre-existing `test_reset_response_*` tests pass byte-for-byte unchanged.

Tracks events (RSM-145) and customised-post handling (RSM-143) are deferred to follow-up tickets per the issue scope.

### How to test the changes in this Pull Request:

**Prerequisites:** Docker running, `pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env start`, block email editor feature flag enabled.

**End-to-end auto-apply on a "core updated" post:**

1. Enable the block email editor: WooCommerce → Settings → Advanced → Features → Block email editor.
2. Visit Marketing → Emails to trigger first-time generation, then capture the baseline meta on a sync-registered email (e.g. "Customer: Account created"):

   ```sh
   POST_ID=$(pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp option get woocommerce_email_templates_customer_new_account_post_id)
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post meta list $POST_ID --keys=_wc_email_template_version,_wc_email_template_source_hash,_wc_email_last_synced_at,_wc_email_template_status
   ```

   Expect the four meta keys present (status may be empty until a sweep runs).

3. Simulate a divergence-detector classification result by stamping the status manually, seeding a stale `_wc_email_last_synced_at`, and marking the backfill complete (the runner gates on this — in the real upgrade flow it's set by `WCEmailTemplateSyncBackfill`):

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post meta update $POST_ID _wc_email_template_status core_updated_uncustomized
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post meta update $POST_ID _wc_email_last_synced_at "2020-01-01 00:00:00"
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp option update woocommerce_email_template_sync_backfill_complete yes
   ```

4. Invoke the runner directly:

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp eval '\Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier::run();'
   ```

5. Re-list the meta — assert:
   - `_wc_email_template_status` flipped to `in_sync`
   - `_wc_email_last_synced_at` is a fresh UTC timestamp (newer than the seeded 2020 value)
   - `_wc_email_template_source_hash` equals `sha1` of the current `post_content`:

     ```sh
     HASH=$(pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post get $POST_ID --field=post_content | shasum -a 1 | awk '{print $1}')
     META=$(pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post meta get $POST_ID _wc_email_template_source_hash)
     [ "$HASH" = "$META" ] && echo OK || echo MISMATCH
     ```

**Race safety (merchant edit between sweep and AS job):**

6. With `$POST_ID` still in scope, mark the post `core_updated_uncustomized` again, then mutate its content to simulate an in-flight merchant edit:

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post meta update $POST_ID _wc_email_template_status core_updated_uncustomized
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post update $POST_ID --post_content="<p>Merchant edit during AS lag</p>"
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp eval '\Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier::run();'
   ```

7. Verify the auto-applier did NOT overwrite the merchant edit:

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post get $POST_ID --field=post_content
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post meta get $POST_ID _wc_email_template_status
   ```

   The content should still be the merchant edit, and `_wc_email_template_status` should remain `core_updated_uncustomized` so the next sweep re-classifies. The hash-mismatch skip should also be visible in the WC log (browse `wp-content/uploads/wc-logs/`) at `info` severity with context `email_template_auto_applier`.

**Reset endpoint BC verification:**

8. Open "Customer: Account created" in the editor (Marketing → Emails). Click ⋮ → Reset to default. Confirm.
9. Verify the response stamps fresh meta (same shape as RSM-148 shipped):

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp post meta list $POST_ID --keys=_wc_email_template_version,_wc_email_template_source_hash,_wc_email_last_synced_at,_wc_email_template_status
   ```

   `_wc_email_template_status` is `in_sync`, `_wc_email_last_synced_at` is a fresh UTC timestamp.

**Idempotency:**

10. Run the AS callback again with no candidates pending:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli wp eval '\Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier::run();'
    ```

    No-op — no meta or content writes; the candidate query returns empty.

### Testing that has already taken place:

- 19 new PHPUnit tests in `WCEmailTemplateAutoApplierTest` covering: per-post atom (1 happy path + 4 `WP_Error` branches + 2 BC paths for `require_uncustomized=false` + re-entrancy flag); `schedule()` (enqueue + double-enqueue guard); `run()` batched runner (apply uncustomized only, failure isolation, race safety, no-op, idempotency, backfill gate, deactivated-plugin silence); end-to-end wiring via `Integration::register_hooks()`.
- 1 new PHPUnit test in `EmailApiControllerTest` confirming the reset endpoint preserves state on `wp_update_post` failure.
- 1 new PHPUnit test in `WCEmailTemplateDivergenceDetectorTest` confirming the new `woocommerce_email_template_divergence_sweep_complete` action fires once per sweep.
- All four pre-existing `test_reset_response_*` tests in `EmailApiControllerTest` pass byte-for-byte unchanged (wire-level BC verification of the reset endpoint refactor).
- Full email-editor PHPUnit suite: 71 tests / 438 assertions pass (`pnpm test:php:env -- --filter 'WCEmailTemplateAutoApplierTest|WCEmailTemplateDivergenceDetectorTest|WCEmailTemplateSyncBackfillTest|WCEmailTemplateSyncRegistryTest|WCTransactionalEmailPostsGeneratorTest|EmailApiControllerTest'`).
- `pnpm lint:php:changes` and PHPStan on `WCEmailTemplateAutoApplier.php` / `WCEmailTemplateDivergenceDetector.php` / `Integration.php` / `EmailApiController.php` — clean. `pnpm lint:changes:branch` failed locally on a pre-existing PHP 8.4 incompatibility in the Suin PSR4 sniff (reproduces against unrelated trunk files); CI runs PHP 8.1 where the sniff works fine.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry already included in the branch at `plugins/woocommerce/changelog/rsm-139-auto-apply-core-template-updates`.

</details>
