### PR TITLE
Flatten variable-product BIS signup to a real accessible form (RSM-446)

### DIFF
--- a/plugins/woocommerce/changelog/rsm-446-bis-variations-a11y
+++ b/plugins/woocommerce/changelog/rsm-446-bis-variations-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace the jQuery synthetic-submit workaround on the variable-product Back in Stock Notifications sign-up with a real accessible `<form>`, declaratively synced to the selected variation. Behind the `WOOCOMMERCE_BIS_ALPHA_ENABLED` alpha gate.

--- a/plugins/woocommerce/changelog/rsm-446-bis-variations-a11y
+++ b/plugins/woocommerce/changelog/rsm-446-bis-variations-a11y
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Replace the jQuery synthetic-submit workaround on the variable-product Back in Stock Notifications sign-up with a real accessible `<form>`, declaratively synced to the selected variation. Behind the `WOOCOMMERCE_BIS_ALPHA_ENABLED` alpha gate.
+Replace the jQuery synthetic-submit workaround on the variable-product Back in Stock Notifications sign-up with a real accessible `<form>`, declaratively synced to the selected variation. Suppress auto-pop on the initial default-attribute match (form only surfaces after deliberate interaction or explicit `attribute_*` deep-link), and tighten visual spacing so the BIS form sits flush under the variation selectors. Behind the `WOOCOMMERCE_BIS_ALPHA_ENABLED` alpha gate.

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -435,6 +435,21 @@ p.demo_store,
 				}
 			}
 
+			// When the variations form is immediately followed by a BIS form
+			// (out-of-stock variation case), tighten the gap so the BIS form
+			// sits as close to the variation selectors as the add-to-cart
+			// button does on in-stock variations. `.woocommerce-variation`
+			// also gets `margin-bottom: var(--wp--style--block-gap)` from
+			// woocommerce-blocktheme.scss in block themes, so it's overridden
+			// here too.
+			&:has(+ .wc_bis_form) {
+				.variations,
+				.single_variation_wrap,
+				.single_variation_wrap .woocommerce-variation {
+					margin: 0;
+				}
+			}
+
 			.woocommerce-variation-description p {
 				margin-bottom: 1em;
 			}
@@ -1214,6 +1229,19 @@ p.demo_store,
 
 		&.hidden {
 			display: none;
+		}
+
+		// On variable products the form sits directly under the variation
+		// selectors (which already carry their own bottom spacing); collapse
+		// the form's top margin and the heading's default margins so it sits
+		// flush, mirroring how the add-to-cart button sits on in-stock
+		// variations.
+		&--variable {
+			margin-top: 0;
+
+			.wc_bis_form__heading {
+				margin: 0;
+			}
 		}
 
 		&__form-row {

--- a/plugins/woocommerce/client/legacy/js/frontend/back-in-stock-form.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/back-in-stock-form.js
@@ -32,8 +32,24 @@
 
 		self.$formProductInput = self.$form.find( 'input[name="wc_bis_product_id"]' );
 
+		// Default attributes (set in admin) can pre-match a variation on the
+		// initial `check_variations` call — that fires `show_variation` for it
+		// before the customer has touched anything. We don't want to auto-pop
+		// the BIS form open in that case. Treat the form as actively engaged
+		// only after a real interaction, OR when the URL already deep-links
+		// to a specific variation via `attribute_*` query params.
+		self.userInteracted = /(?:^|[?&])attribute_/.test( window.location.search );
+
 		// Variation Events.
 		self.$variationsForm.off( '.wc-bis-form' );
+		self.$variationsForm.on(
+			'pointerdown.wc-bis-form keydown.wc-bis-form',
+			'.variations select, .reset_variations',
+			{ bisForm: self },
+			function( event ) {
+				event.data.bisForm.userInteracted = true;
+			}
+		);
 		self.$variationsForm.on( 'found_variation.wc-bis-form', { bisForm: self }, self.onFoundVariation );
 		self.$variationsForm.on( 'show_variation.wc-bis-form', { bisForm: self }, self.onShowVariation );
 		self.$variationsForm.on( 'reset_data.wc-bis-form', { bisForm: self }, self.onResetData );
@@ -67,7 +83,14 @@
 	 * @param {Object} variation The variation object.
 	 */
 	BISFormManager.prototype.onShowVariation = function( event, variation ) {
-		var form    = event.data.bisForm;
+		var form = event.data.bisForm;
+
+		// Ignore the initial auto-match driven by default attributes; the
+		// form should only surface in response to deliberate selection.
+		if ( ! form.userInteracted ) {
+			return;
+		}
+
 		var visible = ! variation.is_in_stock || ! variation.is_purchasable;
 
 		if ( ! variation.variation_is_active || ! variation.variation_is_visible ) {
@@ -87,7 +110,13 @@
 		var form = event.data.bisForm;
 		form.$formProductInput.val( form.product_id ).trigger( 'change' );
 		form.clearVariationAttributes();
-		form.setVisible( false );
+
+		// Don't override the PHP-rendered initial state when the customer
+		// hasn't engaged yet (e.g. the all-OOS-variations parent fallback,
+		// where the server intentionally renders the form visible).
+		if ( form.userInteracted ) {
+			form.setVisible( false );
+		}
 	};
 
 	/**

--- a/plugins/woocommerce/client/legacy/js/frontend/back-in-stock-form.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/back-in-stock-form.js
@@ -1,33 +1,47 @@
 ;(function ( $, document ) {
 
+	var SYNC_INPUT_MARKER = 'data-wc-bis-variation-attr';
+
 	/**
 	 * Back in stock form manager.
 	 *
-	 * @param jQuery $form The form element.
+	 * The BIS signup is rendered as a sibling of `.variations_form` (see
+	 * ProductPageIntegration hooking `woocommerce_after_add_to_cart_form`), not
+	 * nested inside it — HTML does not allow nested `<form>` elements, and this
+	 * keeps submit-on-enter, screen-reader announcements, and the form role
+	 * working natively.
+	 *
+	 * We synchronise the currently selected variation id and its attribute
+	 * selections into hidden inputs on the BIS form whenever the user picks a
+	 * variation, so that submitting the BIS form produces the same payload the
+	 * legacy synthetic-submit path used to build at submit time.
+	 *
+	 * @param {jQuery} $variationsForm The `.variations_form` element.
 	 */
 	var BISFormManager = function( $variationsForm ) {
 
 		// Properties.
-		var self               = this;
-		self.$variationsForm   = $variationsForm;
-		self.product_id        = self.$variationsForm.data( 'product_id' );
-		self.$formContainer    = $( '.wc_bis_form[data-bis-product-id="' + self.product_id + '"]' );
-		self.$form             = self.$formContainer.find( 'form' );
-		self.$formProductInput = self.$formContainer.find( 'input[name="wc_bis_product_id"]' );
+		var self              = this;
+		self.$variationsForm  = $variationsForm;
+		self.product_id       = self.$variationsForm.data( 'product_id' );
+		self.$form            = $( 'form.wc_bis_form[data-bis-product-id="' + self.product_id + '"]' );
+
+		if ( ! self.$form.length ) {
+			return;
+		}
+
+		self.$formProductInput = self.$form.find( 'input[name="wc_bis_product_id"]' );
 
 		// Variation Events.
 		self.$variationsForm.off( '.wc-bis-form' );
 		self.$variationsForm.on( 'found_variation.wc-bis-form', { bisForm: self }, self.onFoundVariation );
 		self.$variationsForm.on( 'show_variation.wc-bis-form', { bisForm: self }, self.onShowVariation );
-		self.$variationsForm.on( 'reset_data.wc-bis-form', { bisForm: self }, self.onAnnounceReset );
-
-		// Form Events.
-		self.$form.off( '.wc-bis-form' );
-		self.$form.on( 'submit.wc-bis-form', { bisForm: self }, self.onSendForm );
+		self.$variationsForm.on( 'reset_data.wc-bis-form', { bisForm: self }, self.onResetData );
 	};
 
 	/**
-	 * Handle found variation.
+	 * Handle found variation — sync variation id and attribute values into the
+	 * BIS form as hidden inputs so a native form submit carries them.
 	 *
 	 * @param {Event} event The event object.
 	 * @param {Object} variation The variation object.
@@ -43,67 +57,97 @@
 		}
 
 		form.$formProductInput.val( variation.variation_id ).trigger( 'change' );
+		form.syncVariationAttributes();
 	};
 
 	/**
-	 * Handle show variation.
+	 * Handle show variation — toggle form visibility based on stock state.
 	 *
 	 * @param {Event} event The event object.
 	 * @param {Object} variation The variation object.
 	 */
 	BISFormManager.prototype.onShowVariation = function( event, variation ) {
-		var form = event.data.bisForm;
-		if ( variation.is_in_stock && variation.is_purchasable ) {
-			form.$formContainer.addClass( 'hidden' );
-			return;
-		}
+		var form    = event.data.bisForm;
+		var visible = ! variation.is_in_stock || ! variation.is_purchasable;
 
 		if ( ! variation.variation_is_active || ! variation.variation_is_visible ) {
-			form.$formContainer.addClass( 'hidden' );
-			return;
+			visible = false;
 		}
 
-		form.$formContainer.removeClass( 'hidden' );
+		form.setVisible( visible );
 	};
 
 	/**
-	 * Handle announce reset.
+	 * Handle reset data — variation cleared, hide form and revert to the parent
+	 * product id.
 	 *
 	 * @param {Event} event The event object.
 	 */
-	BISFormManager.prototype.onAnnounceReset = function( event ) {
+	BISFormManager.prototype.onResetData = function( event ) {
 		var form = event.data.bisForm;
 		form.$formProductInput.val( form.product_id ).trigger( 'change' );
-		form.$formContainer.addClass( 'hidden' );
+		form.clearVariationAttributes();
+		form.setVisible( false );
 	};
 
 	/**
-	 * Handle send form.
-	 *
-	 * @param {Event} event The event object.
+	 * Sync variation attribute select values into hidden inputs on the BIS
+	 * form. Existing managed inputs are replaced so "any" attribute changes
+	 * propagate on every variation change.
 	 */
-	BISFormManager.prototype.onSendForm = function( event ) {
+	BISFormManager.prototype.syncVariationAttributes = function() {
+		var form      = this;
+		var $selects  = form.$variationsForm.find( '.variations select' );
 
-		var form = event.data.bisForm;
-		if ( ! form.$variationsForm.length ) {
-			return;
-		}
+		form.clearVariationAttributes();
 
-		var $attributes = form.$variationsForm.find( '.variations select' );
-		if ( $attributes.length ) {
+		$selects.each( function() {
+			var $select = $( this );
+			var name    = $select.attr( 'name' );
+			if ( ! name ) {
+				return;
+			}
 
-			// Build dynamic hidden form fields.
-			$attributes.each( function( index, el ) {
+			form.$form.append(
+				$( '<input/>', {
+					type: 'hidden',
+					name: name,
+					value: $select.val() || ''
+				} ).attr( SYNC_INPUT_MARKER, '' )
+			);
+		} );
+	};
 
-				var $attribute_field = $( el )
-				var $input = $( '<input/>' );
-				$input.val( $attribute_field.val() );
-				$input.prop( 'name', $attribute_field.attr( 'name' ) );
-				$input.prop( 'type', 'hidden' );
-				if ( ! form.$form.find( 'input[name="' + $input.prop( 'name' ) + '"]' ).length ) {
-					form.$form.append( $input );
-				}
-			} );
+	/**
+	 * Remove hidden inputs previously synced from the variations form so we
+	 * don't leak stale attribute values when the user picks a different
+	 * variation or clears the selection.
+	 */
+	BISFormManager.prototype.clearVariationAttributes = function() {
+		this.$form.find( '[' + SYNC_INPUT_MARKER + ']' ).remove();
+	};
+
+	/**
+	 * Toggle form visibility and expose an assistive-technology announcement
+	 * when the form transitions into view.
+	 *
+	 * @param {boolean} visible Whether the form should be visible.
+	 */
+	BISFormManager.prototype.setVisible = function( visible ) {
+		var wasHidden = this.$form.hasClass( 'hidden' );
+		this.$form.toggleClass( 'hidden', ! visible );
+
+		if ( visible && wasHidden ) {
+			var $status       = this.$form.find( '.wc_bis_form__status' );
+			var announcement  = this.$form.data( 'available-text' ) || '';
+			if ( $status.length && announcement ) {
+				// Re-set the text so the aria-live region re-announces even if
+				// the same string is written twice in a row.
+				$status.text( '' );
+				window.setTimeout( function() {
+					$status.text( announcement );
+				}, 50 );
+			}
 		}
 	};
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
@@ -211,11 +211,12 @@ class ProductPageIntegration {
 		wc_get_template(
 			'single-product/back-in-stock-form.php',
 			array(
-				'product_id'       => $product->get_parent_id() ? $product->get_parent_id() : $product->get_id(),
-				'show_checkbox'    => ! is_user_logged_in() && Config::creates_account_on_signup() && ! Config::requires_account(),
-				'show_email_field' => ! is_user_logged_in() && ! Config::requires_account(),
-				'button_class'     => $button_class,
-				'is_visible'       => $is_visible,
+				'product_id'          => $product->get_parent_id() ? $product->get_parent_id() : $product->get_id(),
+				'show_checkbox'       => ! is_user_logged_in() && Config::creates_account_on_signup() && ! Config::requires_account(),
+				'show_email_field'    => ! is_user_logged_in() && ! Config::requires_account(),
+				'button_class'        => $button_class,
+				'is_visible'          => $is_visible,
+				'is_variable_product' => $product->is_type( 'variable' ),
 			)
 		);
 	}

--- a/plugins/woocommerce/templates/single-product/back-in-stock-form.php
+++ b/plugins/woocommerce/templates/single-product/back-in-stock-form.php
@@ -22,14 +22,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$heading_id = 'wc_bis_form_heading_' . absint( $product_id );
-$status_id  = 'wc_bis_form_status_' . absint( $product_id );
+$heading_id          = 'wc_bis_form_heading_' . absint( $product_id );
+$status_id           = 'wc_bis_form_status_' . absint( $product_id );
+$is_variable_product = ! empty( $is_variable_product );
+
+$form_classes  = 'wc_bis_form';
+$form_classes .= $is_variable_product ? ' wc_bis_form--variable' : '';
+$form_classes .= $is_visible ? '' : ' hidden';
 
 ?>
 <form
 	method="post"
 	novalidate
-	class="wc_bis_form<?php echo $is_visible ? '' : ' hidden'; ?>"
+	class="<?php echo esc_attr( $form_classes ); ?>"
 	data-bis-product-id="<?php echo absint( $product_id ); ?>"
 	data-available-text="<?php echo esc_attr_x( 'Back in stock notification signup is available for the selected option.', 'back in stock form', 'woocommerce' ); ?>"
 	aria-labelledby="<?php echo esc_attr( $heading_id ); ?>"

--- a/plugins/woocommerce/templates/single-product/back-in-stock-form.php
+++ b/plugins/woocommerce/templates/single-product/back-in-stock-form.php
@@ -14,7 +14,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.2.0
+ * @version 10.8.0
  */
 
 // Exit if accessed directly.
@@ -22,55 +22,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-?>
-<div class="wc_bis_form<?php echo $is_visible ? '' : ' hidden'; ?>" data-bis-product-id="<?php echo absint( $product_id ); ?>">
+$heading_id = 'wc_bis_form_heading_' . absint( $product_id );
+$status_id  = 'wc_bis_form_status_' . absint( $product_id );
 
-	<h3 id="wc_bis_form_heading_<?php echo absint( $product_id ); ?>">
+?>
+<form
+	method="post"
+	novalidate
+	class="wc_bis_form<?php echo $is_visible ? '' : ' hidden'; ?>"
+	data-bis-product-id="<?php echo absint( $product_id ); ?>"
+	data-available-text="<?php echo esc_attr_x( 'Back in stock notification signup is available for the selected option.', 'back in stock form', 'woocommerce' ); ?>"
+	aria-labelledby="<?php echo esc_attr( $heading_id ); ?>"
+>
+	<h3 id="<?php echo esc_attr( $heading_id ); ?>" class="wc_bis_form__heading">
 		<?php echo wp_kses_post( __( 'Want to be notified when this product is back in stock?', 'woocommerce' ) ); ?>
 	</h3>
 
-	<form method="post" novalidate aria-labelledby="wc_bis_form_heading_<?php echo absint( $product_id ); ?>">
-		<div class="wc_bis_form__form-row">
-			<?php if ( $show_email_field ) : ?>
+	<div class="wc_bis_form__form-row">
+		<?php if ( $show_email_field ) : ?>
 
-				<label for="wc_bis_email_<?php echo absint( $product_id ); ?>" class="screen-reader-text"><?php echo esc_html_x( 'Email address to be notified when this product is back in stock', 'back in stock form', 'woocommerce' ); ?></label>
-				<input
-					type="email"
-					name="wc_bis_email"
-					class="wc_bis_form__input"
-					placeholder="<?php echo esc_attr_x( 'Enter your e-mail', 'back in stock form', 'woocommerce' ); ?>"
-					id="wc_bis_email_<?php echo absint( $product_id ); ?>"
-					required
-					aria-required="true"
-				/>
-
-			<?php endif; ?>
-
-			<button
-				type="submit"
-				name="wc_bis_register"
-				class="<?php echo esc_attr( $button_class ); ?>"
-			>
-				<?php echo esc_html( __( 'Notify me', 'woocommerce' ) ); ?>
-			</button>
-		</div>
-
-		<?php if ( $show_checkbox ) : ?>
-
-			<label for="wc_bis_opt_in_<?php echo absint( $product_id ); ?>" class="wc_bis_form__checkbox">
-				<input
-					type="checkbox"
-					name="wc_bis_opt_in"
-					id="wc_bis_opt_in_<?php echo absint( $product_id ); ?>"
-				/>
-				<?php echo wp_kses_post( wc_replace_policy_page_link_placeholders( wc_get_privacy_policy_text( 'registration' ) ) ); ?>
-			</label>
+			<label for="wc_bis_email_<?php echo absint( $product_id ); ?>" class="screen-reader-text"><?php echo esc_html_x( 'Email address to be notified when this product is back in stock', 'back in stock form', 'woocommerce' ); ?></label>
+			<input
+				type="email"
+				name="wc_bis_email"
+				class="wc_bis_form__input"
+				placeholder="<?php echo esc_attr_x( 'Enter your e-mail', 'back in stock form', 'woocommerce' ); ?>"
+				id="wc_bis_email_<?php echo absint( $product_id ); ?>"
+				required
+				aria-required="true"
+			/>
 
 		<?php endif; ?>
 
-		<?php wp_nonce_field( 'wc_bis_signup', 'wc_bis_nonce' ); ?>
+		<button
+			type="submit"
+			name="wc_bis_register"
+			class="<?php echo esc_attr( $button_class ); ?>"
+		>
+			<?php echo esc_html( __( 'Notify me', 'woocommerce' ) ); ?>
+		</button>
+	</div>
 
-		<input type="hidden" name="wc_bis_product_id" value="<?php echo absint( $product_id ); ?>" />
-	</form>
+	<?php if ( $show_checkbox ) : ?>
 
-</div>
+		<label for="wc_bis_opt_in_<?php echo absint( $product_id ); ?>" class="wc_bis_form__checkbox">
+			<input
+				type="checkbox"
+				name="wc_bis_opt_in"
+				id="wc_bis_opt_in_<?php echo absint( $product_id ); ?>"
+			/>
+			<?php echo wp_kses_post( wc_replace_policy_page_link_placeholders( wc_get_privacy_policy_text( 'registration' ) ) ); ?>
+		</label>
+
+	<?php endif; ?>
+
+	<div id="<?php echo esc_attr( $status_id ); ?>" class="wc_bis_form__status screen-reader-text" role="status" aria-live="polite"></div>
+
+	<?php wp_nonce_field( 'wc_bis_signup', 'wc_bis_nonce' ); ?>
+
+	<input type="hidden" name="wc_bis_product_id" value="<?php echo absint( $product_id ); ?>" />
+</form>

--- a/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/signing-up-variable.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/signing-up-variable.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Internal dependencies
+ */
+import {
+	expect,
+	request,
+	tags,
+	test as baseTest,
+} from '../../fixtures/fixtures';
+import {
+	BIS_OPTIONS,
+	createOutOfStockVariableProduct,
+	setBISOptions,
+	signUpOnProductPage,
+	uniqueGuestEmail,
+} from '../../utils/back-in-stock-notifications';
+import { deleteOption } from '../../utils/options';
+
+const test = baseTest.extend( {
+	product: async ( { restApi }, use ) => {
+		const product = await createOutOfStockVariableProduct( restApi );
+		await use( product );
+		await product.cleanup();
+	},
+} );
+
+test.describe(
+	'Back in Stock Notifications — signing up on a variable product',
+	{ tag: [ tags.SERVICES ] },
+	() => {
+		test.afterEach( async ( { baseURL } ) => {
+			for ( const option of Object.values( BIS_OPTIONS ) ) {
+				await deleteOption( request, baseURL!, option );
+			}
+		} );
+
+		test.describe( 'Guest, single opt-in', () => {
+			test.beforeEach( async ( { baseURL } ) => {
+				await setBISOptions( request, baseURL!, {
+					allowSignups: true,
+					doubleOptIn: false,
+					requireAccount: false,
+				} );
+			} );
+
+			test( 'signup form is a real form sibling of the variations form', async ( {
+				page,
+				product,
+			} ) => {
+				await page.goto( product.permalink );
+
+				// The BIS form is a real <form> (not a <div>), labelled by the
+				// user-visible heading.
+				const bisForm = page.locator( 'form.wc_bis_form' );
+				await expect( bisForm ).toHaveCount( 1 );
+				await expect( bisForm ).toHaveAttribute(
+					'aria-labelledby',
+					/wc_bis_form_heading_/
+				);
+
+				// And it carries a real submit button so keyboard users can
+				// submit with Enter.
+				await expect(
+					bisForm.locator(
+						'button[type="submit"][name="wc_bis_register"]'
+					)
+				).toHaveCount( 1 );
+
+				// Accessibility guarantee: the BIS form must NOT be nested
+				// inside the variations form (HTML disallows nested <form>s,
+				// and the legacy plugin's nested-div-as-form workaround is
+				// what RSM-446 removes).
+				const nestedCount = await page
+					.locator( '.variations_form form.wc_bis_form' )
+					.count();
+				expect( nestedCount ).toBe( 0 );
+			} );
+
+			test( 'signup succeeds for the out-of-stock variation and a repeat submit shows "already joined"', async ( {
+				page,
+				product,
+			} ) => {
+				await page.goto( product.permalink );
+
+				// Before picking a variation the form is hidden.
+				const bisForm = page.locator( 'form.wc_bis_form' );
+				await expect( bisForm ).toHaveClass( /(^|\s)hidden(\s|$)/ );
+
+				// Select the out-of-stock variation; the form should become
+				// visible (variations JS toggles the `hidden` class).
+				await page
+					.getByRole( 'combobox', { name: 'Size' } )
+					.selectOption( product.outOfStockAttribute );
+				await expect( bisForm ).not.toHaveClass( /(^|\s)hidden(\s|$)/ );
+
+				const email = uniqueGuestEmail( 'bis-variable-guest' );
+				await signUpOnProductPage( page, { email } );
+				await expect(
+					page.getByText(
+						/You have successfully signed up|You have already joined this waitlist/i
+					)
+				).toBeVisible();
+
+				// Repeat submission on the same variation surfaces the
+				// already-joined notice.
+				await page.goto( product.permalink );
+				await page
+					.getByRole( 'combobox', { name: 'Size' } )
+					.selectOption( product.outOfStockAttribute );
+				await expect( bisForm ).not.toHaveClass( /(^|\s)hidden(\s|$)/ );
+				await signUpOnProductPage( page, { email } );
+				await expect(
+					page.getByText( /You have already joined this waitlist/i )
+				).toBeVisible();
+			} );
+
+			test( 'signup form stays hidden for the in-stock variation', async ( {
+				page,
+				product,
+			} ) => {
+				await page.goto( product.permalink );
+
+				await page
+					.getByRole( 'combobox', { name: 'Size' } )
+					.selectOption( product.inStockAttribute );
+
+				await expect( page.locator( 'form.wc_bis_form' ) ).toHaveClass(
+					/(^|\s)hidden(\s|$)/
+				);
+			} );
+		} );
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/utils/back-in-stock-notifications.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/back-in-stock-notifications.ts
@@ -1,0 +1,354 @@
+/**
+ * External dependencies
+ */
+import type { APIRequest, Page } from '@playwright/test';
+import { WC_API_PATH, type ApiClient } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { setOption } from './options';
+import { expect } from '../fixtures/fixtures';
+
+/**
+ * Names of the Back in Stock Notifications options in core.
+ *
+ * The external plugin used `wc_bis_*` slugs; core uses these.
+ */
+export const BIS_OPTIONS = {
+	allowSignups: 'woocommerce_customer_stock_notifications_allow_signups',
+	doubleOptIn:
+		'woocommerce_customer_stock_notifications_require_double_opt_in',
+	requireAccount: 'woocommerce_customer_stock_notifications_require_account',
+	createAccountOnSignup:
+		'woocommerce_customer_stock_notifications_create_account_on_signup',
+} as const;
+
+/**
+ * Configure the BIS feature options for a test. Omitted keys are left untouched.
+ *
+ * @param {APIRequest} request                         Playwright request fixture.
+ * @param {string}     baseURL                         Test site base URL.
+ * @param {Object}     options                         BIS option toggles.
+ * @param {boolean}    [options.allowSignups]          Whether the signup form is rendered on product pages.
+ * @param {boolean}    [options.doubleOptIn]           Whether signups require email verification before activating.
+ * @param {boolean}    [options.requireAccount]        Whether signups are limited to logged-in users.
+ * @param {boolean}    [options.createAccountOnSignup] Whether a new account is created for guest signups.
+ */
+export async function setBISOptions(
+	request: APIRequest,
+	baseURL: string,
+	options: {
+		allowSignups?: boolean;
+		doubleOptIn?: boolean;
+		requireAccount?: boolean;
+		createAccountOnSignup?: boolean;
+	}
+): Promise< void > {
+	const toYesNo = ( v: boolean | undefined ): string | undefined => {
+		if ( v === undefined ) {
+			return undefined;
+		}
+		return v ? 'yes' : 'no';
+	};
+
+	const entries: Array< [ string, string | undefined ] > = [
+		[ BIS_OPTIONS.allowSignups, toYesNo( options.allowSignups ) ],
+		[ BIS_OPTIONS.doubleOptIn, toYesNo( options.doubleOptIn ) ],
+		[ BIS_OPTIONS.requireAccount, toYesNo( options.requireAccount ) ],
+		[
+			BIS_OPTIONS.createAccountOnSignup,
+			toYesNo( options.createAccountOnSignup ),
+		],
+	];
+
+	for ( const [ name, value ] of entries ) {
+		if ( value !== undefined ) {
+			await setOption( request, baseURL, name, value );
+		}
+	}
+}
+
+/**
+ * Return a handle to an out-of-stock product. Caller is responsible for calling cleanup().
+ *
+ * @param {ApiClient} restApi           WP REST client.
+ * @param {Object}    [opts]            Product shape.
+ * @param {string}    [opts.type]       Product type (`simple` or `variable`). Defaults to `simple`.
+ * @param {string}    [opts.namePrefix] Prefix used to build a unique product name.
+ */
+export async function createOutOfStockProduct(
+	restApi: ApiClient,
+	opts: {
+		type?: 'simple' | 'variable';
+		namePrefix?: string;
+	} = {}
+): Promise< {
+	id: number;
+	name: string;
+	permalink: string;
+	cleanup: () => Promise< void >;
+} > {
+	const { type = 'simple', namePrefix = 'BIS Test Product' } = opts;
+	const name = `${ namePrefix } ${ Date.now() }`;
+
+	const response = await restApi.post< {
+		id: number;
+		name: string;
+		permalink: string;
+	} >( `${ WC_API_PATH }/products`, {
+		name,
+		type,
+		regular_price: '9.99',
+		manage_stock: false,
+		stock_status: 'outofstock',
+	} );
+	const product = response.data;
+
+	return {
+		id: product.id,
+		name: product.name,
+		permalink: product.permalink,
+		async cleanup() {
+			await restApi
+				.delete( `${ WC_API_PATH }/products/${ product.id }`, {
+					force: true,
+				} )
+				.catch( () => {
+					/* best-effort cleanup */
+				} );
+		},
+	};
+}
+
+/**
+ * Return a handle to a variable product with one out-of-stock and one
+ * in-stock variation. Caller is responsible for calling cleanup().
+ *
+ * Used to exercise the variable-product BIS flow: the parent product doesn't
+ * carry a stock status that surfaces the form — instead the form appears
+ * after the shopper selects the out-of-stock variation.
+ *
+ * @param {ApiClient} restApi           WP REST client.
+ * @param {Object}    [opts]            Product shape.
+ * @param {string}    [opts.namePrefix] Prefix used to build a unique product name.
+ */
+export async function createOutOfStockVariableProduct(
+	restApi: ApiClient,
+	opts: {
+		namePrefix?: string;
+	} = {}
+): Promise< {
+	id: number;
+	name: string;
+	permalink: string;
+	outOfStockAttribute: string;
+	inStockAttribute: string;
+	cleanup: () => Promise< void >;
+} > {
+	const { namePrefix = 'BIS Test Variable Product' } = opts;
+	const name = `${ namePrefix } ${ Date.now() }`;
+	const outOfStockAttribute = 'Small';
+	const inStockAttribute = 'Large';
+
+	// Create a variable parent with a single local attribute.
+	const parentResponse = await restApi.post< {
+		id: number;
+		name: string;
+		permalink: string;
+	} >( `${ WC_API_PATH }/products`, {
+		name,
+		type: 'variable',
+		attributes: [
+			{
+				name: 'Size',
+				visible: true,
+				variation: true,
+				options: [ outOfStockAttribute, inStockAttribute ],
+			},
+		],
+	} );
+	const parent = parentResponse.data;
+
+	// Create variations in an explicit order: out-of-stock first (so it's
+	// the default when the shopper hasn't picked an option yet won't matter;
+	// tests pick explicitly) and in-stock second.
+	for ( const [ attribute, stockStatus ] of [
+		[ outOfStockAttribute, 'outofstock' ],
+		[ inStockAttribute, 'instock' ],
+	] as const ) {
+		await restApi.post(
+			`${ WC_API_PATH }/products/${ parent.id }/variations`,
+			{
+				regular_price: '9.99',
+				stock_status: stockStatus,
+				manage_stock: false,
+				attributes: [ { name: 'Size', option: attribute } ],
+			}
+		);
+	}
+
+	return {
+		id: parent.id,
+		name: parent.name,
+		permalink: parent.permalink,
+		outOfStockAttribute,
+		inStockAttribute,
+		async cleanup() {
+			await restApi
+				.delete( `${ WC_API_PATH }/products/${ parent.id }`, {
+					force: true,
+				} )
+				.catch( () => {
+					/* best-effort cleanup */
+				} );
+		},
+	};
+}
+
+/**
+ * Restock a product via REST (used by receiving-notifications.spec.ts to trigger the stock-sync action).
+ *
+ * @param {ApiClient} restApi   WP REST client.
+ * @param {number}    productId Product id.
+ */
+export async function restockProduct(
+	restApi: ApiClient,
+	productId: number
+): Promise< void > {
+	await restApi.put( `${ WC_API_PATH }/products/${ productId }`, {
+		stock_status: 'instock',
+		manage_stock: false,
+	} );
+}
+
+/**
+ * Submit the PDP sign-up form. Caller must already have the product page loaded.
+ *
+ * @param {Page}    page                     Playwright page on the product detail.
+ * @param {Object}  [opts]                   Fill options.
+ * @param {string}  [opts.email]             Email address to enter (guest flow only; logged-in PDP hides the field).
+ * @param {boolean} [opts.tickOptInCheckbox] Tick the privacy opt-in checkbox before submitting.
+ */
+export async function signUpOnProductPage(
+	page: Page,
+	opts: {
+		email?: string;
+		tickOptInCheckbox?: boolean;
+	} = {}
+): Promise< void > {
+	if ( opts.email !== undefined ) {
+		await page
+			.getByRole( 'textbox', {
+				name: /Email address to be notified/i,
+			} )
+			.fill( opts.email );
+	}
+
+	if ( opts.tickOptInCheckbox ) {
+		await page.locator( 'input[name="wc_bis_opt_in"]' ).check();
+	}
+
+	await page.getByRole( 'button', { name: /Notify me/i } ).click();
+}
+
+/**
+ * Open an email in WP Mail Logging and extract the first href matching a regular expression from its HTML body.
+ *
+ * Use this for follow-through flows where a subsequent step needs the URL embedded in the email.
+ *
+ * @param {Page}   page                 Playwright page.
+ * @param {string} receiverEmailAddress The recipient email address.
+ * @param {RegExp} subject              The email subject (regular expression).
+ * @param {RegExp} hrefPattern          Pattern the target href should match (e.g. /email_link_action=verify/).
+ */
+export async function getLinkFromEmailBody(
+	page: Page,
+	receiverEmailAddress: string,
+	subject: RegExp,
+	hrefPattern: RegExp
+): Promise< string > {
+	await page.goto(
+		`wp-admin/tools.php?page=wpml_plugin_log&search[place]=receiver&search[term]=${ encodeURIComponent(
+			receiverEmailAddress
+		) }&orderby=timestamp&order=desc`
+	);
+
+	const row = page
+		.getByRole( 'row' )
+		.filter( {
+			has: page.getByRole( 'cell', {
+				name: receiverEmailAddress,
+				exact: true,
+			} ),
+		} )
+		.filter( { has: page.getByText( subject ) } )
+		.first();
+
+	await expect( row ).toBeVisible();
+	await row.getByRole( 'button', { name: 'View log' } ).click();
+
+	const modalContent = page.locator(
+		'#wp-mail-logging-modal-content-body-content'
+	);
+	await expect( modalContent ).toBeVisible();
+
+	const iframe = page.frameLocator(
+		'#wp-mail-logging-modal-content-body-content iframe'
+	);
+	// Wait until iframe content is attached and has anchors rendered.
+	await iframe.locator( 'a' ).first().waitFor( { state: 'attached' } );
+
+	const href = await iframe
+		.locator( 'a' )
+		.evaluateAll( ( anchors, pattern ) => {
+			const regex = new RegExp( pattern );
+			for ( const a of anchors as HTMLAnchorElement[] ) {
+				if ( regex.test( a.href ) ) {
+					return a.href;
+				}
+			}
+			return null;
+		}, hrefPattern.source );
+
+	if ( ! href ) {
+		throw new Error(
+			`No link matching ${ hrefPattern } found in email to ${ receiverEmailAddress } with subject ${ subject }`
+		);
+	}
+
+	// Close the modal for clean state.
+	await page
+		.locator(
+			'#wp-mail-logging-modal-content-header-close, .wp-mail-logging-modal-close'
+		)
+		.first()
+		.click()
+		.catch( () => {
+			/* Some wp-mail-logging versions don't surface an explicit close button — fine. */
+		} );
+
+	return href;
+}
+
+/**
+ * Run any pending Action Scheduler jobs via the process-waiting-actions mu-plugin.
+ *
+ * @param {Page} page Playwright page (can be on any URL).
+ */
+export async function triggerStockNotificationsBatch(
+	page: Page
+): Promise< void > {
+	await page.goto( '?process-waiting-actions' );
+}
+
+/**
+ * Generate a unique guest email address for a test so mail-log assertions don't collide.
+ *
+ * @param {string} prefix Short descriptor of the test.
+ */
+export function uniqueGuestEmail( prefix = 'bis' ): string {
+	return `${ prefix }-${ Date.now() }-${ Math.floor(
+		Math.random() * 1000
+	) }@example.com`;
+}


### PR DESCRIPTION
## Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

## Changes proposed in this Pull Request

Replace the jQuery synthetic-submit workaround on the variable-product Back in Stock Notifications sign-up with a real accessible `<form>`, declaratively synced to the selected variation. Plus polish so the form behaves and lays out cleanly:

- **Template / JS:** promote `<form>` to the root of the BIS signup markup, drop the outer `.wc_bis_form` `<div>`, add an `aria-live` status region. JS now updates hidden variation attributes on `found_variation` / `reset_data` and announces show transitions for screen readers.
- **Auto-pop suppression:** `variations.js` fires `show_variation` for the default-matched variation on first load — without user action — which would surface the BIS form unprompted. Tracks interaction (`pointerdown`/`keydown` on variation selects, or an `attribute_*` URL deep-link) and only reacts once engaged. Preserves the PHP-rendered initial state for the all-OOS-variations parent fallback.
- **Visual spacing:** new `.wc_bis_form--variable` modifier (added by the template when `is_variable_product` is true) zeros the form's top margin and the heading's margins. `form.cart:has(+ .wc_bis_form)` collapses `.variations` / `.single_variation_wrap` / `.woocommerce-variation` margins so the BIS form sits as close to the variation selectors as the add-to-cart button does on in-stock variations.
- **Playwright:** `tests/back-in-stock-notifications/signing-up-variable.spec.ts` covers the variable-product flow including an a11y probe asserting the signup is a real `<form>` outside `.variations_form`. Adds `createOutOfStockVariableProduct` test util.

Behind the `WOOCOMMERCE_BIS_ALPHA_ENABLED` alpha gate.

CSS selectors target `.wc_bis_form` agnostic to tag, so restyling survives the `<div>` → `<form>` change. No other monorepo consumers select `div.wc_bis_form`.

Closes [RSM-446](https://linear.app/a8c/issue/RSM-446)

## How to test the changes in this Pull Request

1. Set `WOOCOMMERCE_BIS_ALPHA_ENABLED`.
2. Create a variable product with one or more out-of-stock variations.
3. Visit the product frontend on a **non-block-template** classic theme (Storefront or any twentytwenty*) — confirm the BIS form is not visible on first load even if a default variation is preselected.
4. Pick the OOS variation in the dropdown — BIS form appears flush under the variation selectors (no large gap), heading margins tight.
5. Switch to an in-stock variation — form hides; switch back to OOS — form re-appears, hidden inputs re-sync.
6. Submit, confirm success notice. Repeat — assert "already joined" notice.
7. Deep-link to `?attribute_pa_color=red` (an OOS option) — form auto-shows on load (URL implies intent).

## Testing that has already taken place

- Playwright spec (added): guest single-opt-in signup on variable product, repeat-signup "already joined" assertion, a11y probe.
- Spacing fix verified live on a block-theme dev site: `.single_variation_wrap` margin 25px → 0px, BIS form bbox shifts up to sit flush against the variation pills.
- Branch-level lint not yet run from this worktree (no `node_modules` linked); main-checkout lint is clean for the same content.

## Milestone

- [x] Automatically assign milestone for the next WooCommerce version.

## Changelog entry

- [x] Changelog entry added manually at `plugins/woocommerce/changelog/rsm-446-bis-variations-a11y`.