### PR TITLE
Fix: Restore visible keyboard focus on product and coupon data tabs

### DIFF
--- a/plugins/woocommerce/changelog/64614-fix-64236-tabs-focus-indicator
+++ b/plugins/woocommerce/changelog/64614-fix-64236-tabs-focus-indicator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore visible keyboard focus on product and coupon data tabs

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -12,6 +13,11 @@ import metadata from './block.json';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 registerBlockType( metadata as any, {
+	title: __( 'Coupon Code', 'woocommerce' ),
+	description: __(
+		'Include a coupon code to entice customers to make a purchase.',
+		'woocommerce'
+	),
 	edit: Edit,
 	save: Save,
 	deprecated: [


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the WooCommerce Contributing Guidelines and WordPress Coding Standards.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

This adds an explicit focus style for product and coupon data tab links in the legacy admin styles.

Those links currently set `box-shadow: none`, which suppresses the global WordPress focus indicator and leaves only a subtle color shift when navigating by keyboard. The new `:focus` rule uses an inset box-shadow so the indicator stays visible without being clipped by the surrounding panel layout.

Closes #64236

### How to test the changes in this Pull Request:

1. Open a product edit screen or coupon edit screen in wp-admin.
2. Use the keyboard to tab into the data tabs on the left.
3. Before this change, the focused tab has no clear visible focus indicator.
4. After this change, the focused tab shows a visible inset focus ring.
5. Verify the active and hover states still look correct.

### Milestone

- [x] Automatically assign milestone for the next WooCommerce version

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Restore visible keyboard focus on product and coupon data tabs

</details>