### PR TITLE
Add experimental product app blueprint configuration

### DIFF
--- a/packages/js/experimental-products-app/README.md
+++ b/packages/js/experimental-products-app/README.md
@@ -1,0 +1,24 @@
+# Experimental Products App
+
+This package is a prototype for the work tracked in [Epic: Improve Product Catalog Management Experience](https://github.com/woocommerce/woocommerce/issues/64414).
+
+It is used to explore a faster, more scalable **All Products** experience in WooCommerce, especially for stores with large catalogs.
+
+Current areas of exploration:
+
+-   A more flexible table-based product view
+-   Better filtering, sorting, and scanning
+-   Inline handling of product variations
+-   Faster quick edit and bulk edit flows
+-   A clearer extension surface for integrations
+
+## Try It Quickly
+
+You can try the experimental products app in [WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fwoocommerce%2Fwoocommerce%2F8588e7cc98f16c51527136ff0600e74967db77a3%2Fpackages%2Fjs%2Fexperimental-products-app%2Fblueprint.json&random=pf6owa52dsr).
+
+The shared Blueprint:
+
+-   Installs WooCommerce nightly, Gutenberg, and WooCommerce Beta Tester
+-   Enables the required feature flags
+-   Imports WooCommerce sample products from CSV
+-   Opens the experimental products dashboard directly

--- a/packages/js/experimental-products-app/blueprint.json
+++ b/packages/js/experimental-products-app/blueprint.json
@@ -1,0 +1,52 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/edit.php?post_type=product&page=woocommerce-products-dashboard",
+	"preferredVersions": {
+		"php": "8.2",
+		"wp": "latest"
+	},
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "url",
+				"url": "https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "gutenberg"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "url",
+				"url": "https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-3.0.0/woocommerce-beta-tester.zip"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-load.php'; delete_transient( '_wc_activation_redirect' ); update_option( 'woocommerce_onboarding_profile', array( 'skipped' => true ) ); update_option( 'wc_admin_helper_feature_values', array( 'product-data-views' => true ) ); $experiments = get_option( 'gutenberg-experiments', array() ); if ( ! is_array( $experiments ) ) { $experiments = array(); } $experiments['gutenberg-editor-inspector-use-dataform'] = true; update_option( 'gutenberg-experiments', $experiments ); if ( 0 === wp_count_posts( 'product' )->publish ) { if ( ! class_exists( '\\Automattic\\WooCommerce\\Admin\\API\\OnboardingTasks' ) ) { require_once WC_ABSPATH . 'src/Admin/API/OnboardingTasks.php'; } $import = \\Automattic\\WooCommerce\\Admin\\API\\OnboardingTasks::import_sample_products_from_csv( WC_ABSPATH . 'sample-data/sample_products.csv' ); if ( is_wp_error( $import ) ) { wp_die( esc_html( $import->get_error_message() ) ); } }"
+		}
+	]
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Add a WordPress Playground `blueprint.json` for `@woocommerce/experimental-products-app` so reviewers can launch a test store directly into the experimental products dashboard. The blueprint installs WooCommerce nightly, Gutenberg, and WooCommerce Beta Tester, enables the required feature flags, and imports WooCommerce sample products through the core CSV importer.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR adds testing and documentation support for an experimental products app and does not change production merchant-facing behavior.

</details>


Part of #64414