### PR TITLE
Simplify block templates compatibility layer checks

### DIFF
--- a/plugins/woocommerce/changelog/fix-simplify-compatibility-layer-checks
+++ b/plugins/woocommerce/changelog/fix-simplify-compatibility-layer-checks
@@ -1,4 +1,4 @@
-Significance: patch
-Type: update
+Significance: minor
+Type: fix
 
-Simplify block templates compatibility layer checks
+Move logic to enable or disable the compatibility layer in block templates from 'template_redirect' to 'template_include' to be more accurate with the resolved template

--- a/plugins/woocommerce/changelog/fix-simplify-compatibility-layer-checks
+++ b/plugins/woocommerce/changelog/fix-simplify-compatibility-layer-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Simplify block templates compatibility layer checks

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -55576,24 +55576,6 @@ parameters:
 			path: src/Blocks/Templates/AbstractTemplateCompatibility.php
 
 		-
-			message: '#^One or more @param tags has an invalid name or invalid syntax\.$#'
-			identifier: phpDoc.parseError
-			count: 2
-			path: src/Blocks/Templates/AbstractTemplateCompatibility.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(boolean\.\)\: Unexpected token "\.", expected variable at offset 211 on line 7$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/Blocks/Templates/AbstractTemplateCompatibility.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(boolean\.\)\: Unexpected token "\.", expected variable at offset 221 on line 7$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/Blocks/Templates/AbstractTemplateCompatibility.php
-
-		-
 			message: '#^Parameter \$parent_block of method Automattic\\WooCommerce\\Blocks\\Templates\\AbstractTemplateCompatibility\:\:update_render_block_data\(\) has invalid type Automattic\\WooCommerce\\Blocks\\Templates\\WP_Block\.$#'
 			identifier: class.notFound
 			count: 1

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -240,20 +240,17 @@ abstract class AbstractTemplateCompatibility {
 	 * @internal
 	 */
 	public function set_compatibility_layer_flag() {
+		$current_template_has_legacy_template_block = $this->current_template_has_legacy_template_block();
+
 		/**
-		 * Filter to disable the compatibility layer for the blockified templates.
+		 * Filter to determine whether the compatibility layer should be disabled.
 		 *
-		 * @since 10.9.0
-		 * @param bool|null $compatibility_layer_status The compatibility layer status. If `null`, the compatibility layer will be enabled or disabled based on the current template.
+		 * @since 11.0.0
+		 * @param bool $should_disable_compatibility_layer Whether the compatibility layer should be disabled.
 		 */
-		$compatibility_layer_status = apply_filters( 'woocommerce_disable_compatibility_layer', null );
+		$should_disable_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', $current_template_has_legacy_template_block );
 
-		// If an extension has already set the compatibility layer status, use it.
-		if ( is_bool( $compatibility_layer_status ) ) {
-			return;
-		}
-
-		if ( $this->current_template_has_legacy_template_block() ) {
+		if ( $should_disable_compatibility_layer ) {
 			add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -27,8 +27,8 @@ abstract class AbstractTemplateCompatibility {
 
 		add_filter(
 			'template_include',
-			function( $template ) {
-				$this->set_compatibility_layer_flag( $template );
+			function ( $template ) {
+				$this->set_compatibility_layer_flag();
 
 				add_filter(
 					'render_block_data',
@@ -39,7 +39,7 @@ abstract class AbstractTemplateCompatibility {
 						* This hook allows to disable the compatibility layer for the blockified templates.
 						*
 						* @since 7.6.0
-						* @param boolean.
+						* @param bool $is_disabled_compatibility_layer Whether the compatibility layer should be disabled.
 						*/
 						$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 
@@ -62,7 +62,7 @@ abstract class AbstractTemplateCompatibility {
 						* This hook allows to disable the compatibility layer for the blockified.
 						*
 						* @since 7.6.0
-						* @param boolean.
+						* @param bool $is_disabled_compatibility_layer Whether the compatibility layer should be disabled.
 						*/
 						$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 
@@ -212,7 +212,7 @@ abstract class AbstractTemplateCompatibility {
 	/**
 	 * Check if the current template has a legacy template block.
 	 *
-	 * @return bool
+	 * @return bool True if the current template has a legacy template block, false otherwise.
 	 *
 	 * @internal
 	 */
@@ -234,6 +234,8 @@ abstract class AbstractTemplateCompatibility {
 
 	/**
 	 * Check if the current template has a legacy template block and disable the compatibility layer if it does.
+	 *
+	 * @return void
 	 *
 	 * @internal
 	 */

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -240,19 +240,16 @@ abstract class AbstractTemplateCompatibility {
 	 * @internal
 	 */
 	public function set_compatibility_layer_flag() {
-		$has_filter = has_filter( 'woocommerce_disable_compatibility_layer' );
+		/**
+		 * Filter to disable the compatibility layer for the blockified templates.
+		 *
+		 * @since 10.9.0
+		 * @param bool|null $compatibility_layer_status The compatibility layer status. If `null`, the compatibility layer will be enabled or disabled based on the current template.
+		 */
+		$compatibility_layer_status = apply_filters( 'woocommerce_disable_compatibility_layer', null );
 
-		if ( $has_filter ) {
-			// In #64504 we moved the `woocommerce_disable_compatibility_layer`
-			// filter from `template_redirect` to `template_include` (which runs
-			// later).
-			// We display a `wc_doing_it_wrong()` message if somebody was
-			// hooking into it too early.
-			wc_doing_it_wrong(
-				'woocommerce_disable_compatibility_layer',
-				'The `woocommerce_disable_compatibility_layer` filter should only be added during or after the `template_include` action, once WooCommerce has determined the default value based on the resolved template.',
-				'10.9.0'
-			);
+		// If an extension has already set the compatibility layer status, use it.
+		if ( is_bool( $compatibility_layer_status ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -240,6 +240,18 @@ abstract class AbstractTemplateCompatibility {
 	 * @internal
 	 */
 	public function set_compatibility_layer_flag() {
+		$has_filter = has_filter( 'woocommerce_disable_compatibility_layer' );
+
+		if ( $has_filter ) {
+			// In #64504 we moved the `woocommerce_disable_compatibility_layer`
+			// filter from `template_redirect` to `template_include` (which runs
+			// later).
+			// We display a `wc_doing_it_wrong()` message if somebody was
+			// hooking into it too early.
+			wc_doing_it_wrong( 'woocommerce_disable_compatibility_layer', 'The `woocommerce_disable_compatibility_layer` filter should be added in `template_include`, after WooCommerce has set the default value based on the resolved template.', '10.9.0' );
+			return;
+		}
+
 		if ( $this->current_template_has_legacy_template_block() ) {
 			add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 		}

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -1,6 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Templates;
 
+use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
+
 /**
  * AbstractTemplateCompatibility class.
  *
@@ -24,49 +26,60 @@ abstract class AbstractTemplateCompatibility {
 		$this->set_hook_data();
 
 		add_filter(
-			'render_block_data',
-			function ( $parsed_block, $source_block, $parent_block ) {
-				/**
-				* Filter to disable the compatibility layer for the blockified templates.
-				*
-				* This hook allows to disable the compatibility layer for the blockified templates.
-				*
-				* @since 7.6.0
-				* @param boolean.
-				*/
-				$is_disabled_compatility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
+			'template_include',
+			function( $template ) {
+				$this->set_compatibility_layer_flag( $template );
 
-				if ( $is_disabled_compatility_layer ) {
-					return $parsed_block;
-				}
+				add_filter(
+					'render_block_data',
+					function ( $parsed_block, $source_block, $parent_block ) {
+						/**
+						* Filter to disable the compatibility layer for the blockified templates.
+						*
+						* This hook allows to disable the compatibility layer for the blockified templates.
+						*
+						* @since 7.6.0
+						* @param boolean.
+						*/
+						$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 
-				return $this->update_render_block_data( $parsed_block, $source_block, $parent_block );
+						if ( $is_disabled_compatibility_layer ) {
+							return $parsed_block;
+						}
+
+						return $this->update_render_block_data( $parsed_block, $source_block, $parent_block );
+					},
+					10,
+					3
+				);
+
+				add_filter(
+					'render_block',
+					function ( $block_content, $block ) {
+						/**
+						* Filter to disable the compatibility layer for the blockified templates.
+						*
+						* This hook allows to disable the compatibility layer for the blockified.
+						*
+						* @since 7.6.0
+						* @param boolean.
+						*/
+						$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
+
+						if ( $is_disabled_compatibility_layer ) {
+							return $block_content;
+						}
+
+						return $this->inject_hooks( $block_content, $block );
+					},
+					10,
+					2
+				);
+
+				return $template;
 			},
 			10,
-			3
-		);
-
-		add_filter(
-			'render_block',
-			function ( $block_content, $block ) {
-				/**
-				* Filter to disable the compatibility layer for the blockified templates.
-				*
-				* This hook allows to disable the compatibility layer for the blockified.
-				*
-				* @since 7.6.0
-				* @param boolean.
-				*/
-				$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
-
-				if ( $is_disabled_compatibility_layer ) {
-					return $block_content;
-				}
-
-				return $this->inject_hooks( $block_content, $block );
-			},
-			10,
-			2
+			1
 		);
 	}
 
@@ -194,5 +207,39 @@ abstract class AbstractTemplateCompatibility {
 			}
 		}
 		return ob_get_clean();
+	}
+
+	/**
+	 * Check if the current template has a legacy template block.
+	 *
+	 * @return bool
+	 *
+	 * @internal
+	 */
+	public function current_template_has_legacy_template_block() {
+		global $_wp_current_template_id;
+
+		if ( empty( $_wp_current_template_id ) ) {
+			return false;
+		}
+
+		$current_template = get_block_template( $_wp_current_template_id, 'wp_template' );
+
+		if ( isset( $current_template ) && BlockTemplateUtils::template_has_legacy_template_block( $current_template ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the current template has a legacy template block and disable the compatibility layer if it does.
+	 *
+	 * @internal
+	 */
+	public function set_compatibility_layer_flag() {
+		if ( $this->current_template_has_legacy_template_block() ) {
+			add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+		}
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -248,7 +248,11 @@ abstract class AbstractTemplateCompatibility {
 			// later).
 			// We display a `wc_doing_it_wrong()` message if somebody was
 			// hooking into it too early.
-			wc_doing_it_wrong( 'woocommerce_disable_compatibility_layer', 'The `woocommerce_disable_compatibility_layer` filter should be added in `template_include`, after WooCommerce has set the default value based on the resolved template.', '10.9.0' );
+			wc_doing_it_wrong(
+				'woocommerce_disable_compatibility_layer',
+				'The `woocommerce_disable_compatibility_layer` filter should only be added during or after the `template_include` action, once WooCommerce has determined the default value based on the resolved template.',
+				'10.9.0'
+			);
 			return;
 		}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -56,12 +56,6 @@ class ProductAttributeTemplate extends AbstractTemplateWithFallback {
 		if ( isset( $queried_object->taxonomy ) && taxonomy_is_product_attribute( $queried_object->taxonomy ) ) {
 			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
 			$compatibility_layer->init();
-
-			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
-
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductBrandTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductBrandTemplate.php
@@ -59,12 +59,6 @@ class ProductBrandTemplate extends AbstractTemplateWithFallback {
 			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
 			$compatibility_layer->init();
 
-			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
-
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
-
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -52,12 +52,6 @@ class ProductCatalogTemplate extends AbstractTemplate {
 		if ( ! is_embed() && ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) && ! is_search() ) {
 			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
 			$compatibility_layer->init();
-
-			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
-
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
@@ -59,12 +59,6 @@ class ProductCategoryTemplate extends AbstractTemplateWithFallback {
 			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
 			$compatibility_layer->init();
 
-			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
-
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
-
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
@@ -51,12 +51,6 @@ class ProductSearchResultsTemplate extends AbstractTemplate {
 		if ( ! is_embed() && is_post_type_archive( 'product' ) && is_search() ) {
 			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
 			$compatibility_layer->init();
-
-			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
-
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
@@ -59,12 +59,6 @@ class ProductTagTemplate extends AbstractTemplateWithFallback {
 			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
 			$compatibility_layer->init();
 
-			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
-
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
-
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -55,34 +55,6 @@ class SingleProductTemplate extends AbstractTemplate {
 			$compatibility_layer = new SingleProductTemplateCompatibility();
 			$compatibility_layer->init();
 
-			$valid_slugs         = array( self::SLUG );
-			$single_product_slug = 'product' === $post->post_type && $post->post_name ? 'single-product-' . $post->post_name : '';
-			if ( $single_product_slug ) {
-				$valid_slugs[] = 'single-product-' . $post->post_name;
-			}
-			$templates = get_block_templates( array( 'slug__in' => $valid_slugs ) );
-
-			if ( count( $templates ) === 0 ) {
-				return;
-			}
-
-			// Use the first template by default.
-			$template = reset( $templates );
-
-			// Check if there is a template matching the slug `single-product-{post_name}`.
-			if ( count( $valid_slugs ) > 1 && count( $templates ) > 1 ) {
-				foreach ( $templates as $t ) {
-					if ( $single_product_slug === $t->slug ) {
-						$template = $t;
-						break;
-					}
-				}
-			}
-
-			if ( isset( $template ) && BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
-
 			$product = wc_get_product( $post->ID );
 			if ( $product ) {
 				$consent = 'I acknowledge that using experimental APIs means my theme or plugin will inevitably break in the next version of WooCommerce';

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/AbstractTemplateCompatibilityTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/AbstractTemplateCompatibilityTest.php
@@ -1,0 +1,195 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Templates;
+
+use Automattic\WooCommerce\Blocks\Templates\AbstractTemplateCompatibility;
+use WP_UnitTestCase;
+
+/**
+ * Tests for AbstractTemplateCompatibility::set_compatibility_layer_flag().
+ */
+class AbstractTemplateCompatibilityTest extends WP_UnitTestCase {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var AbstractTemplateCompatibility
+	 */
+	private $sut;
+
+	/**
+	 * @inheritdoc
+	 */
+	public function tearDown(): void {
+		$this->remove_compatibility_layer_filters();
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Disables the compatibility layer when the template has a legacy template block.
+	 */
+	public function test_disables_compatibility_layer_when_template_has_legacy_block(): void {
+		$this->sut = $this->create_sut( true );
+
+		$this->sut->set_compatibility_layer_flag();
+
+		$this->assertTrue(
+			$this->is_compatibility_layer_disabled(),
+			'Legacy templates should disable the compatibility layer for subsequent checks.'
+		);
+	}
+
+	/**
+	 * @testdox Keeps the compatibility layer enabled when the template is blockified.
+	 */
+	public function test_keeps_compatibility_layer_enabled_when_template_is_blockified(): void {
+		$this->sut = $this->create_sut( false );
+
+		$this->sut->set_compatibility_layer_flag();
+
+		$this->assertFalse(
+			$this->is_compatibility_layer_disabled(),
+			'Blockified templates should keep the compatibility layer enabled by default.'
+		);
+	}
+
+	/**
+	 * @testdox Passes legacy detection as the filter default value.
+	 */
+	public function test_filter_receives_legacy_detection_as_default(): void {
+		$received_default = null;
+
+		add_filter(
+			'woocommerce_disable_compatibility_layer',
+			function ( $should_disable ) use ( &$received_default ) {
+				$received_default = $should_disable;
+
+				return $should_disable;
+			},
+			10,
+			1
+		);
+
+		$this->sut = $this->create_sut( true );
+		$this->sut->set_compatibility_layer_flag();
+
+		$this->assertTrue( $received_default, 'Filter default should reflect legacy template detection.' );
+	}
+
+	/**
+	 * @testdox Keeps the compatibility layer enabled when an extension overrides a legacy template default to false.
+	 */
+	public function test_keeps_compatibility_layer_enabled_when_extension_overrides_legacy_default_to_false(): void {
+		add_filter( 'woocommerce_disable_compatibility_layer', '__return_false' );
+
+		$this->sut = $this->create_sut( true );
+		$this->sut->set_compatibility_layer_flag();
+
+		$this->assertFalse(
+			$this->is_compatibility_layer_disabled(),
+			'Extensions should be able to keep the compatibility layer enabled on legacy templates.'
+		);
+	}
+
+	/**
+	 * @testdox Disables the compatibility layer when an extension overrides a blockified template default to true.
+	 */
+	public function test_disables_compatibility_layer_when_extension_overrides_blockified_default_to_true(): void {
+		add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+
+		$this->sut = $this->create_sut( false );
+		$this->sut->set_compatibility_layer_flag();
+
+		$this->assertTrue(
+			$this->is_compatibility_layer_disabled(),
+			'Extensions should be able to disable the compatibility layer on blockified templates.'
+		);
+	}
+
+	/**
+	 * Applies the compatibility layer filter the same way render callbacks do.
+	 *
+	 * @return bool
+	 */
+	private function is_compatibility_layer_disabled(): bool {
+		/**
+		 * Filter to disable the compatibility layer for the blockified templates.
+		 *
+		 * @since 7.6.0
+		 * @param bool $is_disabled_compatibility_layer Whether the compatibility layer should be disabled.
+		 */
+		return apply_filters( 'woocommerce_disable_compatibility_layer', false );
+	}
+
+	/**
+	 * Creates a test double with a fixed legacy-template detection result.
+	 *
+	 * @param bool $has_legacy_template_block Legacy template detection result to return.
+	 * @return AbstractTemplateCompatibility
+	 */
+	private function create_sut( bool $has_legacy_template_block ): AbstractTemplateCompatibility {
+		return new class( $has_legacy_template_block ) extends AbstractTemplateCompatibility {
+
+			/**
+			 * Whether the current template is detected as having a legacy template block.
+			 *
+			 * @var bool
+			 */
+			private $has_legacy_template_block;
+
+			/**
+			 * @param bool $has_legacy_template_block Legacy template detection result to return.
+			 */
+			public function __construct( bool $has_legacy_template_block ) {
+				$this->has_legacy_template_block = $has_legacy_template_block;
+			}
+
+			/**
+			 * @inheritdoc
+			 */
+			public function current_template_has_legacy_template_block() {
+				return $this->has_legacy_template_block;
+			}
+
+			/**
+			 * @param array       $parsed_block  The block being rendered.
+			 * @param array       $source_block  An un-modified copy of the parsed block.
+			 * @param object|null $parent_block  Parent block, if any.
+			 * @return array
+			 */
+			public function update_render_block_data( $parsed_block, $source_block, $parent_block ) {
+				unset( $source_block, $parent_block );
+
+				return $parsed_block;
+			}
+
+			/**
+			 * @param mixed $block_content The rendered block content.
+			 * @param mixed $block         The parsed block data.
+			 * @return string
+			 */
+			public function inject_hooks( $block_content, $block ) {
+				unset( $block );
+
+				return $block_content;
+			}
+
+			/**
+			 * @inheritdoc
+			 */
+			protected function set_hook_data() {
+				$this->hook_data = array();
+			}
+		};
+	}
+
+	/**
+	 * Removes filters registered during tests.
+	 */
+	private function remove_compatibility_layer_filters(): void {
+		remove_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+		remove_filter( 'woocommerce_disable_compatibility_layer', '__return_false' );
+		remove_all_filters( 'woocommerce_disable_compatibility_layer' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #46876.

The template compatibility layer was activated in `template_redirect`. We had some logic trying to figure out what template was going to be rendered, and based on it, we would check the template contents and enable or disable the compatibility layer accordingly.

That worked fine for most cases, but it was buggy:

1. Themes or users can override the template. For example, if a store had a template for a specific category (ie: _Clothing_), the logic would still check the base _Products by Category_ template when deciding whether to activate the compatibility layer or not (issue #46876).
2. While we don't officially support it, if a store enabled Gutenberg as the product editor, users could swap the templates used by products, causing a mismatch between the template rendered and the template used to decide whether to activate the compatibility layer.
3. The same can be achieved with custom code without enabling Gutenberg as the product editor.
4. If in the future WC wants to support setting different templates per product (#42393), we will encounter the same bug.

I believe all these issues can be resolved by simply moving the logic from `template_redirect` to `template_include`. At that point, we already know which template will be rendered, so we are confident we are checking the contents of the correct one. It also allows simplifying the logic.

Note: Because the filter registration has moved from `template_redirect` to `template_include`, if an extension was reading `woocommerce_disable_compatibility_layer` before `template_include` is run, it will no longer have the template value. IMO it's a valid trade-off, especially considering the value wasn't accurate anyway because the resolved template might be incorrect, so it was already buggy in `trunk`.

### How to test the changes in this Pull Request:

1. Add this code snippet to your site (you can use the Code Snippets extension if needed):
```PHP
add_action( 'woocommerce_before_shop_loop_item_title', function () {
	echo 'Hello world! (This should be printed in any product archive template)';
} );
```
2. Go to Appearance > Editor > Templates > Add New.
3. Create a template for all Product categories.
4. Remove the Product Collection block and in its place paste the Classic Template block (`<!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_cat"} /-->`).
5. Go to Appearance > Editor > Templates > Add New.
6. Now create a template for a specific product category.
7. In this one, replace the Classic Template block with the Product Collection block.
8. Visit both categories in the frontend.
9. Verify the 'Hello world!...' text appears before the product name in both cases. (In `trunk`, because the base category has the Classic Template block, the compatibility layer would be disabled also for the specific template, even though it shouldn't)

Before | After
--- | ---
<img width="1458" height="1076" alt="imatge" src="https://github.com/user-attachments/assets/c3d907fc-2f39-4d54-9175-f7558681da6e" /> | <img width="1458" height="1076" alt="imatge" src="https://github.com/user-attachments/assets/a0f99266-53be-40e6-aa8c-cf9a50cf6eb4" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->