### PR TITLE
Fix typos in test method name and comment (overriden -> overridden)

### DIFF
--- a/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item.php
@@ -101,7 +101,7 @@ class WC_Tests_Base_Order_Item extends WC_Unit_Test_Case {
 	/**
 	 * @testdox 'calculate_cogs_value' sets the value returned by the 'calculate_cogs_core' override, and returns true.
 	 */
-	public function test_calculate_cogs_sets_value_from_core_calculation_overriden_in_child_class() {
+	public function test_calculate_cogs_sets_value_from_core_calculation_overridden_in_child_class() {
 		$this->sut->has_cogs_value = true;
 		$this->enable_cogs_feature();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
@@ -69,7 +69,7 @@ class EvaluateOverridesTest extends WC_Unit_Test_Case {
 		$extensions = $this->get_extensions();
 		$result     = $evaluator->evaluate( array( $extensions[3] ) );
 
-		// Evaluation should pass and return the overriden value.
+		// Evaluation should pass and return the overridden value.
 		$this->assertEquals( 2, $result[0]->order );
 
 		// Reset the default country.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes two spelling typos in test files:

1. `class-wc-tests-order-item.php` line 104: test method `test_calculate_cogs_sets_value_from_core_calculation_overriden_in_child_class` renamed to use "overridden" (double-r).
2. `EvaluateOverridesTest.php` line 72: inline comment "overriden value" corrected to "overridden value".

### How to test the changes in this Pull Request:

1. Open `plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item.php` line 104 and confirm the method name reads `overridden`.
2. Open `plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php` line 72 and confirm the comment reads "overridden".
3. Run the affected test class to confirm it still passes: `pnpm test:php:env -- --filter WC_Tests_Base_Order_Item`.

### Testing that has already taken place:

Test method renames are safe — PHPUnit discovers methods dynamically. No functional test logic was changed.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Test-only typo fix — no production code changed, no changelog needed.

</details>