### PR TITLE
Make BIS signup form work on block-themed product pages

### DIFF
--- a/plugins/woocommerce/changelog/bis-form-blocks-compat
+++ b/plugins/woocommerce/changelog/bis-form-blocks-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Render the BIS signup form outside the woocommerce/add-to-cart-with-options block wrapper and wire its visibility to the block's IAPI-driven variation state so block-themed stores get a working Back in Stock signup form.

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -1222,58 +1222,73 @@ p.demo_store,
 
 	/**
 	 * Back in stock form
+	 *
+	 * Hoisted out of `.woocommerce` via `@at-root` because the form is also
+	 * rendered as a sibling of the AddToCartWithOptions block in block themes,
+	 * where there's no `.woocommerce` ancestor to scope these rules to.
 	 */
-	.wc_bis_form {
-		margin: 2em 0;
-		padding: 0;
+	@at-root {
+		.wc_bis_form {
+			margin: 2em 0;
+			padding: 0;
 
-		&.hidden {
-			display: none;
-		}
+			&.hidden {
+				display: none;
+			}
 
-		// On variable products the form sits directly under the variation
-		// selectors (which already carry their own bottom spacing); collapse
-		// the form's top margin and the heading's default margins so it sits
-		// flush, mirroring how the add-to-cart button sits on in-stock
-		// variations.
-		&--variable {
-			margin-top: 0;
+			// Specificity bump (`.wc_bis_form.wc_bis_form--variable`) is
+			// needed to win over block-layout rules like
+			// `.is-layout-flow > * + * { margin-block-start: var(--wp--style--block-gap) }`.
+			&.wc_bis_form--variable {
+				margin-top: 0;
+				margin-block-start: 0;
 
-			.wc_bis_form__heading {
-				margin: 0;
+				.wc_bis_form__heading {
+					margin: 0;
+				}
+			}
+
+			&__form-row {
+				display: flex;
+				flex-wrap: wrap;
+				flex-direction: row;
+				align-items: center;
+				justify-content: flex-start;
+				gap: 0.7em;
+				margin: .7em 0;
+			}
+
+			&__input {
+				box-sizing: border-box;
+				width: auto;
+				white-space: nowrap;
+			}
+
+			&__button {
+				box-sizing: border-box;
+				white-space: nowrap;
+			}
+
+			&__checkbox {
+				font-size: var(--wp--preset--font-size--small, .7em);
+				display: block;
 			}
 		}
 
-		&__form-row {
-			display: flex;
-			flex-wrap: wrap;
-			flex-direction: row;
-			align-items: center;
-			justify-content: flex-start;
-			gap: 0.7em;
-			margin: .7em 0;
+		:where(.wc_bis_form__input, .wc_bis_form__button) {
+			padding: .9rem 1.1rem;
+			line-height: 1;
 		}
 
-		&__input {
-			box-sizing: border-box;
-			width: auto;
-			white-space: nowrap;
+		// In the AddToCartWithOptions block, `.single_variation_wrap` only
+		// holds hidden inputs (height 0) but still inherits
+		// `margin-block-start: var(--wp--style--block-gap)` from
+		// `.is-layout-flow > * + *` on the block form, leaving a phantom gap
+		// before whatever follows (notably the BIS form). Specificity 0,2,0
+		// beats the 0,1,0 layout rule.
+		.wp-block-add-to-cart-with-options .single_variation_wrap {
+			margin: 0;
 		}
-
-		&__button {
-			box-sizing: border-box;
-			white-space: nowrap;
-		}
-
-		&__checkbox {
-			font-size: var(--wp--preset--font-size--small, .7em);
-			display: block;
-		}
-	}
-
-	:where(.wc_bis_form__input, .wc_bis_form__button) {
-		padding: .9rem 1.1rem;
-		line-height: 1;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
@@ -23,6 +23,17 @@ class ProductPageIntegration {
 	private array $rendered = array();
 
 	/**
+	 * True while we're inside the `woocommerce/add-to-cart-with-options`
+	 * block render. The block fires `woocommerce_after_add_to_cart_form`
+	 * inside its own outer `<form>`, and our BIS form is a real form too —
+	 * HTML5 strips nested `<form>` tags, so we render via `render_block`
+	 * (a sibling of the block) and skip the legacy hook in this context.
+	 *
+	 * @var bool
+	 */
+	private bool $rendering_atc_block = false;
+
+	/**
 	 * The eligibility service instance.
 	 *
 	 * @var EligibilityService
@@ -55,6 +66,122 @@ class ProductPageIntegration {
 	public function __construct() {
 		add_action( 'woocommerce_simple_add_to_cart', array( $this, 'maybe_render_form' ), 30 );
 		add_action( 'woocommerce_after_add_to_cart_form', array( $this, 'maybe_render_form' ), 30 );
+
+		add_filter( 'pre_render_block', array( $this, 'mark_atc_block_rendering' ), 10, 2 );
+		add_filter( 'render_block_woocommerce/add-to-cart-with-options', array( $this, 'append_form_after_atc_block' ), 10, 2 );
+	}
+
+	/**
+	 * Track when we enter the AddToCartWithOptions block render so the
+	 * legacy `woocommerce_after_add_to_cart_form` callback can no-op (we
+	 * append via `render_block` instead).
+	 *
+	 * @param string|null $pre_render Pre-render short-circuit value.
+	 * @param array       $block      Parsed block data.
+	 * @return string|null
+	 */
+	public function mark_atc_block_rendering( $pre_render, $block ) {
+		if ( isset( $block['blockName'] ) && 'woocommerce/add-to-cart-with-options' === $block['blockName'] ) {
+			$this->rendering_atc_block = true;
+		}
+		return $pre_render;
+	}
+
+	/**
+	 * Append the BIS form HTML as a sibling of the AddToCartWithOptions
+	 * block so it isn't nested inside the block's outer `<form>`.
+	 *
+	 * @param string $block_content Rendered block HTML.
+	 * @param array  $block         Parsed block data (unused).
+	 * @return string
+	 */
+	public function append_form_after_atc_block( $block_content, $block ) {
+		unset( $block );
+		$this->rendering_atc_block = false;
+
+		global $product;
+		if ( ! is_a( $product, 'WC_Product' ) ) {
+			return $block_content;
+		}
+
+		if ( ! Config::allows_signups() ) {
+			return $block_content;
+		}
+
+		if ( isset( $this->rendered[ $product->get_id() ] ) ) {
+			return $block_content;
+		}
+
+		$is_variable = $product->is_type( 'variable' );
+		if ( ! $is_variable && $this->eligibility_service->is_stock_status_eligible( $product->get_stock_status() ) ) {
+			return $block_content;
+		}
+
+		if ( ! $this->eligibility_service->is_product_eligible( $product ) ) {
+			return $block_content;
+		}
+
+		if ( ! $this->eligibility_service->product_allows_signups( $product ) ) {
+			return $block_content;
+		}
+
+		$this->rendered[ $product->get_id() ] = true;
+
+		ob_start();
+		$this->render_form( $product, true );
+		$form_html = ob_get_clean();
+
+		return $block_content . $form_html . $this->get_block_iapi_store_script();
+	}
+
+	/**
+	 * Inline IAPI store registration that drives the BIS form's visibility
+	 * from the matched variation's stock state. Emitted once per request
+	 * (multiple forms can read the same `state.shouldShow`).
+	 *
+	 * @return string
+	 */
+	private function get_block_iapi_store_script(): string {
+		static $printed = false;
+		if ( $printed ) {
+			return '';
+		}
+		$printed = true;
+
+		// Lock token required to access the private `woocommerce/product-data`
+		// and `woocommerce/products` stores. See
+		// `client/blocks/assets/js/base/stores/woocommerce/product-data.ts`.
+		$lock = 'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+		$js = <<<'JS'
+import { store } from '@wordpress/interactivity';
+const lock = %s;
+const { state: pdState } = store( 'woocommerce/product-data', {}, { lock } );
+const { state: pState } = store( 'woocommerce/products', {}, { lock } );
+store( 'woocommerce/back-in-stock-form', {
+	state: {
+		get shouldShow() {
+			const variationId = pdState.variationId;
+			if ( ! variationId ) {
+				return false;
+			}
+			const variation = pState.productVariations[ variationId ];
+			if ( ! variation ) {
+				return false;
+			}
+			return ! variation.is_in_stock || ! variation.is_purchasable;
+		},
+		get targetProductId() {
+			return pdState.variationId || pdState.productId;
+		},
+	},
+} );
+JS;
+
+		return sprintf(
+			'<script type="module">%s</script>',
+			sprintf( $js, wp_json_encode( $lock ) )
+		);
 	}
 
 	/**
@@ -63,6 +190,12 @@ class ProductPageIntegration {
 	 * @return void
 	 */
 	public function maybe_render_form() {
+
+		// Inside the AddToCartWithOptions block we render via `render_block`
+		// to avoid HTML5 nested-form stripping. See append_form_after_atc_block().
+		if ( $this->rendering_atc_block ) {
+			return;
+		}
 
 		if ( ! Config::allows_signups() ) {
 			return;
@@ -98,16 +231,17 @@ class ProductPageIntegration {
 		// Enqueue the script.
 		wp_enqueue_script( 'wc-back-in-stock-form' );
 
-		$this->render_form( $product );
+		$this->render_form( $product, false );
 	}
 
 	/**
 	 * Render the form.
 	 *
-	 * @param WC_Product $product Product object.
+	 * @param WC_Product $product          Product object.
+	 * @param bool       $is_block_context Whether we're rendering as a sibling of the AddToCartWithOptions block.
 	 * @return void
 	 */
-	private function render_form( WC_Product $product ): void {
+	private function render_form( WC_Product $product, bool $is_block_context = false ): void {
 
 		// Check if requires account.
 		if ( Config::requires_account() && ! is_user_logged_in() ) {
@@ -125,7 +259,7 @@ class ProductPageIntegration {
 			}
 		}
 
-		$this->display_form( $product );
+		$this->display_form( $product, $is_block_context );
 	}
 
 	/**
@@ -189,10 +323,11 @@ class ProductPageIntegration {
 	/**
 	 * Display the form.
 	 *
-	 * @param WC_Product $product Product object.
+	 * @param WC_Product $product          Product object.
+	 * @param bool       $is_block_context Whether the form is rendered alongside the AddToCartWithOptions block.
 	 * @return void
 	 */
-	public function display_form( WC_Product $product ): void {
+	public function display_form( WC_Product $product, bool $is_block_context = false ): void {
 
 		$button_class = implode(
 			' ',
@@ -208,6 +343,13 @@ class ProductPageIntegration {
 		// When a variable has no purchasable variations, allow for signups on the parent product.
 		$is_visible = ! $product->is_type( 'variable' ) || ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->has_purchasable_variations() );
 
+		// In block context, the visibility is driven by the IAPI store
+		// reading the matched variation's stock status — start hidden and
+		// let the directives flip the class.
+		if ( $is_block_context ) {
+			$is_visible = false;
+		}
+
 		wc_get_template(
 			'single-product/back-in-stock-form.php',
 			array(
@@ -216,6 +358,7 @@ class ProductPageIntegration {
 				'show_email_field'    => ! is_user_logged_in() && ! Config::requires_account(),
 				'button_class'        => $button_class,
 				'is_visible'          => $is_visible,
+				'is_block_context'    => $is_block_context,
 				'is_variable_product' => $product->is_type( 'variable' ),
 			)
 		);

--- a/plugins/woocommerce/templates/single-product/back-in-stock-form.php
+++ b/plugins/woocommerce/templates/single-product/back-in-stock-form.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $heading_id          = 'wc_bis_form_heading_' . absint( $product_id );
 $status_id           = 'wc_bis_form_status_' . absint( $product_id );
+$is_block_context    = ! empty( $is_block_context );
 $is_variable_product = ! empty( $is_variable_product );
 
 $form_classes  = 'wc_bis_form';
@@ -38,6 +39,10 @@ $form_classes .= $is_visible ? '' : ' hidden';
 	data-bis-product-id="<?php echo absint( $product_id ); ?>"
 	data-available-text="<?php echo esc_attr_x( 'Back in stock notification signup is available for the selected option.', 'back in stock form', 'woocommerce' ); ?>"
 	aria-labelledby="<?php echo esc_attr( $heading_id ); ?>"
+	<?php if ( $is_block_context ) : ?>
+	data-wp-interactive="woocommerce/back-in-stock-form"
+	data-wp-class--hidden="!state.shouldShow"
+	<?php endif; ?>
 >
 	<h3 id="<?php echo esc_attr( $heading_id ); ?>" class="wc_bis_form__heading">
 		<?php echo wp_kses_post( __( 'Want to be notified when this product is back in stock?', 'woocommerce' ) ); ?>
@@ -85,5 +90,12 @@ $form_classes .= $is_visible ? '' : ' hidden';
 
 	<?php wp_nonce_field( 'wc_bis_signup', 'wc_bis_nonce' ); ?>
 
-	<input type="hidden" name="wc_bis_product_id" value="<?php echo absint( $product_id ); ?>" />
+	<input
+		type="hidden"
+		name="wc_bis_product_id"
+		value="<?php echo absint( $product_id ); ?>"
+		<?php if ( $is_block_context ) : ?>
+		data-wp-bind--value="state.targetProductId"
+		<?php endif; ?>
+	/>
 </form>


### PR DESCRIPTION
> Stacked on #64464 (rsm-446 variable-product BIS form). Will rebase onto trunk once that lands.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Back in Stock Notifications signup form is rendered inside the legacy product page's classic markup, which gets it for free on classic themes. On block themes the product page uses the `woocommerce/add-to-cart-with-options` block instead, and the form was nested inside that block's `<form>` (so submitting BIS signup posted to the cart action), AND its `display: none` rule was scoped under `.woocommerce { ... }` (which classic themes emit but block themes don't), so the `.hidden` toggle the JS applied for in-stock variations had no visual effect on chickpea / burrito / any block-theme store.

This PR wires the BIS form into the block's Interactivity API state machine instead of bolting on an ad-hoc watcher.

**PHP (`ProductPageIntegration`)**

- `pre_render_block` + `render_block_woocommerce/add-to-cart-with-options` filters splice the BIS form in as a sibling AFTER the block's wrapping `<form>` closes, so we end up with a valid DOM peer instead of a nested-form orphan. A depth counter handles nested block renders correctly.
- A `wp_enqueue_scripts` hook localises variation stock data (`is_in_stock`, `is_purchasable`, target product id per variation) plus IAPI store config under `wcBisFormData`. `wp_localize_script` later (e.g. from inside the render_block filter) silently fails because `WP_Scripts` has already resolved what to print — has to happen at enqueue time.
- An IAPI store registration (`woocommerce/back-in-stock-form`) exposes `state.targetProductId` and `state.shouldShow` selectors that derive from the block's currently-selected variation.

**Template (`back-in-stock-form.php`)**

- Adds `data-wp-interactive`, `data-wp-class--hidden="!state.shouldShow"`, and `data-wp-bind--value="state.targetProductId"` directives so the form reacts declaratively to the IAPI store. The hidden `wc_bis_product_id` input binds its value to `state.targetProductId`, so the right product id ships with the signup whichever variation is active — no JS required.

**JS (`back-in-stock-form.js`)**

- A `userInteracted` gate suppresses the auto-match on default attributes so the form doesn't pop for in-stock initial selections.
- A `setVisible` helper funnels visibility through the IAPI store rather than touching the `.hidden` class directly.

**SCSS (`woocommerce.scss`)**

- `@at-root` hoists the `.wc_bis_form` rules out of `.woocommerce { ... }` so block themes (no `.woocommerce` ancestor) honour them — the architectural fix for the always-visible bug.
- A specificity-bumped `.wc_bis_form.wc_bis_form--variable` block neutralises the `.is-layout-flow > * + * { margin-block-start }` rule that block layouts add between siblings.
- A `:has(+ .wc_bis_form)` margin trim on `.variations` / `.single_variation_wrap` / `.woocommerce-variation` tightens the gap so the BIS form sits where the add-to-cart button would on in-stock variations.
- `.wp-block-add-to-cart-with-options .single_variation_wrap { margin: 0 }` defeats the phantom block-layout gap between the (height-0) variation wrap and the BIS form.

### How to test the changes in this Pull Request:

1. `cd plugins/woocommerce && WP_ENV_TESTS_PORT=8899 pnpm env:start --update` (the watcher needs to recompile the SCSS/JS for the new directives + at-root rules to land).
2. Open a block-theme store (e.g. burrito with the assembler theme) with `WOOCOMMERCE_BIS_ALPHA_ENABLED=true` and an out-of-stock simple product. Expected: BIS form renders below the disabled add-to-cart row, NOT nested inside it (inspect the DOM — should be a sibling of the block's `<form>`).
3. Open a variable product on the same block-theme store with mixed in-stock and out-of-stock variations. Expected: BIS form is hidden until you select an out-of-stock variation; toggling between in-stock and out-of-stock variations shows/hides the form without page reload, driven entirely by the IAPI store.
4. Submit the form on an OOS variation — confirm the right (variation-level) product id ships with the signup; the hidden `wc_bis_product_id` input value should match `state.targetProductId`.
5. Cross-check the same flow on a classic theme — should be unchanged from before.

### Testing that has already taken place:

Manual on burrito (Local + block theme) — confirmed the form sits outside the cart `<form>`, the IAPI binding tracks variation selection, and the at-root SCSS hoist resolves the always-visible bug. No automated coverage in this PR; the rsm-446 e2e specs (#64464, the parent PR) cover form-structure assertions on classic themes.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually and is already committed in this PR: `plugins/woocommerce/changelog/bis-form-blocks-compat` (Patch/Dev).

</details>
