### PR TITLE
fix: dedupe check in BatchProcessingController::enqueue_processor()

### DIFF
--- a/plugins/woocommerce/changelog/64573-ai-agent-rsmapgj-314-1777906535
+++ b/plugins/woocommerce/changelog/64573-ai-agent-rsmapgj-314-1777906535
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix BatchProcessingController dedup check that allowed duplicate entries in the wc_pending_batch_processes option, preventing potential database outages on high-volume stores.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -97,7 +97,7 @@ class BatchProcessingController {
 	 */
 	public function enqueue_processor( string $processor_class_name ): void {
 		$pending_updates = $this->get_enqueued_processors();
-		if ( ! in_array( $processor_class_name, array_keys( $pending_updates ), true ) ) {
+		if ( ! in_array( $processor_class_name, $pending_updates, true ) ) {
 			$pending_updates[] = $processor_class_name;
 			$this->set_enqueued_processors( $pending_updates );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`BatchProcessingController::enqueue_processor()` had a broken dedup check that always evaluated to `false`, so every call appended a duplicate class name to the `wc_pending_batch_processes` option.

```php
// Before (broken):
if ( ! in_array( $processor_class_name, array_keys( $pending_updates ), true ) ) {

// After (fixed):
if ( ! in_array( $processor_class_name, $pending_updates, true ) ) {
```

`$pending_updates` is a numerically-indexed array of class-name strings. `array_keys()` returns integer indices `[0, 1, 2, ...]`, so the strict `in_array()` was comparing the string class name against integers and never matched. Removing `array_keys()` makes `in_array()` compare against the actual class-name values.

**Root cause / impact:** the bug was masked by a short-circuit in `remove_or_retry_failed_processors()` as long as the Action Scheduler watchdog was alive. Once the option bloats enough that the watchdog action itself times out, the watchdog disappears and `remove_or_retry_failed_processors()` runs on every web-request `shutdown` hook, firing one AS DB query per entry. On a high-volume production store this produced ~56,000 duplicate entries and ~9M queries/hour, leading to a full database outage.

Closes #64175

### Screenshots or screen recordings:

<!-- This PR was generated by the RSMAPGJ AI Coder pipeline. UI screenshots are not applicable — backend logic fix. -->

### How to test the changes in this Pull Request:

1. Apply the steps from the linked GitHub issue (woo#64175): place a few orders, then inspect the `wc_pending_batch_processes` option in `wp_options`.
2. Before the fix: the option contains one duplicate `OrderLogsDeletionProcessor` entry per order placed.
3. After the fix: the option contains exactly one entry for `OrderLogsDeletionProcessor`, regardless of how many orders are placed.
4. Run the Batch Processing test suite for the touched area.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix BatchProcessingController dedup check that allowed duplicate entries in the wc_pending_batch_processes option, preventing potential database outages on high-volume stores.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-314
