### PR TITLE
Tweak product list app styles

### DIFF
--- a/packages/js/experimental-products-app/changelog/tweak-product-list-background
+++ b/packages/js/experimental-products-app/changelog/tweak-product-list-background
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Set product list page background to red.

--- a/packages/js/experimental-products-app/changelog/tweak-remove-product-list-toolbar-padding
+++ b/packages/js/experimental-products-app/changelog/tweak-remove-product-list-toolbar-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove horizontal padding from product list toolbar.

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -5,7 +5,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .product_page_woocommerce-products-dashboard {
-	background-color: unset;
+	background-color: red;
 	@import "./fields/components/list-item/style.scss";
 	@import "./fields/downloadable/style.scss";
 	@import "./fields/images/style.scss";
@@ -22,7 +22,7 @@
 }
 
 .woocommerce-product-list__toolbar {
-	padding: 0 var(--wpds-dimension-padding-2xl, 24px);
+	padding: 0;
 }
 
 .woocommerce-product-list .dataviews-wrapper {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Tweak styles for the experimental products app:

- Remove the 24px horizontal padding from `.woocommerce-product-list__toolbar` so the toolbar aligns flush with the surrounding container.
- Set the `.product_page_woocommerce-products-dashboard` background to red.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Build the `@woocommerce/experimental-products-app` package and load WooCommerce admin.
2. Navigate to the experimental All Products (new) page.
3. Verify the product list toolbar no longer has 24px horizontal padding (it sits flush with the list area).
4. Verify the dashboard page background is red.

### Testing that has already taken place:

Local visual check only.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog entries were added manually in this PR under `packages/js/experimental-products-app/changelog/`.