### PR TITLE
Fix quick edit saving empty stock quantity as null instead of 0

### DIFF
--- a/plugins/woocommerce/changelog/fix-61598-quick-edit-stock-quantity-null
+++ b/plugins/woocommerce/changelog/fix-61598-quick-edit-stock-quantity-null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix quick edit saving empty stock quantity as null instead of 0 when manage stock is enabled.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -499,7 +499,12 @@ class WC_Admin_Post_Types {
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
-			$stock_amount = 'yes' === $manage_stock && isset( $request_data['_stock'] ) && is_numeric( wp_unslash( $request_data['_stock'] ) ) ? wc_stock_amount( wp_unslash( $request_data['_stock'] ) ) : '';
+			if ( 'yes' === $manage_stock && isset( $request_data['_stock'] ) ) {
+				$stock_value  = wp_unslash( $request_data['_stock'] );
+				$stock_amount = is_numeric( $stock_value ) ? wc_stock_amount( $stock_value ) : 0;
+			} else {
+				$stock_amount = '';
+			}
 			$product->set_stock_quantity( $stock_amount );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #61598.

When quick editing a product with "Manage stock" enabled and leaving the Stock Quantity field empty, WooCommerce saves `null` to the database instead of `0`. This happens because `is_numeric('')` returns `false`, causing `$stock_amount` to be set to an empty string, which `set_stock_quantity()` converts to `null`.

This causes:
- Product list shows stock level as 0, but full edit shows 1
- Backorder emails show "0 items backordered" instead of the actual count
- Incorrect stock arithmetic because the DB field is null

The fix explicitly defaults non-numeric stock input to `0` when manage stock is enabled, matching the behavior of the full product edit screen.

### How to test the changes in this Pull Request:

1. Create a simple product with backorders allowed
2. Go to Products list, click **Quick Edit** on the product
3. Enable "Manage stock", leave **Stock Quantity** empty, set backorders to "Allow"
4. Save
5. **Before fix:** Stock quantity is null in DB, backorder emails show incorrect counts
6. **After fix:** Stock quantity is correctly saved as 0, backorder emails work properly
7. Also verify: entering a numeric value like 5 still saves correctly as 5

### Testing that has already taken place:

- PHP syntax check passes
- Logic verified: when manage_stock=yes and _stock is provided but empty defaults to 0 instead of null
- Rebased on latest trunk with no conflicts
- Changelog file added