### PR TITLE
Fix: Allow X check digit in GTIN/ISBN field for valid ISBN-10 identifiers

### DIFF
--- a/plugins/woocommerce/changelog/64611-fix-64239-gtin-isbn-x-check-digit
+++ b/plugins/woocommerce/changelog/64611-fix-64239-gtin-isbn-x-check-digit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow X check digit in GTIN/ISBN field for valid ISBN-10 identifiers

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -304,7 +304,7 @@
 				function () {
 					var global_unique_id = $( this ).val();
 
-					if ( /[^0-9\-]/.test( global_unique_id ) ) {
+					if ( /[^0-9Xx\-]/.test( global_unique_id ) ) {
 						$( document.body ).triggerHandler( 'wc_add_error_tip', [
 							$( this ),
 							'i18n_global_unique_id_error',
@@ -325,7 +325,7 @@
 					var global_unique_id = $( this ).val();
 					$( this ).val(
 						global_unique_id
-							.replace( /[^0-9\-]/g, '' )
+							.replace( /[^0-9Xx\-]/g, '' )
 							.replace( /^-+|-+$/g, '' )
 					);
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -893,7 +893,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return void
 	 */
 	public function set_global_unique_id( $global_unique_id ) {
-		$global_unique_id = preg_replace( '/[^0-9\-]/', '', (string) $global_unique_id );
+		$global_unique_id = preg_replace( '/[^0-9Xx\-]/', '', (string) $global_unique_id );
 		if ( $this->get_object_read() && ! empty( $global_unique_id ) && ! wc_product_has_global_unique_id( $this->get_id(), $global_unique_id ) ) {
 			$global_unique_id_found = wc_get_product_id_by_global_unique_id( $global_unique_id );
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -491,7 +491,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_delete_product_notice'        => __( 'This product has produced sales and may be linked to existing orders. Are you sure you want to delete it?', 'woocommerce' ),
 					'i18n_remove_personal_data_notice'  => __( 'This action cannot be reversed. Are you sure you wish to erase personal data from the selected orders?', 'woocommerce' ),
 					'i18n_confirm_delete'               => __( 'Are you sure you wish to delete this item?', 'woocommerce' ),
-					'i18n_global_unique_id_error'       => __( 'Please enter only numbers and hyphens (-).', 'woocommerce' ),
+					'i18n_global_unique_id_error'       => __( 'Please enter only numbers, hyphens (-), and the letter X (ISBN-10 check digit).', 'woocommerce' ),
 					'decimal_point'                     => $decimal,
 					'mon_decimal_point'                 => wc_get_price_decimal_separator(),
 					'ajax_url'                          => admin_url( 'admin-ajax.php' ),

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -347,8 +347,8 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 					'label'    => sprintf( __( '%1$s, %2$s, %3$s, or %4$s', 'woocommerce' ), '<abbr title="' . esc_attr__( 'Global Trade Item Number', 'woocommerce' ) . '">' . esc_html__( 'GTIN', 'woocommerce' ) . '</abbr>', '<abbr title="' . esc_attr__( 'Universal Product Code', 'woocommerce' ) . '">' . esc_html__( 'UPC', 'woocommerce' ) . '</abbr>', '<abbr title="' . esc_attr__( 'European Article Number', 'woocommerce' ) . '">' . esc_html__( 'EAN', 'woocommerce' ) . '</abbr>', '<abbr title="' . esc_attr__( 'International Standard Book Number', 'woocommerce' ) . '">' . esc_html__( 'ISBN', 'woocommerce' ) . '</abbr>' ),
 					'tooltip'  => __( 'Enter a barcode or any other identifier unique to this product. It can help you list this product on other channels or marketplaces.', 'woocommerce' ),
 					'pattern'  => array(
-						'value'   => '[0-9\-]*',
-						'message' => __( 'Please enter only numbers and hyphens (-).', 'woocommerce' ),
+						'value'   => '[0-9Xx\-]*',
+						'message' => __( 'Please enter only numbers, hyphens (-), and the letter X (ISBN-10 check digit).', 'woocommerce' ),
 					),
 				),
 			)

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -784,8 +784,8 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'label'    => sprintf( __( '%1$s, %2$s, %3$s, or %4$s', 'woocommerce' ), '<abbr title="' . esc_attr__( 'Global Trade Item Number', 'woocommerce' ) . '">' . esc_html__( 'GTIN', 'woocommerce' ) . '</abbr>', '<abbr title="' . esc_attr__( 'Universal Product Code', 'woocommerce' ) . '">' . esc_html__( 'UPC', 'woocommerce' ) . '</abbr>', '<abbr title="' . esc_attr__( 'European Article Number', 'woocommerce' ) . '">' . esc_html__( 'EAN', 'woocommerce' ) . '</abbr>', '<abbr title="' . esc_attr__( 'International Standard Book Number', 'woocommerce' ) . '">' . esc_html__( 'ISBN', 'woocommerce' ) . '</abbr>' ),
 					'tooltip'  => __( 'Enter a barcode or any other identifier unique to this product. It can help you list this product on other channels or marketplaces.', 'woocommerce' ),
 					'pattern'  => array(
-						'value'   => '[0-9\-]*',
-						'message' => __( 'Please enter only numbers and hyphens (-).', 'woocommerce' ),
+						'value'   => '[0-9Xx\-]*',
+						'message' => __( 'Please enter only numbers, hyphens (-), and the letter X (ISBN-10 check digit).', 'woocommerce' ),
 					),
 				),
 				'disableConditions' => array(


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The GTIN/ISBN field (`global_unique_id`) silently strips the letter X, which is a valid check digit in ISBN-10 identifiers per ISO 2108. Approximately 5% of all ISBN-10s end in X (representing the value 10 in the modulo-11 checksum). This causes data corruption for bookstores using WooCommerce and leads to Google Merchant Center disapprovals.

The fix updates the sanitizer regex and validation patterns in four locations:

1. **Server-side** (`abstract-wc-product.php`): Changed `preg_replace` pattern from `/[^0-9\-]/` to `/[^0-9Xx\-]/`
2. **Client-side keyup validation** (`woocommerce_admin.js`): Updated regex from `/[^0-9\-]/` to `/[^0-9Xx\-]/`
3. **Client-side change sanitizer** (`woocommerce_admin.js`): Updated replace regex from `/[^0-9\-]/g` to `/[^0-9Xx\-]/g`
4. **Block editor patterns** (`SimpleProductTemplate.php`, `ProductVariationTemplate.php`): Updated HTML pattern from `[0-9\-]*` to `[0-9Xx\-]*`
5. **Validation messages**: Updated from "Please enter only numbers and hyphens (-)" to "Please enter only numbers, hyphens (-), and the letter X (ISBN-10 check digit)"

Closes #64239

### How to test the changes in this Pull Request:

1. Create or edit a simple product
2. In the Inventory section, enter `157249042X` (a valid ISBN-10) in the "GTIN, UPC, EAN, or ISBN" field
3. **Before fix**: The X is stripped on save, saving only `157249042`. Classic editor shows validation error.
4. **After fix**: The full value `157249042X` is saved correctly. No validation error.
5. Also verify programmatically:
   ```php
   $product = wc_get_product( $id );
   $product->set_global_unique_id( '125010856X' );
   $product->save();
   $reloaded = wc_get_product( $id );
   echo $reloaded->get_global_unique_id(); // Should return '125010856X'
   ```
6. Verify that lowercase `x` is also accepted and preserved
7. Verify that other characters (letters other than X) are still stripped as expected

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Allow X check digit in GTIN/ISBN field for valid ISBN-10 identifiers

</details>