### PR TITLE
Fix comment typos and incorrect docblock description

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		/**
 		 * Check for task list initialization.
 		 */
-		private $initalized = false;
+		private $initialized = false;
 
 		/**
 		 * The task list.
@@ -116,12 +116,12 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return array
 		 */
 		public function get_task_list() {
-			if ( $this->task_list || $this->initalized ) {
+			if ( $this->task_list || $this->initialized ) {
 				return $this->task_list;
 			}
 
 			$this->set_task_list( TaskLists::get_list( 'setup' ) );
-			$this->initalized = true;
+			$this->initialized = true;
 			return $this->task_list;
 		}
 

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -905,7 +905,7 @@ if ( 0 < $mu_plugins_count ) :
 
 				if ( ! empty( $_page['shortcode'] ) || ! empty( $_page['block'] ) ) {
 					// We check first if, in a blocks theme, the template content does not load the page content.
-					if ( CartCheckoutUtils::is_overriden_by_custom_template_content( $_page['block'] ) ) {
+					if ( CartCheckoutUtils::is_overridden_by_custom_template_content( $_page['block'] ) ) {
 						$additional_info = __( "This page's content is overridden by custom template content", 'woocommerce' );
 					} elseif ( $_page['shortcode_present'] ) {
 						// Always display the shortcode with square brackets for consistency.

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -154,7 +154,7 @@ class WC_Product_Variable extends WC_Product {
 	 * Note: Variable prices do not show suffixes like other product types. This
 	 * is due to some things like tax classes being set at variation level which
 	 * could differ from the parent price. The only way to show accurate prices
-	 * would be to load the variation and get it's price, which adds extra
+	 * would be to load the variation and get its price, which adds extra
 	 * overhead and still has edge cases where the values would be inaccurate.
 	 *
 	 * Additionally, ranges of prices no longer show 'striked out' sale prices

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -1593,7 +1593,7 @@ class WC_Tracker {
 	 * Check if any core emails are being overridden by a template override.
 	 *
 	 * @param array $template_overrides Template overrides.
-	 * @return array Array with count of core email overrides and the templates that are overriden.
+	 * @return array Array with count of core email overrides and the templates that are overridden.
 	 */
 	public static function get_core_email_overrides( $template_overrides ): array {
 		$email_template_overrides = EmailImprovements::get_core_email_overrides( $template_overrides );

--- a/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
@@ -451,7 +451,7 @@ EOT;
 
 	/**
 	 * JSON can be passed in some more complicated objects, like the payment gateway settings array.
-	 * This function decodes the json (if present) and tries to get it's value.
+	 * This function decodes the json (if present) and tries to get its value.
 	 *
 	 * @param array $arr Array that will be scanned for JSON encoded values.
 	 *

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -309,7 +309,7 @@ class CartCheckoutUtils {
 	 *
 	 * @return bool true if the template has out of sync content.
 	 */
-	public static function is_overriden_by_custom_template_content( string $block ): bool {
+	public static function is_overridden_by_custom_template_content( string $block ): bool {
 
 		$block = str_replace( 'woocommerce/', '', $block );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1349,7 +1349,7 @@ class OrdersTableQuery {
 		$order   = $this->sanitize_order( $this->args['order'] ?? '' );
 		$orderby = $this->sanitize_order_orderby( $this->args['orderby'] ?? 'none' );
 
-		// Set orderby to an empty array by default. This will also be used if sanitize_order_orderby recieved "none".
+		// Set orderby to an empty array by default. This will also be used if sanitize_order_orderby received "none".
 		$this->orderby = array();
 
 		if ( 'include' === $orderby || 'post__in' === $orderby ) {

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -36,7 +36,7 @@ class Packages {
 	/**
 	 * Array of package names and their main package classes.
 	 *
-	 * One a package has been merged into WooCommerce Core it should be moved from the package list and placed in
+	 * Once a package has been merged into WooCommerce Core it should be moved from the package list and placed in
 	 * this list. This will ensure that the feature plugin is disabled as well as provide the class to handle
 	 * initialization for the now-merged feature plugin.
 	 *
@@ -90,7 +90,7 @@ class Packages {
 	}
 
 	/**
-	 * Checks a package exists by looking for it's directory.
+	 * Checks a package exists by looking for its directory.
 	 *
 	 * @param string $package Package name.
 	 * @return boolean
@@ -100,7 +100,7 @@ class Packages {
 	}
 
 	/**
-	 * Checks a package exists by looking for it's directory.
+	 * Checks if a class name corresponds to a merged package and should be loaded.
 	 *
 	 * @param string $class_name Class name.
 	 * @return boolean

--- a/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item.php
@@ -101,7 +101,7 @@ class WC_Tests_Base_Order_Item extends WC_Unit_Test_Case {
 	/**
 	 * @testdox 'calculate_cogs_value' sets the value returned by the 'calculate_cogs_core' override, and returns true.
 	 */
-	public function test_calculate_cogs_sets_value_from_core_calculation_overriden_in_child_class() {
+	public function test_calculate_cogs_sets_value_from_core_calculation_overridden_in_child_class() {
 		$this->sut->has_cogs_value = true;
 		$this->enable_cogs_feature();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
@@ -69,7 +69,7 @@ class EvaluateOverridesTest extends WC_Unit_Test_Case {
 		$extensions = $this->get_extensions();
 		$result     = $evaluator->evaluate( array( $extensions[3] ) );
 
-		// Evaluation should pass and return the overriden value.
+		// Evaluation should pass and return the overridden value.
 		$this->assertEquals( 2, $result[0]->order );
 
 		// Reset the default country.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Several PHP comments contained typos and one docblock had an incorrect copy-pasted description. This PR fixes:

- `src/Packages.php`: "One a package" → "Once a package"; "it's directory" → "its directory" (×2); wrong docblock on `should_load_class()` corrected (was copied from `package_exists()`)
- `includes/class-wc-product-variable.php`: "get it's price" → "get its price"
- `includes/cli/class-wc-cli-rest-command.php`: "get it's value" → "get its value"

### How to test the changes in this Pull Request:

1. Review the diff to confirm all comment text is now correct.
2. Run `php -l` or the PHP linter on the changed files to confirm no syntax issues were introduced.

### Testing that has already taken place:

Changes are limited to PHP comment blocks — no functional code was modified.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
All changes are in PHP comment blocks and docstrings only. No functional code was modified.

</details>