### PR TITLE
Remove deprecated husky v8 headers from git hooks

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,6 +1,3 @@
-#!/usr/bin/env bash
-. "$(dirname "$0")/_/husky.sh"
-
 # The hook documentation: https://git-scm.com/docs/githooks.html#_post_checkout
 CHECKOUT_TYPE=$3
 HEAD_NEW=$2

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,6 +1,3 @@
-#!/usr/bin/env bash
-. "$(dirname "$0")/_/husky.sh"
-
 # The hook documentation: https://git-scm.com/docs/githooks.html#_post_merge
 
 # Auto-switch pnpm versions when pulled changes include pnpm version change.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 ./bin/pre-push.sh


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Husky v9.1.7 is installed, but `.husky/post-merge`, `.husky/post-checkout`, and `.husky/pre-push` still start with the v8-era two-line header (shebang + `. "$(dirname "$0")/_/husky.sh"`). Husky itself prints a deprecation warning on every `git pull` / `git checkout` / `git push`:

> husky - DEPRECATED
>
> Please remove the following two lines from .husky/post-merge:
>
> #!/usr/bin/env sh
> . "\$(dirname -- "\$0")/_/husky.sh"
>
> They WILL FAIL in v10.0.0

In v9 each hook is invoked via husky's own wrapper (`.husky/_/<hook>` → `_/h` → `sh -e <hook>`), so the shebang is ignored and the `husky.sh` source line is dead code that only exists to print the deprecation notice. v10 removes `_/husky.sh` entirely, at which point the source line would hard-fail the hook with a "file not found" error.

This PR removes the deprecated header from all three hooks. The remaining hook bodies use only POSIX shell features and continue to work correctly when invoked under `sh -e` without an explicit shebang.

A previous attempt (PR 64238) made the same change but was self-closed by its author without review.

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `git pull`, `git checkout trunk && git checkout -` (or any branch switch), and `git push --dry-run` against any branch.
3. Confirm that the `husky - DEPRECATED ...` warning no longer appears in the terminal output for any of the three hooks.
4. Confirm that the existing hook behavior still runs:
    - `post-merge`: when pulling a change that touches `pnpm-lock.yaml` or `composer.lock`, the dependency refresh prompt and `pnpm install --frozen-lockfile` still execute.
    - `post-checkout`: when switching branches across a `pnpm-lock.yaml`/`composer.lock` change or a pnpm version mismatch, the warnings/corepack messages still print.
    - `pre-push`: `./bin/pre-push.sh` still runs.

### Testing that has already taken place:

- Confirmed locally that all three hooks fire correctly after the header removal under husky v9.1.7 (macOS, zsh).
- The deprecation warning no longer prints on `git pull` / `git checkout` / `git push`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal-only change to the repository's `.husky/` git hooks. These files are not shipped to users and are not part of any monorepo package, so no changelog entry is needed.

</details>