### PR TITLE
Add OrderMarginCalculator and wc/v3/orders/{id}/margin REST endpoint

### DIFF
--- a/plugins/woocommerce/changelog/add-order-margin-calculator
+++ b/plugins/woocommerce/changelog/add-order-margin-calculator
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add OrderMarginCalculator and wc/v3/orders/{id}/margin REST endpoint to calculate gross margin and profitability per order using Cost of Goods Sold data.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -405,6 +405,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderActionsRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderStatusRestController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Orders\OrderMarginRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController::class )->register();

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
@@ -1,0 +1,37 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Orders;
+
+use Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController;
+use WC_Abstract_Order;
+use WC_Order_Item_Product;
+
+/**
+ * Calculates gross margin and profitability data for orders.
+ *
+ * Margin is computed from the order's Cost of Goods Sold (COGS) value against
+ * the net revenue (subtotal minus discounts). Requires the Cost of Goods Sold
+ * feature to be enabled; returns zeroed data when it is not.
+ *
+ * @since 10.8.0
+ */
+class OrderMarginCalculator {
+
+	/**
+	 * The instance of CostOfGoodsSoldController to use.
+	 *
+	 * @var CostOfGoodsSoldController
+	 */
+	private CostOfGoodsSoldController $cogs_controller;
+
+	/**
+	 * Initialize the instance.
+	 *
+	 * @internal
+	 * @param CostOfGoodsSoldController $cogs_controller The instance of CostOfGoodsSoldController to use.
+	 */
+	final public function init( CostOfGoodsSoldController $cogs_controller ): void {
+		$this->cogs_controller = $cogs_controller;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
@@ -1,5 +1,5 @@
 <?php
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Orders;
 

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
@@ -86,7 +86,7 @@ class OrderMarginCalculator {
 			}
 		}
 
-		return array(
+		$data = array(
 			'net_revenue'  => round( $net_revenue, 4 ),
 			'cogs'         => round( $cogs, 4 ),
 			'gross_profit' => round( $gross_profit, 4 ),
@@ -94,6 +94,16 @@ class OrderMarginCalculator {
 			'cogs_enabled' => $cogs_enabled,
 			'items'        => $items,
 		);
+
+		/**
+		 * Filters the margin data calculated for an order.
+		 *
+		 * @since 10.8.0
+		 *
+		 * @param array             $data  The calculated margin data.
+		 * @param WC_Abstract_Order $order The order the data was calculated for.
+		 */
+		return (array) apply_filters( 'woocommerce_order_margin_data', $data, $order );
 	}
 
 	public function get_margin_for_order_item( WC_Order_Item_Product $item, bool $cogs_enabled = true ): array {

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
@@ -34,4 +34,41 @@ class OrderMarginCalculator {
 	final public function init( CostOfGoodsSoldController $cogs_controller ): void {
 		$this->cogs_controller = $cogs_controller;
 	}
+
+	/**
+	 * Get margin data for a single product line item.
+	 *
+	 * Returns an associative array with:
+	 * - `item_id`      (int)    The order item ID.
+	 * - `product_id`   (int)    The product ID.
+	 * - `name`         (string) The line item name.
+	 * - `quantity`     (float)  The quantity ordered.
+	 * - `revenue`      (float)  Line total (post-discount, pre-tax).
+	 * - `cogs`         (float)  COGS value for this line item.
+	 * - `gross_profit` (float)  revenue minus cogs.
+	 * - `margin`       (float)  gross_profit / revenue * 100, or 0 when revenue is zero.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param WC_Order_Item_Product $item         The line item to calculate margin for.
+	 * @param bool                  $cogs_enabled Whether the COGS feature is active.
+	 * @return array{item_id: int, product_id: int, name: string, quantity: float, revenue: float, cogs: float, gross_profit: float, margin: float}
+	 */
+	public function get_margin_for_order_item( WC_Order_Item_Product $item, bool $cogs_enabled = true ): array {
+		$revenue      = (float) $item->get_total();
+		$cogs         = $cogs_enabled ? (float) $item->get_cogs_value() : 0.0;
+		$gross_profit = $revenue - $cogs;
+		$margin       = $revenue > 0.0 ? ( $gross_profit / $revenue ) * 100.0 : 0.0;
+
+		return array(
+			'item_id'      => (int) $item->get_id(),
+			'product_id'   => (int) $item->get_product_id(),
+			'name'         => $item->get_name(),
+			'quantity'     => (float) $item->get_quantity(),
+			'revenue'      => round( $revenue, 4 ),
+			'cogs'         => round( $cogs, 4 ),
+			'gross_profit' => round( $gross_profit, 4 ),
+			'margin'       => round( $margin, 2 ),
+		);
+	}
 }

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
@@ -54,6 +54,48 @@ class OrderMarginCalculator {
 	 * @param bool                  $cogs_enabled Whether the COGS feature is active.
 	 * @return array{item_id: int, product_id: int, name: string, quantity: float, revenue: float, cogs: float, gross_profit: float, margin: float}
 	 */
+	/**
+	 * Get margin data for an entire order.
+	 *
+	 * Returns an associative array with:
+	 * - `net_revenue`   (float) Subtotal minus discounts, excluding tax and shipping.
+	 * - `cogs`          (float) Total cost of goods sold for the order.
+	 * - `gross_profit`  (float) net_revenue minus cogs.
+	 * - `margin`        (float) gross_profit / net_revenue * 100, or 0 when net_revenue is zero.
+	 * - `cogs_enabled`  (bool)  Whether the COGS feature is currently active.
+	 * - `items`         (array) Per-line-item margin data (see get_margin_for_order_item()).
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param WC_Abstract_Order $order The order to calculate margin for.
+	 * @return array{net_revenue: float, cogs: float, gross_profit: float, margin: float, cogs_enabled: bool, items: array}
+	 */
+	public function get_margin_for_order( WC_Abstract_Order $order ): array {
+		$cogs_enabled   = $this->cogs_controller->feature_is_enabled();
+		$subtotal       = (float) $order->get_subtotal();
+		$discount_total = (float) $order->get_discount_total();
+		$net_revenue    = $subtotal - $discount_total;
+		$cogs           = $cogs_enabled ? (float) $order->get_cogs_total_value() : 0.0;
+		$gross_profit   = $net_revenue - $cogs;
+		$margin         = $net_revenue > 0.0 ? ( $gross_profit / $net_revenue ) * 100.0 : 0.0;
+
+		$items = array();
+		foreach ( $order->get_items() as $item ) {
+			if ( $item instanceof WC_Order_Item_Product ) {
+				$items[] = $this->get_margin_for_order_item( $item, $cogs_enabled );
+			}
+		}
+
+		return array(
+			'net_revenue'  => round( $net_revenue, 4 ),
+			'cogs'         => round( $cogs, 4 ),
+			'gross_profit' => round( $gross_profit, 4 ),
+			'margin'       => round( $margin, 2 ),
+			'cogs_enabled' => $cogs_enabled,
+			'items'        => $items,
+		);
+	}
+
 	public function get_margin_for_order_item( WC_Order_Item_Product $item, bool $cogs_enabled = true ): array {
 		$revenue      = (float) $item->get_total();
 		$cogs         = $cogs_enabled ? (float) $item->get_cogs_value() : 0.0;

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginCalculator.php
@@ -29,6 +29,7 @@ class OrderMarginCalculator {
 	 * Initialize the instance.
 	 *
 	 * @internal
+	 *
 	 * @param CostOfGoodsSoldController $cogs_controller The instance of CostOfGoodsSoldController to use.
 	 */
 	final public function init( CostOfGoodsSoldController $cogs_controller ): void {
@@ -36,34 +37,7 @@ class OrderMarginCalculator {
 	}
 
 	/**
-	 * Get margin data for a single product line item.
-	 *
-	 * Returns an associative array with:
-	 * - `item_id`      (int)    The order item ID.
-	 * - `product_id`   (int)    The product ID.
-	 * - `name`         (string) The line item name.
-	 * - `quantity`     (float)  The quantity ordered.
-	 * - `revenue`      (float)  Line total (post-discount, pre-tax).
-	 * - `cogs`         (float)  COGS value for this line item.
-	 * - `gross_profit` (float)  revenue minus cogs.
-	 * - `margin`       (float)  gross_profit / revenue * 100, or 0 when revenue is zero.
-	 *
-	 * @since 10.8.0
-	 *
-	 * @param WC_Order_Item_Product $item         The line item to calculate margin for.
-	 * @param bool                  $cogs_enabled Whether the COGS feature is active.
-	 * @return array{item_id: int, product_id: int, name: string, quantity: float, revenue: float, cogs: float, gross_profit: float, margin: float}
-	 */
-	/**
-	 * Get margin data for an entire order.
-	 *
-	 * Returns an associative array with:
-	 * - `net_revenue`   (float) Subtotal minus discounts, excluding tax and shipping.
-	 * - `cogs`          (float) Total cost of goods sold for the order.
-	 * - `gross_profit`  (float) net_revenue minus cogs.
-	 * - `margin`        (float) gross_profit / net_revenue * 100, or 0 when net_revenue is zero.
-	 * - `cogs_enabled`  (bool)  Whether the COGS feature is currently active.
-	 * - `items`         (array) Per-line-item margin data (see get_margin_for_order_item()).
+	 * Get margin data for an entire order, including a per-line-item breakdown.
 	 *
 	 * @since 10.8.0
 	 *
@@ -82,7 +56,7 @@ class OrderMarginCalculator {
 		$items = array();
 		foreach ( $order->get_items() as $item ) {
 			if ( $item instanceof WC_Order_Item_Product ) {
-				$items[] = $this->get_margin_for_order_item( $item, $cogs_enabled );
+				$items[] = self::get_margin_for_order_item( $item, $cogs_enabled );
 			}
 		}
 
@@ -106,7 +80,16 @@ class OrderMarginCalculator {
 		return (array) apply_filters( 'woocommerce_order_margin_data', $data, $order );
 	}
 
-	public function get_margin_for_order_item( WC_Order_Item_Product $item, bool $cogs_enabled = true ): array {
+	/**
+	 * Get margin data for a single product line item.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param WC_Order_Item_Product $item         The line item to calculate margin for.
+	 * @param bool                  $cogs_enabled Whether the COGS feature is active.
+	 * @return array{item_id: int, product_id: int, name: string, quantity: float, revenue: float, cogs: float, gross_profit: float, margin: float}
+	 */
+	public static function get_margin_for_order_item( WC_Order_Item_Product $item, bool $cogs_enabled = true ): array {
 		$revenue      = (float) $item->get_total();
 		$cogs         = $cogs_enabled ? (float) $item->get_cogs_value() : 0.0;
 		$gross_profit = $revenue - $cogs;

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
@@ -41,4 +41,29 @@ class OrderMarginRestController extends RestApiControllerBase {
 	protected function get_rest_api_namespace(): string {
 		return 'order-margin';
 	}
+
+	/**
+	 * Register the REST API routes handled by this controller.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->route_namespace,
+			'/orders/(?P<id>[\d]+)/margin',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'get_order_margin' ),
+					'permission_callback' => fn( $request ) => $this->check_permission( $request, 'edit_shop_orders' ),
+					'args'                => array(
+						'id' => array(
+							'description' => __( 'Unique identifier of the order.', 'woocommerce' ),
+							'type'        => 'integer',
+							'required'    => true,
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
 }

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
@@ -1,0 +1,44 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Orders;
+
+use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use WC_Order;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * REST controller exposing order margin data at wc/v3/orders/{id}/margin.
+ *
+ * @since 10.8.0
+ */
+class OrderMarginRestController extends RestApiControllerBase {
+
+	/**
+	 * The OrderMarginCalculator instance to use.
+	 *
+	 * @var OrderMarginCalculator
+	 */
+	private OrderMarginCalculator $margin_calculator;
+
+	/**
+	 * Initialize the instance.
+	 *
+	 * @internal
+	 * @param OrderMarginCalculator $margin_calculator The instance of OrderMarginCalculator to use.
+	 */
+	final public function init( OrderMarginCalculator $margin_calculator ): void {
+		$this->margin_calculator = $margin_calculator;
+	}
+
+	/**
+	 * Get the WooCommerce REST API namespace for the class.
+	 *
+	 * @return string
+	 */
+	protected function get_rest_api_namespace(): string {
+		return 'order-margin';
+	}
+}

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
@@ -27,6 +27,7 @@ class OrderMarginRestController extends RestApiControllerBase {
 	 * Initialize the instance.
 	 *
 	 * @internal
+	 *
 	 * @param OrderMarginCalculator $margin_calculator The instance of OrderMarginCalculator to use.
 	 */
 	final public function init( OrderMarginCalculator $margin_calculator ): void {
@@ -36,6 +37,8 @@ class OrderMarginRestController extends RestApiControllerBase {
 	/**
 	 * Get the WooCommerce REST API namespace for the class.
 	 *
+	 * @since 10.8.0
+	 *
 	 * @return string
 	 */
 	protected function get_rest_api_namespace(): string {
@@ -44,6 +47,8 @@ class OrderMarginRestController extends RestApiControllerBase {
 
 	/**
 	 * Register the REST API routes handled by this controller.
+	 *
+	 * @since 10.8.0
 	 */
 	public function register_routes(): void {
 		register_rest_route(
@@ -70,6 +75,8 @@ class OrderMarginRestController extends RestApiControllerBase {
 	/**
 	 * Handle GET wc/v3/orders/{id}/margin.
 	 *
+	 * @since 10.8.0
+	 *
 	 * @param WP_REST_Request $request The incoming request.
 	 * @return array|WP_Error The margin data or an error.
 	 */
@@ -91,6 +98,8 @@ class OrderMarginRestController extends RestApiControllerBase {
 
 	/**
 	 * Get the schema for the order margin response.
+	 *
+	 * @since 10.8.0
 	 *
 	 * @return array
 	 */

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
@@ -66,4 +66,26 @@ class OrderMarginRestController extends RestApiControllerBase {
 			)
 		);
 	}
+
+	/**
+	 * Handle GET wc/v3/orders/{id}/margin.
+	 *
+	 * @param WP_REST_Request $request The incoming request.
+	 * @return array|WP_Error The margin data or an error.
+	 */
+	protected function get_order_margin( WP_REST_Request $request ) {
+		$order_id = (int) $request->get_param( 'id' );
+		$order    = wc_get_order( $order_id );
+
+		if ( ! $order instanceof WC_Order ) {
+			return new WP_Error(
+				'woocommerce_rest_order_not_found',
+				/* translators: %d: order ID */
+				sprintf( __( 'Order #%d not found.', 'woocommerce' ), $order_id ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $this->margin_calculator->get_margin_for_order( $order );
+	}
 }

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
@@ -1,5 +1,5 @@
 <?php
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Orders;
 

--- a/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderMarginRestController.php
@@ -88,4 +88,100 @@ class OrderMarginRestController extends RestApiControllerBase {
 
 		return $this->margin_calculator->get_margin_for_order( $order );
 	}
+
+	/**
+	 * Get the schema for the order margin response.
+	 *
+	 * @return array
+	 */
+	public function get_public_item_schema(): array {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'order-margin',
+			'type'       => 'object',
+			'properties' => array(
+				'net_revenue'  => array(
+					'description' => __( 'Order subtotal minus discounts, excluding tax and shipping.', 'woocommerce' ),
+					'type'        => 'number',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'cogs'         => array(
+					'description' => __( 'Total cost of goods sold for the order.', 'woocommerce' ),
+					'type'        => 'number',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'gross_profit' => array(
+					'description' => __( 'Net revenue minus cost of goods sold.', 'woocommerce' ),
+					'type'        => 'number',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'margin'       => array(
+					'description' => __( 'Gross profit as a percentage of net revenue.', 'woocommerce' ),
+					'type'        => 'number',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'cogs_enabled' => array(
+					'description' => __( 'Whether the Cost of Goods Sold feature is currently enabled.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'items'        => array(
+					'description' => __( 'Per-line-item margin breakdown.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'item_id'      => array(
+								'description' => __( 'Order item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'readonly'    => true,
+							),
+							'product_id'   => array(
+								'description' => __( 'Product ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'readonly'    => true,
+							),
+							'name'         => array(
+								'description' => __( 'Line item name.', 'woocommerce' ),
+								'type'        => 'string',
+								'readonly'    => true,
+							),
+							'quantity'     => array(
+								'description' => __( 'Quantity ordered.', 'woocommerce' ),
+								'type'        => 'number',
+								'readonly'    => true,
+							),
+							'revenue'      => array(
+								'description' => __( 'Line total after discounts, before tax.', 'woocommerce' ),
+								'type'        => 'number',
+								'readonly'    => true,
+							),
+							'cogs'         => array(
+								'description' => __( 'Cost of goods sold for this line item.', 'woocommerce' ),
+								'type'        => 'number',
+								'readonly'    => true,
+							),
+							'gross_profit' => array(
+								'description' => __( 'Revenue minus cost of goods sold.', 'woocommerce' ),
+								'type'        => 'number',
+								'readonly'    => true,
+							),
+							'margin'       => array(
+								'description' => __( 'Gross profit as a percentage of revenue.', 'woocommerce' ),
+								'type'        => 'number',
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+			),
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
@@ -106,4 +106,31 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 		$this->assertSame( 50.0, $result['margin'] );
 		$this->assertTrue( $result['cogs_enabled'] );
 	}
+
+	/**
+	 * Test that COGS is zeroed out when the feature is disabled.
+	 */
+	public function test_get_margin_for_order_zeros_cogs_when_feature_disabled(): void {
+		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( false );
+		$order = $this->make_order( 100.0, 0.0, 60.0 );
+
+		$result = $this->sut->get_margin_for_order( $order );
+
+		$this->assertSame( 0.0, $result['cogs'] );
+		$this->assertSame( 100.0, $result['gross_profit'] );
+		$this->assertSame( 100.0, $result['margin'] );
+		$this->assertFalse( $result['cogs_enabled'] );
+	}
+
+	/**
+	 * Test that margin is 0 when net revenue is zero (no division by zero).
+	 */
+	public function test_get_margin_for_order_returns_zero_margin_when_net_revenue_is_zero(): void {
+		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
+		$order = $this->make_order( 0.0, 0.0, 0.0 );
+
+		$result = $this->sut->get_margin_for_order( $order );
+
+		$this->assertSame( 0.0, $result['margin'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
@@ -180,4 +180,40 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 		$this->assertSame( 80.0, $result['gross_profit'] );
 		$this->assertSame( 100.0, $result['margin'] );
 	}
+
+	/**
+	 * Test that the woocommerce_order_margin_data filter is applied.
+	 */
+	public function test_get_margin_for_order_applies_filter(): void {
+		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
+		$order = $this->make_order( 100.0, 0.0, 50.0 );
+
+		add_filter(
+			'woocommerce_order_margin_data',
+			function ( array $data ) {
+				$data['custom_field'] = 'injected';
+				return $data;
+			}
+		);
+
+		$result = $this->sut->get_margin_for_order( $order );
+
+		remove_all_filters( 'woocommerce_order_margin_data' );
+
+		$this->assertArrayHasKey( 'custom_field', $result );
+		$this->assertSame( 'injected', $result['custom_field'] );
+	}
+
+	/**
+	 * Test that margin rounds correctly to 2 decimal places.
+	 */
+	public function test_get_margin_for_order_rounds_margin_to_two_decimal_places(): void {
+		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
+		// net_revenue=3, cogs=1 → margin = 66.666...% → rounds to 66.67.
+		$order = $this->make_order( 3.0, 0.0, 1.0 );
+
+		$result = $this->sut->get_margin_for_order( $order );
+
+		$this->assertSame( 66.67, $result['margin'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
@@ -133,4 +133,51 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 
 		$this->assertSame( 0.0, $result['margin'] );
 	}
+
+	/**
+	 * Test that item-level margin is included in the order result.
+	 */
+	public function test_get_margin_for_order_includes_item_breakdown(): void {
+		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
+
+		$item  = $this->make_item( 50.0, 20.0 );
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_subtotal' )->willReturn( 50.0 );
+		$order->method( 'get_discount_total' )->willReturn( 0.0 );
+		$order->method( 'get_cogs_total_value' )->willReturn( 20.0 );
+		$order->method( 'get_items' )->willReturn( array( $item ) );
+
+		$result = $this->sut->get_margin_for_order( $order );
+
+		$this->assertCount( 1, $result['items'] );
+		$this->assertArrayHasKey( 'item_id', $result['items'][0] );
+		$this->assertArrayHasKey( 'margin', $result['items'][0] );
+		$this->assertSame( 60.0, $result['items'][0]['margin'] );
+	}
+
+	/**
+	 * Test per-item margin calculation.
+	 */
+	public function test_get_margin_for_order_item_calculates_correctly(): void {
+		// revenue=80, cogs=20 → gross_profit=60 → margin=75%.
+		$item   = $this->make_item( 80.0, 20.0 );
+		$result = $this->sut->get_margin_for_order_item( $item, true );
+
+		$this->assertSame( 80.0, $result['revenue'] );
+		$this->assertSame( 20.0, $result['cogs'] );
+		$this->assertSame( 60.0, $result['gross_profit'] );
+		$this->assertSame( 75.0, $result['margin'] );
+	}
+
+	/**
+	 * Test that item COGS is zeroed when feature is disabled.
+	 */
+	public function test_get_margin_for_order_item_zeros_cogs_when_feature_disabled(): void {
+		$item   = $this->make_item( 80.0, 20.0 );
+		$result = $this->sut->get_margin_for_order_item( $item, false );
+
+		$this->assertSame( 0.0, $result['cogs'] );
+		$this->assertSame( 80.0, $result['gross_profit'] );
+		$this->assertSame( 100.0, $result['margin'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
@@ -14,11 +14,11 @@ use WC_Order_Item_Product;
 class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 
 	/**
-	 * The system under test.
+	 * The System Under Test.
 	 *
 	 * @var OrderMarginCalculator
 	 */
-	private OrderMarginCalculator $sut;
+	private $sut;
 
 	/**
 	 * Mock CostOfGoodsSoldController.
@@ -74,7 +74,7 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that margin data keys are always present.
+	 * @testdox Should return all expected margin data keys.
 	 */
 	public function test_get_margin_for_order_returns_expected_keys(): void {
 		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
@@ -91,7 +91,7 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test correct margin calculation when COGS is enabled.
+	 * @testdox Should calculate net revenue, COGS, gross profit, and margin correctly when COGS is enabled.
 	 */
 	public function test_get_margin_for_order_calculates_correctly_when_cogs_enabled(): void {
 		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
@@ -108,7 +108,7 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that COGS is zeroed out when the feature is disabled.
+	 * @testdox Should return zero COGS and full revenue as gross profit when the COGS feature is disabled.
 	 */
 	public function test_get_margin_for_order_zeros_cogs_when_feature_disabled(): void {
 		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( false );
@@ -123,7 +123,7 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that margin is 0 when net revenue is zero (no division by zero).
+	 * @testdox Should return zero margin when net revenue is zero to avoid division by zero.
 	 */
 	public function test_get_margin_for_order_returns_zero_margin_when_net_revenue_is_zero(): void {
 		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
@@ -135,7 +135,7 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that item-level margin is included in the order result.
+	 * @testdox Should include a per-line-item margin breakdown in the order result.
 	 */
 	public function test_get_margin_for_order_includes_item_breakdown(): void {
 		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
@@ -156,12 +156,12 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test per-item margin calculation.
+	 * @testdox Should calculate revenue, COGS, gross profit, and margin correctly for a line item.
 	 */
 	public function test_get_margin_for_order_item_calculates_correctly(): void {
 		// revenue=80, cogs=20 → gross_profit=60 → margin=75%.
 		$item   = $this->make_item( 80.0, 20.0 );
-		$result = $this->sut->get_margin_for_order_item( $item, true );
+		$result = OrderMarginCalculator::get_margin_for_order_item( $item, true );
 
 		$this->assertSame( 80.0, $result['revenue'] );
 		$this->assertSame( 20.0, $result['cogs'] );
@@ -170,11 +170,11 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that item COGS is zeroed when feature is disabled.
+	 * @testdox Should zero item COGS and return full revenue as gross profit when COGS feature is disabled.
 	 */
 	public function test_get_margin_for_order_item_zeros_cogs_when_feature_disabled(): void {
 		$item   = $this->make_item( 80.0, 20.0 );
-		$result = $this->sut->get_margin_for_order_item( $item, false );
+		$result = OrderMarginCalculator::get_margin_for_order_item( $item, false );
 
 		$this->assertSame( 0.0, $result['cogs'] );
 		$this->assertSame( 80.0, $result['gross_profit'] );
@@ -182,7 +182,7 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the woocommerce_order_margin_data filter is applied.
+	 * @testdox Should apply the woocommerce_order_margin_data filter to the returned data.
 	 */
 	public function test_get_margin_for_order_applies_filter(): void {
 		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
@@ -205,7 +205,7 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that margin rounds correctly to 2 decimal places.
+	 * @testdox Should round margin to two decimal places.
 	 */
 	public function test_get_margin_for_order_rounds_margin_to_two_decimal_places(): void {
 		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
@@ -1,0 +1,75 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Orders;
+
+use Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController;
+use Automattic\WooCommerce\Internal\Orders\OrderMarginCalculator;
+use WC_Order;
+use WC_Order_Item_Product;
+
+/**
+ * Tests for OrderMarginCalculator.
+ */
+class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * The system under test.
+	 *
+	 * @var OrderMarginCalculator
+	 */
+	private OrderMarginCalculator $sut;
+
+	/**
+	 * Mock CostOfGoodsSoldController.
+	 *
+	 * @var CostOfGoodsSoldController|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $cogs_controller;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->cogs_controller = $this->createMock( CostOfGoodsSoldController::class );
+		$this->sut             = new OrderMarginCalculator();
+		$this->sut->init( $this->cogs_controller );
+	}
+
+	/**
+	 * Creates a mock order with the given financial values.
+	 *
+	 * @param float $subtotal       Order subtotal.
+	 * @param float $discount_total Discount total.
+	 * @param float $cogs_value     COGS total value.
+	 * @return WC_Order|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function make_order( float $subtotal, float $discount_total, float $cogs_value ) {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_subtotal' )->willReturn( $subtotal );
+		$order->method( 'get_discount_total' )->willReturn( $discount_total );
+		$order->method( 'get_cogs_total_value' )->willReturn( $cogs_value );
+		$order->method( 'get_items' )->willReturn( array() );
+		return $order;
+	}
+
+	/**
+	 * Creates a mock product line item.
+	 *
+	 * @param float $total      Line item total.
+	 * @param float $cogs_value COGS value for the item.
+	 * @return WC_Order_Item_Product|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function make_item( float $total, float $cogs_value ) {
+		$item = $this->createMock( WC_Order_Item_Product::class );
+		$item->method( 'get_id' )->willReturn( 1 );
+		$item->method( 'get_product_id' )->willReturn( 10 );
+		$item->method( 'get_name' )->willReturn( 'Test Product' );
+		$item->method( 'get_quantity' )->willReturn( 1.0 );
+		$item->method( 'get_total' )->willReturn( $total );
+		$item->method( 'get_cogs_value' )->willReturn( $cogs_value );
+		return $item;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
@@ -89,4 +89,21 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'cogs_enabled', $result );
 		$this->assertArrayHasKey( 'items', $result );
 	}
+
+	/**
+	 * Test correct margin calculation when COGS is enabled.
+	 */
+	public function test_get_margin_for_order_calculates_correctly_when_cogs_enabled(): void {
+		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
+		// subtotal=100, discount=10 → net_revenue=90; cogs=45 → gross_profit=45; margin=50%.
+		$order = $this->make_order( 100.0, 10.0, 45.0 );
+
+		$result = $this->sut->get_margin_for_order( $order );
+
+		$this->assertSame( 90.0, $result['net_revenue'] );
+		$this->assertSame( 45.0, $result['cogs'] );
+		$this->assertSame( 45.0, $result['gross_profit'] );
+		$this->assertSame( 50.0, $result['margin'] );
+		$this->assertTrue( $result['cogs_enabled'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
@@ -72,4 +72,21 @@ class OrderMarginCalculatorTest extends \WC_Unit_Test_Case {
 		$item->method( 'get_cogs_value' )->willReturn( $cogs_value );
 		return $item;
 	}
+
+	/**
+	 * Test that margin data keys are always present.
+	 */
+	public function test_get_margin_for_order_returns_expected_keys(): void {
+		$this->cogs_controller->method( 'feature_is_enabled' )->willReturn( true );
+		$order = $this->make_order( 100.0, 0.0, 60.0 );
+
+		$result = $this->sut->get_margin_for_order( $order );
+
+		$this->assertArrayHasKey( 'net_revenue', $result );
+		$this->assertArrayHasKey( 'cogs', $result );
+		$this->assertArrayHasKey( 'gross_profit', $result );
+		$this->assertArrayHasKey( 'margin', $result );
+		$this->assertArrayHasKey( 'cogs_enabled', $result );
+		$this->assertArrayHasKey( 'items', $result );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderMarginCalculatorTest.php
@@ -1,5 +1,5 @@
 <?php
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Orders;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds order-level profitability data to WooCommerce core by introducing two new classes:

- **`OrderMarginCalculator`** — calculates gross margin per order and per line item using the existing Cost of Goods Sold (COGS) feature data. Exposes a `woocommerce_order_margin_data` filter for extensibility.
- **`OrderMarginRestController`** — registers a new REST endpoint `GET wc/v3/orders/{id}/margin` (requires `edit_shop_orders` capability) returning net revenue, COGS, gross profit, margin percentage, and a per-line-item breakdown.

When the COGS feature is disabled, the endpoint still responds with zeroed COGS/profit values and a `cogs_enabled: false` flag so consumers can handle both states gracefully.

### How to test the changes in this Pull Request:

1. Enable the **Cost of Goods Sold** feature under **WooCommerce → Settings → Features**.
2. Add a COGS value to one or more products.
3. Place a test order containing those products.
4. Call `GET /wp-json/wc/v3/orders/{id}/margin` (authenticated as a shop manager or admin).
5. Confirm the response contains `net_revenue`, `cogs`, `gross_profit`, `margin`, `cogs_enabled: true`, and an `items` array with per-line-item data.
6. Disable the COGS feature and repeat the request — confirm `cogs_enabled: false` and all COGS/profit values are `0`.
7. Call the endpoint with a non-existent order ID — confirm a `404` response.
8. Call the endpoint as an unauthenticated user — confirm a `401` response.

### Testing that has already taken place:

- 8 PHPUnit unit tests added covering: correct margin calculation, COGS-disabled zeroing, division-by-zero guard (zero net revenue), per-item breakdown, `woocommerce_order_margin_data` filter application, and margin rounding to 2 decimal places.
- Code reviewed for injection safety (all order data retrieved via WooCommerce API methods, no raw input used in calculations).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. Changelog entry created manually in the branch.