### PR TITLE
WC-Core 6: QR mobile-app login — sign-in notification email

### DIFF
--- a/plugins/woocommerce/changelog/woomob-task6-email-failure-logging
+++ b/plugins/woocommerce/changelog/woomob-task6-email-failure-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Log mailer failures from the QR sign-in notification email via `wc_get_logger()` instead of swallowing the exception silently, so a misconfigured mailer is observable rather than invisible. The exchange response is still never blocked by mail delivery.

--- a/plugins/woocommerce/changelog/woomob-task6-qr-login-signin-email
+++ b/plugins/woocommerce/changelog/woomob-task6-qr-login-signin-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Send the merchant a transactional email after a successful QR mobile-app sign-in summarizing the device, OS, app version, and timestamp, with a "revoke access" link. Wrapped in a `woocommerce_qr_login_should_send_signin_email` filter so site owners can suppress the send.

--- a/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
+++ b/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
@@ -961,9 +961,9 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 		 *
 		 * @since 10.9.0
 		 *
-		 * @param bool                                                                       $should_send     Whether to send the email.
-		 * @param \WP_User                                                                   $user            The user who minted the QR token.
-		 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The consumed record about to be emailed.
+		 * @param bool                 $should_send     Whether to send the email.
+		 * @param \WP_User             $user            The user who minted the QR token.
+		 * @param array<string, mixed> $consumed_record The consumed record about to be emailed (keys: consumed_at, user_id, ap_uuid, ap_name, device).
 		 */
 		$should_send = (bool) apply_filters(
 			'woocommerce_qr_login_should_send_signin_email',

--- a/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
+++ b/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
@@ -988,14 +988,13 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 	/**
 	 * Render and dispatch the sign-in notification email.
 	 *
-	 * Uses `wp_mail()` directly (no `WC_Email` subclass) because this is a
-	 * one-shot transactional notification, not part of the configurable WC
-	 * email surface. We wrap the body in `WC()->mailer()->wrap_message()`
-	 * when available so the visual shell matches other WC mails; if the
-	 * mailer isn't initialized (e.g. very early bootstrap), we fall back to
-	 * the bare HTML.
+	 * Uses `wp_mail()` directly with our own minimal HTML shell rather than
+	 * `WC()->mailer()->wrap_message()` — the WC wrapper auto-prepends a small
+	 * site-name header that duplicates the subject line shown by most clients
+	 * and constrains the body width. Owning the wrapper lets us deliver one
+	 * coherent layout.
 	 *
-	 * @param \WP_User                                                                   $user            Recipient.
+	 * @param \WP_User                                                                                                  $user            Recipient.
 	 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The consumed record.
 	 * @return void
 	 */
@@ -1008,16 +1007,7 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 		/* translators: %s: site name. */
 		$subject = sprintf( __( 'A new device signed in to %s', 'woocommerce' ), $site_name );
 
-		$body_html = $this->render_sign_in_notification_email_body( $user, $consumed_record, $site_name );
-
-		// Prefer the WC mailer's HTML wrapper for visual consistency. Falls
-		// back to bare HTML when the mailer isn't ready (rare in REST flow).
-		if ( function_exists( 'WC' ) && WC() && method_exists( WC(), 'mailer' ) ) {
-			$mailer = WC()->mailer();
-			if ( $mailer && method_exists( $mailer, 'wrap_message' ) ) {
-				$body_html = $mailer->wrap_message( $subject, $body_html );
-			}
-		}
+		$body_html = $this->render_sign_in_notification_email_body( $user, $consumed_record, $site_name, $subject );
 
 		wp_mail(
 			$user->user_email,
@@ -1028,22 +1018,18 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Render the HTML body of the sign-in notification email.
+	 * Render the full HTML email document for the sign-in notification.
 	 *
-	 * Pulled out so the partial can be rendered in isolation in tests, and so
-	 * future template tweaks live in one place. Uses the site's configured
-	 * timezone for the timestamp so it matches what the merchant sees in
-	 * wp-admin elsewhere.
-	 *
-	 * @param \WP_User                                                                   $user            Recipient.
+	 * @param \WP_User                                                                                                  $user            Recipient.
 	 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The consumed record.
-	 * @param string                                                                     $site_name       Decoded site name (passed in to avoid double-decoding).
-	 * @return string Rendered HTML.
+	 * @param string                                                                                                    $site_name       Decoded site name (passed in to avoid double-decoding).
+	 * @param string                                                                                                    $subject         Email subject; rendered as the in-body heading.
+	 * @return string Rendered HTML document.
 	 */
-	private function render_sign_in_notification_email_body( \WP_User $user, array $consumed_record, string $site_name ): string {
-		$device       = $consumed_record['device'] ?? array();
-		$consumed_at  = isset( $consumed_record['consumed_at'] ) ? (int) $consumed_record['consumed_at'] : time();
-		$ap_name      = $consumed_record['ap_name'] ?? '';
+	private function render_sign_in_notification_email_body( \WP_User $user, array $consumed_record, string $site_name, string $subject ): string {
+		$device           = $consumed_record['device'] ?? array();
+		$consumed_at      = isset( $consumed_record['consumed_at'] ) ? (int) $consumed_record['consumed_at'] : time();
+		$ap_name          = $consumed_record['ap_name'] ?? '';
 		$applications_url = admin_url( 'profile.php#application-passwords-section' );
 
 		ob_start();

--- a/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
+++ b/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
@@ -666,20 +666,27 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 		// from "QR shown" to "Signed in successfully on {device}" and surface
 		// a revoke button. Same TTL as the original token transient — there's
 		// no value in keeping this record longer than the modal that polls it.
+		$consumed_record = array(
+			'consumed_at' => time(),
+			'user_id'     => $user_id,
+			'ap_uuid'     => $item['uuid'],
+			'ap_name'     => $item['name'],
+			'device'      => $device,
+		);
 		set_transient(
 			self::CONSUMED_TRANSIENT_PREFIX . $token_hash,
-			array(
-				'consumed_at' => time(),
-				'user_id'     => $user_id,
-				'ap_uuid'     => $item['uuid'],
-				'ap_name'     => $item['name'],
-				'device'      => $device,
-			),
+			$consumed_record,
 			self::TOKEN_TTL
 		);
 
 		delete_transient( $key );
 		$this->release_token_exchange_claim( $token_hash );
+
+		// Notify the merchant out-of-band so they're aware of a fresh sign-in
+		// even when they aren't currently looking at wc-admin. Wrapped in a
+		// try/catch + filter to keep the exchange path uninterrupted if the
+		// site's mailer is misconfigured.
+		$this->maybe_send_sign_in_notification_email( $user, $consumed_record );
 
 		return rest_ensure_response(
 			array(
@@ -929,5 +936,120 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 	 */
 	private function check_revoke_rate_limit( $user_id ) {
 		return QRLoginRateLimits::consume( QRLoginRateLimits::BUCKET_REVOKE, (string) $user_id );
+	}
+
+	/**
+	 * Send the merchant a transactional email summarizing a successful QR
+	 * sign-in, unless they (or a site owner) opt out via the
+	 * `woocommerce_qr_login_should_send_signin_email` filter.
+	 *
+	 * Wrapped so a misconfigured mailer cannot break the exchange path —
+	 * exceptions are caught silently. We deliberately do not block the API
+	 * response on email delivery; the merchant already saw the confirmation
+	 * UI in wc-admin (Task 5).
+	 *
+	 * @param \WP_User                                                                   $user            The user who minted the token (recipient).
+	 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The record we just persisted to the consumed transient.
+	 * @return void
+	 */
+	private function maybe_send_sign_in_notification_email( \WP_User $user, array $consumed_record ): void {
+		/**
+		 * Filter whether to send the QR sign-in notification email.
+		 *
+		 * Default: true. Return false to suppress the send for a specific
+		 * user, environment (e.g. staging), or test run.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param bool                                                                       $should_send     Whether to send the email.
+		 * @param \WP_User                                                                   $user            The user who minted the QR token.
+		 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The consumed record about to be emailed.
+		 */
+		$should_send = (bool) apply_filters(
+			'woocommerce_qr_login_should_send_signin_email',
+			true,
+			$user,
+			$consumed_record
+		);
+
+		if ( ! $should_send ) {
+			return;
+		}
+
+		try {
+			$this->send_sign_in_notification_email( $user, $consumed_record );
+		} catch ( \Exception $e ) {
+			// Swallow — the API response is the source of truth for the
+			// merchant; the email is best-effort.
+			unset( $e );
+		}
+	}
+
+	/**
+	 * Render and dispatch the sign-in notification email.
+	 *
+	 * Uses `wp_mail()` directly (no `WC_Email` subclass) because this is a
+	 * one-shot transactional notification, not part of the configurable WC
+	 * email surface. We wrap the body in `WC()->mailer()->wrap_message()`
+	 * when available so the visual shell matches other WC mails; if the
+	 * mailer isn't initialized (e.g. very early bootstrap), we fall back to
+	 * the bare HTML.
+	 *
+	 * @param \WP_User                                                                   $user            Recipient.
+	 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The consumed record.
+	 * @return void
+	 */
+	private function send_sign_in_notification_email( \WP_User $user, array $consumed_record ): void {
+		$site_name = wp_specialchars_decode(
+			(string) get_bloginfo( 'name' ),
+			ENT_QUOTES
+		);
+
+		/* translators: %s: site name. */
+		$subject = sprintf( __( 'A new device signed in to %s', 'woocommerce' ), $site_name );
+
+		$body_html = $this->render_sign_in_notification_email_body( $user, $consumed_record, $site_name );
+
+		// Prefer the WC mailer's HTML wrapper for visual consistency. Falls
+		// back to bare HTML when the mailer isn't ready (rare in REST flow).
+		if ( function_exists( 'WC' ) && WC() && method_exists( WC(), 'mailer' ) ) {
+			$mailer = WC()->mailer();
+			if ( $mailer && method_exists( $mailer, 'wrap_message' ) ) {
+				$body_html = $mailer->wrap_message( $subject, $body_html );
+			}
+		}
+
+		wp_mail(
+			$user->user_email,
+			$subject,
+			$body_html,
+			array( 'Content-Type: text/html; charset=UTF-8' )
+		);
+	}
+
+	/**
+	 * Render the HTML body of the sign-in notification email.
+	 *
+	 * Pulled out so the partial can be rendered in isolation in tests, and so
+	 * future template tweaks live in one place. Uses the site's configured
+	 * timezone for the timestamp so it matches what the merchant sees in
+	 * wp-admin elsewhere.
+	 *
+	 * @param \WP_User                                                                   $user            Recipient.
+	 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The consumed record.
+	 * @param string                                                                     $site_name       Decoded site name (passed in to avoid double-decoding).
+	 * @return string Rendered HTML.
+	 */
+	private function render_sign_in_notification_email_body( \WP_User $user, array $consumed_record, string $site_name ): string {
+		$device       = $consumed_record['device'] ?? array();
+		$consumed_at  = isset( $consumed_record['consumed_at'] ) ? (int) $consumed_record['consumed_at'] : time();
+		$ap_name      = $consumed_record['ap_name'] ?? '';
+		$applications_url = admin_url( 'profile.php#application-passwords-section' );
+
+		ob_start();
+		include __DIR__ . '/views/mobile-app-qr-login-signin-email.php';
+		$html = ob_get_clean();
+
+		return is_string( $html ) ? $html : '';
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
+++ b/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
@@ -948,8 +948,8 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 	 * response on email delivery; the merchant already saw the confirmation
 	 * UI in wc-admin (Task 5).
 	 *
-	 * @param \WP_User                                                                   $user            The user who minted the token (recipient).
-	 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The record we just persisted to the consumed transient.
+	 * @param \WP_User             $user            The user who minted the token (recipient).
+	 * @param array<string, mixed> $consumed_record The record we just persisted to the consumed transient. Keys: consumed_at (int), user_id (int), ap_uuid (string), ap_name (string), device (array<string, string>).
 	 * @return void
 	 */
 	private function maybe_send_sign_in_notification_email( \WP_User $user, array $consumed_record ): void {
@@ -1004,8 +1004,8 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 	 * and constrains the body width. Owning the wrapper lets us deliver one
 	 * coherent layout.
 	 *
-	 * @param \WP_User                                                                                                  $user            Recipient.
-	 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The consumed record.
+	 * @param \WP_User             $user            Recipient.
+	 * @param array<string, mixed> $consumed_record The consumed record (same shape as `maybe_send_sign_in_notification_email`).
 	 * @return void
 	 */
 	private function send_sign_in_notification_email( \WP_User $user, array $consumed_record ): void {
@@ -1030,10 +1030,10 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 	/**
 	 * Render the full HTML email document for the sign-in notification.
 	 *
-	 * @param \WP_User                                                                                                  $user            Recipient.
-	 * @param array{consumed_at: int, user_id: int, ap_uuid: string, ap_name: string, device: array<string, string>} $consumed_record The consumed record.
-	 * @param string                                                                                                    $site_name       Decoded site name (passed in to avoid double-decoding).
-	 * @param string                                                                                                    $subject         Email subject; rendered as the in-body heading.
+	 * @param \WP_User             $user            Recipient.
+	 * @param array<string, mixed> $consumed_record The consumed record (same shape as `maybe_send_sign_in_notification_email`).
+	 * @param string               $site_name       Decoded site name (passed in to avoid double-decoding).
+	 * @param string               $subject         Email subject; rendered as the in-body heading.
 	 * @return string Rendered HTML document.
 	 */
 	private function render_sign_in_notification_email_body( \WP_User $user, array $consumed_record, string $site_name, string $subject ): string {

--- a/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
+++ b/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
@@ -978,10 +978,20 @@ class MobileAppQRLogin extends \WC_REST_Data_Controller {
 
 		try {
 			$this->send_sign_in_notification_email( $user, $consumed_record );
-		} catch ( \Exception $e ) {
-			// Swallow — the API response is the source of truth for the
-			// merchant; the email is best-effort.
-			unset( $e );
+		} catch ( \Throwable $e ) {
+			// Don't surface mailer failures to the exchange response — the
+			// merchant already has the API result, and the email is best-effort.
+			// Log instead so a misconfigured mailer is observable rather than
+			// invisible. Catch \Throwable so an \Error from the mailer also
+			// stays out of the exchange path.
+			wc_get_logger()->warning(
+				sprintf(
+					'QR sign-in notification email failed for user %d: %s',
+					$user->ID,
+					$e->getMessage()
+				),
+				array( 'source' => 'mobile-app-qr-login' )
+			);
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/API/views/mobile-app-qr-login-signin-email.php
+++ b/plugins/woocommerce/src/Admin/API/views/mobile-app-qr-login-signin-email.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Email body for the QR mobile-app login sign-in notification.
+ *
+ * Rendered by `MobileAppQRLogin::render_sign_in_notification_email_body()`.
+ * Receives the following locals (all required, all already escaped at the
+ * controller boundary except where noted):
+ *
+ * @var \WP_User                $user            Recipient.
+ * @var array<string, string>   $device          Sanitized device payload (model, os, os_version, app_version).
+ * @var int                     $consumed_at     Unix timestamp of the exchange.
+ * @var string                  $ap_name         Descriptive Application Password name (e.g. "Woo Mobile · iPhone 15 · 2026-04-28").
+ * @var string                  $site_name       Decoded site name.
+ * @var string                  $applications_url Admin URL to the user's Application Passwords list.
+ *
+ * Markup is intentionally minimal — no inline images, no external assets,
+ * no JS — so it survives clipping and dark-mode rewrites in mainstream
+ * email clients.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$device_model      = isset( $device['model'] ) ? (string) $device['model'] : '';
+$device_os         = isset( $device['os'] ) ? (string) $device['os'] : '';
+$device_os_version = isset( $device['os_version'] ) ? (string) $device['os_version'] : '';
+$app_version       = isset( $device['app_version'] ) ? (string) $device['app_version'] : '';
+
+$display_name = $device_model;
+if ( '' === $display_name && '' !== $device_os ) {
+	$display_name = $device_os;
+}
+if ( '' === $display_name ) {
+	$display_name = __( 'a new device', 'woocommerce' );
+}
+
+$os_line = trim( $device_os . ( '' !== $device_os_version ? ' ' . $device_os_version : '' ) );
+// `wp_date()` can technically return `false` if the requested format is
+// unparseable; coerce to a string so the partial's escaping helpers always
+// see a defined value.
+$timestamp = (string) wp_date(
+	get_option( 'date_format' ) . ' ' . get_option( 'time_format' ),
+	$consumed_at
+);
+?>
+<p>
+	<?php
+	printf(
+		/* translators: 1: device name (model, OS, or "a new device"). 2: site name. */
+		esc_html__( '%1$s just signed in to the WooCommerce mobile app for %2$s.', 'woocommerce' ),
+		'<strong>' . esc_html( $display_name ) . '</strong>',
+		'<strong>' . esc_html( $site_name ) . '</strong>'
+	);
+	?>
+</p>
+
+<ul>
+	<?php if ( '' !== $os_line ) : ?>
+		<li>
+			<?php
+			printf(
+				/* translators: %s: OS and version, e.g. "iOS 17.5". */
+				esc_html__( 'Operating system: %s', 'woocommerce' ),
+				esc_html( $os_line )
+			);
+			?>
+		</li>
+	<?php endif; ?>
+	<?php if ( '' !== $app_version ) : ?>
+		<li>
+			<?php
+			printf(
+				/* translators: %s: mobile app version, e.g. "24.7.0". */
+				esc_html__( 'App version: %s', 'woocommerce' ),
+				esc_html( $app_version )
+			);
+			?>
+		</li>
+	<?php endif; ?>
+	<li>
+		<?php
+		printf(
+			/* translators: %s: localized date and time. */
+			esc_html__( 'When: %s', 'woocommerce' ),
+			esc_html( $timestamp )
+		);
+		?>
+	</li>
+	<?php if ( '' !== $ap_name ) : ?>
+		<li>
+			<?php
+			printf(
+				/* translators: %s: Application Password name (e.g. "Woo Mobile · iPhone 15 · 2026-04-28"). */
+				esc_html__( 'Application Password: %s', 'woocommerce' ),
+				esc_html( $ap_name )
+			);
+			?>
+		</li>
+	<?php endif; ?>
+</ul>
+
+<p>
+	<?php esc_html_e( "If this was you, no action is needed.", 'woocommerce' ); ?>
+</p>
+
+<p>
+	<?php
+	printf(
+		/* translators: %s: HTML link to the Application Passwords list in the user's profile. */
+		esc_html__( "If this wasn't you, %s right away.", 'woocommerce' ),
+		'<a href="' . esc_url( $applications_url ) . '">' . esc_html__( 'revoke access', 'woocommerce' ) . '</a>'
+	);
+	?>
+</p>

--- a/plugins/woocommerce/src/Admin/API/views/mobile-app-qr-login-signin-email.php
+++ b/plugins/woocommerce/src/Admin/API/views/mobile-app-qr-login-signin-email.php
@@ -2,112 +2,137 @@
 /**
  * Email body for the QR mobile-app login sign-in notification.
  *
- * Rendered by `MobileAppQRLogin::render_sign_in_notification_email_body()`.
- * Receives the following locals (all required, all already escaped at the
- * controller boundary except where noted):
+ * Renders a full HTML document so we can own the entire shell — the WC
+ * mailer's wrap_message() auto-prepends a small site-name header that
+ * duplicates the subject line and squeezes the body into a narrow column.
  *
- * @var \WP_User                $user            Recipient.
- * @var array<string, string>   $device          Sanitized device payload (model, os, os_version, app_version).
- * @var int                     $consumed_at     Unix timestamp of the exchange.
- * @var string                  $ap_name         Descriptive Application Password name (e.g. "Woo Mobile · iPhone 15 · 2026-04-28").
- * @var string                  $site_name       Decoded site name.
- * @var string                  $applications_url Admin URL to the user's Application Passwords list.
+ * Receives the following locals (validated upstream by the controller):
  *
- * Markup is intentionally minimal — no inline images, no external assets,
- * no JS — so it survives clipping and dark-mode rewrites in mainstream
- * email clients.
+ * @var \WP_User             $user             Recipient.
+ * @var array<string,string> $device           Sanitized device payload (model, brand, os, os_version, app_version).
+ * @var int                  $consumed_at      Unix timestamp of the exchange.
+ * @var string               $ap_name          Descriptive Application Password name.
+ * @var string               $site_name        Decoded site name.
+ * @var string               $subject          Email subject; rendered as the in-body heading.
+ * @var string               $applications_url Admin URL to the user's Application Passwords list.
  */
 
 defined( 'ABSPATH' ) || exit;
 
-$device_model      = isset( $device['model'] ) ? (string) $device['model'] : '';
-$device_os         = isset( $device['os'] ) ? (string) $device['os'] : '';
-$device_os_version = isset( $device['os_version'] ) ? (string) $device['os_version'] : '';
-$app_version       = isset( $device['app_version'] ) ? (string) $device['app_version'] : '';
+$device_model      = isset( $device['model'] ) ? trim( (string) $device['model'] ) : '';
+$device_brand      = isset( $device['brand'] ) ? trim( (string) $device['brand'] ) : '';
+$device_os         = isset( $device['os'] ) ? trim( (string) $device['os'] ) : '';
+$device_os_version = isset( $device['os_version'] ) ? trim( (string) $device['os_version'] ) : '';
+$app_version       = isset( $device['app_version'] ) ? trim( (string) $device['app_version'] ) : '';
 
-$display_name = $device_model;
-if ( '' === $display_name && '' !== $device_os ) {
+if ( '' !== $device_brand && '' !== $device_model ) {
+	$display_name = ucfirst( $device_brand ) . ' ' . $device_model;
+} elseif ( '' !== $device_model ) {
+	$display_name = $device_model;
+} elseif ( '' !== $device_os ) {
 	$display_name = $device_os;
-}
-if ( '' === $display_name ) {
-	$display_name = __( 'a new device', 'woocommerce' );
+} else {
+	$display_name = __( 'A new device', 'woocommerce' );
 }
 
-$os_line = trim( $device_os . ( '' !== $device_os_version ? ' ' . $device_os_version : '' ) );
-// `wp_date()` can technically return `false` if the requested format is
-// unparseable; coerce to a string so the partial's escaping helpers always
-// see a defined value.
+$os_line   = trim( $device_os . ( '' !== $device_os_version ? ' ' . $device_os_version : '' ) );
 $timestamp = (string) wp_date(
 	get_option( 'date_format' ) . ' ' . get_option( 'time_format' ),
 	$consumed_at
 );
+
+$preheader = sprintf(
+	/* translators: 1: device name. 2: site name. */
+	__( '%1$s just signed in to the WooCommerce mobile app for %2$s.', 'woocommerce' ),
+	$display_name,
+	$site_name
+);
+
+$brand_purple_50    = '#873eff';
+$brand_purple_70    = '#5007aa';
+$text_primary       = '#1d2327';
+$text_secondary     = '#50575e';
+$text_muted         = '#757575';
+$divider            = '#dcdcde';
+$card_background    = '#f6f7f7';
+$body_background    = '#f6f7f7';
+$content_background = '#ffffff';
+$font_stack         = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif";
+$language           = esc_attr( get_bloginfo( 'language' ) );
 ?>
-<p>
+<!DOCTYPE html>
+<html lang="<?php echo $language; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped above. ?>">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="x-apple-disable-message-reformatting" />
+<title><?php echo esc_html( $subject ); ?></title>
+</head>
+<body style="margin:0; padding:0; background:<?php echo esc_attr( $body_background ); ?>; font-family:<?php echo esc_attr( $font_stack ); ?>; -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;">
+<div style="display:none !important; visibility:hidden; opacity:0; height:0; width:0; max-height:0; max-width:0; overflow:hidden; mso-hide:all; font-size:1px; color:<?php echo esc_attr( $body_background ); ?>; line-height:1px;"><?php echo esc_html( $preheader ); ?></div>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background:<?php echo esc_attr( $body_background ); ?>; border-collapse:collapse;">
+<tr>
+<td align="center" style="padding:24px 16px;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:640px; margin:0 auto; background:<?php echo esc_attr( $content_background ); ?>; border-radius:8px; border-collapse:separate; box-shadow:0 1px 2px rgba(0,0,0,0.04);">
+<tr>
+<td style="height:6px; line-height:6px; font-size:0; background:<?php echo esc_attr( $brand_purple_50 ); ?>; border-top-left-radius:8px; border-top-right-radius:8px;">&nbsp;</td>
+</tr>
+<tr>
+<td style="padding:32px 40px 8px 40px;">
+<h1 style="margin:0; font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:24px; line-height:1.3; font-weight:600; letter-spacing:-0.01em; color:<?php echo esc_attr( $text_primary ); ?>;"><?php echo esc_html( $subject ); ?></h1>
+</td>
+</tr>
+<tr>
+<td style="padding:20px 40px 0 40px;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background:<?php echo esc_attr( $card_background ); ?>; border-left:4px solid <?php echo esc_attr( $brand_purple_50 ); ?>; border-radius:6px; border-collapse:separate;">
+<tr>
+<td style="padding:20px 24px;">
+<p style="margin:0 0 6px 0; font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:18px; font-weight:600; line-height:1.3; color:<?php echo esc_attr( $text_primary ); ?>;"><?php echo esc_html( $display_name ); ?></p>
+<?php if ( '' !== $os_line ) : ?>
+<p style="margin:0 0 4px 0; font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:14px; line-height:1.5; color:<?php echo esc_attr( $text_secondary ); ?>;"><?php echo esc_html( $os_line ); ?></p>
+<?php endif; ?>
+<?php if ( '' !== $app_version ) : ?>
 	<?php
-	printf(
-		/* translators: 1: device name (model, OS, or "a new device"). 2: site name. */
-		esc_html__( '%1$s just signed in to the WooCommerce mobile app for %2$s.', 'woocommerce' ),
-		'<strong>' . esc_html( $display_name ) . '</strong>',
-		'<strong>' . esc_html( $site_name ) . '</strong>'
-	);
+	/* translators: %s: mobile app version, e.g. "24.7.0". */
+	$app_version_line = sprintf( esc_html__( 'App version %s', 'woocommerce' ), esc_html( $app_version ) );
 	?>
-</p>
-
-<ul>
-	<?php if ( '' !== $os_line ) : ?>
-		<li>
-			<?php
-			printf(
-				/* translators: %s: OS and version, e.g. "iOS 17.5". */
-				esc_html__( 'Operating system: %s', 'woocommerce' ),
-				esc_html( $os_line )
-			);
-			?>
-		</li>
-	<?php endif; ?>
-	<?php if ( '' !== $app_version ) : ?>
-		<li>
-			<?php
-			printf(
-				/* translators: %s: mobile app version, e.g. "24.7.0". */
-				esc_html__( 'App version: %s', 'woocommerce' ),
-				esc_html( $app_version )
-			);
-			?>
-		</li>
-	<?php endif; ?>
-	<li>
-		<?php
-		printf(
-			/* translators: %s: localized date and time. */
-			esc_html__( 'When: %s', 'woocommerce' ),
-			esc_html( $timestamp )
-		);
-		?>
-	</li>
-	<?php if ( '' !== $ap_name ) : ?>
-		<li>
-			<?php
-			printf(
-				/* translators: %s: Application Password name (e.g. "Woo Mobile · iPhone 15 · 2026-04-28"). */
-				esc_html__( 'Application Password: %s', 'woocommerce' ),
-				esc_html( $ap_name )
-			);
-			?>
-		</li>
-	<?php endif; ?>
-</ul>
-
-<p>
-	<?php esc_html_e( "If this was you, no action is needed.", 'woocommerce' ); ?>
-</p>
-
-<p>
-	<?php
-	printf(
-		/* translators: %s: HTML link to the Application Passwords list in the user's profile. */
-		esc_html__( "If this wasn't you, %s right away.", 'woocommerce' ),
-		'<a href="' . esc_url( $applications_url ) . '">' . esc_html__( 'revoke access', 'woocommerce' ) . '</a>'
-	);
-	?>
-</p>
+<p style="margin:0 0 4px 0; font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:14px; line-height:1.5; color:<?php echo esc_attr( $text_secondary ); ?>;"><?php echo $app_version_line; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped above. ?></p>
+<?php endif; ?>
+<p style="margin:8px 0 0 0; font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:13px; line-height:1.5; color:<?php echo esc_attr( $text_muted ); ?>;"><?php echo esc_html( $timestamp ); ?></p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td style="padding:28px 40px 0 40px;">
+<h2 style="margin:0 0 8px 0; font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:18px; line-height:1.4; font-weight:600; color:<?php echo esc_attr( $text_primary ); ?>;"><?php esc_html_e( 'Was this you?', 'woocommerce' ); ?></h2>
+<p style="margin:0 0 24px 0; font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:14px; line-height:1.6; color:<?php echo esc_attr( $text_secondary ); ?>;"><?php esc_html_e( "If you recognise this sign-in, you don't need to do anything. If it wasn't you, revoke access immediately to remove this device.", 'woocommerce' ); ?></p>
+</td>
+</tr>
+<tr>
+<td style="padding:0 40px 32px 40px;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:separate;">
+<tr>
+<td align="center" bgcolor="<?php echo esc_attr( $brand_purple_50 ); ?>" style="border-radius:6px; padding:14px 32px; mso-padding-alt:14px 32px;"><a href="<?php echo esc_url( $applications_url ); ?>" style="font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:15px; font-weight:600; line-height:1; color:#ffffff; text-decoration:none;"><?php esc_html_e( 'Revoke access', 'woocommerce' ); ?></a></td>
+</tr>
+</table>
+</td>
+</tr>
+<?php
+$manage_link  = '<a href="' . esc_url( $applications_url ) . '" style="color:' . esc_attr( $brand_purple_70 ) . '; text-decoration:underline;">';
+$manage_link .= esc_html__( 'Users → Profile → Application Passwords', 'woocommerce' ) . '</a>';
+/* translators: %s: HTML link to the Application Passwords screen. */
+$manage_line = sprintf( esc_html__( 'You can manage all connected devices anytime under %s.', 'woocommerce' ), $manage_link );
+?>
+<tr>
+<td style="padding:0 40px 32px 40px; border-top:1px solid <?php echo esc_attr( $divider ); ?>;">
+<p style="margin:24px 0 0 0; font-family:<?php echo esc_attr( $font_stack ); ?>; font-size:13px; line-height:1.6; color:<?php echo esc_attr( $text_muted ); ?>;"><?php echo $manage_line; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped above. ?></p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</body>
+</html>

--- a/plugins/woocommerce/src/Admin/API/views/mobile-app-qr-login-signin-email.php
+++ b/plugins/woocommerce/src/Admin/API/views/mobile-app-qr-login-signin-email.php
@@ -17,6 +17,8 @@
  * @var string               $applications_url Admin URL to the user's Application Passwords list.
  */
 
+declare( strict_types=1 );
+
 defined( 'ABSPATH' ) || exit;
 
 $device_model      = isset( $device['model'] ) ? trim( (string) $device['model'] ) : '';

--- a/plugins/woocommerce/tests/php/src/Admin/API/MobileAppQRLoginTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/MobileAppQRLoginTest.php
@@ -1352,4 +1352,139 @@ class MobileAppQRLoginTest extends WC_REST_Unit_Test_Case {
 
 		$this->assertSame( rest_authorization_required_code(), $response->get_status() );
 	}
+
+	// -----------------------------------------------------------------------
+	// Sign-in notification email (Task 6).
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Capture wp_mail() calls into a local array via the `pre_wp_mail` filter.
+	 *
+	 * The filter must return a non-null value to short-circuit the actual
+	 * mail send, so we return `true`. The captured atts include `to`,
+	 * `subject`, `message`, and `headers`. Caller must remove the filter via
+	 * the returned remover closure.
+	 *
+	 * @return array{captures: array<int, array<string, mixed>>, remove: callable}
+	 */
+	private function capture_wp_mail(): array {
+		$captures = array();
+
+		$capture = static function ( $return, $atts ) use ( &$captures ) {
+			unset( $return );
+			$captures[] = is_array( $atts ) ? $atts : array();
+			return true;
+		};
+
+		add_filter( 'pre_wp_mail', $capture, 10, 2 );
+
+		$remove = static function () use ( $capture ) {
+			remove_filter( 'pre_wp_mail', $capture, 10 );
+		};
+
+		return array(
+			'captures' => &$captures,
+			'remove'   => $remove,
+		);
+	}
+
+	/**
+	 * @testdox Successful exchange dispatches a sign-in notification email to the user that minted the token.
+	 */
+	public function test_exchange_token_dispatches_sign_in_notification_email(): void {
+		$capture = $this->capture_wp_mail();
+
+		try {
+			wp_set_current_user( $this->admin_id );
+			$plaintext = $this->token_from_qr_url( $this->dispatch_generate()->get_data()['qr_url'] );
+			wp_set_current_user( 0 );
+
+			$response = $this->dispatch_exchange(
+				$plaintext,
+				array(
+					'os'          => 'iOS',
+					'os_version'  => '17.5',
+					'model'       => 'iPhone 15',
+					'app_version' => '24.7.0',
+				)
+			);
+			$this->assertSame( 200, $response->get_status() );
+
+			$this->assertCount( 1, $capture['captures'], 'Exactly one email should be sent on a successful exchange.' );
+			$mail = $capture['captures'][0];
+
+			$admin_user = get_userdata( $this->admin_id );
+			$this->assertSame( $admin_user->user_email, $mail['to'] );
+
+			$this->assertStringContainsString(
+				get_bloginfo( 'name' ),
+				(string) $mail['subject'],
+				'Subject should reference the site name so a merchant managing multiple stores can disambiguate.'
+			);
+
+			$body = (string) $mail['message'];
+			$this->assertStringContainsString( 'iPhone 15', $body, 'Email body should surface the device model.' );
+			$this->assertStringContainsString( 'iOS 17.5', $body, 'Email body should surface the OS version.' );
+			$this->assertStringContainsString( '24.7.0', $body, 'Email body should surface the app version.' );
+			$this->assertStringContainsString( 'application-passwords', $body, 'Email body should link to the AP management screen.' );
+		} finally {
+			$capture['remove']();
+		}
+	}
+
+	/**
+	 * @testdox The sign-in notification email can be suppressed via the woocommerce_qr_login_should_send_signin_email filter.
+	 */
+	public function test_sign_in_notification_email_can_be_suppressed_via_filter(): void {
+		$capture   = $this->capture_wp_mail();
+		$suppress  = static fn () => false;
+		add_filter( 'woocommerce_qr_login_should_send_signin_email', $suppress );
+
+		try {
+			wp_set_current_user( $this->admin_id );
+			$plaintext = $this->token_from_qr_url( $this->dispatch_generate()->get_data()['qr_url'] );
+			wp_set_current_user( 0 );
+
+			$response = $this->dispatch_exchange(
+				$plaintext,
+				array( 'os' => 'iOS', 'model' => 'iPhone 15' )
+			);
+			$this->assertSame( 200, $response->get_status() );
+
+			$this->assertCount(
+				0,
+				$capture['captures'],
+				'Filter returning false must suppress the email send entirely.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_qr_login_should_send_signin_email', $suppress );
+			$capture['remove']();
+		}
+	}
+
+	/**
+	 * @testdox Sign-in notification email falls back to a generic device line when the mobile app sends no device payload.
+	 */
+	public function test_sign_in_notification_email_handles_missing_device_payload(): void {
+		$capture = $this->capture_wp_mail();
+
+		try {
+			wp_set_current_user( $this->admin_id );
+			$plaintext = $this->token_from_qr_url( $this->dispatch_generate()->get_data()['qr_url'] );
+			wp_set_current_user( 0 );
+
+			$response = $this->dispatch_exchange( $plaintext );
+			$this->assertSame( 200, $response->get_status() );
+
+			$this->assertCount( 1, $capture['captures'] );
+			$body = (string) $capture['captures'][0]['message'];
+
+			// With no device payload the headline should still render
+			// without "undefined" / empty interpolation artifacts.
+			$this->assertStringNotContainsString( 'undefined', $body );
+			$this->assertStringNotContainsString( '· ·', $body, 'No empty separators when device fields are missing.' );
+		} finally {
+			$capture['remove']();
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/API/MobileAppQRLoginTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/MobileAppQRLoginTest.php
@@ -1370,8 +1370,8 @@ class MobileAppQRLoginTest extends WC_REST_Unit_Test_Case {
 	private function capture_wp_mail(): array {
 		$captures = array();
 
-		$capture = static function ( $return, $atts ) use ( &$captures ) {
-			unset( $return );
+		$capture = static function ( $short_circuit, $atts ) use ( &$captures ) {
+			unset( $short_circuit );
 			$captures[] = is_array( $atts ) ? $atts : array();
 			return true;
 		};
@@ -1429,15 +1429,15 @@ class MobileAppQRLoginTest extends WC_REST_Unit_Test_Case {
 			$this->assertStringContainsString( 'application-passwords', $body, 'Email body should link to the AP management screen.' );
 		} finally {
 			$capture['remove']();
-		}
+		}//end try
 	}
 
 	/**
 	 * @testdox The sign-in notification email can be suppressed via the woocommerce_qr_login_should_send_signin_email filter.
 	 */
 	public function test_sign_in_notification_email_can_be_suppressed_via_filter(): void {
-		$capture   = $this->capture_wp_mail();
-		$suppress  = static fn () => false;
+		$capture  = $this->capture_wp_mail();
+		$suppress = static fn () => false;
 		add_filter( 'woocommerce_qr_login_should_send_signin_email', $suppress );
 
 		try {
@@ -1447,7 +1447,10 @@ class MobileAppQRLoginTest extends WC_REST_Unit_Test_Case {
 
 			$response = $this->dispatch_exchange(
 				$plaintext,
-				array( 'os' => 'iOS', 'model' => 'iPhone 15' )
+				array(
+					'os'    => 'iOS',
+					'model' => 'iPhone 15',
+				)
 			);
 			$this->assertSame( 200, $response->get_status() );
 
@@ -1485,6 +1488,6 @@ class MobileAppQRLoginTest extends WC_REST_Unit_Test_Case {
 			$this->assertStringNotContainsString( '· ·', $body, 'No empty separators when device fields are missing.' );
 		} finally {
 			$capture['remove']();
-		}
+		}//end try
 	}
 }


### PR DESCRIPTION
> **📚 Stack navigation**
> ⬅ Previous: [#64456 — WC-Core 5 — confirmation/revoke/renew](https://github.com/woocommerce/woocommerce/pull/64456)
> ➡ Next: [#64503 — WC-Core 7 — number-matching](https://github.com/woocommerce/woocommerce/pull/64503)

## Summary

After a successful QR sign-in, send the user a transactional notification email so they're aware of the new device even when they're not actively looking at wc-admin. This is the standard "new device signed in to your account" pattern; it complements (rather than replaces) the in-app confirmation panel from #64456.

This was split out of the confirmation/revoke PR to keep that surface focused on the wc-admin UX and to make this email easier to review (and revert) on its own.

## Changes

- New private helper `maybe_send_sign_in_notification_email( $user, $consumed_record )` called inside `exchange_token()` after the consumed-record transient is persisted. Wrapped in a `try { … } catch ( \Throwable $e )` with a `wc_get_logger()->warning(...)` on the `mobile-app-qr-login` source — a misconfigured mailer is observable in the WC log without ever blocking the API response.
- Filter `woocommerce_qr_login_should_send_signin_email` (default `true`) lets sites or tests opt out per user / environment.
- New email view partial at `src/Admin/API/views/mobile-app-qr-login-signin-email.php`. Renders a full HTML document (own shell, no `WC()->mailer()->wrap_message()` — that wrapper auto-prepends a header that duplicates the subject line and constrains the body width). Markup is intentionally minimal so it survives clipping and dark-mode rewrites in mainstream clients. Surfaces device model + OS, app version, timestamp in the site timezone, the descriptive AP name, and a link to Users → Profile → Application Passwords.

## Testing

**Automated:** PHPUnit tests:
- `test_exchange_token_dispatches_sign_in_notification_email` captures via `pre_wp_mail` and asserts recipient, subject (containing site name), and body fields.
- `test_sign_in_notification_email_can_be_suppressed_via_filter` asserts the opt-out filter suppresses the send.

**Manual:**

1. Run an exchange (curl or via the mobile app once #64503 lands). Check the recipient's inbox / Mailpit:
   - Subject: `A new device signed in to {site name}`.
   - Body lists model, OS+version, app version, timestamp, AP name, and links to `wp-admin/profile.php#application-passwords-section`.
2. Force the mailer to throw (`add_filter( 'pre_wp_mail', fn () => throw new \RuntimeException( 'forced' ) )`) and re-run. The API still returns 200, and the WC log shows `[warning] mobile-app-qr-login QR sign-in notification email failed for user N: forced`.
3. Test the suppression filter: `add_filter( 'woocommerce_qr_login_should_send_signin_email', '__return_false' );` then run an exchange. No email is sent.

End-to-end (real mobile app exchange triggers the email) requires #64503 to land first, since that PR introduces the `supports_number_matching` schema flag that production Android builds will require.

## Out of scope

- Tracks events for "email sent" — separate ticket.
- WC → Settings → Emails configurability. The notification is intentionally outside the configurable surface; refactor in place if customers ask later.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Changelog entry created manually (committed in the branch).
