### PR TITLE
Remove unnecessary gap in Product Filters block

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-filters-spacing
+++ b/plugins/woocommerce/changelog/fix-product-filters-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unnecessary gap in Product Filters block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
@@ -67,7 +67,6 @@
 		display: flex !important;
 		flex-direction: column;
 		max-height: 100%;
-		gap: var(--wp--preset--spacing--40);
 	}
 
 	.wc-block-product-filters__overlay-header {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Product Filters block overlay has a gap between its parts. In this PR I'm removing it because:

1. On desktop, it's not visible because the header and the footer are hidden.
2. On mobile:

  * the gap between the content and the footer was adding an blank space that made some texts to appear cut off (see the `Category` text in the screenshot below)
  * the gap between the header and the content was used to add some spacing, but IMO it can be removed and it looks good as well (but I can add it back if preferred)

### How to test the changes in this Pull Request:

1. Create a post, page or template with the Product Collection and Product Filters blocks.
2. On mobile, open the Product Filters overlay.
3. Verify there is no gap between the content and the footer, so the text is not cut off.

Before | After
--- | ---
<img width="605" height="1023" alt="Captura de pantalla de 2026-05-05 16-10-08" src="https://github.com/user-attachments/assets/a89e0bdb-99da-48c5-ab7d-3f099184a21f" /> | <img width="605" height="1023" alt="Captura de pantalla de 2026-05-05 16-10-16" src="https://github.com/user-attachments/assets/101d8063-7ab5-45ac-9d1e-ca30bc246785" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->