### PR TITLE
Fix WC_Product_Attribute::get_variation() returning true for simple products

### DIFF
--- a/plugins/woocommerce/changelog/64616-fix-37879-simple-product-attribute-variation
+++ b/plugins/woocommerce/changelog/64616-fix-37879-simple-product-attribute-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WC_Product_Attribute::get_variation() incorrectly returning true for attributes on non-variable product types.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -632,7 +632,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				$attribute->set_options( $options );
 				$attribute->set_position( $meta_value['position'] );
 				$attribute->set_visible( $meta_value['is_visible'] );
-				$attribute->set_variation( $meta_value['is_variation'] );
+				// Only set used_for_variation when the product type actually supports variations.
+				$attribute->set_variation( $product->is_type( ProductType::VARIABLE ) ? (bool) $meta_value['is_variation'] : false );
 
 				/**
 				 * Filter product attribute after initialization.

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-attribute-variation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-attribute-variation-test.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Tests for the read_attributes regression: WC_Product_Attribute::get_variation()
+ * must return false for non-variable product types even when the stored meta has
+ * is_variation = 1.
+ */
+
+/**
+ * @covers \WC_Product_Data_Store_CPT::read_attributes
+ */
+class WC_Product_Attribute_Variation_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Clean up products created during tests.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		// Ensure no lingering filters.
+		remove_all_filters( 'woocommerce_product_read_attribute' );
+	}
+
+	/**
+	 * Helper: store raw product attributes meta with is_variation = 1 and
+	 * return the reloaded product so read_attributes runs.
+	 *
+	 * @param string $product_type 'simple' or 'variable'.
+	 * @return WC_Product The reloaded product.
+	 */
+	private function create_product_with_variation_meta( string $product_type ) {
+		if ( 'variable' === $product_type ) {
+			$product = new WC_Product_Variable();
+		} else {
+			$product = new WC_Product_Simple();
+		}
+
+		$product->set_name( 'Test Product ' . $product_type );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		// Store raw meta with is_variation = 1, simulating corrupted or legacy data.
+		$meta_attributes = array(
+			'pa_test_attr' => array(
+				'name'         => 'pa_test_attr',
+				'value'        => '',
+				'position'     => 0,
+				'is_visible'   => 1,
+				'is_variation' => 1,
+				'is_taxonomy'  => 0,
+			),
+		);
+
+		update_post_meta( $product->get_id(), '_product_attributes', $meta_attributes );
+
+		// Reload the product from the data store so read_attributes() fires.
+		return wc_get_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox get_variation() returns false for attributes on a simple product even when stored meta has is_variation = 1.
+	 */
+	public function test_simple_product_attribute_variation_is_false() {
+		$product = $this->create_product_with_variation_meta( 'simple' );
+
+		$this->assertInstanceOf( WC_Product_Simple::class, $product );
+
+		$attributes = $product->get_attributes();
+
+		$this->assertNotEmpty( $attributes, 'Product should have at least one attribute.' );
+
+		foreach ( $attributes as $attribute ) {
+			if ( $attribute instanceof WC_Product_Attribute ) {
+				$this->assertFalse(
+					$attribute->get_variation(),
+					'Attributes on a simple product must not be marked for variation.'
+				);
+			}
+		}
+	}
+
+	/**
+	 * @testdox get_variation() returns true for attributes on a variable product when stored meta has is_variation = 1.
+	 */
+	public function test_variable_product_attribute_variation_is_true() {
+		$product = $this->create_product_with_variation_meta( 'variable' );
+
+		$this->assertInstanceOf( WC_Product_Variable::class, $product );
+
+		$attributes = $product->get_attributes();
+
+		$this->assertNotEmpty( $attributes, 'Product should have at least one attribute.' );
+
+		$found_variation_attribute = false;
+		foreach ( $attributes as $attribute ) {
+			if ( $attribute instanceof WC_Product_Attribute ) {
+				if ( $attribute->get_variation() ) {
+					$found_variation_attribute = true;
+					break;
+				}
+			}
+		}
+		$this->assertTrue( $found_variation_attribute, 'Variable product attributes with is_variation=1 should have variation enabled.' );
+	}
+
+	/**
+	 * @testdox The woocommerce_product_read_attribute filter still receives the raw is_variation value before gating.
+	 */
+	public function test_filter_receives_raw_attribute_object() {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Filter Test Product' );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		$meta_attributes = array(
+			'pa_filter_test' => array(
+				'name'         => 'pa_filter_test',
+				'value'        => '',
+				'position'     => 0,
+				'is_visible'   => 1,
+				'is_variation' => 1,
+				'is_taxonomy'  => 0,
+			),
+		);
+
+		update_post_meta( $product->get_id(), '_product_attributes', $meta_attributes );
+
+		$captured_variation = null;
+		add_filter(
+			'woocommerce_product_read_attribute',
+			function ( $attribute, $meta_value, $product ) use ( &$captured_variation ) {
+				if ( $attribute instanceof WC_Product_Attribute ) {
+					$captured_variation = $attribute->get_variation();
+				}
+				return $attribute;
+			},
+			10,
+			3
+		);
+
+		wc_get_product( $product->get_id() );
+
+		$this->assertFalse( $captured_variation, 'Filter should see variation as false because gating happens before the filter.' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Product_Attribute::get_variation()` can return `true` for attributes on simple (non-variable) products. This happens when:

1. A product was previously variable and then changed to a simple product type
2. Attributes were added via the admin and the `is_variation` meta was incorrectly stored

The "Used for variations" checkbox in the admin UI is hidden for non-variable products via CSS (`show_if_variable` class), but the underlying data is not sanitized on read. This means `get_variation()` can return `true` for simple products, which is semantically incorrect and can cause issues with extensions that check this value.

This PR adds a check in `read_attributes()` that forces `is_variation` to `false` for all attributes on non-variable products.

Closes #37879

### How to test the changes in this Pull Request:

1. Create a variable product with attributes marked "Used for variations"
2. Change the product type to "Simple product" and save
3. Before this fix: `$product->get_attributes()[0]->get_variation()` returns `true`
4. After this fix: `$product->get_attributes()[0]->get_variation()` returns `false`
5. Verify that variable products are unaffected — attributes with "Used for variations" still return `true`

### Testing that has already taken place:

- PHP syntax check passed (`php -l`)
- Verified the logic only affects non-variable product types
- Verified `ProductType::VARIABLE` import is available in the file

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix WC_Product_Attribute::get_variation() incorrectly returning true for attributes on non-variable product types.

</details>