### PR TITLE
Fix comment typos and incorrect docblock description

### DIFF
--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -154,7 +154,7 @@ class WC_Product_Variable extends WC_Product {
 	 * Note: Variable prices do not show suffixes like other product types. This
 	 * is due to some things like tax classes being set at variation level which
 	 * could differ from the parent price. The only way to show accurate prices
-	 * would be to load the variation and get it's price, which adds extra
+	 * would be to load the variation and get its price, which adds extra
 	 * overhead and still has edge cases where the values would be inaccurate.
 	 *
 	 * Additionally, ranges of prices no longer show 'striked out' sale prices

--- a/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
@@ -451,7 +451,7 @@ EOT;
 
 	/**
 	 * JSON can be passed in some more complicated objects, like the payment gateway settings array.
-	 * This function decodes the json (if present) and tries to get it's value.
+	 * This function decodes the json (if present) and tries to get its value.
 	 *
 	 * @param array $arr Array that will be scanned for JSON encoded values.
 	 *

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -36,7 +36,7 @@ class Packages {
 	/**
 	 * Array of package names and their main package classes.
 	 *
-	 * One a package has been merged into WooCommerce Core it should be moved from the package list and placed in
+	 * Once a package has been merged into WooCommerce Core it should be moved from the package list and placed in
 	 * this list. This will ensure that the feature plugin is disabled as well as provide the class to handle
 	 * initialization for the now-merged feature plugin.
 	 *
@@ -90,7 +90,7 @@ class Packages {
 	}
 
 	/**
-	 * Checks a package exists by looking for it's directory.
+	 * Checks a package exists by looking for its directory.
 	 *
 	 * @param string $package Package name.
 	 * @return boolean
@@ -100,7 +100,7 @@ class Packages {
 	}
 
 	/**
-	 * Checks a package exists by looking for it's directory.
+	 * Checks if a class name corresponds to a merged package and should be loaded.
 	 *
 	 * @param string $class_name Class name.
 	 * @return boolean


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Several PHP comments contained typos and one docblock had an incorrect copy-pasted description. This PR fixes:

- `src/Packages.php`: "One a package" → "Once a package"; "it's directory" → "its directory" (×2); wrong docblock on `should_load_class()` corrected (was copied from `package_exists()`)
- `includes/class-wc-product-variable.php`: "get it's price" → "get its price"
- `includes/cli/class-wc-cli-rest-command.php`: "get it's value" → "get its value"

### How to test the changes in this Pull Request:

1. Review the diff to confirm all comment text is now correct.
2. Run `php -l` or the PHP linter on the changed files to confirm no syntax issues were introduced.

### Testing that has already taken place:

Changes are limited to PHP comment blocks — no functional code was modified.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
All changes are in PHP comment blocks and docstrings only. No functional code was modified.

</details>