### PR TITLE
Fix typo: misplaced apostrophe 'Dont'' -> "Don't" in WC_Admin_Meta_Boxes comment

### DIFF
--- a/plugins/woocommerce/changelog/fix-typo-dont-meta-boxes
+++ b/plugins/woocommerce/changelog/fix-typo-dont-meta-boxes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix typo: misplaced apostrophe 'Dont'' → 'Don't' in WC_Admin_Meta_Boxes comment.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -219,7 +219,7 @@ class WC_Admin_Meta_Boxes {
 			return;
 		}
 
-		// Dont' save meta boxes for revisions or autosaves.
+		// Don't save meta boxes for revisions or autosaves.
 		if ( Constants::is_true( 'DOING_AUTOSAVE' ) || is_int( wp_is_post_revision( $post ) ) || is_int( wp_is_post_autosave( $post ) ) ) {
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a misplaced apostrophe in an inline comment in `WC_Admin_Meta_Boxes`. The word `Dont'` (apostrophe after the t) was corrected to `Don't` — comment-only change, no functional impact.

### How to test the changes in this Pull Request:

1. Open `plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php` around line 222.
2. Confirm the comment now reads `Don't` (not `Dont'`).

### Testing that has already taken place:

Visual inspection confirmed the comment correction. No functional code was changed.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. Changelog entry created manually in the branch.