### PR TITLE
Fix reserved custom attribute collisions

### DIFF
--- a/plugins/woocommerce/changelog/fix-reserved-attribute-variation-collision
+++ b/plugins/woocommerce/changelog/fix-reserved-attribute-variation-collision
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent reserved product attribute names from colliding with variation data.

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -173,6 +173,17 @@ class WC_Product_Variation extends WC_Product_Simple {
 		} elseif ( ! empty( $item_object['variation'] ) && is_array( $item_object['variation'] ) ) {
 			$data = $item_object['variation'];
 		} else {
+			if ( ! empty( $item_object['variation'] ) ) {
+				wc_log_product_attribute_name_collision(
+					'variation',
+					array(
+						'location'     => 'WC_Product_Variation::get_permalink',
+						'product_id'   => $this->get_parent_id(),
+						'variation_id' => $this->get_id(),
+					)
+				);
+			}
+
 			$data = $this->get_variation_attributes();
 		}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -459,7 +459,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 			$attribute_name = wc_sanitize_taxonomy_name( $attribute->get_name() );
 
-			if ( ! wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
+			if ( ! in_array( $attribute_name, wc_get_reserved_product_attribute_structural_names(), true ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -203,6 +203,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$product->set_date_created( time() );
 		}
 
+		$this->validate_attribute_names( $product );
+
 		$id = wp_insert_post(
 			apply_filters(
 				'woocommerce_new_product_data',
@@ -320,8 +322,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @return void
 	 */
 	public function update( &$product ) {
-		$product->save_meta_data();
 		$changes = $product->get_changes();
+
+		if ( array_key_exists( 'attributes', $changes ) ) {
+			$this->validate_attribute_names( $product );
+		}
+
+		$product->save_meta_data();
 
 		// Only update the post when the post data changes.
 		if ( array_intersect( array( 'description', 'short_description', 'name', 'parent_id', 'reviews_allowed', 'status', 'menu_order', 'date_created', 'date_modified', 'slug', 'post_password' ), array_keys( $changes ) ) ) {
@@ -435,6 +442,41 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	| Additional Methods
 	|--------------------------------------------------------------------------
 	*/
+
+	/**
+	 * Validate product attribute names before persisting them.
+	 *
+	 * @since 10.9.0
+	 * @param WC_Product $product Product object.
+	 * @throws WC_Data_Exception When a custom attribute name is reserved.
+	 * @return void
+	 */
+	protected function validate_attribute_names( WC_Product $product ): void {
+		foreach ( $product->get_attributes( 'edit' ) as $attribute ) {
+			if ( ! $attribute instanceof WC_Product_Attribute || $attribute->is_taxonomy() ) {
+				continue;
+			}
+
+			$attribute_name = wc_sanitize_taxonomy_name( $attribute->get_name() );
+
+			if ( ! wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
+				continue;
+			}
+
+			throw new WC_Data_Exception(
+				'product_invalid_attribute_name_reserved',
+				sprintf(
+					/* translators: %s: attribute name */
+					esc_html__( 'Product attribute name "%s" is reserved. Use a different name.', 'woocommerce' ),
+					esc_html( $attribute->get_name() )
+				),
+				400,
+				array(
+					'attribute_name' => esc_html( $attribute->get_name() ),
+				)
+			);
+		}
+	}
 
 	/**
 	 * Read product data. Can be overridden by child classes to load other props.

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -317,7 +317,11 @@ function wc_get_attribute_type_label( $type ) {
  * @return bool
  */
 function wc_check_if_attribute_name_is_reserved( $attribute_name ) {
-	$attribute_name = wc_sanitize_taxonomy_name( $attribute_name );
+	$sanitized_attribute_name = wc_sanitize_taxonomy_name( $attribute_name );
+
+	if ( in_array( $sanitized_attribute_name, wc_get_reserved_product_attribute_structural_names(), true ) ) {
+		return true;
+	}
 
 	// Forbidden attribute names.
 	$reserved_terms = array(
@@ -391,9 +395,6 @@ function wc_check_if_attribute_name_is_reserved( $attribute_name ) {
 		'tb',
 		'term',
 		'type',
-		'variation',
-		'variation_data',
-		'variation_id',
 		'w',
 		'withcomments',
 		'withoutcomments',
@@ -401,6 +402,20 @@ function wc_check_if_attribute_name_is_reserved( $attribute_name ) {
 	);
 
 	return in_array( $attribute_name, $reserved_terms, true );
+}
+
+/**
+ * Get WooCommerce structural keys that cannot be used as product attribute names.
+ *
+ * @since 10.9.0
+ * @return string[]
+ */
+function wc_get_reserved_product_attribute_structural_names() {
+	return array(
+		'variation',
+		'variation_data',
+		'variation_id',
+	);
 }
 
 /**
@@ -414,7 +429,7 @@ function wc_check_if_attribute_name_is_reserved( $attribute_name ) {
 function wc_log_product_attribute_name_collision( $attribute_name, $context = array() ) {
 	$attribute_name = wc_sanitize_taxonomy_name( $attribute_name );
 
-	if ( '' === $attribute_name || ! wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
+	if ( '' === $attribute_name || ! in_array( $attribute_name, wc_get_reserved_product_attribute_structural_names(), true ) ) {
 		return;
 	}
 

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -317,6 +317,8 @@ function wc_get_attribute_type_label( $type ) {
  * @return bool
  */
 function wc_check_if_attribute_name_is_reserved( $attribute_name ) {
+	$attribute_name = wc_sanitize_taxonomy_name( $attribute_name );
+
 	// Forbidden attribute names.
 	$reserved_terms = array(
 		'attachment',
@@ -389,6 +391,9 @@ function wc_check_if_attribute_name_is_reserved( $attribute_name ) {
 		'tb',
 		'term',
 		'type',
+		'variation',
+		'variation_data',
+		'variation_id',
 		'w',
 		'withcomments',
 		'withoutcomments',
@@ -396,6 +401,48 @@ function wc_check_if_attribute_name_is_reserved( $attribute_name ) {
 	);
 
 	return in_array( $attribute_name, $reserved_terms, true );
+}
+
+/**
+ * Log a product attribute name collision with a reserved WooCommerce structural key.
+ *
+ * @since 10.9.0
+ * @param string $attribute_name Attribute name.
+ * @param array  $context        Additional log context.
+ * @return void
+ */
+function wc_log_product_attribute_name_collision( $attribute_name, $context = array() ) {
+	$attribute_name = wc_sanitize_taxonomy_name( $attribute_name );
+
+	if ( '' === $attribute_name || ! wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
+		return;
+	}
+
+	$context = array_merge(
+		$context,
+		array(
+			'source'         => 'attribute-collision',
+			'attribute_name' => $attribute_name,
+		)
+	);
+
+	static $logged   = array();
+	$encoded_context = wp_json_encode( $context );
+	$dedupe_key      = md5( false !== $encoded_context ? $encoded_context : maybe_serialize( $context ) );
+
+	if ( isset( $logged[ $dedupe_key ] ) ) {
+		return;
+	}
+
+	$logged[ $dedupe_key ] = true;
+
+	wc_get_logger()->notice(
+		sprintf(
+			'Product attribute "%s" collides with a reserved WooCommerce structural key and may be ignored in variation data.',
+			$attribute_name
+		),
+		$context
+	);
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4356,31 +4356,53 @@ function wc_get_formatted_cart_item_data( $cart_item, $flat = false ) {
 
 	// Variation values are shown only if they are not found in the title as of 3.0.
 	// This is because variation titles display the attributes.
-	if ( $cart_item['data']->is_type( ProductType::VARIATION ) && is_array( $cart_item['variation'] ) ) {
-		foreach ( $cart_item['variation'] as $name => $value ) {
-			$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( $name ) ) );
+	if ( $cart_item['data']->is_type( ProductType::VARIATION ) ) {
+		$variation_data = isset( $cart_item['variation'] ) ? $cart_item['variation'] : null;
 
-			if ( taxonomy_exists( $taxonomy ) ) {
-				// If this is a term slug, get the term's nice name.
-				$term = get_term_by( 'slug', $value, $taxonomy );
-				if ( ! is_wp_error( $term ) && $term && $term->name ) {
-					$value = $term->name;
+		if ( is_array( $variation_data ) ) {
+			foreach ( $variation_data as $name => $value ) {
+				$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( $name ) ) );
+
+				if ( taxonomy_exists( $taxonomy ) ) {
+					// If this is a term slug, get the term's nice name.
+					$term = get_term_by( 'slug', $value, $taxonomy );
+					if ( ! is_wp_error( $term ) && $term && $term->name ) {
+						$value = $term->name;
+					}
+					$label = wc_attribute_label( $taxonomy );
+				} else {
+					/**
+					 * Filters the variation option name.
+					 *
+					 * @since 2.5.0
+					 *
+					 * @param string     $value   The name to display.
+					 * @param null       $unused  Unused because this is not a variation taxonomy.
+					 * @param string     $taxonomy Taxonomy or product attribute name.
+					 * @param WC_Product $product Product data.
+					 */
+					$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $cart_item['data'] );
+					$label = wc_attribute_label( str_replace( 'attribute_', '', $name ), $cart_item['data'] );
 				}
-				$label = wc_attribute_label( $taxonomy );
-			} else {
-				// If this is a custom option slug, get the options name.
-				$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $cart_item['data'] );
-				$label = wc_attribute_label( str_replace( 'attribute_', '', $name ), $cart_item['data'] );
-			}
 
-			// Check the nicename against the title.
-			if ( '' === $value || wc_is_attribute_in_product_name( $value, $cart_item['data']->get_name() ) ) {
-				continue;
-			}
+				// Check the nicename against the title.
+				if ( '' === $value || wc_is_attribute_in_product_name( $value, $cart_item['data']->get_name() ) ) {
+					continue;
+				}
 
-			$item_data[] = array(
-				'key'   => $label,
-				'value' => $value,
+				$item_data[] = array(
+					'key'   => $label,
+					'value' => $value,
+				);
+			}
+		} elseif ( ! empty( $variation_data ) ) {
+			wc_log_product_attribute_name_collision(
+				'variation',
+				array(
+					'location'     => 'wc_get_formatted_cart_item_data',
+					'product_id'   => $cart_item['data']->get_parent_id(),
+					'variation_id' => $cart_item['data']->get_id(),
+				)
 			);
 		}
 	}

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductItemTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductItemTrait.php
@@ -34,7 +34,7 @@ trait ProductItemTrait {
 	/**
 	 * Format variation data, for example convert slugs such as attribute_pa_size to Size.
 	 *
-	 * @param array       $variation_data Array of data from the cart.
+	 * @param mixed       $variation_data Data from the cart.
 	 * @param \WC_Product $product Product data.
 	 * @return array
 	 */
@@ -42,6 +42,16 @@ trait ProductItemTrait {
 		$return = array();
 
 		if ( ! is_iterable( $variation_data ) ) {
+			if ( ! empty( $variation_data ) ) {
+				wc_log_product_attribute_name_collision(
+					'variation',
+					array(
+						'location'   => 'StoreApi\ProductItemTrait::format_variation_data',
+						'product_id' => $product->get_id(),
+					)
+				);
+			}
+
 			return $return;
 		}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
@@ -111,12 +111,36 @@ class WC_Product_Variation_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Ensure get_permalink() handles non-array variation data without fataling.
+	 * Ensure get_permalink() handles non-array variation data without fataling and logs the collision.
 	 *
-	 * @testdox get_permalink() returns a URL without fataling when $item_object['variation'] is a string rather than the expected variation-attributes array.
+	 * @testdox get_permalink() returns a URL and logs when $item_object['variation'] is a string rather than the expected variation-attributes array.
 	 */
 	public function test_get_permalink_handles_non_array_variation_value() {
-		$url = $this->variation->get_permalink( array( 'variation' => 'some-string-value' ) );
+		$mock_logger = $this->getMockBuilder( WC_Logger_Interface::class )->getMock();
+		$mock_logger
+			->expects( $this->once() )
+			->method( 'notice' )
+			->with(
+				$this->stringContains( 'variation' ),
+				$this->callback(
+					function ( array $context ): bool {
+						return 'attribute-collision' === $context['source']
+							&& 'variation' === $context['attribute_name']
+							&& $this->variation->get_id() === $context['variation_id'];
+					}
+				)
+			);
+
+		$logger_callback = static function () use ( $mock_logger ) {
+			return $mock_logger;
+		};
+		add_filter( 'woocommerce_logging_class', $logger_callback );
+
+		try {
+			$url = $this->variation->get_permalink( array( 'variation' => 'some-string-value' ) );
+		} finally {
+			remove_filter( 'woocommerce_logging_class', $logger_callback );
+		}
 
 		$this->assertIsString( $url );
 		$this->assertNotEmpty( $url );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -76,6 +76,70 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Product save should reject changed custom attributes using reserved structural names.
+	 */
+	public function test_product_save_rejects_reserved_custom_attribute_name(): void {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Reserved attribute test' );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'variation' );
+		$attribute->set_options( array( 'blue' ) );
+		$attribute->set_visible( true );
+
+		$product->set_attributes( array( $attribute ) );
+
+		try {
+			$product->save();
+		} catch ( WC_Data_Exception $exception ) {
+			$error_data = $exception->getErrorData();
+
+			$this->assertSame( 'product_invalid_attribute_name_reserved', $exception->getErrorCode() );
+			$this->assertSame( 400, $exception->getCode() );
+			$this->assertSame( 400, $error_data['status'] );
+			$this->assertSame( 'variation', $error_data['attribute_name'] );
+			return;
+		}
+
+		$this->fail( 'Expected product save to reject reserved custom attribute names.' );
+	}
+
+	/**
+	 * @testdox Product save should leave existing legacy reserved attributes readable when attributes are unchanged.
+	 */
+	public function test_product_save_allows_unchanged_legacy_reserved_attribute_name(): void {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Legacy reserved attribute test' );
+		$product->save();
+
+		update_post_meta(
+			$product->get_id(),
+			'_product_attributes',
+			array(
+				'variation' => array(
+					'name'         => 'variation',
+					'value'        => 'blue',
+					'position'     => 0,
+					'is_visible'   => 1,
+					'is_variation' => 1,
+					'is_taxonomy'  => 0,
+				),
+			)
+		);
+
+		$legacy_product = wc_get_product( $product->get_id() );
+		$legacy_product->set_name( 'Legacy reserved attribute test updated' );
+		$legacy_product->save();
+
+		$updated_product = wc_get_product( $product->get_id() );
+		$this->assertSame(
+			'Legacy reserved attribute test updated',
+			$updated_product->get_name(),
+			'Existing products with legacy reserved attributes should remain editable when attributes are unchanged.'
+		);
+	}
+
+	/**
 	 * Ensure product rating counts are calculated correctly.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -105,6 +105,25 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Product save should allow custom attributes that only match legacy reserved terms after case normalization.
+	 */
+	public function test_product_save_allows_custom_attribute_name_that_only_matches_legacy_reserved_term_after_case_normalization(): void {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Case-sensitive attribute test' );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Type' );
+		$attribute->set_options( array( 'T-shirt' ) );
+		$attribute->set_visible( true );
+
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$this->assertGreaterThan( 0, $product->get_id() );
+		$product->delete( true );
+	}
+
+	/**
 	 * @testdox Product save should leave existing legacy reserved attributes readable when attributes are unchanged.
 	 */
 	public function test_product_save_allows_unchanged_legacy_reserved_attribute_name(): void {

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -170,6 +170,72 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should treat WooCommerce structural keys as reserved attribute names.
+	 *
+	 * @dataProvider get_woocommerce_reserved_attribute_names
+	 *
+	 * @param string $attribute_name Attribute name to check.
+	 */
+	public function test_wc_check_if_attribute_name_is_reserved_includes_woocommerce_structural_names( string $attribute_name ): void {
+		$this->assertTrue(
+			wc_check_if_attribute_name_is_reserved( $attribute_name ),
+			sprintf( 'Attribute name "%s" should be reserved.', $attribute_name )
+		);
+	}
+
+	/**
+	 * Data provider for WooCommerce structural attribute names.
+	 *
+	 * @return array[]
+	 */
+	public function get_woocommerce_reserved_attribute_names(): array {
+		return array(
+			array( 'variation' ),
+			array( 'Variation' ),
+			array( 'variation_id' ),
+			array( 'variation_data' ),
+		);
+	}
+
+	/**
+	 * @testdox Should log reserved product attribute collisions under the attribute-collision source.
+	 */
+	public function test_wc_log_product_attribute_name_collision_uses_attribute_collision_source(): void {
+		$mock_logger = $this->getMockBuilder( WC_Logger_Interface::class )->getMock();
+		$mock_logger
+			->expects( $this->once() )
+			->method( 'notice' )
+			->with(
+				$this->stringContains( 'variation' ),
+				$this->callback(
+					function ( array $context ): bool {
+						return 'attribute-collision' === $context['source']
+							&& 'variation' === $context['attribute_name']
+							&& 'WC_Attribute_Functions_Test' === $context['location'];
+					}
+				)
+			);
+
+		$logger_callback = static function () use ( $mock_logger ) {
+			return $mock_logger;
+		};
+		add_filter( 'woocommerce_logging_class', $logger_callback );
+
+		try {
+			wc_log_product_attribute_name_collision(
+				'variation',
+				array(
+					'source'         => 'caller-source',
+					'attribute_name' => 'caller_attribute',
+					'location'       => 'WC_Attribute_Functions_Test',
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_logging_class', $logger_callback );
+		}
+	}
+
+	/**
 	 * Describes the behavior of the wc_update_attribute() function.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -198,6 +198,14 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should preserve legacy case-sensitive checks for non-structural reserved names.
+	 */
+	public function test_wc_check_if_attribute_name_is_reserved_preserves_legacy_case_sensitive_terms(): void {
+		$this->assertTrue( wc_check_if_attribute_name_is_reserved( 'type' ) );
+		$this->assertFalse( wc_check_if_attribute_name_is_reserved( 'Type' ) );
+	}
+
+	/**
 	 * @testdox Should log reserved product attribute collisions under the attribute-collision source.
 	 */
 	public function test_wc_log_product_attribute_name_collision_uses_attribute_collision_source(): void {
@@ -230,6 +238,27 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 					'location'       => 'WC_Attribute_Functions_Test',
 				)
 			);
+		} finally {
+			remove_filter( 'woocommerce_logging_class', $logger_callback );
+		}
+	}
+
+	/**
+	 * @testdox Should only log structural product attribute name collisions.
+	 */
+	public function test_wc_log_product_attribute_name_collision_ignores_non_structural_reserved_names(): void {
+		$mock_logger = $this->getMockBuilder( WC_Logger_Interface::class )->getMock();
+		$mock_logger
+			->expects( $this->never() )
+			->method( 'notice' );
+
+		$logger_callback = static function () use ( $mock_logger ) {
+			return $mock_logger;
+		};
+		add_filter( 'woocommerce_logging_class', $logger_callback );
+
+		try {
+			wc_log_product_attribute_name_collision( 'type' );
 		} finally {
 			remove_filter( 'woocommerce_logging_class', $logger_callback );
 		}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
@@ -417,4 +417,46 @@ class OrderItemSchemaTest extends TestCase {
 		$order->delete( true );
 		$variable_product->delete( true );
 	}
+
+	/**
+	 * @testdox Should return an empty variation array and log when variation data is not iterable.
+	 */
+	public function test_format_variation_data_logs_non_iterable_variation_data(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Store API product' );
+		$product->save();
+
+		$mock_logger = $this->getMockBuilder( \WC_Logger_Interface::class )->getMock();
+		$mock_logger
+			->expects( $this->once() )
+			->method( 'notice' )
+			->with(
+				$this->stringContains( 'variation' ),
+				$this->callback(
+					function ( array $context ) use ( $product ): bool {
+						return 'attribute-collision' === $context['source']
+							&& 'variation' === $context['attribute_name']
+							&& $product->get_id() === $context['product_id']
+							&& 'StoreApi\ProductItemTrait::format_variation_data' === $context['location'];
+					}
+				)
+			);
+
+		$logger_callback = static function () use ( $mock_logger ) {
+			return $mock_logger;
+		};
+		add_filter( 'woocommerce_logging_class', $logger_callback );
+
+		try {
+			$method = new \ReflectionMethod( OrderItemSchema::class, 'format_variation_data' );
+			$method->setAccessible( true );
+
+			$result = $method->invoke( $this->sut, 'some-string-value', $product );
+		} finally {
+			remove_filter( 'woocommerce_logging_class', $logger_callback );
+			$product->delete( true );
+		}
+
+		$this->assertSame( array(), $result );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Custom per-product attributes named `variation` can collide with WooCommerce cart and order-item structural data. This blocks new or changed custom attributes that use reserved structural names, keeps existing legacy products editable when attributes are unchanged, and logs runtime collisions under the `attribute-collision` source.

Closes #64576.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Attribute_Functions_Test` and confirm it passes.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_Data_Store_CPT_Test` and confirm it passes.
3. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_Variation_Test` and confirm it passes.
4. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter OrderItemSchemaTest` and confirm it passes.
5. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` and confirm it passes.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Attribute_Functions_Test`
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_Data_Store_CPT_Test`
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_Variation_Test`
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter OrderItemSchemaTest`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- `composer exec -- phpstan analyse includes/wc-attribute-functions.php includes/data-stores/class-wc-product-data-store-cpt.php includes/class-wc-product-variation.php includes/wc-template-functions.php src/StoreApi/Utilities/ProductItemTrait.php --memory-limit=2G`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A manual changelog entry is included in `plugins/woocommerce/changelog/fix-reserved-attribute-variation-collision`.

</details>
