### PR TITLE
Fix order summary screen reader text fragmentation

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/filters-in-cart-and-checkout/README.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/filters-in-cart-and-checkout/README.md
@@ -29,6 +29,7 @@ The following [Order Summary Items filters](/docs/block-development/extensible-b
 
 -   `cartItemClass`
 -   `cartItemPrice`
+-   `cartItemScreenReaderPrice`
 -   `itemName`
 -   `subtotalPriceFormat`
 

--- a/plugins/woocommerce/changelog/64480-opr-issue-64452
+++ b/plugins/woocommerce/changelog/64480-opr-issue-64452
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `cartItemScreenReaderPrice` filter output being announced by screen readers as separate fragments instead of a single sentence.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -16,7 +16,7 @@ import {
 	productPriceValidation,
 } from '@woocommerce/blocks-checkout';
 import { getSetting } from '@woocommerce/settings';
-import { createInterpolateElement, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { CartItem, isString } from '@woocommerce/types';
 import { calculateSaleAmount } from '@woocommerce/base-utils';
@@ -162,13 +162,22 @@ const OrderSummaryItem = ( {
 		validation: productPriceScreenReaderValidation,
 	} );
 
-	const ProductPriceScreenReaderOutput = () => {
-		return createInterpolateElement( productPriceScreenReaderFormat, {
-			quantity: <>{ quantity }</>,
-			productName: <>{ name }</>,
-			price: <>{ formatPrice( subtotalPrice, totalsCurrency ) }</>,
-		} );
-	};
+	// Build as one string (not React nodes) so screen readers announce the
+	// full sentence as a single unit rather than separate sibling text nodes.
+	const productPriceScreenReaderText = productPriceScreenReaderFormat.replace(
+		/<(quantity|productName|price)\/>/g,
+		( _match, key ) => {
+			switch ( key ) {
+				case 'quantity':
+					return String( quantity );
+				case 'productName':
+					return name;
+				case 'price':
+					return formatPrice( subtotalPrice, totalsCurrency );
+			}
+			return '';
+		}
+	);
 
 	const cartItemClassNameFilter = applyCheckoutFilter( {
 		filterName: 'cartItemClass',
@@ -241,7 +250,7 @@ const OrderSummaryItem = ( {
 				<ProductMetadata { ...productMetaProps } />
 			</div>
 			<span className="screen-reader-text">
-				<ProductPriceScreenReaderOutput />
+				{ productPriceScreenReaderText }
 			</span>
 			<div
 				className="wc-block-components-order-summary-item__total-price"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In the Checkout block's order summary, the `cartItemScreenReaderPrice` filter output was passed through `createInterpolateElement`, which renders each interpolated value (quantity, product name, price) as a separate sibling Text node. When an item has a quantity greater than 1, screen readers (VoiceOver, NVDA, JAWS) treat the sibling Text nodes as discrete units and announce them as fragments instead of one continuous sentence.

Substitute the placeholders into the format string up-front so the entire announcement is a single Text node. The public filter API is unchanged — extensions still return a string with `<quantity/>`, `<productName/>`, and `<price/>` placeholders. Also adds the missing entry for this filter in the order-summary filters index.

Closes #64452.

Bug introduced in PR #62080.

### How to test the changes in this Pull Request:

1. Add a product to the cart with a quantity of 2 or more.
2. Navigate to the Checkout block page.
3. Open DevTools → Elements and find a `<span class="screen-reader-text">` inside any `.wc-block-components-order-summary-item`.
4. Confirm the span contains a **single** Text node with the full sentence (e.g. `"Total price for 2 Beanie with Logo items: $36.00"`), not multiple sibling text nodes.
5. Enable VoiceOver (`Cmd+F5`) and navigate to the order summary line — the screen reader announces the full sentence in one continuous announcement instead of stuttering through fragments.
6. (Filter regression check) In the console, register a custom filter and confirm the substituted value still renders correctly:

    ```js
    wc.blocksCheckout.registerCheckoutFilters( 'test', {
        cartItemScreenReaderPrice: () => 'TEST <quantity/> × <productName/> = <price/>',
    } );
    ```

   Switch payment method to trigger a re-render, then re-inspect the span — it should be a single Text node containing the substituted custom string.

### Testing that has already taken place:

Manually verified DOM structure in the Checkout block (single Text node confirmed). VoiceOver smoke-tested on macOS.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix `cartItemScreenReaderPrice` filter output being announced by screen readers as separate fragments instead of a single sentence.

</details>
