### PR TITLE
Add 'small' to allowed HTML tags in frontend.ts

### DIFF
--- a/plugins/woocommerce/changelog/64540-trunk
+++ b/plugins/woocommerce/changelog/64540-trunk
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Added 'small' to allowed HTML tags, to fix bug that breaks default markup.
+Add `small` to ALLOWED_TAGS to fix price suffix stripped on variable products.

--- a/plugins/woocommerce/changelog/64540-trunk
+++ b/plugins/woocommerce/changelog/64540-trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added 'small' to allowed HTML tags, to fix bug that breaks default markup.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
@@ -29,6 +29,7 @@ const ALLOWED_TAGS = [
 	'bdi',
 	'del',
 	'ins',
+	'small',
 ];
 const ALLOWED_ATTR = [
 	'class',


### PR DESCRIPTION
small tag was added to the array to not break the default markup when javascript updates the price on page load when using the woocommerce/product-price block

Closes #64539

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Add `small` to ALLOWED_TAGS to fix price suffix stripped on variable products.

</details>

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
