### PR TITLE
Add accessible star-rating control for Review Order page

### DIFF
--- a/plugins/woocommerce/changelog/64525-wooplug-6594-accessible-star-rating-control
+++ b/plugins/woocommerce/changelog/64525-wooplug-6594-accessible-star-rating-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the accessible 5-star rating control used by the Review Order page. Native radio inputs with keyboard navigation (arrows, Home, End), dynamic caption, and visible focus ring; filterable labels via `woocommerce_review_order_rating_labels`.

--- a/plugins/woocommerce/changelog/wooplug-6594-star-rating-control
+++ b/plugins/woocommerce/changelog/wooplug-6594-star-rating-control
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add the accessible 5-star rating control used by the Review Order page. Native radio inputs with keyboard navigation (arrows, Home, End), dynamic caption, and visible focus ring; filterable labels via `woocommerce_review_order_rating_labels`.

--- a/plugins/woocommerce/changelog/wooplug-6594-star-rating-control
+++ b/plugins/woocommerce/changelog/wooplug-6594-star-rating-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the accessible 5-star rating control used by the Review Order page. Native radio inputs with keyboard navigation (arrows, Home, End), dynamic caption, and visible focus ring; filterable labels via `woocommerce_review_order_rating_labels`.

--- a/plugins/woocommerce/client/legacy/css/order-review.scss
+++ b/plugins/woocommerce/client/legacy/css/order-review.scss
@@ -4,10 +4,16 @@
  * Intentionally minimal. The active theme drives typography, color, and
  * button styling; only the interactive star-rating control needs bespoke
  * CSS to map radio inputs to SVG stars.
+ *
+ * The star control renders with `flex-direction: row-reverse`: the DOM
+ * order is 5..1 so that sibling combinators (`~`) can fill all stars up
+ * to the selected/hovered one without relying on `:has()`.
  */
 
 .woocommerce-star-rating {
 	display: inline-flex;
+	flex-direction: row-reverse;
+	justify-content: flex-end;
 	align-items: center;
 	flex-wrap: wrap;
 	gap: 2px;
@@ -42,34 +48,36 @@
 		transition: opacity 100ms ease-in-out;
 	}
 
-	@for $i from 1 through 5 {
-		&:has(.woocommerce-star-rating__input:checked[value="#{$i}"]) {
-			.woocommerce-star-rating__star:nth-of-type(-n + #{$i}) .woocommerce-star-rating__icon {
-				opacity: 1;
-			}
-		}
+	// Fill: a checked input fills its own label and every following sibling
+	// star (which appear visually before it under row-reverse).
+	&__input:checked ~ .woocommerce-star-rating__star .woocommerce-star-rating__icon {
+		opacity: 1;
 	}
 
-	&:hover {
-		.woocommerce-star-rating__star .woocommerce-star-rating__icon {
-			opacity: 0.3;
-		}
-
-		@for $i from 1 through 5 {
-			&:has(.woocommerce-star-rating__star:nth-of-type(#{$i}):hover) {
-				.woocommerce-star-rating__star:nth-of-type(-n + #{$i}) .woocommerce-star-rating__icon {
-					opacity: 1;
-				}
-			}
-		}
+	// Hover preview: when hovering the rating, dim everything, then re-fill
+	// from the hovered star outward (visual left).
+	&:hover .woocommerce-star-rating__icon {
+		opacity: 0.3;
 	}
 
-	&__star:has(.woocommerce-star-rating__input:focus-visible) {
+	&__star:hover .woocommerce-star-rating__icon,
+	&__star:hover ~ .woocommerce-star-rating__star .woocommerce-star-rating__icon {
+		opacity: 1;
+	}
+
+	// Focus ring: the input sits next to its own label; style the label when
+	// the input has visible keyboard focus.
+	&__input:focus-visible + .woocommerce-star-rating__star {
 		outline: 2px solid currentColor;
 		outline-offset: 2px;
 	}
 
+	// Caption keeps a stable footprint so the layout doesn't shift when the
+	// label text changes. Negative order sends it to the visual right of the
+	// stars (under row-reverse, the lowest-ordered item lays out first along
+	// the main axis, which is the rightmost slot).
 	&__caption {
+		order: -1;
 		margin-left: 0.5em;
 		min-height: 1em;
 		min-width: 4em;

--- a/plugins/woocommerce/client/legacy/css/order-review.scss
+++ b/plugins/woocommerce/client/legacy/css/order-review.scss
@@ -1,8 +1,9 @@
 /**
  * Review Order page styles.
  *
- * Currently scoped to the accessible star-rating control. M4's design-token
- * pass (WOOPLUG-6597) will fold these into the broader review-order layout.
+ * Intentionally minimal. The active theme drives typography, color, and
+ * button styling; only the interactive star-rating control needs bespoke
+ * CSS to map radio inputs to SVG stars.
  */
 
 .woocommerce-star-rating {
@@ -29,69 +30,31 @@
 		cursor: pointer;
 		display: inline-flex;
 		padding: 4px;
-		border-radius: 4px;
 		color: currentColor;
 	}
 
 	&__icon {
 		display: block;
-		width: 24px;
-		height: 24px;
+		width: 1.5em;
+		height: 1.5em;
 		fill: currentColor;
 		opacity: 0.3;
 		transition: opacity 100ms ease-in-out;
 	}
 
-	// Light up every star up to (and including) the checked one. Stops at the
-	// next star whose input is checked; modern :has() walks the parent label.
 	@for $i from 1 through 5 {
 		&:has(.woocommerce-star-rating__input:checked[value="#{$i}"]) {
-			.woocommerce-star-rating__star:nth-of-type(-n + #{$i}) {
-				.woocommerce-star-rating__icon {
-					opacity: 1;
-				}
+			.woocommerce-star-rating__star:nth-of-type(-n + #{$i}) .woocommerce-star-rating__icon {
+				opacity: 1;
 			}
 		}
 	}
 
-	// Hover preview: hovered star and every preceding sibling fill in.
-	@for $i from 1 through 5 {
-		&__star:nth-of-type(#{$i}):hover {
-			~ .woocommerce-star-rating__star .woocommerce-star-rating__icon {
-				opacity: 0.3;
-			}
-		}
-	}
-
-	&__star:hover ~ .woocommerce-star-rating__star {
-		.woocommerce-star-rating__icon {
-			opacity: 0.3;
-		}
-	}
-
-	&__star:hover .woocommerce-star-rating__icon {
-		opacity: 1;
-	}
-
-	// While hovering, light up every star to the LEFT of the hovered one.
 	&:hover {
 		.woocommerce-star-rating__star .woocommerce-star-rating__icon {
 			opacity: 0.3;
 		}
 
-		@for $i from 1 through 5 {
-			.woocommerce-star-rating__star:nth-of-type(#{$i}):hover {
-				~ .woocommerce-star-rating__star .woocommerce-star-rating__icon {
-					opacity: 0.3;
-				}
-
-				.woocommerce-star-rating__icon {
-					opacity: 1;
-				}
-			}
-		}
-
-		// Light up everything to the left of the hovered star using :has().
 		@for $i from 1 through 5 {
 			&:has(.woocommerce-star-rating__star:nth-of-type(#{$i}):hover) {
 				.woocommerce-star-rating__star:nth-of-type(-n + #{$i}) .woocommerce-star-rating__icon {
@@ -101,16 +64,13 @@
 		}
 	}
 
-	// Visible focus ring on the wrapping label whenever its input is focused.
 	&__star:has(.woocommerce-star-rating__input:focus-visible) {
 		outline: 2px solid currentColor;
 		outline-offset: 2px;
 	}
 
 	&__caption {
-		margin-left: 8px;
-		font-size: 12px;
-		color: currentColor;
+		margin-left: 0.5em;
 		min-height: 1em;
 		min-width: 4em;
 	}

--- a/plugins/woocommerce/client/legacy/css/order-review.scss
+++ b/plugins/woocommerce/client/legacy/css/order-review.scss
@@ -1,0 +1,117 @@
+/**
+ * Review Order page styles.
+ *
+ * Currently scoped to the accessible star-rating control. M4's design-token
+ * pass (WOOPLUG-6597) will fold these into the broader review-order layout.
+ */
+
+.woocommerce-star-rating {
+	display: inline-flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 2px;
+	line-height: 1;
+
+	// Visually hide the native radios but keep them in the a11y tree.
+	&__input {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	&__star {
+		cursor: pointer;
+		display: inline-flex;
+		padding: 4px;
+		border-radius: 4px;
+		color: currentColor;
+	}
+
+	&__icon {
+		display: block;
+		width: 24px;
+		height: 24px;
+		fill: currentColor;
+		opacity: 0.3;
+		transition: opacity 100ms ease-in-out;
+	}
+
+	// Light up every star up to (and including) the checked one. Stops at the
+	// next star whose input is checked; modern :has() walks the parent label.
+	@for $i from 1 through 5 {
+		&:has(.woocommerce-star-rating__input:checked[value="#{$i}"]) {
+			.woocommerce-star-rating__star:nth-of-type(-n + #{$i}) {
+				.woocommerce-star-rating__icon {
+					opacity: 1;
+				}
+			}
+		}
+	}
+
+	// Hover preview: hovered star and every preceding sibling fill in.
+	@for $i from 1 through 5 {
+		&__star:nth-of-type(#{$i}):hover {
+			~ .woocommerce-star-rating__star .woocommerce-star-rating__icon {
+				opacity: 0.3;
+			}
+		}
+	}
+
+	&__star:hover ~ .woocommerce-star-rating__star {
+		.woocommerce-star-rating__icon {
+			opacity: 0.3;
+		}
+	}
+
+	&__star:hover .woocommerce-star-rating__icon {
+		opacity: 1;
+	}
+
+	// While hovering, light up every star to the LEFT of the hovered one.
+	&:hover {
+		.woocommerce-star-rating__star .woocommerce-star-rating__icon {
+			opacity: 0.3;
+		}
+
+		@for $i from 1 through 5 {
+			.woocommerce-star-rating__star:nth-of-type(#{$i}):hover {
+				~ .woocommerce-star-rating__star .woocommerce-star-rating__icon {
+					opacity: 0.3;
+				}
+
+				.woocommerce-star-rating__icon {
+					opacity: 1;
+				}
+			}
+		}
+
+		// Light up everything to the left of the hovered star using :has().
+		@for $i from 1 through 5 {
+			&:has(.woocommerce-star-rating__star:nth-of-type(#{$i}):hover) {
+				.woocommerce-star-rating__star:nth-of-type(-n + #{$i}) .woocommerce-star-rating__icon {
+					opacity: 1;
+				}
+			}
+		}
+	}
+
+	// Visible focus ring on the wrapping label whenever its input is focused.
+	&__star:has(.woocommerce-star-rating__input:focus-visible) {
+		outline: 2px solid currentColor;
+		outline-offset: 2px;
+	}
+
+	&__caption {
+		margin-left: 8px;
+		font-size: 12px;
+		color: currentColor;
+		min-height: 1em;
+		min-width: 4em;
+	}
+}

--- a/plugins/woocommerce/client/legacy/js/frontend/order-review.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-review.js
@@ -1,0 +1,86 @@
+/* global document, window */
+/**
+ * Progressive enhancement for the Review Order page.
+ *
+ * Adds keyboard navigation (Left/Right/Up/Down + Home/End + Space/Enter) and a
+ * dynamic caption to every `.woocommerce-star-rating` group on the page.
+ * Without this script the underlying native radio inputs still work.
+ */
+( function () {
+	'use strict';
+
+	/**
+	 * @param {HTMLElement} container `.woocommerce-star-rating` element.
+	 */
+	function initGroup( container ) {
+		var inputs = Array.prototype.slice.call(
+			container.querySelectorAll( '.woocommerce-star-rating__input' )
+		);
+		if ( ! inputs.length ) {
+			return;
+		}
+
+		var captionId = container.getAttribute( 'data-caption-id' );
+		var caption = captionId ? document.getElementById( captionId ) : null;
+
+		function syncCaption() {
+			if ( ! caption ) {
+				return;
+			}
+			var checked = inputs.filter( function ( input ) {
+				return input.checked;
+			} )[ 0 ];
+			caption.textContent = checked
+				? checked.getAttribute( 'data-label' ) || ''
+				: '';
+		}
+
+		function focusInput( input ) {
+			input.focus();
+			input.checked = true;
+			input.dispatchEvent( new window.Event( 'change', { bubbles: true } ) );
+		}
+
+		inputs.forEach( function ( input, index ) {
+			input.addEventListener( 'change', syncCaption );
+
+			input.addEventListener( 'keydown', function ( event ) {
+				var nextIndex = null;
+				switch ( event.key ) {
+					case 'ArrowRight':
+					case 'ArrowDown':
+						nextIndex = ( index + 1 ) % inputs.length;
+						break;
+					case 'ArrowLeft':
+					case 'ArrowUp':
+						nextIndex =
+							( index - 1 + inputs.length ) % inputs.length;
+						break;
+					case 'Home':
+						nextIndex = 0;
+						break;
+					case 'End':
+						nextIndex = inputs.length - 1;
+						break;
+					default:
+						return;
+				}
+				event.preventDefault();
+				focusInput( inputs[ nextIndex ] );
+			} );
+		} );
+
+		syncCaption();
+	}
+
+	function init() {
+		var groups = document.querySelectorAll( '.woocommerce-star-rating' );
+		Array.prototype.forEach.call( groups, initGroup );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/plugins/woocommerce/client/legacy/js/frontend/order-review.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-review.js
@@ -37,6 +37,10 @@
 			input.dispatchEvent( new window.Event( 'change', { bubbles: true } ) );
 		}
 
+		// DOM order is 5..1 (reversed for the CSS row-reverse layout), so
+		// "next visual star" is the previous DOM input and vice-versa.
+		// Home/End map to visual-leftmost / visual-rightmost = inputs[last] /
+		// inputs[0] in DOM order.
 		inputs.forEach( function ( input, index ) {
 			input.addEventListener( 'change', syncCaption );
 
@@ -45,18 +49,18 @@
 				switch ( event.key ) {
 					case 'ArrowRight':
 					case 'ArrowDown':
-						nextIndex = ( index + 1 ) % inputs.length;
-						break;
-					case 'ArrowLeft':
-					case 'ArrowUp':
 						nextIndex =
 							( index - 1 + inputs.length ) % inputs.length;
 						break;
+					case 'ArrowLeft':
+					case 'ArrowUp':
+						nextIndex = ( index + 1 ) % inputs.length;
+						break;
 					case 'Home':
-						nextIndex = 0;
+						nextIndex = inputs.length - 1;
 						break;
 					case 'End':
-						nextIndex = inputs.length - 1;
+						nextIndex = 0;
 						break;
 					default:
 						return;

--- a/plugins/woocommerce/client/legacy/js/frontend/order-review.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-review.js
@@ -16,11 +16,7 @@
 		var inputs = Array.prototype.slice.call(
 			container.querySelectorAll( '.woocommerce-star-rating__input' )
 		);
-		if ( ! inputs.length ) {
-			return;
-		}
-
-		var captionId = container.getAttribute( 'data-caption-id' );
+		var captionId = container.getAttribute( 'aria-describedby' );
 		var caption = captionId ? document.getElementById( captionId ) : null;
 
 		function syncCaption() {

--- a/plugins/woocommerce/client/legacy/js/frontend/order-review.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-review.js
@@ -2,8 +2,8 @@
 /**
  * Progressive enhancement for the Review Order page.
  *
- * Adds keyboard navigation (Left/Right/Up/Down + Home/End + Space/Enter) and a
- * dynamic caption to every `.woocommerce-star-rating` group on the page.
+ * Adds keyboard navigation (Left/Right/Up/Down + Home/End) and a dynamic
+ * caption to every `.woocommerce-star-rating` group on the page.
  * Without this script the underlying native radio inputs still work.
  */
 ( function () {

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -411,19 +411,27 @@ class Endpoint {
 	 * `assets/{js|css}/` by the classic-assets pipeline.
 	 */
 	private function enqueue_assets(): void {
-		$plugin_url = untrailingslashit( plugins_url( '', WC_PLUGIN_FILE ) );
-		$suffix     = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+		$plugin_url  = untrailingslashit( plugins_url( '', WC_PLUGIN_FILE ) );
+		$suffix      = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+		$style_path  = '/assets/css/order-review.css';
+		$script_path = '/assets/js/frontend/order-review' . $suffix . '.js';
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- documented in includes/class-wc-frontend-scripts.php.
+		$style_url = (string) apply_filters( 'woocommerce_get_asset_url', $plugin_url . $style_path, $style_path );
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- documented in includes/class-wc-frontend-scripts.php.
+		$script_url = (string) apply_filters( 'woocommerce_get_asset_url', $plugin_url . $script_path, $script_path );
 
 		wp_enqueue_style(
 			'wc-order-review',
-			$plugin_url . '/assets/css/order-review.css',
+			$style_url,
 			array(),
 			Constants::get_constant( 'WC_VERSION' )
 		);
 
 		wp_enqueue_script(
 			'wc-order-review',
-			$plugin_url . '/assets/js/frontend/order-review' . $suffix . '.js',
+			$script_url,
 			array(),
 			Constants::get_constant( 'WC_VERSION' ),
 			true

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -411,33 +411,19 @@ class Endpoint {
 	 * `assets/{js|css}/` by the classic-assets pipeline.
 	 */
 	private function enqueue_assets(): void {
-		$plugin_url  = untrailingslashit( plugins_url( '', WC_PLUGIN_FILE ) );
-		$suffix      = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		$style_path  = '/assets/css/order-review.css';
-		$script_path = '/assets/js/frontend/order-review' . $suffix . '.js';
+		$plugin_url = untrailingslashit( plugins_url( '', WC_PLUGIN_FILE ) );
+		$suffix     = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+		$version    = Constants::get_constant( 'WC_VERSION' );
+		$asset_url  = static function ( string $path ) use ( $plugin_url ): string {
+			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- documented in includes/class-wc-frontend-scripts.php.
+			return (string) apply_filters( 'woocommerce_get_asset_url', $plugin_url . $path, $path );
+		};
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- documented in includes/class-wc-frontend-scripts.php.
-		$style_url = (string) apply_filters( 'woocommerce_get_asset_url', $plugin_url . $style_path, $style_path );
-
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- documented in includes/class-wc-frontend-scripts.php.
-		$script_url = (string) apply_filters( 'woocommerce_get_asset_url', $plugin_url . $script_path, $script_path );
-
-		wp_enqueue_style(
-			'wc-order-review',
-			$style_url,
-			array(),
-			Constants::get_constant( 'WC_VERSION' )
-		);
+		wp_enqueue_style( 'wc-order-review', $asset_url( '/assets/css/order-review.css' ), array(), $version );
 		// Tell WP to swap to the *-rtl.css variant on RTL sites.
 		wp_style_add_data( 'wc-order-review', 'rtl', 'replace' );
 
-		wp_enqueue_script(
-			'wc-order-review',
-			$script_url,
-			array(),
-			Constants::get_constant( 'WC_VERSION' ),
-			true
-		);
+		wp_enqueue_script( 'wc-order-review', $asset_url( '/assets/js/frontend/order-review' . $suffix . '.js' ), array(), $version, true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -7,6 +7,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\OrderReviews;
 
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use WC_Order;
 use WP_Post;
@@ -251,6 +252,10 @@ class Endpoint {
 			$this->render_404();
 			exit;
 		}
+
+		// template_redirect fires after wp_enqueue_scripts but before
+		// wp_head, so styles registered here are still output in <head>.
+		$this->enqueue_assets();
 	}
 
 	/**
@@ -397,6 +402,32 @@ class Endpoint {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Enqueue the JS and CSS that progressively enhance the page.
+	 *
+	 * Both files live under `client/legacy/` and are built into
+	 * `assets/{js|css}/` by the classic-assets pipeline.
+	 */
+	private function enqueue_assets(): void {
+		$plugin_url = untrailingslashit( plugins_url( '', WC_PLUGIN_FILE ) );
+		$suffix     = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		wp_enqueue_style(
+			'wc-order-review',
+			$plugin_url . '/assets/css/order-review.css',
+			array(),
+			Constants::get_constant( 'WC_VERSION' )
+		);
+
+		wp_enqueue_script(
+			'wc-order-review',
+			$plugin_url . '/assets/js/frontend/order-review' . $suffix . '.js',
+			array(),
+			Constants::get_constant( 'WC_VERSION' ),
+			true
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -428,6 +428,8 @@ class Endpoint {
 			array(),
 			Constants::get_constant( 'WC_VERSION' )
 		);
+		// Tell WP to swap to the *-rtl.css variant on RTL sites.
+		wp_style_add_data( 'wc-order-review', 'rtl', 'replace' );
 
 		wp_enqueue_script(
 			'wc-order-review',

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -423,7 +423,16 @@ class Endpoint {
 		// Tell WP to swap to the *-rtl.css variant on RTL sites.
 		wp_style_add_data( 'wc-order-review', 'rtl', 'replace' );
 
-		wp_enqueue_script( 'wc-order-review', $asset_url( '/assets/js/frontend/order-review' . $suffix . '.js' ), array(), $version, true );
+		wp_enqueue_script(
+			'wc-order-review',
+			$asset_url( '/assets/js/frontend/order-review' . $suffix . '.js' ),
+			array(),
+			$version,
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderReviews/StarRating.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/StarRating.php
@@ -42,7 +42,6 @@ class StarRating {
 		$name      = (string) ( $args['name'] ?? '' );
 		$id_prefix = (string) ( $args['id_prefix'] ?? '' );
 		$label_id  = (string) ( $args['label_id'] ?? '' );
-		$selected  = isset( $args['selected'] ) ? (int) $args['selected'] : 0;
 
 		if ( '' === $name || '' === $id_prefix || '' === $label_id ) {
 			return '';
@@ -55,7 +54,7 @@ class StarRating {
 				'name'      => $name,
 				'id_prefix' => $id_prefix,
 				'label_id'  => $label_id,
-				'selected'  => $selected,
+				'selected'  => (int) ( $args['selected'] ?? 0 ),
 				'labels'    => self::get_labels(),
 			)
 		);
@@ -89,19 +88,7 @@ class StarRating {
 		 */
 		$filtered = (array) apply_filters( 'woocommerce_review_order_rating_labels', $labels );
 
-		// Guarantee 1-5 keys are present even after a buggy filter.
-		foreach ( array( 1, 2, 3, 4, 5 ) as $value ) {
-			if ( ! isset( $filtered[ $value ] ) || ! is_string( $filtered[ $value ] ) || '' === $filtered[ $value ] ) {
-				$filtered[ $value ] = $labels[ $value ];
-			}
-		}
-
-		return array(
-			1 => $filtered[1],
-			2 => $filtered[2],
-			3 => $filtered[3],
-			4 => $filtered[4],
-			5 => $filtered[5],
-		);
+		// Keep only known 1-5 keys; fall back to defaults for any the filter dropped.
+		return array_replace( $labels, array_intersect_key( $filtered, $labels ) );
 	}
 }

--- a/plugins/woocommerce/src/Internal/OrderReviews/StarRating.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/StarRating.php
@@ -25,16 +25,17 @@ class StarRating {
 	/**
 	 * Render the rating control. Returns the HTML; does not echo.
 	 *
-	 * @param array{
-	 *     name: string,
-	 *     id_prefix: string,
-	 *     label_id: string,
-	 *     selected?: int|null,
-	 * } $args Render arguments. `name` is the form field name (one per item),
-	 *         `id_prefix` is the prefix used to build unique radio ids,
-	 *         `label_id` is the id of the existing label element that
-	 *         describes the group via `aria-labelledby`, and `selected`
-	 *         optionally pre-selects a value (1-5).
+	 * Required keys in `$args`:
+	 *  - `name` (string): form field name (one per item).
+	 *  - `id_prefix` (string): prefix used to build unique radio ids.
+	 *  - `label_id` (string): id of the existing label element that describes
+	 *    the group via `aria-labelledby`.
+	 *
+	 * Optional:
+	 *  - `selected` (int): pre-selected value 0-5; pass `0` (the default)
+	 *    for no pre-selection.
+	 *
+	 * @param array $args Render arguments. See description for required and optional keys.
 	 * @return string
 	 */
 	public static function render( array $args ): string {

--- a/plugins/woocommerce/src/Internal/OrderReviews/StarRating.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/StarRating.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * StarRating control class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\OrderReviews;
+
+/**
+ * Server-side renderer for the accessible 5-star rating control used on the
+ * Review Order page.
+ *
+ * The control degrades to native `<input type="radio">` elements without
+ * JavaScript and is enhanced by `client/legacy/js/frontend/order-review.js`
+ * for keyboard navigation, a visible focus ring, and the dynamic caption
+ * underneath the stars.
+ *
+ * @internal Just for internal use.
+ *
+ * @since 10.8.0
+ */
+class StarRating {
+
+	/**
+	 * Render the rating control. Returns the HTML; does not echo.
+	 *
+	 * @param array{
+	 *     name: string,
+	 *     id_prefix: string,
+	 *     label_id: string,
+	 *     selected?: int|null,
+	 * } $args Render arguments. `name` is the form field name (one per item),
+	 *         `id_prefix` is the prefix used to build unique radio ids,
+	 *         `label_id` is the id of the existing label element that
+	 *         describes the group via `aria-labelledby`, and `selected`
+	 *         optionally pre-selects a value (1-5).
+	 * @return string
+	 */
+	public static function render( array $args ): string {
+		$name      = (string) ( $args['name'] ?? '' );
+		$id_prefix = (string) ( $args['id_prefix'] ?? '' );
+		$label_id  = (string) ( $args['label_id'] ?? '' );
+		$selected  = isset( $args['selected'] ) ? (int) $args['selected'] : 0;
+
+		if ( '' === $name || '' === $id_prefix || '' === $label_id ) {
+			return '';
+		}
+
+		ob_start();
+		wc_get_template(
+			'order/star-rating.php',
+			array(
+				'name'      => $name,
+				'id_prefix' => $id_prefix,
+				'label_id'  => $label_id,
+				'selected'  => $selected,
+				'labels'    => self::get_labels(),
+			)
+		);
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Default rating labels, indexed 1-5, after the customer-facing filter.
+	 *
+	 * Defaults match the long-standing WooCommerce product-review labels in
+	 * `templates/single-product-reviews.php` so customers see consistent
+	 * wording across the two review entry points.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function get_labels(): array {
+		$labels = array(
+			1 => __( 'Very poor', 'woocommerce' ),
+			2 => __( 'Not that bad', 'woocommerce' ),
+			3 => __( 'Average', 'woocommerce' ),
+			4 => __( 'Good', 'woocommerce' ),
+			5 => __( 'Perfect', 'woocommerce' ),
+		);
+
+		/**
+		 * Filter the labels shown under the star-rating control.
+		 *
+		 * @since 10.8.0
+		 *
+		 * @param array<int, string> $labels Map of rating value (1-5) to label.
+		 */
+		$filtered = (array) apply_filters( 'woocommerce_review_order_rating_labels', $labels );
+
+		// Guarantee 1-5 keys are present even after a buggy filter.
+		foreach ( array( 1, 2, 3, 4, 5 ) as $value ) {
+			if ( ! isset( $filtered[ $value ] ) || ! is_string( $filtered[ $value ] ) || '' === $filtered[ $value ] ) {
+				$filtered[ $value ] = $labels[ $value ];
+			}
+		}
+
+		return array(
+			1 => $filtered[1],
+			2 => $filtered[2],
+			3 => $filtered[3],
+			4 => $filtered[4],
+			5 => $filtered[5],
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/OrderReviews/StarRating.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/StarRating.php
@@ -33,7 +33,9 @@ class StarRating {
 	 *
 	 * Optional:
 	 *  - `selected` (int): pre-selected value 0-5; pass `0` (the default)
-	 *    for no pre-selection.
+	 *    for no pre-selection. Values outside 0-5 are treated as no selection.
+	 *
+	 * @since 10.8.0
 	 *
 	 * @param array $args Render arguments. See description for required and optional keys.
 	 * @return string
@@ -47,6 +49,11 @@ class StarRating {
 			return '';
 		}
 
+		$selected = (int) ( $args['selected'] ?? 0 );
+		if ( $selected < 0 || $selected > 5 ) {
+			$selected = 0;
+		}
+
 		ob_start();
 		wc_get_template(
 			'order/star-rating.php',
@@ -54,7 +61,7 @@ class StarRating {
 				'name'      => $name,
 				'id_prefix' => $id_prefix,
 				'label_id'  => $label_id,
-				'selected'  => (int) ( $args['selected'] ?? 0 ),
+				'selected'  => $selected,
 				'labels'    => self::get_labels(),
 			)
 		);
@@ -67,6 +74,8 @@ class StarRating {
 	 * Defaults match the long-standing WooCommerce product-review labels in
 	 * `templates/single-product-reviews.php` so customers see consistent
 	 * wording across the two review entry points.
+	 *
+	 * @since 10.8.0
 	 *
 	 * @return array<int, string>
 	 */

--- a/plugins/woocommerce/templates/order/star-rating.php
+++ b/plugins/woocommerce/templates/order/star-rating.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Star-rating control partial.
+ *
+ * Theme-overridable. Copy to `yourtheme/woocommerce/order/star-rating.php`.
+ *
+ * Renders five native `<input type="radio">` elements wrapped in a
+ * `role="radiogroup"` container, with SVG icons added as decorative siblings
+ * for the visual stars and a caption span the JS module updates as the
+ * selection changes. Without JavaScript the customer still has a working
+ * (if visually plain) radio group.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 10.8.0
+ *
+ * @var string             $name      Form field name (e.g. `reviews[123][rating]`).
+ * @var string             $id_prefix Prefix used for unique radio ids.
+ * @var string             $label_id  Existing label id; bound via aria-labelledby.
+ * @var int                $selected  Pre-selected value (0 = none).
+ * @var array<int, string> $labels    Map of value (1-5) to caption text.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$caption_id = $id_prefix . '-caption';
+?>
+<div
+	class="woocommerce-star-rating"
+	role="radiogroup"
+	aria-labelledby="<?php echo esc_attr( $label_id ); ?>"
+	aria-describedby="<?php echo esc_attr( $caption_id ); ?>"
+	data-caption-id="<?php echo esc_attr( $caption_id ); ?>"
+>
+	<?php foreach ( $labels as $value => $label ) : ?>
+		<?php
+		$input_id = $id_prefix . '-' . $value;
+		$checked  = $value === $selected;
+		?>
+		<label class="woocommerce-star-rating__star" for="<?php echo esc_attr( $input_id ); ?>">
+			<input
+				class="woocommerce-star-rating__input"
+				type="radio"
+				id="<?php echo esc_attr( $input_id ); ?>"
+				name="<?php echo esc_attr( $name ); ?>"
+				value="<?php echo esc_attr( (string) $value ); ?>"
+				data-label="<?php echo esc_attr( $label ); ?>"
+				<?php checked( $checked ); ?>
+			/>
+			<span class="screen-reader-text">
+				<?php
+				printf(
+					/* translators: 1: numeric star rating 2: label text e.g. "Good" */
+					esc_html__( '%1$d out of 5 stars: %2$s', 'woocommerce' ),
+					(int) $value,
+					esc_html( $label )
+				);
+				?>
+			</span>
+			<svg
+				class="woocommerce-star-rating__icon"
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<path d="M12 2.5l2.92 6.36 6.99.74-5.21 4.74 1.46 6.86L12 17.77l-6.16 3.43 1.46-6.86L2.09 9.6l6.99-.74L12 2.5z" />
+			</svg>
+		</label>
+	<?php endforeach; ?>
+
+	<span
+		id="<?php echo esc_attr( $caption_id ); ?>"
+		class="woocommerce-star-rating__caption"
+		aria-live="polite"
+	>
+		<?php echo $selected > 0 && isset( $labels[ $selected ] ) ? esc_html( $labels[ $selected ] ) : ''; ?>
+	</span>
+</div>

--- a/plugins/woocommerce/templates/order/star-rating.php
+++ b/plugins/woocommerce/templates/order/star-rating.php
@@ -30,7 +30,6 @@ $caption_id = $id_prefix . '-caption';
 	role="radiogroup"
 	aria-labelledby="<?php echo esc_attr( $label_id ); ?>"
 	aria-describedby="<?php echo esc_attr( $caption_id ); ?>"
-	data-caption-id="<?php echo esc_attr( $caption_id ); ?>"
 >
 	<?php foreach ( $labels as $value => $label ) : ?>
 		<?php

--- a/plugins/woocommerce/templates/order/star-rating.php
+++ b/plugins/woocommerce/templates/order/star-rating.php
@@ -23,7 +23,13 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$caption_id = $id_prefix . '-caption';
+$caption_id      = $id_prefix . '-caption';
+$initial_caption = $selected > 0 && isset( $labels[ $selected ] ) ? $labels[ $selected ] : '';
+
+// Render in reverse (5 first, 1 last) so the visual layout — driven by
+// `flex-direction: row-reverse` — can use ~ sibling selectors for the
+// "fill stars 1..N" effect without depending on `:has()`.
+$reversed = array_reverse( $labels, true );
 ?>
 <div
 	class="woocommerce-star-rating"
@@ -31,21 +37,21 @@ $caption_id = $id_prefix . '-caption';
 	aria-labelledby="<?php echo esc_attr( $label_id ); ?>"
 	aria-describedby="<?php echo esc_attr( $caption_id ); ?>"
 >
-	<?php foreach ( $labels as $value => $label ) : ?>
+	<?php foreach ( $reversed as $value => $label ) : ?>
 		<?php
 		$input_id = $id_prefix . '-' . $value;
 		$checked  = $value === $selected;
 		?>
+		<input
+			class="woocommerce-star-rating__input"
+			type="radio"
+			id="<?php echo esc_attr( $input_id ); ?>"
+			name="<?php echo esc_attr( $name ); ?>"
+			value="<?php echo esc_attr( (string) $value ); ?>"
+			data-label="<?php echo esc_attr( $label ); ?>"
+			<?php checked( $checked ); ?>
+		/>
 		<label class="woocommerce-star-rating__star" for="<?php echo esc_attr( $input_id ); ?>">
-			<input
-				class="woocommerce-star-rating__input"
-				type="radio"
-				id="<?php echo esc_attr( $input_id ); ?>"
-				name="<?php echo esc_attr( $name ); ?>"
-				value="<?php echo esc_attr( (string) $value ); ?>"
-				data-label="<?php echo esc_attr( $label ); ?>"
-				<?php checked( $checked ); ?>
-			/>
 			<span class="screen-reader-text">
 				<?php
 				printf(
@@ -73,7 +79,5 @@ $caption_id = $id_prefix . '-caption';
 		id="<?php echo esc_attr( $caption_id ); ?>"
 		class="woocommerce-star-rating__caption"
 		aria-live="polite"
-	>
-		<?php echo $selected > 0 && isset( $labels[ $selected ] ) ? esc_html( $labels[ $selected ] ) : ''; ?>
-	</span>
+	><?php echo esc_html( $initial_caption ); ?></span>
 </div>

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/StarRatingTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/StarRatingTest.php
@@ -1,0 +1,148 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\OrderReviews;
+
+use Automattic\WooCommerce\Internal\OrderReviews\StarRating;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the accessible star-rating renderer.
+ */
+class StarRatingTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Reset filter state between tests.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_review_order_rating_labels' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox render() emits a radiogroup, five radios, and a caption span.
+	 */
+	public function test_render_emits_complete_markup(): void {
+		$html = StarRating::render(
+			array(
+				'name'      => 'reviews[42][rating]',
+				'id_prefix' => 'review-rating-42',
+				'label_id'  => 'review-rating-label-42',
+			)
+		);
+
+		$this->assertStringContainsString( 'role="radiogroup"', $html );
+		$this->assertStringContainsString( 'aria-labelledby="review-rating-label-42"', $html );
+		$this->assertStringContainsString( 'aria-describedby="review-rating-42-caption"', $html );
+
+		// Five inputs, each with a unique id.
+		foreach ( range( 1, 5 ) as $value ) {
+			$this->assertStringContainsString( 'id="review-rating-42-' . $value . '"', $html );
+			$this->assertStringContainsString( 'value="' . $value . '"', $html );
+		}
+
+		$this->assertStringContainsString( 'name="reviews[42][rating]"', $html );
+		$this->assertStringContainsString( 'aria-live="polite"', $html );
+	}
+
+	/**
+	 * @testdox render() returns an empty string when required args are missing.
+	 */
+	public function test_render_returns_empty_when_required_args_missing(): void {
+		$this->assertSame( '', StarRating::render( array() ) );
+		$this->assertSame(
+			'',
+			StarRating::render(
+				array(
+					'name'      => 'foo',
+					'id_prefix' => '',
+					'label_id'  => 'bar',
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox render() pre-checks the supplied selected value.
+	 */
+	public function test_render_marks_selected_value_checked(): void {
+		$html = StarRating::render(
+			array(
+				'name'      => 'reviews[42][rating]',
+				'id_prefix' => 'review-rating-42',
+				'label_id'  => 'review-rating-label-42',
+				'selected'  => 4,
+			)
+		);
+
+		// The `checked()` helper emits `checked='checked'`.
+		$this->assertMatchesRegularExpression(
+			'#id="review-rating-42-4"[^>]*checked#',
+			$html
+		);
+		$this->assertMatchesRegularExpression( '#class="woocommerce-star-rating__caption"[^<]*>\s*Good\s*</span>#s', $html );
+	}
+
+	/**
+	 * @testdox get_labels() returns the documented defaults out of the box.
+	 */
+	public function test_get_labels_returns_defaults(): void {
+		$labels = StarRating::get_labels();
+
+		$this->assertSame(
+			array(
+				1 => 'Very poor',
+				2 => 'Not that bad',
+				3 => 'Average',
+				4 => 'Good',
+				5 => 'Perfect',
+			),
+			$labels
+		);
+	}
+
+	/**
+	 * @testdox woocommerce_review_order_rating_labels filter overrides the defaults.
+	 */
+	public function test_filter_can_override_labels(): void {
+		add_filter(
+			'woocommerce_review_order_rating_labels',
+			static function () {
+				return array(
+					1 => 'Hated it',
+					2 => 'Meh',
+					3 => 'OK',
+					4 => 'Liked it',
+					5 => 'Loved it',
+				);
+			}
+		);
+
+		$this->assertSame( 'Loved it', StarRating::get_labels()[5] );
+	}
+
+	/**
+	 * @testdox A buggy filter that drops keys falls back to the defaults for the missing slots.
+	 */
+	public function test_filter_falls_back_when_keys_missing(): void {
+		add_filter(
+			'woocommerce_review_order_rating_labels',
+			static function () {
+				// Drop entries 2 and 4 entirely; replace 5.
+				return array(
+					1 => 'Tiny',
+					3 => 'Mid',
+					5 => 'Huge',
+				);
+			}
+		);
+
+		$labels = StarRating::get_labels();
+
+		$this->assertSame( 'Tiny', $labels[1] );
+		$this->assertSame( 'Not that bad', $labels[2] );
+		$this->assertSame( 'Mid', $labels[3] );
+		$this->assertSame( 'Good', $labels[4] );
+		$this->assertSame( 'Huge', $labels[5] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/StarRatingTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/StarRatingTest.php
@@ -84,6 +84,23 @@ class StarRatingTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox render() treats an out-of-range selected value as no selection.
+	 */
+	public function test_render_rejects_out_of_range_selected(): void {
+		$args = array(
+			'name'      => 'reviews[42][rating]',
+			'id_prefix' => 'review-rating-42',
+			'label_id'  => 'review-rating-label-42',
+		);
+
+		$above = StarRating::render( array_merge( $args, array( 'selected' => 99 ) ) );
+		$below = StarRating::render( array_merge( $args, array( 'selected' => -3 ) ) );
+
+		$this->assertDoesNotMatchRegularExpression( '#<input[^>]*\bchecked\b#', $above );
+		$this->assertDoesNotMatchRegularExpression( '#<input[^>]*\bchecked\b#', $below );
+	}
+
+	/**
 	 * @testdox get_labels() returns the documented defaults out of the box.
 	 */
 	public function test_get_labels_returns_defaults(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR ships the accessible 5-star rating control used on the Review Order page.

Native `<input type="radio">` × 5 wrapped in a `role="radiogroup"` container, visually replaced by SVG stars. Progressive enhancement adds keyboard nav (Arrow / Home / End), a dynamic caption underneath the stars, and a high-contrast focus ring. Without JavaScript the underlying radio group still works as a plain form field.

Closes \#64308 (WOOPLUG-6594).

Stacks on top of #64483 (the review-order endpoint + landing page).

(For Bug Fixes) Bug introduced in PR \# .

#### Files

```text
src/Internal/OrderReviews/
└── StarRating.php                            server-side renderer + filter-aware labels

templates/order/
├── star-rating.php                           theme-overridable partial

client/legacy/
├── js/frontend/order-review.js               vanilla JS — keyboard nav, caption updates
└── css/order-review.scss                     hide native radios, SVG fill states, focus ring

src/Internal/OrderReviews/Endpoint.php        enqueues the assets only when this endpoint renders, with `wp_style_add_data( ..., 'rtl', 'replace' )` so RTL sites load the `*-rtl.css` variant

tests/php/src/Internal/OrderReviews/StarRatingTest.php
```

#### Public contract

- **Helper:** `Automattic\WooCommerce\Internal\OrderReviews\StarRating::render( array $args )` — `name`, `id_prefix`, `label_id`, `selected?`. Internal class; reviewers / extensions interact through:
- **Filter:** `woocommerce_review_order_rating_labels` — defaults to the existing WC product-review labels (Very poor / Not that bad / Average / Good / Perfect). Filter buggy enough to drop slot keys gets fallback to the default for those slots.
- **Template override:** `templates/order/star-rating.php` (and the JS / CSS, which are regular WC frontend assets).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

> Screenshots to be added.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

> **Note:** Pretty permalinks need to register the review-order rewrite. After pulling this branch, **visit Settings → Permalinks → Save** once (or run `wp rewrite flush`).

> **Note:** This PR ships only the renderer, assets, and tests. The production caller (the per-item form on the Review Order page) lands in #64526. To exercise the control on the UI in this PR alone, apply the temporary demo patch in **Step 0** below — it wires the renderer into the existing per-item placeholder div for visual verification. The patch is purposely *not* committed; #64526 supersedes the placeholder block entirely with the proper form template.

**0. Apply the demo wiring (this PR only).**

   Copy and run from the repo root, on the `wooplug-6594-accessible-star-rating-control` branch:

   ```sh
   git apply <<'PATCH'
   diff --git a/plugins/woocommerce/templates/order/customer-review-order.php b/plugins/woocommerce/templates/order/customer-review-order.php
   --- a/plugins/woocommerce/templates/order/customer-review-order.php
   +++ b/plugins/woocommerce/templates/order/customer-review-order.php
   @@ -113,7 +113,23 @@ $items = (array) apply_filters( 'woocommerce_review_order_eligible_items', $orde
    						<div class="woocommerce-review-order__item-image">
    							<?php echo $image_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_image() returns escaped HTML. ?>
    						</div>
   -						<div class="woocommerce-review-order__item-form-placeholder"></div>
   +						<div class="woocommerce-review-order__item-form-placeholder">
   +							<?php
   +							$item_id         = (int) $item->get_id();
   +							$rating_label_id = 'woocommerce-review-rating-label-' . $item_id;
   +							$rating_control  = \Automattic\WooCommerce\Internal\OrderReviews\StarRating::render(
   +								array(
   +									'name'      => 'reviews[' . $item_id . '][rating]',
   +									'id_prefix' => 'woocommerce-review-rating-' . $item_id,
   +									'label_id'  => $rating_label_id,
   +								)
   +							);
   +							?>
   +							<p id="<?php echo esc_attr( $rating_label_id ); ?>" class="woocommerce-review-order__item-rating-label">
   +								<?php esc_html_e( 'Your rating', 'woocommerce' ); ?>
   +							</p>
   +							<?php echo $rating_control; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- StarRating::render() returns escaped HTML. ?>
   +						</div>
    					</div>
    				</li>
    			<?php endforeach; ?>
   PATCH
   ```

   Reverse with `git apply -R` using the same heredoc, or `git checkout -- plugins/woocommerce/templates/order/customer-review-order.php`.

**1. Set up a test order.**

   1. Place a test order, mark it **Completed**.
   2. Note the order id and the order key (`wp post meta get <id> _order_key`, or copy from the **Pay for order** link in admin).

**2. Visit the Review Order page.**

   1. Open `/review-order/<id>/?key=<order_key>`.
   2. The page renders with: the meta line, "Review your order" H1, intro, "* Mandatory fields" legend, the product, and a **"Your rating *"** label followed by 5 dim stars and an empty caption.

**3. Mouse interaction.**

   1. Click the 4th star. Stars 1-4 fill in; star 5 stays dim. Caption reads **Good**.
   2. Hover over star 2. Stars 1-2 light up as a preview; star 3+ dim. Move the cursor away — the rating stays at 4 (the preview is non-destructive).

**4. Keyboard navigation.**

   1. Tab into the rating control. Focus lands on the currently selected radio (or the first one if none is selected). A visible focus ring appears around the star.
   2. **ArrowRight** / **ArrowDown** moves to the next star and selects it. **ArrowLeft** / **ArrowUp** moves backward.
   3. From the last star, **ArrowRight** wraps to the first. From the first, **ArrowLeft** wraps to the last.
   4. **Home** jumps to star 1. **End** jumps to star 5.
   5. The caption updates to match the selected value at every step.

**5. Without JavaScript.**

   1. Disable JS in DevTools and reload.
   2. The native radio inputs are still keyboard-accessible (Tab to focus a radio, Arrow keys to move within the group). Selection still works; the caption just stays static.

**6. Filter override.**

   1. Add a snippet:
      ```php
      add_filter( 'woocommerce_review_order_rating_labels', function () {
          return array(
              1 => 'Hated it',
              2 => 'Meh',
              3 => 'OK',
              4 => 'Liked it',
              5 => 'Loved it',
          );
      } );
      ```
   2. Reload. Selecting the 5th star now reads **Loved it** in the caption.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- 6 PHPUnit tests in `Internal\OrderReviews\StarRatingTest` — markup completeness, missing-arg guard, pre-selected value, default labels, filter override, filter fallback for missing keys.
- All other tests in `Internal\OrderReviews\` (Scheduler + Endpoint, 21 tests) still pass.
- PHPCS clean on changed files (`lint:php:changes` and branch lint).
- PHPStan clean on every changed file.
- Live browser walk-through: mouse click selects + caption updates; keyboard nav (Arrow / Home / End / wrap) works as specified; visible focus ring appears.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add the accessible 5-star rating control used by the Review Order page. Native radio inputs with keyboard navigation (arrows, Home, End), dynamic caption, and visible focus ring; filterable labels via `woocommerce_review_order_rating_labels`.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>





