### PR TITLE
Fix typo: 'feautre' -> 'feature' in FeaturePluginCompatibility comment

### DIFF
--- a/plugins/woocommerce/changelog/fix-typo-feautre-feature-plugin-compatibility
+++ b/plugins/woocommerce/changelog/fix-typo-feautre-feature-plugin-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix typo: 'feautre' → 'feature' in FeaturePluginCompatibility comment.

--- a/plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php
+++ b/plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php
@@ -23,7 +23,7 @@ final class FeaturePluginCompatibility {
 	public const INCOMPATIBLE = 'incompatible';
 
 	/**
-	 * Plugin compatibility with the feautre is yet to be determined. Internal use only.
+	 * Plugin compatibility with the feature is yet to be determined. Internal use only.
 	 *
 	 * @internal
 	 * @var string


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a spelling typo in a docblock comment in `FeaturePluginCompatibility`. The word `feautre` was corrected to `feature` — comment-only change, no functional impact.

### How to test the changes in this Pull Request:

1. Open `plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php` around line 26.
2. Confirm the comment now reads `feature` (not `feautre`).

### Testing that has already taken place:

Visual inspection confirmed the comment correction. No functional code was changed.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. Changelog entry created manually in the branch.