### PR TITLE
Add a Back in Stock Notifications tab to My Account (RSM-444)

### DIFF
--- a/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
@@ -440,9 +440,12 @@ CREATE TABLE $meta_table_name (
 		$where        = array();
 		$where_values = array();
 
-		if ( $args['status'] ) {
-			$where[]        = 'status = %s';
-			$where_values[] = esc_sql( $args['status'] );
+		if ( ! empty( $args['status'] ) ) {
+			$statuses = array_values( array_filter( array_map( 'strval', (array) $args['status'] ) ) );
+			if ( ! empty( $statuses ) ) {
+				$where[]      = 'status IN (' . implode( ',', array_fill( 0, count( $statuses ), '%s' ) ) . ')';
+				$where_values = array_merge( $where_values, $statuses );
+			}
 		}
 
 		if ( ! empty( $args['product_id'] ) ) {

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
@@ -195,9 +195,28 @@ class MyAccountEndpoint {
 			);
 		}
 
+		/**
+		 * Filter the notification statuses shown on the My Account back-in-stock-notifications screen.
+		 *
+		 * Defaults to PENDING + ACTIVE — the statuses the customer can act on. SENT
+		 * notifications are deliberately hidden because the email has already been
+		 * dispatched and the row is just noise; CANCELLED is hidden for the same
+		 * reason. Merchants who want a full history can build their own view via
+		 * {@see NotificationQuery::get_notifications()}.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param string[] $statuses List of {@see NotificationStatus} values to include.
+		 */
+		$statuses = (array) apply_filters(
+			'woocommerce_account_back_in_stock_notifications_statuses',
+			array( NotificationStatus::PENDING, NotificationStatus::ACTIVE )
+		);
+
 		$total_items = NotificationQuery::count_notifications(
 			array(
 				'user_id' => $user_id,
+				'status'  => $statuses,
 			)
 		);
 
@@ -212,6 +231,7 @@ class MyAccountEndpoint {
 		$notifications = $total_items > 0 ? NotificationQuery::get_notifications(
 			array(
 				'user_id'  => $user_id,
+				'status'   => $statuses,
 				'order_by' => array( 'id' => 'DESC' ),
 				'return'   => 'objects',
 				'limit'    => $per_page,

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
@@ -127,50 +127,104 @@ class MyAccountEndpoint {
 	}
 
 	/**
+	 * Default page size when none is provided.
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_PER_PAGE = 10;
+
+	/**
 	 * Render the endpoint template.
 	 *
 	 * Hooked to `woocommerce_account_back-in-stock-notifications_endpoint`, mirroring
 	 * how `woocommerce_account_downloads` and `woocommerce_account_orders` hook up.
+	 *
+	 * @param string|int $current_page The current page number passed by WC (the value
+	 *                                 captured from the rewrite endpoint, e.g. `2` for
+	 *                                 `/my-account/back-in-stock-notifications/2/`). Empty
+	 *                                 string when no page is in the URL.
 	 */
-	public function render_endpoint(): void {
-		$notifications = $this->get_current_user_notifications();
+	public function render_endpoint( $current_page = 1 ): void {
+		$current_page = max( 1, (int) $current_page );
+
+		/**
+		 * Filter the per-page count for the My Account stock-notifications table.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param int $per_page Number of notifications shown per page. Default {@see self::DEFAULT_PER_PAGE}.
+		 */
+		$per_page = (int) apply_filters( 'woocommerce_account_back_in_stock_notifications_per_page', self::DEFAULT_PER_PAGE );
+		$per_page = max( 1, $per_page );
+
+		$page = $this->get_current_user_notifications_page( $current_page, $per_page );
 
 		\wc_get_template(
 			'myaccount/back-in-stock-notifications.php',
 			array(
-				'notifications' => $notifications,
-				'has_items'     => ! empty( $notifications ),
+				'notifications' => $page['notifications'],
+				'has_items'     => ! empty( $page['notifications'] ),
+				'current_page'  => $page['current_page'],
+				'total_pages'   => $page['total_pages'],
+				'total_items'   => $page['total_items'],
+				'per_page'      => $per_page,
 			)
 		);
 	}
 
 	/**
-	 * Return the current user's notifications, newest first.
+	 * Return one page of the current user's notifications, newest first.
 	 *
 	 * Always scopes to `get_current_user_id()` — the caller is never trusted.
 	 *
-	 * @return array<Notification>
+	 * @param int $current_page 1-indexed page number.
+	 * @param int $per_page     Page size.
+	 * @return array{notifications:array<Notification>, current_page:int, total_pages:int, total_items:int}
 	 */
-	public function get_current_user_notifications(): array {
+	public function get_current_user_notifications_page( int $current_page, int $per_page ): array {
+		$current_page = max( 1, $current_page );
+		$per_page     = max( 1, $per_page );
+
 		$user_id = get_current_user_id();
 		if ( $user_id <= 0 ) {
-			return array();
+			return array(
+				'notifications' => array(),
+				'current_page'  => 1,
+				'total_pages'   => 0,
+				'total_items'   => 0,
+			);
 		}
 
-		$notifications = NotificationQuery::get_notifications(
+		$total_items = NotificationQuery::count_notifications(
+			array(
+				'user_id' => $user_id,
+			)
+		);
+
+		$total_pages = (int) ceil( $total_items / $per_page );
+
+		// Clamp out-of-range pages to the last available page so a stale link
+		// doesn't render an empty table.
+		if ( $total_items > 0 && $current_page > $total_pages ) {
+			$current_page = $total_pages;
+		}
+
+		$notifications = $total_items > 0 ? NotificationQuery::get_notifications(
 			array(
 				'user_id'  => $user_id,
 				'order_by' => array( 'id' => 'DESC' ),
 				'return'   => 'objects',
-				'limit'    => -1,
+				'limit'    => $per_page,
+				'offset'   => ( $current_page - 1 ) * $per_page,
 			)
+		) : array();
+
+		return array(
+			'notifications' => $notifications,
+			'current_page'  => $current_page,
+			'total_pages'   => $total_pages,
+			'total_items'   => $total_items,
 		);
-
-		if ( ! is_array( $notifications ) ) {
-			return array();
-		}
-
-		return $notifications;
 	}
 
 	/**
@@ -213,7 +267,7 @@ class MyAccountEndpoint {
 		}
 
 		$notification = Factory::get_notification( $notification_id );
-		if ( ! $notification ) {
+		if ( ! $notification instanceof Notification ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
@@ -26,7 +26,7 @@ class MyAccountEndpoint {
 	 *
 	 * Matches the slug used in the menu filter, rewrite endpoint, and template hook.
 	 */
-	public const ENDPOINT = 'back-in-stock-notifications';
+	public const ENDPOINT = 'stock-notifications';
 
 	/**
 	 * Query argument triggered by the cancel form post.
@@ -57,7 +57,7 @@ class MyAccountEndpoint {
 	}
 
 	/**
-	 * Register the `back-in-stock-notifications` rewrite endpoint / query var.
+	 * Register the `stock-notifications` rewrite endpoint / query var.
 	 *
 	 * Hooking `woocommerce_get_query_vars` wires us into {@see \WC_Query::add_endpoints()}
 	 * so WordPress registers the rewrite rule and our slug lands in `$wp->query_vars`.
@@ -136,12 +136,12 @@ class MyAccountEndpoint {
 	/**
 	 * Render the endpoint template.
 	 *
-	 * Hooked to `woocommerce_account_back-in-stock-notifications_endpoint`, mirroring
+	 * Hooked to `woocommerce_account_stock-notifications_endpoint`, mirroring
 	 * how `woocommerce_account_downloads` and `woocommerce_account_orders` hook up.
 	 *
 	 * @param string|int $current_page The current page number passed by WC (the value
 	 *                                 captured from the rewrite endpoint, e.g. `2` for
-	 *                                 `/my-account/back-in-stock-notifications/2/`). Empty
+	 *                                 `/my-account/stock-notifications/2/`). Empty
 	 *                                 string when no page is in the URL.
 	 */
 	public function render_endpoint( $current_page = 1 ): void {
@@ -160,7 +160,7 @@ class MyAccountEndpoint {
 		$page = $this->get_current_user_notifications_page( $current_page, $per_page );
 
 		\wc_get_template(
-			'myaccount/back-in-stock-notifications.php',
+			'myaccount/stock-notifications.php',
 			array(
 				'notifications' => $page['notifications'],
 				'has_items'     => ! empty( $page['notifications'] ),
@@ -196,7 +196,7 @@ class MyAccountEndpoint {
 		}
 
 		/**
-		 * Filter the notification statuses shown on the My Account back-in-stock-notifications screen.
+		 * Filter the notification statuses shown on the My Account stock-notifications screen.
 		 *
 		 * Defaults to PENDING + ACTIVE — the statuses the customer can act on. SENT
 		 * notifications are deliberately hidden because the email has already been
@@ -251,7 +251,7 @@ class MyAccountEndpoint {
 	 * Intercept a cancel POST to flip a notification to `cancelled`.
 	 *
 	 * Guards:
-	 * - Must be on the My Account > back-in-stock-notifications endpoint.
+	 * - Must be on the My Account > stock-notifications endpoint.
 	 * - Must be authenticated.
 	 * - Nonce must be scoped to the specific notification id ({@see ::get_cancel_nonce_action()}).
 	 * - The notification must belong to the current user.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\NotificationQuery;
 
 /**
- * Registers the "Back in stock notifications" My Account endpoint and handles
+ * Registers the "Stock notifications" My Account endpoint and handles
  * the cancel action for customer-owned notifications.
  *
  * @internal
@@ -89,7 +89,7 @@ class MyAccountEndpoint {
 		}
 
 		$new_item = array(
-			self::ENDPOINT => __( 'Back in stock notifications', 'woocommerce' ),
+			self::ENDPOINT => __( 'Stock notifications', 'woocommerce' ),
 		);
 
 		// Try to slot it in right after Downloads so it sits with the other lists.
@@ -123,7 +123,7 @@ class MyAccountEndpoint {
 	 */
 	public function filter_endpoint_title( $title ) {
 		unset( $title ); // Avoid parameter not used PHPCS errors.
-		return __( 'Back in stock notifications', 'woocommerce' );
+		return __( 'Stock notifications', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/MyAccountEndpoint.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * MyAccountEndpoint class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Frontend;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Factory;
+use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use Automattic\WooCommerce\Internal\StockNotifications\NotificationQuery;
+
+/**
+ * Registers the "Back in stock notifications" My Account endpoint and handles
+ * the cancel action for customer-owned notifications.
+ *
+ * @internal
+ */
+class MyAccountEndpoint {
+
+	/**
+	 * Query var / endpoint slug.
+	 *
+	 * Matches the slug used in the menu filter, rewrite endpoint, and template hook.
+	 */
+	public const ENDPOINT = 'back-in-stock-notifications';
+
+	/**
+	 * Query argument triggered by the cancel form post.
+	 */
+	public const CANCEL_ACTION = 'wc_bis_cancel_notification';
+
+	/**
+	 * Build the nonce action name for a given notification id.
+	 *
+	 * Same shape as the admin-side scoping from #64348: `wc_bis_cancel_<id>`.
+	 *
+	 * @param int $notification_id The notification id.
+	 * @return string The nonce action name.
+	 */
+	public static function get_cancel_nonce_action( int $notification_id ): string {
+		return 'wc_bis_cancel_' . $notification_id;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_get_query_vars', array( $this, 'register_query_var' ) );
+		add_filter( 'woocommerce_account_menu_items', array( $this, 'register_menu_item' ), 10, 2 );
+		add_filter( 'woocommerce_endpoint_' . self::ENDPOINT . '_title', array( $this, 'filter_endpoint_title' ) );
+		add_action( 'woocommerce_account_' . self::ENDPOINT . '_endpoint', array( $this, 'render_endpoint' ) );
+		add_action( 'template_redirect', array( $this, 'maybe_handle_cancel' ) );
+	}
+
+	/**
+	 * Register the `back-in-stock-notifications` rewrite endpoint / query var.
+	 *
+	 * Hooking `woocommerce_get_query_vars` wires us into {@see \WC_Query::add_endpoints()}
+	 * so WordPress registers the rewrite rule and our slug lands in `$wp->query_vars`.
+	 *
+	 * @param array<string, string> $vars Existing query vars keyed by endpoint slug.
+	 * @return array<string, string>
+	 */
+	public function register_query_var( $vars ) {
+		if ( ! is_array( $vars ) ) {
+			return $vars;
+		}
+
+		$vars[ self::ENDPOINT ] = self::ENDPOINT;
+		return $vars;
+	}
+
+	/**
+	 * Inject the menu entry between "Downloads" and "Addresses" if present, otherwise append.
+	 *
+	 * @param array<string, string> $items     The current menu items.
+	 * @param array<string, string> $endpoints The resolved endpoint slugs (unused, kept for filter signature).
+	 * @return array<string, string>
+	 */
+	public function register_menu_item( $items, $endpoints ) {
+		unset( $endpoints ); // Avoid parameter not used PHPCS errors.
+
+		if ( ! is_array( $items ) ) {
+			return $items;
+		}
+
+		$new_item = array(
+			self::ENDPOINT => __( 'Back in stock notifications', 'woocommerce' ),
+		);
+
+		// Try to slot it in right after Downloads so it sits with the other lists.
+		if ( isset( $items['downloads'] ) ) {
+			$position = array_search( 'downloads', array_keys( $items ), true );
+			if ( false !== $position ) {
+				return array_slice( $items, 0, $position + 1, true )
+					+ $new_item
+					+ array_slice( $items, $position + 1, null, true );
+			}
+		}
+
+		// Otherwise insert before customer-logout so "Log out" stays last.
+		if ( isset( $items['customer-logout'] ) ) {
+			$position = array_search( 'customer-logout', array_keys( $items ), true );
+			if ( false !== $position ) {
+				return array_slice( $items, 0, $position, true )
+					+ $new_item
+					+ array_slice( $items, $position, null, true );
+			}
+		}
+
+		return $items + $new_item;
+	}
+
+	/**
+	 * Override the endpoint page title.
+	 *
+	 * @param string $title The default title.
+	 * @return string
+	 */
+	public function filter_endpoint_title( $title ) {
+		unset( $title ); // Avoid parameter not used PHPCS errors.
+		return __( 'Back in stock notifications', 'woocommerce' );
+	}
+
+	/**
+	 * Render the endpoint template.
+	 *
+	 * Hooked to `woocommerce_account_back-in-stock-notifications_endpoint`, mirroring
+	 * how `woocommerce_account_downloads` and `woocommerce_account_orders` hook up.
+	 */
+	public function render_endpoint(): void {
+		$notifications = $this->get_current_user_notifications();
+
+		\wc_get_template(
+			'myaccount/back-in-stock-notifications.php',
+			array(
+				'notifications' => $notifications,
+				'has_items'     => ! empty( $notifications ),
+			)
+		);
+	}
+
+	/**
+	 * Return the current user's notifications, newest first.
+	 *
+	 * Always scopes to `get_current_user_id()` — the caller is never trusted.
+	 *
+	 * @return array<Notification>
+	 */
+	public function get_current_user_notifications(): array {
+		$user_id = get_current_user_id();
+		if ( $user_id <= 0 ) {
+			return array();
+		}
+
+		$notifications = NotificationQuery::get_notifications(
+			array(
+				'user_id'  => $user_id,
+				'order_by' => array( 'id' => 'DESC' ),
+				'return'   => 'objects',
+				'limit'    => -1,
+			)
+		);
+
+		if ( ! is_array( $notifications ) ) {
+			return array();
+		}
+
+		return $notifications;
+	}
+
+	/**
+	 * Intercept a cancel POST to flip a notification to `cancelled`.
+	 *
+	 * Guards:
+	 * - Must be on the My Account > back-in-stock-notifications endpoint.
+	 * - Must be authenticated.
+	 * - Nonce must be scoped to the specific notification id ({@see ::get_cancel_nonce_action()}).
+	 * - The notification must belong to the current user.
+	 *
+	 * On any guard failure the request is silently dropped (no destructive side effects).
+	 */
+	public function maybe_handle_cancel(): void {
+		global $wp;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( ! isset( $_POST[ self::CANCEL_ACTION ] ) ) {
+			return;
+		}
+
+		if ( ! isset( $wp->query_vars[ self::ENDPOINT ] ) ) {
+			return;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
+		$notification_id = isset( $_POST['notification_id'] ) ? absint( wp_unslash( $_POST['notification_id'] ) ) : 0;
+		if ( $notification_id <= 0 ) {
+			return;
+		}
+
+		$nonce = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		if ( ! wp_verify_nonce( $nonce, self::get_cancel_nonce_action( $notification_id ) ) ) {
+			return;
+		}
+
+		$notification = Factory::get_notification( $notification_id );
+		if ( ! $notification ) {
+			return;
+		}
+
+		if ( (int) $notification->get_user_id() !== get_current_user_id() ) {
+			return;
+		}
+
+		if ( NotificationStatus::CANCELLED === $notification->get_status() ) {
+			return;
+		}
+
+		$notification->set_status( NotificationStatus::CANCELLED );
+		$notification->set_cancellation_source( NotificationCancellationSource::USER );
+		$notification->set_date_cancelled( time() );
+		$notification->save();
+
+		$product_name = $notification->get_product_name();
+		if ( '' !== $product_name ) {
+			\wc_add_notice(
+				sprintf(
+					/* translators: %s: product name */
+					esc_html__( 'Back in stock notification for "%s" cancelled.', 'woocommerce' ),
+					esc_html( $product_name )
+				)
+			);
+		} else {
+			\wc_add_notice( esc_html__( 'Back in stock notification cancelled.', 'woocommerce' ) );
+		}
+
+		wp_safe_redirect( \wc_get_endpoint_url( self::ENDPOINT, '', \wc_get_page_permalink( 'myaccount' ) ) );
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/NotificationQuery.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/NotificationQuery.php
@@ -15,6 +15,37 @@ class NotificationQuery {
 	 * @return array The notifications.
 	 */
 	public static function get_notifications( array $args ): array {
+		$result = self::run_query( $args );
+
+		return is_array( $result ) ? $result : array();
+	}
+
+	/**
+	 * Count notifications matching the given filters.
+	 *
+	 * @param array $args Same filter args as {@see self::get_notifications()}, minus
+	 *                    the `return` / `limit` / `offset` keys (those are forced to
+	 *                    `count` / no-limit).
+	 * @return int Number of matching notifications.
+	 */
+	public static function count_notifications( array $args ): int {
+		$args['return'] = 'count';
+		unset( $args['limit'], $args['offset'] );
+
+		return (int) self::run_query( $args );
+	}
+
+	/**
+	 * Single dispatch site to the underlying data store's `query()` method.
+	 *
+	 * Centralised so the `WC_Data_Store::query()` PHPStan suppression in
+	 * `phpstan-baseline.neon` only needs to cover one call site.
+	 *
+	 * @param array $args Query args.
+	 * @return mixed Whatever the data store returns for the requested `return` mode
+	 *               (array of objects/ids, int for `count`).
+	 */
+	private static function run_query( array $args ) {
 		return \WC_Data_Store::load( 'stock_notification' )->query( $args );
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/StockNotifications.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/StockNotifications.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Privacy\PrivacyEraser;
 use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailManager;
 use Automattic\WooCommerce\Internal\StockNotifications\AsyncTasks\NotificationsProcessor;
 use Automattic\WooCommerce\Internal\StockNotifications\Admin\AdminManager;
+use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoint;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\ProductPageIntegration;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\FormHandlerService;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\NotificationManagementService;
@@ -57,6 +58,7 @@ class StockNotifications {
 		$container->get( ProductPageIntegration::class );
 		$container->get( FormHandlerService::class );
 		$container->get( NotificationManagementService::class );
+		$container->get( MyAccountEndpoint::class );
 
 		if ( is_admin() ) {
 			$container->get( AdminManager::class );

--- a/plugins/woocommerce/templates/myaccount/back-in-stock-notifications.php
+++ b/plugins/woocommerce/templates/myaccount/back-in-stock-notifications.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Back in stock notifications
+ *
+ * Shows the current user's back in stock notifications on the account page.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/back-in-stock-notifications.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 10.8.0
+ *
+ * @var array $notifications Array of Notification objects for the current user.
+ * @var bool  $has_items     Whether there are any notifications to render.
+ */
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoint;
+
+defined( 'ABSPATH' ) || exit;
+
+$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
+
+/**
+ * Fires before the back in stock notifications table is rendered on My Account.
+ *
+ * @since 10.8.0
+ *
+ * @param bool $has_items Whether there are any notifications to render.
+ */
+do_action( 'woocommerce_before_account_back_in_stock_notifications', $has_items );
+
+$status_labels = array(
+	NotificationStatus::PENDING   => __( 'Pending', 'woocommerce' ),
+	NotificationStatus::ACTIVE    => __( 'Active', 'woocommerce' ),
+	NotificationStatus::SENT      => __( 'Sent', 'woocommerce' ),
+	NotificationStatus::CANCELLED => __( 'Cancelled', 'woocommerce' ),
+);
+?>
+
+<?php if ( $has_items ) : ?>
+
+	<table class="woocommerce-back-in-stock-notifications-table woocommerce-MyAccount-back-in-stock-notifications shop_table shop_table_responsive">
+		<thead>
+			<tr>
+				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-product"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
+				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-variation"><?php esc_html_e( 'Variation', 'woocommerce' ); ?></th>
+				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-status"><?php esc_html_e( 'Status', 'woocommerce' ); ?></th>
+				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-date"><?php esc_html_e( 'Date signed up', 'woocommerce' ); ?></th>
+				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-actions"><?php esc_html_e( 'Actions', 'woocommerce' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+		<?php foreach ( $notifications as $notification ) : ?>
+			<?php
+			$status       = (string) $notification->get_status();
+			$status_label = isset( $status_labels[ $status ] ) ? $status_labels[ $status ] : $status;
+			$product_name = $notification->get_product_name();
+			$permalink    = $notification->get_product_permalink();
+			$variation    = $notification->get_product_formatted_variation_list( true );
+			$date_created = $notification->get_date_created();
+			$is_cancelled = NotificationStatus::CANCELLED === $status;
+			$is_sent      = NotificationStatus::SENT === $status;
+			?>
+			<tr class="woocommerce-back-in-stock-notifications-table__row woocommerce-back-in-stock-notifications-table__row--status-<?php echo esc_attr( $status ); ?>">
+				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-product" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
+					<?php if ( '' !== $product_name && '' !== $permalink ) : ?>
+						<a href="<?php echo esc_url( $permalink ); ?>"><?php echo esc_html( $product_name ); ?></a>
+					<?php elseif ( '' !== $product_name ) : ?>
+						<?php echo esc_html( $product_name ); ?>
+					<?php else : ?>
+						<?php esc_html_e( 'Product unavailable', 'woocommerce' ); ?>
+					<?php endif; ?>
+				</td>
+				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-variation" data-title="<?php esc_attr_e( 'Variation', 'woocommerce' ); ?>">
+					<?php echo '' !== $variation ? esc_html( $variation ) : '&mdash;'; ?>
+				</td>
+				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-status" data-title="<?php esc_attr_e( 'Status', 'woocommerce' ); ?>">
+					<?php echo esc_html( $status_label ); ?>
+				</td>
+				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-date" data-title="<?php esc_attr_e( 'Date signed up', 'woocommerce' ); ?>">
+					<?php if ( $date_created ) : ?>
+						<time datetime="<?php echo esc_attr( $date_created->date( 'c' ) ); ?>"><?php echo esc_html( wc_format_datetime( $date_created ) ); ?></time>
+					<?php else : ?>
+						&mdash;
+					<?php endif; ?>
+				</td>
+				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-actions" data-title="<?php esc_attr_e( 'Actions', 'woocommerce' ); ?>">
+					<?php if ( $is_cancelled || $is_sent ) : ?>
+						<button type="button" class="woocommerce-button button<?php echo esc_attr( $wp_button_class ); ?>" disabled><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+					<?php else : ?>
+						<form method="post" action="<?php echo esc_url( wc_get_endpoint_url( MyAccountEndpoint::ENDPOINT, '', wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="woocommerce-back-in-stock-notifications-cancel-form">
+							<input type="hidden" name="<?php echo esc_attr( MyAccountEndpoint::CANCEL_ACTION ); ?>" value="1" />
+							<input type="hidden" name="notification_id" value="<?php echo esc_attr( (string) $notification->get_id() ); ?>" />
+							<?php wp_nonce_field( MyAccountEndpoint::get_cancel_nonce_action( (int) $notification->get_id() ) ); ?>
+							<button type="submit" class="woocommerce-button button<?php echo esc_attr( $wp_button_class ); ?>"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+						</form>
+					<?php endif; ?>
+				</td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+
+<?php else : ?>
+
+	<?php wc_print_notice( esc_html__( "You haven't signed up for any back-in-stock notifications yet.", 'woocommerce' ) . ' <a class="woocommerce-Button wc-forward button' . esc_attr( $wp_button_class ) . '" href="' . esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ) . '">' . esc_html__( 'Browse products', 'woocommerce' ) . '</a>', 'notice' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment ?>
+
+<?php endif; ?>
+
+<?php
+/**
+ * Fires after the back in stock notifications table is rendered on My Account.
+ *
+ * @since 10.8.0
+ *
+ * @param bool $has_items Whether there were any notifications rendered.
+ */
+do_action( 'woocommerce_after_account_back_in_stock_notifications', $has_items );

--- a/plugins/woocommerce/templates/myaccount/back-in-stock-notifications.php
+++ b/plugins/woocommerce/templates/myaccount/back-in-stock-notifications.php
@@ -14,7 +14,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.8.0
+ * @version 10.9.0
  *
  * @var array $notifications Array of Notification objects for the current user.
  * @var bool  $has_items     Whether there are any notifications to render.
@@ -35,13 +35,6 @@ $wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_
  * @param bool $has_items Whether there are any notifications to render.
  */
 do_action( 'woocommerce_before_account_back_in_stock_notifications', $has_items );
-
-$status_labels = array(
-	NotificationStatus::PENDING   => __( 'Pending', 'woocommerce' ),
-	NotificationStatus::ACTIVE    => __( 'Active', 'woocommerce' ),
-	NotificationStatus::SENT      => __( 'Sent', 'woocommerce' ),
-	NotificationStatus::CANCELLED => __( 'Cancelled', 'woocommerce' ),
-);
 ?>
 
 <?php if ( $has_items ) : ?>
@@ -51,7 +44,6 @@ $status_labels = array(
 			<tr>
 				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-product"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
 				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-variation"><?php esc_html_e( 'Variation', 'woocommerce' ); ?></th>
-				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-status"><?php esc_html_e( 'Status', 'woocommerce' ); ?></th>
 				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-date"><?php esc_html_e( 'Date signed up', 'woocommerce' ); ?></th>
 				<th scope="col" class="woocommerce-back-in-stock-notifications-table__header woocommerce-back-in-stock-notifications-table__header-actions"><?php esc_html_e( 'Actions', 'woocommerce' ); ?></th>
 			</tr>
@@ -60,7 +52,6 @@ $status_labels = array(
 		<?php foreach ( $notifications as $notification ) : ?>
 			<?php
 			$status       = (string) $notification->get_status();
-			$status_label = isset( $status_labels[ $status ] ) ? $status_labels[ $status ] : $status;
 			$product_name = $notification->get_product_name();
 			$permalink    = $notification->get_product_permalink();
 			$variation    = $notification->get_product_formatted_variation_list( true );
@@ -80,9 +71,6 @@ $status_labels = array(
 				</td>
 				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-variation" data-title="<?php esc_attr_e( 'Variation', 'woocommerce' ); ?>">
 					<?php echo '' !== $variation ? esc_html( $variation ) : '&mdash;'; ?>
-				</td>
-				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-status" data-title="<?php esc_attr_e( 'Status', 'woocommerce' ); ?>">
-					<?php echo esc_html( $status_label ); ?>
 				</td>
 				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-date" data-title="<?php esc_attr_e( 'Date signed up', 'woocommerce' ); ?>">
 					<?php if ( $date_created ) : ?>

--- a/plugins/woocommerce/templates/myaccount/back-in-stock-notifications.php
+++ b/plugins/woocommerce/templates/myaccount/back-in-stock-notifications.php
@@ -16,8 +16,12 @@
  * @package WooCommerce\Templates
  * @version 10.9.0
  *
- * @var array $notifications Array of Notification objects for the current user.
+ * @var array $notifications Array of Notification objects for the current user (one page).
  * @var bool  $has_items     Whether there are any notifications to render.
+ * @var int   $current_page  1-indexed current page number.
+ * @var int   $total_pages   Total number of pages of notifications.
+ * @var int   $total_items   Total number of notifications across all pages.
+ * @var int   $per_page      Notifications shown per page.
  */
 
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
@@ -95,6 +99,32 @@ do_action( 'woocommerce_before_account_back_in_stock_notifications', $has_items 
 		<?php endforeach; ?>
 		</tbody>
 	</table>
+
+	<?php if ( $total_pages > 1 ) : ?>
+		<?php
+		$endpoint_url = wc_get_endpoint_url( MyAccountEndpoint::ENDPOINT, '', wc_get_page_permalink( 'myaccount' ) );
+		// `format` uses %#% as the page-number placeholder; WC's pretty endpoints
+		// rewrite to `<endpoint>/<page>/`, ugly fallback uses ?<endpoint>=<page>.
+		$pretty = get_option( 'permalink_structure' );
+		$format = $pretty ? '%#%/' : '?' . MyAccountEndpoint::ENDPOINT . '=%#%';
+		$base   = $pretty ? trailingslashit( $endpoint_url ) . '%_%' : $endpoint_url . '%_%';
+		?>
+		<nav class="woocommerce-pagination woocommerce-back-in-stock-notifications-pagination" aria-label="<?php esc_attr_e( 'Back in stock notifications pagination', 'woocommerce' ); ?>">
+			<?php
+			echo paginate_links( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				array(
+					'base'      => $base,
+					'format'    => $format,
+					'current'   => $current_page,
+					'total'     => $total_pages,
+					'prev_text' => esc_html_x( '&larr; Previous', 'pagination', 'woocommerce' ),
+					'next_text' => esc_html_x( 'Next &rarr;', 'pagination', 'woocommerce' ),
+					'type'      => 'list',
+				)
+			);
+			?>
+		</nav>
+	<?php endif; ?>
 
 <?php else : ?>
 

--- a/plugins/woocommerce/templates/myaccount/back-in-stock-notifications.php
+++ b/plugins/woocommerce/templates/myaccount/back-in-stock-notifications.php
@@ -24,7 +24,6 @@
  * @var int   $per_page      Notifications shown per page.
  */
 
-use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoint;
 
 defined( 'ABSPATH' ) || exit;
@@ -55,15 +54,12 @@ do_action( 'woocommerce_before_account_back_in_stock_notifications', $has_items 
 		<tbody>
 		<?php foreach ( $notifications as $notification ) : ?>
 			<?php
-			$status       = (string) $notification->get_status();
 			$product_name = $notification->get_product_name();
 			$permalink    = $notification->get_product_permalink();
 			$variation    = $notification->get_product_formatted_variation_list( true );
 			$date_created = $notification->get_date_created();
-			$is_cancelled = NotificationStatus::CANCELLED === $status;
-			$is_sent      = NotificationStatus::SENT === $status;
 			?>
-			<tr class="woocommerce-back-in-stock-notifications-table__row woocommerce-back-in-stock-notifications-table__row--status-<?php echo esc_attr( $status ); ?>">
+			<tr class="woocommerce-back-in-stock-notifications-table__row woocommerce-back-in-stock-notifications-table__row--status-<?php echo esc_attr( (string) $notification->get_status() ); ?>">
 				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-product" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
 					<?php if ( '' !== $product_name && '' !== $permalink ) : ?>
 						<a href="<?php echo esc_url( $permalink ); ?>"><?php echo esc_html( $product_name ); ?></a>
@@ -84,16 +80,12 @@ do_action( 'woocommerce_before_account_back_in_stock_notifications', $has_items 
 					<?php endif; ?>
 				</td>
 				<td class="woocommerce-back-in-stock-notifications-table__cell woocommerce-back-in-stock-notifications-table__cell-actions" data-title="<?php esc_attr_e( 'Actions', 'woocommerce' ); ?>">
-					<?php if ( $is_cancelled || $is_sent ) : ?>
-						<button type="button" class="woocommerce-button button<?php echo esc_attr( $wp_button_class ); ?>" disabled><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-					<?php else : ?>
-						<form method="post" action="<?php echo esc_url( wc_get_endpoint_url( MyAccountEndpoint::ENDPOINT, '', wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="woocommerce-back-in-stock-notifications-cancel-form">
-							<input type="hidden" name="<?php echo esc_attr( MyAccountEndpoint::CANCEL_ACTION ); ?>" value="1" />
-							<input type="hidden" name="notification_id" value="<?php echo esc_attr( (string) $notification->get_id() ); ?>" />
-							<?php wp_nonce_field( MyAccountEndpoint::get_cancel_nonce_action( (int) $notification->get_id() ) ); ?>
-							<button type="submit" class="woocommerce-button button<?php echo esc_attr( $wp_button_class ); ?>"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-						</form>
-					<?php endif; ?>
+					<form method="post" action="<?php echo esc_url( wc_get_endpoint_url( MyAccountEndpoint::ENDPOINT, '', wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="woocommerce-back-in-stock-notifications-cancel-form">
+						<input type="hidden" name="<?php echo esc_attr( MyAccountEndpoint::CANCEL_ACTION ); ?>" value="1" />
+						<input type="hidden" name="notification_id" value="<?php echo esc_attr( (string) $notification->get_id() ); ?>" />
+						<?php wp_nonce_field( MyAccountEndpoint::get_cancel_nonce_action( (int) $notification->get_id() ) ); ?>
+						<button type="submit" class="woocommerce-button button<?php echo esc_attr( $wp_button_class ); ?>"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+					</form>
 				</td>
 			</tr>
 		<?php endforeach; ?>

--- a/plugins/woocommerce/templates/myaccount/stock-notifications.php
+++ b/plugins/woocommerce/templates/myaccount/stock-notifications.php
@@ -4,7 +4,7 @@
  *
  * Shows the current user's back in stock notifications on the account page.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/back-in-stock-notifications.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/stock-notifications.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to
@@ -101,7 +101,7 @@ do_action( 'woocommerce_before_account_back_in_stock_notifications', $has_items 
 		$format = $pretty ? '%#%/' : '?' . MyAccountEndpoint::ENDPOINT . '=%#%';
 		$base   = $pretty ? trailingslashit( $endpoint_url ) . '%_%' : $endpoint_url . '%_%';
 		?>
-		<nav class="woocommerce-pagination woocommerce-back-in-stock-notifications-pagination" aria-label="<?php esc_attr_e( 'Back in stock notifications pagination', 'woocommerce' ); ?>">
+		<nav class="woocommerce-pagination woocommerce-back-in-stock-notifications-pagination" aria-label="<?php esc_attr_e( 'Stock notifications pagination', 'woocommerce' ); ?>">
 			<?php
 			echo paginate_links( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				array(

--- a/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
@@ -78,7 +78,7 @@ test.describe(
 					await signUpOnProductPage( page );
 
 					await page.goto(
-						'my-account/back-in-stock-notifications/'
+						'my-account/stock-notifications/'
 					);
 
 					// The page renders the expected heading.
@@ -132,7 +132,7 @@ test.describe(
 					await signUpOnProductPage( page );
 
 					await page.goto(
-						'my-account/back-in-stock-notifications/'
+						'my-account/stock-notifications/'
 					);
 
 					const row = page
@@ -179,7 +179,7 @@ test.describe(
 			test( 'renders the empty state and a catalog link', async ( {
 				page,
 			} ) => {
-				await page.goto( 'my-account/back-in-stock-notifications/' );
+				await page.goto( 'my-account/stock-notifications/' );
 
 				await expect(
 					page.getByRole( 'heading', {
@@ -209,7 +209,7 @@ test.describe(
 			test.use( { storageState: { cookies: [], origins: [] } } );
 
 			test( 'is redirected to the login form', async ( { page } ) => {
-				await page.goto( 'my-account/back-in-stock-notifications/' );
+				await page.goto( 'my-account/stock-notifications/' );
 
 				// Standard WC behaviour: unauthenticated account endpoints show
 				// the login form on the My Account page.

--- a/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
@@ -133,12 +133,9 @@ test.describe(
 					allowSignups: true,
 					doubleOptIn: true,
 				} );
-				const pendingProduct = await createOutOfStockProduct(
-					restApi,
-					{
-						namePrefix: 'BIS MyAccount Cancel',
-					}
-				);
+				const pendingProduct = await createOutOfStockProduct( restApi, {
+					namePrefix: 'BIS MyAccount Cancel',
+				} );
 				try {
 					await page.goto( pendingProduct.permalink );
 					await signUpOnProductPage( page );
@@ -164,9 +161,7 @@ test.describe(
 						} )
 					).toBeVisible();
 
-					await row
-						.getByRole( 'button', { name: 'Cancel' } )
-						.click();
+					await row.getByRole( 'button', { name: 'Cancel' } ).click();
 
 					// The refresh after the POST lands us back on the same tab.
 					await expect(

--- a/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
@@ -104,25 +104,16 @@ test.describe(
 						} )
 					).toBeVisible();
 
-					// Exactly one active status cell + one pending status cell.
-					await expect(
-						table.getByRole( 'cell', {
-							name: 'Active',
-							exact: true,
-						} )
-					).toHaveCount( 1 );
-					await expect(
-						table.getByRole( 'cell', {
-							name: 'Pending',
-							exact: true,
-						} )
-					).toHaveCount( 1 );
+					// Exactly two rows — both signups are PENDING/ACTIVE so neither is filtered out.
+					await expect( table.locator( 'tbody tr' ) ).toHaveCount(
+						2
+					);
 				} finally {
 					await secondProduct.cleanup();
 				}
 			} );
 
-			test( 'cancel click on a pending notification moves it to cancelled', async ( {
+			test( 'cancel click removes the row from the My Account list', async ( {
 				page,
 				baseURL,
 				restApi,
@@ -154,12 +145,6 @@ test.describe(
 							} ),
 						} );
 					await expect( row ).toBeVisible();
-					await expect(
-						row.getByRole( 'cell', {
-							name: 'Pending',
-							exact: true,
-						} )
-					).toBeVisible();
 
 					await row.getByRole( 'button', { name: 'Cancel' } ).click();
 
@@ -170,25 +155,18 @@ test.describe(
 						} )
 					).toBeVisible();
 
-					// The row is now cancelled with a disabled Cancel button.
-					const updatedRow = page
-						.locator(
-							'.woocommerce-back-in-stock-notifications-table tbody tr'
+					// The cancelled row is filtered out — only PENDING/ACTIVE rows render.
+					await expect( row ).toHaveCount( 0 );
+
+					// And a notice confirms the cancellation.
+					await expect(
+						page.getByText(
+							new RegExp(
+								`back in stock notification.*${ pendingProduct.name }.*cancelled`,
+								'i'
+							)
 						)
-						.filter( {
-							has: page.getByRole( 'link', {
-								name: new RegExp( pendingProduct.name, 'i' ),
-							} ),
-						} );
-					await expect(
-						updatedRow.getByRole( 'cell', {
-							name: 'Cancelled',
-							exact: true,
-						} )
 					).toBeVisible();
-					await expect(
-						updatedRow.getByRole( 'button', { name: 'Cancel' } )
-					).toBeDisabled();
 				} finally {
 					await pendingProduct.cleanup();
 				}

--- a/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
@@ -84,7 +84,7 @@ test.describe(
 					// The page renders the expected heading.
 					await expect(
 						page.getByRole( 'heading', {
-							name: 'Back in stock notifications',
+							name: 'Stock notifications',
 						} )
 					).toBeVisible();
 
@@ -171,7 +171,7 @@ test.describe(
 					// The refresh after the POST lands us back on the same tab.
 					await expect(
 						page.getByRole( 'heading', {
-							name: 'Back in stock notifications',
+							name: 'Stock notifications',
 						} )
 					).toBeVisible();
 
@@ -210,7 +210,7 @@ test.describe(
 
 				await expect(
 					page.getByRole( 'heading', {
-						name: 'Back in stock notifications',
+						name: 'Stock notifications',
 					} )
 				).toBeVisible();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/back-in-stock-notifications/my-account.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * Internal dependencies
+ */
+import {
+	expect,
+	request,
+	tags,
+	test as baseTest,
+} from '../../fixtures/fixtures';
+import { CUSTOMER_STATE_PATH } from '../../playwright.config';
+import {
+	BIS_OPTIONS,
+	createOutOfStockProduct,
+	setBISOptions,
+	signUpOnProductPage,
+} from '../../utils/back-in-stock-notifications';
+import { deleteOption } from '../../utils/options';
+
+const test = baseTest.extend( {
+	product: async ( { restApi }, use ) => {
+		const product = await createOutOfStockProduct( restApi, {
+			namePrefix: 'BIS MyAccount',
+		} );
+		await use( product );
+		await product.cleanup();
+	},
+} );
+
+test.describe(
+	'Back in Stock Notifications — My Account',
+	{ tag: [ tags.SERVICES ] },
+	() => {
+		test.afterEach( async ( { baseURL } ) => {
+			for ( const option of Object.values( BIS_OPTIONS ) ) {
+				await deleteOption( request, baseURL!, option );
+			}
+		} );
+
+		test.describe( 'Logged-in customer with signups', () => {
+			test.use( { storageState: CUSTOMER_STATE_PATH } );
+
+			test.beforeEach( async ( { baseURL } ) => {
+				// Single opt-in so the signup lands as "active" immediately —
+				// gives us one active row. The second row is created with
+				// double opt-in on, so it stays "pending".
+				await setBISOptions( request, baseURL!, {
+					allowSignups: true,
+					doubleOptIn: false,
+				} );
+			} );
+
+			test( 'renders a pending and an active notification in the tab', async ( {
+				page,
+				baseURL,
+				product,
+				restApi,
+			} ) => {
+				// Row 1: signup while double opt-in is off → active.
+				await page.goto( product.permalink );
+				await signUpOnProductPage( page );
+				await expect(
+					page.getByText(
+						/You have successfully signed up|You have already joined this waitlist/i
+					)
+				).toBeVisible();
+
+				// Row 2: flip double opt-in on, create a second product, sign
+				// up again → pending.
+				await setBISOptions( request, baseURL!, {
+					allowSignups: true,
+					doubleOptIn: true,
+				} );
+				const secondProduct = await createOutOfStockProduct( restApi, {
+					namePrefix: 'BIS MyAccount Pending',
+				} );
+				try {
+					await page.goto( secondProduct.permalink );
+					await signUpOnProductPage( page );
+
+					await page.goto(
+						'my-account/back-in-stock-notifications/'
+					);
+
+					// The page renders the expected heading.
+					await expect(
+						page.getByRole( 'heading', {
+							name: 'Back in stock notifications',
+						} )
+					).toBeVisible();
+
+					// Both products appear as rows.
+					const table = page.locator(
+						'.woocommerce-back-in-stock-notifications-table'
+					);
+					await expect( table ).toBeVisible();
+					await expect(
+						table.getByRole( 'link', {
+							name: new RegExp( product.name, 'i' ),
+						} )
+					).toBeVisible();
+					await expect(
+						table.getByRole( 'link', {
+							name: new RegExp( secondProduct.name, 'i' ),
+						} )
+					).toBeVisible();
+
+					// Exactly one active status cell + one pending status cell.
+					await expect(
+						table.getByRole( 'cell', {
+							name: 'Active',
+							exact: true,
+						} )
+					).toHaveCount( 1 );
+					await expect(
+						table.getByRole( 'cell', {
+							name: 'Pending',
+							exact: true,
+						} )
+					).toHaveCount( 1 );
+				} finally {
+					await secondProduct.cleanup();
+				}
+			} );
+
+			test( 'cancel click on a pending notification moves it to cancelled', async ( {
+				page,
+				baseURL,
+				restApi,
+			} ) => {
+				// Arrange: create a product + one pending signup for the
+				// logged-in customer.
+				await setBISOptions( request, baseURL!, {
+					allowSignups: true,
+					doubleOptIn: true,
+				} );
+				const pendingProduct = await createOutOfStockProduct(
+					restApi,
+					{
+						namePrefix: 'BIS MyAccount Cancel',
+					}
+				);
+				try {
+					await page.goto( pendingProduct.permalink );
+					await signUpOnProductPage( page );
+
+					await page.goto(
+						'my-account/back-in-stock-notifications/'
+					);
+
+					const row = page
+						.locator(
+							'.woocommerce-back-in-stock-notifications-table tbody tr'
+						)
+						.filter( {
+							has: page.getByRole( 'link', {
+								name: new RegExp( pendingProduct.name, 'i' ),
+							} ),
+						} );
+					await expect( row ).toBeVisible();
+					await expect(
+						row.getByRole( 'cell', {
+							name: 'Pending',
+							exact: true,
+						} )
+					).toBeVisible();
+
+					await row
+						.getByRole( 'button', { name: 'Cancel' } )
+						.click();
+
+					// The refresh after the POST lands us back on the same tab.
+					await expect(
+						page.getByRole( 'heading', {
+							name: 'Back in stock notifications',
+						} )
+					).toBeVisible();
+
+					// The row is now cancelled with a disabled Cancel button.
+					const updatedRow = page
+						.locator(
+							'.woocommerce-back-in-stock-notifications-table tbody tr'
+						)
+						.filter( {
+							has: page.getByRole( 'link', {
+								name: new RegExp( pendingProduct.name, 'i' ),
+							} ),
+						} );
+					await expect(
+						updatedRow.getByRole( 'cell', {
+							name: 'Cancelled',
+							exact: true,
+						} )
+					).toBeVisible();
+					await expect(
+						updatedRow.getByRole( 'button', { name: 'Cancel' } )
+					).toBeDisabled();
+				} finally {
+					await pendingProduct.cleanup();
+				}
+			} );
+		} );
+
+		test.describe( 'Logged-in customer with no signups', () => {
+			test.use( { storageState: CUSTOMER_STATE_PATH } );
+
+			test( 'renders the empty state and a catalog link', async ( {
+				page,
+			} ) => {
+				await page.goto( 'my-account/back-in-stock-notifications/' );
+
+				await expect(
+					page.getByRole( 'heading', {
+						name: 'Back in stock notifications',
+					} )
+				).toBeVisible();
+
+				await expect(
+					page.getByText(
+						"You haven't signed up for any back-in-stock notifications yet."
+					)
+				).toBeVisible();
+
+				await expect(
+					page.getByRole( 'link', { name: 'Browse products' } )
+				).toBeVisible();
+
+				await expect(
+					page.locator(
+						'.woocommerce-back-in-stock-notifications-table'
+					)
+				).toHaveCount( 0 );
+			} );
+		} );
+
+		test.describe( 'Anonymous visitor', () => {
+			test.use( { storageState: { cookies: [], origins: [] } } );
+
+			test( 'is redirected to the login form', async ( { page } ) => {
+				await page.goto( 'my-account/back-in-stock-notifications/' );
+
+				// Standard WC behaviour: unauthenticated account endpoints show
+				// the login form on the My Account page.
+				await expect(
+					page.getByRole( 'heading', { name: 'Login' } )
+				).toBeVisible();
+				await expect(
+					page.getByLabel( /Username or email address/i )
+				).toBeVisible();
+			} );
+		} );
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/utils/back-in-stock-notifications.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/back-in-stock-notifications.ts
@@ -1,0 +1,269 @@
+/**
+ * External dependencies
+ */
+import type { APIRequest, Page } from '@playwright/test';
+import { WC_API_PATH, type ApiClient } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { setOption } from './options';
+import { expect } from '../fixtures/fixtures';
+
+/**
+ * Names of the Back in Stock Notifications options in core.
+ *
+ * The external plugin used `wc_bis_*` slugs; core uses these.
+ */
+export const BIS_OPTIONS = {
+	allowSignups: 'woocommerce_customer_stock_notifications_allow_signups',
+	doubleOptIn:
+		'woocommerce_customer_stock_notifications_require_double_opt_in',
+	requireAccount: 'woocommerce_customer_stock_notifications_require_account',
+	createAccountOnSignup:
+		'woocommerce_customer_stock_notifications_create_account_on_signup',
+} as const;
+
+/**
+ * Configure the BIS feature options for a test. Omitted keys are left untouched.
+ *
+ * @param {APIRequest} request                       Playwright request fixture.
+ * @param {string}     baseURL                       Test site base URL.
+ * @param {Object}     options                       BIS option toggles.
+ * @param {boolean}    [options.allowSignups]        Whether the signup form is rendered on product pages.
+ * @param {boolean}    [options.doubleOptIn]         Whether signups require email verification before activating.
+ * @param {boolean}    [options.requireAccount]      Whether signups are limited to logged-in users.
+ * @param {boolean}    [options.createAccountOnSignup] Whether a new account is created for guest signups.
+ */
+export async function setBISOptions(
+	request: APIRequest,
+	baseURL: string,
+	options: {
+		allowSignups?: boolean;
+		doubleOptIn?: boolean;
+		requireAccount?: boolean;
+		createAccountOnSignup?: boolean;
+	}
+): Promise< void > {
+	const toYesNo = ( v: boolean | undefined ): string | undefined => {
+		if ( v === undefined ) {
+			return undefined;
+		}
+		return v ? 'yes' : 'no';
+	};
+
+	const entries: Array< [ string, string | undefined ] > = [
+		[ BIS_OPTIONS.allowSignups, toYesNo( options.allowSignups ) ],
+		[ BIS_OPTIONS.doubleOptIn, toYesNo( options.doubleOptIn ) ],
+		[ BIS_OPTIONS.requireAccount, toYesNo( options.requireAccount ) ],
+		[
+			BIS_OPTIONS.createAccountOnSignup,
+			toYesNo( options.createAccountOnSignup ),
+		],
+	];
+
+	for ( const [ name, value ] of entries ) {
+		if ( value !== undefined ) {
+			await setOption( request, baseURL, name, value );
+		}
+	}
+}
+
+/**
+ * Return a handle to an out-of-stock product. Caller is responsible for calling cleanup().
+ *
+ * @param {ApiClient} restApi        WP REST client.
+ * @param {Object}    [opts]         Product shape.
+ * @param {string}    [opts.type]    Product type (`simple` or `variable`). Defaults to `simple`.
+ * @param {string}    [opts.namePrefix] Prefix used to build a unique product name.
+ */
+export async function createOutOfStockProduct(
+	restApi: ApiClient,
+	opts: {
+		type?: 'simple' | 'variable';
+		namePrefix?: string;
+	} = {}
+): Promise< {
+	id: number;
+	name: string;
+	permalink: string;
+	cleanup: () => Promise< void >;
+} > {
+	const { type = 'simple', namePrefix = 'BIS Test Product' } = opts;
+	const name = `${ namePrefix } ${ Date.now() }`;
+
+	const response = await restApi.post< {
+		id: number;
+		name: string;
+		permalink: string;
+	} >( `${ WC_API_PATH }/products`, {
+		name,
+		type,
+		regular_price: '9.99',
+		manage_stock: false,
+		stock_status: 'outofstock',
+	} );
+	const product = response.data;
+
+	return {
+		id: product.id,
+		name: product.name,
+		permalink: product.permalink,
+		async cleanup() {
+			await restApi
+				.delete( `${ WC_API_PATH }/products/${ product.id }`, {
+					force: true,
+				} )
+				.catch( () => {
+					/* best-effort cleanup */
+				} );
+		},
+	};
+}
+
+/**
+ * Restock a product via REST (used by receiving-notifications.spec.ts to trigger the stock-sync action).
+ *
+ * @param {ApiClient} restApi   WP REST client.
+ * @param {number}    productId Product id.
+ */
+export async function restockProduct(
+	restApi: ApiClient,
+	productId: number
+): Promise< void > {
+	await restApi.put( `${ WC_API_PATH }/products/${ productId }`, {
+		stock_status: 'instock',
+		manage_stock: false,
+	} );
+}
+
+/**
+ * Submit the PDP sign-up form. Caller must already have the product page loaded.
+ *
+ * @param {Page}    page                    Playwright page on the product detail.
+ * @param {Object}  [opts]                  Fill options.
+ * @param {string}  [opts.email]            Email address to enter (guest flow only; logged-in PDP hides the field).
+ * @param {boolean} [opts.tickOptInCheckbox] Tick the privacy opt-in checkbox before submitting.
+ */
+export async function signUpOnProductPage(
+	page: Page,
+	opts: {
+		email?: string;
+		tickOptInCheckbox?: boolean;
+	} = {}
+): Promise< void > {
+	if ( opts.email !== undefined ) {
+		await page
+			.getByRole( 'textbox', {
+				name: /Email address to be notified/i,
+			} )
+			.fill( opts.email );
+	}
+
+	if ( opts.tickOptInCheckbox ) {
+		await page.locator( 'input[name="wc_bis_opt_in"]' ).check();
+	}
+
+	await page.getByRole( 'button', { name: /Notify me/i } ).click();
+}
+
+/**
+ * Open an email in WP Mail Logging and extract the first href matching a regular expression from its HTML body.
+ *
+ * Use this for follow-through flows where a subsequent step needs the URL embedded in the email.
+ *
+ * @param {Page}   page                 Playwright page.
+ * @param {string} receiverEmailAddress The recipient email address.
+ * @param {RegExp} subject              The email subject (regular expression).
+ * @param {RegExp} hrefPattern          Pattern the target href should match (e.g. /email_link_action=verify/).
+ */
+export async function getLinkFromEmailBody(
+	page: Page,
+	receiverEmailAddress: string,
+	subject: RegExp,
+	hrefPattern: RegExp
+): Promise< string > {
+	await page.goto(
+		`wp-admin/tools.php?page=wpml_plugin_log&search[place]=receiver&search[term]=${ encodeURIComponent(
+			receiverEmailAddress
+		) }&orderby=timestamp&order=desc`
+	);
+
+	const row = page
+		.getByRole( 'row' )
+		.filter( {
+			has: page.getByRole( 'cell', {
+				name: receiverEmailAddress,
+				exact: true,
+			} ),
+		} )
+		.filter( { has: page.getByText( subject ) } )
+		.first();
+
+	await expect( row ).toBeVisible();
+	await row.getByRole( 'button', { name: 'View log' } ).click();
+
+	const modalContent = page.locator(
+		'#wp-mail-logging-modal-content-body-content'
+	);
+	await expect( modalContent ).toBeVisible();
+
+	const iframe = page.frameLocator(
+		'#wp-mail-logging-modal-content-body-content iframe'
+	);
+	// Wait until iframe content is attached and has anchors rendered.
+	await iframe.locator( 'a' ).first().waitFor( { state: 'attached' } );
+
+	const href = await iframe
+		.locator( 'a' )
+		.evaluateAll( ( anchors, pattern ) => {
+			const regex = new RegExp( pattern );
+			for ( const a of anchors as HTMLAnchorElement[] ) {
+				if ( regex.test( a.href ) ) {
+					return a.href;
+				}
+			}
+			return null;
+		}, hrefPattern.source );
+
+	if ( ! href ) {
+		throw new Error(
+			`No link matching ${ hrefPattern } found in email to ${ receiverEmailAddress } with subject ${ subject }`
+		);
+	}
+
+	// Close the modal for clean state.
+	await page
+		.locator(
+			'#wp-mail-logging-modal-content-header-close, .wp-mail-logging-modal-close'
+		)
+		.first()
+		.click()
+		.catch( () => {
+			/* Some wp-mail-logging versions don't surface an explicit close button — fine. */
+		} );
+
+	return href;
+}
+
+/**
+ * Run any pending Action Scheduler jobs via the process-waiting-actions mu-plugin.
+ *
+ * @param {Page} page Playwright page (can be on any URL).
+ */
+export async function triggerStockNotificationsBatch(
+	page: Page
+): Promise< void > {
+	await page.goto( '?process-waiting-actions' );
+}
+
+/**
+ * Generate a unique guest email address for a test so mail-log assertions don't collide.
+ *
+ * @param {string} prefix Short descriptor of the test.
+ */
+export function uniqueGuestEmail( prefix = 'bis' ): string {
+	return `${ prefix }-${ Date.now() }-${ Math.floor(
+		Math.random() * 1000
+	) }@example.com`;
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * MyAccountEndpointTests class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Frontend;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Factory;
+use Automattic\WooCommerce\Internal\StockNotifications\Frontend\MyAccountEndpoint;
+use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use WC_Helper_Product;
+
+/**
+ * Tests for the customer-facing MyAccount back-in-stock notifications endpoint.
+ */
+class MyAccountEndpointTests extends \WC_Unit_Test_Case {
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		\wc_clear_notices();
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tearDown(): void {
+		\wc_clear_notices();
+		\wp_set_current_user( 0 );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$_POST = array();
+		global $wp;
+		if ( isset( $wp->query_vars[ MyAccountEndpoint::ENDPOINT ] ) ) {
+			unset( $wp->query_vars[ MyAccountEndpoint::ENDPOINT ] );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Create a notification owned by the given user.
+	 *
+	 * @param int    $user_id User id.
+	 * @param string $status  Notification status.
+	 * @return Notification
+	 */
+	private function create_notification( int $user_id, string $status = NotificationStatus::ACTIVE ): Notification {
+		$user    = \get_user_by( 'id', $user_id );
+		$product = WC_Helper_Product::create_simple_product();
+
+		$notification = new Notification();
+		$notification->set_product_id( $product->get_id() );
+		$notification->set_user_id( $user_id );
+		$notification->set_user_email( $user ? $user->user_email : 'nobody@example.com' );
+		$notification->set_status( $status );
+		$notification->save();
+
+		return $notification;
+	}
+
+	/**
+	 * The endpoint returns the logged-in user's notifications.
+	 */
+	public function test_get_current_user_notifications_returns_users_notifications(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		\wp_set_current_user( $user_id );
+
+		$notification = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
+
+		$endpoint = new MyAccountEndpoint();
+		$results  = $endpoint->get_current_user_notifications();
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( $notification->get_id(), $results[0]->get_id() );
+		$this->assertSame( $user_id, (int) $results[0]->get_user_id() );
+	}
+
+	/**
+	 * User A cannot see user B's notifications via the endpoint helper.
+	 */
+	public function test_get_current_user_notifications_scopes_to_current_user(): void {
+		$user_a = $this->factory->user->create( array( 'role' => 'customer' ) );
+		$user_b = $this->factory->user->create( array( 'role' => 'customer' ) );
+
+		$this->create_notification( $user_a, NotificationStatus::ACTIVE );
+		$b_notification = $this->create_notification( $user_b, NotificationStatus::PENDING );
+
+		\wp_set_current_user( $user_b );
+		$endpoint = new MyAccountEndpoint();
+		$results  = $endpoint->get_current_user_notifications();
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( $b_notification->get_id(), $results[0]->get_id() );
+	}
+
+	/**
+	 * Anonymous visitors get an empty result set without querying by user-supplied ids.
+	 */
+	public function test_get_current_user_notifications_returns_empty_for_anonymous(): void {
+		\wp_set_current_user( 0 );
+
+		$endpoint = new MyAccountEndpoint();
+		$results  = $endpoint->get_current_user_notifications();
+
+		$this->assertSame( array(), $results );
+	}
+
+	/**
+	 * The empty state fires when the user has zero signups.
+	 */
+	public function test_get_current_user_notifications_empty_state(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		\wp_set_current_user( $user_id );
+
+		$endpoint = new MyAccountEndpoint();
+		$results  = $endpoint->get_current_user_notifications();
+
+		$this->assertSame( array(), $results );
+	}
+
+	/**
+	 * A valid nonce for the notification owner cancels the notification.
+	 */
+	public function test_cancel_with_valid_nonce_sets_status_cancelled(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		\wp_set_current_user( $user_id );
+		$notification = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
+
+		$this->simulate_cancel_request( $notification->get_id(), true );
+
+		( new MyAccountEndpoint() )->maybe_handle_cancel();
+
+		$updated = Factory::get_notification( $notification->get_id() );
+		$this->assertInstanceOf( Notification::class, $updated );
+		$this->assertSame( NotificationStatus::CANCELLED, $updated->get_status() );
+		$this->assertSame( NotificationCancellationSource::USER, $updated->get_cancellation_source() );
+	}
+
+	/**
+	 * An invalid nonce does not modify the notification.
+	 */
+	public function test_cancel_with_invalid_nonce_does_not_cancel(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		\wp_set_current_user( $user_id );
+		$notification = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
+
+		$this->simulate_cancel_request( $notification->get_id(), false );
+
+		( new MyAccountEndpoint() )->maybe_handle_cancel();
+
+		$updated = Factory::get_notification( $notification->get_id() );
+		$this->assertInstanceOf( Notification::class, $updated );
+		$this->assertSame( NotificationStatus::ACTIVE, $updated->get_status() );
+	}
+
+	/**
+	 * A nonce scoped to notification A cannot be replayed on notification B.
+	 */
+	public function test_cancel_nonce_for_other_notification_does_not_validate(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		\wp_set_current_user( $user_id );
+
+		$notification_a = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
+		$notification_b = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
+
+		// Nonce was minted against A's id, but we POST it alongside B's id.
+		$nonce = \wp_create_nonce( MyAccountEndpoint::get_cancel_nonce_action( $notification_a->get_id() ) );
+
+		$this->set_endpoint_query_var();
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.WP.GlobalVariablesOverride.Prohibited
+		$_POST = array(
+			MyAccountEndpoint::CANCEL_ACTION => '1',
+			'notification_id'                => (string) $notification_b->get_id(),
+			'_wpnonce'                       => $nonce,
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		( new MyAccountEndpoint() )->maybe_handle_cancel();
+
+		$updated_a = Factory::get_notification( $notification_a->get_id() );
+		$updated_b = Factory::get_notification( $notification_b->get_id() );
+
+		$this->assertInstanceOf( Notification::class, $updated_a );
+		$this->assertInstanceOf( Notification::class, $updated_b );
+		$this->assertSame( NotificationStatus::ACTIVE, $updated_a->get_status() );
+		$this->assertSame( NotificationStatus::ACTIVE, $updated_b->get_status() );
+	}
+
+	/**
+	 * User A cannot cancel user B's notification even when the nonce validates against B's action name
+	 * (WordPress nonces bind to the current user, so this effectively asserts the ownership check).
+	 */
+	public function test_cancel_does_not_touch_other_users_notification(): void {
+		$user_a = $this->factory->user->create( array( 'role' => 'customer' ) );
+		$user_b = $this->factory->user->create( array( 'role' => 'customer' ) );
+
+		$notification_b = $this->create_notification( $user_b, NotificationStatus::ACTIVE );
+
+		// User A logs in and tries to cancel B's notification.
+		\wp_set_current_user( $user_a );
+		$this->simulate_cancel_request( $notification_b->get_id(), true );
+
+		( new MyAccountEndpoint() )->maybe_handle_cancel();
+
+		$updated_b = Factory::get_notification( $notification_b->get_id() );
+		$this->assertInstanceOf( Notification::class, $updated_b );
+		$this->assertSame( NotificationStatus::ACTIVE, $updated_b->get_status() );
+	}
+
+	/**
+	 * An anonymous POST with a cancel payload is silently dropped.
+	 */
+	public function test_cancel_ignored_when_anonymous(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		$notification = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
+
+		\wp_set_current_user( 0 );
+		$this->simulate_cancel_request( $notification->get_id(), true );
+
+		( new MyAccountEndpoint() )->maybe_handle_cancel();
+
+		$updated = Factory::get_notification( $notification->get_id() );
+		$this->assertInstanceOf( Notification::class, $updated );
+		$this->assertSame( NotificationStatus::ACTIVE, $updated->get_status() );
+	}
+
+	/**
+	 * The menu filter adds the Back in stock notifications item.
+	 */
+	public function test_menu_item_is_registered(): void {
+		$endpoint = new MyAccountEndpoint();
+
+		$items = $endpoint->register_menu_item(
+			array(
+				'dashboard'       => 'Dashboard',
+				'orders'          => 'Orders',
+				'downloads'       => 'Downloads',
+				'customer-logout' => 'Log out',
+			),
+			array()
+		);
+
+		$this->assertArrayHasKey( MyAccountEndpoint::ENDPOINT, $items );
+		$this->assertSame( 'Back in stock notifications', $items[ MyAccountEndpoint::ENDPOINT ] );
+
+		// Order preserved: after downloads, logout stays last.
+		$keys = array_keys( $items );
+		$this->assertSame( 'customer-logout', end( $keys ) );
+		$this->assertGreaterThan(
+			(int) array_search( 'downloads', $keys, true ),
+			(int) array_search( MyAccountEndpoint::ENDPOINT, $keys, true )
+		);
+	}
+
+	/**
+	 * The query var filter registers the endpoint slug.
+	 */
+	public function test_query_var_is_registered(): void {
+		$endpoint = new MyAccountEndpoint();
+		$vars     = $endpoint->register_query_var( array( 'orders' => 'orders' ) );
+
+		$this->assertArrayHasKey( MyAccountEndpoint::ENDPOINT, $vars );
+		$this->assertSame( MyAccountEndpoint::ENDPOINT, $vars[ MyAccountEndpoint::ENDPOINT ] );
+	}
+
+	/**
+	 * Helper: fake the global state needed for `maybe_handle_cancel()` to proceed past guards.
+	 *
+	 * @param int  $notification_id Notification id.
+	 * @param bool $valid_nonce     Whether to mint a nonce that validates for this id.
+	 */
+	private function simulate_cancel_request( int $notification_id, bool $valid_nonce ): void {
+		$this->set_endpoint_query_var();
+
+		$nonce = $valid_nonce
+			? \wp_create_nonce( MyAccountEndpoint::get_cancel_nonce_action( $notification_id ) )
+			: 'clearly-not-a-valid-nonce';
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.WP.GlobalVariablesOverride.Prohibited
+		$_POST = array(
+			MyAccountEndpoint::CANCEL_ACTION => '1',
+			'notification_id'                => (string) $notification_id,
+			'_wpnonce'                       => $nonce,
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	/**
+	 * Helper: pretend we are on the My Account > BIS endpoint.
+	 */
+	private function set_endpoint_query_var(): void {
+		global $wp;
+		if ( ! $wp instanceof \WP ) {
+			$wp = new \WP(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+		$wp->query_vars[ MyAccountEndpoint::ENDPOINT ] = '';
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
@@ -149,6 +149,26 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * SENT and CANCELLED notifications are filtered out — only ACTIVE/PENDING render in the My Account view.
+	 */
+	public function test_get_current_user_notifications_page_excludes_sent_and_cancelled(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		\wp_set_current_user( $user_id );
+
+		$active    = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
+		$pending   = $this->create_notification( $user_id, NotificationStatus::PENDING );
+		$this->create_notification( $user_id, NotificationStatus::SENT );
+		$this->create_notification( $user_id, NotificationStatus::CANCELLED );
+
+		$endpoint = new MyAccountEndpoint();
+		$page     = $endpoint->get_current_user_notifications_page( 1, MyAccountEndpoint::DEFAULT_PER_PAGE );
+
+		$this->assertSame( 2, $page['total_items'] );
+		$visible_ids = array_map( static fn ( $n ) => $n->get_id(), $page['notifications'] );
+		$this->assertEqualsCanonicalizing( array( $active->get_id(), $pending->get_id() ), $visible_ids );
+	}
+
+	/**
 	 * Out-of-range page numbers clamp to the last page so a stale link doesn't render an empty table.
 	 */
 	public function test_get_current_user_notifications_page_clamps_out_of_range(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
@@ -73,7 +73,7 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 		$notification = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
 
 		$endpoint = new MyAccountEndpoint();
-		$results  = $endpoint->get_current_user_notifications();
+		$results  = $endpoint->get_current_user_notifications_page( 1, MyAccountEndpoint::DEFAULT_PER_PAGE )['notifications'];
 
 		$this->assertCount( 1, $results );
 		$this->assertSame( $notification->get_id(), $results[0]->get_id() );
@@ -92,7 +92,7 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 
 		\wp_set_current_user( $user_b );
 		$endpoint = new MyAccountEndpoint();
-		$results  = $endpoint->get_current_user_notifications();
+		$results  = $endpoint->get_current_user_notifications_page( 1, MyAccountEndpoint::DEFAULT_PER_PAGE )['notifications'];
 
 		$this->assertCount( 1, $results );
 		$this->assertSame( $b_notification->get_id(), $results[0]->get_id() );
@@ -105,7 +105,7 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 		\wp_set_current_user( 0 );
 
 		$endpoint = new MyAccountEndpoint();
-		$results  = $endpoint->get_current_user_notifications();
+		$results  = $endpoint->get_current_user_notifications_page( 1, MyAccountEndpoint::DEFAULT_PER_PAGE )['notifications'];
 
 		$this->assertSame( array(), $results );
 	}
@@ -118,9 +118,53 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 		\wp_set_current_user( $user_id );
 
 		$endpoint = new MyAccountEndpoint();
-		$results  = $endpoint->get_current_user_notifications();
+		$results  = $endpoint->get_current_user_notifications_page( 1, MyAccountEndpoint::DEFAULT_PER_PAGE )['notifications'];
 
 		$this->assertSame( array(), $results );
+	}
+
+	/**
+	 * Page size is honoured and total counts reflect the full set, not just the page.
+	 */
+	public function test_get_current_user_notifications_page_paginates(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		\wp_set_current_user( $user_id );
+
+		// 7 notifications, fetch page 2 with per_page=3 → expect rows 4-6.
+		$created = array();
+		for ( $i = 0; $i < 7; $i++ ) {
+			$created[] = $this->create_notification( $user_id, NotificationStatus::ACTIVE );
+		}
+		// `id` DESC ordering — newest-first — so page 1 = ids[6..4], page 2 = ids[3..1], page 3 = id[0].
+		$ids_desc = array_reverse( array_map( static fn ( $n ) => $n->get_id(), $created ) );
+
+		$endpoint = new MyAccountEndpoint();
+		$page     = $endpoint->get_current_user_notifications_page( 2, 3 );
+
+		$this->assertSame( 7, $page['total_items'] );
+		$this->assertSame( 3, $page['total_pages'] );
+		$this->assertSame( 2, $page['current_page'] );
+		$this->assertCount( 3, $page['notifications'] );
+		$this->assertSame( array_slice( $ids_desc, 3, 3 ), array_map( static fn ( $n ) => $n->get_id(), $page['notifications'] ) );
+	}
+
+	/**
+	 * Out-of-range page numbers clamp to the last page so a stale link doesn't render an empty table.
+	 */
+	public function test_get_current_user_notifications_page_clamps_out_of_range(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		\wp_set_current_user( $user_id );
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->create_notification( $user_id, NotificationStatus::ACTIVE );
+		}
+
+		$endpoint = new MyAccountEndpoint();
+		// Per-page 2 → 3 pages exist (rows 1-2, 3-4, 5). Asking for page 99 should clamp to 3.
+		$page     = $endpoint->get_current_user_notifications_page( 99, 2 );
+
+		$this->assertSame( 3, $page['current_page'] );
+		$this->assertCount( 1, $page['notifications'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php
@@ -230,7 +230,7 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * The menu filter adds the Back in stock notifications item.
+	 * The menu filter adds the Stock notifications item.
 	 */
 	public function test_menu_item_is_registered(): void {
 		$endpoint = new MyAccountEndpoint();
@@ -246,7 +246,7 @@ class MyAccountEndpointTests extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertArrayHasKey( MyAccountEndpoint::ENDPOINT, $items );
-		$this->assertSame( 'Back in stock notifications', $items[ MyAccountEndpoint::ENDPOINT ] );
+		$this->assertSame( 'Stock notifications', $items[ MyAccountEndpoint::ENDPOINT ] );
 
 		// Order preserved: after downloads, logout stays last.
 		$keys = array_keys( $items );


### PR DESCRIPTION
> Stacked on #64490 (BIS feature toggle). Will rebase onto trunk once that lands.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes [RSM-444](https://linear.app/a8c/issue/RSM-444).

Adds a **Back in stock notifications** tab to WC → My Account so signed-in customers can see and manage their own back-in-stock signups without an admin needing to step in. Registered as a normal WC My Account endpoint via:

- `woocommerce_get_query_vars` — adds the `back-in-stock-notifications` rewrite endpoint.
- `woocommerce_account_menu_items` — inserts the menu item above "Log out".
- `woocommerce_account_back-in-stock-notifications_endpoint` — renders the table from `templates/myaccount/back-in-stock-notifications.php`.

The whole `MyAccountEndpoint` is instantiated from `StockNotifications::init_hooks()`, which is gated by the new `customer_stock_notifications` feature toggle from #64490, so the endpoint and menu item stay hidden whenever the feature is off.

**Security model:**

- Notifications are fetched via `NotificationQuery::get_notifications()` scoped to `get_current_user_id()` — never by client-supplied ids.
- The per-row Cancel action posts a per-notification nonce. Ownership is re-checked on submit so a cancel POST with someone else's notification id (even with a valid nonce for a different one) is silently dropped.
- Anonymous POSTs to the endpoint are silently dropped.

**UI:**

- Table columns: Product · Variation · Date signed up · Actions. The Cancel button is disabled for `sent` / `cancelled` rows and active for `active` / `pending`.
- Empty state: copy + "Browse products" button to the shop page.

The Status column was dropped on iteration — status is implicit from the Cancel-button state (disabled = sent/cancelled, active = active/pending), so the dedicated column was visual noise. The underlying `$status` is still computed because Cancel-button gating and the row's `--status-<value>` CSS hook depend on it. (See the second commit in this PR for the diff.)

### How to test the changes in this Pull Request:

1. `cd plugins/woocommerce && WP_ENV_TESTS_PORT=8899 pnpm env:start --update`. Open wp-admin.
2. Enable the BIS feature: WC → Settings → Advanced → Features → tick **Back in Stock Notifications** → Save.
3. Flush rewrites: `wp rewrite flush` (the new endpoint needs the rewrite rule).
4. Sign up for a couple of out-of-stock products as a logged-in customer (or seed via the BIS admin: WC → Back in Stock → Add new).
5. Visit `/my-account/`. Expected: a new "Back in stock notifications" item in the sidebar, above Log out.
6. Click it. Expected: a table of your signups. Cancel button works for active/pending rows, disabled for sent/cancelled.
7. Toggle the BIS feature OFF in Settings. Reload `/my-account/`. Expected: menu item gone, `/my-account/back-in-stock-notifications/` 404s.

### Testing that has already taken place:

- PHPUnit coverage in `tests/php/src/Internal/StockNotifications/Frontend/MyAccountEndpointTests.php` covers: scoped fetch, A-can't-see-B, anon empty, empty state, cancel-with-valid-nonce, cancel-with-invalid-nonce, cross-notification nonce replay, ownership-blocks-cross-user-cancel, anon-cancel-no-op, menu filter, query-var filter.
- Playwright coverage in `tests/e2e-pw/...`.
- Manual verification on burrito (block theme + Local) — endpoint renders, cancel works, menu item gates with the feature toggle.

### Outstanding (not blocking review)

- 8 PHPStan errors in `MyAccountEndpoint.php` (`is_array()` redundancy + missing `Notification|true` type narrowing on `Factory::get_notification()` returns). Will fix in a follow-up commit on this branch before un-drafting.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

To add — needs `pnpm --filter=@woocommerce/plugin-woocommerce changelog add` (`Minor`/`Add`).

</details>