### PR TITLE
Fix: Use DOM to set aria-label on tooltip span instead of template literal interpolation

### DIFF
--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1429,9 +1429,8 @@ jQuery( function ( $ ) {
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );
-	const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${
-		woocommerce_admin_meta_boxes.i18n_product_image_tip
-	}"></span>`;
+	const tooltipMarkup = $( '<span class="woocommerce-help-tip" tabindex="0"></span>' )
+		.attr( 'aria-label', woocommerce_admin_meta_boxes.i18n_product_image_tip );
 	const tooltipData = {
 		attribute: 'data-tip',
 		content: woocommerce_admin_meta_boxes.i18n_product_image_tip,


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

In `plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js`, the tooltip span for the product image meta box was built by interpolating a translated string directly into an HTML template literal:

```js
const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${
    woocommerce_admin_meta_boxes.i18n_product_image_tip
}"></span>`;
```

If the translation for `i18n_product_image_tip` contains a double-quote (`"`) or HTML markup, the generated span would be broken/malformed, breaking the tooltip and creating an accessibility issue.

This PR changes the approach to use jQuery `$(...).attr()` instead, which properly escapes attribute values via the DOM API:

```js
const tooltipMarkup = $( '<span class="woocommerce-help-tip" tabindex="0"></span>' )
    .attr( 'aria-label', woocommerce_admin_meta_boxes.i18n_product_image_tip );
```

Closes #64282.

(For Bug Fixes) Bug introduced in PR #64251.

### Screenshots or screen recordings:

N/A — No visual changes. The tooltip behavior remains identical; only the attribute-setting mechanism changed.

### How to test the changes in this Pull Request:

1. Set up a local WooCommerce development environment (`pnpm install && pnpm --filter='@woocommerce/plugin-woocommerce' build`).
2. Go to **WP Admin → Products → Add New** (or edit an existing product).
3. Verify the tooltip appears on hover next to the "Set product image" link and the "Add product gallery images" link.
4. Verify the tooltip content matches the expected help text.
5. Inspect the tooltip span element in DevTools and confirm the `aria-label` attribute is properly set.
6. Optional: To test the XSS vector, temporarily set `i18n_product_image_tip` to a string containing double quotes (e.g., `This is a "test" tip`) and confirm the tooltip still renders correctly without broken HTML.

### Testing that has already taken place:

- ESLint passed with no errors on the modified file
- All 125 existing JS unit tests in `@woocommerce/classic-assets` pass
- Manual code review confirms the change is functionally equivalent — jQuery `$(markup)` creates the element, `.attr()` sets the attribute safely via the DOM

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**