### PR TITLE
Restore the Shipping task for US, CO, and MX merchants

### DIFF
--- a/plugins/woocommerce/changelog/64521-wooplug-6631-restore-shipping-task-us-co-mx
+++ b/plugins/woocommerce/changelog/64521-wooplug-6631-restore-shipping-task-us-co-mx
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the Shipping task on US, CO, and MX stores by adding them back to the home-screen auto-zone whitelist.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -58384,18 +58384,6 @@ parameters:
 			path: src/Internal/Admin/Homescreen.php
 
 		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 2
-			path: src/Internal/Admin/Homescreen.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between ''US'' and ''AR''\|''AT''\|''AU''\|''BE''\|''BR''\|''CA''\|''CL''\|''DE''\|''ES''\|''FR''\|''GB''\|''GT''\|''HK''\|''IT''\|''NL''\|''NZ''\|''PE''\|''SG''\|''UY'' will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/Internal/Admin/Homescreen.php
-
-		-
 			message: '#^Argument of an invalid type array\|WP_Error supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 2

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -126,7 +126,7 @@ class Homescreen {
 		if (
 			( 'US' === $country_code && $is_jetpack_installed )
 			||
-			( ! in_array( $country_code, array( 'CA', 'AU', 'NZ', 'SG', 'HK', 'GB', 'ES', 'IT', 'DE', 'FR', 'CL', 'AR', 'PE', 'BR', 'UY', 'GT', 'NL', 'AT', 'BE' ), true ) )
+			( ! in_array( $country_code, array( 'US', 'CA', 'AU', 'NZ', 'SG', 'HK', 'GB', 'ES', 'IT', 'DE', 'FR', 'MX', 'CO', 'CL', 'AR', 'PE', 'BR', 'UY', 'GT', 'NL', 'AT', 'BE' ), true ) )
 			||
 			( 'US' === $country_code && false === $is_jetpack_installed && false === $is_wcs_installed )
 		) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-6631.

(For Bug Fixes) Bug introduced in PR &#35;36873.

Add `US`, `CO`, and `MX` to the country whitelist in `Homescreen::maybe_set_default_shipping_options_on_home()`. Without this entry, the home-screen auto-zone path fires for those countries on first visit, sets `woocommerce_admin_created_default_shipping_zones=yes`, and `Shipping::can_view()` then returns `false` so the Shipping task (with its WCShip / ShipStation / Envia partner placements) never appears.

Why each country is in this fix:

- **US** is a regression. `US` was on the whitelist in the original PR &#35;33547 so the spec's conditional auto-zone branches could work with a deliberate gap for "US + WCS-without-Jetpack" merchants. PR &#35;36873 rewrote the whitelist to add EU + LATAM countries and dropped `US` in the rewrite. The PR scope and testing instructions never mentioned US, no changelog flagged the change, and the deliberate gap collapsed silently.
- **CO and MX** are completing PR &#35;63379. PR &#35;41852 explicitly removed CO and MX from the whitelist when Skydropx was de-featured ("no partner left to recommend, so don't show an empty task"). PR &#35;63379 brought Envia back to MX and CO and added US/MX/CO to `Shipping::can_view()`'s eligible list, but did not update `Homescreen.php`. The codebase is currently inconsistent: `Shipping.php` says yes, `Homescreen.php` hides anyway. There is no record of any product requirement to auto-create a default zone for CO or MX merchants; the original 2022 spec only named US/CA/AU/GB.

The Shipping task's own `can_view()` already permits these countries (post-&#35;63379) and does not need to change. The shipping partner suggestions code is not involved.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

For each of `US`, `CO`, and `MX`:

1. Reset shipping state on the test store:
   ```bash
   wp option update woocommerce_default_country COUNTRY
   wp option update woocommerce_admin_created_default_shipping_zones no
   wp eval "$zones = WC_Shipping_Zones::get_zones(); foreach ($zones as $z) { (new WC_Shipping_Zone($z['id']))->delete(); } $completed = get_option('woocommerce_task_list_tracked_completed_tasks', []); update_option('woocommerce_task_list_tracked_completed_tasks', array_values(array_diff($completed, ['shipping', 'review-shipping'])));"
   wp transient delete woocommerce_shipping_task_zone_count_transient
   ```
2. Visit the WooCommerce home screen.
3. Confirm the Shipping task is visible in the task list.
4. Open the Shipping task and confirm the expected partner placement appears: WCShip + ShipStation for US, Envia for MX/CO.
5. Confirm no "United States (US)" / "Colombia" / "Mexico" zone has been auto-created in WooCommerce → Settings → Shipping.

Regression checks:

6. Repeat steps 1-3 for `UK` (`GB`) and `FR` and confirm the Shipping task continues to appear with the existing partner placements (no behaviour change).
7. Repeat steps 1-3 for one country still in the catch-all branch (e.g. `JP`) and confirm the auto-zone is still created and the Shipping task does not appear.

<!-- End testing instructions -->

### Testing that has already taken place:

- Static review of `Homescreen.php:75-154` confirms the change isolates to a single line of the country whitelist.
- PHPStan and `phpcs-changed` pass on the modified file.
- The Shipping task's `can_view()` eligible-countries data provider in `tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php` already includes US, MX, and CO (added by PR &#35;63379), so no test updates are required for this change.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Restore the Shipping task on US, CO, and MX stores by adding them back to the home-screen auto-zone whitelist.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
