### PR TITLE
Filter push notifications by per-user preferences

### DIFF
--- a/plugins/woocommerce/changelog/issue-RSM-695
+++ b/plugins/woocommerce/changelog/issue-RSM-695
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Filter push notifications by per-user preferences so opted-out merchants don't receive disabled notification types on their devices.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
@@ -164,4 +164,44 @@ abstract class Notification {
 	public function get_resource_id(): int {
 		return $this->resource_id;
 	}
+
+	/**
+	 * Decide whether this notification should be delivered to a user given
+	 * their stored preference value for {@see static::get_type()}.
+	 *
+	 * `$pref_value` is whatever the user has stored under this notification
+	 * type's preference key, or `null` if they have nothing stored. The
+	 * {@see NotificationPreferencesService} stores each preference as an
+	 * object so future sub-fields (thresholds, sub-toggles) can be added
+	 * without bumping the schema version — today's shape is
+	 * `['enabled' => bool]`, future shapes might add e.g.
+	 * `['enabled' => true, 'min_value' => 500]` for an order threshold.
+	 *
+	 * Default: read the universal `enabled` sub-field, defaulting to `true`
+	 * when the value is missing or has no `enabled` key (so newly-added
+	 * notification types are opt-in by default). Subclasses override to
+	 * read richer sub-fields and to consult their own resource (e.g.
+	 * compare an order total to the user's `min_value`).
+	 *
+	 * Subclasses must keep this side-effect-free — the {@see NotificationProcessor}
+	 * may call it once per recipient user per notification.
+	 *
+	 * @param mixed $pref_value The user's stored preference value, or null.
+	 * @return bool True if this notification should be sent to that user.
+	 *
+	 * @since 10.8.0
+	 */
+	public function should_send_to_user( $pref_value ): bool {
+		if ( null === $pref_value ) {
+			return true;
+		}
+
+		if ( is_array( $pref_value ) ) {
+			return (bool) ( $pref_value['enabled'] ?? true );
+		}
+
+		// Defensive fallback for unexpected scalar values; the service
+		// always normalises stored prefs to the array shape above.
+		return (bool) $pref_value;
+	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -64,21 +64,31 @@ class NotificationProcessor {
 	private PushTokensDataStore $data_store;
 
 	/**
+	 * The notification preferences service.
+	 *
+	 * @var NotificationPreferencesService
+	 */
+	private NotificationPreferencesService $preferences_service;
+
+	/**
 	 * Initialize dependencies.
 	 *
 	 * @internal
 	 *
-	 * @param WpcomNotificationDispatcher $dispatcher The WPCOM dispatcher.
-	 * @param PushTokensDataStore         $data_store The push tokens data store.
+	 * @param WpcomNotificationDispatcher    $dispatcher          The WPCOM dispatcher.
+	 * @param PushTokensDataStore            $data_store          The push tokens data store.
+	 * @param NotificationPreferencesService $preferences_service The notification preferences service.
 	 *
 	 * @since 10.7.0
 	 */
 	final public function init(
 		WpcomNotificationDispatcher $dispatcher,
-		PushTokensDataStore $data_store
+		PushTokensDataStore $data_store,
+		NotificationPreferencesService $preferences_service
 	): void {
-		$this->dispatcher = $dispatcher;
-		$this->data_store = $data_store;
+		$this->dispatcher          = $dispatcher;
+		$this->data_store          = $data_store;
+		$this->preferences_service = $preferences_service;
 	}
 
 	/**
@@ -133,8 +143,19 @@ class NotificationProcessor {
 		);
 
 		/**
-		 * There are no recipients to send to. We don't want to retry as this
-		 * isn't a 'recoverable error', so mark as sent and return.
+		 * Filter out tokens whose owning user does not want this notification.
+		 * The decision is delegated to the notification itself via
+		 * {@see Notification::should_send_to_user()} so per-type preference
+		 * shapes (simple bool today, parametrized arrays in the future) stay
+		 * encapsulated alongside the type's resource access.
+		 */
+		$tokens = $this->filter_tokens_by_preferences( $tokens, $notification );
+
+		/**
+		 * There are no recipients to send to (either no tokens at all, or
+		 * every owning user opted out of this notification type). We don't
+		 * want to retry as this isn't a 'recoverable error', so mark as sent
+		 * and return.
 		 */
 		if ( empty( $tokens ) ) {
 			$notification->write_meta( self::SENT_META_KEY );
@@ -155,6 +176,51 @@ class NotificationProcessor {
 		 */
 
 		return false;
+	}
+
+	/**
+	 * Returns the subset of $tokens whose owning user wants $notification.
+	 *
+	 * The decision is delegated to {@see Notification::should_send_to_user()}
+	 * so per-type preference shapes (simple bool today, parametrized arrays
+	 * in the future) stay encapsulated alongside the type's resource access.
+	 * Tokens with no owning user are dropped — there are no preferences to
+	 * consult.
+	 *
+	 * Decisions are memoized per user for the duration of one call, since
+	 * the same user can have several registered tokens (iOS, iPad, Android,
+	 * browser) and we don't want to re-read user meta or re-fetch the
+	 * resource for every token.
+	 *
+	 * @param PushToken[]  $tokens       The tokens to filter.
+	 * @param Notification $notification The notification being processed.
+	 *
+	 * @return PushToken[] The tokens whose owner wants the notification.
+	 *
+	 * @since 10.8.0
+	 */
+	private function filter_tokens_by_preferences( array $tokens, Notification $notification ): array {
+		$type           = $notification->get_type();
+		$decision_cache = array();
+
+		return array_values(
+			array_filter(
+				$tokens,
+				function ( PushToken $token ) use ( $notification, $type, &$decision_cache ) {
+					$user_id = $token->get_user_id();
+					if ( ! $user_id ) {
+						return false;
+					}
+
+					if ( ! isset( $decision_cache[ $user_id ] ) ) {
+						$prefs                      = $this->preferences_service->get_preferences( $user_id );
+						$decision_cache[ $user_id ] = $notification->should_send_to_user( $prefs[ $type ] ?? null );
+					}
+
+					return $decision_cache[ $user_id ];
+				}
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NotificationTest.php
@@ -102,4 +102,46 @@ class NotificationTest extends WC_Unit_Test_Case {
 			)
 		);
 	}
+
+	/**
+	 * Default `should_send_to_user` should:
+	 *  - treat `null` (no stored value) as opt-in,
+	 *  - read `enabled` from the array shape today's storage produces,
+	 *  - default to `true` when the array shape is missing the `enabled`
+	 *    key (so newly-added notification types are opt-in by default),
+	 *  - and fall back to a defensive bool cast for unexpected scalars.
+	 *
+	 * @return array<string, array<mixed>>
+	 */
+	public function provider_should_send_to_user_default(): array {
+		return array(
+			'null pref means opt-in by default'         => array( null, true ),
+			'array with enabled true'                   => array( array( 'enabled' => true ), true ),
+			'array with enabled false'                  => array( array( 'enabled' => false ), false ),
+			'array missing enabled defaults to true'    => array( array( 'min_value' => 500 ), true ),
+			'empty array defaults to true'              => array( array(), true ),
+			'array with truthy enabled (1) is true'     => array( array( 'enabled' => 1 ), true ),
+			'array with falsy enabled (0) is false'     => array( array( 'enabled' => 0 ), false ),
+			'scalar bool true (defensive fallback)'     => array( true, true ),
+			'scalar bool false (defensive fallback)'    => array( false, false ),
+			'scalar truthy string (defensive fallback)' => array( '1', true ),
+			'scalar empty string (defensive fallback)'  => array( '', false ),
+		);
+	}
+
+	/**
+	 * @testdox Default should_send_to_user with $_dataName returns $expected.
+	 * @dataProvider provider_should_send_to_user_default
+	 *
+	 * @param mixed $pref_value The stored preference value.
+	 * @param bool  $expected   The expected decision.
+	 */
+	public function test_should_send_to_user_default_behavior( $pref_value, bool $expected ): void {
+		$notification = $this->getMockBuilder( NewOrderNotification::class )
+			->setConstructorArgs( array( 1 ) )
+			->onlyMethods( array( 'to_payload', 'has_meta', 'write_meta', 'delete_meta' ) )
+			->getMock();
+
+		$this->assertSame( $expected, $notification->should_send_to_user( $pref_value ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -9,7 +9,9 @@ use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\WpcomNotificat
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewReviewNotification;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 use WC_Helper_Product;
 use WC_Unit_Test_Case;
@@ -41,6 +43,13 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	private $data_store;
 
 	/**
+	 * Mock preferences service.
+	 *
+	 * @var NotificationPreferencesService
+	 */
+	private $preferences_service;
+
+	/**
 	 * A test order ID.
 	 *
 	 * @var int
@@ -53,12 +62,23 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->dispatcher = $this->createMock( WpcomNotificationDispatcher::class );
-		$this->data_store = $this->createMock( PushTokensDataStore::class );
-		$this->order_id   = wc_create_order( array( 'status' => 'processing' ) )->get_id();
+		$this->dispatcher          = $this->createMock( WpcomNotificationDispatcher::class );
+		$this->data_store          = $this->createMock( PushTokensDataStore::class );
+		$this->preferences_service = $this->createMock( NotificationPreferencesService::class );
+		$this->order_id            = wc_create_order( array( 'status' => 'processing' ) )->get_id();
 
 		$this->sut = new NotificationProcessor();
-		$this->sut->init( $this->dispatcher, $this->data_store );
+		$this->sut->init( $this->dispatcher, $this->data_store, $this->preferences_service );
+
+		// By default every user has every notification type enabled, so existing
+		// tests behave as before. Per-user/per-type filtering is exercised in
+		// the dedicated preferences tests below.
+		$this->preferences_service->method( 'get_preferences' )->willReturn(
+			array(
+				'store_order'  => array( 'enabled' => true ),
+				'store_review' => array( 'enabled' => true ),
+			)
+		);
 
 		$this->data_store->method( 'get_tokens_for_roles' )->willReturn(
 			array(
@@ -203,7 +223,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $data_store );
+		$sut->init( $this->dispatcher, $data_store, $this->preferences_service );
 
 		$notification = new NewOrderNotification( $this->order_id );
 		$result       = $sut->process( $notification );
@@ -213,6 +233,258 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$order = wc_get_order( $this->order_id );
 
 		$this->assertNotEmpty( $order->get_meta( NotificationProcessor::SENT_META_KEY ) );
+	}
+
+	/**
+	 * @testdox Should mark as sent and skip dispatch when every owning user has the type disabled.
+	 */
+	public function test_process_skips_dispatch_when_all_users_opted_out(): void {
+		$preferences_service = $this->createMock( NotificationPreferencesService::class );
+		$preferences_service->method( 'get_preferences' )->willReturn(
+			array(
+				'store_order'  => array( 'enabled' => false ),
+				'store_review' => array( 'enabled' => true ),
+			)
+		);
+
+		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
+
+		$sut = new NotificationProcessor();
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+
+		$notification = new NewOrderNotification( $this->order_id );
+		$result       = $sut->process( $notification );
+
+		$this->assertTrue( $result );
+
+		$order = wc_get_order( $this->order_id );
+
+		$this->assertNotEmpty( $order->get_meta( NotificationProcessor::SENT_META_KEY ) );
+	}
+
+	/**
+	 * @testdox Should dispatch only to tokens whose owning user has the notification type enabled.
+	 */
+	public function test_process_filters_tokens_by_user_preferences(): void {
+		$enabled_token  = new PushToken(
+			array(
+				'user_id'       => 1,
+				'token'         => 'enabled-token',
+				'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+				'platform'      => PushToken::PLATFORM_APPLE,
+				'device_locale' => 'en_US',
+				'device_uuid'   => 'enabled-uuid',
+			)
+		);
+		$disabled_token = new PushToken(
+			array(
+				'user_id'       => 2,
+				'token'         => 'disabled-token',
+				'origin'        => PushToken::ORIGIN_WOOCOMMERCE_ANDROID,
+				'platform'      => PushToken::PLATFORM_ANDROID,
+				'device_locale' => 'en_US',
+				'device_uuid'   => 'disabled-uuid',
+			)
+		);
+
+		$data_store = $this->createMock( PushTokensDataStore::class );
+		$data_store->method( 'get_tokens_for_roles' )->willReturn(
+			array( $enabled_token, $disabled_token )
+		);
+
+		$preferences_service = $this->createMock( NotificationPreferencesService::class );
+		$preferences_service->method( 'get_preferences' )->willReturnCallback(
+			function ( int $user_id ) {
+				return array(
+					'store_order'  => array( 'enabled' => 1 === $user_id ),
+					'store_review' => array( 'enabled' => true ),
+				);
+			}
+		);
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->with(
+				$this->anything(),
+				$this->callback(
+					function ( array $tokens ) use ( $enabled_token ) {
+						return 1 === count( $tokens ) && $tokens[0] === $enabled_token;
+					}
+				)
+			)
+			->willReturn(
+				array(
+					'success'     => true,
+					'retry_after' => null,
+				)
+			);
+
+		$sut = new NotificationProcessor();
+		$sut->init( $this->dispatcher, $data_store, $preferences_service );
+
+		$notification = new NewOrderNotification( $this->order_id );
+		$result       = $sut->process( $notification );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @testdox Should respect the notification type when filtering by preferences.
+	 */
+	public function test_process_respects_preferences_per_notification_type(): void {
+		$preferences_service = $this->createMock( NotificationPreferencesService::class );
+		$preferences_service->method( 'get_preferences' )->willReturn(
+			array(
+				'store_order'  => array( 'enabled' => true ),
+				'store_review' => array( 'enabled' => false ),
+			)
+		);
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->willReturn(
+				array(
+					'success'     => true,
+					'retry_after' => null,
+				)
+			);
+
+		$sut = new NotificationProcessor();
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+
+		// store_order is enabled — should dispatch.
+		$order_notification = new NewOrderNotification( $this->order_id );
+		$this->assertTrue( $sut->process( $order_notification ) );
+
+		// store_review is disabled — should mark sent without dispatching.
+		$product             = WC_Helper_Product::create_simple_product();
+		$comment_id          = wp_insert_comment(
+			array(
+				'comment_post_ID' => $product->get_id(),
+				'comment_type'    => 'review',
+				'comment_content' => 'Great!',
+				'comment_author'  => 'Tester',
+			)
+		);
+		$review_notification = new NewReviewNotification( $comment_id );
+
+		$this->assertTrue( $sut->process( $review_notification ) );
+		$this->assertNotEmpty(
+			get_comment_meta( $comment_id, NotificationProcessor::SENT_META_KEY, true )
+		);
+	}
+
+	/**
+	 * @testdox Should look up preferences and decide once per user even when one user has multiple tokens.
+	 */
+	public function test_process_memoizes_filter_decision_per_user(): void {
+		$tokens = array(
+			new PushToken(
+				array(
+					'user_id'       => 7,
+					'token'         => 'ios-token',
+					'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+					'platform'      => PushToken::PLATFORM_APPLE,
+					'device_locale' => 'en_US',
+					'device_uuid'   => 'ios-uuid',
+				)
+			),
+			new PushToken(
+				array(
+					'user_id'       => 7,
+					'token'         => 'android-token',
+					'origin'        => PushToken::ORIGIN_WOOCOMMERCE_ANDROID,
+					'platform'      => PushToken::PLATFORM_ANDROID,
+					'device_locale' => 'en_US',
+					'device_uuid'   => 'android-uuid',
+				)
+			),
+		);
+
+		$data_store = $this->createMock( PushTokensDataStore::class );
+		$data_store->method( 'get_tokens_for_roles' )->willReturn( $tokens );
+
+		$preferences_service = $this->createMock( NotificationPreferencesService::class );
+		// One user, two tokens — preferences must be read at most once for that user.
+		$preferences_service->expects( $this->once() )
+			->method( 'get_preferences' )
+			->with( 7 )
+			->willReturn( array( 'store_order' => array( 'enabled' => true ) ) );
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->with(
+				$this->anything(),
+				$this->callback(
+					static function ( array $dispatched ) {
+						return 2 === count( $dispatched );
+					}
+				)
+			)
+			->willReturn(
+				array(
+					'success'     => true,
+					'retry_after' => null,
+				)
+			);
+
+		$sut = new NotificationProcessor();
+		$sut->init( $this->dispatcher, $data_store, $preferences_service );
+
+		$this->assertTrue( $sut->process( new NewOrderNotification( $this->order_id ) ) );
+	}
+
+	/**
+	 * Locks the delegation contract: the processor must consult
+	 * {@see Notification::should_send_to_user()} for the per-user decision and
+	 * pass it the raw stored preference value (so parametrized prefs like
+	 * `['enabled' => true, 'min_value' => 500]` reach the subclass intact
+	 * once the storage layer is widened to support them).
+	 *
+	 * @testdox Should delegate the filter decision to the notification, passing the user's stored pref value.
+	 */
+	public function test_process_delegates_filter_decision_to_notification(): void {
+		$pref_value = array(
+			'enabled'   => true,
+			'min_value' => 500,
+		);
+
+		$preferences_service = $this->createMock( NotificationPreferencesService::class );
+		$preferences_service->method( 'get_preferences' )->willReturn(
+			array( 'store_order' => $pref_value )
+		);
+
+		$notification = $this->getMockBuilder( Notification::class )
+			->setConstructorArgs( array( $this->order_id ) )
+			->onlyMethods(
+				array(
+					'get_type',
+					'to_payload',
+					'has_meta',
+					'write_meta',
+					'delete_meta',
+					'should_send_to_user',
+				)
+			)
+			->getMock();
+		$notification->method( 'get_type' )->willReturn( 'store_order' );
+		$notification->method( 'has_meta' )->willReturn( false );
+		$notification->expects( $this->once() )
+			->method( 'should_send_to_user' )
+			->with( $this->equalTo( $pref_value ) )
+			->willReturn( false );
+
+		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
+
+		$sut = new NotificationProcessor();
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+
+		$result = $sut->process( $notification );
+
+		$this->assertTrue( $result );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Per-user push notification preferences now exist via `NotificationPreferencesService` (landed in #64351), but `NotificationProcessor` still dispatches every notification to every token returned by `PushTokensDataStore::get_tokens_for_roles()`, ignoring each user's opt-out. This PR adds the filter step so a user who disables `store_order` (or `store_review`) stops receiving those pushes on their devices.

The filter runs after `get_tokens_for_roles()` and before dispatch: it drops tokens whose owning user has opted out, and the existing empty-tokens path then handles "everyone opted out" by writing `SENT_META_KEY` and returning success — no retry, no duplicate sends.

#### Why `Notification::should_send_to_user()` and not boolean logic in the processor

The decision lives on a new `Notification::should_send_to_user($pref_value): bool` instance method, which the processor calls once per recipient. The default implementation reads `$pref_value['enabled']` from the wrapped preference shape the service stores today (`['enabled' => bool, ...]`), falling back to `true` when nothing is stored or the `enabled` key is absent — newly-added notification types are therefore opt-in by default and existing types keep working unchanged. Three reasons for delegating to the notification rather than hard-coding `(bool) ($prefs[$type]['enabled'] ?? true)` inline in the processor:

1. **Type-agnostic processor.** `NotificationProcessor` never reads `$prefs['store_order']` or any specific sub-field — it asks the notification: "given this user's stored value for your type, should we send?" Orchestration code stays free of per-type knowledge.

2. **Co-locates the predicate with the resource.** Decisions for parametrized preferences depend on the underlying resource (e.g. compare an order total to a user's `min_value`). The notification subclass already lazily fetches that resource — `NewOrderNotification::to_payload()` calls `wc_get_order( $this->get_resource_id() )`. Putting the filter alongside avoids a parallel "filter classes" registry and lets the subclass reuse the same accessor pattern.

3. **Open/closed for future preference sub-fields.** The wrapped preference shape was introduced precisely to accommodate forward-compatible sub-fields without a schema migration. When `store_order` later grows a `min_value` threshold (or `store_review` grows `min_rating`), the change is one `should_send_to_user()` override on the subclass — zero changes to `NotificationProcessor`, zero changes to the storage layer, no preference-schema bump.

Per-user decisions are memoized for the duration of one `process()` call, since the same user can have several registered tokens (iOS, iPad, Android, browser); without the cache we would hit `get_user_meta()` once per token.

### How to test the changes in this Pull Request:

This might be tricky because the apps don't do that in production yet, but I'm happy to provide an Android build that would do it. 

1. With the branch applied, register at least two admin or shop_manager users with push tokens via the WooCommerce mobile app (uses the existing push-token endpoint).
2. As one of those users, disable `store_order` by calling `POST /wp-json/wc/v3/wc-push-notifications/preferences` with body `{ "store_order": { "enabled": false } }`.
3. Place a new order in the store (status `processing`).
4. Confirm the user who disabled `store_order` does **not** receive a push, while the other user does.
5. Re-enable `store_order` for the first user and place another order — both users should now receive the push.
6. Repeat for reviews: disable `store_review` for one user, leave a product review, confirm only the other user receives the review push.

### Testing that has already taken place:

- Tested manually on a local install with the custom Android app build
- Unit tests added in this PR cover (`NotificationTest`): the default `should_send_to_user` against `null`, the wrapped-shape variants (`['enabled' => true|false|1|0]`, an array missing the `enabled` key, an empty array), and defensive fallbacks for unexpected scalar values.
- Unit tests added in this PR cover (`NotificationProcessorTest`): the empty-after-filter short-circuit, per-user filtering with multiple users having different preferences, per-type respect (one type enabled while another disabled), per-user memoization (one user with two tokens triggers a single `get_preferences()` read), and the delegation contract (a mocked `Notification` proves the processor passes the raw stored pref value — including a future `min_value` parametrized shape — through unchanged).
- `php -l` syntax check clean on all modified files.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was created manually as part of this PR at `plugins/woocommerce/changelog/issue-RSM-695`.

</details>
