### PR TITLE
Add screen reader announcements for order note actions

### DIFF
--- a/plugins/woocommerce/changelog/pr-64533
+++ b/plugins/woocommerce/changelog/pr-64533
@@ -1,0 +1,3 @@
+significance: patch
+type: add
+message: Add screen reader announcements for order note actions

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1389,6 +1389,7 @@ jQuery( function ( $ ) {
 				$( 'ul.order_notes' ).prepend( response );
 				$( '#woocommerce-order-notes' ).unblock();
 				$( '#add_order_note' ).val( '' );
+				wp.a11y.speak( woocommerce_admin_meta_boxes.i18n_note_added );
 				window.wcTracks.recordEvent( 'order_edit_add_order_note', {
 					order_id: woocommerce_admin_meta_boxes.post_id,
 					note_type: data.note_type || 'private',
@@ -1419,6 +1420,7 @@ jQuery( function ( $ ) {
 
 				$.post( woocommerce_admin_meta_boxes.ajax_url, data, function() {
 					$( note ).remove();
+					wp.a11y.speak( woocommerce_admin_meta_boxes.i18n_note_deleted );
 				});
 			}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -595,7 +595,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			if ( $this->is_order_meta_box_screen( $screen_id ) ) {
 				$default_location = wc_get_customer_default_location();
 
-				wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-backbone-modal', 'selectWoo', 'wc-clipboard' ), $version );
+				wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-backbone-modal', 'selectWoo', 'wc-clipboard', 'wp-a11y' ), $version );
 				wp_localize_script(
 					'wc-admin-order-meta-boxes',
 					'woocommerce_admin_meta_boxes_order',
@@ -702,6 +702,8 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_permission_revoke'                          => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
 					'i18n_tax_rate_already_exists'                    => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),
 					'i18n_delete_note'                                => __( 'Are you sure you wish to delete this note? This action cannot be undone.', 'woocommerce' ),
+					'i18n_note_added'                                 => __( 'Order note added.', 'woocommerce' ),
+					'i18n_note_deleted'                               => __( 'Order note deleted.', 'woocommerce' ),
 					'i18n_apply_coupon'                               => __( 'Enter a coupon code to apply. Discounts are applied to line totals, before taxes.', 'woocommerce' ),
 					'i18n_add_fee'                                    => __( 'Enter a fixed amount or percentage to apply as a fee.', 'woocommerce' ),
 					'i18n_attribute_name_placeholder'                 => __( 'New attribute', 'woocommerce' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds screen reader announcements (via `wp.a11y.speak`) for order note actions in the WooCommerce admin. When a user adds or deletes an order note, a screen reader announcement is now triggered to confirm the action, improving accessibility for users who rely on assistive technology.

Closes #64512.

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Orders** and open an order
2. Add a new order note in the "Order notes" meta box
3. Verify a screen reader announcement is triggered (use a screen reader or check the `#a11y-speak-polite` element)
4. Delete an order note and verify the deletion announcement is triggered
5. Test with both private and customer note types
6. Verify no visual regressions in the order notes panel

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Add

#### Message

Add screen reader announcements for order note actions

</details>
