### PR TITLE
Don't allow adding multiple Product Filters blocks on the same page or template

### DIFF
--- a/plugins/woocommerce/changelog/update-product-filters-no-multiple
+++ b/plugins/woocommerce/changelog/update-product-filters-no-multiple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Don't allow adding multiple Product Filters blocks on the same page or template

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/block.json
@@ -15,7 +15,7 @@
 			"enableContrastChecker": false,
 			"button": true
 		},
-		"multiple": true,
+		"multiple": false,
 		"inserter": true,
 		"interactivity": true,
 		"typography": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adding two Product Filter blocks on the same page or template causes some unexpected behavior. Until those are fixed, this PR sets `multiple` to `false` in the block's `block.json` file. This way, the block can't be added more than once on the same page or template.

### Screenshots or screen recordings:

### How to test the changes in this Pull Request:

1. Create a post or page (or edit a template).
2. Add a Product Filters block.
3. Try adding another one.
4. Verify it's grayed out and can't be added.

<img width="861" height="407" alt="imatge" src="https://github.com/user-attachments/assets/04400201-89b0-44d8-a6a6-955f6cb78c75" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->