### PR TITLE
Fix: Use order item data for prices in Store API order item response

### DIFF
--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -78,7 +78,6 @@ class OrderItemSchema extends ItemSchema {
 			$product_properties['sku']                = $product->get_sku();
 			$product_properties['permalink']          = $product->get_permalink();
 			$product_properties['catalog_visibility'] = $product->get_catalog_visibility();
-			$product_properties['prices']             = $this->prepare_order_item_price_response( $order_item, $product, get_option( 'woocommerce_tax_display_cart' ) );
 			$product_properties['sold_individually']  = $product->is_sold_individually();
 			$product_properties['images']             = $this->get_images( $product );
 
@@ -88,6 +87,10 @@ class OrderItemSchema extends ItemSchema {
 				$product_properties['variation'] = $this->get_variation_data_from_order_item( $order_item, $product );
 			}
 		}
+
+		// Always compute prices from order item data so historical order prices
+		// remain accurate even when the product is deleted or its price changes.
+		$product_properties['prices'] = $this->prepare_order_item_price_response( $order_item, get_option( 'woocommerce_tax_display_cart' ) );
 
 		return [
 			'key'                  => $order->get_order_key(),
@@ -122,14 +125,16 @@ class OrderItemSchema extends ItemSchema {
 	 * instead of the product's current live prices.
 	 *
 	 * This ensures that historical order data is not affected by subsequent
-	 * price changes (e.g., sales) on the product.
+	 * price changes (e.g., sales) on the product, and that prices are still
+	 * available even when the product has been deleted.
 	 *
 	 * @param \WC_Order_Item_Product $order_item      Order item instance.
-	 * @param \WC_Product            $product         Product instance.
 	 * @param string                 $tax_display_mode If returned prices are incl or excl of tax.
 	 * @return array
+	 *
+	 * @since 10.9.0
 	 */
-	protected function prepare_order_item_price_response( \WC_Order_Item_Product $order_item, \WC_Product $product, $tax_display_mode = '' ) {
+	protected function prepare_order_item_price_response( \WC_Order_Item_Product $order_item, $tax_display_mode = '' ) {
 		$tax_display_mode = $this->get_tax_display_mode( $tax_display_mode );
 		$price_decimals   = wc_get_price_decimals();
 		$quantity         = $order_item->get_quantity();

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -78,7 +78,7 @@ class OrderItemSchema extends ItemSchema {
 			$product_properties['sku']                = $product->get_sku();
 			$product_properties['permalink']          = $product->get_permalink();
 			$product_properties['catalog_visibility'] = $product->get_catalog_visibility();
-			$product_properties['prices']             = $this->prepare_product_price_response( $product, get_option( 'woocommerce_tax_display_cart' ) );
+			$product_properties['prices']             = $this->prepare_order_item_price_response( $order_item, $product, get_option( 'woocommerce_tax_display_cart' ) );
 			$product_properties['sold_individually']  = $product->is_sold_individually();
 			$product_properties['images']             = $this->get_images( $product );
 
@@ -115,6 +115,56 @@ class OrderItemSchema extends ItemSchema {
 			'totals'               => (object) $this->prepare_currency_response( $this->get_totals( $order_item ) ),
 			'catalog_visibility'   => $product_properties['catalog_visibility'],
 		];
+	}
+
+	/**
+	 * Get an array of pricing data derived from the order item's stored prices
+	 * instead of the product's current live prices.
+	 *
+	 * This ensures that historical order data is not affected by subsequent
+	 * price changes (e.g., sales) on the product.
+	 *
+	 * @param \WC_Order_Item_Product $order_item      Order item instance.
+	 * @param \WC_Product            $product         Product instance.
+	 * @param string                 $tax_display_mode If returned prices are incl or excl of tax.
+	 * @return array
+	 */
+	protected function prepare_order_item_price_response( \WC_Order_Item_Product $order_item, \WC_Product $product, $tax_display_mode = '' ) {
+		$tax_display_mode = $this->get_tax_display_mode( $tax_display_mode );
+		$price_decimals   = wc_get_price_decimals();
+		$quantity         = $order_item->get_quantity();
+
+		// Calculate per-unit price from order item stored data.
+		$line_subtotal     = (float) $order_item->get_subtotal();
+		$line_subtotal_tax = (float) $order_item->get_subtotal_tax();
+
+		$unit_price_excl_tax = $quantity > 0 ? $line_subtotal / $quantity : 0;
+		$unit_price_incl_tax = $quantity > 0 ? ( $line_subtotal + $line_subtotal_tax ) / $quantity : 0;
+
+
+		$unit_price      = 'incl' === $tax_display_mode ? $unit_price_incl_tax : $unit_price_excl_tax;
+
+		// Use order item's unit price for all price fields to maintain consistency
+		// with historical order data.
+		$prices = array(
+			'price'         => $this->prepare_money_response( $unit_price, $price_decimals ),
+			'regular_price' => $this->prepare_money_response( $unit_price, $price_decimals ),
+			'sale_price'    => $this->prepare_money_response( $unit_price, $price_decimals ),
+			'price_range'   => null,
+		);
+
+		$prices = $this->prepare_currency_response( $prices );
+
+		// Add raw prices with higher precision.
+		$rounding_precision = wc_get_rounding_precision();
+		$prices['raw_prices'] = array(
+			'precision'     => $rounding_precision,
+			'price'         => $this->prepare_money_response( $unit_price, $rounding_precision ),
+			'regular_price' => $this->prepare_money_response( $unit_price, $rounding_precision ),
+			'sale_price'    => $this->prepare_money_response( $unit_price, $rounding_precision ),
+		);
+
+		return $prices;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
@@ -417,4 +417,63 @@ class OrderItemSchemaTest extends TestCase {
 		$order->delete( true );
 		$variable_product->delete( true );
 	}
+
+	/**
+	 * Test that prices reflect order item data, not current product prices.
+	 *
+	 * When a product goes on sale after an order was placed, the order item
+	 * prices should still reflect the original price paid at the time of purchase.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/53326
+	 */
+	public function test_get_item_response_prices_use_order_data_not_current_product_price(): void {
+		// Arrange - Create a product at $20.
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '20.00' );
+		$product->set_sale_price( '' );
+		$product->set_price( '20.00' );
+		$product->save();
+
+		// Create an order with this product at $20.
+		$order = new \WC_Order();
+		$order->add_product( $product, 2 );
+		$order->save();
+
+		$items = $order->get_items();
+		$item  = reset( $items );
+
+		// Verify the order item was created with the correct price.
+		$this->assertEquals( '40.00', $item->get_subtotal() ); // 2 x $20
+
+		// Act part 1 - Get item response BEFORE price change.
+		$result_before = $this->sut->get_item_response( $item );
+
+		// Now put the product on sale for $10.
+		$product->set_sale_price( '10.00' );
+		$product->set_price( '10.00' );
+		$product->save();
+
+		// Reload the item to get fresh data.
+		$item_after_sale = new \WC_Order_Item_Product( $item->get_id() );
+
+		// Act part 2 - Get item response AFTER price change.
+		$result_after = $this->sut->get_item_response( $item_after_sale );
+
+		// Assert - prices should be the SAME before and after the sale.
+		$prices_before = (array) $result_before['prices'];
+		$prices_after  = (array) $result_after['prices'];
+
+		// The per-unit price should be $20 (from order data), not $10 (current sale price).
+		$this->assertEquals( $prices_before['price'], $prices_after['price'], 'Price should not change when product goes on sale' );
+		$this->assertEquals( $prices_before['regular_price'], $prices_after['regular_price'], 'Regular price should not change when product goes on sale' );
+		$this->assertEquals( $prices_before['sale_price'], $prices_after['sale_price'], 'Sale price field should not change when product goes on sale' );
+
+		// The totals should also reflect the original $20/unit price.
+		$totals = (array) $result_after['totals'];
+		$this->assertEquals( '40.00', $totals['line_subtotal'], 'Line subtotal should be 40.00 (2 x $20)' );
+
+		// Cleanup.
+		$order->delete( true );
+		$product->delete( true );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
@@ -463,14 +463,23 @@ class OrderItemSchemaTest extends TestCase {
 		$prices_before = (array) $result_before['prices'];
 		$prices_after  = (array) $result_after['prices'];
 
+		// Verify price keys exist.
+		$this->assertArrayHasKey( 'price', $prices_after );
+		$this->assertArrayHasKey( 'regular_price', $prices_after );
+		$this->assertArrayHasKey( 'sale_price', $prices_after );
+
 		// The per-unit price should be $20 (from order data), not $10 (current sale price).
+		$this->assertEquals( '2000', $prices_after['price'], 'Unit price should be 20.00 (stored as cents in minor unit)' );
+		$this->assertEquals( '2000', $prices_after['regular_price'], 'Regular price should be 20.00 from order data' );
+		$this->assertEquals( '2000', $prices_after['sale_price'], 'Sale price field should be 20.00 from order data' );
+
 		$this->assertEquals( $prices_before['price'], $prices_after['price'], 'Price should not change when product goes on sale' );
 		$this->assertEquals( $prices_before['regular_price'], $prices_after['regular_price'], 'Regular price should not change when product goes on sale' );
 		$this->assertEquals( $prices_before['sale_price'], $prices_after['sale_price'], 'Sale price field should not change when product goes on sale' );
 
 		// The totals should also reflect the original $20/unit price.
 		$totals = (array) $result_after['totals'];
-		$this->assertEquals( '40.00', $totals['line_subtotal'], 'Line subtotal should be 40.00 (2 x $20)' );
+		$this->assertEquals( '4000', $totals['line_subtotal'], 'Line subtotal should be 40.00 (2 x $20)' );
 
 		// Cleanup.
 		$order->delete( true );


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a bug where the Store API order item response (`prices` field) returned the **current live product price** instead of the **price at the time of purchase** stored in the order item data.

When a merchant puts a product on sale, all historical orders would incorrectly show the new sale price in the `prices` object, even though the `totals` object correctly reflected the original purchase price.

**Root cause:** `OrderItemSchema::get_item_response()` called `prepare_product_price_response($product, ...)` which queries the live product for its current price.

**Fix:** Introduced `prepare_order_item_price_response()` which computes per-unit prices from the order item's stored `subtotal` and `subtotal_tax` data, ensuring historical accuracy.

Closes #53326.

### Files changed:

- `plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php` — New `prepare_order_item_price_response()` method that derives prices from order item data; switched `get_item_response()` to use it.
- `plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php` — New test `test_get_item_response_prices_use_order_data_not_current_product_price()` that creates an order, then puts the product on sale, and asserts prices remain unchanged.

### Screenshots or screen recordings:

N/A — No visual changes. Only the Store API JSON response is affected.

### How to test the changes in this Pull Request:

1. Create a simple product priced at $20.
2. Place an order for 2 units of that product.
3. Note the order item `prices` in the Store API response (e.g., `GET /wp-json/wc/store/v1/orders/{id}`).
4. Put the product on sale for $10.
5. Re-fetch the same order via the Store API.
6. **Before this fix:** `prices.price` would show $10 (current sale price).
7. **After this fix:** `prices.price` shows $20 (original purchase price from order data).

Alternatively, run the new PHPUnit test:
```
pnpm test:unit:env -- --filter=OrderItemSchemaTest
```

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**