### PR TITLE
Add color picker for wc-visual attributes

### DIFF
--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -20,14 +20,10 @@ const normalizeColor = ( value: string ) => {
 
 const getInitialColor = ( input: HTMLInputElement ) => {
 	const attributeValue = normalizeColor(
-		input.getAttribute( 'value' ) ?? ''
+		input.value || input.getAttribute( 'value' ) || ''
 	);
 
-	if ( attributeValue ) {
-		return attributeValue;
-	}
-
-	return '';
+	return attributeValue;
 };
 
 const ColorField = ( { input }: { input: HTMLInputElement } ) => {
@@ -36,6 +32,9 @@ const ColorField = ( { input }: { input: HTMLInputElement } ) => {
 	const triggerRef = useRef< HTMLButtonElement | null >( null );
 
 	useEffect( () => {
+		if ( input.value === color ) {
+			return;
+		}
 		input.value = color;
 		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
 		input.dispatchEvent( new Event( 'change', { bubbles: true } ) );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -95,7 +95,7 @@ const ColorField = ( { input }: { input: HTMLInputElement } ) => {
 	return (
 		<>
 			<button
-				ref={ triggerRef as never }
+				ref={ triggerRef }
 				type="button"
 				className="wc-admin-visual-attribute-color-picker-trigger"
 				onClick={ () => setIsPopoverVisible( true ) }

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -31,6 +31,42 @@ const ColorField = ( { input }: { input: HTMLInputElement } ) => {
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const triggerRef = useRef< HTMLButtonElement | null >( null );
 
+	// Listen to changes in the input field. Because WP core uses jQuery, we
+	// can't listen to native `change` and `input` events. Instead, we override
+	// the `value` property to sync input changes to the color picker.
+	// @see https://github.com/WordPress/wordpress-develop/blob/bd4e3c97903743ab455682f32dbf38d1b38b715a/src/js/_enqueues/admin/tags.js#L194
+	useEffect( () => {
+		const syncColorWithInput = ( nextValue: string ) => {
+			const nextColor = normalizeColor( nextValue );
+
+			setColor( nextColor );
+		};
+		const inputPrototype = HTMLInputElement.prototype;
+		const valueDescriptor = Object.getOwnPropertyDescriptor(
+			inputPrototype,
+			'value'
+		);
+		let hasValueOverride = false;
+
+		if ( valueDescriptor?.get && valueDescriptor.set ) {
+			Object.defineProperty( input, 'value', {
+				...valueDescriptor,
+				configurable: true,
+				set( nextValue: string ) {
+					valueDescriptor.set?.call( this, nextValue );
+					syncColorWithInput( nextValue );
+				},
+			} );
+			hasValueOverride = true;
+		}
+
+		return () => {
+			if ( hasValueOverride ) {
+				delete ( input as { value?: string } ).value;
+			}
+		};
+	}, [ input ] );
+
 	useEffect( () => {
 		if ( normalizeColor( input.value ) === color ) {
 			return;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -11,7 +11,7 @@ const FALLBACK_COLOR = '#000000';
 const EMPTY_COLOR_VALUE = '';
 
 const normalizeColor = ( value: string ) => {
-	if ( ! value ) {
+	if ( typeof value !== 'string' || ! value ) {
 		return '';
 	}
 
@@ -32,7 +32,7 @@ const ColorField = ( { input }: { input: HTMLInputElement } ) => {
 	const triggerRef = useRef< HTMLButtonElement | null >( null );
 
 	useEffect( () => {
-		if ( input.value === color ) {
+		if ( normalizeColor( input.value ) === color ) {
 			return;
 		}
 		input.value = color;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -111,13 +111,15 @@ const ColorField = ( { input }: { input: HTMLInputElement } ) => {
 				/>
 				<span>{ displayedColorValue }</span>
 			</button>
-			<button
-				type="button"
-				className="button-link wc-admin-visual-attribute-color-picker-clear"
-				onClick={ clearColor }
-			>
-				{ __( 'Clear', 'woocommerce' ) }
-			</button>
+			{ color && (
+				<button
+					type="button"
+					className="button-link wc-admin-visual-attribute-color-picker-clear"
+					onClick={ clearColor }
+				>
+					{ __( 'Clear', 'woocommerce' ) }
+				</button>
+			) }
 			{ isPopoverVisible && triggerRef.current && (
 				<Popover
 					anchor={ triggerRef.current }

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -37,7 +37,6 @@ const ColorField = ( { input }: { input: HTMLInputElement } ) => {
 
 	useEffect( () => {
 		input.value = color;
-		input.setAttribute( 'value', color );
 		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
 		input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
 	}, [ color, input ] );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -2,13 +2,7 @@
  * External dependencies
  */
 import { ColorPicker, Popover } from '@wordpress/components';
-import {
-	createRoot,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { createRoot, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const INPUT_SELECTOR = 'input.wc-admin-visual-attribute-color-input';
@@ -18,7 +12,7 @@ const EMPTY_COLOR_VALUE = '';
 
 const normalizeColor = ( value: string ) => {
 	if ( ! value ) {
-		return EMPTY_COLOR_VALUE;
+		return '';
 	}
 
 	return value.trim().toLowerCase();
@@ -33,26 +27,13 @@ const getInitialColor = ( input: HTMLInputElement ) => {
 		return attributeValue;
 	}
 
-	const propertyValue = normalizeColor( input.value );
-
-	// Native color inputs report #000000 when empty; treat that implicit value as empty.
-	if ( propertyValue === FALLBACK_COLOR ) {
-		return EMPTY_COLOR_VALUE;
-	}
-
-	return propertyValue;
+	return '';
 };
 
-type ColorFieldProps = {
-	input: HTMLInputElement;
-};
-
-const ColorField = ( { input }: ColorFieldProps ) => {
-	const initialColor = useMemo( () => getInitialColor( input ), [ input ] );
-	const [ color, setColor ] = useState( initialColor );
+const ColorField = ( { input }: { input: HTMLInputElement } ) => {
+	const [ color, setColor ] = useState( () => getInitialColor( input ) );
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const triggerRef = useRef< HTMLButtonElement | null >( null );
-	// const hasColorPickerPointerInteraction = useRef( false );
 
 	useEffect( () => {
 		input.value = color;
@@ -82,7 +63,7 @@ const ColorField = ( { input }: ColorFieldProps ) => {
 			<button
 				ref={ triggerRef as never }
 				type="button"
-				className="regular-text wc-admin-visual-attribute-color-picker-trigger"
+				className="wc-admin-visual-attribute-color-picker-trigger"
 				onClick={ () => setIsPopoverVisible( true ) }
 				aria-haspopup="dialog"
 			>
@@ -91,14 +72,8 @@ const ColorField = ( { input }: ColorFieldProps ) => {
 						color ? '' : ' is-empty'
 					}` }
 					style={ color ? { backgroundColor: color } : undefined }
-				>
-					{ ! color && (
-						<span
-							aria-hidden="true"
-							className="wc-admin-color-swatch-empty-indicator"
-						/>
-					) }
-				</span>
+					aria-hidden="true"
+				/>
 				<span>{ displayedColorValue }</span>
 			</button>
 			<button
@@ -117,9 +92,6 @@ const ColorField = ( { input }: ColorFieldProps ) => {
 					<ColorPicker
 						color={ popoverColor }
 						onChange={ handleColorSelection }
-						// onPointerDown={ () => {
-						// 	hasColorPickerPointerInteraction.current = true;
-						// } }
 					/>
 				</Popover>
 			) }
@@ -142,8 +114,8 @@ const mountColorPicker = ( input: HTMLInputElement ) => {
 	const root = createRoot( wrapper );
 	root.render( <ColorField input={ input } /> );
 
+	// Make sure labels associated to the input also trigger the color picker.
 	const associatedLabels = input.labels ? Array.from( input.labels ) : [];
-
 	associatedLabels.forEach( ( labelElement ) => {
 		labelElement.addEventListener( 'click', ( event ) => {
 			event.preventDefault();

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -64,6 +64,7 @@ const ColorField = ( { input }: { input: HTMLInputElement } ) => {
 				className="wc-admin-visual-attribute-color-picker-trigger"
 				onClick={ () => setIsPopoverVisible( true ) }
 				aria-haspopup="dialog"
+				aria-expanded={ isPopoverVisible }
 			>
 				<span
 					className={ `wc-admin-color-swatch${

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -1,0 +1,188 @@
+/**
+ * External dependencies
+ */
+import { ColorPicker, Popover } from '@wordpress/components';
+import {
+	createRoot,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const INPUT_SELECTOR = 'input.wc-admin-visual-attribute-color-input';
+const WRAPPER_CLASS = 'wc-admin-visual-attribute-color-picker-root';
+const FALLBACK_COLOR = '#000000';
+const EMPTY_COLOR_VALUE = '';
+
+const normalizeColor = ( value: string ) => {
+	if ( ! value ) {
+		return EMPTY_COLOR_VALUE;
+	}
+
+	return value.trim().toLowerCase();
+};
+
+const getInitialColor = ( input: HTMLInputElement ) => {
+	const attributeValue = normalizeColor(
+		input.getAttribute( 'value' ) ?? ''
+	);
+
+	if ( attributeValue ) {
+		return attributeValue;
+	}
+
+	const propertyValue = normalizeColor( input.value );
+
+	// Native color inputs report #000000 when empty; treat that implicit value as empty.
+	if ( propertyValue === FALLBACK_COLOR ) {
+		return EMPTY_COLOR_VALUE;
+	}
+
+	return propertyValue;
+};
+
+type ColorFieldProps = {
+	input: HTMLInputElement;
+};
+
+const ColorField = ( { input }: ColorFieldProps ) => {
+	const initialColor = useMemo( () => getInitialColor( input ), [ input ] );
+	const [ color, setColor ] = useState( initialColor );
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
+	const triggerRef = useRef< HTMLButtonElement | null >( null );
+	// const hasColorPickerPointerInteraction = useRef( false );
+
+	useEffect( () => {
+		input.value = color;
+		input.setAttribute( 'value', color );
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+	}, [ color, input ] );
+
+	const handleColorSelection = ( value: string ) => {
+		const nextColor = normalizeColor( value );
+		setColor( nextColor );
+	};
+
+	const clearColor = () => {
+		setColor( EMPTY_COLOR_VALUE );
+		setIsPopoverVisible( false );
+	};
+
+	const displayedColorValue = color
+		? color.toUpperCase()
+		: __( 'Select a color', 'woocommerce' );
+
+	const popoverColor = color || FALLBACK_COLOR;
+
+	return (
+		<>
+			<button
+				ref={ triggerRef as never }
+				type="button"
+				className="regular-text wc-admin-visual-attribute-color-picker-trigger"
+				onClick={ () => setIsPopoverVisible( true ) }
+				aria-haspopup="dialog"
+			>
+				<span
+					className={ `wc-admin-color-swatch${
+						color ? '' : ' is-empty'
+					}` }
+					style={ color ? { backgroundColor: color } : undefined }
+				>
+					{ ! color && (
+						<span
+							aria-hidden="true"
+							className="wc-admin-color-swatch-empty-indicator"
+						/>
+					) }
+				</span>
+				<span>{ displayedColorValue }</span>
+			</button>
+			<button
+				type="button"
+				className="button-link wc-admin-visual-attribute-color-picker-clear"
+				onClick={ clearColor }
+			>
+				{ __( 'Clear', 'woocommerce' ) }
+			</button>
+			{ isPopoverVisible && triggerRef.current && (
+				<Popover
+					anchor={ triggerRef.current }
+					onClose={ () => setIsPopoverVisible( false ) }
+					placement="bottom-start"
+				>
+					<ColorPicker
+						color={ popoverColor }
+						onChange={ handleColorSelection }
+						// onPointerDown={ () => {
+						// 	hasColorPickerPointerInteraction.current = true;
+						// } }
+					/>
+				</Popover>
+			) }
+		</>
+	);
+};
+
+const mountColorPicker = ( input: HTMLInputElement ) => {
+	if ( input.dataset.wcColorPickerMounted === '1' ) {
+		return;
+	}
+
+	input.dataset.wcColorPickerMounted = '1';
+	input.style.display = 'none';
+
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = WRAPPER_CLASS;
+	input.insertAdjacentElement( 'beforebegin', wrapper );
+
+	const root = createRoot( wrapper );
+	root.render( <ColorField input={ input } /> );
+
+	const associatedLabels = input.labels ? Array.from( input.labels ) : [];
+
+	associatedLabels.forEach( ( labelElement ) => {
+		labelElement.addEventListener( 'click', ( event ) => {
+			event.preventDefault();
+
+			const trigger = wrapper.querySelector< HTMLButtonElement >(
+				'.wc-admin-visual-attribute-color-picker-trigger'
+			);
+
+			trigger?.click();
+		} );
+	} );
+};
+
+const mountAllColorPickers = ( context: ParentNode = document ) => {
+	const colorInputs = context.querySelectorAll( INPUT_SELECTOR );
+
+	colorInputs.forEach( ( inputElement ) => {
+		if ( inputElement instanceof HTMLInputElement ) {
+			mountColorPicker( inputElement );
+		}
+	} );
+};
+
+const startObserver = () => {
+	const observer = new MutationObserver( ( mutationList ) => {
+		mutationList.forEach( ( mutation ) => {
+			mutation.addedNodes.forEach( ( node ) => {
+				if ( node instanceof HTMLElement ) {
+					mountAllColorPickers( node );
+				}
+			} );
+		} );
+	} );
+
+	observer.observe( document.body, {
+		childList: true,
+		subtree: true,
+	} );
+};
+
+mountAllColorPickers();
+startObserver();

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/visual-attribute-color-picker/index.tsx
@@ -142,7 +142,15 @@ const mountColorPicker = ( input: HTMLInputElement ) => {
 	}
 
 	input.dataset.wcColorPickerMounted = '1';
-	input.style.display = 'none';
+	input.style.height = '0';
+	input.style.width = '0';
+	input.style.position = 'absolute';
+	input.style.top = '0';
+	input.style.left = '0';
+	input.style.opacity = '0';
+	input.style.visibility = 'hidden';
+	input.style.pointerEvents = 'none';
+	input.style.userSelect = 'none';
 
 	const wrapper = document.createElement( 'div' );
 	wrapper.className = WRAPPER_CLASS;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9643,7 +9643,7 @@ body.woocommerce-settings-payments-section_legacy {
 	padding: 0 12px;
 	min-height: 40px;
 	background: #fff;
-	border: 1px solid #8c8f94;
+	border: 1px solid #949494;
 	border-radius: 2px;
 	text-align: left;
 	font-size: 13px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9616,13 +9616,13 @@ body.woocommerce-settings-payments-section_legacy {
 	background-color: #fff;
 	display: inline-block;
 	vertical-align: middle;
-	vertical-align: center;
 	border: 1px solid #7e8993;
 	border-radius: 2px;
 	margin-right: 0.5em;
 	height: 1em;
 	width: 1em;
 	position: relative;
+	top: -1px;
 
 	&.is-empty::before {
 		content: '';

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1006,9 +1006,7 @@ $font-sf-pro-display: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe U
 		width: 100%;
 	}
 
-	input[type="color"] {
-		display: block;
-		margin: 6px 0;
+	.wc-admin-visual-attribute-color-picker-trigger {
 		width: 100%;
 	}
 }
@@ -9615,12 +9613,49 @@ body.woocommerce-settings-payments-section_legacy {
 }
 
 .wc-admin-color-swatch {
+	background-color: #fff;
 	display: inline-block;
 	vertical-align: middle;
 	vertical-align: center;
 	border: 1px solid #7e8993;
 	border-radius: 2px;
 	margin-right: 6px;
-	width: 12px;
 	height: 12px;
+	width: 12px;
+	position: relative;
+}
+
+.wc-admin-color-swatch-empty-indicator {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background: linear-gradient(to bottom right, transparent 47%, #7e8993 47%, #7e8993 53%, transparent 53%);
+}
+
+.wc-admin-visual-attribute-color-picker-trigger {
+	width: 95%;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 0 12px;
+	min-height: 40px;
+	background: #fff;
+	border: 1px solid #8c8f94;
+	border-radius: 2px;
+	text-align: left;
+	font-size: 13px;
+	line-height: 1.4;
+	cursor: pointer;
+
+	+ .wc-admin-visual-attribute-color-picker-clear {
+		display: block;
+		margin: 2px 0 5px;
+	}
+
+
+	.wc-admin-color-swatch {
+		margin-right: 0;
+	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9619,19 +9619,20 @@ body.woocommerce-settings-payments-section_legacy {
 	vertical-align: center;
 	border: 1px solid #7e8993;
 	border-radius: 2px;
-	margin-right: 6px;
-	height: 12px;
-	width: 12px;
+	margin-right: 0.5em;
+	height: 1em;
+	width: 1em;
 	position: relative;
-}
 
-.wc-admin-color-swatch-empty-indicator {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	background: linear-gradient(to bottom right, transparent 47%, #7e8993 47%, #7e8993 53%, transparent 53%);
+	&.is-empty::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		background: linear-gradient(to bottom right, transparent 47%, #7e8993 47%, #7e8993 53%, transparent 53%);
+	}
 }
 
 .wc-admin-visual-attribute-color-picker-trigger {
@@ -9653,7 +9654,6 @@ body.woocommerce-settings-payments-section_legacy {
 		display: block;
 		margin: 2px 0 5px;
 	}
-
 
 	.wc-admin-color-swatch {
 		margin-right: 0;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -401,10 +401,6 @@ class WC_Admin_Taxonomies {
 			return;
 		}
 
-		if ( ! array_key_exists( 'wc-visual', wc_get_attribute_types() ) ) {
-			return;
-		}
-
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'visual-attribute-color-picker', true, array( 'wp-components' ) );
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 use Automattic\WooCommerce\Internal\AssignDefaultCategory;
 
 /**
@@ -93,6 +94,7 @@ class WC_Admin_Taxonomies {
 		add_filter( 'wp_terms_checklist_args', array( $this, 'disable_checked_ontop' ) );
 
 		// Admin footer scripts for taxonomy screens.
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_visual_attribute_color_picker_script' ) );
 		add_action( 'admin_footer', array( $this, 'scripts_at_product_cat_screen_footer' ) );
 		add_action( 'admin_footer', array( $this, 'scripts_at_visual_attribute_screen_footer' ) );
 	}
@@ -349,7 +351,7 @@ class WC_Admin_Taxonomies {
 		?>
 		<div class="form-field term-color-wrap">
 			<label for="term_color"><?php esc_html_e( 'Color value', 'woocommerce' ); ?></label>
-			<input name="term_color" id="term_color" type="color" value="" />
+			<input name="term_color" id="term_color" class="wc-admin-visual-attribute-color-input" type="color" value="" />
 		</div>
 		<?php
 	}
@@ -372,10 +374,39 @@ class WC_Admin_Taxonomies {
 		<tr class="form-field term-color-wrap">
 			<th scope="row" valign="top"><label for="term_color"><?php esc_html_e( 'Color value', 'woocommerce' ); ?></label></th>
 			<td>
-				<input name="term_color" id="term_color" type="color" value="<?php echo esc_attr( $color_value ); ?>" />
+				<input name="term_color" id="term_color" class="wc-admin-visual-attribute-color-input" type="color" value="<?php echo esc_attr( $color_value ); ?>" />
 			</td>
 		</tr>
 		<?php
+	}
+
+	/**
+	 * Enqueue Gutenberg color picker script for visual attribute forms.
+	 *
+	 * @return void
+	 */
+	public function enqueue_visual_attribute_color_picker_script() {
+		$screen = get_current_screen();
+
+		if ( ! $screen ) {
+			return;
+		}
+
+		$taxonomy = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		
+
+		$is_product_editor_screen        = in_array( $screen->id, array( 'product' ), true );
+		$is_visual_attribute_term_screen = 0 === strpos( $screen->id, 'edit-pa_' ) && $this->is_visual_product_attribute_taxonomy( $taxonomy );
+
+		if ( ! $is_product_editor_screen && ! $is_visual_attribute_term_screen ) {
+			return;
+		}
+		
+		if ( ! array_key_exists( 'wc-visual', wc_get_attribute_types() ) ) {
+			return;
+		}
+
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'visual-attribute-color-picker', true, array( 'wp-components' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -393,7 +393,6 @@ class WC_Admin_Taxonomies {
 		}
 
 		$taxonomy = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		
 
 		$is_product_editor_screen        = in_array( $screen->id, array( 'product' ), true );
 		$is_visual_attribute_term_screen = 0 === strpos( $screen->id, 'edit-pa_' ) && $this->is_visual_product_attribute_taxonomy( $taxonomy );
@@ -401,7 +400,7 @@ class WC_Admin_Taxonomies {
 		if ( ! $is_product_editor_screen && ! $is_visual_attribute_term_screen ) {
 			return;
 		}
-		
+
 		if ( ! array_key_exists( 'wc-visual', wc_get_attribute_types() ) ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -351,7 +351,7 @@ class WC_Admin_Taxonomies {
 		?>
 		<div class="form-field term-color-wrap">
 			<label for="term_color"><?php esc_html_e( 'Color value', 'woocommerce' ); ?></label>
-			<input name="term_color" id="term_color" class="wc-admin-visual-attribute-color-input" type="color" value="" />
+			<input name="term_color" id="term_color" class="wc-admin-visual-attribute-color-input" type="text" value="" />
 		</div>
 		<?php
 	}
@@ -374,7 +374,7 @@ class WC_Admin_Taxonomies {
 		<tr class="form-field term-color-wrap">
 			<th scope="row" valign="top"><label for="term_color"><?php esc_html_e( 'Color value', 'woocommerce' ); ?></label></th>
 			<td>
-				<input name="term_color" id="term_color" class="wc-admin-visual-attribute-color-input" type="color" value="<?php echo esc_attr( $color_value ); ?>" />
+				<input name="term_color" id="term_color" class="wc-admin-visual-attribute-color-input" type="text" value="<?php echo esc_attr( $color_value ); ?>" />
 			</td>
 		</tr>
 		<?php
@@ -427,6 +427,8 @@ class WC_Admin_Taxonomies {
 
 			if ( $color_value ) {
 				update_term_meta( $term_id, 'color', $color_value );
+			} elseif ( '' === $color_value ) {
+				delete_term_meta( $term_id, 'color' );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -404,16 +404,20 @@ class WC_Admin_Taxonomies {
 			return;
 		}
 
-		$taxonomy = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_product_editor_screen = 'product' === $screen->id;
 
-		$is_product_editor_screen        = in_array( $screen->id, array( 'product' ), true );
-		$is_visual_attribute_term_screen = 0 === strpos( $screen->id, 'edit-pa_' ) && $this->is_visual_product_attribute_taxonomy( $taxonomy );
-
-		if ( ! $is_product_editor_screen && ! $is_visual_attribute_term_screen ) {
+		if ( $is_product_editor_screen && array_key_exists( 'wc-visual', wc_get_attribute_types() ) ) {
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'visual-attribute-color-picker', true, array( 'wp-components' ) );
 			return;
 		}
 
-		WCAdminAssets::register_script( 'wp-admin-scripts', 'visual-attribute-color-picker', true, array( 'wp-components' ) );
+		$is_attribute_term_screen = 0 === strpos( $screen->id, 'edit-pa_' );
+		$taxonomy                 = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( $is_attribute_term_screen && $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'visual-attribute-color-picker', true, array( 'wp-components' ) );
+			return;
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -85,8 +85,20 @@ class WC_Admin_Taxonomies {
 				add_action( $taxonomy . '_pre_add_form', array( $this, 'product_attribute_description' ) );
 				add_action( $taxonomy . '_add_form_fields', array( $this, 'add_product_attribute_term_fields' ) );
 				add_action( $taxonomy . '_edit_form_fields', array( $this, 'edit_product_attribute_term_fields' ), 10, 1 );
-				add_filter( "manage_edit-{$taxonomy}_columns", array( $this, 'add_term_color_columns' ) );
-				add_filter( "manage_{$taxonomy}_custom_column", array( $this, 'render_term_color_column' ), 10, 3 );
+				add_filter(
+					"manage_edit-{$taxonomy}_columns",
+					function ( $columns ) use ( $taxonomy ) {
+						return $this->add_term_color_columns( $columns, $taxonomy );
+					}
+				);
+				add_filter(
+					"manage_{$taxonomy}_custom_column",
+					function ( $content, $column, $term_id ) use ( $taxonomy ) {
+						return $this->render_term_color_column( $content, $column, $term_id, $taxonomy );
+					},
+					10,
+					3
+				);
 			}
 		}
 
@@ -475,13 +487,13 @@ class WC_Admin_Taxonomies {
 	/**
 	 * Add custom columns for product attribute terms.
 	 *
-	 * @param array $columns Existing columns.
+	 * @param array  $columns  Existing columns.
+	 * @param string $taxonomy Taxonomy slug (bound when the filter is registered).
 	 * @return array
 	 *
 	 * @internal
 	 */
-	public function add_term_color_columns( $columns ) {
-		$taxonomy = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	public function add_term_color_columns( $columns, $taxonomy ) {
 		if ( ! $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
 			return $columns;
 		}
@@ -504,21 +516,21 @@ class WC_Admin_Taxonomies {
 	/**
 	 * Render color column for product attribute terms.
 	 *
-	 * @param string $columns Existing columns HTML.
-	 * @param string $column  Current column key.
-	 * @param int    $term_id Term ID.
+	 * @param string $content  Column output so far (often empty string).
+	 * @param string $column   Current column key.
+	 * @param int    $term_id  Term ID.
+	 * @param string $taxonomy Taxonomy slug (bound when the filter is registered).
 	 * @return string
 	 *
 	 * @internal
 	 */
-	public function render_term_color_column( $columns, $column, $term_id ) {
+	public function render_term_color_column( $content, $column, $term_id, $taxonomy ) {
 		if ( 'color' !== $column ) {
-			return $columns;
+			return $content;
 		}
 
-		$taxonomy = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
-			return $columns;
+			return $content;
 		}
 
 		$color_value = get_term_meta( $term_id, 'color', true );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -79,7 +79,7 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 						<input id="wc-modal-add-attribute-term-input" type="text" name="term" value="" />
 						<# if ( data.isVisualAttribute ) { #>
 							<label for="wc-modal-add-attribute-term-color"><?php esc_html_e( 'Color value', 'woocommerce' ); ?></label>
-							<input id="wc-modal-add-attribute-term-color" class="wc-admin-visual-attribute-color-input" type="color" name="term_color" value="" />
+							<input id="wc-modal-add-attribute-term-color" class="wc-admin-visual-attribute-color-input" type="text" name="term_color" value="" />
 						<# } #>
 					</form>
 				</article>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -79,7 +79,7 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 						<input id="wc-modal-add-attribute-term-input" type="text" name="term" value="" />
 						<# if ( data.isVisualAttribute ) { #>
 							<label for="wc-modal-add-attribute-term-color"><?php esc_html_e( 'Color value', 'woocommerce' ); ?></label>
-							<input id="wc-modal-add-attribute-term-color" type="color" name="term_color" value="" />
+							<input id="wc-modal-add-attribute-term-color" class="wc-admin-visual-attribute-color-input" type="color" name="term_color" value="" />
 						<# } #>
 					</form>
 				</article>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/64324.

This PR adds the Gutenberg color picker to the screens where product attributes can be edited. This color picker replaces the native color picker from the browser.

The functionality depends on the `wc-visual` attribute type being enabled, so its, in fact, behind a feature flag.

### How to test the changes in this Pull Request:

0. Enable the feature flag if needed (see #64344).
1. With a block theme, go to Products > Attributes.
2. Create a new 'Color / Image' attribute.
3. Add some colors to the terms, verify the Gutenberg color picker is used.
4. Edit a variable product that has an attribute of the 'Color / Image' type.
5. Inside the Attributes tab, click on the 'Create value' button to create a new color.
6. Verify the popup shows the Gutenberg color picker.

<img width="783" height="731" alt="imatge" src="https://github.com/user-attachments/assets/72ae6b4f-7332-4685-a698-0bdf58931783" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
