### PR TITLE
Wire Shopper Collection block to the shopper-lists Store API

### DIFF
--- a/plugins/woocommerce/changelog/64563-rsm-shopper-collections-iapi-skeleton
+++ b/plugins/woocommerce/changelog/64563-rsm-shopper-collections-iapi-skeleton
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Wire the Shopper Collection block to the shopper-lists Store API via a private Interactivity API store.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -1,0 +1,414 @@
+/**
+ * External dependencies
+ */
+import { getConfig, getContext, store } from '@wordpress/interactivity';
+import type { AsyncAction } from '@wordpress/interactivity';
+import type {
+	CartImageItem,
+	CartVariationItem,
+	CurrencyInfo,
+	Currency,
+} from '@woocommerce/types';
+import type {
+	Store as CartStore,
+	SelectedAttributes,
+} from '@woocommerce/stores/woocommerce/cart';
+
+/**
+ * Internal dependencies
+ */
+import { formatPriceWithCurrency } from '../../../../../packages/prices/utils/currency';
+
+// Mirrors `ShopperListItemSchema`.
+type ShopperListItemPrices = CurrencyInfo & {
+	price: string;
+	regular_price: string;
+	sale_price: string;
+};
+
+type RawShopperListItem = {
+	key: string;
+	id: number;
+	product_id: number;
+	variation_id: number;
+	quantity: number;
+	product_exists: boolean;
+	name: string;
+	permalink: string;
+	images: CartImageItem[];
+	variation: CartVariationItem[];
+	prices: ShopperListItemPrices | null;
+	date_added_gmt: string;
+};
+
+// Flat fields directives bind to; mirrored by `ShopperCollection::enrich_item_for_display()` in PHP.
+type DisplayFields = {
+	thumbnail: string;
+	alt: string;
+	hasImage: boolean;
+	priceLabel: string;
+	quantityLabel: string;
+};
+
+export type ShopperListItem = RawShopperListItem & DisplayFields;
+
+type ListState = {
+	items: ShopperListItem[];
+	isLoading: boolean;
+	error: string | null;
+};
+
+type Lists = Record< string, ListState >;
+
+type ListContext = {
+	listName: string;
+};
+
+type IteratedContext = ListContext & {
+	listItem?: ShopperListItem;
+};
+
+type AddItemPayload = {
+	slug: string;
+	productId: number;
+	variationId?: number;
+	variation?: SelectedAttributes[];
+	quantity?: number;
+};
+
+type AddItemFromCartKeyPayload = {
+	slug: string;
+	cartItemKey: string;
+};
+
+type ListItemRef = {
+	slug: string;
+	key: string;
+};
+
+export type ShopperListsStore = {
+	state: {
+		lists: Lists;
+	};
+	actions: {
+		loadList: ( slug: string ) => Promise< void >;
+		addItem: ( payload: AddItemPayload ) => Promise< void >;
+		addItemFromCartKey: (
+			payload: AddItemFromCartKeyPayload
+		) => Promise< void >;
+		removeItem: ( payload: ListItemRef ) => Promise< void >;
+		moveItemToCart: ( payload: ListItemRef ) => Promise< void >;
+		removeCurrentItem: () => Promise< void >;
+		moveCurrentItemToCart: () => Promise< void >;
+	};
+};
+
+// Stores are locked to prevent 3PD usage until the API is stable.
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+const NAMESPACE = 'woocommerce/shopper-collections';
+const REST_PATH = 'wc/store/v1/shopper-lists';
+
+type ShopperCollectionsConfig = {
+	restUrl: string;
+	nonce: string;
+	placeholderImgSrc: string;
+};
+
+const config = ( getConfig( NAMESPACE ) ||
+	{} ) as Partial< ShopperCollectionsConfig >;
+
+const restState = {
+	restUrl: config.restUrl ?? '',
+	nonce: config.nonce ?? '',
+};
+
+const placeholderImgSrc = config.placeholderImgSrc ?? '';
+
+const currencyFromItemPrices = (
+	prices: NonNullable< RawShopperListItem[ 'prices' ] >
+): Currency => ( {
+	code: prices.currency_code as Currency[ 'code' ],
+	symbol: prices.currency_symbol,
+	thousandSeparator: prices.currency_thousand_separator,
+	decimalSeparator: prices.currency_decimal_separator,
+	minorUnit: prices.currency_minor_unit,
+	prefix: prices.currency_prefix,
+	suffix: prices.currency_suffix,
+} );
+
+const enrichItemForDisplay = ( item: RawShopperListItem ): ShopperListItem => {
+	const thumbnail = item.images?.[ 0 ]?.thumbnail ?? '';
+	const alt = item.images?.[ 0 ]?.alt ?? '';
+	const name = item.name ?? '';
+	const exists = Boolean( item.product_exists );
+
+	const priceLabel =
+		exists && item.prices
+			? formatPriceWithCurrency(
+					item.prices.price,
+					currencyFromItemPrices( item.prices )
+			  )
+			: '';
+
+	return {
+		...item,
+		name,
+		thumbnail: thumbnail || placeholderImgSrc,
+		alt: alt || name,
+		hasImage: Boolean( thumbnail || placeholderImgSrc ),
+		priceLabel,
+		quantityLabel: `Qty: ${ item.quantity }`,
+	};
+};
+
+const enrichItems = ( items: RawShopperListItem[] ): ShopperListItem[] =>
+	items.map( enrichItemForDisplay );
+
+const restRequest = async (
+	path: string,
+	init: { method: string; body?: Record< string, unknown > }
+): Promise< unknown > => {
+	if ( ! restState.restUrl ) {
+		throw new Error(
+			'Shopper Collections store is missing its REST URL config.'
+		);
+	}
+	const headers: Record< string, string > = {
+		Accept: 'application/json',
+	};
+	if ( restState.nonce ) {
+		headers[ 'X-WP-Nonce' ] = restState.nonce;
+	}
+	const requestInit: RequestInit = {
+		method: init.method,
+		credentials: 'include',
+		headers,
+	};
+	if ( init.body !== undefined ) {
+		headers[ 'Content-Type' ] = 'application/json';
+		requestInit.body = JSON.stringify( init.body );
+	}
+	const response = await fetch( restState.restUrl + path, requestInit );
+	const rotatedNonce = response.headers.get( 'X-WP-Nonce' );
+	if ( rotatedNonce ) {
+		restState.nonce = rotatedNonce;
+	}
+	const contentType = response.headers.get( 'Content-Type' ) || '';
+	// 204 responses can advertise application/json with an empty body, which
+	// would make `response.json()` throw on parse. Read as text first.
+	const rawBody =
+		response.status === 204 ? '' : await response.text();
+	const data =
+		rawBody && contentType.includes( 'application/json' )
+			? JSON.parse( rawBody )
+			: null;
+	if ( ! response.ok ) {
+		const message =
+			data &&
+			typeof data === 'object' &&
+			'message' in data &&
+			typeof ( data as { message: unknown } ).message === 'string'
+				? ( data as { message: string } ).message
+				: `Request failed with status ${ response.status }.`;
+		throw new Error( message );
+	}
+	return data;
+};
+
+const ensureListSlot = ( lists: Lists, slug: string ): ListState => {
+	if ( ! lists[ slug ] ) {
+		lists[ slug ] = { items: [], isLoading: false, error: null };
+	}
+	return lists[ slug ];
+};
+
+// Replace the item with the same key, or append it. POST may merge quantities
+// server-side, so we always trust the returned row over any local copy.
+const upsertItem = ( slot: ListState, raw: RawShopperListItem ): void => {
+	const enriched = enrichItemForDisplay( raw );
+	const index = slot.items.findIndex( ( row ) => row.key === enriched.key );
+	if ( index >= 0 ) {
+		slot.items[ index ] = enriched;
+	} else {
+		slot.items.push( enriched );
+	}
+};
+
+const toSelectedAttributes = (
+	variation: ShopperListItem[ 'variation' ]
+): SelectedAttributes[] =>
+	variation.map( ( v ) => ( {
+		attribute: v.attribute,
+		value: v.value,
+	} ) );
+
+const errorMessage = ( error: unknown ): string => {
+	if ( error instanceof Error ) {
+		return error.message;
+	}
+	if (
+		error &&
+		typeof error === 'object' &&
+		'message' in error &&
+		typeof ( error as { message: unknown } ).message === 'string'
+	) {
+		return ( error as { message: string } ).message;
+	}
+	return 'Unknown error.';
+};
+
+const { state, actions } = store< ShopperListsStore >(
+	NAMESPACE,
+	{
+		state: {
+			lists: {},
+		},
+
+		actions: {
+			*loadList( slug: string ): AsyncAction< void > {
+				const slot = ensureListSlot( state.lists, slug );
+				slot.isLoading = true;
+				slot.error = null;
+				try {
+					const items = ( yield restRequest(
+						`${ REST_PATH }/${ slug }/items`,
+						{ method: 'GET' }
+					) ) as RawShopperListItem[];
+					slot.items = enrichItems( items );
+				} catch ( error ) {
+					slot.error = errorMessage( error );
+				} finally {
+					slot.isLoading = false;
+				}
+			},
+
+			*addItem( payload: AddItemPayload ): AsyncAction< void > {
+				const { slug, productId, variationId, variation, quantity } =
+					payload;
+				const slot = ensureListSlot( state.lists, slug );
+				slot.error = null;
+				try {
+					const body: Record< string, unknown > = {
+						product_id: productId,
+					};
+					if ( variationId ) {
+						body.variation_id = variationId;
+					}
+					if ( variation && variation.length ) {
+						body.variation = variation;
+					}
+					if ( typeof quantity === 'number' ) {
+						body.quantity = quantity;
+					}
+					const saved = ( yield restRequest(
+						`${ REST_PATH }/${ slug }/items`,
+						{ method: 'POST', body }
+					) ) as RawShopperListItem;
+					upsertItem( slot, saved );
+				} catch ( error ) {
+					slot.error = errorMessage( error );
+					throw error;
+				}
+			},
+
+			*addItemFromCartKey(
+				payload: AddItemFromCartKeyPayload
+			): AsyncAction< void > {
+				const { slug, cartItemKey } = payload;
+				const slot = ensureListSlot( state.lists, slug );
+				slot.error = null;
+				try {
+					const saved = ( yield restRequest(
+						`${ REST_PATH }/${ slug }/items`,
+						{
+							method: 'POST',
+							body: { cart_item_key: cartItemKey },
+						}
+					) ) as RawShopperListItem;
+					upsertItem( slot, saved );
+				} catch ( error ) {
+					slot.error = errorMessage( error );
+					throw error;
+				}
+			},
+
+			*removeItem( payload: ListItemRef ): AsyncAction< void > {
+				const { slug, key } = payload;
+				const slot = ensureListSlot( state.lists, slug );
+				slot.error = null;
+
+				// Optimistic update: drop the row first so the UI feels
+				// instant, then send the request. Restore on failure.
+				const index = slot.items.findIndex(
+					( row ) => row.key === key
+				);
+				if ( index < 0 ) {
+					return;
+				}
+				const [ removed ] = slot.items.splice( index, 1 );
+
+				try {
+					yield restRequest(
+						`${ REST_PATH }/${ slug }/items/${ key }`,
+						{ method: 'DELETE' }
+					);
+				} catch ( error ) {
+					slot.items.splice( index, 0, removed );
+					slot.error = errorMessage( error );
+					throw error;
+				}
+			},
+
+			*moveItemToCart( payload: ListItemRef ): AsyncAction< void > {
+				const { slug, key } = payload;
+				const slot = ensureListSlot( state.lists, slug );
+				const item = slot.items.find( ( row ) => row.key === key );
+				if ( ! item ) {
+					return;
+				}
+				if ( ! item.product_exists ) {
+					slot.error =
+						'This product is no longer available in the catalog.';
+					return;
+				}
+				const { actions: cartActions } = store< CartStore >(
+					'woocommerce',
+					{},
+					{ lock: universalLock }
+				);
+				yield cartActions.addCartItem( {
+					id: item.id,
+					quantity: item.quantity,
+					variation: toSelectedAttributes( item.variation ),
+					type: item.variation_id > 0 ? 'variation' : 'simple',
+				} );
+				yield actions.removeItem( { slug, key } );
+			},
+
+			*removeCurrentItem(): AsyncAction< void > {
+				const ctx = getContext< IteratedContext >();
+				if ( ! ctx?.listName || ! ctx.listItem ) {
+					return;
+				}
+				yield actions.removeItem( {
+					slug: ctx.listName,
+					key: ctx.listItem.key,
+				} );
+			},
+
+			*moveCurrentItemToCart(): AsyncAction< void > {
+				const ctx = getContext< IteratedContext >();
+				if ( ! ctx?.listName || ! ctx.listItem ) {
+					return;
+				}
+				yield actions.moveItemToCart( {
+					slug: ctx.listName,
+					key: ctx.listItem.key,
+				} );
+			},
+		},
+	},
+	{ lock: universalLock }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -198,8 +198,7 @@ const restRequest = async (
 	const contentType = response.headers.get( 'Content-Type' ) || '';
 	// 204 responses can advertise application/json with an empty body, which
 	// would make `response.json()` throw on parse. Read as text first.
-	const rawBody =
-		response.status === 204 ? '' : await response.text();
+	const rawBody = response.status === 204 ? '' : await response.text();
 	const data =
 		rawBody && contentType.includes( 'application/json' )
 			? JSON.parse( rawBody )

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -1,6 +1,4 @@
 /**
- * Side-effect import that boots the Shopper Collection iAPI store on the
- * frontend. The store itself will be wired in a follow-up that adds the
- * `@woocommerce/stores/woocommerce/shopper-lists` module.
+ * External dependencies
  */
-export {};
+import '@woocommerce/stores/woocommerce/shopper-lists';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -1,6 +1,5 @@
-// The block IS the grid. supports.layout's `columnCount` attribute drives
-// our --wc-shopper-collection-columns CSS variable (set inline on the wrapper
-// in both editor preview and PHP render). No nested grids, no inner blocks.
+// The block IS the grid; `--wc-shopper-collection-columns` is set inline
+// from the layout.columnCount attribute (editor preview + PHP render).
 .wc-block-shopper-collection {
 	display: grid;
 	gap: var(--wp--style--block-gap, 1.5em);
@@ -18,22 +17,22 @@
 	flex-direction: column;
 	gap: 0.25em;
 
-	// Image and price visual styling come from the shared atomic classes
-	// (wc-block-components-product-image / -price) loaded by the global
-	// wc-blocks stylesheet — no per-element rules needed here.
+	// Schema thumbnails are 300px+; constrain so they fit narrow columns.
+	.wc-block-components-product-image {
+		a,
+		img {
+			display: block;
+			max-width: 100%;
+			height: auto;
+		}
+	}
 
-	// Title spacing/line-height matches Product Collection's default
-	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
-	// We target wp-block-post-title (core's post-title class) because the
-	// editor preview mirrors PC's editor render, which uses core/post-title.
+	// Match Product Collection's default product-title look.
 	.wp-block-post-title {
 		line-height: 1.4;
 		margin: 0 0 0.75rem;
 	}
 
-	// Variation and quantity have no atomic equivalent in Product Collection,
-	// so we own their styling. Center-aligned and small to mirror the rest
-	// of the row (price + button use the WP `has-small-font-size` preset).
 	&__variation,
 	&__quantity {
 		color: rgba(0, 0, 0, 0.7);
@@ -42,10 +41,7 @@
 		text-align: center;
 	}
 
-	// Remove button overlays the image (mirrors Product Collection's
-	// sale-badge slot — top-right corner inside the product-image wrapper).
-	// Positioned absolute with align-self: flex-end so the parent's
-	// __inner-container flex layout pushes it to the right edge.
+	// Overlays the image like Product Collection's sale-badge slot.
 	&__remove {
 		align-self: flex-end;
 		appearance: none;

--- a/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
@@ -46,6 +46,8 @@ const entries = {
 		'./assets/js/base/stores/store-notices.ts',
 	'@woocommerce/stores/woocommerce/products':
 		'./assets/js/base/stores/woocommerce/products.ts',
+	'@woocommerce/stores/woocommerce/shopper-lists':
+		'./assets/js/base/stores/woocommerce/shopper-lists.ts',
 };
 
 module.exports = {

--- a/plugins/woocommerce/client/blocks/tsconfig.base.json
+++ b/plugins/woocommerce/client/blocks/tsconfig.base.json
@@ -124,6 +124,9 @@
 			"@woocommerce/stores/woocommerce/products": [
 				"assets/js/base/stores/woocommerce/products"
 			],
+			"@woocommerce/stores/woocommerce/shopper-lists": [
+				"assets/js/base/stores/woocommerce/shopper-lists"
+			],
 			"@woocommerce/type-defs/*": [
 				"assets/js/types/type-defs/*"
 			],

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -5,12 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 /**
- * Shopper Collection block.
- *
- * Renders a collection curated by the shopper (e.g. Saved for Later). The data
- * source and frontend interactivity are wired in follow-up tasks; this class
- * is the structural backbone that registers the block and outputs the
- * server-side container the iAPI store will hydrate.
+ * Shopper Collection block (e.g. Saved for Later).
  */
 final class ShopperCollection extends AbstractBlock {
 	/**
@@ -29,35 +24,193 @@ final class ShopperCollection extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$column_count = isset( $attributes['layout']['columnCount'] ) && is_numeric( $attributes['layout']['columnCount'] )
-			? max( 1, (int) $attributes['layout']['columnCount'] )
-			: 3;
+		$column_count = max( 1, (int) ( $attributes['layout']['columnCount'] ?? 3 ) );
+		$list_name    = (string) ( $attributes['listName'] ?? 'saved-for-later' );
 
-		$wrapper_attributes = array(
-			'class'               => 'wc-block-shopper-collection',
-			'data-wp-interactive' => 'woocommerce/shopper-collections',
-			'data-wp-context'     => '{}',
-			'data-wp-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),
-			'style'               => sprintf( '--wc-shopper-collection-columns:%d;', $column_count ),
+		wp_interactivity_config(
+			'woocommerce/shopper-collections',
+			array(
+				'restUrl'           => esc_url_raw( rest_url() ),
+				'nonce'             => wp_create_nonce( 'wp_rest' ),
+				'placeholderImgSrc' => self::placeholder_image(),
+			)
 		);
 
-		return sprintf(
-			'<ul %1$s>%2$s</ul>',
-			get_block_wrapper_attributes( $wrapper_attributes ),
-			$this->get_placeholder_markup()
+		wp_interactivity_state(
+			'woocommerce/shopper-collections',
+			array(
+				'lists' => array(
+					$list_name => $this->prefetch_list_state( $list_name ),
+				),
+			)
 		);
+
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class'               => 'wc-block-shopper-collection',
+				'data-wp-interactive' => 'woocommerce/shopper-collections',
+				'data-wp-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),
+				'style'               => sprintf( '--wc-shopper-collection-columns:%d;', $column_count ),
+			)
+		);
+
+		// Bind the empty-state to `.items.0.key` (string), not `.items.0` (array):
+		// the HTML tag processor's set_attribute() calls strtr() and crashes on arrays.
+		$items_path          = sprintf( 'state.lists.%s.items', $list_name );
+		$first_item_key_path = $items_path . '.0.key';
+		$context             = array( 'listName' => $list_name );
+
+		ob_start();
+		?>
+		<ul
+			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core helper output. ?>
+			<?php echo $wrapper_attributes; ?>
+			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core helper output. ?>
+			<?php echo wp_interactivity_data_wp_context( $context ); ?>
+		>
+			<template data-wp-each--list-item="<?php echo esc_attr( $items_path ); ?>" data-wp-each-key="context.listItem.key">
+				<li class="wc-block-shopper-collection-item">
+					<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+						<a data-wp-bind--href="context.listItem.permalink">
+							<img data-wp-bind--src="context.listItem.thumbnail" data-wp-bind--alt="context.listItem.alt" data-wp-bind--hidden="!context.listItem.hasImage">
+						</a>
+						<div class="wc-block-components-product-image__inner-container">
+							<button
+								type="button"
+								class="wc-block-shopper-collection-item__remove"
+								aria-label="<?php esc_attr_e( 'Remove from list', 'woocommerce' ); ?>"
+								data-wp-on--click="actions.removeCurrentItem"
+							>
+								<?php esc_html_e( 'Remove', 'woocommerce' ); ?>
+							</button>
+						</div>
+					</div>
+					<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
+						<a data-wp-bind--href="context.listItem.permalink" data-wp-text="context.listItem.name"></a>
+					</h2>
+					<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="!context.listItem.product_exists">
+						<span class="wc-block-components-product-price__value" data-wp-text="context.listItem.priceLabel"></span>
+					</div>
+					<span class="wc-block-shopper-collection-item__quantity" data-wp-text="context.listItem.quantityLabel" data-wp-bind--hidden="!context.listItem.product_exists"></span>
+					<div class="wp-block-button wc-block-components-product-button" data-wp-bind--hidden="!context.listItem.product_exists">
+						<button
+							type="button"
+							class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+							data-wp-on--click="actions.moveCurrentItemToCart"
+						>
+							<?php esc_html_e( 'Move to cart', 'woocommerce' ); ?>
+						</button>
+					</div>
+				</li>
+			</template>
+			<li class="wc-block-shopper-collection__empty" data-wp-bind--hidden="<?php echo esc_attr( $first_item_key_path ); ?>">
+				<?php esc_html_e( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ); ?>
+			</li>
+		</ul>
+		<?php
+		return (string) ob_get_clean();
 	}
 
 	/**
-	 * Placeholder markup for the rendered block. The real `data-wp-each` template
-	 * over `state.currentListItems` will be added once the iAPI store lands.
+	 * Pre-fetch the active list via the Store API for SSR seeding of the iAPI store.
+	 *
+	 * @param string $list_name Slug of the list to prefetch.
+	 * @return array{items: array<int, array<string, mixed>>, isLoading: bool, error: ?string}
+	 */
+	private function prefetch_list_state( string $list_name ): array {
+		$state = array(
+			'items'     => array(),
+			'isLoading' => false,
+			'error'     => null,
+		);
+
+		if ( ! is_user_logged_in() ) {
+			return $state;
+		}
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/shopper-lists/' . $list_name . '/items' );
+		$response = rest_do_request( $request );
+		$error    = $response->as_error();
+
+		if ( $error instanceof \WP_Error ) {
+			$state['error'] = $error->get_error_message();
+			return $state;
+		}
+
+		// JSON round-trip flattens nested stdClass (images[], prices); the iAPI
+		// server-side path resolver only traverses associative arrays.
+		$decoded = json_decode( (string) wp_json_encode( $response->get_data() ), true );
+
+		if ( is_array( $decoded ) ) {
+			$state['items'] = array_map(
+				static fn( $item ) => self::enrich_item_for_display( $item ),
+				$decoded
+			);
+		}
+
+		return $state;
+	}
+
+	/**
+	 * Add display fields to a raw item. Mirrored on the JS side so SSR and CSR match.
+	 *
+	 * @param array $item Raw item array from the Store API.
+	 * @return array
+	 */
+	private static function enrich_item_for_display( array $item ): array {
+		$placeholder = self::placeholder_image();
+		$thumbnail   = (string) ( $item['images'][0]['thumbnail'] ?? '' );
+		$alt         = (string) ( $item['images'][0]['alt'] ?? '' );
+		$name        = (string) $item['name'];
+
+		$item['thumbnail']     = '' !== $thumbnail ? $thumbnail : $placeholder;
+		$item['alt']           = '' !== $alt ? $alt : $name;
+		$item['hasImage']      = '' !== $thumbnail || '' !== $placeholder;
+		$item['quantityLabel'] = sprintf( 'Qty: %d', absint( $item['quantity'] ) );
+		$item['priceLabel']    = is_array( $item['prices'] )
+			? self::format_currency_amount( $item['prices'] )
+			: '';
+
+		return $item;
+	}
+
+	/**
+	 * Memoized thumbnail placeholder URL.
 	 *
 	 * @return string
 	 */
-	private function get_placeholder_markup(): string {
-		return sprintf(
-			'<li class="wc-block-shopper-collection__empty">%s</li>',
-			esc_html__( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' )
+	private static function placeholder_image(): string {
+		static $cached = null;
+		if ( null === $cached ) {
+			$cached = (string) wc_placeholder_img_src( 'woocommerce_thumbnail' );
+		}
+		return $cached;
+	}
+
+	/**
+	 * Format a Store API `prices` payload. Mirrors JS `formatPriceWithCurrency`.
+	 *
+	 * @param array $prices Money response (`price`, `currency_*` fields).
+	 * @return string
+	 */
+	private static function format_currency_amount( array $prices ): string {
+		$price = (string) $prices['price'];
+		if ( '' === $price ) {
+			return '';
+		}
+
+		$minor_unit = (int) $prices['currency_minor_unit'];
+		$amount     = (int) $price / ( 10 ** $minor_unit );
+		$formatted  = number_format(
+			$amount,
+			$minor_unit,
+			(string) $prices['currency_decimal_separator'],
+			(string) $prices['currency_thousand_separator']
+		);
+
+		return html_entity_decode(
+			(string) $prices['currency_prefix'] . $formatted . (string) $prices['currency_suffix'],
+			ENT_QUOTES | ENT_HTML5
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

> [!NOTE]
> **Stacked on #64472.** This PR targets `rsm-shopper-collections/add-storeapi-endpoints` while #64472 is still under review. Once #64472 merges, this should be retargeted to `feature/shopper-collections`.

Wires the Shopper Collection block (Saved for Later variation) to the shopper-lists Store API. After this PR a logged-in customer's saved items render server-side on first paint, and the **Remove** and **Move to cart** buttons work correctly.

The Interactivity API store is implemented in `assets/js/base/stores/woocommerce/` and handles the four CRUD calls against the relevant StoreApi endpoints.

On the PHP side, `ShopperCollection.php` prefetches the list via `rest_do_request()` for consistency, enriches each row (formatted price, thumbnail with placeholder fallback, alt-text fallback, quantity label) and seeds `wp_interactivity_state` so the SSR pass renders fully populated rows.

### Screenshots or screen recordings:

<img width="1439" height="753" alt="screencast" src="https://github.com/user-attachments/assets/2ecb2024-c4dc-4673-88e0-44f5854c0ba3" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

You'll need a logged-in customer account and at least **two products** in the catalog. Take note of their product IDs.

1.  In **wp-admin → Pages**, create a new page. Insert the **Saved for Later** block (search for "saved for later" in the inserter). Publish the page and visit it. The block should render an empty-state row.

2.  Stay logged in as the same user. Open the browser DevTools console **on the page itself** and run the snippet below twice (once per product ID) to seed two items. It uses the nonce + REST URL the block already injected on the page:

    ```js
    const cfg = JSON.parse( document.getElementById( 'wp-script-module-data-@wordpress/interactivity' ).textContent ).config[ 'woocommerce/shopper-collections' ];

    fetch( `${ cfg.restUrl }wc/store/v1/shopper-lists/saved-for-later/items`, { method: 'POST', credentials: 'include', headers: { 'Content-Type':
      'application/json', 'X-WP-Nonce': cfg.nonce }, body: JSON.stringify( { product_id: 12 } ) } ).then( r => r.json() );
    ```

    Replace `12` with a real product ID.

    <details>
    <summary><strong>cURL alternative (using Application Passwords)</strong></summary>

    If you'd rather not use the browser console, generate an Application Password for the user under **wp-admin → Users → (your user) → Application Passwords**, then:

    ```bash
    curl -X POST 'https://your-site.example/wp-json/wc/store/v1/shopper-lists/saved-for-later/items' \\
      -u 'your-username:xxxx xxxx xxxx xxxx xxxx xxxx' \\
      -H 'Content-Type: application/json' \\
      -d '{"product_id": 12}'
    ```

    Application Passwords authenticate via the \`Authorization: Basic\` header, which bypasses the cookie/nonce auth path — no \`X-WP-Nonce\` needed. The spaces in the password as displayed by WordPress can be kept as-is; WP normalizes them.
    </details>

3.  Reload the page. The block should render two rows on first paint, each with a thumbnail, product title, formatted price, and "Qty: 1". No flash of empty/placeholder content.

4.  Click **Remove** on one row. The row disappears immediately. Reload — the row stays gone (state persists server-side).

5.  Click **Move to cart** on the remaining row. The product is added to the cart (verify via the Cart page or the mini cart) and the row disappears from the saved list. Reload: the list is empty and the empty-state row ("Nothing saved yet — items you save from the cart will appear here.") is shown.

6.  Sanity check: log out and reload the page. The block should render the empty state with no console errors. (Endpoints would 401 if hit, but no calls fire until the user clicks a button.)

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Wire the Shopper Collection block to the shopper-lists Store API via a private Interactivity API store.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>