### PR TITLE
Fix typo: missing apostrophe 'dont' -> "don't" in BlockHooksTrait comment

### DIFF
--- a/plugins/woocommerce/changelog/fix-typo-dont-block-hooks-trait
+++ b/plugins/woocommerce/changelog/fix-typo-dont-block-hooks-trait
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix typo: missing apostrophe in 'dont' → 'don't' in BlockHooksTrait comment.

--- a/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
@@ -161,7 +161,7 @@ trait BlockHooksTrait {
 		$pattern_slug = is_array( $context ) && isset( $context['slug'] ) ? $context['slug'] : '';
 		if ( ! $pattern_slug ) {
 			/**
-			 * Woo patterns have a slug property in $context, but core/theme patterns dont.
+			 * Woo patterns have a slug property in $context, but core/theme patterns don't.
 			 * In that case, we fallback to the name property, as they're the same.
 			 */
 			$pattern_slug = is_array( $context ) && isset( $context['name'] ) ? $context['name'] : '';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a missing apostrophe in an inline comment in `BlockHooksTrait`. The word `dont` was corrected to `don't` — comment-only change, no functional impact.

### How to test the changes in this Pull Request:

1. Open `plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php` around line 164.
2. Confirm the comment now reads `don't` (not `dont`).

### Testing that has already taken place:

Visual inspection confirmed the comment correction. No functional code was changed.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. Changelog entry created manually in the branch.