### PR TITLE
Add categories as default column in All Products list

### DIFF
--- a/packages/js/experimental-products-app/changelog/add-categories-default-column
+++ b/packages/js/experimental-products-app/changelog/add-categories-default-column
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add categories as a default column in the product list, before price

--- a/packages/js/experimental-products-app/src/product-list/layouts.ts
+++ b/packages/js/experimental-products-app/src/product-list/layouts.ts
@@ -10,6 +10,7 @@ export const DEFAULT_PRODUCT_TABLE_FIELDS = [
 	'product_status',
 	'sku',
 	'stock',
+	'categories',
 	'price',
 ] as const;
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds `categories` to the default columns shown in the experimental All Products list (`packages/js/experimental-products-app`). The column is inserted between `stock` and `price` so the layout reads: status, sku, stock, categories, price.

The `categories` field was already registered and available via column configuration — this PR just makes it visible out of the box rather than requiring users to enable it manually.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1424" height="904" alt="image" src="https://github.com/user-attachments/assets/7b6b504b-4b99-459c-80d6-3d13bcc78555" /> | <img width="1421" height="901" alt="image" src="https://github.com/user-attachments/assets/60a33217-c57b-4892-a1bb-554b0b3e1057" />|


### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce watch:build` and load the WooCommerce admin.
2. Navigate to the experimental All Products screen.
3. Confirm the table shows a `Categories` column between `Stock` and `Price` by default (without needing to toggle it on via the view config).
4. Open the view configuration and confirm `Categories` is still toggleable like any other field.

### Testing that has already taken place:

- Verified the column appears in the default layout in local dev.
- No changes to the `categories` field rendering itself — only the default visibility ordering.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was added manually at `packages/js/experimental-products-app/changelog/add-categories-default-column` (Significance: minor, Type: add).

- [ ] Automatically create a changelog entry from the details below.