### PR TITLE
Fix Coupon Code block title and description not displaying translated

### DIFF
--- a/plugins/woocommerce/changelog/64613-fix-64222-coupon-code-block-translations
+++ b/plugins/woocommerce/changelog/64613-fix-64222-coupon-code-block-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Coupon Code block title and description not displaying translated in non-English locales.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -12,6 +13,11 @@ import metadata from './block.json';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 registerBlockType( metadata as any, {
+	title: __( 'Coupon Code', 'woocommerce' ),
+	description: __(
+		'Include a coupon code to entice customers to make a purchase.',
+		'woocommerce'
+	),
 	edit: Edit,
 	save: Save,
 	deprecated: [


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Coupon Code block (`woocommerce/coupon-code`) has hardcoded English strings for `title` and `description` in `block.json`. These strings are never passed through translation functions, so they always display in English regardless of the site language.

This PR adds translatable `title` and `description` via `registerBlockType()`, which overrides the `block.json` values at runtime with properly localized strings.

Closes #64222

### How to test the changes in this Pull Request:

1. Set your site language to a non-English locale (e.g., Italian)
2. Ensure WooCommerce translations are up to date
3. Open the block editor and insert the Coupon Code block
4. Verify the block title shows the translated string instead of "Coupon Code"
5. Verify the block description is also translated in the block inserter

### Testing that has already taken place:

- Verified the code change follows the same pattern used by other WooCommerce blocks (e.g., `filter-wrapper`, `product-search`)
- TypeScript/JS only change, no PHP impact

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix Coupon Code block title and description not displaying translated in non-English locales.

</details>