### PR TITLE
Order notes meta box: clarify visibility, modernize bubble styling

### DIFF
--- a/plugins/woocommerce/changelog/64999-sprinkle-order-notes-visibility
+++ b/plugins/woocommerce/changelog/64999-sprinkle-order-notes-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Order notes meta box: clarify note visibility (visibility label, dynamic CTA, customer-note header, email template link, customer-note delete confirmation) and modernize bubble styling for WP admin alignment.

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -27,6 +27,11 @@ $subtext:           #767676 !default;                                  // small,
 // Border radius tokens — mirrors WP Design System naming.
 $radius-s:          2px !default;                                      // Small radius: inputs, buttons, selects.
 
+// Grayscale tokens — mirror @wordpress/base-styles/_colors.scss for WP 7.0 alignment.
+// Adjacent work in #64280 adds $gray-700 and $gray-900 — coordinate on merge.
+$gray-100:          #f6f7f7 !default;                                  // Subtle backgrounds.
+$gray-200:          #dcdcde !default;                                  // Borders, dividers.
+
 // export vars as CSS vars
 :root {
 	--woocommerce: #{$woocommerce};

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2858,10 +2858,6 @@ ul.wc_coupon_list_block {
 	margin: 0;
 	padding: 0;
 
-	ul.order_notes li {
-		padding: 0 10px;
-	}
-
 	button {
 		margin: 1px;
 		vertical-align: top;
@@ -3557,13 +3553,18 @@ ul.wc_coupon_list_block {
 
 /* Order notes */
 ul.order_notes {
-	padding: 2px 0 0;
+	list-style: none;
+	padding: 16px 12px;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
 
 	li {
 		.note_content {
-			padding: 10px;
-			background: #efefef;
-			position: relative;
+			background: #fff;
+			border: 1px solid $gray-200;
+			border-radius: 4px;
 
 			p {
 				margin: 0;
@@ -3572,67 +3573,96 @@ ul.order_notes {
 			}
 		}
 
+		.note_header {
+			margin: 0;
+			padding: 6px 12px;
+			// Mirrors @wordpress/components Notice is-warning variant
+			// (bg #fef8ee, accent #f0b849). Supplementary cue — info is
+			// also in the label text itself.
+			background: #fef8ee;
+			border-bottom: 1px solid $gray-200;
+			border-top-left-radius: 3px;
+			border-top-right-radius: 3px;
+			font-size: 11px;
+			font-weight: 600;
+		}
+
+		.note_body {
+			padding: 8px 12px;
+		}
+
 		p.meta {
-			padding: 10px;
-			color: #999;
+			padding: 4px 0 0;
+			color: $subtext;
 			margin: 0;
 			font-size: 11px;
 
 			.exact-date {
-				border-bottom: 1px dotted #999;
+				border-bottom: 0;
+				text-decoration: none;
 			}
 		}
 
 		a.delete_note {
 			color: $red;
-		}
-
-		.note_content::after {
-			content: "";
-			display: block;
-			position: absolute;
-			bottom: -10px;
-			left: 20px;
-			width: 0;
-			height: 0;
-			border-width: 10px 10px 0 0;
-			border-style: solid;
-			border-color: #efefef transparent;
+			margin-left: 4px;
 		}
 	}
 
-	li.system-note {
-		.note_content {
-			background: #d7cad2;
-		}
-
-		.note_content::after {
-			border-color: #d7cad2 transparent;
-		}
+	li.no-items {
+		color: $subtext;
+		padding: 16px 0;
+		text-align: center;
 	}
 
-	li.customer-note {
-		.note_content {
-			background: #a7cedc;
-		}
-
-		.note_content::after {
-			border-color: #a7cedc transparent;
-		}
+	li.system-note .note_content {
+		// Auto-generated notes (status changes, webhooks, etc.) are
+		// visually de-emphasised so manual notes scan more easily.
+		background: $gray-100;
 	}
 }
 
 .add_note {
-	border-top: 1px solid #ddd;
-	padding: 10px 10px 0;
+	border-bottom: 1px solid $gray-200;
+	padding: 16px 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
 
-	h4 {
-		margin-top: 5px !important;
+	> p {
+		margin: 0;
+	}
+
+	label {
+		display: block;
+		margin-bottom: 4px;
 	}
 
 	#add_order_note {
 		width: 100%;
-		height: 50px;
+		height: 60px;
+	}
+
+	.order_note_visibility {
+		select {
+			width: 100%;
+			max-width: 100%;
+		}
+
+		.add_note_email_settings {
+			margin: 6px 0 0;
+			font-size: 12px;
+			color: $subtext;
+
+			a {
+				color: inherit;
+			}
+		}
+	}
+
+	.add_note_actions button.add_note {
+		width: 100%;
+		text-align: center;
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1359,8 +1359,24 @@ jQuery( function ( $ ) {
 		init: function() {
 			$( '#woocommerce-order-notes' )
 				.on( 'click', 'button.add_note', this.add_order_note )
-				.on( 'click', 'a.delete_note', this.delete_order_note );
+				.on( 'click', 'a.delete_note', this.delete_order_note )
+				.on( 'change', 'select#order_note_type', this.update_note_type_ui );
 
+			// Sync the CTA + helper link to reflect the current select state on load.
+			$( 'select#order_note_type' ).trigger( 'change' );
+		},
+
+		update_note_type_ui: function() {
+			var $option      = $( this ).find( ':selected' );
+			// Fallback: extension-injected options may lack data-button-label.
+			// Default to the first option's label so the button never shows stale text.
+			var defaultLabel = $( this ).find( 'option:first' ).data( 'button-label' );
+			var label        = $option.data( 'button-label' ) || defaultLabel;
+			var isCustomer   = 'customer' === $( this ).val();
+			if ( label ) {
+				$( '#woocommerce-order-notes button.add_note' ).text( label );
+			}
+			$( '#woocommerce-order-notes .add_note_email_settings' ).prop( 'hidden', ! isCustomer );
 		},
 
 		add_order_note: function() {
@@ -1400,8 +1416,12 @@ jQuery( function ( $ ) {
 		},
 
 		delete_order_note: function() {
-			if ( window.confirm( woocommerce_admin_meta_boxes.i18n_delete_note ) ) {
-				var note = $( this ).closest( 'li.note' );
+			var note = $( this ).closest( 'li.note' );
+			var message = note.hasClass( 'customer-note' )
+				? woocommerce_admin_meta_boxes.i18n_delete_customer_note
+				: woocommerce_admin_meta_boxes.i18n_delete_note;
+
+			if ( window.confirm( message ) ) {
 
 				$( note ).block({
 					message: null,
@@ -1418,7 +1438,25 @@ jQuery( function ( $ ) {
 				};
 
 				$.post( woocommerce_admin_meta_boxes.ajax_url, data, function() {
+					if ( window.wcTracks && window.wcTracks.recordEvent ) {
+						var noteType = note.hasClass( 'customer-note' ) ? 'customer' : 'private';
+						var dateStr  = note.find( '.exact-date' ).attr( 'title' );
+						var addedAt  = dateStr ? new Date( dateStr.replace( ' ', 'T' ) ) : null;
+						var seconds  = ( addedAt && ! isNaN( addedAt.valueOf() ) )
+							? Math.round( ( Date.now() - addedAt.getTime() ) / 1000 )
+							: null;
+						window.wcTracks.recordEvent( 'order_edit_delete_order_note', {
+							order_id:            woocommerce_admin_meta_boxes.post_id,
+							note_type:           noteType,
+							status:              $( '#order_status' ).val(),
+							seconds_since_added: seconds
+						} );
+					}
 					$( note ).remove();
+					var $list = $( 'ul.order_notes' );
+					if ( 0 === $list.find( 'li.note' ).length ) {
+						$list.append( $( '<li class="no-items"></li>' ).text( woocommerce_admin_meta_boxes.i18n_no_notes_yet ) );
+					}
 				});
 			}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -702,6 +702,8 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_permission_revoke'                          => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
 					'i18n_tax_rate_already_exists'                    => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),
 					'i18n_delete_note'                                => __( 'Are you sure you wish to delete this note? This action cannot be undone.', 'woocommerce' ),
+					'i18n_delete_customer_note'                       => __( 'Are you sure you wish to delete this note? This action cannot be undone. Caution: This only removes the note from your records — it does not recall the email already sent to the customer.', 'woocommerce' ),
+					'i18n_no_notes_yet'                               => __( 'There are no notes yet.', 'woocommerce' ),
 					'i18n_apply_coupon'                               => __( 'Enter a coupon code to apply. Discounts are applied to line totals, before taxes.', 'woocommerce' ),
 					'i18n_add_fee'                                    => __( 'Enter a fixed amount or percentage to apply as a fee.', 'woocommerce' ),
 					'i18n_attribute_name_placeholder'                 => __( 'New attribute', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -33,19 +33,40 @@ class WC_Meta_Box_Order_Notes {
 		} else {
 			$notes = array();
 		}
+
+		$private_button_label  = __( 'Add private note', 'woocommerce' );
+		$customer_button_label = __( 'Send note to customer →', 'woocommerce' );
+		$email_settings_url    = admin_url( 'admin.php?page=wc-settings&tab=email&section=wc_email_customer_note' );
 		?>
 		<div class="add_note">
 			<p>
-				<label for="add_order_note"><?php esc_html_e( 'Add note', 'woocommerce' ); ?> <?php echo wc_help_tip( __( 'Add a note for your reference, or add a customer note (the user will be notified).', 'woocommerce' ) ); ?></label>
-				<textarea type="text" name="order_note" id="add_order_note" class="input-text" cols="20" rows="5"></textarea>
+				<label for="add_order_note"><?php esc_html_e( 'Add note', 'woocommerce' ); ?></label>
+				<textarea name="order_note" id="add_order_note" class="input-text" cols="20" rows="5"></textarea>
 			</p>
-			<p>
-				<label for="order_note_type" class="screen-reader-text"><?php esc_html_e( 'Note type', 'woocommerce' ); ?></label>
+			<div class="order_note_visibility">
+				<label for="order_note_type"><?php esc_html_e( 'Visibility', 'woocommerce' ); ?></label>
 				<select name="order_note_type" id="order_note_type">
-					<option value=""><?php esc_html_e( 'Private note', 'woocommerce' ); ?></option>
-					<option value="customer"><?php esc_html_e( 'Note to customer', 'woocommerce' ); ?></option>
+					<option value="" data-button-label="<?php echo esc_attr( $private_button_label ); ?>"><?php esc_html_e( 'Private note', 'woocommerce' ); ?></option>
+					<option value="customer" data-button-label="<?php echo esc_attr( $customer_button_label ); ?>"><?php esc_html_e( 'Public note to customer', 'woocommerce' ); ?></option>
 				</select>
-				<button type="button" class="add_note button"><?php esc_html_e( 'Add', 'woocommerce' ); ?></button>
+				<p class="add_note_email_settings" hidden>
+					<?php
+					$email_template_link = sprintf(
+						'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span aria-hidden="true">&#8599;</span><span class="screen-reader-text">%3$s</span></a>',
+						esc_url( $email_settings_url ),
+						esc_html__( 'email template', 'woocommerce' ),
+						esc_html__( '(opens in a new tab)', 'woocommerce' )
+					);
+					printf(
+						/* translators: %s: link to the customer note email template settings */
+						esc_html__( 'Preview or edit %s', 'woocommerce' ),
+						$email_template_link // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped above.
+					);
+					?>
+				</p>
+			</div>
+			<p class="add_note_actions">
+				<button type="button" class="add_note button"><?php echo esc_html( $private_button_label ); ?></button>
 			</p>
 		</div>
 		<?php

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-notes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-notes.php
@@ -19,27 +19,40 @@ defined( 'ABSPATH' ) || exit;
 			?>
 			<li rel="<?php echo absint( $note->id ); ?>" class="<?php echo esc_attr( implode( ' ', $css_class ) ); ?>">
 				<div class="note_content">
-					<?php
-					$content = wp_kses_post( $note->content );
-					$content = wc_wptexturize_order_note( $content );
-					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- the content goes through wp_kses_post above.
-					echo wpautop( $content );
-					?>
+					<?php if ( $note->customer_note ) : ?>
+						<div class="note_header"><?php esc_html_e( 'Sent to customer', 'woocommerce' ); ?></div>
+					<?php endif; ?>
+					<div class="note_body">
+						<?php
+						$content = wp_kses_post( $note->content );
+						$content = wc_wptexturize_order_note( $content );
+						// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- the content goes through wp_kses_post above.
+						echo wpautop( $content );
+						?>
+					</div>
 				</div>
 				<p class="meta">
 					<abbr class="exact-date" title="<?php echo esc_attr( $note->date_created->date( 'Y-m-d H:i:s' ) ); ?>">
 						<?php
-						/* translators: %1$s: note date %2$s: note time */
+						/* translators: %1$s: order note date, %2$s: order note time */
 						echo esc_html( sprintf( __( '%1$s at %2$s', 'woocommerce' ), $note->date_created->date_i18n( wc_date_format() ), $note->date_created->date_i18n( wc_time_format() ) ) );
 						?>
 					</abbr>
 					<?php
 					if ( 'system' !== $note->added_by ) :
-						/* translators: %s: note author */
+						/* translators: %s: order note author */
 						echo esc_html( sprintf( ' ' . __( 'by %s', 'woocommerce' ), $note->added_by ) );
 					endif;
 					?>
-					<a href="#" class="delete_note" role="button"><?php esc_html_e( 'Delete note', 'woocommerce' ); ?></a>
+					<?php
+					$note_date_label   = $note->date_created->date_i18n( wc_date_format() );
+					$delete_aria_label = 'system' === $note->added_by
+						/* translators: %s: order note date */
+						? sprintf( __( 'Delete system note from %s', 'woocommerce' ), $note_date_label )
+						/* translators: %1$s: order note author, %2$s: order note date */
+						: sprintf( __( 'Delete note from %1$s on %2$s', 'woocommerce' ), $note->added_by, $note_date_label );
+					?>
+					<a href="#" class="delete_note" role="button" aria-label="<?php echo esc_attr( $delete_aria_label ); ?>"><?php esc_html_e( 'Delete', 'woocommerce' ); ?></a>
 				</p>
 			</li>
 			<?php

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1705,31 +1705,48 @@ class WC_AJAX {
 			$comment_id = $order->add_order_note( $note, $is_customer_note, true );
 			$note       = wc_get_order_note( $comment_id );
 
+			if ( ! $note ) {
+				wp_die();
+			}
+
 			$note_classes   = array( 'note' );
 			$note_classes[] = $is_customer_note ? 'customer-note' : '';
 			$note_classes   = apply_filters( 'woocommerce_order_note_class', array_filter( $note_classes ), $note );
 			?>
 			<li rel="<?php echo absint( $note->id ); ?>" class="<?php echo esc_attr( implode( ' ', $note_classes ) ); ?>">
 				<div class="note_content">
-					<?php
-					$content = wc_wptexturize_order_note( $note->content );
-					echo wp_kses_post( wpautop( make_clickable( $content ) ) );
-					?>
+					<?php if ( $is_customer_note ) : ?>
+						<div class="note_header"><?php esc_html_e( 'Sent to customer', 'woocommerce' ); ?></div>
+					<?php endif; ?>
+					<div class="note_body">
+						<?php
+						$content = wc_wptexturize_order_note( $note->content );
+						echo wp_kses_post( wpautop( make_clickable( $content ) ) );
+						?>
+					</div>
 				</div>
 				<p class="meta">
-					<abbr class="exact-date" title="<?php echo esc_attr( $note->date_created->date( 'y-m-d h:i:s' ) ); ?>">
+					<abbr class="exact-date" title="<?php echo esc_attr( $note->date_created->date( 'Y-m-d H:i:s' ) ); ?>">
 						<?php
-						/* translators: $1: Date created, $2 Time created */
-						printf( esc_html__( 'added on %1$s at %2$s', 'woocommerce' ), esc_html( $note->date_created->date_i18n( wc_date_format() ) ), esc_html( $note->date_created->date_i18n( wc_time_format() ) ) );
+						/* translators: %1$s: order note date, %2$s: order note time */
+						printf( esc_html__( '%1$s at %2$s', 'woocommerce' ), esc_html( $note->date_created->date_i18n( wc_date_format() ) ), esc_html( $note->date_created->date_i18n( wc_time_format() ) ) );
 						?>
 					</abbr>
 					<?php
 					if ( 'system' !== $note->added_by ) :
-						/* translators: %s: note author */
+						/* translators: %s: order note author */
 						printf( ' ' . esc_html__( 'by %s', 'woocommerce' ), esc_html( $note->added_by ) );
 					endif;
 					?>
-					<a href="#" class="delete_note" role="button"><?php esc_html_e( 'Delete note', 'woocommerce' ); ?></a>
+					<?php
+					$note_date_label   = $note->date_created->date_i18n( wc_date_format() );
+					$delete_aria_label = 'system' === $note->added_by
+						/* translators: %s: order note date */
+						? sprintf( __( 'Delete system note from %s', 'woocommerce' ), $note_date_label )
+						/* translators: %1$s: order note author, %2$s: order note date */
+						: sprintf( __( 'Delete note from %1$s on %2$s', 'woocommerce' ), $note->added_by, $note_date_label );
+					?>
+					<a href="#" class="delete_note" role="button" aria-label="<?php echo esc_attr( $delete_aria_label ); ?>"><?php esc_html_e( 'Delete', 'woocommerce' ); ?></a>
 				</p>
 			</li>
 			<?php

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -8605,33 +8605,9 @@ parameters:
 			path: includes/class-wc-ajax.php
 
 		-
-			message: '#^Cannot access property \$added_by on stdClass\|null\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: includes/class-wc-ajax.php
-
-		-
 			message: '#^Cannot access property \$children on WP_Error\|WP_Term\|null\.$#'
 			identifier: property.nonObject
 			count: 4
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Cannot access property \$content on stdClass\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Cannot access property \$date_created on stdClass\|null\.$#'
-			identifier: property.nonObject
-			count: 3
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Cannot access property \$id on stdClass\|null\.$#'
-			identifier: property.nonObject
-			count: 1
 			path: includes/class-wc-ajax.php
 
 		-

--- a/plugins/woocommerce/tests/e2e-pw/tests/order/order-edit.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/order/order-edit.spec.ts
@@ -209,7 +209,7 @@ test.describe( 'Edit order', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
 			.fill(
 				'This order is a test order. It is only a test. This note is a private note.'
 			);
-		await page.getByRole( 'button', { name: 'Add', exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Add private note' } ).click();
 
 		// verify the note saved
 		await expect(
@@ -238,8 +238,12 @@ test.describe( 'Edit order', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
 			.fill(
 				'This order is a test order. It is only a test. This note is a note to the customer.'
 			);
-		await page.getByLabel( 'Note type' ).selectOption( 'Note to customer' );
-		await page.getByRole( 'button', { name: 'Add', exact: true } ).click();
+		await page
+			.getByLabel( 'Visibility' )
+			.selectOption( 'Public note to customer' );
+		await page
+			.getByRole( 'button', { name: 'Send note to customer' } )
+			.click();
 
 		// verify the note saved
 		await expect(
@@ -257,7 +261,7 @@ test.describe( 'Edit order', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
 		// verify the note is gone
 		await expect(
 			page.getByText(
-				'This order is a test order. It is only a test. This note is a private note.'
+				'This order is a test order. It is only a test. This note is a note to the customer.'
 			)
 		).toBeHidden();
 	} );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The "Note to customer" action on the order edit screen emails the customer immediately, but nothing in the UI signals that consequence until after the click. [Real-world feedback](https://x.com/PineDigitalCo/status/1910348409426358379) flagged how easy it is to misuse — a private internal note typed in haste gets sent to the customer.

This PR addresses the visibility clarity and modernizes the surrounding UI.

#### Form changes

- Visible **"Visibility"** label above the type dropdown (was screen-reader-only)
- Dynamic button label that reflects what will actually happen: **"Add private note"** / **"Send note to customer →"**
- Full-width button (secondary, not primary). The button-primary class is deliberately omitted — a primary button felt too aggressive for a destructive-by-default action like "Send note to customer". Full-width is less common in classic wp-admin meta boxes, but there's solid precedent for full-width actions in narrow sidebar contexts — the block editor's post-publish panel and the Customizer's Save & Publish button both use it. Visual hierarchy reads cleaner at full width, and the prominence suits an action with an irreversible side effect (sending the customer email).
- **"Preview or edit email template ↗"** helper link, only shown when "Public note to customer" is selected (opens in a new tab) — gives merchants quick access to customize the email that's about to go out
- Dropdown option re-labeled "Note to customer" → **"Public note to customer"** for clearer scope
- **Removed the help-tooltip** that was next to the "Add note" label. Its content ("Add a note for your reference, or add a customer note (the user will be notified)") is now carried more clearly by the visible Visibility label, the dynamic CTA, and the email template helper link.

#### Note rendering changes

- Customer notes get a **"Sent to customer"** header band inside the bubble with a supplementary yellow tint (matches `@wordpress/components` Notice `is-warning`), making it impossible to miss that this got emailed
- Bubble restyle: thin gray border (`$gray-200`), no chat-bubble tail. The bubble bg now communicates **how the note got here**, not just what kind it is:
  - **System notes** (auto-generated by WC: status changes, payment events, webhook callbacks) sit on a muted gray bg (`$gray-100`) — visually de-emphasized so manual notes scan more easily on busy orders.
  - **Manual private notes** (a human deliberately typed) sit on white — primary content weight.
  - **Customer notes** (manual + sent via email) sit on white with a yellow header band — same content weight as private, with the "this left the building" marker.
- This corrects an old WC palette where system notes were given a dusty pink `#d7cad2` background — semantically misleading (red-adjacent for routine auto-events).
- Meta line ("Apr 17, 2025 by admin Delete") rendered in 11px muted gray, hits AA contrast at 4.5:1
- Bug fix: empty state ("There are no notes yet") now reappears after deleting the last note (was a real bug — the JS removed the `<li>` without restoring the empty state)

#### Confirmation copy

- Customer-note delete confirmation now warns that the email cannot be recalled:
  > Are you sure you wish to delete this note? This action cannot be undone. Caution: This only removes the note from your records — it does not recall the email already sent to the customer.
- Private-note confirmation unchanged

#### Accessibility improvements

- **Visibility label is now visible to sighted users.** The original markup used `class="screen-reader-text"` on the dropdown's label, so anyone not using a screen reader had no visual indication of what the dropdown controlled. Now visible to everyone.
- **Customer-note differentiation no longer relies on color alone.** Previously a customer note was distinguished from a private note only by the bubble's blue background — a [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html) failure for users who don't perceive color (colorblindness, grayscale displays, high-contrast modes). Now the differentiation is carried primarily by a "Sent to customer" text label in a header band above the note body. The supplementary yellow tint (`#fef8ee` — mirrors `@wordpress/components` Notice `is-warning` variant) reinforces the cue visually but isn't load-bearing — text labels remain visible on grayscale/high-contrast displays.
- **Meta line text now passes WCAG AA contrast.** Original was `color: #999` on the white meta-box background — **2.85:1**, fails AA (which requires 4.5:1 for normal text). New color `$subtext` (`#767676`) hits **4.51:1** on white.

#### Known inconsistency (deliberate, follow-up in flight)

The form labels in this meta box ("Add note", "Visibility") don't visually match labels elsewhere on the order edit page (e.g. "Date created", which still uses the older bold-label pattern). This is intentional — labels here align with the WordPress 7.0 admin design language. The follow-up to bring the rest of the order edit page into the same style is open as [#64564](https://github.com/woocommerce/woocommerce/pull/64564) (Align Order Edit meta boxes with WordPress 7.0 design conventions). Once both land, the page reads consistently end-to-end.

#### Tracks events

Adds a new `wcadmin_order_edit_delete_order_note` event in the JS delete handler. Mirrors the existing `wcadmin_order_edit_add_order_note` event (same `order_id`, `note_type`, `status` props) with one extra prop:

- `seconds_since_added` — seconds elapsed between the note's creation timestamp and the delete action. Approximate (browser-local clock vs server-rendered timestamp), null on parse failure. Sufficient for a coarse "deleted shortly after creation" derived metric.

The intent is to enable a **"regret rate"** derived metric — customer notes deleted within a short window of being added are likely accidental sends. The email itself can't be recalled, but the visible record can be scrubbed; tracking this gives us a rough proxy for how often the original UI clarity issue was actually causing harm. Pre/post comparison of this metric should let us measure whether the redesign reduced misuse.

Registration: a parallel PR is being opened to `Automattic/tracks-events-registration` to register the event metadata in the Tracks Event Directory. Linked from the registration PR back to this one via the `diff` field.

#### i18n note

The button arrow `→` is included inside the translated string `__('Send note to customer →')` rather than concatenated outside. This lets translators preserve, replace (e.g. `←` for RTL), or drop the arrow as appropriate per locale.

#### Tokenization

- Adds `$gray-100` / `$gray-200` to legacy `_variables.scss` (mirrors `@wordpress/base-styles/_colors.scss`)
- Overlaps benignly with [#64280](https://github.com/woocommerce/woocommerce/pull/64280) (which adds `$gray-700` / `$gray-900` — disjoint sets, whoever merges first wins on `_variables.scss`, no visual conflict either way)

#### Code health

- The AJAX handler that renders newly-added notes had a copy of the LI markup that had drifted from the template. Both paths now produce equivalent markup. They remain two separate copies — full deduplication is out of scope for this PR; flagging as a follow-up.

#### Notes for extension authors

This PR changes the structural CSS of order notes. No PHP hooks, action signatures, REST endpoints, or class names are removed — the changes are markup/styling only. Extensions targeting the following CSS will see cosmetic effects:

- **`.note_content::after` removed.** The chat-bubble tail pseudo-element is gone. Plugins like `woocommerce-colored-order-notes` that color the tail will silently no-op for that selector. Body coloring via `.note_content` background still works.
- **Dotted underline on `.exact-date` removed.** Plugins targeting `.exact-date { border-bottom }` will no-op.
- **New `.note_header`, `.note_body`, `.note_label` wrappers inside `.note_content`.** Extensions selecting `.note_content > p` directly will still match (the body content is inside `.note_body`, but the inline `<p>` produced by `wpautop()` is unchanged). Extensions wanting to reach the bubble's text content directly should prefer `.note_body p`.
- **System-note background changed.** Was `#d7cad2` (pinkish/mauve), now `$gray-100` (light gray) — system notes are still visually distinct from private (white) and customer (white + yellow band) notes, just with a different shade. Plugins overriding `li.system-note .note_content { background }` will still apply.

None of these are hard breaks — markup contracts and class names are preserved.

#### Constraints

- No Gutenberg component imports — keeps the order edit page light. Visuals achieved with classic wp-admin elements + Dashicons.
- All Dashicons + colors used are available on every WP version WC currently supports — no version-gating needed. Tested on WP 6.9 and WP 7.0+ — the meta box itself renders consistently in both, sitting naturally inside whatever surrounding admin chrome the WP version provides (postbox borders, default font, button heights inherit from core).

### Screenshots or screen recordings:

<img width="2860" height="1796" alt="image" src="https://github.com/user-attachments/assets/73190e15-e32a-4587-ae43-6a7cc73057ee" />

<img width="1604" height="832" alt="image" src="https://github.com/user-attachments/assets/f73845e8-671e-4fcb-ba06-571b7b741db4" />


### How to test the changes in this Pull Request:

1. Open any order in wp-admin → **Orders → [order] → Order notes** (right sidebar meta box)
2. **Form behavior:**
   - Confirm "Visibility" label is visible above the dropdown
   - Switch dropdown to "Public note to customer" — button changes to "Send note to customer →", and a "Preview or edit email template ↗" helper link appears under the dropdown (opens in a new tab when clicked)
   - Switch back to "Private note" — button reverts to "Add private note", helper link disappears
3. **Add a private note** — appears as a gray bubble (no header), with meta line ("Apr 17, 2025 at 9:36 am by admin Delete") below in muted gray
4. **Add a public note** — appears with a "Sent to customer" header band (yellow tint), a thin divider, then the body
5. **Delete a customer note** — confirmation dialog includes the "Caution: ... cannot recall email already sent" warning; private notes get the original short confirmation
6. **Delete the last note** — empty state ("There are no notes yet") should reappear immediately
7. **HPOS:** repeat all of the above on the HPOS edit screen (`?page=wc-orders&action=edit&id=…`) — same meta box, should look identical
8. **Cross-version:** the meta box reads correctly on WP 6.9 and WP 7.0+, sitting naturally inside each version's admin chrome

### Testing that has already taken place:

- [x] Local testing on WP 7.x (HPOS-enabled)
- [x] Local testing on WP 6.9
- [x] `pnpm lint:changes:branch` clean (0 errors; pre-existing warnings unrelated)
- [x] `phpstan analyse` clean on all modified PHP files
- [x] `composer exec phpcs-changed` passing
- [x] e2e spec `order-edit.spec.ts` updated to match new button labels

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Added: `plugins/woocommerce/changelog/64999-sprinkle-order-notes-visibility`




