### PR TITLE
Update #64324 changelog entry

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-wc-visual-attribute-type
+++ b/plugins/woocommerce/changelog/fix-add-wc-visual-attribute-type
@@ -1,4 +1,4 @@
 Significance: minor
-Type: add
+Type: update
 
-Add wc-visual attribute type to allow setting colors for attributes
+Rename 'Select' attribute type to 'Text' in all user-facing strings


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/64324 we changed the user-facing text of the default product attribute type from 'Select' to 'Text' to better represent how it's used in block themes.

As discussed in p1777880123056269-slack-C0AURPUD15G, we want to update the changelog entry so the change is clearly stated.

### How to test the changes in this Pull Request:

Nothing to test.
