### PR TITLE
chore: refresh PHPStan baseline after PR 64406

### DIFF
--- a/plugins/woocommerce/changelog/64406-phpstan-baseline-refresh
+++ b/plugins/woocommerce/changelog/64406-phpstan-baseline-refresh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Refresh PHPStan baseline to reflect changes from PR 64406.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -18267,7 +18267,7 @@ parameters:
 		-
 			message: '#^Property WooCommerce\:\:\$customer \(WC_Customer\) in empty\(\) is not falsy\.$#'
 			identifier: empty.property
-			count: 2
+			count: 1
 			path: includes/data-stores/class-wc-product-variable-data-store-cpt.php
 
 		-


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

PR 64406 (the VAT-exempt variable-product-prices fix) merged to trunk on 2026-05-01 and naturally resolved one of two `empty( WC()->customer )` occurrences that the PHPStan baseline was tracking in `class-wc-product-variable-data-store-cpt.php`. The baseline still expects `count: 2`, so every in-flight PR's PHPStan check fails on this drift once it merges trunk. This refreshes the baseline to `count: 1` to match reality.

Per the WooCommerce backend dev policy, the PHPStan baseline can only shrink — it must never be added to. That is exactly what is happening here: a one-line shrink from `count: 2` to `count: 1`.

Bug introduced in PR 64406.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce phpstan` from the repo root. PHPStan should pass on this branch.
2. Optionally compare to trunk where PHPStan now fails on the stale baseline entry for `WooCommerce::$customer` in `class-wc-product-variable-data-store-cpt.php`.

### Testing that has already taken place:

Verified `composer phpstan:baseline` produces exactly the one-line shrink (`count: 2` to `count: 1`) for the `WooCommerce::$customer` entry in `class-wc-product-variable-data-store-cpt.php`. No other baseline entries changed.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was created manually in this commit (`plugins/woocommerce/changelog/64406-phpstan-baseline-refresh`).

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message

Refresh PHPStan baseline to reflect changes from PR 64406.

</details>