### PR TITLE
Add woocommerce_edit_account_form_before_password action hook

### DIFF
--- a/plugins/woocommerce/changelog/64615-fix-32068-edit-account-before-password-hook
+++ b/plugins/woocommerce/changelog/64615-fix-32068-edit-account-before-password-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woocommerce_edit_account_form_before_password action hook to the edit account form template.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -12,6 +13,11 @@ import metadata from './block.json';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 registerBlockType( metadata as any, {
+	title: __( 'Coupon Code', 'woocommerce' ),
+	description: __(
+		'Include a coupon code to entice customers to make a purchase.',
+		'woocommerce'
+	),
 	edit: Edit,
 	save: Save,
 	deprecated: [

--- a/plugins/woocommerce/templates/myaccount/form-edit-account.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.5.0
+ * @version 10.9.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -58,6 +58,15 @@ do_action( 'woocommerce_before_edit_account_form' );
 		 * @since 8.7.0
 		 */
 		do_action( 'woocommerce_edit_account_form_fields' );
+	?>
+
+	<?php
+		/**
+		 * Fires before the password change section on the edit account form.
+		 *
+		 * @since 10.9.0
+		 */
+		do_action( 'woocommerce_edit_account_form_before_password' );
 	?>
 
 	<fieldset>


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Currently, the `form-edit-account.php` template has action hooks at the start (`woocommerce_edit_account_form_start`), after account fields (`woocommerce_edit_account_form_fields`), after the password section (`woocommerce_edit_account_form`), and at the end (`woocommerce_edit_account_form_end`). However, there is no hook **before the password change fieldset**, making it impossible to inject custom fields above the password section without overriding the entire template.

This PR adds a new `woocommerce_edit_account_form_before_password` action hook immediately before the password change fieldset, following the same pattern as the existing hooks in the template.

Closes #32068

### How to test the changes in this Pull Request:

1. Add this snippet to a custom plugin or theme `functions.php`:
```php
add_action( 'woocommerce_edit_account_form_before_password', function() {
    echo '<p class="woocommerce-form-row form-row-wide">Custom field before password section</p>';
});
```
2. Go to My Account → Account Details
3. Verify the custom content appears above the "Password change" fieldset
4. Verify all existing hooks still fire in the correct order
5. Verify the form still submits and saves correctly

### Testing that has already taken place:

- PHP syntax check passed (`php -l`)
- Verified the hook placement matches the pattern of existing hooks in the template
- Verified template version bumped

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Minor

#### Type

- [x] Add - Adds new functionality

#### Message

Add woocommerce_edit_account_form_before_password action hook to the edit account form template.

</details>