### PR TITLE
Fix fatal TypeError when product attribute is named 'variation'

### DIFF
--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -170,7 +170,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 			$data_keys   = array_map( 'wc_variation_attribute_name', wp_list_pluck( $item_object['item_meta_array'], 'key' ) );
 			$data_values = wp_list_pluck( $item_object['item_meta_array'], 'value' );
 			$data        = array_intersect_key( array_combine( $data_keys, $data_values ), $this->get_variation_attributes() );
-		} elseif ( ! empty( $item_object['variation'] ) ) {
+		} elseif ( ! empty( $item_object['variation'] ) && is_array( $item_object['variation'] ) ) {
 			$data = $item_object['variation'];
 		} else {
 			$data = $this->get_variation_attributes();

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
@@ -109,4 +109,16 @@ class WC_Product_Variation_Test extends WC_Unit_Test_Case {
 		$this->variation->set_cogs_value( $defined_value );
 		$this->assertEquals( $expected_value, $this->variation->get_cogs_total_value() );
 	}
+
+	/**
+	 * Ensure get_permalink() handles non-array variation data without fataling.
+	 *
+	 * @testdox get_permalink() returns a URL without fataling when $item_object['variation'] is a string rather than the expected variation-attributes array.
+	 */
+	public function test_get_permalink_handles_non_array_variation_value() {
+		$url = $this->variation->get_permalink( array( 'variation' => 'some-string-value' ) );
+
+		$this->assertIsString( $url );
+		$this->assertNotEmpty( $url );
+	}
 }


### PR DESCRIPTION
## Submission Review Guidelines
- [x] I have read the Contributing Guidelines for this project.
- [x] I agree to follow the Code of Conduct that this project has adopted.

## Changes proposed in this Pull Request
Closes #41422.

When a variable product has an attribute named `"variation"`, calling `get_permalink()` on a `WC_Product_Variation` instance causes a fatal `TypeError` because `$item_object[variation]` is a string (the attribute value) instead of the expected array of variation attributes.

The `elseif` branch at line 173 checks `! empty( $item_object["variation"] )` but does not verify the value is actually an array. When a custom attribute is named `"variation"`, the key holds a string, which then gets passed to `array_filter()` on line 177 — causing the fatal.

This PR adds an `is_array()` check to the elseif condition, matching the pattern already used in `wc-template-functions.php:4341`.

## How to test the changes in this Pull Request
1. Create a variable product with an attribute named `"variation"` (e.g., `"variation" | "Small | Medium | Large"`)
2. Create variations for the product
3. Add a variation to the cart and complete checkout
4. View the order received page
5. **Before fix:** Fatal error `array_filter(): Argument #1 ($array) must be of type array, string given`
6. **After fix:** Order received page loads correctly with proper permalink

## Testing that has already taken place
- PHP syntax check passes
- phpcs lint: no new errors (pre-existing hook comment warnings only)
- Code logic: follows established pattern in `wc-template-functions.php:4341`

## Changelog
- [x] Automatically create on merge
- Significance: Patch
- Type: Fix
- Message: Fix fatal TypeError in WC_Product_Variation::get_permalink when product attribute is named "variation"