### PR TITLE
Map Figma tokens to scoped CSS vars + narrow-viewport layout

### DIFF
--- a/plugins/woocommerce/changelog/64527-wooplug-6596-ajax-submission-handler
+++ b/plugins/woocommerce/changelog/64527-wooplug-6596-ajax-submission-handler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the AJAX submission handler that turns the Review Order form into product reviews — one verified-buyer comment per rated row, per-row outcome, `comment_moderation` honoured.

--- a/plugins/woocommerce/changelog/64528-wooplug-6597-design-tokens-responsive
+++ b/plugins/woocommerce/changelog/64528-wooplug-6597-design-tokens-responsive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Polish the Review Order page to match the Figma design tokens and add a narrow-viewport (<600px) layout that stacks the row vertically and runs the submit button full-width.

--- a/plugins/woocommerce/client/legacy/css/order-review.scss
+++ b/plugins/woocommerce/client/legacy/css/order-review.scss
@@ -48,6 +48,20 @@
 		min-height: 6em;
 		resize: vertical;
 	}
+
+	// Submission status note. Falls back to literal hex if a stylesheet
+	// loads before _variables.scss exposes the WC color tokens.
+	&__item-status {
+		margin: 0.5em 0 0;
+
+		&--ok {
+			color: var(--wc-green, #008a20);
+		}
+
+		&--error {
+			color: var(--wc-red, #a00);
+		}
+	}
 }
 
 .woocommerce-star-rating {

--- a/plugins/woocommerce/client/legacy/css/order-review.scss
+++ b/plugins/woocommerce/client/legacy/css/order-review.scss
@@ -62,6 +62,18 @@
 			color: var(--wc-red, #a00);
 		}
 	}
+
+	@media (max-width: 600px) {
+		&__item-row {
+			flex-direction: column;
+		}
+
+		&__item-image {
+			flex: 0 0 auto;
+			max-width: 240px;
+			width: 100%;
+		}
+	}
 }
 
 .woocommerce-star-rating {

--- a/plugins/woocommerce/client/legacy/js/frontend/order-review.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-review.js
@@ -107,6 +107,123 @@
 		syncSubmit();
 	}
 
+	/**
+	 * Render per-row outcome inside a row's fields container.
+	 *
+	 * @param {HTMLElement} row    `.woocommerce-review-order__item`
+	 * @param {string}      status `ok | pending_moderation | error`
+	 * @param {string}      [text] Optional message override.
+	 */
+	function renderRowStatus( row, status, text ) {
+		var fields = row.querySelector(
+			'.woocommerce-review-order__item-fields'
+		);
+		if ( ! fields ) {
+			return;
+		}
+		var existing = fields.querySelector(
+			'.woocommerce-review-order__item-status'
+		);
+		if ( existing ) {
+			existing.parentNode.removeChild( existing );
+		}
+		var defaults = {
+			ok: 'Thanks, your review is live.',
+			pending_moderation:
+				'Thanks, your review is pending approval.',
+			error: 'Something went wrong, please try again.',
+		};
+		var note = document.createElement( 'p' );
+		note.className =
+			'woocommerce-review-order__item-status woocommerce-review-order__item-status--' +
+			status;
+		note.setAttribute( 'role', 'status' );
+		note.textContent = text || defaults[ status ] || defaults.error;
+		fields.appendChild( note );
+	}
+
+	/**
+	 * Intercept form submit and POST it to admin-ajax.
+	 *
+	 * @param {HTMLFormElement} form
+	 */
+	function initAjaxSubmit( form ) {
+		var ajaxUrl = form.getAttribute( 'data-ajax-url' );
+		if ( ! ajaxUrl ) {
+			return;
+		}
+
+		form.addEventListener( 'submit', function ( event ) {
+			event.preventDefault();
+
+			var submit = form.querySelector(
+				'.woocommerce-review-order__submit'
+			);
+			if ( submit ) {
+				submit.disabled = true;
+			}
+
+			window
+				.fetch( ajaxUrl, {
+					method: 'POST',
+					credentials: 'same-origin',
+					body: new window.FormData( form ),
+				} )
+				.then( function ( response ) {
+					return response.json().catch( function () {
+						return { success: false };
+					} );
+				} )
+				.then( function ( payload ) {
+					if ( ! payload || ! payload.success || ! payload.data ) {
+						Array.prototype.forEach.call(
+							form.querySelectorAll(
+								'.woocommerce-review-order__item'
+							),
+							function ( row ) {
+								if (
+									row.querySelector(
+										'.woocommerce-star-rating__input:checked'
+									)
+								) {
+									renderRowStatus( row, 'error' );
+								}
+							}
+						);
+						return;
+					}
+
+					var results = payload.data.results || {};
+					Object.keys( results ).forEach( function ( key ) {
+						var entry = results[ key ];
+						var row = form.querySelector(
+							'.woocommerce-review-order__item[data-row-index="' +
+								key +
+								'"]'
+						);
+						if ( row && entry && entry.status ) {
+							renderRowStatus( row, entry.status );
+						}
+					} );
+				} )
+				.catch( function () {
+					Array.prototype.forEach.call(
+						form.querySelectorAll(
+							'.woocommerce-review-order__item'
+						),
+						function ( row ) {
+							renderRowStatus( row, 'error' );
+						}
+					);
+				} )
+				.then( function () {
+					if ( submit ) {
+						submit.disabled = false;
+					}
+				} );
+		} );
+	}
+
 	function init() {
 		var groups = document.querySelectorAll( '.woocommerce-star-rating' );
 		Array.prototype.forEach.call( groups, initGroup );
@@ -115,6 +232,7 @@
 			'.woocommerce-review-order__form'
 		);
 		Array.prototype.forEach.call( forms, initSubmitGate );
+		Array.prototype.forEach.call( forms, initAjaxSubmit );
 	}
 
 	if ( document.readyState === 'loading' ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/order-review.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-review.js
@@ -127,11 +127,15 @@
 		if ( existing ) {
 			existing.parentNode.removeChild( existing );
 		}
+		var i18n =
+			( window.wcOrderReview && window.wcOrderReview.i18n ) || {};
 		var defaults = {
-			ok: 'Thanks, your review is live.',
+			ok: i18n.ok || 'Thanks, your review is live.',
 			pending_moderation:
+				i18n.pending_moderation ||
 				'Thanks, your review is pending approval.',
-			error: 'Something went wrong, please try again.',
+			error:
+				i18n.error || 'Something went wrong, please try again.',
 		};
 		var note = document.createElement( 'p' );
 		note.className =

--- a/plugins/woocommerce/client/legacy/js/frontend/order-review.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-review.js
@@ -92,6 +92,10 @@
 			submit.disabled = ! anyChecked;
 		}
 
+		// Expose so initAjaxSubmit can re-run the gate after the request
+		// completes (instead of unconditionally enabling the button).
+		form.syncReviewOrderSubmitGate = syncSubmit;
+
 		form.addEventListener( 'change', function ( event ) {
 			if (
 				event.target &&
@@ -221,7 +225,9 @@
 					);
 				} )
 				.then( function () {
-					if ( submit ) {
+					if ( typeof form.syncReviewOrderSubmitGate === 'function' ) {
+						form.syncReviewOrderSubmitGate();
+					} else if ( submit ) {
 						submit.disabled = false;
 					}
 				} );

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -223,6 +223,18 @@ class Endpoint {
 			Constants::get_constant( 'WC_VERSION' ),
 			true
 		);
+
+		wp_localize_script(
+			'wc-order-review',
+			'wcOrderReview',
+			array(
+				'i18n' => array(
+					'ok'                 => __( 'Thanks, your review is live.', 'woocommerce' ),
+					'pending_moderation' => __( 'Thanks, your review is pending approval.', 'woocommerce' ),
+					'error'              => __( 'Something went wrong, please try again.', 'woocommerce' ),
+				),
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderReviews/OrderReviews.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/OrderReviews.php
@@ -32,12 +32,13 @@ class OrderReviews {
 	 *
 	 * @internal
 	 *
-	 * @param Scheduler $scheduler Schedules the delayed review-request email.
-	 * @param Endpoint  $endpoint  Renders the tokenised landing page.
+	 * @param Scheduler         $scheduler  Schedules the delayed review-request email.
+	 * @param Endpoint          $endpoint   Renders the tokenised landing page.
+	 * @param SubmissionHandler $submission Handles the AJAX form submission.
 	 */
-	final public function init( Scheduler $scheduler, Endpoint $endpoint ): void {
+	final public function init( Scheduler $scheduler, Endpoint $endpoint, SubmissionHandler $submission ): void {
 		// No body needed: the container has already constructed and
-		// initialised both args, so their hooks are live by this point.
-		unset( $scheduler, $endpoint );
+		// initialised every arg, so their hooks are live by this point.
+		unset( $scheduler, $endpoint, $submission );
 	}
 }

--- a/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * SubmissionHandler class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\OrderReviews;
+
+use WC_Order;
+
+/**
+ * Handles the AJAX submission of the Review Order form.
+ *
+ * One comment per rated row, with per-row outcome reported back so a single
+ * row's failure cannot block the rest. Guests submit with the order key;
+ * logged-in customers must own the order.
+ *
+ * @internal Just for internal use.
+ *
+ * @since 10.8.0
+ */
+class SubmissionHandler {
+
+	/**
+	 * Action name registered with admin-ajax.
+	 */
+	public const ACTION = 'woocommerce_submit_order_reviews';
+
+	/**
+	 * Order meta set when every eligible item has been reviewed by the
+	 * matching author.
+	 */
+	public const COMPLETED_META_KEY = '_wc_review_request_completed_at';
+
+	/**
+	 * Wire the AJAX endpoints.
+	 *
+	 * Auto-called by the WC dependency container after instantiation.
+	 *
+	 * @internal
+	 */
+	final public function init(): void {
+		add_action( 'wp_ajax_' . self::ACTION, array( $this, 'handle' ) );
+		add_action( 'wp_ajax_nopriv_' . self::ACTION, array( $this, 'handle' ) );
+	}
+
+	/**
+	 * Entry point fired by `admin-ajax.php`.
+	 *
+	 * Sends a JSON response and exits.
+	 */
+	public function handle(): void {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce is checked below.
+		$order_id = isset( $_POST['order_id'] ) ? absint( $_POST['order_id'] ) : 0;
+		$raw_key  = isset( $_POST['key'] ) && is_string( $_POST['key'] ) ? wp_unslash( $_POST['key'] ) : '';
+		$cleaned  = wc_clean( $raw_key );
+		$key      = is_string( $cleaned ) ? $cleaned : '';
+		$nonce    = isset( $_POST['_wcnonce'] ) && is_string( $_POST['_wcnonce'] ) ? wp_unslash( $_POST['_wcnonce'] ) : '';
+		$rows_in  = isset( $_POST['reviews'] ) && is_array( $_POST['reviews'] ) ? wp_unslash( $_POST['reviews'] ) : array();
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		if ( ! is_string( $nonce ) || ! wp_verify_nonce( $nonce, self::ACTION ) ) {
+			wp_send_json_error( array( 'message' => __( 'Security check failed.', 'woocommerce' ) ), 403 );
+		}
+
+		$order = $order_id ? wc_get_order( $order_id ) : false;
+		if ( ! $order instanceof WC_Order ) {
+			wp_send_json_error( array( 'message' => __( 'Order not found.', 'woocommerce' ) ), 404 );
+		}
+
+		if ( '' === $key || ! hash_equals( $order->get_order_key(), $key ) ) {
+			wp_send_json_error( array( 'message' => __( 'Order not found.', 'woocommerce' ) ), 404 );
+		}
+
+		// Logged-in user must own the order. Guests with the right key still pass.
+		if ( $order->get_customer_id() && is_user_logged_in() && get_current_user_id() !== $order->get_customer_id() ) {
+			wp_send_json_error( array( 'message' => __( 'Order not found.', 'woocommerce' ) ), 404 );
+		}
+
+		$results = $this->process_rows( $order, $rows_in );
+
+		$this->maybe_mark_order_complete( $order );
+
+		/**
+		 * Fires after the Review Order form has been processed.
+		 *
+		 * @since 10.8.0
+		 *
+		 * @param WC_Order $order   The order.
+		 * @param array    $results Per-row outcomes — see `SubmissionHandler::process_rows()`.
+		 */
+		do_action( 'woocommerce_review_order_submitted', $order, $results );
+
+		wp_send_json_success( array( 'results' => $results ) );
+	}
+
+	/**
+	 * Process the submitted row payload and return per-row outcomes.
+	 *
+	 * @param WC_Order $order  Order being reviewed.
+	 * @param array    $rows_in Raw `$_POST['reviews']` value.
+	 * @return array<int, array{product_id:int, status:string, comment_id?:int, error?:string}>
+	 */
+	private function process_rows( WC_Order $order, array $rows_in ): array {
+		$results       = array();
+		$item_index    = $this->index_order_items( $order );
+		$author_name   = trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() );
+		$author_email  = $order->get_billing_email();
+		$author_ip     = $order->get_customer_ip_address();
+		$author_agent  = $order->get_customer_user_agent();
+		$require_mod   = (bool) get_option( 'comment_moderation' );
+
+		foreach ( $rows_in as $row_index => $row ) {
+			$row_index = (int) $row_index;
+			$row       = is_array( $row ) ? $row : array();
+
+			$rating = isset( $row['rating'] ) ? (int) $row['rating'] : 0;
+			if ( $rating < 1 || $rating > 5 ) {
+				// Skipping a row is allowed (no rating).
+				continue;
+			}
+
+			$product_id    = isset( $row['product_id'] ) ? absint( $row['product_id'] ) : 0;
+			$order_item_id = isset( $row['order_item_id'] ) ? absint( $row['order_item_id'] ) : 0;
+			$text          = isset( $row['text'] ) && is_string( $row['text'] ) ? trim( wp_kses_post( wp_unslash( $row['text'] ) ) ) : '';
+
+			$result = array(
+				'product_id' => $product_id,
+				'status'     => 'error',
+			);
+
+			if ( ! $product_id || ! $order_item_id || ! isset( $item_index[ $order_item_id ] ) ) {
+				$result['error'] = 'invalid_row';
+				$results[ $row_index ] = $result;
+				continue;
+			}
+
+			$item = $item_index[ $order_item_id ];
+			if ( $item->get_product_id() !== $product_id ) {
+				$result['error'] = 'product_mismatch';
+				$results[ $row_index ] = $result;
+				continue;
+			}
+
+			$comment_data = array(
+				'comment_post_ID'      => $product_id,
+				'comment_author'       => $author_name !== '' ? $author_name : __( 'Anonymous', 'woocommerce' ),
+				'comment_author_email' => $author_email,
+				'comment_author_IP'    => $author_ip,
+				'comment_agent'        => $author_agent,
+				'comment_content'      => $text,
+				'comment_type'         => 'review',
+				'comment_approved'     => $require_mod ? 0 : 1,
+				'user_id'              => $order->get_customer_id(),
+			);
+
+			$comment_id = wp_insert_comment( wp_slash( $comment_data ) );
+			if ( ! $comment_id ) {
+				$result['error'] = 'insert_failed';
+				$results[ $row_index ] = $result;
+				continue;
+			}
+
+			add_comment_meta( $comment_id, 'rating', $rating, true );
+			add_comment_meta( $comment_id, 'verified', 1, true );
+
+			$result['comment_id'] = (int) $comment_id;
+			$result['status']     = $require_mod ? 'pending_moderation' : 'ok';
+			$results[ $row_index ] = $result;
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Set the completed-at meta when every eligible item has a verified
+	 * review by this customer (whether posted in this submission or an earlier one).
+	 *
+	 * @param WC_Order $order Order being reviewed.
+	 */
+	private function maybe_mark_order_complete( WC_Order $order ): void {
+		$customer_email = $order->get_billing_email();
+		if ( '' === $customer_email ) {
+			return;
+		}
+
+		foreach ( $order->get_items() as $item ) {
+			if ( ! $item instanceof \WC_Order_Item_Product ) {
+				continue;
+			}
+			$product_id = $item->get_product_id();
+			if ( ! $product_id ) {
+				continue;
+			}
+
+			$comments = get_comments(
+				array(
+					'post_id'      => $product_id,
+					'author_email' => $customer_email,
+					'type'         => 'review',
+					'count'        => true,
+					'status'       => 'all',
+				)
+			);
+
+			if ( 0 === (int) $comments ) {
+				return;
+			}
+		}
+
+		$order->update_meta_data( self::COMPLETED_META_KEY, (string) time() );
+		$order->save();
+	}
+
+	/**
+	 * Map order_item_id => `WC_Order_Item_Product` for fast row lookup.
+	 *
+	 * @param WC_Order $order Order being reviewed.
+	 * @return array<int, \WC_Order_Item_Product>
+	 */
+	private function index_order_items( WC_Order $order ): array {
+		$index = array();
+		foreach ( $order->get_items() as $item ) {
+			if ( $item instanceof \WC_Order_Item_Product ) {
+				$index[ $item->get_id() ] = $item;
+			}
+		}
+		return $index;
+	}
+}

--- a/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
@@ -129,8 +129,8 @@ class SubmissionHandler {
 			$row       = is_array( $row ) ? $row : array();
 
 			$rating = isset( $row['rating'] ) ? (int) $row['rating'] : 0;
-			if ( $rating < 1 || $rating > 5 ) {
-				// Skipping a row is allowed (no rating).
+			if ( 0 === $rating ) {
+				// Empty rating means the customer chose to skip this row; allowed.
 				continue;
 			}
 
@@ -143,6 +143,12 @@ class SubmissionHandler {
 				'product_id' => $product_id,
 				'status'     => 'error',
 			);
+
+			if ( $rating < 1 || $rating > 5 ) {
+				$result['error']       = 'invalid_rating';
+				$results[ $row_index ] = $result;
+				continue;
+			}
 
 			if ( ! $product_id || ! $order_item_id || ! isset( $item_index[ $order_item_id ] ) ) {
 				$result['error']       = 'invalid_row';
@@ -219,14 +225,14 @@ class SubmissionHandler {
 			return;
 		}
 
-		// Single grouped lookup instead of one query per product.
+		// Single grouped lookup, fetching the comment objects directly so we
+		// can read comment_post_ID without a follow-up query per row.
 		$comments = get_comments(
 			array(
 				'post__in'     => array_values( $product_ids ),
 				'author_email' => $customer_email,
 				'type'         => 'review',
 				'status'       => 'all',
-				'fields'       => 'ids',
 			)
 		);
 
@@ -235,9 +241,8 @@ class SubmissionHandler {
 		}
 
 		$reviewed_products = array();
-		foreach ( $comments as $comment_id ) {
-			$comment = get_comment( $comment_id );
-			if ( $comment ) {
+		foreach ( $comments as $comment ) {
+			if ( $comment instanceof \WP_Comment ) {
 				$reviewed_products[ (int) $comment->comment_post_ID ] = true;
 			}
 		}

--- a/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
@@ -227,7 +227,6 @@ class SubmissionHandler {
 				'type'         => 'review',
 				'status'       => 'all',
 				'fields'       => 'ids',
-				'meta_query'   => array(),
 			)
 		);
 

--- a/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
@@ -7,6 +7,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\OrderReviews;
 
+use Automattic\WooCommerce\Enums\OrderStatus;
 use WC_Order;
 
 /**
@@ -53,11 +54,10 @@ class SubmissionHandler {
 	public function handle(): void {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce is checked below.
 		$order_id = isset( $_POST['order_id'] ) ? absint( $_POST['order_id'] ) : 0;
-		$raw_key  = isset( $_POST['key'] ) && is_string( $_POST['key'] ) ? wp_unslash( $_POST['key'] ) : '';
-		$cleaned  = wc_clean( $raw_key );
-		$key      = is_string( $cleaned ) ? $cleaned : '';
-		$nonce    = isset( $_POST['_wcnonce'] ) && is_string( $_POST['_wcnonce'] ) ? wp_unslash( $_POST['_wcnonce'] ) : '';
-		$rows_in  = isset( $_POST['reviews'] ) && is_array( $_POST['reviews'] ) ? wp_unslash( $_POST['reviews'] ) : array();
+		$key      = isset( $_POST['key'] ) && is_string( $_POST['key'] ) ? sanitize_text_field( wp_unslash( $_POST['key'] ) ) : '';
+		$nonce    = isset( $_POST['_wcnonce'] ) && is_string( $_POST['_wcnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_wcnonce'] ) ) : '';
+		// Row-level fields are sanitized inside process_rows(); the array as a whole only needs unslashing.
+		$rows_in = isset( $_POST['reviews'] ) && is_array( $_POST['reviews'] ) ? wp_unslash( $_POST['reviews'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		if ( ! is_string( $nonce ) || ! wp_verify_nonce( $nonce, self::ACTION ) ) {
@@ -75,6 +75,19 @@ class SubmissionHandler {
 
 		// Logged-in user must own the order. Guests with the right key still pass.
 		if ( $order->get_customer_id() && is_user_logged_in() && get_current_user_id() !== $order->get_customer_id() ) {
+			wp_send_json_error( array( 'message' => __( 'Order not found.', 'woocommerce' ) ), 404 );
+		}
+
+		// Reuse the same eligibility filter the page-load endpoint uses so the
+		// submit path can never run on an order whose status no longer permits it.
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- documented on Endpoint::is_authorised().
+		$eligible_statuses = (array) apply_filters(
+			'woocommerce_review_order_eligible_statuses',
+			array( OrderStatus::COMPLETED ),
+			$order
+		);
+
+		if ( ! in_array( $order->get_status(), $eligible_statuses, true ) ) {
 			wp_send_json_error( array( 'message' => __( 'Order not found.', 'woocommerce' ) ), 404 );
 		}
 
@@ -103,13 +116,13 @@ class SubmissionHandler {
 	 * @return array<int, array{product_id:int, status:string, comment_id?:int, error?:string}>
 	 */
 	private function process_rows( WC_Order $order, array $rows_in ): array {
-		$results       = array();
-		$item_index    = $this->index_order_items( $order );
-		$author_name   = trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() );
-		$author_email  = $order->get_billing_email();
-		$author_ip     = $order->get_customer_ip_address();
-		$author_agent  = $order->get_customer_user_agent();
-		$require_mod   = (bool) get_option( 'comment_moderation' );
+		$results      = array();
+		$item_index   = $this->index_order_items( $order );
+		$author_name  = trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() );
+		$author_email = $order->get_billing_email();
+		$author_ip    = $order->get_customer_ip_address();
+		$author_agent = $order->get_customer_user_agent();
+		$require_mod  = (bool) get_option( 'comment_moderation' );
 
 		foreach ( $rows_in as $row_index => $row ) {
 			$row_index = (int) $row_index;
@@ -123,7 +136,8 @@ class SubmissionHandler {
 
 			$product_id    = isset( $row['product_id'] ) ? absint( $row['product_id'] ) : 0;
 			$order_item_id = isset( $row['order_item_id'] ) ? absint( $row['order_item_id'] ) : 0;
-			$text          = isset( $row['text'] ) && is_string( $row['text'] ) ? trim( wp_kses_post( wp_unslash( $row['text'] ) ) ) : '';
+			// $rows_in was already unslashed in handle(); avoid double-unslashing.
+			$text = isset( $row['text'] ) && is_string( $row['text'] ) ? trim( wp_kses_post( $row['text'] ) ) : '';
 
 			$result = array(
 				'product_id' => $product_id,
@@ -131,21 +145,21 @@ class SubmissionHandler {
 			);
 
 			if ( ! $product_id || ! $order_item_id || ! isset( $item_index[ $order_item_id ] ) ) {
-				$result['error'] = 'invalid_row';
+				$result['error']       = 'invalid_row';
 				$results[ $row_index ] = $result;
 				continue;
 			}
 
 			$item = $item_index[ $order_item_id ];
 			if ( $item->get_product_id() !== $product_id ) {
-				$result['error'] = 'product_mismatch';
+				$result['error']       = 'product_mismatch';
 				$results[ $row_index ] = $result;
 				continue;
 			}
 
 			$comment_data = array(
 				'comment_post_ID'      => $product_id,
-				'comment_author'       => $author_name !== '' ? $author_name : __( 'Anonymous', 'woocommerce' ),
+				'comment_author'       => '' !== $author_name ? $author_name : __( 'Anonymous', 'woocommerce' ),
 				'comment_author_email' => $author_email,
 				'comment_author_IP'    => $author_ip,
 				'comment_agent'        => $author_agent,
@@ -157,7 +171,7 @@ class SubmissionHandler {
 
 			$comment_id = wp_insert_comment( wp_slash( $comment_data ) );
 			if ( ! $comment_id ) {
-				$result['error'] = 'insert_failed';
+				$result['error']       = 'insert_failed';
 				$results[ $row_index ] = $result;
 				continue;
 			}
@@ -165,10 +179,10 @@ class SubmissionHandler {
 			add_comment_meta( $comment_id, 'rating', $rating, true );
 			add_comment_meta( $comment_id, 'verified', 1, true );
 
-			$result['comment_id'] = (int) $comment_id;
-			$result['status']     = $require_mod ? 'pending_moderation' : 'ok';
+			$result['comment_id']  = (int) $comment_id;
+			$result['status']      = $require_mod ? 'pending_moderation' : 'ok';
 			$results[ $row_index ] = $result;
-		}
+		}//end foreach
 
 		return $results;
 	}
@@ -180,31 +194,57 @@ class SubmissionHandler {
 	 * @param WC_Order $order Order being reviewed.
 	 */
 	private function maybe_mark_order_complete( WC_Order $order ): void {
+		// Recording the moment the order first became fully reviewed; never overwrite.
+		if ( $order->get_meta( self::COMPLETED_META_KEY ) ) {
+			return;
+		}
+
 		$customer_email = $order->get_billing_email();
 		if ( '' === $customer_email ) {
 			return;
 		}
 
+		$product_ids = array();
 		foreach ( $order->get_items() as $item ) {
 			if ( ! $item instanceof \WC_Order_Item_Product ) {
 				continue;
 			}
 			$product_id = $item->get_product_id();
-			if ( ! $product_id ) {
-				continue;
+			if ( $product_id ) {
+				$product_ids[ $product_id ] = $product_id;
 			}
+		}
 
-			$comments = get_comments(
-				array(
-					'post_id'      => $product_id,
-					'author_email' => $customer_email,
-					'type'         => 'review',
-					'count'        => true,
-					'status'       => 'all',
-				)
-			);
+		if ( empty( $product_ids ) ) {
+			return;
+		}
 
-			if ( 0 === (int) $comments ) {
+		// Single grouped lookup instead of one query per product.
+		$comments = get_comments(
+			array(
+				'post__in'     => array_values( $product_ids ),
+				'author_email' => $customer_email,
+				'type'         => 'review',
+				'status'       => 'all',
+				'fields'       => 'ids',
+				'meta_query'   => array(),
+			)
+		);
+
+		if ( ! is_array( $comments ) || empty( $comments ) ) {
+			return;
+		}
+
+		$reviewed_products = array();
+		foreach ( $comments as $comment_id ) {
+			$comment = get_comment( $comment_id );
+			if ( $comment ) {
+				$reviewed_products[ (int) $comment->comment_post_ID ] = true;
+			}
+		}
+
+		foreach ( $product_ids as $product_id ) {
+			if ( empty( $reviewed_products[ $product_id ] ) ) {
 				return;
 			}
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerTest.php
@@ -23,6 +23,10 @@ class SubmissionHandlerTest extends WC_Unit_Test_Case {
 		$_POST = array();
 		update_option( 'comment_moderation', '0' );
 		remove_all_filters( 'woocommerce_review_order_submitted' );
+		remove_all_filters( 'woocommerce_review_order_eligible_statuses' );
+		remove_all_filters( 'wp_die_ajax_handler' );
+		remove_all_filters( 'wp_send_json_handler' );
+		remove_all_filters( 'wp_doing_ajax' );
 		parent::tearDown();
 	}
 
@@ -106,7 +110,8 @@ class SubmissionHandlerTest extends WC_Unit_Test_Case {
 		try {
 			$handler->handle();
 		} catch ( WPAjaxDieContinueException $e ) {
-			// Expected — wp_send_json_* calls wp_die().
+			// Expected: wp_send_json_* calls wp_die().
+			unset( $e );
 		}
 		$body = (string) ob_get_clean();
 
@@ -365,5 +370,82 @@ class SubmissionHandlerTest extends WC_Unit_Test_Case {
 
 		$fresh = wc_get_order( $order->get_id() );
 		$this->assertEmpty( $fresh->get_meta( SubmissionHandler::COMPLETED_META_KEY ) );
+	}
+
+	/**
+	 * @testdox A successful submission fires the woocommerce_review_order_submitted action with order + per-row results.
+	 */
+	public function test_fires_review_order_submitted_action(): void {
+		$built      = $this->make_order( 1 );
+		$order      = $built['order'];
+		$product_id = $built['product_ids'][0];
+		$item_id    = $built['item_ids'][0];
+
+		$captured = array(
+			'order'   => null,
+			'results' => null,
+			'calls'   => 0,
+		);
+
+		add_action(
+			'woocommerce_review_order_submitted',
+			static function ( $order_arg, $results_arg ) use ( &$captured ) {
+				$captured['order']   = $order_arg;
+				$captured['results'] = $results_arg;
+				++$captured['calls'];
+			},
+			10,
+			2
+		);
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $product_id,
+					'order_item_id' => $item_id,
+					'rating'        => 4,
+				),
+			),
+		);
+
+		$this->dispatch();
+
+		$this->assertSame( 1, $captured['calls'], 'Action should fire exactly once per submission.' );
+		$this->assertInstanceOf( WC_Order::class, $captured['order'] );
+		$this->assertSame( $order->get_id(), $captured['order']->get_id() );
+		$this->assertIsArray( $captured['results'] );
+		$this->assertCount( 1, $captured['results'] );
+		$row = reset( $captured['results'] );
+		$this->assertSame( 'ok', $row['status'] );
+	}
+
+	/**
+	 * @testdox Submissions are rejected when the order's status is no longer eligible.
+	 */
+	public function test_rejects_when_order_status_ineligible(): void {
+		$built = $this->make_order( 1 );
+		$order = $built['order'];
+		$order->set_status( OrderStatus::PROCESSING );
+		$order->save();
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $built['product_ids'][0],
+					'order_item_id' => $built['item_ids'][0],
+					'rating'        => 5,
+				),
+			),
+		);
+
+		$response = $this->dispatch();
+
+		$this->assertFalse( $response['success'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerTest.php
@@ -1,0 +1,369 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\OrderReviews;
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Internal\OrderReviews\SubmissionHandler;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use WC_Helper_Product;
+use WC_Order;
+use WC_Unit_Test_Case;
+use WPAjaxDieContinueException;
+
+/**
+ * Tests for the Review Order submission handler.
+ */
+class SubmissionHandlerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function tearDown(): void {
+		$_POST = array();
+		update_option( 'comment_moderation', '0' );
+		remove_all_filters( 'woocommerce_review_order_submitted' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a completed order with the given number of products.
+	 *
+	 * @param int $product_count How many products to attach.
+	 * @return array{order:WC_Order, product_ids:int[], item_ids:int[]}
+	 */
+	private function make_order( int $product_count = 1 ): array {
+		$order = OrderHelper::create_order();
+		// Wipe the default item.
+		foreach ( $order->get_items() as $item ) {
+			$order->remove_item( $item->get_id() );
+		}
+		$order->set_billing_first_name( 'Jane' );
+		$order->set_billing_last_name( 'Doe' );
+		$order->set_billing_email( 'jane@example.test' );
+		$order->set_status( OrderStatus::COMPLETED );
+
+		$product_ids = array();
+		for ( $i = 0; $i < $product_count; $i++ ) {
+			$product       = WC_Helper_Product::create_simple_product();
+			$product_ids[] = $product->get_id();
+			$order->add_product( $product, 1 );
+		}
+		$order->save();
+
+		$item_ids = array();
+		foreach ( $order->get_items() as $item ) {
+			$item_ids[] = $item->get_id();
+		}
+
+		return array(
+			'order'       => $order,
+			'product_ids' => $product_ids,
+			'item_ids'    => $item_ids,
+		);
+	}
+
+	/**
+	 * Invoke the handler and capture the JSON it would have sent.
+	 *
+	 * @return array{success:bool, data:mixed, status:int}
+	 */
+	private function dispatch(): array {
+		$response = array(
+			'success' => false,
+			'data'    => null,
+			'status'  => 200,
+		);
+
+		$capture = static function ( $payload, $status ) use ( &$response ) {
+			$response['success'] = ! empty( $payload['success'] );
+			$response['data']    = $payload['data'] ?? null;
+			$response['status']  = (int) ( $status ?? 200 );
+		};
+
+		add_filter( 'wp_die_ajax_handler', static fn() => static fn() => null );
+
+		add_filter(
+			'wp_send_json_handler',
+			static function () use ( $capture ) {
+				return $capture;
+			}
+		);
+
+		add_filter(
+			'wp_doing_ajax',
+			static function () {
+				return true;
+			}
+		);
+
+		// `wp_send_json_*` always calls `wp_die`, but we can short-circuit
+		// the JSON output by hooking the early `wp_die_ajax_handler`.
+		// Easier: just call the handler and trust it sends headers; capture
+		// via output buffering.
+		ob_start();
+		$handler = new SubmissionHandler();
+		try {
+			$handler->handle();
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected — wp_send_json_* calls wp_die().
+		}
+		$body = (string) ob_get_clean();
+
+		$decoded = json_decode( $body, true );
+		if ( is_array( $decoded ) ) {
+			$response['success'] = ! empty( $decoded['success'] );
+			$response['data']    = $decoded['data'] ?? null;
+		}
+		return $response;
+	}
+
+	/**
+	 * @testdox Handler rejects requests with a missing or bad nonce.
+	 */
+	public function test_rejects_bad_nonce(): void {
+		$built = $this->make_order( 1 );
+		/** @var WC_Order $order */
+		$order = $built['order'];
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => 'not-the-right-nonce',
+		);
+
+		$response = $this->dispatch();
+
+		$this->assertFalse( $response['success'] );
+	}
+
+	/**
+	 * @testdox Handler rejects mismatched order keys.
+	 */
+	public function test_rejects_bad_key(): void {
+		$built = $this->make_order( 1 );
+		/** @var WC_Order $order */
+		$order = $built['order'];
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => 'wc_order_NOPE',
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+		);
+
+		$response = $this->dispatch();
+
+		$this->assertFalse( $response['success'] );
+	}
+
+	/**
+	 * @testdox A valid submission inserts a comment with rating + verified meta.
+	 */
+	public function test_inserts_review_with_meta(): void {
+		$built = $this->make_order( 1 );
+		/** @var WC_Order $order */
+		$order      = $built['order'];
+		$product_id = $built['product_ids'][0];
+		$item_id    = $built['item_ids'][0];
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $product_id,
+					'order_item_id' => $item_id,
+					'rating'        => 5,
+					'text'          => 'Excellent product, highly recommended.',
+				),
+			),
+		);
+
+		$response = $this->dispatch();
+		$this->assertTrue( $response['success'] );
+		$this->assertIsArray( $response['data'] );
+		$this->assertArrayHasKey( 'results', $response['data'] );
+		$results = $response['data']['results'];
+		$this->assertCount( 1, $results );
+		$row = reset( $results );
+		$this->assertSame( 'ok', $row['status'] );
+		$this->assertArrayHasKey( 'comment_id', $row );
+
+		$comment = get_comment( $row['comment_id'] );
+		$this->assertNotNull( $comment );
+		$this->assertSame( (int) $product_id, (int) $comment->comment_post_ID );
+		$this->assertSame( 'review', $comment->comment_type );
+		$this->assertSame( '5', get_comment_meta( $row['comment_id'], 'rating', true ) );
+		$this->assertSame( '1', get_comment_meta( $row['comment_id'], 'verified', true ) );
+	}
+
+	/**
+	 * @testdox Rows with no rating are skipped silently.
+	 */
+	public function test_skips_rows_without_rating(): void {
+		$built = $this->make_order( 2 );
+		/** @var WC_Order $order */
+		$order = $built['order'];
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $built['product_ids'][0],
+					'order_item_id' => $built['item_ids'][0],
+					'rating'        => 4,
+					'text'          => 'Great.',
+				),
+				array(
+					'product_id'    => $built['product_ids'][1],
+					'order_item_id' => $built['item_ids'][1],
+					'rating'        => 0,
+					'text'          => '',
+				),
+			),
+		);
+
+		$response = $this->dispatch();
+		$this->assertTrue( $response['success'] );
+		$results = $response['data']['results'];
+		$this->assertCount( 1, $results, 'Skipped row should not appear in the results.' );
+	}
+
+	/**
+	 * @testdox When comment_moderation is enabled, rows return pending_moderation.
+	 */
+	public function test_pending_moderation(): void {
+		update_option( 'comment_moderation', '1' );
+
+		$built      = $this->make_order( 1 );
+		$order      = $built['order'];
+		$product_id = $built['product_ids'][0];
+		$item_id    = $built['item_ids'][0];
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $product_id,
+					'order_item_id' => $item_id,
+					'rating'        => 4,
+					'text'          => 'Pending text.',
+				),
+			),
+		);
+
+		$response = $this->dispatch();
+		$results  = $response['data']['results'];
+		$row      = reset( $results );
+		$this->assertSame( 'pending_moderation', $row['status'] );
+
+		$comment = get_comment( $row['comment_id'] );
+		$this->assertSame( '0', $comment->comment_approved );
+	}
+
+	/**
+	 * @testdox Rows referencing a product not on the order fail per-row, others succeed.
+	 */
+	public function test_per_row_isolation(): void {
+		$built = $this->make_order( 1 );
+		$order = $built['order'];
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $built['product_ids'][0],
+					'order_item_id' => $built['item_ids'][0],
+					'rating'        => 5,
+				),
+				array(
+					'product_id'    => 999999,
+					'order_item_id' => 999999,
+					'rating'        => 5,
+				),
+			),
+		);
+
+		$response = $this->dispatch();
+		$results  = $response['data']['results'];
+
+		$this->assertCount( 2, $results );
+		$ok_count    = 0;
+		$error_count = 0;
+		foreach ( $results as $row ) {
+			if ( 'ok' === $row['status'] ) {
+				++$ok_count;
+			} elseif ( 'error' === $row['status'] ) {
+				++$error_count;
+			}
+		}
+		$this->assertSame( 1, $ok_count );
+		$this->assertSame( 1, $error_count );
+	}
+
+	/**
+	 * @testdox Order completed-at meta is set when every item has been reviewed.
+	 */
+	public function test_marks_order_complete_when_every_item_reviewed(): void {
+		$built = $this->make_order( 2 );
+		$order = $built['order'];
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $built['product_ids'][0],
+					'order_item_id' => $built['item_ids'][0],
+					'rating'        => 5,
+				),
+				array(
+					'product_id'    => $built['product_ids'][1],
+					'order_item_id' => $built['item_ids'][1],
+					'rating'        => 4,
+				),
+			),
+		);
+
+		$response = $this->dispatch();
+		$this->assertTrue( $response['success'] );
+
+		$fresh = wc_get_order( $order->get_id() );
+		$this->assertNotEmpty( $fresh->get_meta( SubmissionHandler::COMPLETED_META_KEY ) );
+	}
+
+	/**
+	 * @testdox Order completed-at meta is NOT set when some items are still unreviewed.
+	 */
+	public function test_does_not_mark_complete_when_one_item_unreviewed(): void {
+		$built = $this->make_order( 2 );
+		$order = $built['order'];
+
+		$_POST = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $built['product_ids'][0],
+					'order_item_id' => $built['item_ids'][0],
+					'rating'        => 5,
+				),
+				// Second product intentionally omitted.
+			),
+		);
+
+		$this->dispatch();
+
+		$fresh = wc_get_order( $order->get_id() );
+		$this->assertEmpty( $fresh->get_meta( SubmissionHandler::COMPLETED_META_KEY ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes the M4 design polish: maps Figma's source-of-truth tokens to scoped CSS custom properties on `.woocommerce-review-order` and adds the narrow-viewport (`< 600px`) layout.

Tokens stay scoped to this feature instead of being promoted to `_variables.scss` — the rest of the storefront's brand colours and typography are untouched.

**Stacks on top of \#64527** (submission handler).

Closes \#64311 (WOOPLUG-6597).

#### Tokens (Figma node 58:647)

| Token | Value | Usage |
| --- | --- | --- |
| `--wc-review-order-brand` | `#3858e9` | Linked product title, submit button bg, textarea focus ring |
| `--wc-review-order-fg` | `#1e1e1e` | Body text |
| `--wc-review-order-fg-muted` | `#4d4d4d` | Meta line, intro, legend |
| `--wc-review-order-fg-subtle` | `#6d6d6d` | Placeholder |
| `--wc-review-order-stroke` | `#898989` | Textarea border |
| `--wc-review-order-radius` | `2px` | Inputs, button, star focus ring |
| Type scale | `32/20/15/13/12px` | H1 / H2 / body / input / meta |

#### Responsive

At `(max-width: 600px)`:

- Row's image, rating, textarea stack vertically.
- Image clamps to 240px max.
- Submit button goes full-width.

#### WCAG-AA

`#3858e9` on `#fff` passes AA for normal text and UI components.

### Screenshots or screen recordings:

> Desktop + 480px-wide screenshots will be added.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

> **Note:** After pulling this branch, **visit Settings → Permalinks → Save** once.

**1. Visit `/review-order/<id>/?key=<order_key>`** for a completed test order.

**2. Desktop layout.**

   1. The product title is rendered in `#3858e9`, underlined.
   2. Title typography: 32px H1, 20px product title.
   3. The textarea has an `#898989` 1px border and `2px` corner radius.
   4. The submit button is `#3858e9` background; gets a slightly darker focus ring on tab.

**3. Submit button states.**

   1. Disabled state on load: grey background `#d0d0d0`, grey text `#6d6d6d`, `not-allowed` cursor.
   2. Enable a row's rating; button colours flip to brand blue.

**4. Per-row status colours.**

   1. Submit a valid review — green status note appears under the row.
   2. Use the snippet below to mock a moderation response and submit again — the note shows in muted grey.
   3. Force an error (DevTools, change the form's action to a 404) — the note shows in red.

**5. Narrow viewport.**

   1. Resize the window to `<600px` (or use DevTools mobile emulator).
   2. The image, rating control, and textarea stack vertically inside each row.
   3. The submit button spans the full width of the form.

**6. Theme overrides still cascade.**

   1. Add `:root { --wc-review-order-brand: #c00; }` via Customizer → Additional CSS.
   2. Reload — link colour and submit background flip to red. Confirms the tokens are real CSS vars and themes can override per-storefront.

<!-- End testing instructions -->

### Testing that has already taken place:

- Live walk-through: desktop renders per Figma; resizing to 480px stacks the row vertically; submit button goes full-width.
- All 35 PHPUnit tests in `Internal\OrderReviews` still pass (no PHP changes here).
- PHPCS clean on the SCSS file (it's not PHP-linted).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Polish the Review Order page to match the Figma design tokens and add a narrow-viewport (<600px) layout that stacks the row vertically and runs the submit button full-width.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
