### PR TITLE
Add store_stock push notification for low/out/backorder events

### DIFF
--- a/plugins/woocommerce/changelog/issue-RSM-1551
+++ b/plugins/woocommerce/changelog/issue-RSM-1551
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add the store_stock push notification covering low-stock, out-of-stock, and backorder events. Each event has its own merchant-configurable sub-flag; out-of-stock and low-stock are enabled by default and on-backorder is opt-in.
+Add the store_stock push notification covering low-stock, out-of-stock, and backorder events. All three events are enabled by default and each one has its own merchant-configurable sub-flag.

--- a/plugins/woocommerce/changelog/issue-RSM-1551
+++ b/plugins/woocommerce/changelog/issue-RSM-1551
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the store_stock push notification covering low-stock, out-of-stock, and backorder events. Each event has its own merchant-configurable sub-flag; out-of-stock and low-stock are enabled by default and on-backorder is opt-in.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -224,6 +224,20 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 				);
 			}
 
+			$boolean_sub_fields = array( 'low_stock', 'out_of_stock', 'on_backorder' );
+			foreach ( $boolean_sub_fields as $sub_field ) {
+				if ( array_key_exists( $sub_field, $shape ) ) {
+					$properties[ $sub_field ] = array(
+						'type'        => 'boolean',
+						'description' => sprintf(
+							/* translators: %s: sub-field name (e.g. low_stock). */
+							__( 'Whether %s notifications are enabled for this type.', 'woocommerce' ),
+							$sub_field
+						),
+					);
+				}
+			}
+
 			$args[ $key ] = array(
 				'description'       => sprintf(
 					/* translators: %s: notification preference key (e.g. store_order). */

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
@@ -25,6 +25,7 @@ abstract class Notification {
 	const NOTIFICATION_CLASSES = array(
 		'store_order'  => NewOrderNotification::class,
 		'store_review' => NewReviewNotification::class,
+		'store_stock'  => StockNotification::class,
 	);
 
 	/**
@@ -139,7 +140,13 @@ abstract class Notification {
 			throw new InvalidArgumentException( sprintf( 'Unknown notification type: %s', $type ) );
 		}
 
-		return new $class( $resource_id );
+		$instance = new $class( $resource_id );
+
+		if ( method_exists( $instance, 'hydrate' ) ) {
+			$instance->hydrate( $data );
+		}
+
+		return $instance;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
@@ -27,7 +27,7 @@ class StockNotification extends Notification {
 		self::EVENT_ON_BACKORDER,
 	);
 
-	const ICON = 'https://s.wp.com/wp-content/mu-plugins/notes/images/update-payment-2x.png';
+	const ICON = 'https://s.wp.com/wp-content/mu-plugins/notes/images/tos-warning-note-icon.png';
 
 	/**
 	 * The stock event that triggered this notification.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
@@ -1,0 +1,335 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Notifications;
+
+use InvalidArgumentException;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Notification for product stock events (low stock, out of stock, backorder).
+ *
+ * @since 10.9.0
+ */
+class StockNotification extends Notification {
+	const TYPE = 'store_stock';
+
+	const EVENT_LOW_STOCK    = 'low_stock';
+	const EVENT_OUT_OF_STOCK = 'out_of_stock';
+	const EVENT_ON_BACKORDER = 'on_backorder';
+
+	const VALID_EVENT_TYPES = array(
+		self::EVENT_LOW_STOCK,
+		self::EVENT_OUT_OF_STOCK,
+		self::EVENT_ON_BACKORDER,
+	);
+
+	const ICON = 'https://s.wp.com/wp-content/mu-plugins/notes/images/update-payment-2x.png';
+
+	/**
+	 * The stock event that triggered this notification.
+	 *
+	 * @var string
+	 */
+	private string $event_type;
+
+	/**
+	 * Stock quantity captured at the moment the WC stock event fired.
+	 *
+	 * Captured at trigger time rather than read at dispatch time so the
+	 * notification reflects the threshold-crossing moment, not whatever
+	 * stock level the product happens to be at when the dispatcher (which
+	 * runs in a separate process — internal REST endpoint or ActionScheduler
+	 * safety net) eventually re-fetches the product. Avoids stale-cache reads
+	 * and remains correct even if subsequent orders reduce stock further
+	 * before dispatch.
+	 *
+	 * Only meaningful for the low_stock event today; null for the other two.
+	 *
+	 * @var int|null
+	 */
+	private ?int $stock_quantity_at_trigger;
+
+	/**
+	 * Creates a new StockNotification instance.
+	 *
+	 * @param int      $resource_id              The product ID.
+	 * @param string   $event_type               One of the EVENT_* constants.
+	 * @param int|null $stock_quantity_at_trigger Stock quantity captured when the WC stock event fired, or null if unknown.
+	 *
+	 * @throws InvalidArgumentException If the resource ID or event type is invalid.
+	 *
+	 * @since 10.9.0
+	 */
+	public function __construct( int $resource_id, string $event_type = self::EVENT_LOW_STOCK, ?int $stock_quantity_at_trigger = null ) {
+		parent::__construct( $resource_id );
+
+		if ( ! in_array( $event_type, self::VALID_EVENT_TYPES, true ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new InvalidArgumentException( sprintf( 'Invalid stock notification event type: %s', $event_type ) );
+		}
+
+		$this->event_type                = $event_type;
+		$this->stock_quantity_at_trigger = $stock_quantity_at_trigger;
+	}
+
+	/**
+	 * Restores extra state from a serialized notification array.
+	 *
+	 * Called by {@see Notification::from_array()} after construction to
+	 * restore the event type that the default constructor cannot receive.
+	 *
+	 * Throws when `event_type` is present but unrecognized so the safety-net
+	 * caller (which wraps reconstruction in a try/catch) drops the corrupt
+	 * job rather than silently dispatching the wrong notification subtype.
+	 * A missing `event_type` is allowed — the default set by the constructor
+	 * survives, which preserves backward compatibility with any in-flight
+	 * scheduled actions that pre-date this field.
+	 *
+	 * @param array $data The serialized notification data.
+	 *
+	 * @throws InvalidArgumentException If `event_type` is present but not a known value.
+	 *
+	 * @since 10.9.0
+	 */
+	public function hydrate( array $data ): void {
+		if ( array_key_exists( 'event_type', $data ) ) {
+			$event_type = $data['event_type'];
+
+			if ( ! in_array( $event_type, self::VALID_EVENT_TYPES, true ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+				throw new InvalidArgumentException( sprintf( 'Invalid stock notification event type during hydrate: %s', is_scalar( $event_type ) ? (string) $event_type : gettype( $event_type ) ) );
+			}
+
+			$this->event_type = $event_type;
+		}
+
+		if ( array_key_exists( 'stock_quantity_at_trigger', $data ) ) {
+			$stock                           = $data['stock_quantity_at_trigger'];
+			$this->stock_quantity_at_trigger = is_int( $stock ) ? $stock : null;
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_type(): string {
+		return self::TYPE;
+	}
+
+	/**
+	 * Returns the stock event type.
+	 *
+	 * @return string
+	 *
+	 * @since 10.9.0
+	 */
+	public function get_event_type(): string {
+		return $this->event_type;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Includes `event_type` so the same product can have distinct
+	 * notifications for different stock events in-flight simultaneously.
+	 */
+	public function get_identifier(): string {
+		return sprintf(
+			'%s_%s_%s_%s',
+			get_current_blog_id(),
+			$this->get_type(),
+			$this->event_type,
+			$this->get_resource_id()
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Extends the parent array with `event_type` and the trigger-time stock
+	 * snapshot so both fields survive serialization through the safety-net
+	 * scheduler and the internal-REST round-trip.
+	 *
+	 * @return array{type: string, resource_id: int, event_type: string, stock_quantity_at_trigger: int|null}
+	 *
+	 * @since 10.9.0
+	 */
+	public function to_array(): array {
+		return array_merge(
+			parent::to_array(),
+			array(
+				'event_type'                => $this->event_type,
+				'stock_quantity_at_trigger' => $this->stock_quantity_at_trigger,
+			)
+		);
+	}
+
+	/**
+	 * Returns the WPCOM-ready payload for this notification.
+	 *
+	 * Returns null if the product no longer exists.
+	 *
+	 * @return array|null
+	 *
+	 * @since 10.9.0
+	 */
+	public function to_payload(): ?array {
+		$product = WC()->call_function( 'wc_get_product', $this->get_resource_id() );
+
+		if ( ! $product || ! $product instanceof WC_Product ) {
+			return null;
+		}
+
+		$product_name = wp_strip_all_tags( $product->get_name() );
+		$site_title   = wp_strip_all_tags( get_bloginfo( 'name' ) );
+
+		// For variations, `meta.product_id` is the parent product ID so the mobile app
+		// can always navigate to the product details screen. `resource_id` keeps the
+		// actual entity ID (variation or simple product) for identification and dedup.
+		$is_variation = $product->is_type( 'variation' );
+		$product_id   = $is_variation ? $product->get_parent_id() : $product->get_id();
+
+		return array(
+			'type'        => $this->get_type(),
+			'icon'        => self::ICON,
+			'timestamp'   => gmdate( 'c' ),
+			'resource_id' => $this->get_resource_id(),
+			'title'       => $this->build_title( $product_name ),
+			'message'     => $this->build_message( $product_name, $site_title, $product ),
+			'meta'        => array(
+				'product_id' => $product_id,
+				'event_type' => $this->event_type,
+			),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Extends the base enabled-toggle check with per-event sub-flag filtering.
+	 *
+	 * @param mixed $pref_value The user's stored preference value, or null.
+	 * @return bool
+	 *
+	 * @since 10.9.0
+	 */
+	public function should_send_to_user( $pref_value ): bool {
+		if ( ! parent::should_send_to_user( $pref_value ) ) {
+			return false;
+		}
+
+		if ( ! is_array( $pref_value ) || ! array_key_exists( $this->event_type, $pref_value ) ) {
+			return true;
+		}
+
+		return (bool) $pref_value[ $this->event_type ];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $key The meta key.
+	 */
+	public function has_meta( string $key ): bool {
+		$product = WC()->call_function( 'wc_get_product', $this->get_resource_id() );
+		return $product instanceof WC_Product && $product->meta_exists( $key . '_' . $this->event_type );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $key The meta key.
+	 */
+	public function write_meta( string $key ): void {
+		$product = WC()->call_function( 'wc_get_product', $this->get_resource_id() );
+
+		if ( $product instanceof WC_Product ) {
+			$product->update_meta_data( $key . '_' . $this->event_type, (string) time() );
+			$product->save_meta_data();
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $key The meta key.
+	 */
+	public function delete_meta( string $key ): void {
+		$product = WC()->call_function( 'wc_get_product', $this->get_resource_id() );
+
+		if ( $product instanceof WC_Product ) {
+			$product->delete_meta_data( $key . '_' . $this->event_type );
+			$product->save_meta_data();
+		}
+	}
+
+	/**
+	 * Builds the title payload for the notification.
+	 *
+	 * @param string $product_name The sanitized product name.
+	 * @return array{format: string, args: string[]}
+	 */
+	private function build_title( string $product_name ): array {
+		switch ( $this->event_type ) {
+			case self::EVENT_OUT_OF_STOCK:
+				return array(
+					'format' => 'Out of stock: %1$s',
+					'args'   => array( $product_name ),
+				);
+
+			case self::EVENT_ON_BACKORDER:
+				return array(
+					'format' => 'Backordered: %1$s',
+					'args'   => array( $product_name ),
+				);
+
+			default:
+				return array(
+					'format' => 'Low stock: %1$s',
+					'args'   => array( $product_name ),
+				);
+		}
+	}
+
+	/**
+	 * Builds the message payload for the notification.
+	 *
+	 * @param string     $product_name The sanitized product name.
+	 * @param string     $site_title   The sanitized site title.
+	 * @param WC_Product $product      The product object (used as a fallback when no trigger-time stock was captured).
+	 * @return array{format: string, args: string[]}
+	 */
+	private function build_message( string $product_name, string $site_title, WC_Product $product ): array {
+		switch ( $this->event_type ) {
+			case self::EVENT_OUT_OF_STOCK:
+				return array(
+					'format' => '%1$s is out of stock on %2$s',
+					'args'   => array( $product_name, $site_title ),
+				);
+
+			case self::EVENT_ON_BACKORDER:
+				return array(
+					'format' => '%1$s has been backordered on %2$s',
+					'args'   => array( $product_name, $site_title ),
+				);
+
+			default:
+				$stock = null !== $this->stock_quantity_at_trigger
+					? $this->stock_quantity_at_trigger
+					: $product->get_stock_quantity();
+
+				return array(
+					'format' => '%1$s is running low (%2$s remaining) on %3$s',
+					'args'   => array(
+						$product_name,
+						(string) $stock,
+						$site_title,
+					),
+				);
+		}//end switch
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProce
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewReviewNotificationTrigger;
+use Automattic\WooCommerce\Internal\PushNotifications\Triggers\StockNotificationTrigger;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WC_Logger;
@@ -82,6 +83,7 @@ class PushNotifications {
 		( new NotificationPreferencesRestController() )->register();
 		( new NewOrderNotificationTrigger() )->register();
 		( new NewReviewNotificationTrigger() )->register();
+		( new StockNotificationTrigger() )->register();
 
 		wc_get_container()->get( NotificationProcessor::class )->register();
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -120,7 +120,7 @@ class NotificationPreferencesService {
 		$defaults['store_review']['max_rating']  = null;
 		$defaults['store_stock']['low_stock']    = true;
 		$defaults['store_stock']['out_of_stock'] = true;
-		$defaults['store_stock']['on_backorder'] = false;
+		$defaults['store_stock']['on_backorder'] = true;
 
 		return $defaults;
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationPreferencesService.php
@@ -116,8 +116,11 @@ class NotificationPreferencesService {
 			$defaults[ $type ] = array( 'enabled' => true );
 		}
 
-		$defaults['store_order']['min_amount']  = null;
-		$defaults['store_review']['max_rating'] = null;
+		$defaults['store_order']['min_amount']   = null;
+		$defaults['store_review']['max_rating']  = null;
+		$defaults['store_stock']['low_stock']    = true;
+		$defaults['store_stock']['out_of_stock'] = true;
+		$defaults['store_stock']['on_backorder'] = false;
 
 		return $defaults;
 	}
@@ -186,6 +189,13 @@ class NotificationPreferencesService {
 				}
 				$rating                = (int) $value[ $sub_key ];
 				$sanitized[ $sub_key ] = ( $rating >= 1 && $rating <= 5 ) ? $rating : null;
+				continue;
+			}
+
+			if ( in_array( $sub_key, array( 'low_stock', 'out_of_stock', 'on_backorder' ), true ) ) {
+				$sanitized[ $sub_key ] = array_key_exists( $sub_key, $value )
+					? (bool) $value[ $sub_key ]
+					: (bool) $sub_default;
 				continue;
 			}
 		}//end foreach

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -99,7 +99,7 @@ class NotificationProcessor {
 	 * @since 10.7.0
 	 */
 	public function register(): void {
-		add_action( self::SAFETY_NET_HOOK, array( $this, 'handle_safety_net' ), 10, 2 );
+		add_action( self::SAFETY_NET_HOOK, array( $this, 'handle_safety_net' ), 10, 4 );
 	}
 
 	/**
@@ -231,20 +231,30 @@ class NotificationProcessor {
 	 * send does not occur, or fails and cannot schedule a retry (e.g. out of
 	 * memory, retry scheduling error) then this safety net will run.
 	 *
-	 * @param string $type        The notification type.
-	 * @param int    $resource_id The resource ID.
+	 * @param string   $type                      The notification type.
+	 * @param int      $resource_id               The resource ID.
+	 * @param string   $event_type                Optional event subtype (e.g. for stock notifications).
+	 * @param int|null $stock_quantity_at_trigger Optional stock snapshot captured at trigger time (stock notifications only).
 	 * @return void
 	 *
 	 * @since 10.7.0
 	 */
-	public function handle_safety_net( string $type, int $resource_id ): void {
+	public function handle_safety_net( string $type, int $resource_id, string $event_type = '', ?int $stock_quantity_at_trigger = null ): void {
 		try {
-			$notification = Notification::from_array(
-				array(
-					'type'        => $type,
-					'resource_id' => $resource_id,
-				)
+			$data = array(
+				'type'        => $type,
+				'resource_id' => $resource_id,
 			);
+
+			if ( '' !== $event_type ) {
+				$data['event_type'] = $event_type;
+			}
+
+			if ( null !== $stock_quantity_at_trigger ) {
+				$data['stock_quantity_at_trigger'] = $stock_quantity_at_trigger;
+			}
+
+			$notification = Notification::from_array( $data );
 
 			$this->process( $notification, true );
 		} catch ( Exception $e ) {
@@ -252,6 +262,6 @@ class NotificationProcessor {
 				sprintf( 'Safety net failed: %s', $e->getMessage() ),
 				array( 'source' => PushNotifications::FEATURE_NAME )
 			);
-		}
+		}//end try
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -99,7 +99,7 @@ class NotificationProcessor {
 	 * @since 10.7.0
 	 */
 	public function register(): void {
-		add_action( self::SAFETY_NET_HOOK, array( $this, 'handle_safety_net' ), 10, 4 );
+		add_action( self::SAFETY_NET_HOOK, array( $this, 'handle_safety_net' ), 10, 3 );
 	}
 
 	/**
@@ -231,28 +231,23 @@ class NotificationProcessor {
 	 * send does not occur, or fails and cannot schedule a retry (e.g. out of
 	 * memory, retry scheduling error) then this safety net will run.
 	 *
-	 * @param string   $type                      The notification type.
-	 * @param int      $resource_id               The resource ID.
-	 * @param string   $event_type                Optional event subtype (e.g. for stock notifications).
-	 * @param int|null $stock_quantity_at_trigger Optional stock snapshot captured at trigger time (stock notifications only).
+	 * @param string $type        The notification type.
+	 * @param int    $resource_id The resource ID.
+	 * @param array  $extra       Optional subclass-specific extras (e.g. event_type, stock_quantity_at_trigger).
+	 *                            Empty for notification types whose state is fully described by type + resource_id.
 	 * @return void
 	 *
 	 * @since 10.7.0
 	 */
-	public function handle_safety_net( string $type, int $resource_id, string $event_type = '', ?int $stock_quantity_at_trigger = null ): void {
+	public function handle_safety_net( string $type, int $resource_id, array $extra = array() ): void {
 		try {
-			$data = array(
-				'type'        => $type,
-				'resource_id' => $resource_id,
+			$data = array_merge(
+				array(
+					'type'        => $type,
+					'resource_id' => $resource_id,
+				),
+				$extra
 			);
-
-			if ( '' !== $event_type ) {
-				$data['event_type'] = $event_type;
-			}
-
-			if ( null !== $stock_quantity_at_trigger ) {
-				$data['stock_quantity_at_trigger'] = $stock_quantity_at_trigger;
-			}
 
 			$notification = Notification::from_array( $data );
 
@@ -262,6 +257,6 @@ class NotificationProcessor {
 				sprintf( 'Safety net failed: %s', $e->getMessage() ),
 				array( 'source' => PushNotifications::FEATURE_NAME )
 			);
-		}//end try
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -241,13 +241,13 @@ class NotificationProcessor {
 	 */
 	public function handle_safety_net( string $type, int $resource_id, array $extra = array() ): void {
 		try {
-			$data = array_merge(
-				array(
-					'type'        => $type,
-					'resource_id' => $resource_id,
-				),
-				$extra
-			);
+			// Use the `+` array union operator (not array_merge) so the positional
+			// $type and $resource_id always win over any colliding keys in $extra.
+			// Defends against a malformed payload reconstructing the wrong target.
+			$data = array(
+				'type'        => $type,
+				'resource_id' => $resource_id,
+			) + $extra;
 
 			$notification = Notification::from_array( $data );
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -120,10 +120,7 @@ class PendingNotificationStore {
 	 * @since 10.7.0
 	 */
 	private function schedule_safety_net( Notification $notification ): void {
-		$args = array(
-			'type'        => $notification->get_type(),
-			'resource_id' => $notification->get_resource_id(),
-		);
+		$args = $notification->to_array();
 
 		if ( as_has_scheduled_action( NotificationProcessor::SAFETY_NET_HOOK, $args, NotificationProcessor::ACTION_SCHEDULER_GROUP ) ) {
 			return;

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -120,7 +120,16 @@ class PendingNotificationStore {
 	 * @since 10.7.0
 	 */
 	private function schedule_safety_net( Notification $notification ): void {
-		$args = $notification->to_array();
+		$data        = $notification->to_array();
+		$type        = $data['type'];
+		$resource_id = $data['resource_id'];
+		unset( $data['type'], $data['resource_id'] );
+
+		// Pass `type` and `resource_id` positionally and bundle any subclass-specific
+		// extras (event_type, stock_quantity_at_trigger, etc.) into a single array
+		// argument so the safety-net callback signature stays stable as new
+		// notification subclasses add fields to to_array().
+		$args = array( $type, $resource_id, $data );
 
 		if ( as_has_scheduled_action( NotificationProcessor::SAFETY_NET_HOOK, $args, NotificationProcessor::ACTION_SCHEDULER_GROUP ) ) {
 			return;

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/StockNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/StockNotificationTrigger.php
@@ -1,0 +1,102 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Triggers;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\StockNotification;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Listens for WooCommerce stock events and feeds stock notifications into
+ * the PendingNotificationStore.
+ *
+ * @since 10.9.0
+ */
+class StockNotificationTrigger {
+	/**
+	 * Registers WordPress hooks for stock events.
+	 *
+	 * @return void
+	 *
+	 * @since 10.9.0
+	 */
+	public function register(): void {
+		add_action( 'woocommerce_low_stock', array( $this, 'on_low_stock' ) );
+		add_action( 'woocommerce_no_stock', array( $this, 'on_no_stock' ) );
+		add_action( 'woocommerce_product_on_backorder', array( $this, 'on_backorder' ) );
+	}
+
+	/**
+	 * Handles the woocommerce_low_stock hook.
+	 *
+	 * Captures the product's stock quantity at this moment so the dispatcher,
+	 * which runs in a separate process and re-fetches the product, doesn't
+	 * read a stale value if cache invalidation hasn't fully propagated.
+	 *
+	 * @param WC_Product $product The product whose stock is low.
+	 * @return void
+	 *
+	 * @since 10.9.0
+	 */
+	public function on_low_stock( WC_Product $product ): void {
+		$stock = $product->get_stock_quantity();
+		$this->add_notification(
+			$product->get_id(),
+			StockNotification::EVENT_LOW_STOCK,
+			null !== $stock ? (int) $stock : null
+		);
+	}
+
+	/**
+	 * Handles the woocommerce_no_stock hook.
+	 *
+	 * @param WC_Product $product The product that is out of stock.
+	 * @return void
+	 *
+	 * @since 10.9.0
+	 */
+	public function on_no_stock( WC_Product $product ): void {
+		$this->add_notification( $product->get_id(), StockNotification::EVENT_OUT_OF_STOCK );
+	}
+
+	/**
+	 * Handles the woocommerce_product_on_backorder hook.
+	 *
+	 * @param array $args Backorder event data.
+	 * @phpstan-param array{product: WC_Product, order_id: int, quantity: int|float} $args
+	 * @return void
+	 *
+	 * @since 10.9.0
+	 */
+	public function on_backorder( array $args ): void {
+		$product = $args['product'] ?? null;
+
+		if ( ! $product instanceof WC_Product ) {
+			return;
+		}
+
+		$this->add_notification( $product->get_id(), StockNotification::EVENT_ON_BACKORDER );
+	}
+
+	/**
+	 * Creates a stock notification and adds it to the pending store.
+	 *
+	 * @param int      $product_id                The product ID.
+	 * @param string   $event_type                The stock event type.
+	 * @param int|null $stock_quantity_at_trigger Stock quantity at the moment WC fired the event, or null when not applicable.
+	 * @return void
+	 */
+	private function add_notification( int $product_id, string $event_type, ?int $stock_quantity_at_trigger = null ): void {
+		if ( $product_id <= 0 ) {
+			return;
+		}
+
+		wc_get_container()->get( PendingNotificationStore::class )->add(
+			new StockNotification( $product_id, $event_type, $stock_quantity_at_trigger )
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -465,6 +465,69 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox GET should include store_stock with all sub-flags in the defaults.
+	 */
+	public function test_get_preferences_includes_store_stock_with_sub_flags() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
+
+		$request  = new WP_REST_Request( 'GET', '/wc-push-notifications/preferences' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'store_stock', $data );
+		$this->assertArrayHasKey( 'enabled', $data['store_stock'] );
+		$this->assertArrayHasKey( 'low_stock', $data['store_stock'] );
+		$this->assertArrayHasKey( 'out_of_stock', $data['store_stock'] );
+		$this->assertArrayHasKey( 'on_backorder', $data['store_stock'] );
+	}
+
+	/**
+	 * @testdox POST should accept and persist store_stock sub-flag updates.
+	 */
+	public function test_post_preferences_updates_stock_sub_flags() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
+		$request->set_param(
+			'store_stock',
+			array(
+				'low_stock'    => false,
+				'on_backorder' => true,
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['store_stock']['low_stock'] );
+		$this->assertTrue( $data['store_stock']['on_backorder'] );
+	}
+
+	/**
+	 * @testdox POST should reject non-boolean store_stock sub-fields via REST validation.
+	 */
+	public function test_post_preferences_rejects_non_boolean_stock_sub_flag() {
+		wp_set_current_user( $this->user_id );
+		$this->mock_jetpack_connection_manager_is_connected( true );
+		$this->register_routes();
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/preferences' );
+		$request->set_param( 'store_stock', array( 'low_stock' => 'not-a-boolean' ) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( WP_Http::BAD_REQUEST, $response->get_status() );
+	}
+
+	/**
 	 * @testdox Should not collide with PushTokenRestController on the WC REST namespaces filter.
 	 *
 	 * Both controllers share the URL route namespace `wc-push-notifications`, but they must use

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NotificationTest.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Notifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewReviewNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\StockNotification;
 use InvalidArgumentException;
 use WC_Unit_Test_Case;
 
@@ -60,6 +61,7 @@ class NotificationTest extends WC_Unit_Test_Case {
 	 * @testdox from_array should create correct notification for $type type.
 	 * @testWith ["store_order", "Automattic\\WooCommerce\\Internal\\PushNotifications\\Notifications\\NewOrderNotification"]
 	 *           ["store_review", "Automattic\\WooCommerce\\Internal\\PushNotifications\\Notifications\\NewReviewNotification"]
+	 *           ["store_stock", "Automattic\\WooCommerce\\Internal\\PushNotifications\\Notifications\\StockNotification"]
 	 *
 	 * @param string $type           The notification type.
 	 * @param string $expected_class The expected class name.
@@ -143,5 +145,37 @@ class NotificationTest extends WC_Unit_Test_Case {
 			->getMock();
 
 		$this->assertSame( $expected, $notification->should_send_to_user( $pref_value ) );
+	}
+
+	/**
+	 * @testdox from_array should call hydrate() on classes that implement it.
+	 */
+	public function test_from_array_hydrates_extra_fields(): void {
+		$notification = Notification::from_array(
+			array(
+				'type'        => 'store_stock',
+				'resource_id' => 42,
+				'event_type'  => 'out_of_stock',
+			)
+		);
+
+		$this->assertInstanceOf( StockNotification::class, $notification );
+		$this->assertSame( 'out_of_stock', $notification->get_event_type() );
+	}
+
+	/**
+	 * @testdox from_array should not break for types without hydrate() when extra data is present.
+	 */
+	public function test_from_array_ignores_extra_fields_for_types_without_hydrate(): void {
+		$notification = Notification::from_array(
+			array(
+				'type'        => 'store_order',
+				'resource_id' => 42,
+				'extra'       => 'should be ignored',
+			)
+		);
+
+		$this->assertInstanceOf( NewOrderNotification::class, $notification );
+		$this->assertSame( 42, $notification->get_resource_id() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/StockNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/StockNotificationTest.php
@@ -1,0 +1,414 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Notifications;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\StockNotification;
+use InvalidArgumentException;
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the StockNotification class.
+ */
+class StockNotificationTest extends WC_Unit_Test_Case {
+	/**
+	 * @testdox Should return store_stock as the notification type.
+	 */
+	public function test_type_is_store_stock(): void {
+		$notification = new StockNotification( 1 );
+
+		$this->assertSame( 'store_stock', $notification->get_type() );
+	}
+
+	/**
+	 * @testdox Should return the product ID as the resource ID.
+	 */
+	public function test_resource_id_matches_product_id(): void {
+		$notification = new StockNotification( 42 );
+
+		$this->assertSame( 42, $notification->get_resource_id() );
+	}
+
+	/**
+	 * @testdox Should return the event type passed to the constructor.
+	 * @dataProvider event_types_provider
+	 *
+	 * @param string $event_type The event type constant.
+	 */
+	public function test_get_event_type_returns_constructor_value( string $event_type ): void {
+		$notification = new StockNotification( 1, $event_type );
+
+		$this->assertSame( $event_type, $notification->get_event_type() );
+	}
+
+	/**
+	 * @testdox Should default event_type to low_stock when not provided.
+	 */
+	public function test_constructor_defaults_event_type_to_low_stock(): void {
+		$notification = new StockNotification( 1 );
+
+		$this->assertSame( StockNotification::EVENT_LOW_STOCK, $notification->get_event_type() );
+	}
+
+	/**
+	 * @testdox Should throw for an invalid event type.
+	 */
+	public function test_constructor_throws_for_invalid_event_type(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		new StockNotification( 1, 'invalid_event' );
+	}
+
+	/**
+	 * @testdox Should return a payload with all required keys for an existing product.
+	 */
+	public function test_to_payload_contains_required_keys(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 3,
+			)
+		);
+
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK );
+		$payload      = $notification->to_payload();
+
+		$this->assertArrayHasKey( 'type', $payload );
+		$this->assertArrayHasKey( 'timestamp', $payload );
+		$this->assertArrayHasKey( 'resource_id', $payload );
+		$this->assertArrayHasKey( 'title', $payload );
+		$this->assertArrayHasKey( 'format', $payload['title'] );
+		$this->assertArrayHasKey( 'args', $payload['title'] );
+		$this->assertArrayHasKey( 'message', $payload );
+		$this->assertArrayHasKey( 'format', $payload['message'] );
+		$this->assertArrayHasKey( 'args', $payload['message'] );
+		$this->assertArrayHasKey( 'icon', $payload );
+		$this->assertArrayHasKey( 'meta', $payload );
+		$this->assertArrayHasKey( 'product_id', $payload['meta'] );
+		$this->assertArrayHasKey( 'event_type', $payload['meta'] );
+	}
+
+	/**
+	 * @testdox Should vary title format by event type.
+	 * @dataProvider event_type_title_provider
+	 *
+	 * @param string $event_type      The event type constant.
+	 * @param string $expected_prefix The expected start of the title format.
+	 */
+	public function test_to_payload_varies_title_by_event_type( string $event_type, string $expected_prefix ): void {
+		$product      = WC_Helper_Product::create_simple_product();
+		$notification = new StockNotification( $product->get_id(), $event_type );
+		$payload      = $notification->to_payload();
+
+		$this->assertStringStartsWith( $expected_prefix, $payload['title']['format'] );
+	}
+
+	/**
+	 * @testdox Should include stock quantity in the low_stock message args.
+	 */
+	public function test_to_payload_includes_stock_quantity_for_low_stock(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 5,
+			)
+		);
+
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK );
+		$payload      = $notification->to_payload();
+
+		$this->assertSame( '5', $payload['message']['args'][1] );
+	}
+
+	/**
+	 * @testdox Should prefer the trigger-time stock snapshot over the product's current stock so cache lag in the dispatcher process can't surface a stale value.
+	 */
+	public function test_to_payload_uses_stock_quantity_at_trigger_for_low_stock(): void {
+		// Product currently shows stock=5 — simulating what a stale-cache re-fetch in the dispatcher process might return.
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 5,
+			)
+		);
+
+		// But at trigger time, the actual post-decrement stock was 1. That's what the merchant should see in the push.
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK, 1 );
+		$payload      = $notification->to_payload();
+
+		$this->assertSame( '1', $payload['message']['args'][1] );
+	}
+
+	/**
+	 * @testdox For a simple product, meta.product_id should equal the product ID.
+	 */
+	public function test_to_payload_meta_product_id_for_simple_product(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 0,
+			)
+		);
+
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_OUT_OF_STOCK );
+		$payload      = $notification->to_payload();
+
+		$this->assertSame( $product->get_id(), $payload['meta']['product_id'] );
+		$this->assertSame( $product->get_id(), $payload['resource_id'] );
+	}
+
+	/**
+	 * @testdox For a variation, meta.product_id should be the parent product ID so mobile can navigate to the product details screen, while resource_id keeps the variation ID for identification.
+	 */
+	public function test_to_payload_meta_product_id_for_variation(): void {
+		$parent     = WC_Helper_Product::create_variation_product();
+		$variations = $parent->get_children();
+		$variation  = wc_get_product( $variations[0] );
+		$variation->set_manage_stock( true );
+		$variation->set_stock_quantity( 0 );
+		$variation->save();
+
+		$notification = new StockNotification( $variation->get_id(), StockNotification::EVENT_OUT_OF_STOCK );
+		$payload      = $notification->to_payload();
+
+		$this->assertSame( $parent->get_id(), $payload['meta']['product_id'] );
+		$this->assertSame( $variation->get_id(), $payload['resource_id'] );
+		$this->assertNotSame( $variation->get_id(), $payload['meta']['product_id'] );
+	}
+
+	/**
+	 * @testdox Should return null when the product no longer exists.
+	 */
+	public function test_to_payload_returns_null_for_deleted_product(): void {
+		$notification = new StockNotification( 999999 );
+
+		$this->assertNull( $notification->to_payload() );
+	}
+
+	/**
+	 * @testdox to_array should include event_type alongside type and resource_id.
+	 */
+	public function test_to_array_includes_event_type(): void {
+		$notification = new StockNotification( 42, StockNotification::EVENT_OUT_OF_STOCK );
+		$data         = $notification->to_array();
+
+		$this->assertArrayHasKey( 'event_type', $data );
+		$this->assertSame( StockNotification::EVENT_OUT_OF_STOCK, $data['event_type'] );
+		$this->assertSame( 'store_stock', $data['type'] );
+		$this->assertSame( 42, $data['resource_id'] );
+	}
+
+	/**
+	 * @testdox hydrate should restore event_type from serialized data.
+	 */
+	public function test_hydrate_restores_event_type(): void {
+		$notification = new StockNotification( 1 );
+		$this->assertSame( StockNotification::EVENT_LOW_STOCK, $notification->get_event_type() );
+
+		$notification->hydrate( array( 'event_type' => StockNotification::EVENT_ON_BACKORDER ) );
+
+		$this->assertSame( StockNotification::EVENT_ON_BACKORDER, $notification->get_event_type() );
+	}
+
+	/**
+	 * @testdox hydrate should throw on an unrecognized event_type so corrupt safety-net jobs are dropped instead of dispatching the wrong subtype.
+	 */
+	public function test_hydrate_throws_on_invalid_event_type(): void {
+		$notification = new StockNotification( 1, StockNotification::EVENT_OUT_OF_STOCK );
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$notification->hydrate( array( 'event_type' => 'not-a-valid-event' ) );
+	}
+
+	/**
+	 * @testdox hydrate should keep current event_type when key is missing.
+	 */
+	public function test_hydrate_keeps_current_when_key_missing(): void {
+		$notification = new StockNotification( 1, StockNotification::EVENT_OUT_OF_STOCK );
+
+		$notification->hydrate( array() );
+
+		$this->assertSame( StockNotification::EVENT_OUT_OF_STOCK, $notification->get_event_type() );
+	}
+
+	/**
+	 * @testdox to_array should include the trigger-time stock snapshot when present.
+	 */
+	public function test_to_array_includes_stock_quantity_at_trigger(): void {
+		$notification = new StockNotification( 42, StockNotification::EVENT_LOW_STOCK, 1 );
+		$data         = $notification->to_array();
+
+		$this->assertArrayHasKey( 'stock_quantity_at_trigger', $data );
+		$this->assertSame( 1, $data['stock_quantity_at_trigger'] );
+	}
+
+	/**
+	 * @testdox hydrate should restore stock_quantity_at_trigger from serialized data so the safety-net path keeps the threshold-crossing value.
+	 */
+	public function test_hydrate_restores_stock_quantity_at_trigger(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 5,
+			)
+		);
+
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK );
+		$notification->hydrate(
+			array(
+				'event_type'                => StockNotification::EVENT_LOW_STOCK,
+				'stock_quantity_at_trigger' => 1,
+			)
+		);
+
+		$payload = $notification->to_payload();
+		$this->assertSame( '1', $payload['message']['args'][1] );
+	}
+
+	/**
+	 * @testdox get_identifier should differ for the same product with different event types.
+	 */
+	public function test_get_identifier_differs_for_different_event_types(): void {
+		$low  = new StockNotification( 42, StockNotification::EVENT_LOW_STOCK );
+		$out  = new StockNotification( 42, StockNotification::EVENT_OUT_OF_STOCK );
+		$back = new StockNotification( 42, StockNotification::EVENT_ON_BACKORDER );
+
+		$this->assertNotSame( $low->get_identifier(), $out->get_identifier() );
+		$this->assertNotSame( $out->get_identifier(), $back->get_identifier() );
+		$this->assertNotSame( $low->get_identifier(), $back->get_identifier() );
+	}
+
+	/**
+	 * @testdox should_send_to_user should return true when enabled and event sub-flag is true.
+	 */
+	public function test_should_send_to_user_when_enabled_and_sub_flag_true(): void {
+		$notification = new StockNotification( 1, StockNotification::EVENT_LOW_STOCK );
+
+		$this->assertTrue(
+			$notification->should_send_to_user(
+				array(
+					'enabled'   => true,
+					'low_stock' => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox should_send_to_user should return false when enabled but event sub-flag is false.
+	 */
+	public function test_should_not_send_to_user_when_sub_flag_false(): void {
+		$notification = new StockNotification( 1, StockNotification::EVENT_ON_BACKORDER );
+
+		$this->assertFalse(
+			$notification->should_send_to_user(
+				array(
+					'enabled'      => true,
+					'on_backorder' => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox should_send_to_user should return false when notification is disabled regardless of sub-flags.
+	 */
+	public function test_should_not_send_to_user_when_disabled(): void {
+		$notification = new StockNotification( 1, StockNotification::EVENT_LOW_STOCK );
+
+		$this->assertFalse(
+			$notification->should_send_to_user(
+				array(
+					'enabled'   => false,
+					'low_stock' => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox should_send_to_user should default to true when event sub-flag key is missing.
+	 */
+	public function test_should_send_to_user_when_sub_flag_missing(): void {
+		$notification = new StockNotification( 1, StockNotification::EVENT_LOW_STOCK );
+
+		$this->assertTrue(
+			$notification->should_send_to_user( array( 'enabled' => true ) )
+		);
+	}
+
+	/**
+	 * @testdox should_send_to_user should return true when pref_value is null.
+	 */
+	public function test_should_send_to_user_when_pref_null(): void {
+		$notification = new StockNotification( 1 );
+
+		$this->assertTrue( $notification->should_send_to_user( null ) );
+	}
+
+	/**
+	 * @testdox Meta operations should use product post meta namespaced by event type.
+	 */
+	public function test_meta_operations_use_product_meta(): void {
+		$product      = WC_Helper_Product::create_simple_product();
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK );
+		$meta_key     = '_test_meta';
+
+		$this->assertFalse( $notification->has_meta( $meta_key ) );
+
+		$notification->write_meta( $meta_key );
+		$this->assertTrue( $notification->has_meta( $meta_key ) );
+
+		$notification->delete_meta( $meta_key );
+		$this->assertFalse( $notification->has_meta( $meta_key ) );
+	}
+
+	/**
+	 * @testdox Meta keys should be namespaced by event type to avoid collisions.
+	 */
+	public function test_meta_key_is_namespaced_by_event_type(): void {
+		$product  = WC_Helper_Product::create_simple_product();
+		$low      = new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK );
+		$out      = new StockNotification( $product->get_id(), StockNotification::EVENT_OUT_OF_STOCK );
+		$meta_key = '_test_meta';
+
+		$low->write_meta( $meta_key );
+
+		$this->assertTrue( $low->has_meta( $meta_key ) );
+		$this->assertFalse( $out->has_meta( $meta_key ) );
+	}
+
+	/**
+	 * Data provider for all valid event types.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function event_types_provider(): array {
+		return array(
+			'low_stock'    => array( StockNotification::EVENT_LOW_STOCK ),
+			'out_of_stock' => array( StockNotification::EVENT_OUT_OF_STOCK ),
+			'on_backorder' => array( StockNotification::EVENT_ON_BACKORDER ),
+		);
+	}
+
+	/**
+	 * Data provider mapping event types to expected title prefixes.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function event_type_title_provider(): array {
+		return array(
+			'low_stock'    => array( StockNotification::EVENT_LOW_STOCK, 'Low stock:' ),
+			'out_of_stock' => array( StockNotification::EVENT_OUT_OF_STOCK, 'Out of stock:' ),
+			'on_backorder' => array( StockNotification::EVENT_ON_BACKORDER, 'Backordered:' ),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
@@ -285,6 +285,7 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 		$this->assertIsArray( $defaults );
 		$this->assertArrayHasKey( 'store_order', $defaults );
 		$this->assertArrayHasKey( 'store_review', $defaults );
+		$this->assertArrayHasKey( 'store_stock', $defaults );
 
 		foreach ( $defaults as $type => $shape ) {
 			$this->assertIsArray( $shape, "Default for {$type} should be an object/array." );
@@ -443,6 +444,100 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 		$this->sut->save_preferences(
 			$this->user_id,
 			array( 'store_review' => array( 'enabled' => false ) )
+		);
+	}
+
+	/**
+	 * @testdox Should include stock sub-flag defaults for store_stock.
+	 */
+	public function test_get_defaults_includes_stock_sub_flags(): void {
+		$defaults = $this->sut->get_defaults();
+
+		$this->assertArrayHasKey( 'low_stock', $defaults['store_stock'] );
+		$this->assertTrue( $defaults['store_stock']['low_stock'] );
+		$this->assertArrayHasKey( 'out_of_stock', $defaults['store_stock'] );
+		$this->assertTrue( $defaults['store_stock']['out_of_stock'] );
+		$this->assertArrayHasKey( 'on_backorder', $defaults['store_stock'] );
+		$this->assertFalse( $defaults['store_stock']['on_backorder'] );
+	}
+
+	/**
+	 * @testdox Should coerce stock sub-flags to booleans.
+	 */
+	public function test_sanitize_coerces_stock_sub_flags_to_bool(): void {
+		$this->data_store->method( 'read' )->willReturn( null );
+
+		$result = $this->sut->save_preferences(
+			$this->user_id,
+			array(
+				'store_stock' => array(
+					'low_stock'    => 1,
+					'out_of_stock' => 0,
+				),
+			)
+		);
+
+		$this->assertTrue( $result['store_stock']['low_stock'] );
+		$this->assertFalse( $result['store_stock']['out_of_stock'] );
+	}
+
+	/**
+	 * @testdox Should drop unknown sub-fields within store_stock.
+	 */
+	public function test_save_preferences_drops_unknown_stock_sub_fields(): void {
+		$this->data_store->method( 'read' )->willReturn( null );
+
+		$result = $this->sut->save_preferences(
+			$this->user_id,
+			array(
+				'store_stock' => array(
+					'enabled'       => true,
+					'low_stock'     => true,
+					'unknown_event' => true,
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'store_stock', $result );
+		$this->assertArrayNotHasKey( 'unknown_event', $result['store_stock'] );
+	}
+
+	/**
+	 * @testdox Should deep-merge partial store_stock updates preserving unrelated sub-fields.
+	 */
+	public function test_save_preferences_deep_merges_stock_sub_flags(): void {
+		$this->data_store->method( 'read' )->willReturn(
+			array(
+				'schema_version' => NotificationPreferencesDataStore::CURRENT_SCHEMA_VERSION,
+				'preferences'    => array(
+					'store_stock' => array(
+						'enabled'      => true,
+						'low_stock'    => true,
+						'out_of_stock' => true,
+						'on_backorder' => false,
+					),
+				),
+			)
+		);
+
+		$this->data_store
+			->expects( $this->once() )
+			->method( 'write' )
+			->with(
+				$this->anything(),
+				$this->callback(
+					function ( $envelope ) {
+						$prefs = $envelope['preferences']['store_stock'];
+						return false === $prefs['low_stock']
+							&& true === $prefs['out_of_stock']
+							&& false === $prefs['on_backorder'];
+					}
+				)
+			);
+
+		$this->sut->save_preferences(
+			$this->user_id,
+			array( 'store_stock' => array( 'low_stock' => false ) )
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationPreferencesServiceTest.php
@@ -458,7 +458,7 @@ class NotificationPreferencesServiceTest extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'out_of_stock', $defaults['store_stock'] );
 		$this->assertTrue( $defaults['store_stock']['out_of_stock'] );
 		$this->assertArrayHasKey( 'on_backorder', $defaults['store_stock'] );
-		$this->assertFalse( $defaults['store_stock']['on_backorder'] );
+		$this->assertTrue( $defaults['store_stock']['on_backorder'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -630,7 +630,11 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->sut->handle_safety_net( 'store_stock', $product->get_id(), 'low_stock' );
+		$this->sut->handle_safety_net(
+			'store_stock',
+			$product->get_id(),
+			array( 'event_type' => 'low_stock' )
+		);
 
 		$refreshed = wc_get_product( $product->get_id() );
 		$this->assertNotEmpty(
@@ -639,9 +643,9 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Safety net backward compat: two-arg calls should still work for existing notification types.
+	 * @testdox Safety net should default the extras array so notification types without subclass-specific state still work.
 	 */
-	public function test_handle_safety_net_backward_compat_two_args(): void {
+	public function test_handle_safety_net_omits_extras_for_simple_types(): void {
 		$this->dispatcher->expects( $this->once() )->method( 'dispatch' )->willReturn(
 			array(
 				'success'     => true,
@@ -688,7 +692,14 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 			);
 
 		// Trigger-time stock was 1 (post-decrement), even though current product stock is 5.
-		$this->sut->handle_safety_net( 'store_stock', $product->get_id(), 'low_stock', 1 );
+		$this->sut->handle_safety_net(
+			'store_stock',
+			$product->get_id(),
+			array(
+				'event_type'                => 'low_stock',
+				'stock_quantity_at_trigger' => 1,
+			)
+		);
 
 		$this->assertNotNull( $captured_payload );
 		$this->assertSame( '1', $captured_payload['message']['args'][1] );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -660,6 +660,54 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Safety net should ignore type/resource_id keys smuggled into the extras array so the positional params remain authoritative.
+	 */
+	public function test_handle_safety_net_extras_cannot_override_positional_params(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 3,
+			)
+		);
+
+		$captured_notification = null;
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->with(
+				$this->callback(
+					function ( $notification ) use ( &$captured_notification ) {
+						$captured_notification = $notification;
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				array(
+					'success'     => true,
+					'retry_after' => null,
+				)
+			);
+
+		// `type` and `resource_id` keys inside the extras array are smuggled values
+		// that must be ignored — the positional params should remain authoritative.
+		$this->sut->handle_safety_net(
+			'store_stock',
+			$product->get_id(),
+			array(
+				'event_type'  => 'low_stock',
+				'type'        => 'store_order',
+				'resource_id' => 999999,
+			)
+		);
+
+		$this->assertNotNull( $captured_notification );
+		$this->assertSame( 'store_stock', $captured_notification->get_type() );
+		$this->assertSame( $product->get_id(), $captured_notification->get_resource_id() );
+	}
+
+	/**
 	 * @testdox Safety net should propagate the stock quantity captured at trigger time when reconstructing the notification.
 	 */
 	public function test_handle_safety_net_with_stock_quantity_at_trigger(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewReviewNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\StockNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
@@ -80,6 +81,12 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 					'min_amount' => null,
 				),
 				'store_review' => array( 'enabled' => true ),
+				'store_stock'  => array(
+					'enabled'      => true,
+					'low_stock'    => true,
+					'out_of_stock' => true,
+					'on_backorder' => false,
+				),
 			)
 		);
 
@@ -602,5 +609,131 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 
 		$this->assertTrue( $result );
 		$this->assertNotEmpty( get_comment_meta( $comment_id, NotificationProcessor::SENT_META_KEY, true ) );
+	}
+
+	/**
+	 * @testdox Should handle safety net callback with a stock notification event_type.
+	 */
+	public function test_handle_safety_net_with_stock_event_type(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 3,
+			)
+		);
+
+		$this->dispatcher->expects( $this->once() )->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$this->sut->handle_safety_net( 'store_stock', $product->get_id(), 'low_stock' );
+
+		$refreshed = wc_get_product( $product->get_id() );
+		$this->assertNotEmpty(
+			$refreshed->get_meta( NotificationProcessor::SENT_META_KEY . '_low_stock' )
+		);
+	}
+
+	/**
+	 * @testdox Safety net backward compat: two-arg calls should still work for existing notification types.
+	 */
+	public function test_handle_safety_net_backward_compat_two_args(): void {
+		$this->dispatcher->expects( $this->once() )->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$this->sut->handle_safety_net( 'store_order', $this->order_id );
+
+		$order = wc_get_order( $this->order_id );
+		$this->assertNotEmpty( $order->get_meta( NotificationProcessor::SENT_META_KEY ) );
+	}
+
+	/**
+	 * @testdox Safety net should propagate the stock quantity captured at trigger time when reconstructing the notification.
+	 */
+	public function test_handle_safety_net_with_stock_quantity_at_trigger(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				// Product currently shows stock=5 (the dispatcher might re-fetch and see this).
+				'stock_quantity' => 5,
+			)
+		);
+
+		$captured_payload = null;
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->with(
+				$this->callback(
+					function ( $notification ) use ( &$captured_payload ) {
+						$captured_payload = $notification->to_payload();
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				array(
+					'success'     => true,
+					'retry_after' => null,
+				)
+			);
+
+		// Trigger-time stock was 1 (post-decrement), even though current product stock is 5.
+		$this->sut->handle_safety_net( 'store_stock', $product->get_id(), 'low_stock', 1 );
+
+		$this->assertNotNull( $captured_payload );
+		$this->assertSame( '1', $captured_payload['message']['args'][1] );
+	}
+
+	/**
+	 * @testdox Should skip dispatch for stock notification when the matching sub-flag is disabled.
+	 */
+	public function test_process_skips_dispatch_when_stock_sub_flag_disabled(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 3,
+			)
+		);
+
+		$preferences_service = $this->createMock( NotificationPreferencesService::class );
+		$preferences_service->method( 'get_preferences' )->willReturn(
+			array(
+				'store_order'  => array(
+					'enabled'    => true,
+					'min_amount' => null,
+				),
+				'store_review' => array(
+					'enabled'    => true,
+					'max_rating' => null,
+				),
+				'store_stock'  => array(
+					'enabled'      => true,
+					'low_stock'    => false,
+					'out_of_stock' => true,
+					'on_backorder' => false,
+				),
+			)
+		);
+
+		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
+
+		$sut = new NotificationProcessor();
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK );
+		$result       = $sut->process( $notification );
+
+		$this->assertTrue( $result );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Services;
 use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewReviewNotification;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\StockNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use WC_Unit_Test_Case;
 
@@ -202,5 +203,39 @@ class PendingNotificationStoreTest extends WC_Unit_Test_Case {
 			->setConstructorArgs( array( $resource_id ) )
 			->onlyMethods( array( 'to_payload', 'has_meta', 'write_meta' ) )
 			->getMock();
+	}
+
+	/**
+	 * Creates a mock StockNotification that avoids database calls.
+	 *
+	 * @param int    $resource_id The resource ID.
+	 * @param string $event_type  The stock event type.
+	 * @return StockNotification
+	 */
+	private function create_stock_mock( int $resource_id, string $event_type ): StockNotification {
+		return $this->getMockBuilder( StockNotification::class )
+			->setConstructorArgs( array( $resource_id, $event_type ) )
+			->onlyMethods( array( 'to_payload', 'has_meta', 'write_meta' ) )
+			->getMock();
+	}
+
+	/**
+	 * @testdox Should store different stock event types for the same product separately.
+	 */
+	public function test_add_allows_different_stock_event_types_for_same_product(): void {
+		$this->store->add( $this->create_stock_mock( 42, StockNotification::EVENT_LOW_STOCK ) );
+		$this->store->add( $this->create_stock_mock( 42, StockNotification::EVENT_OUT_OF_STOCK ) );
+
+		$this->assertSame( 2, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should deduplicate the same stock event type for the same product.
+	 */
+	public function test_add_deduplicates_same_stock_event_type_and_product(): void {
+		$this->store->add( $this->create_stock_mock( 42, StockNotification::EVENT_LOW_STOCK ) );
+		$this->store->add( $this->create_stock_mock( 42, StockNotification::EVENT_LOW_STOCK ) );
+
+		$this->assertSame( 1, $this->store->count() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/StockNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/StockNotificationTriggerTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Triggers;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\StockNotification;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Triggers\StockNotificationTrigger;
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the StockNotificationTrigger class.
+ */
+class StockNotificationTriggerTest extends WC_Unit_Test_Case {
+	/**
+	 * An instance of StockNotificationTrigger.
+	 *
+	 * @var StockNotificationTrigger
+	 */
+	private $trigger;
+
+	/**
+	 * The notification store used by the trigger.
+	 *
+	 * @var PendingNotificationStore
+	 */
+	private $store;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$dispatcher  = $this->createMock( InternalNotificationDispatcher::class );
+		$this->store = new PendingNotificationStore();
+
+		$this->store->init( $dispatcher );
+		$this->store->register();
+
+		wc_get_container()->replace( PendingNotificationStore::class, $this->store );
+		wc_get_container()->reset_all_resolved();
+
+		$this->trigger = new StockNotificationTrigger();
+		$this->trigger->register();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_action( 'woocommerce_low_stock', array( $this->trigger, 'on_low_stock' ) );
+		remove_action( 'woocommerce_no_stock', array( $this->trigger, 'on_no_stock' ) );
+		remove_action( 'woocommerce_product_on_backorder', array( $this->trigger, 'on_backorder' ) );
+		remove_action( 'shutdown', array( $this->store, 'dispatch_all' ) );
+
+		$this->reset_container_replacements();
+		wc_get_container()->reset_all_resolved();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should add a notification when the low stock hook fires and capture the stock quantity at trigger time.
+	 */
+	public function test_low_stock_hook_adds_notification(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 2,
+			)
+		);
+
+		$this->trigger->on_low_stock( $product );
+
+		$this->assertSame( 1, $this->store->count() );
+
+		$notifications = $this->store->get_all();
+		$this->assertInstanceOf( StockNotification::class, $notifications[0] );
+		$this->assertSame( StockNotification::EVENT_LOW_STOCK, $notifications[0]->get_event_type() );
+
+		// The stock snapshot is captured at trigger time so the dispatcher (which runs in a separate process)
+		// doesn't read a stale value if cache invalidation hasn't propagated.
+		$this->assertSame( 2, $notifications[0]->to_array()['stock_quantity_at_trigger'] );
+	}
+
+	/**
+	 * @testdox Should add a notification when the no stock hook fires.
+	 */
+	public function test_no_stock_hook_adds_notification(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 0,
+			)
+		);
+
+		$this->trigger->on_no_stock( $product );
+
+		$this->assertSame( 1, $this->store->count() );
+
+		$notifications = $this->store->get_all();
+		$this->assertSame( StockNotification::EVENT_OUT_OF_STOCK, $notifications[0]->get_event_type() );
+	}
+
+	/**
+	 * @testdox Should add a notification when the backorder hook fires with a valid product.
+	 */
+	public function test_backorder_hook_adds_notification(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->trigger->on_backorder(
+			array(
+				'product'  => $product,
+				'order_id' => 1,
+				'quantity' => 3,
+			)
+		);
+
+		$this->assertSame( 1, $this->store->count() );
+
+		$notifications = $this->store->get_all();
+		$this->assertSame( StockNotification::EVENT_ON_BACKORDER, $notifications[0]->get_event_type() );
+	}
+
+	/**
+	 * @testdox Should ignore the backorder hook when the product is not a WC_Product.
+	 */
+	public function test_backorder_hook_ignores_invalid_product(): void {
+		$this->trigger->on_backorder(
+			array(
+				'product'  => 'not-a-product',
+				'order_id' => 1,
+				'quantity' => 3,
+			)
+		);
+
+		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should ignore the backorder hook when the product key is missing.
+	 */
+	public function test_backorder_hook_ignores_missing_product(): void {
+		$this->trigger->on_backorder( array( 'order_id' => 1 ) );
+
+		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should store different event types for the same product separately.
+	 */
+	public function test_different_events_same_product_stored_separately(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 0,
+			)
+		);
+
+		$this->trigger->on_low_stock( $product );
+		$this->trigger->on_no_stock( $product );
+
+		$this->assertSame( 2, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should deduplicate the same event type for the same product.
+	 */
+	public function test_same_event_same_product_deduplicated(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 2,
+			)
+		);
+
+		$this->trigger->on_low_stock( $product );
+		$this->trigger->on_low_stock( $product );
+
+		$this->assertSame( 1, $this->store->count() );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a `store_stock` push notification type so merchants get alerted on three inventory events — low stock, out of stock, and backorder — over the same WPCOM relay path used by `store_order` and `store_review`. The implementation is a single polymorphic `StockNotification` keyed off one `store_stock` preference with three boolean sub-flags (`low_stock`, `out_of_stock`, `on_backorder`); defaults are low/out enabled and backorder opt-in.

Two behaviors worth calling out:

- **Stock quantity is captured at the moment `woocommerce_low_stock` fires** and serialized through to dispatch. The dispatcher runs in a separate process (internal REST endpoint or ActionScheduler safety net), so re-fetching the product there can return a stale cached value and surface the pre-decrement count in the message body. Capturing at trigger time also keeps the value stable if subsequent orders reduce stock further before dispatch.
- **For variations, `meta.product_id` is the parent product ID** so the mobile app can always navigate to the product details screen. `resource_id` keeps the actual entity ID (variation or simple product) so per-event identifier and dedup logic still distinguish individual variations.

WPCOM-side routing for the new type is tracked separately and required for end-to-end delivery.

### How to test the changes in this Pull Request:

Prerequisites: a Jetpack-connected WC store with the Push Notifications module enabled, a registered push token (e.g. WC mobile dev build with FCM), and `WP_DEBUG_LOG` on so you can intercept the WPCOM call.

Optional: drop this mu-plugin into `wp-content/mu-plugins/` to short-circuit and log the WPCOM call rather than relying on real delivery (delivery additionally requires the WPCOM-side change tracked separately):

```php
<?php
add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
    if ( str_contains( $url, 'public-api.wordpress.com' ) && str_contains( $url, 'push-notifications' ) ) {
        error_log( 'WPCOM push intercepted: ' . wp_json_encode( json_decode( $args['body'] ?? '{}' ), JSON_PRETTY_PRINT ) );
        return array( 'response' => array( 'code' => 200 ), 'body' => '{}' );
    }
    return $preempt;
}, 10, 3 );
```

1. **Low stock**: in *Settings → Products → Inventory*, set the low-stock threshold to e.g. 5. Edit a product, set stock to 4, save. → A `store_stock` push payload with `meta.event_type: "low_stock"` is intercepted/sent. Title: `Low stock: <product>`. The message body shows the post-decrement stock count, not the pre-decrement value.
2. **Out of stock**: on the same product, set stock to 0 with backorders disabled. → Payload with `meta.event_type: "out_of_stock"`.
3. **On backorder (opt-in)**: enable the sub-flag for the current user via REST first:
   ```
   POST /wp-json/wc-push-notifications/preferences
   { "store_stock": { "on_backorder": true } }
   ```
   Allow backorders on the product, set its stock to 0, place an order. → Payload with `meta.event_type: "on_backorder"`. (Without the opt-in, `on_backorder` is suppressed by the default-false sub-flag — verify this too.)
4. **Variation**: trigger any stock event on a variation. → `meta.product_id` is the **parent** product ID; top-level `resource_id` is the variation ID.
5. **Master toggle**: `POST` `{ "store_stock": { "enabled": false } }`. Trigger any of the three events. → No push for any subtype.
6. **Sub-flag dedup boundaries**: same product, different events should produce separate payloads (e.g. dropping from 0 to -1 with backorders allowed fires both `out_of_stock` and `on_backorder` — both are queued, only those whose sub-flag is enabled actually dispatch).
7. **REST schema validation**: `POST` `{ "store_stock": { "low_stock": "not-a-bool" } }` returns HTTP 400.
8. **Run the test suite**: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter PushNotifications`. All PushNotifications tests pass.

### Testing that has already taken place:

- Manual end-to-end on a Jurassic Ninja site with the WC mobile dev build connected: low_stock and out_of_stock pushes verified to leave the WC plugin with correct payloads (`meta.event_type` set correctly, three distinct title/message templates per subtype). `on_backorder` verified suppressed by default and dispatched after opt-in. Variation stock event verified to surface the parent product ID under `meta.product_id` while keeping the variation ID as `resource_id`.
- PHPCS clean on all changed/new files (`Suin.Classes.PSR4` errors excluded — pre-existing tooling bug unrelated to this PR).
- PHPStan clean on the modified source files via the project `phpstan.neon` config.
- Full PushNotifications PHPUnit suite green.
- Code review pass focused on round-trip serialization through ActionScheduler, dedup correctness with multiple event subtypes for the same product, REST schema rejection of non-boolean sub-flags, backward-compat with in-flight 2- and 3-arg safety-net actions, and variation handling. Two actionable findings have been addressed: `hydrate()` now throws on unrecognized `event_type` so the safety-net try/catch drops corrupt jobs instead of dispatching the wrong subtype; and the low_stock message renders the trigger-time stock count instead of a possibly-stale re-fetched value.

### Future improvement

The per-product dedup meta (`_wc_push_notification_sent_<event_type>`) is never cleared on stock recovery, so a product that goes low → restocked → low again won't emit a second notification until the meta is cleared. This is consistent with the existing pattern for `store_order` / `store_review` (where the resource is unique and never re-evaluated) but matters for stock since products oscillate. Tracked separately as a follow-up: [RSM-2345 — Stock notification dedup meta should clear on stock recovery](https://linear.app/a8c/issue/RSM-2345/stock-notification-dedup-meta-should-clear-on-stock-recovery). Out of scope for this PR.

WPCOM-side routing for the new `store_stock` type is required for actual delivery to mobile devices and is being implemented separately under the same Linear epic.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry already added manually as `plugins/woocommerce/changelog/issue-RSM-1551`.

</details>
