### PR TITLE
Fix typos in PHP comments, docblocks, and one test method name (combined from asimsolehria contributions)

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -219,7 +219,7 @@ class WC_Admin_Meta_Boxes {
 			return;
 		}
 
-		// Dont' save meta boxes for revisions or autosaves.
+		// Don't save meta boxes for revisions or autosaves.
 		if ( Constants::is_true( 'DOING_AUTOSAVE' ) || is_int( wp_is_post_revision( $post ) ) || is_int( wp_is_post_autosave( $post ) ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/DataStore.php
@@ -178,7 +178,7 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 		}
 
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// @todo remove these assignements when refactoring segmenter classes to use query objects.
+		// @todo remove these assignments when refactoring segmenter classes to use query objects.
 		$totals_query          = array(
 			'from_clause'       => $this->total_query->get_sql_clause( 'join' ),
 			'where_time_clause' => $this->total_query->get_sql_clause( 'where_time' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -377,7 +377,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// @todo Remove these assignements when refactoring segmenter classes to use query objects.
+		// @todo Remove these assignments when refactoring segmenter classes to use query objects.
 		$totals_query    = array(
 			'from_clause'       => $this->total_query->get_sql_clause( 'join' ),
 			'where_time_clause' => $where_time,

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/DataStore.php
@@ -184,7 +184,7 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 		);
 
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// @todo remove these assignements when refactoring segmenter classes to use query objects.
+		// @todo remove these assignments when refactoring segmenter classes to use query objects.
 		$totals_query          = array(
 			'from_clause'       => $this->total_query->get_sql_clause( 'join' ),
 			'where_time_clause' => $this->total_query->get_sql_clause( 'where_time' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
@@ -200,7 +200,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// @todo remove these assignements when refactoring segmenter classes to use query objects.
+		// @todo remove these assignments when refactoring segmenter classes to use query objects.
 		$totals_query          = array(
 			'from_clause'       => $this->total_query->get_sql_clause( 'join' ),
 			'where_time_clause' => $this->total_query->get_sql_clause( 'where_time' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/DataStore.php
@@ -206,7 +206,7 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 		/* phpcs:enable */
 
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// @todo remove these assignements when refactoring segmenter classes to use query objects.
+		// @todo remove these assignments when refactoring segmenter classes to use query objects.
 		$totals_query          = array(
 			'from_clause'       => $this->total_query->get_sql_clause( 'join' ),
 			'where_time_clause' => $this->total_query->get_sql_clause( 'where_time' ),

--- a/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
@@ -161,7 +161,7 @@ trait BlockHooksTrait {
 		$pattern_slug = is_array( $context ) && isset( $context['slug'] ) ? $context['slug'] : '';
 		if ( ! $pattern_slug ) {
 			/**
-			 * Woo patterns have a slug property in $context, but core/theme patterns dont.
+			 * Woo patterns have a slug property in $context, but core/theme patterns don't.
 			 * In that case, we fallback to the name property, as they're the same.
 			 */
 			$pattern_slug = is_array( $context ) && isset( $context['name'] ) ? $context['name'] : '';

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -185,7 +185,7 @@ class CartCheckoutUtils {
 	 * Migrate checkout block field visibility attributes to settings when using the checkout block.
 	 *
 	 * This migration routine is called if the options (woocommerce_checkout_phone_field, woocommerce_checkout_company_field,
-	 * woocommerce_checkout_address_2_field) are not set. They are not set by default; they were orignally set by the
+	 * woocommerce_checkout_address_2_field) are not set. They are not set by default; they were originally set by the
 	 * customizer interface of the legacy shortcode based checkout.
 	 *
 	 * Once migration is initiated, the settings will be updated and will not trigger this routine again.

--- a/plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php
+++ b/plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php
@@ -23,7 +23,7 @@ final class FeaturePluginCompatibility {
 	public const INCOMPATIBLE = 'incompatible';
 
 	/**
-	 * Plugin compatibility with the feautre is yet to be determined. Internal use only.
+	 * Plugin compatibility with the feature is yet to be determined. Internal use only.
 	 *
 	 * @internal
 	 * @var string

--- a/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item.php
@@ -101,7 +101,7 @@ class WC_Tests_Base_Order_Item extends WC_Unit_Test_Case {
 	/**
 	 * @testdox 'calculate_cogs_value' sets the value returned by the 'calculate_cogs_core' override, and returns true.
 	 */
-	public function test_calculate_cogs_sets_value_from_core_calculation_overriden_in_child_class() {
+	public function test_calculate_cogs_sets_value_from_core_calculation_overridden_in_child_class() {
 		$this->sut->has_cogs_value = true;
 		$this->enable_cogs_feature();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
@@ -69,7 +69,7 @@ class EvaluateOverridesTest extends WC_Unit_Test_Case {
 		$extensions = $this->get_extensions();
 		$result     = $evaluator->evaluate( array( $extensions[3] ) );
 
-		// Evaluation should pass and return the overriden value.
+		// Evaluation should pass and return the overridden value.
 		$this->assertEquals( 2, $result[0]->order );
 
 		// Reset the default country.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Combines six small typo-only PRs from asimsolehria into a single PR for ease of review. Each underlying PR fixes a misspelling in a PHP comment, docblock, or one PHPUnit test method name — no behavior changes, no public API changes.

Combined from:
- woocommerce/woocommerce#64580 — `Dont'` → `Don't` in `WC_Admin_Meta_Boxes`
- woocommerce/woocommerce#64579 — `dont` → `don't` in `BlockHooksTrait`
- woocommerce/woocommerce#64578 — `feautre` → `feature` in `FeaturePluginCompatibility`
- woocommerce/woocommerce#64577 — `orignally` → `originally` in `CartCheckoutUtils`
- woocommerce/woocommerce#64463 — `overriden` → `overridden` (one test method name, one test comment)
- woocommerce/woocommerce#64434 — `assignements` → `assignments` in five Reports `Stats/DataStore` todo comments

The remaining open PRs from this contributor that did more than fix a typo (woocommerce/woocommerce#64461 renames a public method with a deprecation wrapper, woocommerce/woocommerce#64462 adds a `bool` type declaration to a property and removes a phpstan baseline entry) are intentionally not included here and should be reviewed on their own.

### How to test the changes in this Pull Request:

1. `git diff trunk...fix/combine-typo-fixes-asimsolehria` and confirm every change is a single-line fix in a comment, docblock, or test method name.
2. Run the affected legacy test class to confirm it still passes:
   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Tests_Base_Order_Item
   ```
3. Run the affected modern test to confirm it still passes:
   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter EvaluateOverridesTest
   ```
4. (Optional) Open `WooCommerce → Status` in WP admin and confirm the page still loads (touches `CartCheckoutUtils` indirectly).

### Testing that has already taken place:

Each underlying change was already reviewed in its individual PR. Combined diff was re-reviewed for accuracy of corrected spellings, no surrounding context changes, and no behavior impact.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

Manually targeting milestone **10.9.0**.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Comments, docblocks, and one PHPUnit test method name only — no production behavior or public API change.

</details>