### PR TITLE
Remove Facebook from OBW plugin rotation

### DIFF
--- a/plugins/woocommerce/changelog/tweak-remove-facebook-obw-plugin-rotation
+++ b/plugins/woocommerce/changelog/tweak-remove-facebook-obw-plugin-rotation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove Facebook for WooCommerce from the onboarding wizard plugin rotation.

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -594,13 +594,6 @@ class DefaultFreeExtensions {
 				'learn_more_link'  => 'https://woocommerce.com/products/snapchat/?utm_source=storeprofiler&utm_medium=product&utm_campaign=freefeatures',
 				'install_priority' => 1,
 			),
-			'facebook-for-woocommerce'            => array(
-				'label'            => __( 'Grow your business with Facebook and Instagram', 'woocommerce' ),
-				'image_url'        => plugins_url( '/assets/images/core-profiler/logo-facebook.svg', WC_PLUGIN_FILE ),
-				'description'      => __( 'List products and create ads on Facebook and Instagram.', 'woocommerce' ),
-				'learn_more_link'  => 'https://woocommerce.com/products/facebook/?utm_source=storeprofiler&utm_medium=product&utm_campaign=freefeatures',
-				'install_priority' => 2,
-			),
 			'reddit-for-woocommerce'              => array(
 				'label'            => __( 'Find New Customers with Reddit Ads', 'woocommerce' ),
 				'image_url'        => plugins_url( '/assets/images/core-profiler/logo-reddit.svg', WC_PLUGIN_FILE ),

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -91,7 +91,6 @@ class DefaultFreeExtensions {
 						self::get_plugin( 'woocommerce-services:tax' ),
 						self::get_plugin( 'tiktok-for-business' ),
 						self::get_plugin( 'snapchat-for-woocommerce' ),
-						self::get_plugin( 'facebook-for-woocommerce' ),
 						self::get_plugin( 'reddit-for-woocommerce' ),
 					)
 				),
@@ -644,12 +643,12 @@ class DefaultFreeExtensions {
 			self::get_rules_for_wcservices_tax_countries(),
 		);
 
-		// TikTok, Pinterest, and Facebook share a single spot with 1/3 rotation each.
+		// TikTok and Pinterest share a single spot with 1/2 rotation each.
 		$_plugins['tiktok-for-business']['is_visible'] = array(
 			array(
 				'type'        => 'option',
 				'option_name' => 'woocommerce_remote_variant_assignment',
-				'value'       => array( 1, 40 ),
+				'value'       => array( 1, 60 ),
 				'default'     => false,
 				'operation'   => 'range',
 			),
@@ -659,17 +658,7 @@ class DefaultFreeExtensions {
 			array(
 				'type'        => 'option',
 				'option_name' => 'woocommerce_remote_variant_assignment',
-				'value'       => array( 41, 80 ),
-				'default'     => false,
-				'operation'   => 'range',
-			),
-		);
-
-		$_plugins['facebook-for-woocommerce']['is_visible'] = array(
-			array(
-				'type'        => 'option',
-				'option_name' => 'woocommerce_remote_variant_assignment',
-				'value'       => array( 81, 120 ),
+				'value'       => array( 61, 120 ),
 				'default'     => false,
 				'operation'   => 'range',
 			),

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensionsTest.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin\RemoteFreeExtensions;
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensionsTest.php
@@ -124,6 +124,43 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Core profiler defaults should exclude Facebook from the growth plugin rotation.
+	 */
+	public function test_core_profiler_excludes_facebook_from_growth_plugin_rotation(): void {
+		$plugin_slugs = array_map(
+			function ( $plugin ) {
+				return $plugin->key;
+			},
+			$this->get_core_profiler_plugins()
+		);
+
+		$this->assertNotContains(
+			'facebook-for-woocommerce',
+			$plugin_slugs,
+			'Facebook should not be included in the core profiler defaults.'
+		);
+	}
+
+	/**
+	 * @testdox Core profiler defaults should split the growth plugin rotation between TikTok and Pinterest.
+	 */
+	public function test_core_profiler_splits_growth_plugin_rotation_between_tiktok_and_pinterest(): void {
+		$tiktok    = $this->get_core_profiler_plugin_by_slug( 'tiktok-for-business' );
+		$pinterest = $this->get_core_profiler_plugin_by_slug( 'pinterest-for-woocommerce' );
+
+		$this->assertSame(
+			array( 1, 60 ),
+			$tiktok->is_visible[0]->value,
+			'TikTok should cover the first half of the shared rotation.'
+		);
+		$this->assertSame(
+			array( 61, 120 ),
+			$pinterest->is_visible[0]->value,
+			'Pinterest should cover the second half of the shared rotation.'
+		);
+	}
+
+	/**
 	 * Evaluates bundles passed as argument and extracts keys of recommended plugins.
 	 *
 	 * @param array $bundles Array of bundles to evaluate.
@@ -146,5 +183,36 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 			},
 			$results['bundles'][0]['plugins']
 		);
+	}
+
+	/**
+	 * Gets default core profiler plugin specs.
+	 *
+	 * @return array
+	 */
+	private function get_core_profiler_plugins(): array {
+		foreach ( DefaultFreeExtensions::get_all() as $bundle ) {
+			if ( 'obw/core-profiler' === $bundle->key ) {
+				return $bundle->plugins;
+			}
+		}
+
+		$this->fail( 'Core profiler bundle was not found.' );
+	}
+
+	/**
+	 * Gets a default core profiler plugin by slug.
+	 *
+	 * @param string $slug Plugin slug.
+	 * @return object
+	 */
+	private function get_core_profiler_plugin_by_slug( string $slug ): object {
+		foreach ( $this->get_core_profiler_plugins() as $plugin ) {
+			if ( $slug === $plugin->key ) {
+				return $plugin;
+			}
+		}
+
+		$this->fail( "Plugin {$slug} was not found." );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Facebook for WooCommerce is being retired from Woo-managed surfaces, so it should no longer appear in the WooCommerce onboarding wizard plugin rotation.

This removes Facebook from the core profiler default plugin bundle and changes the shared TikTok/Pinterest placement from a three-way split to a 50/50 rotation. It also adds regression coverage for the default core profiler plugin specs.

Sibling PR for WooCommerce.com: https://github.com/Automattic/woocommerce.com/pull/25480

### How to test the changes in this Pull Request:

1. On a test site running this branch, start the WooCommerce onboarding wizard.
2. Set `woocommerce_remote_variant_assignment` to a value between `1` and `60`, then view the plugin recommendations step.
3. Confirm TikTok for WooCommerce is eligible for the shared growth placement.
4. Set `woocommerce_remote_variant_assignment` to a value between `61` and `120`, then view the plugin recommendations step again.
5. Confirm Pinterest for WooCommerce is eligible for the shared growth placement.
6. Confirm Facebook for WooCommerce is not shown in the onboarding wizard plugin recommendations.

### Testing that has already taken place:

Added unit test coverage for the core profiler defaults to confirm Facebook is excluded and TikTok/Pinterest split the shared rotation.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was created manually in `plugins/woocommerce/changelog/tweak-remove-facebook-obw-plugin-rotation`.

</details>
