### PR TITLE
Add OPcache-backed caching for parsed GraphQL queries

### DIFF
--- a/plugins/woocommerce/changelog/64596-64166-graphql-opcache-cache
+++ b/plugins/woocommerce/changelog/64596-64166-graphql-opcache-cache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add OPcache-backed caching for parsed GraphQL queries, with fallback to the WP object cache.

--- a/plugins/woocommerce/src/Internal/Api/Main.php
+++ b/plugins/woocommerce/src/Internal/Api/Main.php
@@ -173,6 +173,10 @@ class Main {
 
 		$settings = wc_get_container()->get( Settings::class );
 		$settings->register();
+
+		if ( self::is_enabled() ) {
+			add_action( OpcacheFileExpiry::ACTION_HOOK, array( OpcacheFileExpiry::class, 'handle_cleanup_action' ) );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/Main.php
+++ b/plugins/woocommerce/src/Internal/Api/Main.php
@@ -58,6 +58,14 @@ class Main {
 	public const OPTION_MAX_QUERY_COMPLEXITY = 'woocommerce_graphql_max_query_complexity';
 
 	/**
+	 * Option name for the "OPcache-based caching" setting.
+	 *
+	 * When enabled, parsed query ASTs are written to disk as PHP files so
+	 * that OPcache serves them from shared memory on subsequent requests.
+	 */
+	public const OPTION_OPCACHE_ENABLED = 'woocommerce_graphql_opcache_enabled';
+
+	/**
 	 * Option name for the "ObjectCache-based caching" setting.
 	 */
 	public const OPTION_OBJECT_CACHE_ENABLED = 'woocommerce_graphql_object_cache_enabled';
@@ -101,6 +109,17 @@ class Main {
 	 */
 	public static function is_apq_enabled(): bool {
 		return wc_string_to_bool( get_option( self::OPTION_APQ_ENABLED, 'yes' ) );
+	}
+
+	/**
+	 * Whether the OPcache-backed query cache is enabled.
+	 *
+	 * Defaults to true. Activation also depends on OPcache being loaded and
+	 * the cache directory being writable; see {@see QueryCache} for the
+	 * runtime capability check.
+	 */
+	public static function is_opcache_enabled(): bool {
+		return wc_string_to_bool( get_option( self::OPTION_OPCACHE_ENABLED, 'yes' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
+++ b/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
@@ -41,10 +41,14 @@ class OpcacheFileExpiry {
 			return 0;
 		}
 
-		$cutoff = time() - self::FILE_TTL;
+		$files = glob( $dir . '/*.php' );
+		if ( false === $files ) {
+			return 0;
+		}
 
-		$count = 0;
-		foreach ( glob( $dir . '/*.php' ) ?: array() as $path ) {
+		$cutoff = time() - self::FILE_TTL;
+		$count  = 0;
+		foreach ( $files as $path ) {
 			$mtime = $fs->mtime( $path );
 			if ( false !== $mtime && $mtime < $cutoff && $fs->delete( $path ) ) {
 				++$count;

--- a/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
+++ b/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\Api;
+
+/**
+ * Deletes expired OPcache cache files via Action Scheduler.
+ */
+class OpcacheFileExpiry {
+
+	/**
+	 * Action Scheduler hook name for the cleanup job.
+	 */
+	public const ACTION_HOOK = 'woocommerce_graphql_opcache_cleanup';
+
+	/**
+	 * Action Scheduler group for the cleanup job.
+	 */
+	public const ACTION_GROUP = 'woocommerce-graphql';
+
+	/**
+	 * TTL (in seconds) for OPcache cache files.
+	 */
+	public const FILE_TTL = 7 * DAY_IN_SECONDS;
+
+	/**
+	 * Delete OPcache cache files older than {@see self::FILE_TTL}.
+	 *
+	 * AST contents are a pure function of the query, so this is a disk-usage
+	 * bound, not a correctness concern. Returns the count.
+	 */
+	public static function delete_expired_files(): int {
+		$dir = QueryCache::get_opcache_cache_dir();
+		if ( '' === $dir || ! is_dir( $dir ) ) {
+			return 0;
+		}
+
+		$fs = self::wp_filesystem();
+		if ( ! $fs ) {
+			return 0;
+		}
+
+		$cutoff = time() - self::FILE_TTL;
+
+		$count = 0;
+		foreach ( glob( $dir . '/*.php' ) ?: array() as $path ) {
+			$mtime = $fs->mtime( $path );
+			if ( false !== $mtime && $mtime < $cutoff && $fs->delete( $path ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Action Scheduler callback: delete expired files and reschedule.
+	 *
+	 * Immediate reschedule when files were deleted (drain the backlog), 24h
+	 * otherwise.
+	 *
+	 * @internal
+	 */
+	public static function handle_cleanup_action(): void {
+		$interval = self::delete_expired_files() > 0 ? 1 : DAY_IN_SECONDS;
+
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action( time() + $interval, self::ACTION_HOOK, array(), self::ACTION_GROUP );
+		}
+	}
+
+	/**
+	 * Schedule the cleanup if it isn't already scheduled.
+	 *
+	 * Called from {@see QueryCache::write_to_opcache()} so the first run is
+	 * triggered by the first write — no separate bootstrap step.
+	 */
+	public static function ensure_scheduled(): void {
+		if ( ! function_exists( 'as_has_scheduled_action' ) || ! function_exists( 'as_schedule_single_action' ) ) {
+			return;
+		}
+		if ( as_has_scheduled_action( self::ACTION_HOOK, array(), self::ACTION_GROUP ) ) {
+			return;
+		}
+		as_schedule_single_action( time() + DAY_IN_SECONDS, self::ACTION_HOOK, array(), self::ACTION_GROUP );
+	}
+
+	/**
+	 * Lazy-initialize WP_Filesystem; null if the direct method isn't available.
+	 */
+	private static function wp_filesystem(): ?\WP_Filesystem_Base {
+		global $wp_filesystem;
+		if ( ! $wp_filesystem ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			if ( ! WP_Filesystem() ) {
+				return null;
+			}
+		}
+		return $wp_filesystem;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
+++ b/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
@@ -31,7 +31,7 @@ class OpcacheFileExpiry {
 			return 0;
 		}
 
-		$fs = self::wp_filesystem();
+		$fs = Utils::wp_filesystem();
 		if ( ! $fs ) {
 			return 0;
 		}
@@ -83,19 +83,5 @@ class OpcacheFileExpiry {
 			return;
 		}
 		as_schedule_single_action( time() + DAY_IN_SECONDS, self::ACTION_HOOK, array(), self::ACTION_GROUP );
-	}
-
-	/**
-	 * Lazy-initialize WP_Filesystem; null if the direct method isn't available.
-	 */
-	private static function wp_filesystem(): ?\WP_Filesystem_Base {
-		global $wp_filesystem;
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-			if ( ! WP_Filesystem() ) {
-				return null;
-			}
-		}
-		return $wp_filesystem;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
+++ b/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
@@ -20,12 +20,7 @@ class OpcacheFileExpiry {
 	public const ACTION_GROUP = 'woocommerce-graphql';
 
 	/**
-	 * TTL (in seconds) for OPcache cache files.
-	 */
-	public const FILE_TTL = 7 * DAY_IN_SECONDS;
-
-	/**
-	 * Delete OPcache cache files older than {@see self::FILE_TTL}.
+	 * Delete OPcache cache files older than {@see QueryCache::get_cache_ttl()}.
 	 *
 	 * AST contents are a pure function of the query, so this is a disk-usage
 	 * bound, not a correctness concern. Returns the count.
@@ -46,7 +41,7 @@ class OpcacheFileExpiry {
 			return 0;
 		}
 
-		$cutoff = time() - self::FILE_TTL;
+		$cutoff = time() - QueryCache::get_cache_ttl();
 		$count  = 0;
 		foreach ( $files as $path ) {
 			$mtime = $fs->mtime( $path );

--- a/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
+++ b/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
@@ -20,6 +20,11 @@ class OpcacheFileExpiry {
 	public const ACTION_GROUP = 'woocommerce-graphql';
 
 	/**
+	 * Object-cache key used to short-circuit {@see self::ensure_scheduled()}.
+	 */
+	private const SCHEDULED_CACHE_KEY = 'graphql_opcache_cleanup_scheduled';
+
+	/**
 	 * Delete OPcache cache files older than {@see QueryCache::get_cache_ttl()}.
 	 *
 	 * AST contents are a pure function of the query, so this is a disk-usage
@@ -76,12 +81,18 @@ class OpcacheFileExpiry {
 	 * triggered by the first write — no separate bootstrap step.
 	 */
 	public static function ensure_scheduled(): void {
+		if ( wp_cache_get( self::SCHEDULED_CACHE_KEY, QueryCache::CACHE_GROUP ) ) {
+			return;
+		}
+
 		if ( ! function_exists( 'as_has_scheduled_action' ) || ! function_exists( 'as_schedule_single_action' ) ) {
 			return;
 		}
-		if ( as_has_scheduled_action( self::ACTION_HOOK, array(), self::ACTION_GROUP ) ) {
-			return;
+
+		if ( ! as_has_scheduled_action( self::ACTION_HOOK, array(), self::ACTION_GROUP ) ) {
+			as_schedule_single_action( time() + DAY_IN_SECONDS, self::ACTION_HOOK, array(), self::ACTION_GROUP );
 		}
-		as_schedule_single_action( time() + DAY_IN_SECONDS, self::ACTION_HOOK, array(), self::ACTION_GROUP );
+
+		wp_cache_set( self::SCHEDULED_CACHE_KEY, true, QueryCache::CACHE_GROUP, HOUR_IN_SECONDS );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -264,7 +264,8 @@ class QueryCache {
 			return false;
 		}
 
-		$status = opcache_get_status( false );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- opcache.restrict_api raises E_WARNING when the calling path is disallowed; the false return is handled below.
+		$status = @opcache_get_status( false );
 		if ( ! is_array( $status ) || empty( $status['opcache_enabled'] ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -303,18 +303,18 @@ class QueryCache {
 			return false;
 		}
 
-		if ( ! is_writable( $dir ) ) {
+		$fs = $this->wp_filesystem();
+		if ( ! $fs || ! $fs->is_writable( $dir ) ) {
 			return false;
 		}
 
 		// Best-effort hardening; ignore failures (e.g. read-only permissions).
-		$fs       = $this->wp_filesystem();
 		$htaccess = $dir . '/.htaccess';
 		$index    = $dir . '/index.html';
-		if ( $fs && ! file_exists( $htaccess ) ) {
+		if ( ! file_exists( $htaccess ) ) {
 			$fs->put_contents( $htaccess, "Deny from all\n" );
 		}
-		if ( $fs && ! file_exists( $index ) ) {
+		if ( ! file_exists( $index ) ) {
 			$fs->put_contents( $index, '' );
 		}
 

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -172,7 +172,11 @@ class QueryCache {
 		if ( $for_apq || Main::is_object_cache_enabled() ) {
 			$cached = wp_cache_get( $this->build_cache_key( $hash ), self::CACHE_GROUP );
 			if ( is_array( $cached ) ) {
-				return AST::fromArray( $cached );
+				try {
+					return AST::fromArray( $cached );
+				} catch ( \Throwable ) {
+					return false;
+				}
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -174,7 +174,7 @@ class QueryCache {
 			if ( is_array( $cached ) ) {
 				try {
 					return AST::fromArray( $cached );
-				} catch ( \Throwable ) {
+				} catch ( \Throwable $e ) {
 					return false;
 				}
 			}
@@ -366,7 +366,7 @@ class QueryCache {
 
 		try {
 			return AST::fromArray( $data );
-		} catch ( \Throwable ) {
+		} catch ( \Throwable $e ) {
 			return false;
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -81,7 +81,7 @@ class QueryCache {
 			&& is_array( $apq )
 			&& 1 === ( $apq['version'] ?? null )
 			&& is_string( $apq_hash )
-			&& '' !== $apq_hash ) {
+			&& 1 === preg_match( '/^[a-f0-9]{64}$/', $apq_hash ) ) {
 			return $this->resolve_apq( $query, $apq_hash );
 		}
 

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -286,7 +286,15 @@ class QueryCache {
 		 *
 		 * @param string $dir Default cache directory under wp-uploads.
 		 */
-		return (string) apply_filters( 'woocommerce_graphql_opcache_cache_dir', $default );
+		$dir = (string) apply_filters( 'woocommerce_graphql_opcache_cache_dir', $default );
+
+		// Reject stream wrappers (e.g. phar://, http://) to keep file_put_contents,
+		// rename, and include constrained to local filesystem paths.
+		if ( '' === $dir || wp_is_stream( $dir ) ) {
+			return '';
+		}
+
+		return $dir;
 	}
 
 	/**
@@ -298,6 +306,10 @@ class QueryCache {
 	 */
 	private function ensure_opcache_dir_writable(): bool {
 		$dir = $this->get_opcache_cache_dir();
+
+		if ( '' === $dir ) {
+			return false;
+		}
 
 		if ( ! is_dir( $dir ) && ! wp_mkdir_p( $dir ) ) {
 			return false;

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -283,8 +283,10 @@ class QueryCache {
 	 * Defaults to a versioned subdirectory under wp-uploads so it inherits
 	 * the writability guarantees WordPress places on uploads. Filterable
 	 * for tests and unusual hosting layouts.
+	 *
+	 * @internal Public for {@see OpcacheFileExpiry}; not part of the plugin's external API.
 	 */
-	private function get_opcache_cache_dir(): string {
+	public static function get_opcache_cache_dir(): string {
 		$upload_dir = wp_get_upload_dir();
 		$default    = trailingslashit( $upload_dir['basedir'] ) . self::OPCACHE_DIR_RELATIVE;
 
@@ -314,7 +316,7 @@ class QueryCache {
 	 * the directory ends up non-writable.
 	 */
 	private function ensure_opcache_dir_writable(): bool {
-		$dir = $this->get_opcache_cache_dir();
+		$dir = self::get_opcache_cache_dir();
 
 		if ( '' === $dir ) {
 			return false;
@@ -349,7 +351,7 @@ class QueryCache {
 	 * @return DocumentNode|false
 	 */
 	private function read_from_opcache( string $hash ) {
-		$path = $this->get_opcache_cache_dir() . '/' . $hash . '.php';
+		$path = self::get_opcache_cache_dir() . '/' . $hash . '.php';
 
 		if ( ! is_file( $path ) ) {
 			return false;
@@ -387,7 +389,7 @@ class QueryCache {
 	 * @param DocumentNode $document The parsed AST.
 	 */
 	private function write_to_opcache( string $hash, DocumentNode $document ): void {
-		$dir  = $this->get_opcache_cache_dir();
+		$dir  = self::get_opcache_cache_dir();
 		$path = $dir . '/' . $hash . '.php';
 		$tmp  = $path . '.' . bin2hex( random_bytes( 8 ) ) . '.tmp';
 
@@ -413,6 +415,8 @@ class QueryCache {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			@opcache_compile_file( $path );
 		}
+
+		OpcacheFileExpiry::ensure_scheduled();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -256,15 +256,11 @@ class QueryCache {
 	 * directory to exist (or be creatable) and be writable.
 	 */
 	private function compute_is_opcache_usable(): bool {
-		if ( ! function_exists( 'opcache_get_status' ) ) {
+		if ( ! function_exists( 'opcache_get_status' ) || ! ini_get( 'opcache.enable' ) ) {
 			return false;
 		}
 
-		// opcache_get_status() returns false when OPcache is disabled or in
-		// restricted mode (opcache.restrict_api). Suppress the warning that
-		// restricted mode emits — false return is the meaningful signal.
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$status = @opcache_get_status( false );
+		$status = opcache_get_status( false );
 		if ( ! is_array( $status ) || empty( $status['opcache_enabled'] ) ) {
 			return false;
 		}
@@ -312,15 +308,14 @@ class QueryCache {
 		}
 
 		// Best-effort hardening; ignore failures (e.g. read-only permissions).
+		$fs       = $this->wp_filesystem();
 		$htaccess = $dir . '/.htaccess';
 		$index    = $dir . '/index.html';
-		if ( ! file_exists( $htaccess ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.NoSilencedErrors.Discouraged
-			@file_put_contents( $htaccess, "Deny from all\n" );
+		if ( $fs && ! file_exists( $htaccess ) ) {
+			$fs->put_contents( $htaccess, "Deny from all\n" );
 		}
-		if ( ! file_exists( $index ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.NoSilencedErrors.Discouraged
-			@file_put_contents( $index, '' );
+		if ( $fs && ! file_exists( $index ) ) {
+			$fs->put_contents( $index, '' );
 		}
 
 		return true;
@@ -340,11 +335,9 @@ class QueryCache {
 		}
 
 		// File contents are produced by self::write_to_opcache() and only
-		// ever return a primitive array. Suppress include-time warnings to
-		// fail soft on a missing or malformed file; the caller will fall
-		// back to parsing.
-		// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-		$data = @include $path;
+		// ever return a primitive array. The caller falls back to parsing
+		// when the include returns a non-array.
+		$data = include $path;
 
 		if ( ! is_array( $data ) ) {
 			return false;
@@ -384,10 +377,11 @@ class QueryCache {
 			return;
 		}
 
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		if ( ! @rename( $tmp, $path ) ) {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
-			@unlink( $tmp );
+		$fs = $this->wp_filesystem();
+		if ( ! $fs || ! $fs->move( $tmp, $path, true ) ) {
+			if ( $fs ) {
+				$fs->delete( $tmp );
+			}
 			return;
 		}
 
@@ -416,5 +410,20 @@ class QueryCache {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Lazy-initialize and return the WP_Filesystem global, or null when the
+	 * direct method isn't available (e.g. credentials prompt would be needed).
+	 */
+	private function wp_filesystem(): ?\WP_Filesystem_Base {
+		global $wp_filesystem;
+		if ( ! $wp_filesystem ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			if ( ! WP_Filesystem() ) {
+				return null;
+			}
+		}
+		return $wp_filesystem;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -9,8 +9,13 @@ use Automattic\WooCommerce\Vendor\GraphQL\Language\Parser;
 use Automattic\WooCommerce\Vendor\GraphQL\Utils\AST;
 
 /**
- * Caches parsed GraphQL ASTs in the WP object cache and implements the
- * Apollo Automatic Persisted Queries (APQ) protocol.
+ * Caches parsed GraphQL ASTs and implements the Apollo Automatic Persisted
+ * Queries (APQ) protocol.
+ *
+ * Two backends are supported. OPcache (filesystem) is preferred: parsed ASTs
+ * are written as PHP files so that OPcache serves them from shared memory.
+ * The WP object cache is used as a fallback when OPcache isn't available or
+ * the cache directory isn't writable.
  */
 class QueryCache {
 	/**
@@ -25,6 +30,20 @@ class QueryCache {
 	 * Update this constant when bumping the major version in composer.json.
 	 */
 	private const CACHE_KEY_PREFIX = 'graphql_ast_v15_';
+
+	/**
+	 * Subdirectory (under wp-uploads) for the OPcache-backed file cache.
+	 * The version segment matches {@see self::CACHE_KEY_PREFIX} so a major
+	 * webonyx upgrade naturally orphans the previous version's files.
+	 */
+	private const OPCACHE_DIR_RELATIVE = 'wc-graphql-cache/v15';
+
+	/**
+	 * Cached result of {@see self::is_opcache_usable()} for the current request.
+	 *
+	 * @var ?bool
+	 */
+	private ?bool $opcache_usable = null;
 
 	/**
 	 * Default time-to-live (in seconds) applied when the option is unset or non-positive.
@@ -72,7 +91,7 @@ class QueryCache {
 		}
 
 		// APQ keeps using the cache; it has its own settings toggle.
-		if ( ! Main::is_object_cache_enabled() ) {
+		if ( ! $this->is_caching_enabled() ) {
 			return $this->parse( $query );
 		}
 
@@ -102,16 +121,16 @@ class QueryCache {
 				);
 			}
 
-			$doc = $this->get_cached_document( $apq_hash );
+			$doc = $this->get_cached_document( $apq_hash, true );
 			if ( false !== $doc ) {
 				return $doc;
 			}
 
-			return $this->parse_and_cache( $query, $apq_hash );
+			return $this->parse_and_cache( $query, $apq_hash, true );
 		}
 
 		// Hash-only lookup.
-		$doc = $this->get_cached_document( $apq_hash );
+		$doc = $this->get_cached_document( $apq_hash, true );
 		if ( false !== $doc ) {
 			return $doc;
 		}
@@ -120,18 +139,44 @@ class QueryCache {
 	}
 
 	/**
+	 * Whether at least one cache backend is enabled (and, for OPcache, usable).
+	 *
+	 * Used to short-circuit the standard-query path when neither backend is
+	 * available, so the request is parsed once with no cache lookup overhead.
+	 */
+	private function is_caching_enabled(): bool {
+		return ( Main::is_opcache_enabled() && $this->is_opcache_usable() )
+			|| Main::is_object_cache_enabled();
+	}
+
+	/**
 	 * Retrieve a cached DocumentNode by hash.
 	 *
-	 * @param string $hash The SHA-256 hash.
+	 * Tries OPcache first when enabled and usable, then falls back to the
+	 * WP object cache. APQ requests pass $for_apq=true so the object cache
+	 * is consulted regardless of the standard-query toggle, matching the
+	 * pre-OPcache behaviour where APQ always persisted via the object cache.
+	 *
+	 * @param string $hash    The SHA-256 hash.
+	 * @param bool   $for_apq Whether the lookup is for an APQ request.
 	 * @return DocumentNode|false
 	 */
-	private function get_cached_document( string $hash ) {
-		$cached = wp_cache_get( $this->build_cache_key( $hash ), self::CACHE_GROUP );
-		if ( false === $cached || ! is_array( $cached ) ) {
-			return false;
+	private function get_cached_document( string $hash, bool $for_apq = false ) {
+		if ( Main::is_opcache_enabled() && $this->is_opcache_usable() ) {
+			$doc = $this->read_from_opcache( $hash );
+			if ( false !== $doc ) {
+				return $doc;
+			}
 		}
 
-		return AST::fromArray( $cached );
+		if ( $for_apq || Main::is_object_cache_enabled() ) {
+			$cached = wp_cache_get( $this->build_cache_key( $hash ), self::CACHE_GROUP );
+			if ( is_array( $cached ) ) {
+				return AST::fromArray( $cached );
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -152,19 +197,28 @@ class QueryCache {
 	/**
 	 * Parse a query, cache the resulting AST, and return the DocumentNode.
 	 *
+	 * Writes to OPcache when enabled and usable; otherwise to the object
+	 * cache. APQ requests pass $for_apq=true so the object cache is used
+	 * even when the standard-query toggle is off.
+	 *
 	 * Returns an error array if the query has a syntax error.
 	 *
-	 * @param string $query The GraphQL query string.
-	 * @param string $hash  The SHA-256 hash to cache under.
+	 * @param string $query   The GraphQL query string.
+	 * @param string $hash    The SHA-256 hash to cache under.
+	 * @param bool   $for_apq Whether the request is an APQ registration.
 	 * @return DocumentNode|array
 	 */
-	private function parse_and_cache( string $query, string $hash ) {
+	private function parse_and_cache( string $query, string $hash, bool $for_apq = false ) {
 		$document = $this->parse( $query );
 		if ( ! $document instanceof DocumentNode ) {
 			return $document;
 		}
 
-		wp_cache_set( $this->build_cache_key( $hash ), $document->toArray(), self::CACHE_GROUP, self::get_cache_ttl() );
+		if ( Main::is_opcache_enabled() && $this->is_opcache_usable() ) {
+			$this->write_to_opcache( $hash, $document );
+		} elseif ( $for_apq || Main::is_object_cache_enabled() ) {
+			wp_cache_set( $this->build_cache_key( $hash ), $document->toArray(), self::CACHE_GROUP, self::get_cache_ttl() );
+		}
 
 		return $document;
 	}
@@ -177,6 +231,173 @@ class QueryCache {
 	 */
 	private function build_cache_key( string $hash ): string {
 		return self::CACHE_KEY_PREFIX . $hash;
+	}
+
+	/**
+	 * Whether the OPcache file backend can be used for this request.
+	 *
+	 * Memoised per request: the underlying checks (opcache_get_status,
+	 * filesystem writability) don't change mid-request and are wasteful
+	 * to repeat across the read and write paths.
+	 */
+	private function is_opcache_usable(): bool {
+		if ( null !== $this->opcache_usable ) {
+			return $this->opcache_usable;
+		}
+
+		$this->opcache_usable = $this->compute_is_opcache_usable();
+		return $this->opcache_usable;
+	}
+
+	/**
+	 * Underlying capability check for the OPcache file backend.
+	 *
+	 * Requires the OPcache extension to be loaded and enabled, and the cache
+	 * directory to exist (or be creatable) and be writable.
+	 */
+	private function compute_is_opcache_usable(): bool {
+		if ( ! function_exists( 'opcache_get_status' ) ) {
+			return false;
+		}
+
+		// opcache_get_status() returns false when OPcache is disabled or in
+		// restricted mode (opcache.restrict_api). Suppress the warning that
+		// restricted mode emits — false return is the meaningful signal.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$status = @opcache_get_status( false );
+		if ( ! is_array( $status ) || empty( $status['opcache_enabled'] ) ) {
+			return false;
+		}
+
+		return $this->ensure_opcache_dir_writable();
+	}
+
+	/**
+	 * Resolve the directory where OPcache cache files are written.
+	 *
+	 * Defaults to a versioned subdirectory under wp-uploads so it inherits
+	 * the writability guarantees WordPress places on uploads. Filterable
+	 * for tests and unusual hosting layouts.
+	 */
+	private function get_opcache_cache_dir(): string {
+		$upload_dir = wp_get_upload_dir();
+		$default    = trailingslashit( $upload_dir['basedir'] ) . self::OPCACHE_DIR_RELATIVE;
+
+		/**
+		 * Filters the directory where parsed GraphQL ASTs are written for OPcache.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param string $dir Default cache directory under wp-uploads.
+		 */
+		return (string) apply_filters( 'woocommerce_graphql_opcache_cache_dir', $default );
+	}
+
+	/**
+	 * Ensure the OPcache cache directory exists and is writable.
+	 *
+	 * Creates the directory on first use and drops a deny-all .htaccess and
+	 * an empty index.html alongside it. Returns false if creation fails or
+	 * the directory ends up non-writable.
+	 */
+	private function ensure_opcache_dir_writable(): bool {
+		$dir = $this->get_opcache_cache_dir();
+
+		if ( ! is_dir( $dir ) && ! wp_mkdir_p( $dir ) ) {
+			return false;
+		}
+
+		if ( ! is_writable( $dir ) ) {
+			return false;
+		}
+
+		// Best-effort hardening; ignore failures (e.g. read-only permissions).
+		$htaccess = $dir . '/.htaccess';
+		$index    = $dir . '/index.html';
+		if ( ! file_exists( $htaccess ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.NoSilencedErrors.Discouraged
+			@file_put_contents( $htaccess, "Deny from all\n" );
+		}
+		if ( ! file_exists( $index ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.NoSilencedErrors.Discouraged
+			@file_put_contents( $index, '' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Read a cached DocumentNode from the OPcache file backend.
+	 *
+	 * @param string $hash The SHA-256 hash.
+	 * @return DocumentNode|false
+	 */
+	private function read_from_opcache( string $hash ) {
+		$path = $this->get_opcache_cache_dir() . '/' . $hash . '.php';
+
+		if ( ! is_file( $path ) ) {
+			return false;
+		}
+
+		// File contents are produced by self::write_to_opcache() and only
+		// ever return a primitive array. Suppress include-time warnings to
+		// fail soft on a missing or malformed file; the caller will fall
+		// back to parsing.
+		// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+		$data = @include $path;
+
+		if ( ! is_array( $data ) ) {
+			return false;
+		}
+
+		try {
+			return AST::fromArray( $data );
+		} catch ( \Throwable ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Persist a parsed AST to the OPcache file backend.
+	 *
+	 * Writes atomically (temp file + rename) so concurrent readers never see
+	 * a partial file, and explicitly invalidates OPcache for the destination
+	 * path so installs running with opcache.validate_timestamps=0 still see
+	 * the new version.
+	 *
+	 * Failures are intentionally silent: the caller already holds a valid
+	 * DocumentNode, and a failed cache write only forfeits the optimisation
+	 * for one request.
+	 *
+	 * @param string       $hash     The SHA-256 hash to cache under.
+	 * @param DocumentNode $document The parsed AST.
+	 */
+	private function write_to_opcache( string $hash, DocumentNode $document ): void {
+		$dir  = $this->get_opcache_cache_dir();
+		$path = $dir . '/' . $hash . '.php';
+		$tmp  = $path . '.' . bin2hex( random_bytes( 8 ) ) . '.tmp';
+
+		$contents = "<?php\nreturn " . var_export( $document->toArray(), true ) . ";\n"; // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		if ( false === file_put_contents( $tmp, $contents, LOCK_EX ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( ! @rename( $tmp, $path ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+			@unlink( $tmp );
+			return;
+		}
+
+		if ( function_exists( 'opcache_invalidate' ) ) {
+			opcache_invalidate( $path, true );
+		}
+		if ( function_exists( 'opcache_compile_file' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			@opcache_compile_file( $path );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -21,7 +21,7 @@ class QueryCache {
 	/**
 	 * WP object-cache group.
 	 */
-	private const CACHE_GROUP = 'wc-graphql';
+	public const CACHE_GROUP = 'wc-graphql';
 
 	/**
 	 * Cache key prefix. Includes the library major version so that upgrading

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -326,7 +326,7 @@ class QueryCache {
 			return false;
 		}
 
-		$fs = $this->wp_filesystem();
+		$fs = Utils::wp_filesystem();
 		if ( ! $fs || ! $fs->is_writable( $dir ) ) {
 			return false;
 		}
@@ -400,7 +400,7 @@ class QueryCache {
 			return;
 		}
 
-		$fs = $this->wp_filesystem();
+		$fs = Utils::wp_filesystem();
 		if ( ! $fs || ! $fs->move( $tmp, $path, true ) ) {
 			if ( $fs ) {
 				$fs->delete( $tmp );
@@ -435,20 +435,5 @@ class QueryCache {
 				),
 			),
 		);
-	}
-
-	/**
-	 * Lazy-initialize and return the WP_Filesystem global, or null when the
-	 * direct method isn't available (e.g. credentials prompt would be needed).
-	 */
-	private function wp_filesystem(): ?\WP_Filesystem_Base {
-		global $wp_filesystem;
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-			if ( ! WP_Filesystem() ) {
-				return null;
-			}
-		}
-		return $wp_filesystem;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -197,9 +197,10 @@ class QueryCache {
 	/**
 	 * Parse a query, cache the resulting AST, and return the DocumentNode.
 	 *
-	 * Writes to OPcache when enabled and usable; otherwise to the object
-	 * cache. APQ requests pass $for_apq=true so the object cache is used
-	 * even when the standard-query toggle is off.
+	 * Writes to OPcache when enabled and usable. APQ registrations always
+	 * also write to the object cache so hash-only lookups still resolve if
+	 * OPcache later becomes unavailable (toggle off, dir unwritable, files
+	 * cleaned up, or a silent write_to_opcache failure).
 	 *
 	 * Returns an error array if the query has a syntax error.
 	 *
@@ -214,9 +215,12 @@ class QueryCache {
 			return $document;
 		}
 
-		if ( Main::is_opcache_enabled() && $this->is_opcache_usable() ) {
+		$used_opcache = Main::is_opcache_enabled() && $this->is_opcache_usable();
+		if ( $used_opcache ) {
 			$this->write_to_opcache( $hash, $document );
-		} elseif ( $for_apq || Main::is_object_cache_enabled() ) {
+		}
+
+		if ( $for_apq || ( Main::is_object_cache_enabled() && ! $used_opcache ) ) {
 			wp_cache_set( $this->build_cache_key( $hash ), $document->toArray(), self::CACHE_GROUP, self::get_cache_ttl() );
 		}
 

--- a/plugins/woocommerce/src/Internal/Api/Settings.php
+++ b/plugins/woocommerce/src/Internal/Api/Settings.php
@@ -95,6 +95,13 @@ class Settings {
 				'custom_attributes' => array( 'min' => '1' ),
 			),
 			array(
+				'title'   => __( 'Enable OPcache-based caching', 'woocommerce' ),
+				'desc'    => __( 'Cache parsed queries on disk as PHP files so OPcache can serve them from shared memory. Falls back to the object cache when the filesystem is not writable.', 'woocommerce' ),
+				'id'      => Main::OPTION_OPCACHE_ENABLED,
+				'default' => 'yes',
+				'type'    => 'checkbox',
+			),
+			array(
 				'title'   => __( 'Enable ObjectCache-based caching', 'woocommerce' ),
 				'desc'    => __( 'Cache parsed queries in the WP object cache', 'woocommerce' ),
 				'id'      => Main::OPTION_OBJECT_CACHE_ENABLED,

--- a/plugins/woocommerce/src/Internal/Api/Utils.php
+++ b/plugins/woocommerce/src/Internal/Api/Utils.php
@@ -186,4 +186,19 @@ class Utils {
 		}//end try
 		// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 	}
+
+	/**
+	 * Lazy-initialize and return the WP_Filesystem global, or null when the
+	 * direct method isn't available (e.g. credentials prompt would be needed).
+	 */
+	public static function wp_filesystem(): ?\WP_Filesystem_Base {
+		global $wp_filesystem;
+		if ( ! $wp_filesystem ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			if ( ! WP_Filesystem() ) {
+				return null;
+			}
+		}
+		return $wp_filesystem;
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Api/OpcacheFileExpiryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/OpcacheFileExpiryTest.php
@@ -1,0 +1,119 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Api;
+
+use Automattic\WooCommerce\Internal\Api\OpcacheFileExpiry;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for {@see OpcacheFileExpiry} — TTL-based deletion of cached files.
+ */
+class OpcacheFileExpiryTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Track temp dirs for removal in tearDown.
+	 *
+	 * @var string[]
+	 */
+	private array $temp_dirs_to_clean = array();
+
+	/**
+	 * Skip on PHP < 8.1 because OpcacheFileExpiry imports from the GraphQL
+	 * stack autoloaded only on PHP 8.1+.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		if ( PHP_VERSION_ID < 80100 ) {
+			$this->markTestSkipped( 'OpcacheFileExpiry tests require PHP 8.1+.' );
+		}
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_graphql_opcache_cache_dir' );
+		foreach ( $this->temp_dirs_to_clean as $dir ) {
+			$this->rrmdir( $dir );
+		}
+		$this->temp_dirs_to_clean = array();
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( OpcacheFileExpiry::ACTION_HOOK );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox delete_expired_files removes only files whose mtime is older than the TTL.
+	 */
+	public function test_delete_expired_files_removes_only_expired(): void {
+		$dir = $this->register_temp_cache_dir();
+
+		$fresh   = $dir . '/' . str_repeat( 'a', 64 ) . '.php';
+		$expired = $dir . '/' . str_repeat( 'b', 64 ) . '.php';
+		file_put_contents( $fresh, '<?php return array();' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $expired, '<?php return array();' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		touch( $expired, time() - OpcacheFileExpiry::FILE_TTL - 1 );
+
+		$deleted = OpcacheFileExpiry::delete_expired_files();
+
+		$this->assertSame( 1, $deleted );
+		$this->assertFileExists( $fresh );
+		$this->assertFileDoesNotExist( $expired );
+	}
+
+	/**
+	 * @testdox delete_expired_files returns 0 when the cache directory does not exist.
+	 */
+	public function test_delete_expired_files_returns_zero_when_dir_missing(): void {
+		add_filter(
+			'woocommerce_graphql_opcache_cache_dir',
+			static function () {
+				return '/nonexistent/path/that/does/not/exist';
+			}
+		);
+
+		$this->assertSame( 0, OpcacheFileExpiry::delete_expired_files() );
+	}
+
+	/**
+	 * Create a per-test cache directory, point the OPcache filter at it, and
+	 * register it for cleanup in tearDown.
+	 */
+	private function register_temp_cache_dir(): string {
+		$dir = sys_get_temp_dir() . '/wc-graphql-cleanup-test-' . bin2hex( random_bytes( 6 ) );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		mkdir( $dir, 0700, true );
+
+		add_filter(
+			'woocommerce_graphql_opcache_cache_dir',
+			static function () use ( $dir ) {
+				return $dir;
+			}
+		);
+
+		$this->temp_dirs_to_clean[] = $dir;
+		return $dir;
+	}
+
+	/**
+	 * Recursively remove a directory tree.
+	 */
+	private function rrmdir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+		foreach ( scandir( $dir ) as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . '/' . $entry;
+			if ( is_dir( $path ) ) {
+				$this->rrmdir( $path );
+			} else {
+				wp_delete_file( $path );
+			}
+		}
+		rmdir( $dir );
+		// phpcs:enable
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Api/OpcacheFileExpiryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/OpcacheFileExpiryTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\Api;
 
 use Automattic\WooCommerce\Internal\Api\OpcacheFileExpiry;
+use Automattic\WooCommerce\Internal\Api\QueryCache;
 use WC_Unit_Test_Case;
 
 /**
@@ -54,7 +55,7 @@ class OpcacheFileExpiryTest extends WC_Unit_Test_Case {
 		$expired = $dir . '/' . str_repeat( 'b', 64 ) . '.php';
 		file_put_contents( $fresh, '<?php return array();' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		file_put_contents( $expired, '<?php return array();' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		touch( $expired, time() - OpcacheFileExpiry::FILE_TTL - 1 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_touch
+		touch( $expired, time() - QueryCache::get_cache_ttl() - 1 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_touch
 
 		$deleted = OpcacheFileExpiry::delete_expired_files();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Api/OpcacheFileExpiryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/OpcacheFileExpiryTest.php
@@ -29,6 +29,9 @@ class OpcacheFileExpiryTest extends WC_Unit_Test_Case {
 		}
 	}
 
+	/**
+	 * Clean up filters, temp dirs, and scheduled actions between tests.
+	 */
 	public function tearDown(): void {
 		remove_all_filters( 'woocommerce_graphql_opcache_cache_dir' );
 		foreach ( $this->temp_dirs_to_clean as $dir ) {
@@ -51,7 +54,7 @@ class OpcacheFileExpiryTest extends WC_Unit_Test_Case {
 		$expired = $dir . '/' . str_repeat( 'b', 64 ) . '.php';
 		file_put_contents( $fresh, '<?php return array();' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		file_put_contents( $expired, '<?php return array();' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		touch( $expired, time() - OpcacheFileExpiry::FILE_TTL - 1 );
+		touch( $expired, time() - OpcacheFileExpiry::FILE_TTL - 1 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_touch
 
 		$deleted = OpcacheFileExpiry::delete_expired_files();
 
@@ -96,6 +99,8 @@ class OpcacheFileExpiryTest extends WC_Unit_Test_Case {
 
 	/**
 	 * Recursively remove a directory tree.
+	 *
+	 * @param string $dir Path to remove.
 	 */
 	private function rrmdir( string $dir ): void {
 		if ( ! is_dir( $dir ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -339,7 +339,7 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 		$this->skip_if_opcache_disabled();
 
 		$not_a_dir                     = tempnam( sys_get_temp_dir(), 'wc-graphql-cache-' );
-		$this->temp_files_to_clean[]   = $not_a_dir;
+		$this->temp_files_to_clean[]    = $not_a_dir;
 
 		add_filter(
 			'woocommerce_graphql_opcache_cache_dir',

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -36,6 +36,11 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 			$this->markTestSkipped( 'QueryCache tests require PHP 8.1+.' );
 		}
 
+		// OPcache caching defaults to 'yes'; turn it off so the existing
+		// object-cache assertions aren't bypassed by a writable filesystem.
+		// Individual tests may opt back in.
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'no' );
+
 		wp_cache_flush();
 		$this->sut = new QueryCache();
 	}
@@ -45,6 +50,12 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		delete_option( Main::OPTION_OBJECT_CACHE_ENABLED );
+		delete_option( Main::OPTION_OPCACHE_ENABLED );
+		remove_all_filters( 'woocommerce_graphql_opcache_cache_dir' );
+		foreach ( $this->temp_dirs_to_clean as $dir ) {
+			$this->rrmdir( $dir );
+		}
+		$this->temp_dirs_to_clean = array();
 		wp_cache_flush();
 		parent::tearDown();
 	}
@@ -199,6 +210,158 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 			wp_cache_get( $this->cache_key_for( '{ __typename }' ), 'wc-graphql' ),
 			'No cache entry should be written when the ObjectCache toggle is off.'
 		);
+	}
+
+	/**
+	 * @testdox resolve writes a parsed AST as a PHP file when OPcache is enabled and the dir is writable.
+	 */
+	public function test_resolve_writes_to_opcache_file_when_toggle_on(): void {
+		$dir = $this->use_temp_opcache_dir();
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'yes' );
+
+		$query = '{ widget { id } }';
+		$result = $this->sut->resolve( $query, array() );
+
+		$this->assertInstanceOf( DocumentNode::class, $result );
+		$this->assertFileExists( $dir . '/' . hash( 'sha256', $query ) . '.php' );
+	}
+
+	/**
+	 * @testdox resolve does not write to the OPcache dir when the toggle is off.
+	 */
+	public function test_resolve_does_not_write_to_opcache_file_when_toggle_off(): void {
+		$dir = $this->use_temp_opcache_dir();
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'no' );
+
+		$query = '{ widget { id } }';
+		$this->sut->resolve( $query, array() );
+
+		$this->assertFileDoesNotExist( $dir . '/' . hash( 'sha256', $query ) . '.php' );
+	}
+
+	/**
+	 * @testdox resolve returns the AST from the OPcache file on the second call.
+	 */
+	public function test_resolve_returns_document_from_opcache_on_second_call(): void {
+		$this->use_temp_opcache_dir();
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'yes' );
+
+		$query  = '{ widget { id } }';
+		$first  = $this->sut->resolve( $query, array() );
+		$second = $this->sut->resolve( $query, array() );
+
+		$this->assertInstanceOf( DocumentNode::class, $first );
+		$this->assertInstanceOf( DocumentNode::class, $second );
+		$this->assertEquals( $first->toArray(), $second->toArray() );
+	}
+
+	/**
+	 * @testdox apq registration persists across the OPcache file backend.
+	 */
+	public function test_apq_round_trip_via_opcache(): void {
+		$this->use_temp_opcache_dir();
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'yes' );
+
+		$query      = '{ widget { id } }';
+		$hash       = hash( 'sha256', $query );
+		$extensions = array(
+			'persistedQuery' => array(
+				'version'    => 1,
+				'sha256Hash' => $hash,
+			),
+		);
+
+		$register = $this->sut->resolve( $query, $extensions );
+		$this->assertInstanceOf( DocumentNode::class, $register );
+
+		$lookup = $this->sut->resolve( null, $extensions );
+		$this->assertInstanceOf( DocumentNode::class, $lookup );
+	}
+
+	/**
+	 * @testdox resolve falls back to the object cache when the OPcache dir is not writable.
+	 */
+	public function test_resolve_falls_back_to_object_cache_when_opcache_dir_unwritable(): void {
+		// Point the filter at a path that is impossible to create or write.
+		add_filter(
+			'woocommerce_graphql_opcache_cache_dir',
+			static function () {
+				return '/this/path/cannot/be/created/by/php/wc-graphql-cache';
+			}
+		);
+
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'yes' );
+		update_option( Main::OPTION_OBJECT_CACHE_ENABLED, 'yes' );
+
+		$result = $this->sut->resolve( '{ __typename }', array() );
+
+		$this->assertInstanceOf( DocumentNode::class, $result );
+		$this->assertNotFalse(
+			wp_cache_get( $this->cache_key_for( '{ __typename }' ), 'wc-graphql' ),
+			'Should have fallen back to the object cache when the OPcache dir is unwritable.'
+		);
+	}
+
+	/**
+	 * Point the OPcache backend at a per-test temp dir, return the path, and
+	 * register a teardown hook to remove it.
+	 *
+	 * Skips the calling test if OPcache is not enabled in this environment
+	 * (typical for PHP CLI without opcache.enable_cli=1) — the file-backend
+	 * capability check requires opcache_get_status to report enabled.
+	 */
+	private function use_temp_opcache_dir(): string {
+		if ( ! function_exists( 'opcache_get_status' ) ) {
+			$this->markTestSkipped( 'OPcache extension not available.' );
+		}
+		$status = @opcache_get_status( false );
+		if ( ! is_array( $status ) || empty( $status['opcache_enabled'] ) ) {
+			$this->markTestSkipped( 'OPcache is not enabled in this environment.' );
+		}
+
+		$dir = sys_get_temp_dir() . '/wc-graphql-test-' . bin2hex( random_bytes( 6 ) );
+		mkdir( $dir, 0700, true );
+
+		add_filter(
+			'woocommerce_graphql_opcache_cache_dir',
+			static function () use ( $dir ) {
+				return $dir;
+			}
+		);
+
+		$this->temp_dirs_to_clean[] = $dir;
+
+		return $dir;
+	}
+
+	/**
+	 * Track temp dirs for removal in tearDown.
+	 *
+	 * @var string[]
+	 */
+	private array $temp_dirs_to_clean = array();
+
+	/**
+	 * Recursively remove a directory tree.
+	 *
+	 * @param string $dir Path to remove.
+	 */
+	private function rrmdir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		foreach ( scandir( $dir ) as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . '/' . $entry;
+			if ( is_dir( $path ) ) {
+				$this->rrmdir( $path );
+			} else {
+				unlink( $path );
+			}
+		}
+		rmdir( $dir );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -56,6 +56,12 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 			$this->rrmdir( $dir );
 		}
 		$this->temp_dirs_to_clean = array();
+		foreach ( $this->temp_files_to_clean as $file ) {
+			if ( file_exists( $file ) ) {
+				wp_delete_file( $file );
+			}
+		}
+		$this->temp_files_to_clean = array();
 		wp_cache_flush();
 		parent::tearDown();
 	}
@@ -282,11 +288,15 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	 * @testdox resolve falls back to the object cache when the OPcache dir is not writable.
 	 */
 	public function test_resolve_falls_back_to_object_cache_when_opcache_dir_unwritable(): void {
-		// Point the filter at a path that is impossible to create or write.
+		$this->skip_if_opcache_disabled();
+
+		$not_a_dir                     = tempnam( sys_get_temp_dir(), 'wc-graphql-cache-' );
+		$this->temp_files_to_clean[]   = $not_a_dir;
+
 		add_filter(
 			'woocommerce_graphql_opcache_cache_dir',
-			static function () {
-				return '/this/path/cannot/be/created/by/php/wc-graphql-cache';
+			static function () use ( $not_a_dir ) {
+				return $not_a_dir;
 			}
 		);
 
@@ -303,14 +313,13 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Point the OPcache backend at a per-test temp dir, return the path, and
-	 * register a teardown hook to remove it.
+	 * Skip the calling test if OPcache is not enabled in this environment.
 	 *
-	 * Skips the calling test if OPcache is not enabled in this environment
-	 * (typical for PHP CLI without opcache.enable_cli=1) — the file-backend
-	 * capability check requires opcache_get_status to report enabled.
+	 * Typical for PHP CLI without opcache.enable_cli=1 — the file-backend
+	 * capability check requires opcache_get_status to report enabled, so
+	 * tests that exercise that path are not meaningful without it.
 	 */
-	private function use_temp_opcache_dir(): string {
+	private function skip_if_opcache_disabled(): void {
 		if ( ! function_exists( 'opcache_get_status' ) || ! ini_get( 'opcache.enable' ) ) {
 			$this->markTestSkipped( 'OPcache is not enabled in this environment.' );
 		}
@@ -318,6 +327,14 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 		if ( ! is_array( $status ) || empty( $status['opcache_enabled'] ) ) {
 			$this->markTestSkipped( 'OPcache is not enabled in this environment.' );
 		}
+	}
+
+	/**
+	 * Point the OPcache backend at a per-test temp dir, return the path, and
+	 * register a teardown hook to remove it.
+	 */
+	private function use_temp_opcache_dir(): string {
+		$this->skip_if_opcache_disabled();
 
 		$dir = sys_get_temp_dir() . '/wc-graphql-test-' . bin2hex( random_bytes( 6 ) );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
@@ -341,6 +358,13 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	 * @var string[]
 	 */
 	private array $temp_dirs_to_clean = array();
+
+	/**
+	 * Track temp files for removal in tearDown.
+	 *
+	 * @var string[]
+	 */
+	private array $temp_files_to_clean = array();
 
 	/**
 	 * Recursively remove a directory tree.

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -351,7 +351,7 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 		if ( ! is_dir( $dir ) ) {
 			return;
 		}
-		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_unlink, WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 		foreach ( scandir( $dir ) as $entry ) {
 			if ( '.' === $entry || '..' === $entry ) {
 				continue;
@@ -360,7 +360,7 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 			if ( is_dir( $path ) ) {
 				$this->rrmdir( $path );
 			} else {
-				unlink( $path );
+				wp_delete_file( $path );
 			}
 		}
 		rmdir( $dir );

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -358,8 +358,8 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	public function test_resolve_falls_back_to_object_cache_when_opcache_dir_unwritable(): void {
 		$this->skip_if_opcache_disabled();
 
-		$not_a_dir                     = tempnam( sys_get_temp_dir(), 'wc-graphql-cache-' );
-		$this->temp_files_to_clean[]    = $not_a_dir;
+		$not_a_dir                   = tempnam( sys_get_temp_dir(), 'wc-graphql-cache-' );
+		$this->temp_files_to_clean[] = $not_a_dir;
 
 		add_filter(
 			'woocommerce_graphql_opcache_cache_dir',

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -219,6 +219,24 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox resolve treats a malformed object-cache entry as a cache miss and reparses.
+	 */
+	public function test_resolve_treats_malformed_object_cache_entry_as_miss(): void {
+		update_option( Main::OPTION_OBJECT_CACHE_ENABLED, 'yes' );
+
+		$query = '{ __typename }';
+		wp_cache_set( $this->cache_key_for( $query ), array( 'not' => 'a valid AST' ), 'wc-graphql' );
+
+		$result = $this->sut->resolve( $query, array() );
+
+		$this->assertInstanceOf(
+			DocumentNode::class,
+			$result,
+			'A corrupted cache payload must be treated as a miss and the query reparsed.'
+		);
+	}
+
+	/**
 	 * @testdox resolve writes a parsed AST as a PHP file when OPcache is enabled and the dir is writable.
 	 */
 	public function test_resolve_writes_to_opcache_file_when_toggle_on(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -285,6 +285,36 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox apq hash-only lookup resolves from the object cache when OPcache becomes unavailable after registration.
+	 */
+	public function test_apq_lookup_falls_back_to_object_cache_when_opcache_disabled(): void {
+		$this->use_temp_opcache_dir();
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'yes' );
+
+		$query      = '{ widget { id } }';
+		$hash       = hash( 'sha256', $query );
+		$extensions = array(
+			'persistedQuery' => array(
+				'version'    => 1,
+				'sha256Hash' => $hash,
+			),
+		);
+
+		$register = $this->sut->resolve( $query, $extensions );
+		$this->assertInstanceOf( DocumentNode::class, $register );
+
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'no' );
+		$this->sut = new QueryCache();
+
+		$lookup = $this->sut->resolve( null, $extensions );
+		$this->assertInstanceOf(
+			DocumentNode::class,
+			$lookup,
+			'APQ hash-only lookup must still resolve from the object cache after OPcache is disabled.'
+		);
+	}
+
+	/**
 	 * @testdox resolve falls back to the object cache when the OPcache dir is not writable.
 	 */
 	public function test_resolve_falls_back_to_object_cache_when_opcache_dir_unwritable(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -182,6 +182,26 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox apq is ignored when the hash is not 64-char lowercase hex — guards the OPcache include path against traversal.
+	 */
+	public function test_apq_rejects_malformed_hash(): void {
+		$extensions = array(
+			'persistedQuery' => array(
+				'version'    => 1,
+				'sha256Hash' => 'not-a-sha256-hash',
+			),
+		);
+
+		$result = $this->sut->resolve( '{ widget { id } }', $extensions );
+
+		$this->assertInstanceOf(
+			DocumentNode::class,
+			$result,
+			'A malformed APQ hash must bypass APQ dispatch so it never reaches the OPcache include path.'
+		);
+	}
+
+	/**
 	 * @testdox get_cache_ttl exposes the configured TTL.
 	 */
 	public function test_get_cache_ttl_is_a_day(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Api;
 
 use Automattic\WooCommerce\Internal\Api\Main;
 use Automattic\WooCommerce\Internal\Api\QueryCache;
+use Automattic\WooCommerce\Internal\Api\OpcacheFileExpiry;
 use Automattic\WooCommerce\Vendor\GraphQL\Language\AST\DocumentNode;
 use WC_Unit_Test_Case;
 
@@ -62,6 +63,9 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 			}
 		}
 		$this->temp_files_to_clean = array();
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( OpcacheFileExpiry::ACTION_HOOK );
+		}
 		wp_cache_flush();
 		parent::tearDown();
 	}
@@ -377,6 +381,26 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 		$this->assertNotFalse(
 			wp_cache_get( $this->cache_key_for( '{ __typename }' ), 'wc-graphql' ),
 			'Should have fallen back to the object cache when the OPcache dir is unwritable.'
+		);
+	}
+
+	/**
+	 * @testdox writing to the OPcache backend schedules the cleanup sweep on first write.
+	 */
+	public function test_first_write_schedules_cleanup(): void {
+		$this->use_temp_opcache_dir();
+		update_option( Main::OPTION_OPCACHE_ENABLED, 'yes' );
+
+		$this->assertFalse(
+			as_has_scheduled_action( OpcacheFileExpiry::ACTION_HOOK ),
+			'Pre-condition: no cleanup action should be scheduled before the first write.'
+		);
+
+		$this->sut->resolve( '{ __typename }', array() );
+
+		$this->assertTrue(
+			as_has_scheduled_action( OpcacheFileExpiry::ACTION_HOOK ),
+			'A successful OPcache write must schedule the cleanup sweep.'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/QueryCacheTest.php
@@ -219,7 +219,7 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 		$dir = $this->use_temp_opcache_dir();
 		update_option( Main::OPTION_OPCACHE_ENABLED, 'yes' );
 
-		$query = '{ widget { id } }';
+		$query  = '{ widget { id } }';
 		$result = $this->sut->resolve( $query, array() );
 
 		$this->assertInstanceOf( DocumentNode::class, $result );
@@ -311,15 +311,16 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 	 * capability check requires opcache_get_status to report enabled.
 	 */
 	private function use_temp_opcache_dir(): string {
-		if ( ! function_exists( 'opcache_get_status' ) ) {
-			$this->markTestSkipped( 'OPcache extension not available.' );
+		if ( ! function_exists( 'opcache_get_status' ) || ! ini_get( 'opcache.enable' ) ) {
+			$this->markTestSkipped( 'OPcache is not enabled in this environment.' );
 		}
-		$status = @opcache_get_status( false );
+		$status = opcache_get_status( false );
 		if ( ! is_array( $status ) || empty( $status['opcache_enabled'] ) ) {
 			$this->markTestSkipped( 'OPcache is not enabled in this environment.' );
 		}
 
 		$dir = sys_get_temp_dir() . '/wc-graphql-test-' . bin2hex( random_bytes( 6 ) );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
 		mkdir( $dir, 0700, true );
 
 		add_filter(
@@ -350,6 +351,7 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 		if ( ! is_dir( $dir ) ) {
 			return;
 		}
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_unlink, WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 		foreach ( scandir( $dir ) as $entry ) {
 			if ( '.' === $entry || '..' === $entry ) {
 				continue;
@@ -362,6 +364,7 @@ class QueryCacheTest extends WC_Unit_Test_Case {
 			}
 		}
 		rmdir( $dir );
+		// phpcs:enable
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Api/SettingsTest.php
@@ -222,6 +222,18 @@ class SettingsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox add_settings defines the OPcache checkbox with a 'yes' default.
+	 */
+	public function test_add_settings_defines_opcache_checkbox(): void {
+		$fields = $this->sut->add_settings( array(), Settings::SECTION_ID );
+		$by_id  = array_column( $fields, null, 'id' );
+
+		$this->assertArrayHasKey( Main::OPTION_OPCACHE_ENABLED, $by_id );
+		$this->assertSame( 'checkbox', $by_id[ Main::OPTION_OPCACHE_ENABLED ]['type'] );
+		$this->assertSame( 'yes', $by_id[ Main::OPTION_OPCACHE_ENABLED ]['default'] );
+	}
+
+	/**
 	 * @testdox add_settings defines the max query depth field with min=1 and the default constant as default.
 	 */
 	public function test_add_settings_defines_max_query_depth_field(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds an OPcache-backed cache layer for parsed GraphQL ASTs, layered on top of the existing object-cache and APQ mechanisms.

When enabled, parsed `DocumentNode`s are written to disk as PHP files (`return [...];`) under `wp-content/uploads/wc-graphql-cache/v15/`. OPcache stores them as compiled bytecode in shared memory, so subsequent reads are a `require` away — no string parsing, no `unserialize`, no remote cache call.

Resolution chain on every standard query (and on APQ):

1. **OPcache file backend** when its toggle is on **and** the OPcache extension is enabled **and** the cache directory is writable.
2. **WP object cache** otherwise (when its toggle is on; APQ always uses it as the ultimate fallback to preserve persisted-query semantics).
3. **No cache** — parse on every request.

Implementation notes:

-   New `OPTION_OPCACHE_ENABLED` option (default `yes`) and matching settings checkbox under WooCommerce → Settings → Advanced → GraphQL.
-   Capability check (`is_opcache_usable()`) is memoised per request so the read and write paths don't duplicate the work.
-   Cache directory path is filterable via `woocommerce_graphql_opcache_cache_dir` (used by tests; useful on hosts with non-standard layouts).
-   First-time directory creation drops a deny-all `.htaccess` and an empty `index.html` alongside the cache files.
-   Writes are atomic: temp file with a random suffix, then `rename()` over the destination. Concurrent readers never see a partial file.
-   `opcache_invalidate()` is called after each successful write so installs running with `opcache.validate_timestamps=0` still pick up new entries; `opcache_compile_file()` pre-warms the bytecode for the very next request.
-   Versioned subdirectory (`v15`) mirrors the existing `graphql_ast_v15_` cache key prefix — bumping the webonyx major version naturally orphans old files.
-   APQ keeps using the WP object cache as a fallback regardless of the standard-query toggle, preserving the pre-OPcache behaviour where APQ always persisted via the object cache.
-   No TTL on the file backend by design: AST contents are a pure function of the query string and the parser version, so staleness isn't a concern. Disk usage is bounded by the unique-query space; if that becomes a problem, we can add cleanup separately.

Closes #64166.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Prerequisites**

-   The `dual_code_graphql_api` feature flag must be enabled (WooCommerce → Settings → Advanced → Features).
-   PHP 8.1+ and a working OPcache extension (`opcache_get_status()` returning `opcache_enabled => true`). 

**Settings UI**

1. Go to **WooCommerce → Settings → Advanced → GraphQL**.
2. Confirm a new checkbox **Enable OPcache-based caching** appears above **Enable ObjectCache-based caching**, defaulting to checked.
3. Toggle it off, save, reload — checkbox state persists.

**OPcache file is created on first request**

1. Make sure both the OPcache toggle and the ObjectCache toggle are **on**.
2. Delete the directory `wp-content/uploads/wc-graphql-cache/` if it already exists.
3. Send a GraphQL request, e.g.:
    ```sh
    curl -X POST -H 'Content-Type: application/json' \
      -d '{"query":"{ __typename }"}' \
      http://your-site.test/wp-json/wc/graphql
    ```
4. Confirm a directory `wp-content/uploads/wc-graphql-cache/v15/` was created and contains:
    - `<sha256>.php` — a PHP file whose content begins with `<?php` and `return array (...)`. Open it; the array should describe a `Document` AST with a `__typename` selection.
    - `.htaccess` containing `Deny from all`.
    - `index.html` (empty).
5. Send the same request again. Confirm the response is identical.
6. Inspect the file's mtime — it should NOT update on the second request (cache hit, no rewrite).

**OPcache file is NOT created when the toggle is off**

1. Turn the OPcache toggle **off**, leave ObjectCache **on**.
2. Delete `wp-content/uploads/wc-graphql-cache/`.
3. Send a GraphQL request.
4. Confirm the directory was NOT recreated.

**Fallback to object cache when filesystem isn't writable**

1. With the OPcache toggle **on** and ObjectCache **on**, make the cache directory unwritable:
    ```sh
    chmod -w wp-content/uploads/wc-graphql-cache/v15
    ```
2. Send a GraphQL request with a brand-new query string.
3. Confirm the request still succeeds.
4. Confirm no new file appeared in the OPcache directory.
5. Restore writability: `chmod +w wp-content/uploads/wc-graphql-cache/v15`.

**APQ still works through the OPcache layer**

Note: if you are using a persistent object cache, make sure to wipe it before proceeding to avoid false positives from previously cached queries.

1. With both toggles on **and** APQ enabled, do a hash-only request first:
    ```sh
    HASH=$(php -r 'echo hash("sha256", "{ __typename }");')
    curl -X POST -H 'Content-Type: application/json' \
      -d "{\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$HASH\"}}}" \
      http://your-site.test/wp-json/wc/graphql
    ```
    Expect: `PERSISTED_QUERY_NOT_FOUND` error.
2. Register the query (full query + matching hash):
    ```sh
    curl -X POST -H 'Content-Type: application/json' \
      -d "{\"query\":\"{ __typename }\",\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$HASH\"}}}" \
      http://your-site.test/wp-json/wc/graphql
    ```
    Expect: a normal data response.
3. Confirm a `<HASH>.php` file now exists under `wp-content/uploads/wc-graphql-cache/v15/`.
4. Repeat step 1 (hash-only). Expect: a normal data response (cache hit via OPcache).

### OPcache cache file expiry

### Test 1 — Scheduling on first write, then deletion of expired files

1. Wipe any existing opcache files:
   ```sh
   rm -rf wp-content/uploads/wc-graphql-cache/
   ```
2. Go to **Tools → Scheduled Actions** and filter by `woocommerce_graphql_opcache_cleanup`. Confirm there are no pending actions.
3. Send a GraphQL request:
   ```sh
   curl -X POST -H 'Content-Type: application/json' \
     -d '{"query":"{ __typename }"}' \
     http://your-site.test/wp-json/wc/graphql
   ```
4. Confirm a `<sha256>.php` file now exists under `wp-content/uploads/wc-graphql-cache/v15/`.
5. Refresh Scheduled Actions. **Expected:** one pending action for hook `woocommerce_graphql_opcache_cleanup`, scheduled for ~24h from now.
6. Backdate the file ~30 days:
   ```sh
   touch -d '30 days ago' wp-content/uploads/wc-graphql-cache/v15/<the-hash>.
   ```
7. Trigger cleanup now:
   ```sh
   wp action-scheduler run --hooks=woocommerce_graphql_opcache_cleanup
   ```
8. **Expected:** the backdated file is gone. A new pending action exists, scheduled ~1s after the run (drain mode).

### Test 2 — Fresh files survive

1. Make any request to the graphql API.
2. List the cache dir:
   ```sh
   ls -la wp-content/uploads/wc-graphql-cache/v15/
   ```
3. Trigger cleanup:
   ```sh
   wp action-scheduler run --hooks=woocommerce_graphql_opcache_cleanup
   ```
4. **Expected:** all files survive. Next pending action should be 24h later.

### Test 3 — No duplicate scheduling

1. After any of the above, filter Scheduled Actions on hook `woocommerce_graphql_opcache_cleanup`, status **Pending**.
2. Send another GraphQL request.
3. **Expected:** still exactly **one** pending action.

<!-- End testing instructions -->

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add OPcache-backed caching for parsed GraphQL queries, with fallback to the WP object cache.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>