### PR TITLE
Fix typo in OrdersTableQuery comment

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		/**
 		 * Check for task list initialization.
 		 */
-		private $initalized = false;
+		private $initialized = false;
 
 		/**
 		 * The task list.
@@ -116,12 +116,12 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return array
 		 */
 		public function get_task_list() {
-			if ( $this->task_list || $this->initalized ) {
+			if ( $this->task_list || $this->initialized ) {
 				return $this->task_list;
 			}
 
 			$this->set_task_list( TaskLists::get_list( 'setup' ) );
-			$this->initalized = true;
+			$this->initialized = true;
 			return $this->task_list;
 		}
 

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -905,7 +905,7 @@ if ( 0 < $mu_plugins_count ) :
 
 				if ( ! empty( $_page['shortcode'] ) || ! empty( $_page['block'] ) ) {
 					// We check first if, in a blocks theme, the template content does not load the page content.
-					if ( CartCheckoutUtils::is_overriden_by_custom_template_content( $_page['block'] ) ) {
+					if ( CartCheckoutUtils::is_overridden_by_custom_template_content( $_page['block'] ) ) {
 						$additional_info = __( "This page's content is overridden by custom template content", 'woocommerce' );
 					} elseif ( $_page['shortcode_present'] ) {
 						// Always display the shortcode with square brackets for consistency.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -1593,7 +1593,7 @@ class WC_Tracker {
 	 * Check if any core emails are being overridden by a template override.
 	 *
 	 * @param array $template_overrides Template overrides.
-	 * @return array Array with count of core email overrides and the templates that are overriden.
+	 * @return array Array with count of core email overrides and the templates that are overridden.
 	 */
 	public static function get_core_email_overrides( $template_overrides ): array {
 		$email_template_overrides = EmailImprovements::get_core_email_overrides( $template_overrides );

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -309,7 +309,7 @@ class CartCheckoutUtils {
 	 *
 	 * @return bool true if the template has out of sync content.
 	 */
-	public static function is_overriden_by_custom_template_content( string $block ): bool {
+	public static function is_overridden_by_custom_template_content( string $block ): bool {
 
 		$block = str_replace( 'woocommerce/', '', $block );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1349,7 +1349,7 @@ class OrdersTableQuery {
 		$order   = $this->sanitize_order( $this->args['order'] ?? '' );
 		$orderby = $this->sanitize_order_orderby( $this->args['orderby'] ?? 'none' );
 
-		// Set orderby to an empty array by default. This will also be used if sanitize_order_orderby recieved "none".
+		// Set orderby to an empty array by default. This will also be used if sanitize_order_orderby received "none".
 		$this->orderby = array();
 
 		if ( 'include' === $orderby || 'post__in' === $orderby ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a spelling typo in a code comment inside `OrdersTableQuery.php`. The word "recieved" was corrected to "received" in the comment that explains behavior when `sanitize_order_orderby` is passed `"none"`.

### How to test the changes in this Pull Request:

1. Open `plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php` around line 1352.
2. Confirm the comment reads `received` (not `recieved`).

### Testing that has already taken place:

Comment-only change — no functional code was modified.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Comment-only typo fix — no functional change, no changelog needed.

</details>