### PR TITLE
Fix: Use DOM API to set aria-label on tooltip span

### DIFF
--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1429,9 +1429,16 @@ jQuery( function ( $ ) {
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );
-	const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${
-		woocommerce_admin_meta_boxes.i18n_product_image_tip
-	}"></span>`;
+	const createTooltip = () => {
+		const el = document.createElement( 'span' );
+		el.className = 'woocommerce-help-tip';
+		el.tabIndex = 0;
+		el.setAttribute(
+			'aria-label',
+			woocommerce_admin_meta_boxes.i18n_product_image_tip
+		);
+		return el;
+	};
 	const tooltipData = {
 		attribute: 'data-tip',
 		content: woocommerce_admin_meta_boxes.i18n_product_image_tip,
@@ -1442,7 +1449,7 @@ jQuery( function ( $ ) {
 	};
 
 	if ( setProductImageLink ) {
-		$( tooltipMarkup )
+		$( createTooltip() )
 			.insertAfter( setProductImageLink )
 			.tipTip( tooltipData );
 	}
@@ -1450,7 +1457,7 @@ jQuery( function ( $ ) {
 	const addProductImagesLink = $( '.add_product_images > a' );
 
 	if ( addProductImagesLink ) {
-		$( tooltipMarkup )
+		$( createTooltip() )
 			.insertAfter( addProductImagesLink )
 			.tipTip( tooltipData );
 	}


### PR DESCRIPTION
## Summary

Fixes #64282

Replaces template literal string interpolation with the DOM API (`createElement` + `setAttribute`) to safely set `aria-label` on the product image tooltip `<span>`.

### Problem

The current code interpolates a translated string directly into an HTML template literal:

```js
const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${woocommerce_admin_meta_boxes.i18n_product_image_tip}"></span>`;
```

If the translation for `i18n_product_image_tip` contains a double-quote (`"`) or HTML markup, the generated `<span>` will be broken/malformed.

### Solution

- Use `document.createElement` + `setAttribute` to build the tooltip element, which safely handles any string content
- Create a `createTooltip()` factory function since the same tooltip is inserted in two locations and a single DOM element can only exist once in the DOM tree

### Testing Instructions

1. Edit a product in wp-admin
2. Verify the help tip tooltip appears next to "Set product image" link
3. Verify the help tip tooltip appears next to "Add product gallery images" link
4. Hover/click both tooltips and confirm tipTip still works
5. Inspect the DOM to confirm `aria-label` is properly set

### Files Changed

- `plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js`

Requested by @Aljullu during code review of #64251.