### PR TITLE
Add Store API endpoints for shopper lists

### DIFF
--- a/plugins/woocommerce/changelog/rsm-shopper-collections-add-storeapi-endpoints
+++ b/plugins/woocommerce/changelog/rsm-shopper-collections-add-storeapi-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the foundation for shopper lists via new Store API endpoints under /wc/store/v1/shopper-lists. Lists are persisted per-user in usermeta.

--- a/plugins/woocommerce/phpstan.neon
+++ b/plugins/woocommerce/phpstan.neon
@@ -39,6 +39,17 @@ parameters:
 		WC_TEMPLATE_DEBUG_MODE: bool
 	ignoreErrors:
 		- identifier: missingType.iterableValue
+		# ShopperListItemSchema uses ProductItemTrait only for format_variation_data();
+		# the trait's unused prepare_product_price_response() assumes a ProductSchema parent.
+		-
+			message: '#Call to an undefined method Automattic\\WooCommerce\\StoreApi\\Schemas\\V1\\ShopperListItemSchema::get_tax_display_mode\(\)#'
+			path: src/StoreApi/Utilities/ProductItemTrait.php
+		-
+			message: '#Call to an undefined method Automattic\\WooCommerce\\StoreApi\\Schemas\\V1\\ShopperListItemSchema::get_price_function_from_tax_display_mode\(\)#'
+			path: src/StoreApi/Utilities/ProductItemTrait.php
+		-
+			message: '#Call to an undefined static method Automattic\\WooCommerce\\StoreApi\\Schemas\\V1\\AbstractSchema::prepare_product_price_response\(\)#'
+			path: src/StoreApi/Utilities/ProductItemTrait.php
 	parallel:
 		maximumNumberOfProcesses: 4
 

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -115,7 +115,7 @@ class ShopperList {
 			return new self(
 				$user_id,
 				'saved-for-later',
-				'Saved for Later',
+				__( 'Saved for later', 'woocommerce' ),
 				false,
 				current_time( 'mysql', true ),
 				array()

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -126,12 +126,24 @@ class ShopperList {
 	}
 
 	/**
-	 * Add (or replace by key) an item.
+	 * Add an item, or merge quantities if it already exists.
 	 *
 	 * @param ShopperListItem $item Item to add.
 	 */
 	public function add_item( ShopperListItem $item ): void {
-		$this->items[ $item->get_key() ] = $item;
+		$key = $item->get_key();
+
+		if ( isset( $this->items[ $key ] ) ) {
+			$this->items[ $key ] = ShopperListItem::from_array(
+				array_merge(
+					$this->items[ $key ]->to_array(),
+					array( 'quantity' => $this->items[ $key ]->get_quantity() + $item->get_quantity() )
+				)
+			);
+			return;
+		}
+
+		$this->items[ $key ] = $item;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -29,13 +29,6 @@ class ShopperList {
 	private $slug;
 
 	/**
-	 * List name.
-	 *
-	 * @var string
-	 */
-	private $name;
-
-	/**
 	 * Whether the list is public.
 	 *
 	 * @var bool
@@ -61,7 +54,6 @@ class ShopperList {
 	 *
 	 * @param int                            $user_id          Owning user ID.
 	 * @param string                         $slug             List slug.
-	 * @param string                         $name             Human-readable name.
 	 * @param bool                           $is_public        Whether the list is shareable.
 	 * @param string                         $date_created_gmt MySQL DATETIME, GMT.
 	 * @param array<string, ShopperListItem> $items            Items keyed by storage key.
@@ -69,14 +61,12 @@ class ShopperList {
 	private function __construct(
 		int $user_id,
 		string $slug,
-		string $name,
 		bool $is_public,
 		string $date_created_gmt,
 		array $items
 	) {
 		$this->user_id          = $user_id;
 		$this->slug             = $slug;
-		$this->name             = $name;
 		$this->is_public        = $is_public;
 		$this->date_created_gmt = $date_created_gmt;
 		$this->items            = $items;
@@ -115,7 +105,6 @@ class ShopperList {
 			return new self(
 				$user_id,
 				'saved-for-later',
-				__( 'Saved for later', 'woocommerce' ),
 				false,
 				current_time( 'mysql', true ),
 				array()
@@ -209,7 +198,6 @@ class ShopperList {
 
 		return array(
 			'slug'             => $this->slug,
-			'name'             => $this->name,
 			'is_public'        => $this->is_public,
 			'date_created_gmt' => $this->date_created_gmt,
 			'items'            => $items_array,
@@ -235,7 +223,6 @@ class ShopperList {
 		return new self(
 			$user_id,
 			$data['slug'] ?? '',
-			$data['name'] ?? '',
 			$data['is_public'] ?? false,
 			$data['date_created_gmt'] ?? current_time( 'mysql', true ),
 			$items

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -1,0 +1,242 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\Utilities\Users;
+
+/**
+ * A user's saved list of products.
+ */
+class ShopperList {
+	/**
+	 * Prefix for per-list usermeta key for list details.
+	 */
+	const META_KEY_PREFIX = '_wc_shopper_list_';
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * List slug.
+	 *
+	 * @var string
+	 */
+	private $slug;
+
+	/**
+	 * List name.
+	 *
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * Whether the list is public.
+	 *
+	 * @var bool
+	 */
+	private $is_public;
+
+	/**
+	 * Datetime the list was created.
+	 *
+	 * @var string
+	 */
+	private $date_created_gmt;
+
+	/**
+	 * Items in the list.
+	 *
+	 * @var array<string, ShopperListItem>
+	 */
+	private $items;
+
+	/**
+	 * Construct from already-validated values. Use the static factories instead.
+	 *
+	 * @param int                            $user_id          Owning user ID.
+	 * @param string                         $slug             List slug.
+	 * @param string                         $name             Human-readable name.
+	 * @param bool                           $is_public        Whether the list is shareable.
+	 * @param string                         $date_created_gmt MySQL DATETIME, GMT.
+	 * @param array<string, ShopperListItem> $items            Items keyed by storage key.
+	 */
+	private function __construct(
+		int $user_id,
+		string $slug,
+		string $name,
+		bool $is_public,
+		string $date_created_gmt,
+		array $items
+	) {
+		$this->user_id          = $user_id;
+		$this->slug             = $slug;
+		$this->name             = $name;
+		$this->is_public        = $is_public;
+		$this->date_created_gmt = $date_created_gmt;
+		$this->items            = $items;
+	}
+
+	/**
+	 * Load a list by slug. Auto-creates saved-for-later. Returns false for any other list that doesn't exist.
+	 *
+	 * @throws \RuntimeException When the stored data is corrupt (non-array meta value).
+	 *
+	 * @param string   $slug List identifier.
+	 * @param int|null $user_id Defaults to the current user.
+	 * @return self|false
+	 */
+	public static function get_by_slug( string $slug, ?int $user_id = null ) {
+		$user_id = null === $user_id ? get_current_user_id() : $user_id;
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+
+		$stored = Users::get_site_user_meta( $user_id, self::META_KEY_PREFIX . $slug );
+
+		if ( is_array( $stored ) ) {
+			return self::from_array( $stored, $user_id );
+		}
+
+		// Anything other than the empty default means a row exists but isn't an array — corruption.
+		if ( '' !== $stored && false !== $stored && null !== $stored ) {
+			throw new \RuntimeException(
+				esc_html( sprintf( 'Corrupt shopper list data for user %d list %s', $user_id, $slug ) )
+			);
+		}
+
+		// Empty default — list doesn't exist. Auto-create saved-for-later only.
+		if ( 'saved-for-later' === $slug ) {
+			$list = new self(
+				$user_id,
+				'saved-for-later',
+				'Saved for Later',
+				false,
+				current_time( 'mysql', true ),
+				array()
+			);
+			$list->save();
+			return $list;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get all of the user's lists.
+	 *
+	 * @param int|null $user_id Defaults to the current user.
+	 * @return array<string, self>
+	 */
+	public static function get_all_for_user( ?int $user_id = null ): array {
+		$sfl = self::get_by_slug( 'saved-for-later', $user_id );
+		return $sfl ? array( 'saved-for-later' => $sfl ) : array();
+	}
+
+	/**
+	 * The list slug (e.g. 'saved-for-later').
+	 */
+	public function get_slug(): string {
+		return $this->slug;
+	}
+
+	/**
+	 * Add (or replace by key) an item.
+	 *
+	 * @param ShopperListItem $item Item to add.
+	 */
+	public function add_item( ShopperListItem $item ): void {
+		$this->items[ $item->key() ] = $item;
+	}
+
+	/**
+	 * Remove an item by key. Returns false if the key wasn't present.
+	 *
+	 * @param string $key Storage key of the item to remove.
+	 */
+	public function remove_item( string $key ): bool {
+		if ( ! isset( $this->items[ $key ] ) ) {
+			return false;
+		}
+		unset( $this->items[ $key ] );
+		return true;
+	}
+
+	/**
+	 * Get all items currently in the list.
+	 *
+	 * @return array<string, ShopperListItem>
+	 */
+	public function get_items(): array {
+		return $this->items;
+	}
+
+	/**
+	 * Find an item by key.
+	 *
+	 * @param string $key Storage key.
+	 */
+	public function find_item( string $key ): ?ShopperListItem {
+		return $this->items[ $key ] ?? null;
+	}
+
+	/**
+	 * Persist the current state to user meta.
+	 */
+	public function save(): void {
+		Users::update_site_user_meta(
+			$this->user_id,
+			self::META_KEY_PREFIX . $this->slug,
+			$this->to_array()
+		);
+	}
+
+	/**
+	 * Storage / response shape.
+	 */
+	public function to_array(): array {
+		$items_array = array();
+		foreach ( $this->items as $key => $item ) {
+			$items_array[ $key ] = $item->to_array();
+		}
+
+		return array(
+			'slug'             => $this->slug,
+			'name'             => $this->name,
+			'is_public'        => $this->is_public,
+			'date_created_gmt' => $this->date_created_gmt,
+			'items'            => $items_array,
+		);
+	}
+
+	/**
+	 * Build a ShopperList from a stored array (deserialising items into ShopperListItem instances).
+	 *
+	 * @param array $data    Stored list record.
+	 * @param int   $user_id Owning user ID.
+	 */
+	private static function from_array( array $data, int $user_id ): self {
+		$items = array();
+		if ( ! empty( $data['items'] ) && is_array( $data['items'] ) ) {
+			foreach ( $data['items'] as $key => $item_data ) {
+				if ( is_array( $item_data ) ) {
+					$items[ (string) $key ] = ShopperListItem::from_array( $item_data );
+				}
+			}
+		}
+
+		return new self(
+			$user_id,
+			$data['slug'] ?? '',
+			$data['name'] ?? '',
+			$data['is_public'] ?? false,
+			$data['date_created_gmt'] ?? current_time( 'mysql', true ),
+			$items
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -29,13 +29,6 @@ class ShopperList {
 	private $slug;
 
 	/**
-	 * Whether the list is public.
-	 *
-	 * @var bool
-	 */
-	private $is_public;
-
-	/**
 	 * Datetime the list was created.
 	 *
 	 * @var string
@@ -54,20 +47,17 @@ class ShopperList {
 	 *
 	 * @param int                            $user_id          Owning user ID.
 	 * @param string                         $slug             List slug.
-	 * @param bool                           $is_public        Whether the list is shareable.
 	 * @param string                         $date_created_gmt MySQL DATETIME, GMT.
 	 * @param array<string, ShopperListItem> $items            Items keyed by storage key.
 	 */
 	private function __construct(
 		int $user_id,
 		string $slug,
-		bool $is_public,
 		string $date_created_gmt,
 		array $items
 	) {
 		$this->user_id          = $user_id;
 		$this->slug             = $slug;
-		$this->is_public        = $is_public;
 		$this->date_created_gmt = $date_created_gmt;
 		$this->items            = $items;
 	}
@@ -105,7 +95,6 @@ class ShopperList {
 			return new self(
 				$user_id,
 				'saved-for-later',
-				false,
 				current_time( 'mysql', true ),
 				array()
 			);
@@ -198,7 +187,6 @@ class ShopperList {
 
 		return array(
 			'slug'             => $this->slug,
-			'is_public'        => $this->is_public,
 			'date_created_gmt' => $this->date_created_gmt,
 			'items'            => $items_array,
 		);
@@ -223,7 +211,6 @@ class ShopperList {
 		return new self(
 			$user_id,
 			$data['slug'] ?? '',
-			$data['is_public'] ?? false,
 			$data['date_created_gmt'] ?? current_time( 'mysql', true ),
 			$items
 		);

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -65,8 +65,6 @@ class ShopperList {
 	/**
 	 * Load a list by slug. Returns false for any other list that doesn't exist.
 	 *
-	 * @throws \RuntimeException When the stored data is corrupt (non-array meta value).
-	 *
 	 * @param string   $slug List identifier.
 	 * @param int|null $user_id Defaults to the current user.
 	 * @return self|false
@@ -83,14 +81,7 @@ class ShopperList {
 			return self::from_array( $stored, $user_id );
 		}
 
-		// Anything other than the empty default means a row exists but isn't an array, signaling corrupt data.
-		if ( '' !== $stored && false !== $stored && null !== $stored ) {
-			throw new \RuntimeException(
-				esc_html( sprintf( 'Corrupt shopper list data for user %d list %s', $user_id, $slug ) )
-			);
-		}
-
-		// Return an in-memory saved-for-later list; it's persisted lazily on the first add_item()+save().
+		// In-memory saved-for-later; persisted lazily on the first save().
 		if ( 'saved-for-later' === $slug ) {
 			return new self(
 				$user_id,
@@ -205,7 +196,7 @@ class ShopperList {
 	}
 
 	/**
-	 * Build a ShopperList from a stored array (deserialising items into ShopperListItem instances).
+	 * Build a ShopperList from a stored array.
 	 *
 	 * @param array $data    Stored list record.
 	 * @param int   $user_id Owning user ID.
@@ -214,8 +205,14 @@ class ShopperList {
 		$items = array();
 		if ( ! empty( $data['items'] ) && is_array( $data['items'] ) ) {
 			foreach ( $data['items'] as $key => $item_data ) {
-				if ( is_array( $item_data ) ) {
+				if ( ! is_array( $item_data ) ) {
+					continue;
+				}
+
+				try {
 					$items[ (string) $key ] = ShopperListItem::from_array( $item_data );
+				} catch ( \Throwable $e ) {
+					continue;
 				}
 			}
 		}

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -110,9 +110,9 @@ class ShopperList {
 			);
 		}
 
-		// Auto-create saved-for-later when necessary.
+		// Return an in-memory saved-for-later list; it's persisted lazily on the first add_item()+save().
 		if ( 'saved-for-later' === $slug ) {
-			$list = new self(
+			return new self(
 				$user_id,
 				'saved-for-later',
 				'Saved for Later',
@@ -120,8 +120,6 @@ class ShopperList {
 				current_time( 'mysql', true ),
 				array()
 			);
-			$list->save();
-			return $list;
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -57,7 +57,7 @@ class ShopperList {
 	private $items;
 
 	/**
-	 * Construct from already-validated values. Use the static factories instead.
+	 * Private constructor. Use the static factories to obtain concrete instances.
 	 *
 	 * @param int                            $user_id          Owning user ID.
 	 * @param string                         $slug             List slug.
@@ -83,7 +83,7 @@ class ShopperList {
 	}
 
 	/**
-	 * Load a list by slug. Auto-creates saved-for-later. Returns false for any other list that doesn't exist.
+	 * Load a list by slug. Returns false for any other list that doesn't exist.
 	 *
 	 * @throws \RuntimeException When the stored data is corrupt (non-array meta value).
 	 *
@@ -92,8 +92,8 @@ class ShopperList {
 	 * @return self|false
 	 */
 	public static function get_by_slug( string $slug, ?int $user_id = null ) {
-		$user_id = null === $user_id ? get_current_user_id() : $user_id;
-		if ( $user_id <= 0 ) {
+		$user_id = absint( $user_id ? $user_id : get_current_user_id() );
+		if ( ! $user_id ) {
 			return false;
 		}
 
@@ -103,14 +103,14 @@ class ShopperList {
 			return self::from_array( $stored, $user_id );
 		}
 
-		// Anything other than the empty default means a row exists but isn't an array — corruption.
+		// Anything other than the empty default means a row exists but isn't an array, signaling corrupt data.
 		if ( '' !== $stored && false !== $stored && null !== $stored ) {
 			throw new \RuntimeException(
 				esc_html( sprintf( 'Corrupt shopper list data for user %d list %s', $user_id, $slug ) )
 			);
 		}
 
-		// Empty default — list doesn't exist. Auto-create saved-for-later only.
+		// Auto-create saved-for-later when necessary.
 		if ( 'saved-for-later' === $slug ) {
 			$list = new self(
 				$user_id,
@@ -134,8 +134,10 @@ class ShopperList {
 	 * @return array<string, self>
 	 */
 	public static function get_all_for_user( ?int $user_id = null ): array {
-		$sfl = self::get_by_slug( 'saved-for-later', $user_id );
-		return $sfl ? array( 'saved-for-later' => $sfl ) : array();
+		// For now, only saved-for-later exists.
+		return array(
+			'saved-for-later' => self::get_by_slug( 'saved-for-later', $user_id )
+		);
 	}
 
 	/**
@@ -151,7 +153,7 @@ class ShopperList {
 	 * @param ShopperListItem $item Item to add.
 	 */
 	public function add_item( ShopperListItem $item ): void {
-		$this->items[ $item->key() ] = $item;
+		$this->items[ $item->get_key() ] = $item;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -135,8 +135,10 @@ class ShopperList {
 	 */
 	public static function get_all_for_user( ?int $user_id = null ): array {
 		// For now, only saved-for-later exists.
-		return array(
-			'saved-for-later' => self::get_by_slug( 'saved-for-later', $user_id )
+		return array_filter(
+			array(
+				'saved-for-later' => self::get_by_slug( 'saved-for-later', $user_id ),
+			)
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -43,13 +43,6 @@ class ShopperListItem {
 	private $quantity;
 
 	/**
-	 * Custom item data captured at save time (extension fields).
-	 *
-	 * @var array
-	 */
-	private $item_data;
-
-	/**
 	 * MySQL DATETIME the item was saved, in GMT.
 	 *
 	 * @var string
@@ -78,7 +71,6 @@ class ShopperListItem {
 	 * @param int    $variation_id          Variation ID, or 0.
 	 * @param array  $variation             Variation attributes.
 	 * @param int    $quantity              Saved quantity.
-	 * @param array  $item_data             Custom item data.
 	 * @param string $date_added_gmt        MySQL DATETIME, GMT.
 	 * @param string $product_title_at_save Title snapshot.
 	 * @param string $price_at_save         Price snapshot.
@@ -89,7 +81,6 @@ class ShopperListItem {
 		int $variation_id,
 		array $variation,
 		int $quantity,
-		array $item_data,
 		string $date_added_gmt,
 		string $product_title_at_save,
 		string $price_at_save
@@ -99,7 +90,6 @@ class ShopperListItem {
 		$this->variation_id          = $variation_id;
 		$this->variation             = $variation;
 		$this->quantity              = $quantity;
-		$this->item_data             = $item_data;
 		$this->date_added_gmt        = $date_added_gmt;
 		$this->product_title_at_save = $product_title_at_save;
 		$this->price_at_save         = $price_at_save;
@@ -117,7 +107,6 @@ class ShopperListItem {
 			$data['variation_id'] ?? 0,
 			isset( $data['variation'] ) && is_array( $data['variation'] ) ? $data['variation'] : array(),
 			$data['quantity'] ?? 1,
-			isset( $data['item_data'] ) && is_array( $data['item_data'] ) ? $data['item_data'] : array(),
 			$data['date_added_gmt'] ?? '',
 			$data['product_title_at_save'] ?? '',
 			$data['price_at_save'] ?? ''
@@ -129,11 +118,10 @@ class ShopperListItem {
 	 *
 	 * @param int   $product_or_variation_id Product or variation ID.
 	 * @param array $variation               Variation attributes keyed by attribute name.
-	 * @param array $item_data               Custom item data.
 	 * @param int   $quantity                Saved quantity. Coerced to a minimum of 1.
 	 * @return self|null Null if the underlying product can't be resolved.
 	 */
-	public static function from_product( int $product_or_variation_id, array $variation = array(), array $item_data = array(), int $quantity = 1 ): ?self {
+	public static function from_product( int $product_or_variation_id, array $variation = array(), int $quantity = 1 ): ?self {
 		$product = wc_get_product( absint( $product_or_variation_id ) );
 		if ( ! $product ) {
 			return null;
@@ -143,12 +131,11 @@ class ShopperListItem {
 		$product_id   = $variation_id ? $product->get_parent_id() : $product->get_id();
 
 		return new self(
-			self::generate_key( $product_id, $variation_id, $variation, $item_data ),
+			self::generate_key( $product_id, $variation_id, $variation ),
 			$product_id,
 			$variation_id,
 			$variation,
 			max( 1, $quantity ),
-			$item_data,
 			current_time( 'mysql', true ),
 			$product->get_title(),
 			$product->get_price()
@@ -186,7 +173,6 @@ class ShopperListItem {
 			'variation_id'          => $this->variation_id,
 			'variation'             => $this->variation,
 			'quantity'              => $this->quantity,
-			'item_data'             => $this->item_data,
 			'date_added_gmt'        => $this->date_added_gmt,
 			'product_title_at_save' => $this->product_title_at_save,
 			'price_at_save'         => $this->price_at_save,
@@ -195,14 +181,14 @@ class ShopperListItem {
 
 	/**
 	 * Compute a deterministic item key. Mirrors WC_Cart::generate_cart_id() so the same
-	 * product+variation+item_data always hashes to the same key.
+	 * product+variation always hashes to the same key, regardless of the input key order
+	 * for variation attributes.
 	 *
 	 * @param int   $product_id   Product ID.
 	 * @param int   $variation_id Variation ID, or 0.
 	 * @param array $variation    Variation attributes.
-	 * @param array $item_data    Custom item data.
 	 */
-	private static function generate_key( int $product_id, int $variation_id, array $variation, array $item_data ): string {
+	private static function generate_key( int $product_id, int $variation_id, array $variation ): string {
 		$id_parts = array( $product_id );
 
 		if ( $variation_id ) {
@@ -210,22 +196,12 @@ class ShopperListItem {
 		}
 
 		if ( ! empty( $variation ) ) {
+			ksort( $variation );
 			$variation_key = '';
 			foreach ( $variation as $k => $v ) {
 				$variation_key .= trim( (string) $k ) . trim( (string) $v );
 			}
 			$id_parts[] = $variation_key;
-		}
-
-		if ( ! empty( $item_data ) ) {
-			$item_data_key = '';
-			foreach ( $item_data as $k => $v ) {
-				if ( is_array( $v ) || is_object( $v ) ) {
-					$v = http_build_query( (array) $v );
-				}
-				$item_data_key .= trim( (string) $k ) . trim( (string) $v );
-			}
-			$id_parts[] = $item_data_key;
 		}
 
 		return md5( implode( '_', $id_parts ) );

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -98,15 +98,25 @@ class ShopperListItem {
 	/**
 	 * Construct from a stored item array (from user_meta).
 	 *
+	 * @throws \Exception
+	 *
 	 * @param array $data Stored item record.
 	 */
 	public static function from_array( array $data ): self {
+		if (
+			empty( $data['key'] ) || ! is_string( $data['key'] )
+			|| empty( $data['product_id'] ) || ! is_int( $data['product_id'] )
+			|| empty( $data['quantity'] ) || ! is_int( $data['quantity'] )
+		) {
+			throw new \Exception( 'Shopper list item requires "key" (string), "product_id" (int), and "quantity" (int).' );
+		}
+
 		return new self(
-			$data['key'] ?? '',
-			$data['product_id'] ?? 0,
-			$data['variation_id'] ?? 0,
-			isset( $data['variation'] ) && is_array( $data['variation'] ) ? $data['variation'] : array(),
-			$data['quantity'] ?? 1,
+			$data['key'],
+			absint( $data['product_id'] ),
+			absint( $data['variation_id'] ?? 0 ),
+			$data['variation'] ?? array(),
+			absint( $data['quantity'] ),
 			$data['date_added_gmt'] ?? '',
 			$data['product_title_at_save'] ?? '',
 			$data['price_at_save'] ?? ''

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -98,7 +98,7 @@ class ShopperListItem {
 	/**
 	 * Construct from a stored item array (from user_meta).
 	 *
-	 * @throws \Exception
+	 * @throws \Exception When the stored payload is missing required fields.
 	 *
 	 * @param array $data Stored item record.
 	 */

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -164,6 +164,13 @@ class ShopperListItem {
 	}
 
 	/**
+	 * Saved quantity.
+	 */
+	public function get_quantity(): int {
+		return $this->quantity;
+	}
+
+	/**
 	 * Storage / response shape.
 	 */
 	public function to_array(): array {

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -130,9 +130,10 @@ class ShopperListItem {
 	 * @param int   $product_or_variation_id Product or variation ID.
 	 * @param array $variation               Variation attributes keyed by attribute name.
 	 * @param array $item_data               Custom item data.
+	 * @param int   $quantity                Saved quantity. Coerced to a minimum of 1.
 	 * @return self|null Null if the underlying product can't be resolved.
 	 */
-	public static function from_product( int $product_or_variation_id, array $variation = array(), array $item_data = array() ): ?self {
+	public static function from_product( int $product_or_variation_id, array $variation = array(), array $item_data = array(), int $quantity = 1 ): ?self {
 		$product = wc_get_product( absint( $product_or_variation_id ) );
 		if ( ! $product ) {
 			return null;
@@ -141,13 +142,12 @@ class ShopperListItem {
 		$variation_id = $product->is_type( 'variation' ) ? $product->get_id() : 0;
 		$product_id   = $variation_id ? $product->get_parent_id() : $product->get_id();
 
-		// Quantity is hardcoded to 1 for now.
 		return new self(
 			self::generate_key( $product_id, $variation_id, $variation, $item_data ),
 			$product_id,
 			$variation_id,
 			$variation,
-			1,
+			max( 1, $quantity ),
 			$item_data,
 			current_time( 'mysql', true ),
 			$product->get_title(),

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -5,9 +5,6 @@ namespace Automattic\WooCommerce\Internal\ShopperLists;
 
 /**
  * A single saved item within a shopper list.
- *
- * Identity is the deterministic md5 of product + variation + item_data, so
- * adding the same payload twice always lands in the same slot (idempotent UPSERT).
  */
 class ShopperListItem {
 	/**
@@ -74,7 +71,7 @@ class ShopperListItem {
 	private $price_at_save;
 
 	/**
-	 * Construct from already-validated values. Use the static factories instead.
+	 * Private constructor. Use the static factories to obtain concrete instances.
 	 *
 	 * @param string $key                   Storage key (md5 of identity tuple).
 	 * @param int    $product_id            Product ID.
@@ -136,15 +133,15 @@ class ShopperListItem {
 	 * @return self|null Null if the underlying product can't be resolved.
 	 */
 	public static function from_product( int $product_or_variation_id, array $variation = array(), array $item_data = array() ): ?self {
-		$product = $product_or_variation_id > 0 ? wc_get_product( $product_or_variation_id ) : false;
-
-		if ( ! $product instanceof \WC_Product ) {
+		$product = wc_get_product( absint( $product_or_variation_id ) );
+		if ( ! $product ) {
 			return null;
 		}
 
 		$variation_id = $product->is_type( 'variation' ) ? $product->get_id() : 0;
-		$product_id   = $variation_id > 0 ? $product->get_parent_id() : $product->get_id();
+		$product_id   = $variation_id ? $product->get_parent_id() : $product->get_id();
 
+		// Quantity is hardcoded to 1 for now.
 		return new self(
 			self::generate_key( $product_id, $variation_id, $variation, $item_data ),
 			$product_id,
@@ -161,21 +158,21 @@ class ShopperListItem {
 	/**
 	 * Storage key — also used as the response identifier.
 	 */
-	public function key(): string {
+	public function get_key(): string {
 		return $this->key;
 	}
 
 	/**
 	 * Product ID at save time.
 	 */
-	public function product_id(): int {
+	public function get_product_id(): int {
 		return $this->product_id;
 	}
 
 	/**
 	 * Variation ID at save time, or 0 for non-variable products.
 	 */
-	public function variation_id(): int {
+	public function get_variation_id(): int {
 		return $this->variation_id;
 	}
 
@@ -208,7 +205,7 @@ class ShopperListItem {
 	private static function generate_key( int $product_id, int $variation_id, array $variation, array $item_data ): string {
 		$id_parts = array( $product_id );
 
-		if ( $variation_id > 0 ) {
+		if ( $variation_id ) {
 			$id_parts[] = $variation_id;
 		}
 

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -3,6 +3,8 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\ShopperLists;
 
+use Automattic\WooCommerce\Enums\ProductType;
+
 /**
  * A single saved item within a shopper list.
  */
@@ -115,6 +117,8 @@ class ShopperListItem {
 	/**
 	 * Construct from a product (or variation) ID and optional payload fields.
 	 *
+	 * @throws \InvalidArgumentException When the provided variation attributes do not match the variation product.
+	 *
 	 * @param int   $product_or_variation_id Product or variation ID.
 	 * @param array $variation               Variation attributes keyed by attribute name.
 	 * @param int   $quantity                Saved quantity. Coerced to a minimum of 1.
@@ -126,8 +130,19 @@ class ShopperListItem {
 			return null;
 		}
 
-		$variation_id = $product->is_type( 'variation' ) ? $product->get_id() : 0;
-		$product_id   = $variation_id ? $product->get_parent_id() : $product->get_id();
+		if ( $product->is_type( ProductType::VARIATION ) ) {
+			$variation_id = $product->get_id();
+			$product_id   = $product->get_parent_id();
+			$variation    = self::resolve_variation_attributes( $product, $variation );
+		} elseif ( $product->is_type( ProductType::VARIABLE ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'When saving a variation, product_id must be the variation ID, not the parent product ID.', 'woocommerce' )
+			);
+		} else {
+			$product_id   = $product->get_id();
+			$variation_id = 0;
+			$variation    = array();
+		}
 
 		return new self(
 			self::generate_key( $product_id, $variation_id, $variation ),
@@ -138,6 +153,87 @@ class ShopperListItem {
 			current_time( 'mysql', true ),
 			$product->get_title()
 		);
+	}
+
+	/**
+	 * Resolve and validate the variation attribute array against the variation product.
+	 *
+	 * Mirrors {@see CartController::parse_variation_data()}: specific values come from
+	 * the variation (server-authoritative); "any" slots must be supplied by the caller
+	 * with a value that exists on the parent product.
+	 *
+	 * @throws \InvalidArgumentException When the supplied variation attributes are
+	 *                                   missing required values or don't match the
+	 *                                   variation product.
+	 *
+	 * @param \WC_Product $variation_product     Variation product.
+	 * @param array       $requested_attributes  Variation attributes supplied by the caller, keyed by `attribute_<slug>`.
+	 * @return array
+	 */
+	private static function resolve_variation_attributes( \WC_Product $variation_product, array $requested_attributes ): array {
+		$parent = wc_get_product( $variation_product->get_parent_id() );
+		if ( ! $parent || ! $parent->is_type( ProductType::VARIABLE ) || ! $variation_product->is_type( ProductType::VARIATION ) ) {
+			return array();
+		}
+
+		$result = array();
+
+		$all_attributes       = array_filter( $parent->get_attributes(), fn( $attribute ) => $attribute->get_variation() );
+		$variation_attributes = wc_get_product_variation_attributes( $variation_product->get_id() );
+
+		foreach ( $all_attributes as $name => $attribute ) {
+			$key      = 'attribute_' . $name;
+			$expected = $variation_attributes[ $key ] ?? '';
+
+			// Variation doesn't provide attribute ('any' attribute).
+			if ( '' === $expected ) {
+				if ( ! isset( $requested_attributes[ $key ] ) ) {
+					throw new \InvalidArgumentException(
+						esc_html(
+							sprintf(
+								/* translators: %s: attribute name. */
+								__( 'Attribute "%s" is required.', 'woocommerce' ),
+								$name
+							)
+						)
+					);
+				}
+
+				if ( ! in_array( $requested_attributes[ $key ], $attribute->get_slugs(), true ) ) {
+					throw new \InvalidArgumentException(
+						esc_html(
+							sprintf(
+								/* translators: 1: attribute name, 2: comma-separated allowed values. */
+								__( 'Invalid value posted for "%1$s". Allowed values: %2$s', 'woocommerce' ),
+								$name,
+								implode( ', ', $attribute->get_slugs() )
+							)
+						)
+					);
+				}
+
+				$result[ $key ] = $requested_attributes[ $key ];
+				continue;
+			}//end if
+
+			// Variation provides attribute.
+			if ( isset( $requested_attributes[ $key ] ) && $requested_attributes[ $key ] !== $expected ) {
+				throw new \InvalidArgumentException(
+					esc_html(
+						sprintf(
+							/* translators: 1: attribute name, 2: expected value. */
+							__( 'Invalid value posted for "%1$s". Expected "%2$s".', 'woocommerce' ),
+							$name,
+							$expected
+						)
+					)
+				);
+			}
+
+			$result[ $key ] = $expected;
+		}//end foreach
+
+		return $result;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -1,0 +1,236 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ShopperLists;
+
+/**
+ * A single saved item within a shopper list.
+ *
+ * Identity is the deterministic md5 of product + variation + item_data, so
+ * adding the same payload twice always lands in the same slot (idempotent UPSERT).
+ */
+class ShopperListItem {
+	/**
+	 * Storage key (md5 of identity tuple).
+	 *
+	 * @var string
+	 */
+	private $key;
+
+	/**
+	 * Product ID at the time the item was saved.
+	 *
+	 * @var int
+	 */
+	private $product_id;
+
+	/**
+	 * Variation ID at the time the item was saved (0 for non-variable products).
+	 *
+	 * @var int
+	 */
+	private $variation_id;
+
+	/**
+	 * Variation attributes captured at save time.
+	 *
+	 * @var array
+	 */
+	private $variation;
+
+	/**
+	 * Saved quantity (always 1 in the current contract).
+	 *
+	 * @var int
+	 */
+	private $quantity;
+
+	/**
+	 * Custom item data captured at save time (extension fields).
+	 *
+	 * @var array
+	 */
+	private $item_data;
+
+	/**
+	 * MySQL DATETIME the item was saved, in GMT.
+	 *
+	 * @var string
+	 */
+	private $date_added_gmt;
+
+	/**
+	 * Snapshot of the product title at save time.
+	 *
+	 * @var string
+	 */
+	private $product_title_at_save;
+
+	/**
+	 * Snapshot of the product price at save time.
+	 *
+	 * @var string
+	 */
+	private $price_at_save;
+
+	/**
+	 * Construct from already-validated values. Use the static factories instead.
+	 *
+	 * @param string $key                   Storage key (md5 of identity tuple).
+	 * @param int    $product_id            Product ID.
+	 * @param int    $variation_id          Variation ID, or 0.
+	 * @param array  $variation             Variation attributes.
+	 * @param int    $quantity              Saved quantity.
+	 * @param array  $item_data             Custom item data.
+	 * @param string $date_added_gmt        MySQL DATETIME, GMT.
+	 * @param string $product_title_at_save Title snapshot.
+	 * @param string $price_at_save         Price snapshot.
+	 */
+	private function __construct(
+		string $key,
+		int $product_id,
+		int $variation_id,
+		array $variation,
+		int $quantity,
+		array $item_data,
+		string $date_added_gmt,
+		string $product_title_at_save,
+		string $price_at_save
+	) {
+		$this->key                   = $key;
+		$this->product_id            = $product_id;
+		$this->variation_id          = $variation_id;
+		$this->variation             = $variation;
+		$this->quantity              = $quantity;
+		$this->item_data             = $item_data;
+		$this->date_added_gmt        = $date_added_gmt;
+		$this->product_title_at_save = $product_title_at_save;
+		$this->price_at_save         = $price_at_save;
+	}
+
+	/**
+	 * Construct from a stored item array (from user_meta).
+	 *
+	 * @param array $data Stored item record.
+	 */
+	public static function from_array( array $data ): self {
+		return new self(
+			$data['key'] ?? '',
+			$data['product_id'] ?? 0,
+			$data['variation_id'] ?? 0,
+			isset( $data['variation'] ) && is_array( $data['variation'] ) ? $data['variation'] : array(),
+			$data['quantity'] ?? 1,
+			isset( $data['item_data'] ) && is_array( $data['item_data'] ) ? $data['item_data'] : array(),
+			$data['date_added_gmt'] ?? '',
+			$data['product_title_at_save'] ?? '',
+			$data['price_at_save'] ?? ''
+		);
+	}
+
+	/**
+	 * Construct from a product (or variation) ID and optional payload fields.
+	 *
+	 * @param int   $product_or_variation_id Product or variation ID.
+	 * @param array $variation               Variation attributes keyed by attribute name.
+	 * @param array $item_data               Custom item data.
+	 * @return self|null Null if the underlying product can't be resolved.
+	 */
+	public static function from_product( int $product_or_variation_id, array $variation = array(), array $item_data = array() ): ?self {
+		$product = $product_or_variation_id > 0 ? wc_get_product( $product_or_variation_id ) : false;
+
+		if ( ! $product instanceof \WC_Product ) {
+			return null;
+		}
+
+		$variation_id = $product->is_type( 'variation' ) ? $product->get_id() : 0;
+		$product_id   = $variation_id > 0 ? $product->get_parent_id() : $product->get_id();
+
+		return new self(
+			self::generate_key( $product_id, $variation_id, $variation, $item_data ),
+			$product_id,
+			$variation_id,
+			$variation,
+			1,
+			$item_data,
+			current_time( 'mysql', true ),
+			$product->get_title(),
+			$product->get_price()
+		);
+	}
+
+	/**
+	 * Storage key — also used as the response identifier.
+	 */
+	public function key(): string {
+		return $this->key;
+	}
+
+	/**
+	 * Product ID at save time.
+	 */
+	public function product_id(): int {
+		return $this->product_id;
+	}
+
+	/**
+	 * Variation ID at save time, or 0 for non-variable products.
+	 */
+	public function variation_id(): int {
+		return $this->variation_id;
+	}
+
+	/**
+	 * Storage / response shape.
+	 */
+	public function to_array(): array {
+		return array(
+			'key'                   => $this->key,
+			'product_id'            => $this->product_id,
+			'variation_id'          => $this->variation_id,
+			'variation'             => $this->variation,
+			'quantity'              => $this->quantity,
+			'item_data'             => $this->item_data,
+			'date_added_gmt'        => $this->date_added_gmt,
+			'product_title_at_save' => $this->product_title_at_save,
+			'price_at_save'         => $this->price_at_save,
+		);
+	}
+
+	/**
+	 * Compute a deterministic item key. Mirrors WC_Cart::generate_cart_id() so the same
+	 * product+variation+item_data always hashes to the same key.
+	 *
+	 * @param int   $product_id   Product ID.
+	 * @param int   $variation_id Variation ID, or 0.
+	 * @param array $variation    Variation attributes.
+	 * @param array $item_data    Custom item data.
+	 */
+	private static function generate_key( int $product_id, int $variation_id, array $variation, array $item_data ): string {
+		$id_parts = array( $product_id );
+
+		if ( $variation_id > 0 ) {
+			$id_parts[] = $variation_id;
+		}
+
+		if ( ! empty( $variation ) ) {
+			$variation_key = '';
+			foreach ( $variation as $k => $v ) {
+				$variation_key .= trim( (string) $k ) . trim( (string) $v );
+			}
+			$id_parts[] = $variation_key;
+		}
+
+		if ( ! empty( $item_data ) ) {
+			$item_data_key = '';
+			foreach ( $item_data as $k => $v ) {
+				if ( is_array( $v ) || is_object( $v ) ) {
+					$v = http_build_query( (array) $v );
+				}
+				$item_data_key .= trim( (string) $k ) . trim( (string) $v );
+			}
+			$id_parts[] = $item_data_key;
+		}
+
+		return md5( implode( '_', $id_parts ) );
+	}
+}

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -57,13 +57,6 @@ class ShopperListItem {
 	private $product_title_at_save;
 
 	/**
-	 * Snapshot of the product price at save time.
-	 *
-	 * @var string
-	 */
-	private $price_at_save;
-
-	/**
 	 * Private constructor. Use the static factories to obtain concrete instances.
 	 *
 	 * @param string $key                   Storage key (md5 of identity tuple).
@@ -73,7 +66,6 @@ class ShopperListItem {
 	 * @param int    $quantity              Saved quantity.
 	 * @param string $date_added_gmt        MySQL DATETIME, GMT.
 	 * @param string $product_title_at_save Title snapshot.
-	 * @param string $price_at_save         Price snapshot.
 	 */
 	private function __construct(
 		string $key,
@@ -82,8 +74,7 @@ class ShopperListItem {
 		array $variation,
 		int $quantity,
 		string $date_added_gmt,
-		string $product_title_at_save,
-		string $price_at_save
+		string $product_title_at_save
 	) {
 		$this->key                   = $key;
 		$this->product_id            = $product_id;
@@ -92,7 +83,6 @@ class ShopperListItem {
 		$this->quantity              = $quantity;
 		$this->date_added_gmt        = $date_added_gmt;
 		$this->product_title_at_save = $product_title_at_save;
-		$this->price_at_save         = $price_at_save;
 	}
 
 	/**
@@ -118,8 +108,7 @@ class ShopperListItem {
 			$data['variation'] ?? array(),
 			absint( $data['quantity'] ),
 			$data['date_added_gmt'] ?? '',
-			$data['product_title_at_save'] ?? '',
-			$data['price_at_save'] ?? ''
+			$data['product_title_at_save'] ?? ''
 		);
 	}
 
@@ -147,8 +136,7 @@ class ShopperListItem {
 			$variation,
 			max( 1, $quantity ),
 			current_time( 'mysql', true ),
-			$product->get_title(),
-			$product->get_price()
+			$product->get_title()
 		);
 	}
 
@@ -192,7 +180,6 @@ class ShopperListItem {
 			'quantity'              => $this->quantity,
 			'date_added_gmt'        => $this->date_added_gmt,
 			'product_title_at_save' => $this->product_title_at_save,
-			'price_at_save'         => $this->price_at_save,
 		);
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -81,16 +81,28 @@ class ShopperListItems extends AbstractRoute {
 						'type'        => 'string',
 					),
 					'product_id'    => array(
-						'description' => __( 'Product ID to save directly when cart_item_key is not supplied.', 'woocommerce' ),
-						'type'        => 'integer',
-					),
-					'variation_id'  => array(
-						'description' => __( 'Variation ID, when saving a variation product directly.', 'woocommerce' ),
+						'description' => __( 'Product or variation ID to save. Required when cart_item_key is not supplied.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
 					'variation'     => array(
-						'description' => __( 'Variation attributes keyed by attribute name.', 'woocommerce' ),
+						'description' => __( 'Chosen attributes (for variations).', 'woocommerce' ),
 						'type'        => 'array',
+						'context'     => array( 'view', 'edit' ),
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'attribute' => array(
+									'description' => __( 'Variation attribute name.', 'woocommerce' ),
+									'type'        => 'string',
+									'context'     => array( 'view', 'edit' ),
+								),
+								'value'     => array(
+									'description' => __( 'Variation attribute value.', 'woocommerce' ),
+									'type'        => 'string',
+									'context'     => array( 'view', 'edit' ),
+								),
+							),
+						),
 					),
 					'quantity'      => array(
 						'description' => __( 'Quantity for the saved item.', 'woocommerce' ),
@@ -151,7 +163,11 @@ class ShopperListItems extends AbstractRoute {
 
 		[ $lookup_id, $variation, $quantity ] = $this->resolve_item_payload( $request );
 
-		$item = ShopperListItem::from_product( $lookup_id, $variation, $quantity );
+		try {
+			$item = ShopperListItem::from_product( $lookup_id, $variation, $quantity );
+		} catch ( \InvalidArgumentException $e ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_invalid_variation', esc_html( $e->getMessage() ), 400 );
+		}
 		if ( ! $item ) {
 			throw new RouteException( 'woocommerce_rest_shopper_list_unknown_product', esc_html__( 'No product exists for the supplied item.', 'woocommerce' ), 404 );
 		}
@@ -202,11 +218,14 @@ class ShopperListItems extends AbstractRoute {
 			throw new RouteException( 'woocommerce_rest_shopper_list_missing_item_input', esc_html__( 'Provide cart_item_key or product_id.', 'woocommerce' ), 400 );
 		}
 
-		$variation_id = absint( $request->get_param( 'variation_id' ) );
+		$variation = wp_list_pluck( (array) $request->get_param( 'variation' ), 'value', 'attribute' );
 
 		return array(
-			$variation_id ? $variation_id : $product_id,
-			(array) $request->get_param( 'variation' ),
+			$product_id,
+			(array) array_combine(
+				array_map( 'wc_variation_attribute_name', array_keys( $variation ) ),
+				array_values( $variation )
+			),
 			absint( $request->get_param( 'quantity' ) ),
 		);
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -95,6 +95,7 @@ class ShopperListItems extends AbstractRoute {
 					'quantity'      => array(
 						'description' => __( 'Quantity for the saved item.', 'woocommerce' ),
 						'type'        => 'integer',
+						'default'     => 1,
 					),
 				),
 			),

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListSchema;
 
 /**
  * GET / POST on /shopper-lists/{slug}/items.
@@ -158,9 +159,29 @@ class ShopperListItems extends AbstractRoute {
 		$list->add_item( $item );
 		$list->save();
 
-		$response = rest_ensure_response( $this->prepare_item_for_response( $item->to_array(), $request ) );
-		$response->set_status( 201 );
-		return $response;
+		return $this->prepare_list_response( $list, 201 );
+	}
+
+	/**
+	 * Render a full ShopperList response (metadata + items) for write endpoints.
+	 *
+	 * @param ShopperList $list   List to render.
+	 * @param int         $status HTTP status to set on the response.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	private function prepare_list_response( ShopperList $list, int $status = 200 ): \WP_REST_Response {
+		$items = array_values( $list->get_items() );
+		$this->prime_product_caches_for_items( $items );
+
+		$list_schema       = $this->schema_controller->get( ShopperListSchema::IDENTIFIER );
+		$response          = (array) $list_schema->get_item_response( $list->to_array() );
+		$response['items'] = array_map(
+			fn( ShopperListItem $item ) => $this->schema->get_item_response( $item->to_array() ),
+			$items
+		);
+
+		return new \WP_REST_Response( $response, $status );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -97,10 +97,6 @@ class ShopperListItems extends AbstractRoute {
 						'description' => __( 'Quantity for the saved item.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
-					'item_data'     => array(
-						'description' => __( 'Custom item data captured with the saved item.', 'woocommerce' ),
-						'type'        => 'array',
-					),
 				),
 			),
 			'schema' => array( $this->schema, 'get_public_item_schema' ),
@@ -153,9 +149,9 @@ class ShopperListItems extends AbstractRoute {
 			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
 		}
 
-		[ $lookup_id, $variation, $item_data, $quantity ] = $this->resolve_item_payload( $request );
+		[ $lookup_id, $variation, $quantity ] = $this->resolve_item_payload( $request );
 
-		$item = ShopperListItem::from_product( $lookup_id, $variation, $item_data, $quantity );
+		$item = ShopperListItem::from_product( $lookup_id, $variation, $quantity );
 		if ( ! $item ) {
 			throw new RouteException( 'woocommerce_rest_shopper_list_unknown_product', esc_html__( 'No product exists for the supplied item.', 'woocommerce' ), 404 );
 		}
@@ -189,9 +185,9 @@ class ShopperListItems extends AbstractRoute {
 	}
 
 	/**
-	 * Resolve the POST input into a uniform payload (product lookup id, variation, item_data).
+	 * Resolve the POST input into a uniform payload (product lookup id, variation, quantity).
 	 *
-	 * Accepts either an existing cart_item_key, or direct product_id/variation_id/variation/item_data.
+	 * Accepts either an existing cart_item_key, or direct product_id/variation_id/variation.
 	 *
 	 * @throws RouteException When neither a cart_item_key nor a product_id is supplied, or the cart_item_key is unknown.
 	 *
@@ -199,7 +195,7 @@ class ShopperListItems extends AbstractRoute {
 	 *
 	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
 	 *
-	 * @return array{0:int,1:array,2:array,3:int} `[ lookup_id, variation, item_data, quantity ]`.
+	 * @return array{0:int,1:array,2:int} `[ lookup_id, variation, quantity ]`.
 	 */
 	private function resolve_item_payload( \WP_REST_Request $request ): array {
 		$cart_item_key = (string) $request->get_param( 'cart_item_key' );
@@ -218,7 +214,6 @@ class ShopperListItems extends AbstractRoute {
 			return array(
 				$variation_id ? $variation_id : $product_id,
 				$variation_attrs,
-				$this->extract_custom_cart_item_data( $line ),
 				absint( $line['quantity'] ?? 1 ),
 			);
 		}
@@ -233,26 +228,8 @@ class ShopperListItems extends AbstractRoute {
 		return array(
 			$variation_id ? $variation_id : $product_id,
 			(array) $request->get_param( 'variation' ),
-			(array) $request->get_param( 'item_data' ),
 			absint( $request->get_param( 'quantity' ) ),
 		);
-	}
-
-	/**
-	 * Strip the WC_Product and line totals from a cart line, leaving only serializable custom fields.
-	 *
-	 * @param array $cart_item Cart item array.
-	 */
-	private function extract_custom_cart_item_data( array $cart_item ): array {
-		$skip = array( 'data', 'data_hash', 'product_id', 'variation_id', 'variation', 'quantity', 'key', 'line_subtotal', 'line_subtotal_tax', 'line_total', 'line_tax', 'line_tax_data' );
-		$data = array();
-		foreach ( $cart_item as $k => $v ) {
-			if ( in_array( $k, $skip, true ) ) {
-				continue;
-			}
-			$data[ $k ] = $v;
-		}
-		return $data;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -153,9 +153,9 @@ class ShopperListItems extends AbstractRoute {
 			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
 		}
 
-		[ $lookup_id, $variation, $item_data ] = $this->resolve_item_payload( $request );
+		[ $lookup_id, $variation, $item_data, $quantity ] = $this->resolve_item_payload( $request );
 
-		$item = ShopperListItem::from_product( $lookup_id, $variation, $item_data );
+		$item = ShopperListItem::from_product( $lookup_id, $variation, $item_data, $quantity );
 		if ( ! $item ) {
 			throw new RouteException( 'woocommerce_rest_shopper_list_unknown_product', esc_html__( 'No product exists for the supplied item.', 'woocommerce' ), 404 );
 		}
@@ -199,7 +199,7 @@ class ShopperListItems extends AbstractRoute {
 	 *
 	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
 	 *
-	 * @return array{0:int,1:array,2:array} `[ lookup_id, variation, item_data ]`.
+	 * @return array{0:int,1:array,2:array,3:int} `[ lookup_id, variation, item_data, quantity ]`.
 	 */
 	private function resolve_item_payload( \WP_REST_Request $request ): array {
 		$cart_item_key = (string) $request->get_param( 'cart_item_key' );
@@ -219,6 +219,7 @@ class ShopperListItems extends AbstractRoute {
 				$variation_id ? $variation_id : $product_id,
 				$variation_attrs,
 				$this->extract_custom_cart_item_data( $line ),
+				absint( $line['quantity'] ?? 1 ),
 			);
 		}
 
@@ -233,6 +234,7 @@ class ShopperListItems extends AbstractRoute {
 			$variation_id ? $variation_id : $product_id,
 			(array) $request->get_param( 'variation' ),
 			(array) $request->get_param( 'item_data' ),
+			absint( $request->get_param( 'quantity' ) ),
 		);
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -115,7 +115,6 @@ class ShopperListItems extends AbstractRoute {
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
 		$list = ShopperList::get_by_slug( (string) $request['slug'] );
-
 		if ( ! $list ) {
 			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
 		}
@@ -152,7 +151,6 @@ class ShopperListItems extends AbstractRoute {
 		[ $lookup_id, $variation, $item_data ] = $this->resolve_item_payload( $request );
 
 		$item = ShopperListItem::from_product( $lookup_id, $variation, $item_data );
-
 		if ( ! $item ) {
 			throw new RouteException( 'woocommerce_rest_shopper_list_unknown_product', esc_html__( 'No product exists for the supplied item.', 'woocommerce' ), 404 );
 		}
@@ -182,39 +180,39 @@ class ShopperListItems extends AbstractRoute {
 		$cart_item_key = (string) $request->get_param( 'cart_item_key' );
 
 		if ( $cart_item_key ) {
-			$cart = wc()->cart;
+			$cart = WC()->cart;
 			if ( ! $cart instanceof \WC_Cart || empty( $cart->cart_contents[ $cart_item_key ] ) ) {
 				throw new RouteException( 'woocommerce_rest_shopper_list_invalid_cart_item_key', esc_html__( 'No cart item exists for the supplied key.', 'woocommerce' ), 404 );
 			}
 
 			$line            = $cart->cart_contents[ $cart_item_key ];
-			$product_id      = (int) ( $line['product_id'] ?? 0 );
-			$variation_id    = (int) ( $line['variation_id'] ?? 0 );
+			$product_id      = absint( $line['product_id'] ?? 0 );
+			$variation_id    = absint( $line['variation_id'] ?? 0 );
 			$variation_attrs = isset( $line['variation'] ) && is_array( $line['variation'] ) ? $line['variation'] : array();
 
 			return array(
-				$variation_id > 0 ? $variation_id : $product_id,
+				$variation_id ? $variation_id : $product_id,
 				$variation_attrs,
 				$this->extract_custom_cart_item_data( $line ),
 			);
 		}
 
-		$product_id = (int) $request->get_param( 'product_id' );
-		if ( $product_id <= 0 ) {
+		$product_id = absint( $request->get_param( 'product_id' ) );
+		if ( ! $product_id ) {
 			throw new RouteException( 'woocommerce_rest_shopper_list_missing_item_input', esc_html__( 'Provide cart_item_key or product_id.', 'woocommerce' ), 400 );
 		}
 
-		$variation_id = (int) $request->get_param( 'variation_id' );
+		$variation_id = absint( $request->get_param( 'variation_id' ) );
 
 		return array(
-			$variation_id > 0 ? $variation_id : $product_id,
+			$variation_id ? $variation_id : $product_id,
 			(array) $request->get_param( 'variation' ),
 			(array) $request->get_param( 'item_data' ),
 		);
 	}
 
 	/**
-	 * Strip the WC_Product and line totals from a cart line, leaving only serialisable custom fields.
+	 * Strip the WC_Product and line totals from a cart line, leaving only serializable custom fields.
 	 *
 	 * @param array $cart_item Cart item array.
 	 */
@@ -236,18 +234,11 @@ class ShopperListItems extends AbstractRoute {
 	 * @param ShopperListItem[] $items Items.
 	 */
 	private function prime_product_caches_for_items( array $items ): void {
-		$ids = array();
-		foreach ( $items as $item ) {
-			$id = $item->variation_id() > 0 ? $item->variation_id() : $item->product_id();
-			if ( $id > 0 ) {
-				$ids[] = $id;
-			}
-		}
+		$ids = array_map(
+			fn( $item ) => $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id(),
+			$items
+		);
 
-		if ( empty( $ids ) ) {
-			return;
-		}
-
-		_prime_post_caches( array_values( array_unique( $ids ) ) );
+		_prime_post_caches( array_unique( $ids ) );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -1,0 +1,253 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * GET / POST on /shopper-lists/{slug}/items.
+ *
+ * GET returns the items in a list.
+ * POST saves an item to the list either from an existing cart line or from direct item payload fields.
+ */
+class ShopperListItems extends AbstractRoute {
+	/**
+	 * Route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-list-items';
+
+	/**
+	 * Schema identifier this route uses.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'shopper-list-item';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/shopper-lists/(?P<slug>[a-z0-9-]+)/items';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array(
+			'args'   => array(
+				'slug' => array(
+					'description' => __( 'Stable slug for the list.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+			),
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'cart_item_key' => array(
+						'description' => __( 'Existing cart item key to copy into the list.', 'woocommerce' ),
+						'type'        => 'string',
+					),
+					'product_id'    => array(
+						'description' => __( 'Product ID to save directly when cart_item_key is not supplied.', 'woocommerce' ),
+						'type'        => 'integer',
+					),
+					'variation_id'  => array(
+						'description' => __( 'Variation ID, when saving a variation product directly.', 'woocommerce' ),
+						'type'        => 'integer',
+					),
+					'variation'     => array(
+						'description' => __( 'Variation attributes keyed by attribute name.', 'woocommerce' ),
+						'type'        => 'array',
+					),
+					'quantity'      => array(
+						'description' => __( 'Quantity for the saved item.', 'woocommerce' ),
+						'type'        => 'integer',
+					),
+					'item_data'     => array(
+						'description' => __( 'Custom item data captured with the saved item.', 'woocommerce' ),
+						'type'        => 'array',
+					),
+				),
+			),
+			'schema' => array( $this->schema, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Return the items in the requested list.
+	 *
+	 * @throws RouteException When the list doesn't exist.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		$list = ShopperList::get_by_slug( (string) $request['slug'] );
+
+		if ( ! $list ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+		}
+
+		$items = array_values( $list->get_items() );
+		$this->prime_product_caches_for_items( $items );
+
+		$response = array();
+		foreach ( $items as $item ) {
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $item->to_array(), $request ) );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Add an item to the requested list from cart_item_key or direct product payload fields.
+	 *
+	 * @throws RouteException On validation failure.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_post_response( \WP_REST_Request $request ) {
+		$list = ShopperList::get_by_slug( (string) $request['slug'] );
+
+		if ( ! $list ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+		}
+
+		[ $lookup_id, $variation, $item_data ] = $this->resolve_item_payload( $request );
+
+		$item = ShopperListItem::from_product( $lookup_id, $variation, $item_data );
+
+		if ( ! $item ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_unknown_product', esc_html__( 'No product exists for the supplied item.', 'woocommerce' ), 404 );
+		}
+
+		$list->add_item( $item );
+		$list->save();
+
+		$response = rest_ensure_response( $this->prepare_item_for_response( $item->to_array(), $request ) );
+		$response->set_status( 201 );
+		return $response;
+	}
+
+	/**
+	 * Resolve the POST input into a uniform payload (product lookup id, variation, item_data).
+	 *
+	 * Accepts either an existing cart_item_key, or direct product_id/variation_id/variation/item_data.
+	 *
+	 * @throws RouteException When neither a cart_item_key nor a product_id is supplied, or the cart_item_key is unknown.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return array{0:int,1:array,2:array} `[ lookup_id, variation, item_data ]`.
+	 */
+	private function resolve_item_payload( \WP_REST_Request $request ): array {
+		$cart_item_key = (string) $request->get_param( 'cart_item_key' );
+
+		if ( $cart_item_key ) {
+			$cart = wc()->cart;
+			if ( ! $cart instanceof \WC_Cart || empty( $cart->cart_contents[ $cart_item_key ] ) ) {
+				throw new RouteException( 'woocommerce_rest_shopper_list_invalid_cart_item_key', esc_html__( 'No cart item exists for the supplied key.', 'woocommerce' ), 404 );
+			}
+
+			$line            = $cart->cart_contents[ $cart_item_key ];
+			$product_id      = (int) ( $line['product_id'] ?? 0 );
+			$variation_id    = (int) ( $line['variation_id'] ?? 0 );
+			$variation_attrs = isset( $line['variation'] ) && is_array( $line['variation'] ) ? $line['variation'] : array();
+
+			return array(
+				$variation_id > 0 ? $variation_id : $product_id,
+				$variation_attrs,
+				$this->extract_custom_cart_item_data( $line ),
+			);
+		}
+
+		$product_id = (int) $request->get_param( 'product_id' );
+		if ( $product_id <= 0 ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_missing_item_input', esc_html__( 'Provide cart_item_key or product_id.', 'woocommerce' ), 400 );
+		}
+
+		$variation_id = (int) $request->get_param( 'variation_id' );
+
+		return array(
+			$variation_id > 0 ? $variation_id : $product_id,
+			(array) $request->get_param( 'variation' ),
+			(array) $request->get_param( 'item_data' ),
+		);
+	}
+
+	/**
+	 * Strip the WC_Product and line totals from a cart line, leaving only serialisable custom fields.
+	 *
+	 * @param array $cart_item Cart item array.
+	 */
+	private function extract_custom_cart_item_data( array $cart_item ): array {
+		$skip = array( 'data', 'data_hash', 'product_id', 'variation_id', 'variation', 'quantity', 'key', 'line_subtotal', 'line_subtotal_tax', 'line_total', 'line_tax', 'line_tax_data' );
+		$data = array();
+		foreach ( $cart_item as $k => $v ) {
+			if ( in_array( $k, $skip, true ) ) {
+				continue;
+			}
+			$data[ $k ] = $v;
+		}
+		return $data;
+	}
+
+	/**
+	 * Prime post caches before the per-item product lookup loop in the schema.
+	 *
+	 * @param ShopperListItem[] $items Items.
+	 */
+	private function prime_product_caches_for_items( array $items ): void {
+		$ids = array();
+		foreach ( $items as $item ) {
+			$id = $item->variation_id() > 0 ? $item->variation_id() : $item->product_id();
+			if ( $id > 0 ) {
+				$ids[] = $id;
+			}
+		}
+
+		if ( empty( $ids ) ) {
+			return;
+		}
+
+		_prime_post_caches( array_values( array_unique( $ids ) ) );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -169,17 +169,17 @@ class ShopperListItems extends AbstractRoute {
 	/**
 	 * Render a full ShopperList response (metadata + items) for write endpoints.
 	 *
-	 * @param ShopperList $list   List to render.
-	 * @param int         $status HTTP status to set on the response.
+	 * @param ShopperList $shopper_list Shopper list to render.
+	 * @param int         $status       HTTP status to set on the response.
 	 *
 	 * @return \WP_REST_Response
 	 */
-	private function prepare_list_response( ShopperList $list, int $status = 200 ): \WP_REST_Response {
-		$items = array_values( $list->get_items() );
+	private function prepare_list_response( ShopperList $shopper_list, int $status = 200 ): \WP_REST_Response {
+		$items = array_values( $shopper_list->get_items() );
 		$this->prime_product_caches_for_items( $items );
 
 		$list_schema       = $this->schema_controller->get( ShopperListSchema::IDENTIFIER );
-		$response          = (array) $list_schema->get_item_response( $list->to_array() );
+		$response          = (array) $list_schema->get_item_response( $shopper_list->to_array() );
 		$response['items'] = array_map(
 			fn( ShopperListItem $item ) => $this->schema->get_item_response( $item->to_array() ),
 			$items

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
-use Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListSchema;
 
 /**
  * GET / POST on /shopper-lists/{slug}/items.
@@ -159,29 +158,8 @@ class ShopperListItems extends AbstractRoute {
 		$list->add_item( $item );
 		$list->save();
 
-		return $this->prepare_list_response( $list, 201 );
-	}
-
-	/**
-	 * Render a full ShopperList response (metadata + items) for write endpoints.
-	 *
-	 * @param ShopperList $shopper_list Shopper list to render.
-	 * @param int         $status       HTTP status to set on the response.
-	 *
-	 * @return \WP_REST_Response
-	 */
-	private function prepare_list_response( ShopperList $shopper_list, int $status = 200 ): \WP_REST_Response {
-		$items = array_values( $shopper_list->get_items() );
-		$this->prime_product_caches_for_items( $items );
-
-		$list_schema       = $this->schema_controller->get( ShopperListSchema::IDENTIFIER );
-		$response          = (array) $list_schema->get_item_response( $shopper_list->to_array() );
-		$response['items'] = array_map(
-			fn( ShopperListItem $item ) => $this->schema->get_item_response( $item->to_array() ),
-			$items
-		);
-
-		return new \WP_REST_Response( $response, $status );
+		$saved = $list->find_item( $item->get_key() ) ?? $item;
+		return new \WP_REST_Response( $this->schema->get_item_response( $saved->to_array() ), 201 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -63,7 +63,9 @@ class ShopperListItems extends AbstractRoute {
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_response' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
 				'args'                => array(
 					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
@@ -71,7 +73,9 @@ class ShopperListItems extends AbstractRoute {
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'get_response' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
 				'args'                => array(
 					'cart_item_key' => array(
 						'description' => __( 'Existing cart item key to copy into the list.', 'woocommerce' ),

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -196,12 +196,16 @@ class ShopperListItems extends AbstractRoute {
 		$cart_item_key = (string) $request->get_param( 'cart_item_key' );
 
 		if ( $cart_item_key ) {
-			$cart = WC()->cart;
-			if ( ! $cart instanceof \WC_Cart || empty( $cart->cart_contents[ $cart_item_key ] ) ) {
+			if ( ! did_action( 'woocommerce_load_cart_from_session' ) || ! wc()->cart ) {
+				wc_load_cart();
+			}
+
+			$cart_contents = wc()->cart->get_cart();
+			if ( empty( $cart_contents[ $cart_item_key ] ) ) {
 				throw new RouteException( 'woocommerce_rest_shopper_list_invalid_cart_item_key', esc_html__( 'No cart item exists for the supplied key.', 'woocommerce' ), 404 );
 			}
 
-			$line            = $cart->cart_contents[ $cart_item_key ];
+			$line            = $cart_contents[ $cart_item_key ];
 			$product_id      = absint( $line['product_id'] ?? 0 );
 			$variation_id    = absint( $line['variation_id'] ?? 0 );
 			$variation_attrs = isset( $line['variation'] ) && is_array( $line['variation'] ) ? $line['variation'] : array();
@@ -211,7 +215,7 @@ class ShopperListItems extends AbstractRoute {
 				$variation_attrs,
 				absint( $line['quantity'] ?? 1 ),
 			);
-		}
+		}//end if
 
 		$product_id = absint( $request->get_param( 'product_id' ) );
 		if ( ! $product_id ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -102,13 +102,13 @@ class ShopperListItemsByKey extends AbstractRoute {
 	/**
 	 * Render a full ShopperList response (metadata + items) for write endpoints.
 	 *
-	 * @param ShopperList $list   List to render.
-	 * @param int         $status HTTP status to set on the response.
+	 * @param ShopperList $shopper_list List to render.
+	 * @param int         $status       HTTP status to set on the response.
 	 *
 	 * @return \WP_REST_Response
 	 */
-	private function prepare_list_response( ShopperList $list, int $status = 200 ): \WP_REST_Response {
-		$items    = array_values( $list->get_items() );
+	private function prepare_list_response( ShopperList $shopper_list, int $status = 200 ): \WP_REST_Response {
+		$items    = array_values( $shopper_list->get_items() );
 		$item_ids = array_map(
 			fn( ShopperListItem $item ) => $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id(),
 			$items
@@ -116,7 +116,7 @@ class ShopperListItemsByKey extends AbstractRoute {
 		_prime_post_caches( array_unique( $item_ids ) );
 
 		$list_schema       = $this->schema_controller->get( ShopperListSchema::IDENTIFIER );
-		$response          = (array) $list_schema->get_item_response( $list->to_array() );
+		$response          = (array) $list_schema->get_item_response( $shopper_list->to_array() );
 		$response['items'] = array_map(
 			fn( ShopperListItem $item ) => $this->schema->get_item_response( $item->to_array() ),
 			$items

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -4,9 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
-use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
-use Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListSchema;
 
 /**
  * DELETE /shopper-lists/{slug}/items/{key}.
@@ -96,32 +94,6 @@ class ShopperListItemsByKey extends AbstractRoute {
 
 		$list->save();
 
-		return $this->prepare_list_response( $list );
-	}
-
-	/**
-	 * Render a full ShopperList response (metadata + items) for write endpoints.
-	 *
-	 * @param ShopperList $shopper_list List to render.
-	 * @param int         $status       HTTP status to set on the response.
-	 *
-	 * @return \WP_REST_Response
-	 */
-	private function prepare_list_response( ShopperList $shopper_list, int $status = 200 ): \WP_REST_Response {
-		$items    = array_values( $shopper_list->get_items() );
-		$item_ids = array_map(
-			fn( ShopperListItem $item ) => $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id(),
-			$items
-		);
-		_prime_post_caches( array_unique( $item_ids ) );
-
-		$list_schema       = $this->schema_controller->get( ShopperListSchema::IDENTIFIER );
-		$response          = (array) $list_schema->get_item_response( $shopper_list->to_array() );
-		$response['items'] = array_map(
-			fn( ShopperListItem $item ) => $this->schema->get_item_response( $item->to_array() ),
-			$items
-		);
-
-		return new \WP_REST_Response( $response, $status );
+		return new \WP_REST_Response( null, 204 );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -4,7 +4,9 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListSchema;
 
 /**
  * DELETE /shopper-lists/{slug}/items/{key}.
@@ -92,6 +94,32 @@ class ShopperListItemsByKey extends AbstractRoute {
 
 		$list->save();
 
-		return new \WP_REST_Response( null, 204 );
+		return $this->prepare_list_response( $list );
+	}
+
+	/**
+	 * Render a full ShopperList response (metadata + items) for write endpoints.
+	 *
+	 * @param ShopperList $list   List to render.
+	 * @param int         $status HTTP status to set on the response.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	private function prepare_list_response( ShopperList $list, int $status = 200 ): \WP_REST_Response {
+		$items    = array_values( $list->get_items() );
+		$item_ids = array_map(
+			fn( ShopperListItem $item ) => $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id(),
+			$items
+		);
+		_prime_post_caches( array_unique( $item_ids ) );
+
+		$list_schema       = $this->schema_controller->get( ShopperListSchema::IDENTIFIER );
+		$response          = (array) $list_schema->get_item_response( $list->to_array() );
+		$response['items'] = array_map(
+			fn( ShopperListItem $item ) => $this->schema->get_item_response( $item->to_array() ),
+			$items
+		);
+
+		return new \WP_REST_Response( $response, $status );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -1,0 +1,97 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * DELETE /shopper-lists/{slug}/items/{key}.
+ */
+class ShopperListItemsByKey extends AbstractRoute {
+	/**
+	 * Route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-list-items-by-key';
+
+	/**
+	 * Schema identifier this route uses.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'shopper-list-item';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/shopper-lists/(?P<slug>[a-z0-9-]+)/items/(?P<key>[\w-]{32})';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array(
+			'args'   => array(
+				'slug' => array(
+					'description' => __( 'Stable slug for the list.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+				'key'  => array(
+					'description' => __( 'Item key.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+			),
+			array(
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => 'is_user_logged_in',
+			),
+			'schema' => array( $this->schema, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Delete a single item from a list.
+	 *
+	 * @throws RouteException When the list or item doesn't exist.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_delete_response( \WP_REST_Request $request ) {
+		$list = ShopperList::get_by_slug( (string) $request['slug'] );
+
+		if ( ! $list ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+		}
+
+		if ( ! $list->remove_item( (string) $request['key'] ) ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_item_not_found', esc_html__( 'No saved item exists for the supplied key.', 'woocommerce' ), 404 );
+		}
+
+		$list->save();
+
+		return new \WP_REST_Response( null, 204 );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -64,7 +64,9 @@ class ShopperListItemsByKey extends AbstractRoute {
 			array(
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => array( $this, 'get_response' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
 			),
 			'schema' => array( $this->schema, 'get_public_item_schema' ),
 		);

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
@@ -1,0 +1,81 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+
+/**
+ * GET /shopper-lists — collection of the current user's shopper lists.
+ */
+class ShopperLists extends AbstractRoute {
+	/**
+	 * Route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-lists';
+
+	/**
+	 * Schema identifier this route uses.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'shopper-list';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/shopper-lists';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array(
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			'schema' => array( $this->schema, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Return the lists for the current user.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		$response = array();
+
+		foreach ( ShopperList::get_all_for_user() as $list ) {
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $list->to_array(), $request ) );
+		}
+
+		return rest_ensure_response( $response );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
@@ -51,7 +51,9 @@ class ShopperLists extends AbstractRoute {
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_response' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
 				'args'                => array(
 					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 				),

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
@@ -58,7 +58,9 @@ class ShopperListsBySlug extends AbstractRoute {
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_response' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
 				'args'                => array(
 					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 				),

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
@@ -1,0 +1,90 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * GET /shopper-lists/{slug} — metadata for a single list.
+ */
+class ShopperListsBySlug extends AbstractRoute {
+	/**
+	 * Route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-lists-by-slug';
+
+	/**
+	 * Schema identifier this route uses.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'shopper-list';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/shopper-lists/(?P<slug>[a-z0-9-]+)';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array(
+			'args'   => array(
+				'slug' => array(
+					'description' => __( 'Stable slug for the list.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+			),
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			'schema' => array( $this->schema, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Return the list metadata for the requested slug.
+	 *
+	 * @throws RouteException When the list doesn't exist.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		$list = ShopperList::get_by_slug( (string) $request['slug'] );
+
+		if ( ! $list ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+		}
+
+		return rest_ensure_response( $this->prepare_item_for_response( $list->to_array(), $request ) );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -70,6 +70,10 @@ class RoutesController {
 				Routes\V1\Products::IDENTIFIER           => Routes\V1\Products::class,
 				Routes\V1\ProductsById::IDENTIFIER       => Routes\V1\ProductsById::class,
 				Routes\V1\ProductsBySlug::IDENTIFIER     => Routes\V1\ProductsBySlug::class,
+				Routes\V1\ShopperLists::IDENTIFIER       => Routes\V1\ShopperLists::class,
+				Routes\V1\ShopperListsBySlug::IDENTIFIER => Routes\V1\ShopperListsBySlug::class,
+				Routes\V1\ShopperListItems::IDENTIFIER   => Routes\V1\ShopperListItems::class,
+				Routes\V1\ShopperListItemsByKey::IDENTIFIER => Routes\V1\ShopperListItemsByKey::class,
 			],
 			'private' => [
 				// This route should be moved outside of the Store API namespace.

--- a/plugins/woocommerce/src/StoreApi/SchemaController.php
+++ b/plugins/woocommerce/src/StoreApi/SchemaController.php
@@ -56,6 +56,8 @@ class SchemaController {
 				Schemas\V1\ProductCollectionDataSchema::IDENTIFIER => Schemas\V1\ProductCollectionDataSchema::class,
 				Schemas\V1\ProductReviewSchema::IDENTIFIER => Schemas\V1\ProductReviewSchema::class,
 				Schemas\V1\PatternsSchema::IDENTIFIER      => Schemas\V1\PatternsSchema::class,
+				Schemas\V1\ShopperListSchema::IDENTIFIER   => Schemas\V1\ShopperListSchema::class,
+				Schemas\V1\ShopperListItemSchema::IDENTIFIER => Schemas\V1\ShopperListItemSchema::class,
 				Schemas\V1\Agentic\CheckoutSessionSchema::IDENTIFIER => Schemas\V1\Agentic\CheckoutSessionSchema::class,
 			],
 		];

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\SchemaController;
-use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
 
 /**
  * ShopperListItemSchema class.
@@ -15,8 +14,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
  * the two states via the `product_exists` boolean.
  */
 class ShopperListItemSchema extends AbstractSchema {
-	use ProductItemTrait;
-
 	/**
 	 * The schema item name.
 	 *
@@ -295,5 +292,57 @@ class ShopperListItemSchema extends AbstractSchema {
 				'sale_price'    => '' === $sale_price ? '' : $this->prepare_money_response( $sale_price, $decimals ),
 			)
 		);
+	}
+
+	/**
+	 * Format variation attribute data into [{ raw_attribute, attribute, value }] objects.
+	 *
+	 * Mirrors ProductItemTrait::format_variation_data. We can't `use` the trait directly
+	 * because its sibling `prepare_product_price_response` calls `parent::` (assumes a
+	 * ProductSchema parent). Refactoring the trait to drop that coupling is a follow-up.
+	 *
+	 * @param array       $variation_data Variation attributes keyed by attribute_*.
+	 * @param \WC_Product $product        Live product.
+	 * @return array
+	 */
+	private function format_variation_data( array $variation_data, \WC_Product $product ): array {
+		$return = array();
+
+		foreach ( $variation_data as $key => $value ) {
+			$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( (string) $key ) ) );
+
+			if ( taxonomy_exists( $taxonomy ) ) {
+				$term = get_term_by( 'slug', $value, $taxonomy );
+				if ( ! is_wp_error( $term ) && $term && $term->name ) {
+					/**
+					 * Filters the variation option name.
+					 *
+					 * This filter is documented in src/StoreApi/Utilities/ProductItemTrait.php.
+					 *
+					 * @since 10.8.0
+					 */
+					$value = apply_filters( 'woocommerce_variation_option_name', $term->name, $term, $taxonomy, $product );
+				}
+				$label = wc_attribute_label( $taxonomy );
+			} else {
+				/**
+				 * Filters the variation option name.
+				 *
+				 * This filter is documented in src/StoreApi/Utilities/ProductItemTrait.php.
+				 *
+				 * @since 10.8.0
+				 */
+				$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $product );
+				$label = wc_attribute_label( str_replace( 'attribute_', '', (string) $key ), $product );
+			}//end if
+
+			$return[] = array(
+				'raw_attribute' => $this->prepare_html_response( (string) $key ),
+				'attribute'     => $this->prepare_html_response( (string) $label ),
+				'value'         => $this->prepare_html_response( (string) $value ),
+			);
+		}//end foreach
+
+		return $return;
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
 
 /**
  * ShopperListItemSchema class.
@@ -14,6 +15,9 @@ use Automattic\WooCommerce\StoreApi\SchemaController;
  * the two states via the `product_exists` boolean.
  */
 class ShopperListItemSchema extends AbstractSchema {
+	// We only call format_variation_data(); see phpstan.neon for the related suppressions.
+	use ProductItemTrait;
+
 	/**
 	 * The schema item name.
 	 *
@@ -292,57 +296,5 @@ class ShopperListItemSchema extends AbstractSchema {
 				'sale_price'    => '' === $sale_price ? '' : $this->prepare_money_response( $sale_price, $decimals ),
 			)
 		);
-	}
-
-	/**
-	 * Format variation attribute data into [{ raw_attribute, attribute, value }] objects.
-	 *
-	 * Mirrors ProductItemTrait::format_variation_data. We can't `use` the trait directly
-	 * because its sibling `prepare_product_price_response` calls `parent::` (assumes a
-	 * ProductSchema parent). Refactoring the trait to drop that coupling is a follow-up.
-	 *
-	 * @param array       $variation_data Variation attributes keyed by attribute_*.
-	 * @param \WC_Product $product        Live product.
-	 * @return array
-	 */
-	private function format_variation_data( array $variation_data, \WC_Product $product ): array {
-		$return = array();
-
-		foreach ( $variation_data as $key => $value ) {
-			$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( (string) $key ) ) );
-
-			if ( taxonomy_exists( $taxonomy ) ) {
-				$term = get_term_by( 'slug', $value, $taxonomy );
-				if ( ! is_wp_error( $term ) && $term && $term->name ) {
-					/**
-					 * Filters the variation option name.
-					 *
-					 * This filter is documented in src/StoreApi/Utilities/ProductItemTrait.php.
-					 *
-					 * @since 10.8.0
-					 */
-					$value = apply_filters( 'woocommerce_variation_option_name', $term->name, $term, $taxonomy, $product );
-				}
-				$label = wc_attribute_label( $taxonomy );
-			} else {
-				/**
-				 * Filters the variation option name.
-				 *
-				 * This filter is documented in src/StoreApi/Utilities/ProductItemTrait.php.
-				 *
-				 * @since 10.8.0
-				 */
-				$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $product );
-				$label = wc_attribute_label( str_replace( 'attribute_', '', (string) $key ), $product );
-			}//end if
-
-			$return[] = array(
-				'raw_attribute' => $this->prepare_html_response( (string) $key ),
-				'attribute'     => $this->prepare_html_response( (string) $label ),
-				'value'         => $this->prepare_html_response( (string) $value ),
-			);
-		}//end foreach
-
-		return $return;
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -1,0 +1,354 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+
+/**
+ * ShopperListItemSchema class.
+ *
+ * One row in a shopper list. Serves live product data when the product still
+ * exists in the catalog, and at-save tombstone data when it doesn't, distinguishing
+ * the two states via the `product_exists` boolean.
+ */
+class ShopperListItemSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'shopper_list_item';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-list-item';
+
+	/**
+	 * Image attachment schema instance.
+	 *
+	 * @var ImageAttachmentSchema
+	 */
+	protected $image_attachment_schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ExtendSchema     $extend Rest Extending instance.
+	 * @param SchemaController $controller Schema Controller instance.
+	 */
+	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
+		parent::__construct( $extend, $controller );
+		$schema = $this->controller->get( ImageAttachmentSchema::IDENTIFIER );
+		if ( $schema instanceof ImageAttachmentSchema ) {
+			$this->image_attachment_schema = $schema;
+		}
+	}
+
+	/**
+	 * Item schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return array(
+			'key'                   => array(
+				'description' => __( 'Stable identifier for the saved item within its list.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'id'                    => array(
+				'description' => __( 'Variation ID if applicable, otherwise product ID.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'product_id'            => array(
+				'description' => __( 'Product ID at the time the item was saved.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'variation_id'          => array(
+				'description' => __( 'Variation ID at the time the item was saved, or 0 for non-variable products.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'quantity'              => array(
+				'description' => __( 'Quantity of this saved item.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'product_exists'        => array(
+				'description' => __( 'True when the underlying product still exists in the catalog. When false, the row is a tombstone served from at-save snapshot data.', 'woocommerce' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'name'                  => array(
+				'description' => __( 'Product name. Live when product_exists is true; falls back to product_title_at_save otherwise.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'permalink'             => array(
+				'description' => __( 'Product URL. Empty when the product no longer exists.', 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'uri',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'images'                => array(
+				'description' => __( 'List of images for the live product. Empty when the product no longer exists.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => $this->image_attachment_schema->get_properties(),
+				),
+			),
+			'variation'             => array(
+				'description' => __( 'Chosen variation attributes, if applicable.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'raw_attribute' => array(
+							'description' => __( 'Variation system generated attribute name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'attribute'     => array(
+							'description' => __( 'Variation attribute name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'value'         => array(
+							'description' => __( 'Variation attribute value.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+			'prices'                => array(
+				'description' => __( 'Live product prices. Omitted when the product no longer exists.', 'woocommerce' ),
+				'type'        => array( 'object', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'properties'  => array_merge(
+					$this->get_store_currency_properties(),
+					array(
+						'price'         => array(
+							'description' => __( 'Current product price.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'regular_price' => array(
+							'description' => __( 'Regular product price.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'sale_price'    => array(
+							'description' => __( 'Sale product price, if applicable.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					)
+				),
+			),
+			'item_data'             => array(
+				'description' => __( 'Custom item data captured at save time (extension fields).', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type' => 'object',
+				),
+			),
+			'date_added_gmt'        => array(
+				'description' => __( 'The date the item was saved, as GMT.', 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'product_title_at_save' => array(
+				'description' => __( 'Snapshot of the product title taken when the item was saved. Used as the rendered name when product_exists is false.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'price_at_save'         => array(
+				'description' => __( 'Snapshot of the product price taken when the item was saved. Used as the rendered price when product_exists is false.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		);
+	}
+
+	/**
+	 * Convert a stored item record into the response shape.
+	 *
+	 * @param array $item Stored item record.
+	 * @return array
+	 */
+	public function get_item_response( $item ) {
+		$variation_id = $item['variation_id'] ?? 0;
+		$product_id   = $variation_id > 0 ? $variation_id : ( $item['product_id'] ?? 0 );
+		$product      = $product_id ? wc_get_product( $product_id ) : false;
+		$has_product  = $product instanceof \WC_Product;
+
+		$response = array(
+			'key'                   => $item['key'] ?? '',
+			'id'                    => $product_id,
+			'product_id'            => $item['product_id'] ?? 0,
+			'variation_id'          => $item['variation_id'] ?? 0,
+			'quantity'              => $item['quantity'] ?? 1,
+			'product_exists'        => $has_product,
+			'item_data'             => isset( $item['item_data'] ) && is_array( $item['item_data'] ) ? $item['item_data'] : array(),
+			'date_added_gmt'        => wc_rest_prepare_date_response( $item['date_added_gmt'] ?? current_time( 'mysql', true ) ),
+			'product_title_at_save' => $item['product_title_at_save'] ?? '',
+			'price_at_save'         => $item['price_at_save'] ?? '',
+		);
+
+		$variation_data = isset( $item['variation'] ) && is_array( $item['variation'] ) ? $item['variation'] : array();
+
+		if ( $has_product ) {
+			$response['name']      = $this->get_name( $product );
+			$response['permalink'] = $product->get_permalink();
+			$response['images']    = $this->get_images( $product );
+			$response['variation'] = $this->format_variation_data( $variation_data, $product );
+			$response['prices']    = (object) $this->get_prices( $product );
+		} else {
+			$response['name']      = $item['product_title_at_save'] ?? '';
+			$response['permalink'] = '';
+			$response['images']    = array();
+			$response['variation'] = $this->format_variation_data( $variation_data, null );
+			$response['prices']    = null;
+		}//end if
+
+		return $response;
+	}
+
+	/**
+	 * Get the displayable name for the live product.
+	 *
+	 * @param \WC_Product $product Live product instance.
+	 * @return string
+	 */
+	private function get_name( \WC_Product $product ): string {
+		$prepared = $this->prepare_html_response( $product->get_title() );
+		return is_string( $prepared ) ? $prepared : (string) $product->get_title();
+	}
+
+	/**
+	 * Get the main image for a shopper list item.
+	 *
+	 * Returns the product's main image only — shopper list rows are compact and
+	 * the gallery isn't needed at the row level.
+	 *
+	 * @param \WC_Product $product Live product instance.
+	 * @return array
+	 */
+	private function get_images( \WC_Product $product ): array {
+		$image_id = (int) $product->get_image_id();
+		if ( $image_id <= 0 ) {
+			return array();
+		}
+
+		$image = $this->image_attachment_schema->get_item_response( $image_id );
+		return $image ? array( $image ) : array();
+	}
+
+	/**
+	 * Compute live prices for the saved item.
+	 *
+	 * @param \WC_Product $product Live product instance.
+	 * @return array
+	 */
+	private function get_prices( \WC_Product $product ): array {
+		$decimals      = wc_get_price_decimals();
+		$regular_price = $product->get_regular_price();
+		$sale_price    = $product->get_sale_price();
+		$current_price = $product->get_price();
+
+		return $this->prepare_currency_response(
+			array(
+				'price'         => $this->prepare_money_response( $current_price, $decimals ),
+				'regular_price' => $this->prepare_money_response( '' === $regular_price ? $current_price : $regular_price, $decimals ),
+				'sale_price'    => '' === $sale_price ? '' : $this->prepare_money_response( $sale_price, $decimals ),
+			)
+		);
+	}
+
+	/**
+	 * Format variation attribute data into [{ raw_attribute, attribute, value }] objects.
+	 *
+	 * Mirrors ProductItemTrait::format_variation_data but works without requiring
+	 * a ProductSchema parent class. Tolerates a null product (tombstone path).
+	 *
+	 * @param array            $variation_data Variation attributes keyed by attribute_*.
+	 * @param \WC_Product|null $product        Live product, or null if missing.
+	 * @return array
+	 */
+	private function format_variation_data( array $variation_data, $product ): array {
+		$return = array();
+
+		foreach ( $variation_data as $key => $value ) {
+			$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( (string) $key ) ) );
+
+			if ( taxonomy_exists( $taxonomy ) ) {
+				$term = get_term_by( 'slug', $value, $taxonomy );
+				if ( ! is_wp_error( $term ) && $term && $term->name ) {
+					/**
+					 * Filters the variation option name.
+					 *
+					 * This filter is documented in src/StoreApi/Utilities/ProductItemTrait.php.
+					 *
+					 * @since 10.8.0
+					 */
+					$value = apply_filters( 'woocommerce_variation_option_name', $term->name, $term, $taxonomy, $product );
+				}
+				$label = wc_attribute_label( $taxonomy );
+			} else {
+				/**
+				 * Filters the variation option name.
+				 *
+				 * This filter is documented in src/StoreApi/Utilities/ProductItemTrait.php.
+				 *
+				 * @since 10.8.0
+				 */
+				$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $product );
+				$label = $product instanceof \WC_Product
+					? wc_attribute_label( str_replace( 'attribute_', '', (string) $key ), $product )
+					: str_replace( 'attribute_', '', (string) $key );
+			}//end if
+
+			$return[] = array(
+				'raw_attribute' => $this->prepare_html_response( (string) $key ),
+				'attribute'     => $this->prepare_html_response( (string) $label ),
+				'value'         => $this->prepare_html_response( (string) $value ),
+			);
+		}//end foreach
+
+		return $return;
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -42,15 +42,18 @@ class ShopperListItemSchema extends AbstractSchema {
 	/**
 	 * Constructor.
 	 *
+	 * @throws \RuntimeException When the ImageAttachmentSchema is not registered.
+	 *
 	 * @param ExtendSchema     $extend Rest Extending instance.
 	 * @param SchemaController $controller Schema Controller instance.
 	 */
 	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
 		parent::__construct( $extend, $controller );
 		$schema = $this->controller->get( ImageAttachmentSchema::IDENTIFIER );
-		if ( $schema instanceof ImageAttachmentSchema ) {
-			$this->image_attachment_schema = $schema;
+		if ( ! $schema instanceof ImageAttachmentSchema ) {
+			throw new \RuntimeException( 'ImageAttachmentSchema is not registered in SchemaController.' );
 		}
+		$this->image_attachment_schema = $schema;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -173,15 +173,6 @@ class ShopperListItemSchema extends AbstractSchema {
 					)
 				),
 			),
-			'item_data'             => array(
-				'description' => __( 'Custom item data captured at save time (extension fields).', 'woocommerce' ),
-				'type'        => 'array',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'items'       => array(
-					'type' => 'object',
-				),
-			),
 			'date_added_gmt'        => array(
 				'description' => __( 'The date the item was saved, as GMT.', 'woocommerce' ),
 				'type'        => 'string',
@@ -225,7 +216,6 @@ class ShopperListItemSchema extends AbstractSchema {
 			'variation_id'          => $item['variation_id'] ?? 0,
 			'quantity'              => $item['quantity'] ?? 1,
 			'product_exists'        => $has_product,
-			'item_data'             => isset( $item['item_data'] ) && is_array( $item['item_data'] ) ? $item['item_data'] : array(),
 			'date_added_gmt'        => wc_rest_prepare_date_response( $item['date_added_gmt'] ?? current_time( 'mysql', true ) ),
 			'product_title_at_save' => $item['product_title_at_save'] ?? '',
 			'price_at_save'         => '' === $price_at_save ? '' : $this->prepare_money_response( $price_at_save, wc_get_price_decimals() ),

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -190,12 +190,6 @@ class ShopperListItemSchema extends AbstractSchema {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'price_at_save'         => array(
-				'description' => __( 'Snapshot of the product price taken when the item was saved. Used as the rendered price when product_exists is false.', 'woocommerce' ),
-				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-			),
 		);
 	}
 
@@ -211,8 +205,6 @@ class ShopperListItemSchema extends AbstractSchema {
 		$product      = $product_id ? wc_get_product( $product_id ) : false;
 		$has_product  = $product instanceof \WC_Product;
 
-		$price_at_save = $item['price_at_save'] ?? '';
-
 		$response = array(
 			'key'                   => $item['key'] ?? '',
 			'id'                    => $product_id,
@@ -222,7 +214,6 @@ class ShopperListItemSchema extends AbstractSchema {
 			'product_exists'        => $has_product,
 			'date_added_gmt'        => wc_rest_prepare_date_response( $item['date_added_gmt'] ?? current_time( 'mysql', true ) ),
 			'product_title_at_save' => $item['product_title_at_save'] ?? '',
-			'price_at_save'         => '' === $price_at_save ? '' : $this->prepare_money_response( $price_at_save, wc_get_price_decimals() ),
 		);
 
 		$variation_data = isset( $item['variation'] ) && is_array( $item['variation'] ) ? $item['variation'] : array();

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -216,6 +216,8 @@ class ShopperListItemSchema extends AbstractSchema {
 		$product      = $product_id ? wc_get_product( $product_id ) : false;
 		$has_product  = $product instanceof \WC_Product;
 
+		$price_at_save = $item['price_at_save'] ?? '';
+
 		$response = array(
 			'key'                   => $item['key'] ?? '',
 			'id'                    => $product_id,
@@ -226,7 +228,7 @@ class ShopperListItemSchema extends AbstractSchema {
 			'item_data'             => isset( $item['item_data'] ) && is_array( $item['item_data'] ) ? $item['item_data'] : array(),
 			'date_added_gmt'        => wc_rest_prepare_date_response( $item['date_added_gmt'] ?? current_time( 'mysql', true ) ),
 			'product_title_at_save' => $item['product_title_at_save'] ?? '',
-			'price_at_save'         => $item['price_at_save'] ?? '',
+			'price_at_save'         => '' === $price_at_save ? '' : $this->prepare_money_response( $price_at_save, wc_get_price_decimals() ),
 		);
 
 		$variation_data = isset( $item['variation'] ) && is_array( $item['variation'] ) ? $item['variation'] : array();
@@ -238,7 +240,7 @@ class ShopperListItemSchema extends AbstractSchema {
 			$response['variation'] = $this->format_variation_data( $variation_data, $product );
 			$response['prices']    = (object) $this->get_prices( $product );
 		} else {
-			$response['name']      = $item['product_title_at_save'] ?? '';
+			$response['name']      = $this->prepare_html_response( (string) ( $item['product_title_at_save'] ?? '' ) );
 			$response['permalink'] = '';
 			$response['images']    = array();
 			$response['variation'] = $this->format_variation_data( $variation_data, null );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
 
 /**
  * ShopperListItemSchema class.
@@ -14,6 +15,8 @@ use Automattic\WooCommerce\StoreApi\SchemaController;
  * the two states via the `product_exists` boolean.
  */
 class ShopperListItemSchema extends AbstractSchema {
+	use ProductItemTrait;
+
 	/**
 	 * The schema item name.
 	 *
@@ -233,7 +236,7 @@ class ShopperListItemSchema extends AbstractSchema {
 			$response['name']      = $this->prepare_html_response( (string) ( $item['product_title_at_save'] ?? '' ) );
 			$response['permalink'] = '';
 			$response['images']    = array();
-			$response['variation'] = $this->format_variation_data( $variation_data, null );
+			$response['variation'] = array();
 			$response['prices']    = null;
 		}//end if
 
@@ -273,6 +276,9 @@ class ShopperListItemSchema extends AbstractSchema {
 	/**
 	 * Compute live prices for the saved item.
 	 *
+	 * We don't extend ProductSchema because saved items aren't products. The shape
+	 * here is a thin subset of cart-item prices.
+	 *
 	 * @param \WC_Product $product Live product instance.
 	 * @return array
 	 */
@@ -289,58 +295,5 @@ class ShopperListItemSchema extends AbstractSchema {
 				'sale_price'    => '' === $sale_price ? '' : $this->prepare_money_response( $sale_price, $decimals ),
 			)
 		);
-	}
-
-	/**
-	 * Format variation attribute data into [{ raw_attribute, attribute, value }] objects.
-	 *
-	 * Mirrors ProductItemTrait::format_variation_data but works without requiring
-	 * a ProductSchema parent class. Tolerates a null product (tombstone path).
-	 *
-	 * @param array            $variation_data Variation attributes keyed by attribute_*.
-	 * @param \WC_Product|null $product        Live product, or null if missing.
-	 * @return array
-	 */
-	private function format_variation_data( array $variation_data, $product ): array {
-		$return = array();
-
-		foreach ( $variation_data as $key => $value ) {
-			$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( (string) $key ) ) );
-
-			if ( taxonomy_exists( $taxonomy ) ) {
-				$term = get_term_by( 'slug', $value, $taxonomy );
-				if ( ! is_wp_error( $term ) && $term && $term->name ) {
-					/**
-					 * Filters the variation option name.
-					 *
-					 * This filter is documented in src/StoreApi/Utilities/ProductItemTrait.php.
-					 *
-					 * @since 10.8.0
-					 */
-					$value = apply_filters( 'woocommerce_variation_option_name', $term->name, $term, $taxonomy, $product );
-				}
-				$label = wc_attribute_label( $taxonomy );
-			} else {
-				/**
-				 * Filters the variation option name.
-				 *
-				 * This filter is documented in src/StoreApi/Utilities/ProductItemTrait.php.
-				 *
-				 * @since 10.8.0
-				 */
-				$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $product );
-				$label = $product instanceof \WC_Product
-					? wc_attribute_label( str_replace( 'attribute_', '', (string) $key ), $product )
-					: str_replace( 'attribute_', '', (string) $key );
-			}//end if
-
-			$return[] = array(
-				'raw_attribute' => $this->prepare_html_response( (string) $key ),
-				'attribute'     => $this->prepare_html_response( (string) $label ),
-				'value'         => $this->prepare_html_response( (string) $value ),
-			);
-		}//end foreach
-
-		return $return;
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -63,56 +63,56 @@ class ShopperListItemSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return array(
-			'key'                   => array(
+			'key'            => array(
 				'description' => __( 'Stable identifier for the saved item within its list.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'id'                    => array(
+			'id'             => array(
 				'description' => __( 'Variation ID if applicable, otherwise product ID.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'product_id'            => array(
+			'product_id'     => array(
 				'description' => __( 'Product ID at the time the item was saved.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'variation_id'          => array(
+			'variation_id'   => array(
 				'description' => __( 'Variation ID at the time the item was saved, or 0 for non-variable products.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'quantity'              => array(
+			'quantity'       => array(
 				'description' => __( 'Quantity of this saved item.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'product_exists'        => array(
+			'product_exists' => array(
 				'description' => __( 'True when the underlying product still exists in the catalog. When false, the row is a tombstone served from at-save snapshot data.', 'woocommerce' ),
 				'type'        => 'boolean',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'name'                  => array(
-				'description' => __( 'Product name. Live when product_exists is true; falls back to product_title_at_save otherwise.', 'woocommerce' ),
+			'name'           => array(
+				'description' => __( 'Product name. Live when product_exists is true; falls back to the at-save title snapshot otherwise.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'permalink'             => array(
+			'permalink'      => array(
 				'description' => __( 'Product URL. Empty when the product no longer exists.', 'woocommerce' ),
 				'type'        => 'string',
 				'format'      => 'uri',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'images'                => array(
+			'images'         => array(
 				'description' => __( 'List of images for the live product. Empty when the product no longer exists.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
@@ -122,7 +122,7 @@ class ShopperListItemSchema extends AbstractSchema {
 					'properties' => $this->image_attachment_schema->get_properties(),
 				),
 			),
-			'variation'             => array(
+			'variation'      => array(
 				'description' => __( 'Chosen variation attributes, if applicable.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
@@ -151,7 +151,7 @@ class ShopperListItemSchema extends AbstractSchema {
 					),
 				),
 			),
-			'prices'                => array(
+			'prices'         => array(
 				'description' => __( 'Live product prices. Omitted when the product no longer exists.', 'woocommerce' ),
 				'type'        => array( 'object', 'null' ),
 				'context'     => array( 'view', 'edit' ),
@@ -180,16 +180,10 @@ class ShopperListItemSchema extends AbstractSchema {
 					)
 				),
 			),
-			'date_added_gmt'        => array(
+			'date_added_gmt' => array(
 				'description' => __( 'The date the item was saved, as GMT.', 'woocommerce' ),
 				'type'        => 'string',
 				'format'      => 'date-time',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-			),
-			'product_title_at_save' => array(
-				'description' => __( 'Snapshot of the product title taken when the item was saved. Used as the rendered name when product_exists is false.', 'woocommerce' ),
-				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
@@ -209,14 +203,13 @@ class ShopperListItemSchema extends AbstractSchema {
 		$has_product  = $product instanceof \WC_Product;
 
 		$response = array(
-			'key'                   => $item['key'] ?? '',
-			'id'                    => $product_id,
-			'product_id'            => $item['product_id'] ?? 0,
-			'variation_id'          => $item['variation_id'] ?? 0,
-			'quantity'              => $item['quantity'] ?? 1,
-			'product_exists'        => $has_product,
-			'date_added_gmt'        => wc_rest_prepare_date_response( $item['date_added_gmt'] ?? current_time( 'mysql', true ) ),
-			'product_title_at_save' => $item['product_title_at_save'] ?? '',
+			'key'            => $item['key'] ?? '',
+			'id'             => $product_id,
+			'product_id'     => $item['product_id'] ?? 0,
+			'variation_id'   => $item['variation_id'] ?? 0,
+			'quantity'       => $item['quantity'] ?? 1,
+			'product_exists' => $has_product,
+			'date_added_gmt' => wc_rest_prepare_date_response( $item['date_added_gmt'] ?? current_time( 'mysql', true ) ),
 		);
 
 		$variation_data = isset( $item['variation'] ) && is_array( $item['variation'] ) ? $item['variation'] : array();

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
@@ -37,12 +37,6 @@ class ShopperListSchema extends AbstractSchema {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'is_public'        => array(
-				'description' => __( 'Whether the list is shareable.', 'woocommerce' ),
-				'type'        => 'boolean',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-			),
 			'date_created_gmt' => array(
 				'description' => __( 'The date the list was created, as GMT.', 'woocommerce' ),
 				'type'        => 'string',
@@ -70,7 +64,6 @@ class ShopperListSchema extends AbstractSchema {
 
 		return array(
 			'slug'             => $shopper_list['slug'] ?? '',
-			'is_public'        => $shopper_list['is_public'] ?? false,
 			'date_created_gmt' => wc_rest_prepare_date_response( $shopper_list['date_created_gmt'] ?? current_time( 'mysql', true ) ),
 			'item_count'       => count( $items ),
 		);

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
@@ -37,12 +37,6 @@ class ShopperListSchema extends AbstractSchema {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'name'             => array(
-				'description' => __( 'Human-readable list name.', 'woocommerce' ),
-				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-			),
 			'is_public'        => array(
 				'description' => __( 'Whether the list is shareable.', 'woocommerce' ),
 				'type'        => 'boolean',
@@ -76,7 +70,6 @@ class ShopperListSchema extends AbstractSchema {
 
 		return array(
 			'slug'             => $shopper_list['slug'] ?? '',
-			'name'             => $shopper_list['name'] ?? '',
 			'is_public'        => $shopper_list['is_public'] ?? false,
 			'date_created_gmt' => wc_rest_prepare_date_response( $shopper_list['date_created_gmt'] ?? current_time( 'mysql', true ) ),
 			'item_count'       => count( $items ),

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
@@ -36,15 +36,18 @@ class ShopperListSchema extends AbstractSchema {
 	/**
 	 * Constructor.
 	 *
+	 * @throws \RuntimeException When the ShopperListItemSchema is not registered.
+	 *
 	 * @param ExtendSchema     $extend Rest Extending instance.
 	 * @param SchemaController $controller Schema Controller instance.
 	 */
 	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
 		parent::__construct( $extend, $controller );
 		$schema = $this->controller->get( ShopperListItemSchema::IDENTIFIER );
-		if ( $schema instanceof ShopperListItemSchema ) {
-			$this->item_schema = $schema;
+		if ( ! $schema instanceof ShopperListItemSchema ) {
+			throw new \RuntimeException( 'ShopperListItemSchema is not registered in SchemaController.' );
 		}
+		$this->item_schema = $schema;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
@@ -1,0 +1,85 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+/**
+ * ShopperListSchema class.
+ *
+ * Represents the metadata for a single shopper list. Items are exposed via a
+ * separate endpoint and serialised by ShopperListItemSchema.
+ */
+class ShopperListSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'shopper_list';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-list';
+
+	/**
+	 * Schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return array(
+			'slug'             => array(
+				'description' => __( 'Stable slug for the list.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'name'             => array(
+				'description' => __( 'Human-readable list name.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'is_public'        => array(
+				'description' => __( 'Whether the list is shareable.', 'woocommerce' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'date_created_gmt' => array(
+				'description' => __( 'The date the list was created, as GMT.', 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'item_count'       => array(
+				'description' => __( 'Number of items currently in the list.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		);
+	}
+
+	/**
+	 * Convert a stored list record into the response shape.
+	 *
+	 * @param array $shopper_list List array (as returned by ShopperList::to_array()).
+	 * @return array
+	 */
+	public function get_item_response( $shopper_list ) {
+		$items = isset( $shopper_list['items'] ) && is_array( $shopper_list['items'] ) ? $shopper_list['items'] : array();
+
+		return array(
+			'slug'             => $shopper_list['slug'] ?? '',
+			'name'             => $shopper_list['name'] ?? '',
+			'is_public'        => $shopper_list['is_public'] ?? false,
+			'date_created_gmt' => wc_rest_prepare_date_response( $shopper_list['date_created_gmt'] ?? current_time( 'mysql', true ) ),
+			'item_count'       => count( $items ),
+		);
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
@@ -3,11 +3,13 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+
 /**
  * ShopperListSchema class.
  *
- * Represents the metadata for a single shopper list. Items are exposed via a
- * separate endpoint and serialised by ShopperListItemSchema.
+ * Represents a single shopper list, including its saved items.
  */
 class ShopperListSchema extends AbstractSchema {
 	/**
@@ -23,6 +25,27 @@ class ShopperListSchema extends AbstractSchema {
 	 * @var string
 	 */
 	const IDENTIFIER = 'shopper-list';
+
+	/**
+	 * Item schema instance.
+	 *
+	 * @var ShopperListItemSchema
+	 */
+	protected $item_schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ExtendSchema     $extend Rest Extending instance.
+	 * @param SchemaController $controller Schema Controller instance.
+	 */
+	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
+		parent::__construct( $extend, $controller );
+		$schema = $this->controller->get( ShopperListItemSchema::IDENTIFIER );
+		if ( $schema instanceof ShopperListItemSchema ) {
+			$this->item_schema = $schema;
+		}
+	}
 
 	/**
 	 * Schema properties.
@@ -50,6 +73,16 @@ class ShopperListSchema extends AbstractSchema {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
+			'items'            => array(
+				'description' => __( 'List of saved items.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->item_schema->get_properties() ),
+				),
+			),
 		);
 	}
 
@@ -62,10 +95,29 @@ class ShopperListSchema extends AbstractSchema {
 	public function get_item_response( $shopper_list ) {
 		$items = isset( $shopper_list['items'] ) && is_array( $shopper_list['items'] ) ? $shopper_list['items'] : array();
 
+		$product_ids = array_filter(
+			array_map(
+				static function ( $item ) {
+					$variation_id = absint( $item['variation_id'] ?? 0 );
+					return $variation_id ? $variation_id : absint( $item['product_id'] ?? 0 );
+				},
+				$items
+			)
+		);
+		if ( ! empty( $product_ids ) ) {
+			_prime_post_caches( array_unique( $product_ids ) );
+		}
+
 		return array(
 			'slug'             => $shopper_list['slug'] ?? '',
 			'date_created_gmt' => wc_rest_prepare_date_response( $shopper_list['date_created_gmt'] ?? current_time( 'mysql', true ) ),
 			'item_count'       => count( $items ),
+			'items'            => array_values(
+				array_map(
+					fn( $item ) => $this->item_schema->get_item_response( $item ),
+					$items
+				)
+			),
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -156,7 +156,7 @@ class ShopperLists extends ControllerTestCase {
 	}
 
 	/**
-	 * Test POST /shopper-lists/saved-for-later/items with a real cart_item_key returns the full list.
+	 * Test POST /shopper-lists/saved-for-later/items with a real cart_item_key returns the saved item.
 	 */
 	public function test_post_item_via_cart_item_key() {
 		wp_set_current_user( $this->customer_id );
@@ -171,13 +171,10 @@ class ShopperLists extends ControllerTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertSame( 'saved-for-later', $data['slug'] );
-		$this->assertSame( 1, $data['item_count'] );
-		$this->assertCount( 1, $data['items'] );
-		$this->assertSame( $this->product->get_id(), $data['items'][0]['product_id'] );
-		$this->assertSame( 1, $data['items'][0]['quantity'], 'Saved quantity should mirror the cart line quantity.' );
-		$this->assertTrue( $data['items'][0]['product_exists'] );
-		$this->assertSame( $this->product->get_title(), $data['items'][0]['name'] );
+		$this->assertSame( $this->product->get_id(), $data['product_id'] );
+		$this->assertSame( 1, $data['quantity'], 'Saved quantity should mirror the cart line quantity.' );
+		$this->assertTrue( $data['product_exists'] );
+		$this->assertSame( $this->product->get_title(), $data['name'] );
 		$this->assertNotEmpty( wc()->cart->cart_contents, 'Cart should still contain the line — POST is additive only.' );
 	}
 
@@ -193,7 +190,7 @@ class ShopperLists extends ControllerTestCase {
 	}
 
 	/**
-	 * Test POST /shopper-lists/saved-for-later/items via direct product payload returns the full list.
+	 * Test POST /shopper-lists/saved-for-later/items via direct product payload returns the saved item.
 	 */
 	public function test_post_item_via_manual_product_payload() {
 		wp_set_current_user( $this->customer_id );
@@ -209,9 +206,8 @@ class ShopperLists extends ControllerTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertCount( 1, $data['items'] );
-		$this->assertSame( $this->product->get_id(), $data['items'][0]['product_id'] );
-		$this->assertSame( 2, $data['items'][0]['quantity'], 'Posted quantity should be honored.' );
+		$this->assertSame( $this->product->get_id(), $data['product_id'] );
+		$this->assertSame( 2, $data['quantity'], 'Posted quantity should be honored.' );
 	}
 
 	/**
@@ -246,7 +242,7 @@ class ShopperLists extends ControllerTestCase {
 	}
 
 	/**
-	 * Test that adding the same cart line twice does not produce a duplicate row.
+	 * Test that adding the same cart line twice merges quantities into a single row.
 	 */
 	public function test_post_item_is_idempotent_for_same_cart_line() {
 		wp_set_current_user( $this->customer_id );
@@ -257,9 +253,11 @@ class ShopperLists extends ControllerTestCase {
 
 		$this->assertEquals( 201, $first->get_status() );
 		$this->assertEquals( 201, $second->get_status() );
-		$this->assertSame( 1, $first->get_data()['item_count'] );
-		$this->assertSame( 1, $second->get_data()['item_count'], 'Same cart line should not produce a duplicate row.' );
-		$this->assertSame( $first->get_data()['items'][0]['key'], $second->get_data()['items'][0]['key'] );
+		$this->assertSame( $first->get_data()['key'], $second->get_data()['key'], 'Same cart line should resolve to the same item key.' );
+		$this->assertSame( 2, $second->get_data()['quantity'], 'Repeating the same cart line must merge quantities.' );
+
+		$items_response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+		$this->assertCount( 1, $items_response->get_data(), 'Same cart line should not produce a duplicate row.' );
 	}
 
 	/**
@@ -278,22 +276,22 @@ class ShopperLists extends ControllerTestCase {
 	}
 
 	/**
-	 * Test that DELETE removes the item and returns the full list with the remaining items.
+	 * Test that DELETE removes the item and returns 204 No Content.
 	 */
 	public function test_delete_item_removes_item() {
 		wp_set_current_user( $this->customer_id );
 		$cart_item_key = $this->add_product_to_cart();
 
 		$created = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
-		$key     = $created->get_data()['items'][0]['key'];
+		$key     = $created->get_data()['key'];
 
 		$response = $this->dispatch( 'DELETE', '/wc/store/v1/shopper-lists/saved-for-later/items/' . $key );
-		$data     = $response->get_data();
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertSame( 'saved-for-later', $data['slug'] );
-		$this->assertSame( 0, $data['item_count'] );
-		$this->assertCount( 0, $data['items'] );
+		$this->assertEquals( 204, $response->get_status() );
+		$this->assertNull( $response->get_data() );
+
+		$items_response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+		$this->assertCount( 0, $items_response->get_data(), 'List should be empty after the only item is deleted.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -175,7 +175,7 @@ class ShopperLists extends ControllerTestCase {
 		$this->assertSame( 1, $data['item_count'] );
 		$this->assertCount( 1, $data['items'] );
 		$this->assertSame( $this->product->get_id(), $data['items'][0]['product_id'] );
-		$this->assertSame( 1, $data['items'][0]['quantity'], 'Stored quantity should be normalized to 1 in v1.' );
+		$this->assertSame( 1, $data['items'][0]['quantity'], 'Saved quantity should mirror the cart line quantity.' );
 		$this->assertTrue( $data['items'][0]['product_exists'] );
 		$this->assertSame( $this->product->get_title(), $data['items'][0]['name'] );
 		$this->assertNotEmpty( wc()->cart->cart_contents, 'Cart should still contain the line — POST is additive only.' );
@@ -217,7 +217,7 @@ class ShopperLists extends ControllerTestCase {
 		$this->assertEquals( 201, $response->get_status() );
 		$this->assertCount( 1, $data['items'] );
 		$this->assertSame( $this->product->get_id(), $data['items'][0]['product_id'] );
-		$this->assertSame( 1, $data['items'][0]['quantity'], 'Stored quantity should be normalized to 1 in v1.' );
+		$this->assertSame( 2, $data['items'][0]['quantity'], 'Posted quantity should be honored.' );
 		$this->assertSame( 'manual', $data['items'][0]['item_data'][0]['value'] );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -156,7 +156,7 @@ class ShopperLists extends ControllerTestCase {
 	}
 
 	/**
-	 * Test POST /shopper-lists/saved-for-later/items with a real cart_item_key.
+	 * Test POST /shopper-lists/saved-for-later/items with a real cart_item_key returns the full list.
 	 */
 	public function test_post_item_via_cart_item_key() {
 		wp_set_current_user( $this->customer_id );
@@ -171,10 +171,13 @@ class ShopperLists extends ControllerTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertSame( $this->product->get_id(), $data['product_id'] );
-		$this->assertSame( 1, $data['quantity'], 'Stored quantity should be normalized to 1 in v1.' );
-		$this->assertTrue( $data['product_exists'] );
-		$this->assertSame( $this->product->get_title(), $data['name'] );
+		$this->assertSame( 'saved-for-later', $data['slug'] );
+		$this->assertSame( 1, $data['item_count'] );
+		$this->assertCount( 1, $data['items'] );
+		$this->assertSame( $this->product->get_id(), $data['items'][0]['product_id'] );
+		$this->assertSame( 1, $data['items'][0]['quantity'], 'Stored quantity should be normalized to 1 in v1.' );
+		$this->assertTrue( $data['items'][0]['product_exists'] );
+		$this->assertSame( $this->product->get_title(), $data['items'][0]['name'] );
 		$this->assertNotEmpty( wc()->cart->cart_contents, 'Cart should still contain the line — POST is additive only.' );
 	}
 
@@ -190,7 +193,7 @@ class ShopperLists extends ControllerTestCase {
 	}
 
 	/**
-	 * Test POST /shopper-lists/saved-for-later/items via direct product payload.
+	 * Test POST /shopper-lists/saved-for-later/items via direct product payload returns the full list.
 	 */
 	public function test_post_item_via_manual_product_payload() {
 		wp_set_current_user( $this->customer_id );
@@ -212,9 +215,10 @@ class ShopperLists extends ControllerTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertSame( $this->product->get_id(), $data['product_id'] );
-		$this->assertSame( 1, $data['quantity'], 'Stored quantity should be normalized to 1 in v1.' );
-		$this->assertSame( 'manual', $data['item_data'][0]['value'] );
+		$this->assertCount( 1, $data['items'] );
+		$this->assertSame( $this->product->get_id(), $data['items'][0]['product_id'] );
+		$this->assertSame( 1, $data['items'][0]['quantity'], 'Stored quantity should be normalized to 1 in v1.' );
+		$this->assertSame( 'manual', $data['items'][0]['item_data'][0]['value'] );
 	}
 
 	/**
@@ -260,10 +264,9 @@ class ShopperLists extends ControllerTestCase {
 
 		$this->assertEquals( 201, $first->get_status() );
 		$this->assertEquals( 201, $second->get_status() );
-		$this->assertSame( $first->get_data()['key'], $second->get_data()['key'] );
-
-		$items_response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
-		$this->assertCount( 1, $items_response->get_data(), 'Same cart line should not produce a duplicate row.' );
+		$this->assertSame( 1, $first->get_data()['item_count'] );
+		$this->assertSame( 1, $second->get_data()['item_count'], 'Same cart line should not produce a duplicate row.' );
+		$this->assertSame( $first->get_data()['items'][0]['key'], $second->get_data()['items'][0]['key'] );
 	}
 
 	/**
@@ -282,21 +285,22 @@ class ShopperLists extends ControllerTestCase {
 	}
 
 	/**
-	 * Test that DELETE removes the item and returns 204.
+	 * Test that DELETE removes the item and returns the full list with the remaining items.
 	 */
 	public function test_delete_item_removes_item() {
 		wp_set_current_user( $this->customer_id );
 		$cart_item_key = $this->add_product_to_cart();
 
 		$created = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
-		$key     = $created->get_data()['key'];
+		$key     = $created->get_data()['items'][0]['key'];
 
 		$response = $this->dispatch( 'DELETE', '/wc/store/v1/shopper-lists/saved-for-later/items/' . $key );
+		$data     = $response->get_data();
 
-		$this->assertEquals( 204, $response->get_status() );
-
-		$items_response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
-		$this->assertCount( 0, $items_response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 'saved-for-later', $data['slug'] );
+		$this->assertSame( 0, $data['item_count'] );
+		$this->assertCount( 0, $data['items'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -1,0 +1,343 @@
+<?php
+/**
+ * Shopper Lists Route Tests.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+
+/**
+ * Tests for the /wc/store/v1/shopper-lists/* endpoints.
+ */
+class ShopperLists extends ControllerTestCase {
+
+	/**
+	 * Test product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * Test customer user ID.
+	 *
+	 * @var int
+	 */
+	private $customer_id;
+
+	/**
+	 * Second test customer user ID, used to verify cross-user isolation.
+	 *
+	 * @var int
+	 */
+	private $other_customer_id;
+
+	/**
+	 * Setup test data.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$fixtures      = new FixtureData();
+		$this->product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		$this->customer_id       = $this->factory->user->create(
+			array(
+				'role'       => 'customer',
+				'user_email' => 'shopper-lists-1@test.com',
+			)
+		);
+		$this->other_customer_id = $this->factory->user->create(
+			array(
+				'role'       => 'customer',
+				'user_email' => 'shopper-lists-2@test.com',
+			)
+		);
+	}
+
+	/**
+	 * Tear down test data.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		if ( $this->customer_id ) {
+			wp_delete_user( $this->customer_id );
+		}
+		if ( $this->other_customer_id ) {
+			wp_delete_user( $this->other_customer_id );
+		}
+	}
+
+	/**
+	 * Helper: dispatch a request and return the response.
+	 *
+	 * @param string $method HTTP method.
+	 * @param string $route Route path.
+	 * @param array  $params Body params.
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch( string $method, string $route, array $params = array() ): \WP_REST_Response {
+		$request = new \WP_REST_Request( $method, $route );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Helper: add the test product to the cart and return its cart_item_key.
+	 *
+	 * @return string
+	 */
+	private function add_product_to_cart(): string {
+		$key = wc()->cart->add_to_cart( $this->product->get_id(), 1 );
+		$this->assertNotEmpty( $key, 'add_to_cart should return a non-empty cart item key.' );
+		return (string) $key;
+	}
+
+	/**
+	 * Test that an unauthenticated request to GET /shopper-lists is rejected.
+	 */
+	public function test_get_lists_requires_login() {
+		wp_set_current_user( 0 );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists' );
+
+		$this->assertContains( $response->get_status(), array( 401, 403 ), 'Unauthenticated requests must be rejected by the permission callback.' );
+	}
+
+	/**
+	 * Test that a logged-in user starts with saved-for-later auto-created and empty.
+	 */
+	public function test_get_lists_returns_save_for_later_for_logged_in_user() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists' );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+		$this->assertCount( 1, $data, 'Only saved-for-later is returned in v1.' );
+		$this->assertSame( 'saved-for-later', $data[0]['slug'] );
+		$this->assertSame( 0, $data[0]['item_count'] );
+	}
+
+	/**
+	 * Test that GET /shopper-lists/saved-for-later returns the list metadata.
+	 */
+	public function test_get_list_by_id_returns_save_for_later_metadata() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later' );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 'saved-for-later', $data['slug'] );
+	}
+
+	/**
+	 * Test that GET /shopper-lists/{slug} returns 404 for any list other than saved-for-later.
+	 */
+	public function test_get_list_by_id_returns_404_for_unsupported_list() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/wishlist' );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test POST /shopper-lists/saved-for-later/items with a real cart_item_key.
+	 */
+	public function test_post_item_via_cart_item_key() {
+		wp_set_current_user( $this->customer_id );
+
+		$cart_item_key = $this->add_product_to_cart();
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/saved-for-later/items',
+			array( 'cart_item_key' => $cart_item_key )
+		);
+		$data     = $response->get_data();
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertSame( $this->product->get_id(), $data['product_id'] );
+		$this->assertSame( 1, $data['quantity'], 'Stored quantity should be normalized to 1 in v1.' );
+		$this->assertTrue( $data['product_exists'] );
+		$this->assertSame( $this->product->get_title(), $data['name'] );
+		$this->assertNotEmpty( wc()->cart->cart_contents, 'Cart should still contain the line — POST is additive only.' );
+	}
+
+	/**
+	 * Test POST rejects requests without cart_item_key or product_id.
+	 */
+	public function test_post_item_requires_cart_item_key_or_product_id() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test POST /shopper-lists/saved-for-later/items via direct product payload.
+	 */
+	public function test_post_item_via_manual_product_payload() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/saved-for-later/items',
+			array(
+				'product_id' => $this->product->get_id(),
+				'quantity'   => 2,
+				'item_data'  => array(
+					array(
+						'key'   => 'source',
+						'value' => 'manual',
+					),
+				),
+			)
+		);
+		$data     = $response->get_data();
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertSame( $this->product->get_id(), $data['product_id'] );
+		$this->assertSame( 1, $data['quantity'], 'Stored quantity should be normalized to 1 in v1.' );
+		$this->assertSame( 'manual', $data['item_data'][0]['value'] );
+	}
+
+	/**
+	 * Test POST rejects an unknown cart_item_key.
+	 */
+	public function test_post_item_unknown_cart_item_key_returns_404() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/saved-for-later/items',
+			array( 'cart_item_key' => 'thiskeydoesnotexist' )
+		);
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test POST returns 404 for any slug other than saved-for-later.
+	 */
+	public function test_post_item_unsupported_slug_returns_404() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/wishlist/items',
+			array( 'cart_item_key' => $cart_item_key )
+		);
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test that adding the same cart line twice does not produce a duplicate row.
+	 */
+	public function test_post_item_is_idempotent_for_same_cart_line() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+
+		$first  = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+		$second = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+
+		$this->assertEquals( 201, $first->get_status() );
+		$this->assertEquals( 201, $second->get_status() );
+		$this->assertSame( $first->get_data()['key'], $second->get_data()['key'] );
+
+		$items_response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+		$this->assertCount( 1, $items_response->get_data(), 'Same cart line should not produce a duplicate row.' );
+	}
+
+	/**
+	 * Test that GET /items returns the saved items.
+	 */
+	public function test_get_items_returns_saved_items() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+
+		$this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+	}
+
+	/**
+	 * Test that DELETE removes the item and returns 204.
+	 */
+	public function test_delete_item_removes_item() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+
+		$created = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+		$key     = $created->get_data()['key'];
+
+		$response = $this->dispatch( 'DELETE', '/wc/store/v1/shopper-lists/saved-for-later/items/' . $key );
+
+		$this->assertEquals( 204, $response->get_status() );
+
+		$items_response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+		$this->assertCount( 0, $items_response->get_data() );
+	}
+
+	/**
+	 * Test that DELETE returns 404 when the item does not exist.
+	 */
+	public function test_delete_item_unknown_returns_404() {
+		wp_set_current_user( $this->customer_id );
+
+		// Auto-create the list so the route reaches the item-lookup branch.
+		$this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later' );
+
+		$nonexistent_key = str_repeat( 'a', 32 );
+		$response        = $this->dispatch( 'DELETE', '/wc/store/v1/shopper-lists/saved-for-later/items/' . $nonexistent_key );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test that a logged-out user cannot delete via the route.
+	 */
+	public function test_delete_item_requires_login() {
+		wp_set_current_user( 0 );
+
+		$nonexistent_key = str_repeat( 'a', 32 );
+		$response        = $this->dispatch( 'DELETE', '/wc/store/v1/shopper-lists/saved-for-later/items/' . $nonexistent_key );
+
+		$this->assertContains( $response->get_status(), array( 401, 403 ) );
+	}
+
+	/**
+	 * Test that one user cannot see another user's items.
+	 */
+	public function test_users_lists_are_isolated() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+		$this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+
+		wp_set_current_user( $this->other_customer_id );
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 0, $response->get_data(), 'Other user should not see the first user\'s items.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -204,12 +204,6 @@ class ShopperLists extends ControllerTestCase {
 			array(
 				'product_id' => $this->product->get_id(),
 				'quantity'   => 2,
-				'item_data'  => array(
-					array(
-						'key'   => 'source',
-						'value' => 'manual',
-					),
-				),
 			)
 		);
 		$data     = $response->get_data();
@@ -218,7 +212,6 @@ class ShopperLists extends ControllerTestCase {
 		$this->assertCount( 1, $data['items'] );
 		$this->assertSame( $this->product->get_id(), $data['items'][0]['product_id'] );
 		$this->assertSame( 2, $data['items'][0]['quantity'], 'Posted quantity should be honored.' );
-		$this->assertSame( 'manual', $data['items'][0]['item_data'][0]['value'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -118,10 +118,10 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 		$response = $this->sut->get_item_response( $item );
 
 		$this->assertFalse( $response['product_exists'], 'product_exists must be false when the product is gone' );
-		$this->assertSame( 'Snapshot Title', $response['name'], 'Tombstone name should fall back to product_title_at_save' );
+		$this->assertSame( 'Snapshot Title', $response['name'], 'Tombstone name should fall back to the at-save title snapshot' );
 		$this->assertSame( '', $response['permalink'], 'permalink should be empty in tombstone path' );
 		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );
 		$this->assertNull( $response['prices'], 'Live prices should be null for missing products' );
-		$this->assertSame( 'Snapshot Title', $response['product_title_at_save'] );
+		$this->assertArrayNotHasKey( 'product_title_at_save', $response, 'Internal at-save title snapshot should not leak into the public response' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -80,7 +80,6 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 			'variation_id'          => $variation_id,
 			'variation'             => $variation,
 			'quantity'              => 1,
-			'item_data'             => array(),
 			'date_added_gmt'        => '2024-04-25 03:20:00',
 			'product_title_at_save' => $title,
 			'price_at_save'         => $price,

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -1,0 +1,131 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Schemas;
+
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListItemSchema;
+use WC_Unit_Test_Case;
+
+/**
+ * ShopperListItemSchemaTest class.
+ */
+class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ShopperListItemSchema
+	 */
+	private $sut;
+
+	/**
+	 * ExtendSchema instance.
+	 *
+	 * @var ExtendSchema
+	 */
+	private $extend;
+
+	/**
+	 * SchemaController instance.
+	 *
+	 * @var SchemaController
+	 */
+	private $schema_controller;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+
+		$this->extend            = new ExtendSchema( $formatters );
+		$this->schema_controller = new SchemaController( $this->extend );
+		$this->sut               = new ShopperListItemSchema( $this->extend, $this->schema_controller );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->sut               = null;
+		$this->extend            = null;
+		$this->schema_controller = null;
+	}
+
+	/**
+	 * Build a minimal stored item record around a product.
+	 *
+	 * @param int    $product_id   Product ID.
+	 * @param int    $variation_id Variation ID, or 0.
+	 * @param array  $variation    Variation attributes.
+	 * @param string $title        Title snapshot.
+	 * @param string $price        Price snapshot.
+	 * @return array
+	 */
+	private function build_item( int $product_id, int $variation_id = 0, array $variation = array(), string $title = 'Snapshot Title', string $price = '9.99' ): array {
+		return array(
+			'key'                   => md5( (string) $product_id ),
+			'product_id'            => $product_id,
+			'variation_id'          => $variation_id,
+			'variation'             => $variation,
+			'quantity'              => 1,
+			'item_data'             => array(),
+			'date_added_gmt'        => '2024-04-25 03:20:00',
+			'product_title_at_save' => $title,
+			'price_at_save'         => $price,
+		);
+	}
+
+	/**
+	 * @testdox Should serve live product data and product_exists=true when the product exists.
+	 */
+	public function test_returns_live_data_when_product_exists(): void {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Live T-Shirt',
+				'regular_price' => 19.99,
+			)
+		);
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id(), 0, array(), 'Snapshot T-Shirt', '5.00' ) );
+
+		$this->assertTrue( $response['product_exists'], 'product_exists must be true when the product still exists' );
+		$this->assertSame( 'Live T-Shirt', $response['name'], 'Live name should be served, not the snapshot' );
+		$this->assertSame( $product->get_permalink(), $response['permalink'] );
+		$this->assertNotNull( $response['prices'], 'Live prices should be populated' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should fall back to at-save snapshot data when the product no longer exists.
+	 */
+	public function test_falls_back_to_snapshot_when_product_missing(): void {
+		$product    = \WC_Helper_Product::create_simple_product( true, array( 'name' => 'About to be Deleted' ) );
+		$product_id = $product->get_id();
+		$item       = $this->build_item( $product_id, 0, array(), 'Snapshot Title', '12.50' );
+		wp_delete_post( $product_id, true );
+
+		$response = $this->sut->get_item_response( $item );
+
+		$this->assertFalse( $response['product_exists'], 'product_exists must be false when the product is gone' );
+		$this->assertSame( 'Snapshot Title', $response['name'], 'Tombstone name should fall back to product_title_at_save' );
+		$this->assertSame( '', $response['permalink'], 'permalink should be empty in tombstone path' );
+		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );
+		$this->assertNull( $response['prices'], 'Live prices should be null for missing products' );
+		$this->assertSame( 'Snapshot Title', $response['product_title_at_save'] );
+		$this->assertSame( '12.50', $response['price_at_save'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -126,6 +126,6 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );
 		$this->assertNull( $response['prices'], 'Live prices should be null for missing products' );
 		$this->assertSame( 'Snapshot Title', $response['product_title_at_save'] );
-		$this->assertSame( '12.50', $response['price_at_save'] );
+		$this->assertSame( '1250', $response['price_at_save'], 'price_at_save should be formatted via prepare_money_response (smallest unit)' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -70,10 +70,9 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 	 * @param int    $variation_id Variation ID, or 0.
 	 * @param array  $variation    Variation attributes.
 	 * @param string $title        Title snapshot.
-	 * @param string $price        Price snapshot.
 	 * @return array
 	 */
-	private function build_item( int $product_id, int $variation_id = 0, array $variation = array(), string $title = 'Snapshot Title', string $price = '9.99' ): array {
+	private function build_item( int $product_id, int $variation_id = 0, array $variation = array(), string $title = 'Snapshot Title' ): array {
 		return array(
 			'key'                   => md5( (string) $product_id ),
 			'product_id'            => $product_id,
@@ -82,7 +81,6 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 			'quantity'              => 1,
 			'date_added_gmt'        => '2024-04-25 03:20:00',
 			'product_title_at_save' => $title,
-			'price_at_save'         => $price,
 		);
 	}
 
@@ -98,7 +96,7 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$response = $this->sut->get_item_response( $this->build_item( $product->get_id(), 0, array(), 'Snapshot T-Shirt', '5.00' ) );
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id(), 0, array(), 'Snapshot T-Shirt' ) );
 
 		$this->assertTrue( $response['product_exists'], 'product_exists must be true when the product still exists' );
 		$this->assertSame( 'Live T-Shirt', $response['name'], 'Live name should be served, not the snapshot' );
@@ -114,7 +112,7 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 	public function test_falls_back_to_snapshot_when_product_missing(): void {
 		$product    = \WC_Helper_Product::create_simple_product( true, array( 'name' => 'About to be Deleted' ) );
 		$product_id = $product->get_id();
-		$item       = $this->build_item( $product_id, 0, array(), 'Snapshot Title', '12.50' );
+		$item       = $this->build_item( $product_id, 0, array(), 'Snapshot Title' );
 		wp_delete_post( $product_id, true );
 
 		$response = $this->sut->get_item_response( $item );
@@ -125,6 +123,5 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );
 		$this->assertNull( $response['prices'], 'Live prices should be null for missing products' );
 		$this->assertSame( 'Snapshot Title', $response['product_title_at_save'] );
-		$this->assertSame( '1250', $response['price_at_save'], 'price_at_save should be formatted via prepare_money_response (smallest unit)' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -1,0 +1,102 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
+use WC_Unit_Test_Case;
+
+/**
+ * Unit tests for ShopperListItem.
+ */
+class ShopperListItemTests extends WC_Unit_Test_Case {
+	/**
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Item SUT Product',
+				'regular_price' => 19.99,
+			)
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		if ( $this->product ) {
+			$this->product->delete( true );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox from_product should build an item from a live product, snapshotting title/price and persisting item_data.
+	 */
+	public function test_from_product_builds_item_from_live_product(): void {
+		$item = ShopperListItem::from_product(
+			$this->product->get_id(),
+			array(),
+			array(
+				array(
+					'key'   => 'source',
+					'value' => 'manual',
+				),
+			)
+		);
+
+		$this->assertInstanceOf( ShopperListItem::class, $item );
+		$arr = $item->to_array();
+		$this->assertSame( $this->product->get_title(), $arr['product_title_at_save'] );
+		$this->assertSame( (string) $this->product->get_price(), $arr['price_at_save'] );
+		$this->assertSame( 1, $arr['quantity'], 'Quantity is hardcoded to 1 in v1.' );
+		$this->assertSame( 'manual', $arr['item_data'][0]['value'] );
+	}
+
+	/**
+	 * @testdox from_product should return null when the product can't be resolved.
+	 */
+	public function test_from_product_returns_null_for_missing_product(): void {
+		$this->assertNull( ShopperListItem::from_product( 99999999 ) );
+	}
+
+	/**
+	 * @testdox The same product+item_data should always produce the same key, and different item_data should produce different keys.
+	 */
+	public function test_key_is_deterministic_and_varies_by_inputs(): void {
+		$first  = ShopperListItem::from_product( $this->product->get_id() );
+		$second = ShopperListItem::from_product( $this->product->get_id() );
+		$noted  = ShopperListItem::from_product(
+			$this->product->get_id(),
+			array(),
+			array(
+				array(
+					'key'   => 'note',
+					'value' => 'gift',
+				),
+			)
+		);
+
+		$this->assertSame( $first->key(), $second->key(), 'Same inputs must produce the same key.' );
+		$this->assertNotSame( $first->key(), $noted->key(), 'Different item_data must produce different keys.' );
+	}
+
+	/**
+	 * @testdox to_array round-trips through from_array.
+	 */
+	public function test_round_trips_through_from_array(): void {
+		$original = ShopperListItem::from_product( $this->product->get_id() );
+		$rebuilt  = ShopperListItem::from_array( $original->to_array() );
+
+		$this->assertSame( $original->to_array(), $rebuilt->to_array() );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -76,40 +76,6 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Same product+variation should always produce the same key, regardless of variation key order.
-	 */
-	public function test_key_is_stable_under_variation_reordering(): void {
-		$id    = $this->product->get_id();
-		$first = ShopperListItem::from_product(
-			$id,
-			array(
-				'attribute_size'  => 'L',
-				'attribute_color' => 'red',
-			)
-		);
-		$other = ShopperListItem::from_product(
-			$id,
-			array(
-				'attribute_color' => 'red',
-				'attribute_size'  => 'L',
-			)
-		);
-
-		$this->assertSame( $first->get_key(), $other->get_key(), 'Variation attribute order must not affect the key.' );
-	}
-
-	/**
-	 * @testdox Different variation values should produce different keys.
-	 */
-	public function test_key_varies_with_variation_values(): void {
-		$id  = $this->product->get_id();
-		$red = ShopperListItem::from_product( $id, array( 'attribute_color' => 'red' ) );
-		$blu = ShopperListItem::from_product( $id, array( 'attribute_color' => 'blue' ) );
-
-		$this->assertNotSame( $red->get_key(), $blu->get_key(), 'Different variation values must produce different keys.' );
-	}
-
-	/**
 	 * @testdox to_array round-trips through from_array.
 	 */
 	public function test_round_trips_through_from_array(): void {
@@ -117,5 +83,71 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 		$rebuilt  = ShopperListItem::from_array( $original->to_array() );
 
 		$this->assertSame( $original->to_array(), $rebuilt->to_array() );
+	}
+
+	/**
+	 * @testdox from_product validates the variation array against the variation product, like cart does.
+	 */
+	public function test_from_variation_validates_against_variation_product(): void {
+		$variable = \WC_Helper_Product::create_variation_product();
+
+		$find = function ( array $attrs ) use ( $variable ): int {
+			foreach ( $variable->get_children() as $variation_id ) {
+				$expected = wc_get_product_variation_attributes( (int) $variation_id );
+				if ( empty( array_diff_assoc( $attrs, $expected ) ) ) {
+					return (int) $variation_id;
+				}
+			}
+			$this->fail( 'No variation matched the requested attribute set.' );
+		};
+
+		$all_specific = $find(
+			array(
+				'attribute_pa_size'   => 'huge',
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_number' => '0',
+			)
+		);
+		$any_number   = $find(
+			array(
+				'attribute_pa_size'   => 'huge',
+				'attribute_pa_colour' => 'blue',
+				'attribute_pa_number' => '',
+			)
+		);
+
+		// Specific attrs: server fills them in even when the caller passes nothing.
+		$variation = ShopperListItem::from_product( $all_specific, array() )->to_array()['variation'];
+		$this->assertSame( 'huge', $variation['attribute_pa_size'] );
+		$this->assertSame( 'red', $variation['attribute_pa_colour'] );
+		$this->assertSame( '0', $variation['attribute_pa_number'] );
+
+		// Specific attrs: client value mismatching the variation is rejected.
+		try {
+			ShopperListItem::from_product( $all_specific, array( 'attribute_pa_colour' => 'blue' ) );
+			$this->fail( 'Expected mismatched specific value to throw.' );
+		} catch ( \InvalidArgumentException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
+
+		// "Any" slot: missing client value is rejected.
+		try {
+			ShopperListItem::from_product( $any_number, array() );
+			$this->fail( 'Expected missing any-slot value to throw.' );
+		} catch ( \InvalidArgumentException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
+
+		// "Any" slot: a value present on the parent is accepted and stored.
+		$variation = ShopperListItem::from_product( $any_number, array( 'attribute_pa_number' => '2' ) )->to_array()['variation'];
+		$this->assertSame( '2', $variation['attribute_pa_number'] );
+
+		// "Any" slot: a value not in the parent's slugs is rejected.
+		try {
+			ShopperListItem::from_product( $any_number, array( 'attribute_pa_number' => '99' ) );
+			$this->fail( 'Expected invalid any-slot value to throw.' );
+		} catch ( \InvalidArgumentException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -40,7 +40,7 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox from_product should build an item from a live product, snapshotting title/price.
+	 * @testdox from_product should build an item from a live product, snapshotting the title.
 	 */
 	public function test_from_product_builds_item_from_live_product(): void {
 		$item = ShopperListItem::from_product( $this->product->get_id(), array(), 3 );
@@ -48,7 +48,6 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( ShopperListItem::class, $item );
 		$arr = $item->to_array();
 		$this->assertSame( $this->product->get_title(), $arr['product_title_at_save'] );
-		$this->assertSame( (string) $this->product->get_price(), $arr['price_at_save'] );
 		$this->assertSame( 3, $arr['quantity'], 'Quantity should reflect the value passed to from_product.' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -51,15 +51,29 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 					'key'   => 'source',
 					'value' => 'manual',
 				),
-			)
+			),
+			3
 		);
 
 		$this->assertInstanceOf( ShopperListItem::class, $item );
 		$arr = $item->to_array();
 		$this->assertSame( $this->product->get_title(), $arr['product_title_at_save'] );
 		$this->assertSame( (string) $this->product->get_price(), $arr['price_at_save'] );
-		$this->assertSame( 1, $arr['quantity'], 'Quantity is hardcoded to 1 in v1.' );
+		$this->assertSame( 3, $arr['quantity'], 'Quantity should reflect the value passed to from_product.' );
 		$this->assertSame( 'manual', $arr['item_data'][0]['value'] );
+	}
+
+	/**
+	 * @testdox from_product should default quantity to 1 and coerce zero/negative values up to 1.
+	 */
+	public function test_from_product_normalizes_quantity_floor(): void {
+		$default = ShopperListItem::from_product( $this->product->get_id() );
+		$this->assertInstanceOf( ShopperListItem::class, $default );
+		$this->assertSame( 1, $default->to_array()['quantity'] );
+
+		$zero = ShopperListItem::from_product( $this->product->get_id(), array(), array(), 0 );
+		$this->assertInstanceOf( ShopperListItem::class, $zero );
+		$this->assertSame( 1, $zero->to_array()['quantity'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -62,6 +62,10 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 		$zero = ShopperListItem::from_product( $this->product->get_id(), array(), 0 );
 		$this->assertInstanceOf( ShopperListItem::class, $zero );
 		$this->assertSame( 1, $zero->to_array()['quantity'] );
+
+		$negative = ShopperListItem::from_product( $this->product->get_id(), array(), -5 );
+		$this->assertInstanceOf( ShopperListItem::class, $negative );
+		$this->assertSame( 1, $negative->to_array()['quantity'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -86,8 +86,8 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertSame( $first->key(), $second->key(), 'Same inputs must produce the same key.' );
-		$this->assertNotSame( $first->key(), $noted->key(), 'Different item_data must produce different keys.' );
+		$this->assertSame( $first->get_key(), $second->get_key(), 'Same inputs must produce the same key.' );
+		$this->assertNotSame( $first->get_key(), $noted->get_key(), 'Different item_data must produce different keys.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -40,27 +40,16 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox from_product should build an item from a live product, snapshotting title/price and persisting item_data.
+	 * @testdox from_product should build an item from a live product, snapshotting title/price.
 	 */
 	public function test_from_product_builds_item_from_live_product(): void {
-		$item = ShopperListItem::from_product(
-			$this->product->get_id(),
-			array(),
-			array(
-				array(
-					'key'   => 'source',
-					'value' => 'manual',
-				),
-			),
-			3
-		);
+		$item = ShopperListItem::from_product( $this->product->get_id(), array(), 3 );
 
 		$this->assertInstanceOf( ShopperListItem::class, $item );
 		$arr = $item->to_array();
 		$this->assertSame( $this->product->get_title(), $arr['product_title_at_save'] );
 		$this->assertSame( (string) $this->product->get_price(), $arr['price_at_save'] );
 		$this->assertSame( 3, $arr['quantity'], 'Quantity should reflect the value passed to from_product.' );
-		$this->assertSame( 'manual', $arr['item_data'][0]['value'] );
 	}
 
 	/**
@@ -71,7 +60,7 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( ShopperListItem::class, $default );
 		$this->assertSame( 1, $default->to_array()['quantity'] );
 
-		$zero = ShopperListItem::from_product( $this->product->get_id(), array(), array(), 0 );
+		$zero = ShopperListItem::from_product( $this->product->get_id(), array(), 0 );
 		$this->assertInstanceOf( ShopperListItem::class, $zero );
 		$this->assertSame( 1, $zero->to_array()['quantity'] );
 	}
@@ -84,24 +73,37 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The same product+item_data should always produce the same key, and different item_data should produce different keys.
+	 * @testdox Same product+variation should always produce the same key, regardless of variation key order.
 	 */
-	public function test_key_is_deterministic_and_varies_by_inputs(): void {
-		$first  = ShopperListItem::from_product( $this->product->get_id() );
-		$second = ShopperListItem::from_product( $this->product->get_id() );
-		$noted  = ShopperListItem::from_product(
-			$this->product->get_id(),
-			array(),
+	public function test_key_is_stable_under_variation_reordering(): void {
+		$id    = $this->product->get_id();
+		$first = ShopperListItem::from_product(
+			$id,
 			array(
-				array(
-					'key'   => 'note',
-					'value' => 'gift',
-				),
+				'attribute_size'  => 'L',
+				'attribute_color' => 'red',
+			)
+		);
+		$other = ShopperListItem::from_product(
+			$id,
+			array(
+				'attribute_color' => 'red',
+				'attribute_size'  => 'L',
 			)
 		);
 
-		$this->assertSame( $first->get_key(), $second->get_key(), 'Same inputs must produce the same key.' );
-		$this->assertNotSame( $first->get_key(), $noted->get_key(), 'Different item_data must produce different keys.' );
+		$this->assertSame( $first->get_key(), $other->get_key(), 'Variation attribute order must not affect the key.' );
+	}
+
+	/**
+	 * @testdox Different variation values should produce different keys.
+	 */
+	public function test_key_varies_with_variation_values(): void {
+		$id  = $this->product->get_id();
+		$red = ShopperListItem::from_product( $id, array( 'attribute_color' => 'red' ) );
+		$blu = ShopperListItem::from_product( $id, array( 'attribute_color' => 'blue' ) );
+
+		$this->assertNotSame( $red->get_key(), $blu->get_key(), 'Different variation values must produce different keys.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -84,17 +84,44 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_by_slug should throw when the stored data is corrupt.
+	 * @testdox get_by_slug should self-heal saved-for-later when the stored meta is corrupt.
 	 */
-	public function test_load_throws_on_corrupt_data(): void {
+	public function test_load_self_heals_corrupt_saved_for_later(): void {
 		Users::update_site_user_meta(
 			$this->user_id,
 			ShopperList::META_KEY_PREFIX . self::SAVED_FOR_LATER_SLUG,
 			'this-is-not-an-array'
 		);
 
-		$this->expectException( \RuntimeException::class );
-		ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+
+		$this->assertInstanceOf( ShopperList::class, $list );
+		$this->assertSame( array(), $list->get_items(), 'Corrupt meta must yield an empty in-memory list.' );
+	}
+
+	/**
+	 * @testdox get_by_slug should skip individual corrupt items but still return the rest of the list.
+	 */
+	public function test_load_skips_corrupt_items(): void {
+		$good_item = $this->item->to_array();
+		Users::update_site_user_meta(
+			$this->user_id,
+			ShopperList::META_KEY_PREFIX . self::SAVED_FOR_LATER_SLUG,
+			array(
+				'slug'             => self::SAVED_FOR_LATER_SLUG,
+				'date_created_gmt' => '2026-04-01 00:00:00',
+				'items'            => array(
+					$good_item['key']   => $good_item,
+					'broken-row-key' => array( 'variation_id' => 0 ), // missing key + product_id
+				),
+			)
+		);
+
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+
+		$this->assertInstanceOf( ShopperList::class, $list );
+		$this->assertCount( 1, $list->get_items(), 'Bad rows should be skipped, the rest kept.' );
+		$this->assertNotNull( $list->find_item( $good_item['key'] ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -55,9 +55,9 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_by_slug should auto-create saved-for-later on first read.
+	 * @testdox get_by_slug should return an in-memory saved-for-later list on first read without persisting it.
 	 */
-	public function test_load_auto_creates_save_for_later(): void {
+	public function test_load_returns_in_memory_save_for_later_without_persisting(): void {
 		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
 
 		$this->assertInstanceOf( ShopperList::class, $list );
@@ -65,7 +65,19 @@ class ShopperListTests extends WC_Unit_Test_Case {
 		$this->assertSame( array(), $list->get_items() );
 
 		$persisted = Users::get_site_user_meta( $this->user_id, ShopperList::META_KEY_PREFIX . 'saved-for-later' );
-		$this->assertIsArray( $persisted, 'Auto-created list should be persisted to user meta.' );
+		$this->assertSame( '', $persisted, 'Empty saved-for-later should not be persisted until the first add.' );
+	}
+
+	/**
+	 * @testdox saved-for-later should be persisted lazily on the first add_item()+save().
+	 */
+	public function test_save_for_later_is_persisted_on_first_add(): void {
+		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+		$list->add_item( $this->make_item() );
+		$list->save();
+
+		$persisted = Users::get_site_user_meta( $this->user_id, ShopperList::META_KEY_PREFIX . 'saved-for-later' );
+		$this->assertIsArray( $persisted );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -98,7 +98,7 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox add_item/remove_item round-trip through save() and reload, are idempotent, and report unknown keys.
+	 * @testdox add_item/remove_item round-trip through save() and reload, merge quantities for the same key, and report unknown keys.
 	 */
 	public function test_list_item_crud(): void {
 		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
@@ -109,7 +109,10 @@ class ShopperListTests extends WC_Unit_Test_Case {
 
 		$reloaded = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
 		$this->assertCount( 1, $reloaded->get_items(), 'Adding the same item twice must keep a single row.' );
-		$this->assertNotNull( $reloaded->find_item( $this->item->get_key() ) );
+
+		$merged = $reloaded->find_item( $this->item->get_key() );
+		$this->assertNotNull( $merged );
+		$this->assertSame( 2, $merged->get_quantity(), 'Quantities must be summed when the same product+variation is added again.' );
 
 		$this->assertFalse( $reloaded->remove_item( 'nonexistent-key' ), 'remove_item should return false for unknown keys.' );
 		$this->assertTrue( $reloaded->remove_item( $this->item->get_key() ) );

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -115,7 +115,7 @@ class ShopperListTests extends WC_Unit_Test_Case {
 
 		$reloaded = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
 		$this->assertCount( 1, $reloaded->get_items() );
-		$this->assertNotNull( $reloaded->find_item( $item->key() ) );
+		$this->assertNotNull( $reloaded->find_item( $item->get_key() ) );
 	}
 
 	/**
@@ -142,7 +142,7 @@ class ShopperListTests extends WC_Unit_Test_Case {
 		$list->save();
 
 		$reloaded = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-		$this->assertTrue( $reloaded->remove_item( $item->key() ) );
+		$this->assertTrue( $reloaded->remove_item( $item->get_key() ) );
 		$reloaded->save();
 
 		$this->assertSame( array(), ShopperList::get_by_slug( 'saved-for-later', $this->user_id )->get_items() );

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -12,6 +12,8 @@ use WC_Unit_Test_Case;
  * Unit tests for ShopperList.
  */
 class ShopperListTests extends WC_Unit_Test_Case {
+	private const SAVED_FOR_LATER_SLUG = 'saved-for-later';
+
 	/**
 	 * @var int
 	 */
@@ -21,6 +23,11 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	 * @var \WC_Product
 	 */
 	private $product;
+
+	/**
+	 * @var ShopperListItem
+	 */
+	private $item;
 
 	/**
 	 * Set up.
@@ -35,6 +42,7 @@ class ShopperListTests extends WC_Unit_Test_Case {
 				'regular_price' => 19.99,
 			)
 		);
+		$this->item    = ShopperListItem::from_product( $this->product->get_id() );
 	}
 
 	/**
@@ -48,36 +56,22 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Build a ShopperListItem for the test product.
+	 * @testdox saved-for-later is in-memory only on first read and is persisted lazily on the first add_item()+save().
 	 */
-	private function make_item(): ShopperListItem {
-		return ShopperListItem::from_product( $this->product->get_id() );
-	}
-
-	/**
-	 * @testdox get_by_slug should return an in-memory saved-for-later list on first read without persisting it.
-	 */
-	public function test_load_returns_in_memory_save_for_later_without_persisting(): void {
-		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+	public function test_save_for_later_persistence_is_lazy(): void {
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
 
 		$this->assertInstanceOf( ShopperList::class, $list );
-		$this->assertSame( 'saved-for-later', $list->get_slug() );
+		$this->assertSame( self::SAVED_FOR_LATER_SLUG, $list->get_slug() );
 		$this->assertSame( array(), $list->get_items() );
 
-		$persisted = Users::get_site_user_meta( $this->user_id, ShopperList::META_KEY_PREFIX . 'saved-for-later' );
-		$this->assertSame( '', $persisted, 'Empty saved-for-later should not be persisted until the first add.' );
-	}
+		$meta_key = ShopperList::META_KEY_PREFIX . self::SAVED_FOR_LATER_SLUG;
+		$this->assertSame( '', Users::get_site_user_meta( $this->user_id, $meta_key ), 'Empty saved-for-later should not be persisted before the first add.' );
 
-	/**
-	 * @testdox saved-for-later should be persisted lazily on the first add_item()+save().
-	 */
-	public function test_save_for_later_is_persisted_on_first_add(): void {
-		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-		$list->add_item( $this->make_item() );
+		$list->add_item( $this->item );
 		$list->save();
 
-		$persisted = Users::get_site_user_meta( $this->user_id, ShopperList::META_KEY_PREFIX . 'saved-for-later' );
-		$this->assertIsArray( $persisted );
+		$this->assertIsArray( Users::get_site_user_meta( $this->user_id, $meta_key ), 'saved-for-later should be persisted after the first add+save.' );
 	}
 
 	/**
@@ -95,92 +89,32 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	public function test_load_throws_on_corrupt_data(): void {
 		Users::update_site_user_meta(
 			$this->user_id,
-			ShopperList::META_KEY_PREFIX . 'saved-for-later',
+			ShopperList::META_KEY_PREFIX . self::SAVED_FOR_LATER_SLUG,
 			'this-is-not-an-array'
 		);
 
 		$this->expectException( \RuntimeException::class );
-		ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+		ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
 	}
 
 	/**
-	 * @testdox get_by_slug should default to the current user when user_id is omitted.
+	 * @testdox add_item/remove_item round-trip through save() and reload, are idempotent, and report unknown keys.
 	 */
-	public function test_load_defaults_to_current_user(): void {
-		wp_set_current_user( $this->user_id );
+	public function test_list_item_crud(): void {
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
 
-		$list = ShopperList::get_by_slug( 'saved-for-later' );
-
-		$this->assertInstanceOf( ShopperList::class, $list );
-		$this->assertSame( 'saved-for-later', $list->get_slug() );
-	}
-
-	/**
-	 * @testdox add_item should persist after save() and round-trip through reload.
-	 */
-	public function test_add_item_persists_through_save_and_reload(): void {
-		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-		$item = $this->make_item();
-
-		$list->add_item( $item );
+		$list->add_item( $this->item );
+		$list->add_item( $this->item );
 		$list->save();
 
-		$reloaded = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-		$this->assertCount( 1, $reloaded->get_items() );
-		$this->assertNotNull( $reloaded->find_item( $item->get_key() ) );
-	}
+		$reloaded = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+		$this->assertCount( 1, $reloaded->get_items(), 'Adding the same item twice must keep a single row.' );
+		$this->assertNotNull( $reloaded->find_item( $this->item->get_key() ) );
 
-	/**
-	 * @testdox add_item should be idempotent — adding the same item twice keeps a single row.
-	 */
-	public function test_add_item_is_idempotent_for_same_product(): void {
-		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-
-		$list->add_item( $this->make_item() );
-		$list->add_item( $this->make_item() );
-		$list->save();
-
-		$this->assertCount( 1, ShopperList::get_by_slug( 'saved-for-later', $this->user_id )->get_items() );
-	}
-
-	/**
-	 * @testdox remove_item should remove an existing item and return true.
-	 */
-	public function test_remove_item_removes_existing(): void {
-		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-		$item = $this->make_item();
-
-		$list->add_item( $item );
-		$list->save();
-
-		$reloaded = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-		$this->assertTrue( $reloaded->remove_item( $item->get_key() ) );
+		$this->assertFalse( $reloaded->remove_item( 'nonexistent-key' ), 'remove_item should return false for unknown keys.' );
+		$this->assertTrue( $reloaded->remove_item( $this->item->get_key() ) );
 		$reloaded->save();
 
-		$this->assertSame( array(), ShopperList::get_by_slug( 'saved-for-later', $this->user_id )->get_items() );
-	}
-
-	/**
-	 * @testdox remove_item should return false for an unknown key.
-	 */
-	public function test_remove_item_returns_false_for_unknown_key(): void {
-		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-
-		$this->assertFalse( $list->remove_item( 'nonexistent-key' ) );
-	}
-
-	/**
-	 * @testdox One user's items should not be visible to another user.
-	 */
-	public function test_lists_are_isolated_between_users(): void {
-		$user_b = $this->factory->user->create( array( 'role' => 'customer' ) );
-
-		$list_a = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
-		$list_a->add_item( $this->make_item() );
-		$list_a->save();
-
-		$list_b = ShopperList::get_by_slug( 'saved-for-later', $user_b );
-		$this->assertSame( array(), $list_b->get_items() );
-		$this->assertCount( 1, ShopperList::get_by_slug( 'saved-for-later', $this->user_id )->get_items() );
+		$this->assertSame( array(), ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id )->get_items() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -111,8 +111,9 @@ class ShopperListTests extends WC_Unit_Test_Case {
 				'slug'             => self::SAVED_FOR_LATER_SLUG,
 				'date_created_gmt' => '2026-04-01 00:00:00',
 				'items'            => array(
-					$good_item['key']   => $good_item,
-					'broken-row-key' => array( 'variation_id' => 0 ), // missing key + product_id
+					$good_item['key'] => $good_item,
+					// Missing key + product_id.
+					'broken-row-key'  => array( 'variation_id' => 0 ),
 				),
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -1,0 +1,174 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
+use Automattic\WooCommerce\Internal\Utilities\Users;
+use WC_Unit_Test_Case;
+
+/**
+ * Unit tests for ShopperList.
+ */
+class ShopperListTests extends WC_Unit_Test_Case {
+	/**
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		$this->product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'List SUT Product',
+				'regular_price' => 19.99,
+			)
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		if ( $this->product ) {
+			$this->product->delete( true );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a ShopperListItem for the test product.
+	 */
+	private function make_item(): ShopperListItem {
+		return ShopperListItem::from_product( $this->product->get_id() );
+	}
+
+	/**
+	 * @testdox get_by_slug should auto-create saved-for-later on first read.
+	 */
+	public function test_load_auto_creates_save_for_later(): void {
+		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+
+		$this->assertInstanceOf( ShopperList::class, $list );
+		$this->assertSame( 'saved-for-later', $list->get_slug() );
+		$this->assertSame( array(), $list->get_items() );
+
+		$persisted = Users::get_site_user_meta( $this->user_id, ShopperList::META_KEY_PREFIX . 'saved-for-later' );
+		$this->assertIsArray( $persisted, 'Auto-created list should be persisted to user meta.' );
+	}
+
+	/**
+	 * @testdox get_by_slug should return false for any list slug other than saved-for-later.
+	 */
+	public function test_load_returns_false_for_unsupported_list_slug(): void {
+		$this->assertFalse( ShopperList::get_by_slug( 'wishlist', $this->user_id ) );
+		$this->assertFalse( ShopperList::get_by_slug( 'INVALID', $this->user_id ) );
+		$this->assertFalse( ShopperList::get_by_slug( '', $this->user_id ) );
+	}
+
+	/**
+	 * @testdox get_by_slug should throw when the stored data is corrupt.
+	 */
+	public function test_load_throws_on_corrupt_data(): void {
+		Users::update_site_user_meta(
+			$this->user_id,
+			ShopperList::META_KEY_PREFIX . 'saved-for-later',
+			'this-is-not-an-array'
+		);
+
+		$this->expectException( \RuntimeException::class );
+		ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+	}
+
+	/**
+	 * @testdox get_by_slug should default to the current user when user_id is omitted.
+	 */
+	public function test_load_defaults_to_current_user(): void {
+		wp_set_current_user( $this->user_id );
+
+		$list = ShopperList::get_by_slug( 'saved-for-later' );
+
+		$this->assertInstanceOf( ShopperList::class, $list );
+		$this->assertSame( 'saved-for-later', $list->get_slug() );
+	}
+
+	/**
+	 * @testdox add_item should persist after save() and round-trip through reload.
+	 */
+	public function test_add_item_persists_through_save_and_reload(): void {
+		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+		$item = $this->make_item();
+
+		$list->add_item( $item );
+		$list->save();
+
+		$reloaded = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+		$this->assertCount( 1, $reloaded->get_items() );
+		$this->assertNotNull( $reloaded->find_item( $item->key() ) );
+	}
+
+	/**
+	 * @testdox add_item should be idempotent — adding the same item twice keeps a single row.
+	 */
+	public function test_add_item_is_idempotent_for_same_product(): void {
+		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+
+		$list->add_item( $this->make_item() );
+		$list->add_item( $this->make_item() );
+		$list->save();
+
+		$this->assertCount( 1, ShopperList::get_by_slug( 'saved-for-later', $this->user_id )->get_items() );
+	}
+
+	/**
+	 * @testdox remove_item should remove an existing item and return true.
+	 */
+	public function test_remove_item_removes_existing(): void {
+		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+		$item = $this->make_item();
+
+		$list->add_item( $item );
+		$list->save();
+
+		$reloaded = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+		$this->assertTrue( $reloaded->remove_item( $item->key() ) );
+		$reloaded->save();
+
+		$this->assertSame( array(), ShopperList::get_by_slug( 'saved-for-later', $this->user_id )->get_items() );
+	}
+
+	/**
+	 * @testdox remove_item should return false for an unknown key.
+	 */
+	public function test_remove_item_returns_false_for_unknown_key(): void {
+		$list = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+
+		$this->assertFalse( $list->remove_item( 'nonexistent-key' ) );
+	}
+
+	/**
+	 * @testdox One user's items should not be visible to another user.
+	 */
+	public function test_lists_are_isolated_between_users(): void {
+		$user_b = $this->factory->user->create( array( 'role' => 'customer' ) );
+
+		$list_a = ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+		$list_a->add_item( $this->make_item() );
+		$list_a->save();
+
+		$list_b = ShopperList::get_by_slug( 'saved-for-later', $user_b );
+		$this->assertSame( array(), $list_b->get_items() );
+		$this->assertCount( 1, ShopperList::get_by_slug( 'saved-for-later', $this->user_id )->get_items() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is the first PR in a series introducing shopper lists to WooCommerce. It lays the groundwork: the Store API surface plus the data layer behind it. The frontend pieces (block, Cart-block "Save for later" link, the iAPI store, etc.) will follow in separate PRs.

The PR adds:

- A new PHP namespace `Automattic\WooCommerce\Internal\ShopperLists` containing the `ShopperList` and `ShopperListItem` value objects. Lists are persisted per-user in user meta (one row per list), encapsulated inside these classes so the storage backend can change later without touching routes or the API contract.
- New Store API routes:
  - `GET /wc/store/v1/shopper-lists` — the user's lists. Auto-creates `saved-for-later` on first write.
  - `GET /wc/store/v1/shopper-lists/{slug}` — a single list, with its items embedded.
  - `GET /wc/store/v1/shopper-lists/{slug}/items` — items in a list.
  - `POST /wc/store/v1/shopper-lists/{slug}/items` — save an item, accepting either an existing `cart_item_key` or a direct `product_id` (with optional `variation_id` / `variation` keys). `quantity` can be used to specify quantity as well.
  - `DELETE /wc/store/v1/shopper-lists/{slug}/items/{key}` — remove a single saved item.
- Two Store API schemas (`ShopperListSchema`, `ShopperListItemSchema`). The list schema embeds its items in responses (mirroring how `CartSchema` embeds cart items). The item schema serves live product data when available, and falls back to an at-save title snapshot when the underlying product has been deleted.

All routes require a logged-in user.

> [!NOTE]
> I intentionally left out some of the implementation like `POST|UPDATE|DELETE` requests to do list CRUD, `ExtendSchema` and other extension points (filters) to keep this PR minimal and in line with what's required for the first iteration of the feature. Will submit a PR for those later.

closes WOOPRD-3508

### How to test the changes in this Pull Request:

1. Make a `GET` request to `/wp-json/wc/store/v1/shopper-lists`, which should fail given you've not authenticated.
1. Generate an Application Password for your user (Users → Edit → Application Passwords). The endpoints accept basic auth, no nonce required.
2. Pick a real product ID from your store.
3. `GET /wp-json/wc/store/v1/shopper-lists` and confirm you get a `200` response with an array containing a single `saved-for-later` list, `item_count: 0` and an empty `items` array. The list is auto-created on first write.
4. `POST /shopper-lists/saved-for-later/items` with body `{ "product_id": <id> }` and confirm you get a `201` and a response item with `product_exists: true`, `quantity: 1`, populated snapshot fields, and live product `name` / `prices`.
5. Repeat the same POST and you should get the same `key` back but now with `quantity: 2`. Subsequent `GET /shopper-lists/saved-for-later/items` still returns one row.
6. `DELETE /shopper-lists/saved-for-later/items/{key}`, expect `204` with an empty body. Then `GET /shopper-lists/saved-for-later/items` and confirm the row is gone.
7. Save another item, then permanently delete the underlying product (e.g. via wp-cli). `GET /shopper-lists/saved-for-later/items` — expect the row to remain, `product_exists: false`, `name` falling back to `product_title_at_save`, `prices: null`.
8. Verify the error responses below:
   | Request | Expected status |
   |---|---|
   | `POST /shopper-lists/saved-for-later/items` with empty body | `400` |
   | `POST /shopper-lists/saved-for-later/items` with `{ "product_id": 9999999 }` | `404` |
   | `GET /shopper-lists/wishlist` (any unsupported slug) | `404` |
   | `POST /shopper-lists/wishlist/items` (any body) | `404` |
   | Unauthenticated `GET /shopper-lists` | `401` |

### Testing that has already taken place:

- Unit tests for the data layer and the item schema.
- Manual HTTP-client testing against a local site covering the happy paths, the tombstone path, idempotency, and the negative paths above.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually at `changelog/rsm-shopper-collections-add-storeapi-endpoints` (significance: minor, type: add).

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry.