### PR TITLE
Link meta box radius bridge to upstream Trac ticket #65142

### DIFF
--- a/plugins/woocommerce/changelog/tweak-metabox-radius-trac-link
+++ b/plugins/woocommerce/changelog/tweak-metabox-radius-trac-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Link the meta box border-radius bridge CSS to its upstream Trac ticket so future maintainers know when to remove it.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8607,8 +8607,8 @@ table.bar_chart {
 	// ourselves, scoped to Woo editor screens, as a bridge until Core unifies
 	// this.
 	//
-	// TODO: Remove these rules when Core rounds editor .postbox containers
-	// (upstream Trac ticket to be filed).
+	// TODO: Remove these rules when Core rounds editor .postbox containers.
+	// Upstream proposal: https://core.trac.wordpress.org/ticket/65142
 	&.post-type-product,
 	&.post-type-shop_order,
 	&.post-type-shop_coupon,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Tiny follow-up to #64191. When that PR shipped, the bridge CSS in `admin.scss` had a TODO comment with a `(upstream Trac ticket to be filed)` placeholder — I've now filed the upstream ticket and this updates the TODO to point at it.

**Trac ticket:** https://core.trac.wordpress.org/ticket/65142 — proposes Core rounds editor `.postbox` containers to match the dashboard widget pattern already shipped in WP 7.0. If/when Core adopts it, the entire `.wc-wp-version-gte-70` block in #64191 can be deleted.

**Part of:** RSM — Woo Sprinkles

### Screenshots or screen recordings:

No visual changes — this is a comment + URL update only.

### How to test the changes in this Pull Request:

1. View the diff — only two files changed, both trivial.
2. Open `plugins/woocommerce/client/legacy/css/admin.scss` and find the `BRIDGE` comment block (around line 8604).
3. Confirm the `TODO` line now references `https://core.trac.wordpress.org/ticket/65142` instead of the placeholder text.

### Testing that has already taken place:

CSS-only comment + URL update; no behavioural change.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry created manually for `@woocommerce/plugin-woocommerce`.