### PR TITLE
Fix: Prevent merchants from setting the same thousand and decimal separator

### DIFF
--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -433,6 +433,27 @@ class WC_Settings_General extends WC_Settings_Page {
 			"
 		);
 	}
+
+	/**
+	 * Save settings and validate that thousand and decimal separators are different.
+	 *
+	 * @since 10.9.0
+	 */
+	public function save() {
+		$thousand_sep = isset( $_POST['woocommerce_price_thousand_sep'] ) ? wc_clean( wp_unslash( $_POST['woocommerce_price_thousand_sep'] ) ) : get_option( 'woocommerce_price_thousand_sep' );
+		$decimal_sep  = isset( $_POST['woocommerce_price_decimal_sep'] ) ? wc_clean( wp_unslash( $_POST['woocommerce_price_decimal_sep'] ) ) : get_option( 'woocommerce_price_decimal_sep' );
+
+		if ( $thousand_sep === $decimal_sep && '' !== $thousand_sep ) {
+			// Revert to previous values.
+			$_POST['woocommerce_price_thousand_sep'] = get_option( 'woocommerce_price_thousand_sep' );
+			$_POST['woocommerce_price_decimal_sep']  = get_option( 'woocommerce_price_decimal_sep' );
+
+			// Add admin notice.
+			WC_Admin_Settings::add_error( __( 'The thousand separator and decimal separator cannot be the same character. The previous values have been restored.', 'woocommerce' ) );
+		}
+
+		parent::save();
+	}
 }
 
 return new WC_Settings_General();

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -440,13 +440,15 @@ class WC_Settings_General extends WC_Settings_Page {
 	 * @since 10.9.0
 	 */
 	public function save() {
-		$thousand_sep = isset( $_POST['woocommerce_price_thousand_sep'] ) ? wc_clean( wp_unslash( $_POST['woocommerce_price_thousand_sep'] ) ) : get_option( 'woocommerce_price_thousand_sep' );
-		$decimal_sep  = isset( $_POST['woocommerce_price_decimal_sep'] ) ? wc_clean( wp_unslash( $_POST['woocommerce_price_decimal_sep'] ) ) : get_option( 'woocommerce_price_decimal_sep' );
+		$previous_thousand_sep = (string) get_option( 'woocommerce_price_thousand_sep', ',' );
+		$previous_decimal_sep  = (string) get_option( 'woocommerce_price_decimal_sep', '.' );
+		$thousand_sep          = isset( $_POST['woocommerce_price_thousand_sep'] ) ? wc_clean( wp_unslash( $_POST['woocommerce_price_thousand_sep'] ) ) : $previous_thousand_sep;
+		$decimal_sep           = isset( $_POST['woocommerce_price_decimal_sep'] ) ? wc_clean( wp_unslash( $_POST['woocommerce_price_decimal_sep'] ) ) : $previous_decimal_sep;
 
 		if ( $thousand_sep === $decimal_sep && '' !== $thousand_sep ) {
 			// Revert to previous values.
-			$_POST['woocommerce_price_thousand_sep'] = get_option( 'woocommerce_price_thousand_sep' );
-			$_POST['woocommerce_price_decimal_sep']  = get_option( 'woocommerce_price_decimal_sep' );
+			$_POST['woocommerce_price_thousand_sep'] = $previous_thousand_sep;
+			$_POST['woocommerce_price_decimal_sep']  = $previous_decimal_sep;
 
 			// Add admin notice.
 			WC_Admin_Settings::add_error( __( 'The thousand separator and decimal separator cannot be the same character. The previous values have been restored.', 'woocommerce' ) );

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-settings-general-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-settings-general-test.php
@@ -1,0 +1,136 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_Settings_General.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+class WC_Settings_General_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Option names used in tests, cleaned up in tearDown().
+	 *
+	 * @var string[]
+	 */
+	private array $option_names_to_clean = array();
+
+	/**
+	 * Clean up options after each test.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->option_names_to_clean as $option_name ) {
+			delete_option( $option_name );
+		}
+		$this->option_names_to_clean = array();
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should allow saving when thousand and decimal separators are different.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/46047
+	 */
+	public function test_save_allows_different_separators(): void {
+		$this->option_names_to_clean[] = 'woocommerce_price_thousand_sep';
+		$this->option_names_to_clean[] = 'woocommerce_price_decimal_sep';
+
+		// Set initial values.
+		update_option( 'woocommerce_price_thousand_sep', '.' );
+		update_option( 'woocommerce_price_decimal_sep', ',' );
+
+		// Simulate form submission with different (but swapped) separators.
+		$_POST['woocommerce_price_thousand_sep'] = ',';
+		$_POST['woocommerce_price_decimal_sep']  = '.';
+
+		$settings = new WC_Settings_General();
+		$settings->save();
+
+		$this->assertEquals( ',', get_option( 'woocommerce_price_thousand_sep' ), 'Thousand separator should be updated to comma' );
+		$this->assertEquals( '.', get_option( 'woocommerce_price_decimal_sep' ), 'Decimal separator should be updated to period' );
+
+		unset( $_POST['woocommerce_price_thousand_sep'], $_POST['woocommerce_price_decimal_sep'] );
+	}
+
+	/**
+	 * @testdox Should revert separators when merchant sets them to the same character.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/46047
+	 */
+	public function test_save_reverts_same_separators(): void {
+		$this->option_names_to_clean[] = 'woocommerce_price_thousand_sep';
+		$this->option_names_to_clean[] = 'woocommerce_price_decimal_sep';
+
+		// Set initial values.
+		update_option( 'woocommerce_price_thousand_sep', ',' );
+		update_option( 'woocommerce_price_decimal_sep', '.' );
+
+		// Simulate form submission with the SAME separator.
+		$_POST['woocommerce_price_thousand_sep'] = '.';
+		$_POST['woocommerce_price_decimal_sep']  = '.';
+
+		$settings = new WC_Settings_General();
+		$settings->save();
+
+		// Values should be reverted to the previous ones.
+		$this->assertEquals( ',', get_option( 'woocommerce_price_thousand_sep' ), 'Thousand separator should be reverted to previous value (comma)' );
+		$this->assertEquals( '.', get_option( 'woocommerce_price_decimal_sep' ), 'Decimal separator should be reverted to previous value (period)' );
+
+		unset( $_POST['woocommerce_price_thousand_sep'], $_POST['woocommerce_price_decimal_sep'] );
+	}
+
+	/**
+	 * @testdox Should allow saving when both separators are empty strings.
+	 *
+	 * Some merchants may prefer no separators.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/46047
+	 */
+	public function test_save_allows_both_empty_separators(): void {
+		$this->option_names_to_clean[] = 'woocommerce_price_thousand_sep';
+		$this->option_names_to_clean[] = 'woocommerce_price_decimal_sep';
+
+		// Set initial values.
+		update_option( 'woocommerce_price_thousand_sep', ',' );
+		update_option( 'woocommerce_price_decimal_sep', '.' );
+
+		// Simulate form submission with both empty.
+		$_POST['woocommerce_price_thousand_sep'] = '';
+		$_POST['woocommerce_price_decimal_sep']  = '';
+
+		$settings = new WC_Settings_General();
+		$settings->save();
+
+		$this->assertEquals( '', get_option( 'woocommerce_price_thousand_sep' ), 'Empty thousand separator should be allowed' );
+		$this->assertEquals( '', get_option( 'woocommerce_price_decimal_sep' ), 'Empty decimal separator should be allowed' );
+
+		unset( $_POST['woocommerce_price_thousand_sep'], $_POST['woocommerce_price_decimal_sep'] );
+	}
+
+	/**
+	 * @testdox Should revert separators when both are set to a dot.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/46047
+	 */
+	public function test_save_reverts_same_dot_separators(): void {
+		$this->option_names_to_clean[] = 'woocommerce_price_thousand_sep';
+		$this->option_names_to_clean[] = 'woocommerce_price_decimal_sep';
+
+		// Set initial values.
+		update_option( 'woocommerce_price_thousand_sep', ',' );
+		update_option( 'woocommerce_price_decimal_sep', '.' );
+
+		// Simulate form submission with both as dot.
+		$_POST['woocommerce_price_thousand_sep'] = '.';
+		$_POST['woocommerce_price_decimal_sep']  = '.';
+
+		$settings = new WC_Settings_General();
+		$settings->save();
+
+		// Values should be reverted.
+		$this->assertEquals( ',', get_option( 'woocommerce_price_thousand_sep' ), 'Thousand separator should be reverted to comma' );
+		$this->assertEquals( '.', get_option( 'woocommerce_price_decimal_sep' ), 'Decimal separator should be reverted to period' );
+
+		unset( $_POST['woocommerce_price_thousand_sep'], $_POST['woocommerce_price_decimal_sep'] );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a bug where merchants can set the same character for both the thousand separator and decimal separator in **WooCommerce → Settings → General**. This produces ambiguous price formatting on the storefront (e.g., `1.000.00` where both separators are dots).

No country in WooCommerce's locale database uses the same character for both separators, and the resulting price display is confusing for customers.

**Fix:** Added a `save()` method override in `WC_Settings_General` that:

1. Compares the submitted thousand separator and decimal separator values
2. If they match (and are not empty), reverts both to their previously saved values
3. Displays an admin error notice: "The thousand separator and decimal separator cannot be the same character. The previous values have been restored."

Closes #46047.

### Files changed:

- `plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php` — Added `save()` method with separator validation
- `plugins/woocommerce/tests/php/includes/admin/class-wc-settings-general-test.php` — New test class with 4 tests covering: different separators allowed, same separators reverted, both empty allowed, same dot separators reverted

### Screenshots or screen recordings:

N/A — Backend validation only. No UI changes beyond the admin error notice.

### How to test the changes in this Pull Request:

1. Go to **WooCommerce → Settings → General**.
2. Scroll to **Currency options**.
3. Set both **Thousand separator** and **Decimal separator** to the same character (e.g., both `.`).
4. Click **Save changes**.
5. **Expected:** An error notice appears and both values are reverted to their previous settings.
6. Now set them to different characters (e.g., `,` and `.`).
7. Click **Save changes**.
8. **Expected:** Values are saved successfully with no error.

Alternatively, run the PHPUnit tests:
```
pnpm test:unit:env -- --filter=WC_Settings_General_Test
```

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**