### PR TITLE
Skip BIS double opt-in flow for logged-in customers

### DIFF
--- a/plugins/woocommerce/changelog/bis-skip-double-opt-in-for-logged-in-users
+++ b/plugins/woocommerce/changelog/bis-skip-double-opt-in-for-logged-in-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Skip the Back in Stock Notifications double opt-in flow for logged-in customers — they go straight to ACTIVE regardless of the site-wide require_double_opt_in setting. Anonymous signups still go through the verify-email flow as before.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
@@ -120,7 +120,7 @@ class SignupService {
 			}
 
 			if ( NotificationStatus::PENDING === $notification->get_status() ) {
-				if ( Config::requires_double_opt_in() ) {
+				if ( $this->should_require_double_opt_in( $user_id ) ) {
 					return new SignupResult( self::SIGNUP_ALREADY_JOINED_DOUBLE_OPT_IN, $notification );
 				}
 
@@ -146,6 +146,8 @@ class SignupService {
 			$user_id         = $account_created ? $account_created : $user_id;
 		}
 
+		$requires_double_opt_in = $this->should_require_double_opt_in( $user_id );
+
 		$notification = new Notification();
 		$notification->set_status( NotificationStatus::ACTIVE );
 		$notification->set_product_id( $product_id );
@@ -156,7 +158,7 @@ class SignupService {
 			$notification->update_meta_data( 'posted_attributes', $posted_attributes );
 		}
 
-		if ( Config::requires_double_opt_in() ) {
+		if ( $requires_double_opt_in ) {
 			$notification->set_status( NotificationStatus::PENDING );
 		}
 
@@ -174,12 +176,12 @@ class SignupService {
 		 */
 		do_action( 'woocommerce_customer_stock_notifications_signup', $notification );
 
-		if ( Config::requires_double_opt_in() && NotificationStatus::PENDING === $notification->get_status() ) {
+		if ( $requires_double_opt_in && NotificationStatus::PENDING === $notification->get_status() ) {
 			$this->email_manager->send_verify_email( $notification );
 		}
 
 		$signup_code = self::SIGNUP_SUCCESS;
-		if ( Config::requires_double_opt_in() ) {
+		if ( $requires_double_opt_in ) {
 			$signup_code = $account_created
 				? self::SIGNUP_SUCCESS_ACCOUNT_CREATED_DOUBLE_OPT_IN
 				: self::SIGNUP_SUCCESS_DOUBLE_OPT_IN;
@@ -187,6 +189,35 @@ class SignupService {
 			$signup_code = self::SIGNUP_SUCCESS_ACCOUNT_CREATED;
 		}
 		return new SignupResult( $signup_code, $notification );
+	}
+
+	/**
+	 * Whether the signup should go through the double opt-in flow.
+	 *
+	 * Logged-in users are treated as already-verified — they confirmed their
+	 * email at account registration and the signup form pulls the email from
+	 * their profile (no chance to enter someone else's). Asking them to
+	 * verify again per stock-notification signup is friction without a
+	 * security benefit. The site-wide `requires_double_opt_in()` setting
+	 * still governs anonymous signups.
+	 *
+	 * @param int $user_id The signing-up user id (0 for anonymous).
+	 * @return bool
+	 */
+	private function should_require_double_opt_in( int $user_id ): bool {
+		$required = Config::requires_double_opt_in() && empty( $user_id );
+
+		/**
+		 * Filter whether to require double opt-in for a stock-notification signup.
+		 *
+		 * Default: site-wide `requires_double_opt_in()` setting AND signup is anonymous.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param bool $required Whether to require double opt-in for this signup.
+		 * @param int  $user_id  The signing-up user id (0 for anonymous).
+		 */
+		return (bool) apply_filters( 'woocommerce_customer_stock_notifications_signup_requires_double_opt_in', $required, $user_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/SignupService.php
@@ -194,28 +194,45 @@ class SignupService {
 	/**
 	 * Whether the signup should go through the double opt-in flow.
 	 *
-	 * Logged-in users are treated as already-verified — they confirmed their
-	 * email at account registration and the signup form pulls the email from
-	 * their profile (no chance to enter someone else's). Asking them to
-	 * verify again per stock-notification signup is friction without a
-	 * security benefit. The site-wide `requires_double_opt_in()` setting
-	 * still governs anonymous signups.
+	 * Logged-in WordPress users are treated as already-verified — they
+	 * demonstrated email control at account registration (or password reset)
+	 * and the signup form pulls the email from their profile, with no chance
+	 * to type someone else's. Asking them to re-verify per stock-notification
+	 * signup is friction without a security benefit. The site-wide
+	 * `requires_double_opt_in()` setting still governs anonymous signups.
 	 *
-	 * @param int $user_id The signing-up user id (0 for anonymous).
+	 * Note: this checks `is_user_logged_in()`, not the `$user_id` argument
+	 * passed to {@see self::signup()}. The two diverge in two cases that
+	 * matter here:
+	 * - Anonymous signups with `Config::creates_account_on_signup()` enabled
+	 *   resolve a non-zero `$user_id` mid-flow via `create_customer()`. That
+	 *   freshly-minted account has done zero email verification, so it must
+	 *   still go through double opt-in.
+	 * - Programmatic (e.g. cron) callers may pass an arbitrary `$user_id`
+	 *   without an authenticated session. Those callers haven't proved
+	 *   anything about the email's owner either.
+	 *
+	 * @param int $user_id The signing-up user id (0 for anonymous). Passed through
+	 *                     to the filter for context; not used in the default policy.
 	 * @return bool
 	 */
 	private function should_require_double_opt_in( int $user_id ): bool {
-		$required = Config::requires_double_opt_in() && empty( $user_id );
+		$required = Config::requires_double_opt_in() && ! is_user_logged_in();
 
 		/**
 		 * Filter whether to require double opt-in for a stock-notification signup.
 		 *
-		 * Default: site-wide `requires_double_opt_in()` setting AND signup is anonymous.
+		 * Default: site-wide `requires_double_opt_in()` setting AND the request is
+		 * not from a logged-in WP user (i.e. `is_user_logged_in()` returns false).
 		 *
 		 * @since 10.9.0
 		 *
 		 * @param bool $required Whether to require double opt-in for this signup.
-		 * @param int  $user_id  The signing-up user id (0 for anonymous).
+		 * @param int  $user_id  The signing-up user id (0 for anonymous). May be
+		 *                       non-zero even when not logged in (e.g. account-
+		 *                       on-signup or cron callers); the default policy
+		 *                       intentionally ignores this and uses the auth
+		 *                       context instead.
 		 */
 		return (bool) apply_filters( 'woocommerce_customer_stock_notifications_signup_requires_double_opt_in', $required, $user_id );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -106,7 +106,7 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should NOT send the verify email when the signup is from a logged-in user, even with double opt-in enabled site-wide.
+	 * @testdox Should NOT send the verify email when the signup is from an authenticated user session, even with double opt-in enabled site-wide.
 	 */
 	public function test_verify_email_not_sent_for_logged_in_user_even_when_double_opt_in_required() {
 		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'yes' );
@@ -118,6 +118,9 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 				'user_email' => 'logged-in@example.com',
 			)
 		);
+		// Establish the auth context — `should_require_double_opt_in()` reads
+		// `is_user_logged_in()`, not the `$user_id` arg.
+		wp_set_current_user( $user_id );
 
 		$this->email_manager
 			->expects( $this->never() )
@@ -130,6 +133,40 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 		$notification = $result->get_notification();
 		$this->assertInstanceOf( Notification::class, $notification );
 		$this->assertSame( NotificationStatus::ACTIVE, $notification->get_status() );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * @testdox Should still send the verify email for an anonymous account-on-signup flow even though `$user_id` becomes non-zero mid-flow.
+	 *
+	 * Regression guard for the auth-context check: `Config::creates_account_on_signup()`
+	 * mints a user mid-flow, leaving `$user_id > 0` by the time the double-opt-in
+	 * decision is made — but the request is still anonymous (`is_user_logged_in()`
+	 * is false), so the signup must still go through the verify-email round-trip.
+	 */
+	public function test_verify_email_still_sent_for_account_on_signup_anonymous_flow() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'yes' );
+		update_option( 'woocommerce_customer_stock_notifications_create_account_on_signup', 'yes' );
+
+		$product = $this->create_out_of_stock_product();
+
+		$this->email_manager
+			->expects( $this->once() )
+			->method( 'send_verify_email' )
+			->with(
+				$this->callback(
+					static function ( $arg ) {
+						return $arg instanceof Notification
+							&& NotificationStatus::PENDING === $arg->get_status();
+					}
+				)
+			);
+
+		// Anonymous: no auth context, no $user_id passed in.
+		$this->sut->signup( $product->get_id(), 0, 'fresh-account@example.com' );
+
+		delete_option( 'woocommerce_customer_stock_notifications_create_account_on_signup' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -106,6 +106,28 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should NOT send the verify email when the signup is from a logged-in user, even with double opt-in enabled site-wide.
+	 */
+	public function test_verify_email_not_sent_for_logged_in_user_even_when_double_opt_in_required() {
+		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'yes' );
+
+		$product = $this->create_out_of_stock_product();
+		$user_id = $this->factory->user->create( array( 'role' => 'customer', 'user_email' => 'logged-in@example.com' ) );
+
+		$this->email_manager
+			->expects( $this->never() )
+			->method( 'send_verify_email' );
+
+		$result = $this->sut->signup( $product->get_id(), $user_id, 'logged-in@example.com' );
+
+		$this->assertInstanceOf( \Automattic\WooCommerce\Internal\StockNotifications\Frontend\SignupResult::class, $result );
+		$this->assertSame( \Automattic\WooCommerce\Internal\StockNotifications\Frontend\SignupService::SIGNUP_SUCCESS, $result->get_code() );
+		$notification = $result->get_notification();
+		$this->assertInstanceOf( Notification::class, $notification );
+		$this->assertSame( NotificationStatus::ACTIVE, $notification->get_status() );
+	}
+
+	/**
 	 * Create an out-of-stock simple product for signup.
 	 *
 	 * @return \WC_Product_Simple

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Frontend/SignupServiceTests.php
@@ -112,7 +112,12 @@ class SignupServiceTests extends \WC_Unit_Test_Case {
 		update_option( 'woocommerce_customer_stock_notifications_require_double_opt_in', 'yes' );
 
 		$product = $this->create_out_of_stock_product();
-		$user_id = $this->factory->user->create( array( 'role' => 'customer', 'user_email' => 'logged-in@example.com' ) );
+		$user_id = $this->factory->user->create(
+			array(
+				'role'       => 'customer',
+				'user_email' => 'logged-in@example.com',
+			)
+		);
 
 		$this->email_manager
 			->expects( $this->never() )


### PR DESCRIPTION
> **Proposal — looking for a confidence check on the policy.** Pulled out of #64510 (My Account stock-notifications tab) so the discussion isn't entangled with the UI work.
>
> /cc @xristos3490 — would value your read here, especially the threat-model section.

### What:

Logged-in customers go straight to `ACTIVE` on a Back in Stock signup, regardless of the site-wide `Config::requires_double_opt_in()` setting. Anonymous signups continue to honor the setting and receive the verify-email round-trip.

The change funnels all four `Config::requires_double_opt_in()` checks in `SignupService::signup()` through one helper:

```php
private function should_require_double_opt_in( int $user_id ): bool {
    $required = Config::requires_double_opt_in() && empty( $user_id );

    return (bool) apply_filters(
        'woocommerce_customer_stock_notifications_signup_requires_double_opt_in',
        $required,
        $user_id
    );
}
```

A new filter — `woocommerce_customer_stock_notifications_signup_requires_double_opt_in` — lets merchants force the strict behavior back if they want.

### Why:

The double opt-in flow exists to prove the email-address-typer controls the inbox. For a logged-in WP user that's *usually* already true:

- The BIS form doesn't show an email field for logged-in users — it's pulled from their profile, so there's no chance to type someone else's address.
- Self-registered customers via WC's "Send password setup link" flow had to receive that link to first log in → implicit verification.
- WC checkout-created accounts use the same password-by-email flow → same implicit verification.

So in the common case the double opt-in is redundant friction.

### Threat model — where this gets shaky:

WordPress doesn't *enforce* email verification at registration. Cases where a logged-in user might NOT have a verified email:

- Admin-created accounts (admin sets the password directly without an email round-trip).
- Plugins that bypass WC's password-setup-link flow.
- Email changes via My Account → Account details (no re-verification).

In those cases, a logged-in user could opt their account email into BIS for products without the email owner having proved control.

**Worst case impact**: their inbox gets one BIS email per restock until they click unsubscribe. Low-impact spam, bounded by the unsubscribe link in every email. Compared to other emails an account can already trigger (welcome, password reset, order receipts), the marginal risk is small.

The judgment call: is the friction reduction worth the marginal risk? My read is yes for an alpha — easy to walk back, and merchants paranoid about deliverability can flip the filter. Open to being wrong.

### Alternatives I considered and rejected:

- **Add a setting "skip double opt-in for logged-in users" defaulting to off**. Most flexible but requires merchants to opt in to the better UX. The friction is exactly the thing this PR is trying to remove, so a default-off setting doesn't really help.
- **Only skip for users who are also `current_user_can( 'edit_posts' )` or have placed an order**. Tries to use other proxies for "real customer", but feels like overengineering — and a spammer who can log in already has the email-derived access.
- **Drop the change**. Status quo, every signup through the verification round-trip. Safe, but reverses Chris's earlier concern about consistency / lifecycle alignment that landed in #64348.

### How to test the changes in this Pull Request:

1. Enable the BIS feature: WC → Settings → Advanced → Features → tick **Back in Stock Notifications** → Save (this PR is independent of #64490 but you'll want the feature on to test).
2. Turn double opt-in **on**: WC → Settings → Products → Stock notifications → "Require double opt-in" → Save.
3. As a **logged-in customer**, sign up for an out-of-stock product. Expected: success notice ("You have successfully signed up..."), no verify-email screen, no verify email received.
4. Log out. As an **anonymous visitor**, sign up for the same (or another OOS) product. Expected: "Please check your email" notice and a verify email arrives. Behavior unchanged from trunk.
5. Run the new PHPUnit test: `pnpm test:php:env -- --filter test_verify_email_not_sent_for_logged_in_user_even_when_double_opt_in_required`.

### Testing that has already taken place:

- New PHPUnit test asserts no verify email is sent for a logged-in signup with double opt-in on, and the resulting notification lands as `ACTIVE`.
- Existing tests (`test_verify_email_sent_when_double_opt_in_required`, `test_verify_email_not_sent_when_double_opt_in_disabled`) still pass — both use `user_id = 0` (anonymous) so they're unaffected.
- PHPStan clean on `SignupService.php` (PHP 8.2).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually and is already committed in this PR: `plugins/woocommerce/changelog/bis-skip-double-opt-in-for-logged-in-users` (Minor/Tweak).

</details>
