### PR TITLE
Export common payment method icons from @woocommerce/blocks-checkout

### DIFF
--- a/plugins/woocommerce/changelog/64617-fix-42154-export-common-payment-icons
+++ b/plugins/woocommerce/changelog/64617-fix-42154-export-common-payment-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Export shared payment method icons and `getCommonIconProps` from `@woocommerce/blocks-checkout`.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/payment-method-icons/test/common-icons.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/payment-method-icons/test/common-icons.test.ts
@@ -1,10 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	commonIcons,
-	getCommonIconProps,
-} from '../common-icons';
+import { commonIcons, getCommonIconProps } from '../common-icons';
 
 describe( 'common-icons exports', () => {
 	describe( 'commonIcons', () => {
@@ -41,9 +38,7 @@ describe( 'common-icons exports', () => {
 					alt: 'Visa',
 				} )
 			);
-			expect( typeof ( result as { src: string } ).src ).toBe(
-				'string'
-			);
+			expect( typeof ( result as { src: string } ).src ).toBe( 'string' );
 		} );
 
 		it( 'returns an empty object for an unknown id', () => {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/payment-method-icons/test/common-icons.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/payment-method-icons/test/common-icons.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import {
+	commonIcons,
+	getCommonIconProps,
+} from '../common-icons';
+
+describe( 'common-icons exports', () => {
+	describe( 'commonIcons', () => {
+		it( 'is an array of icon definitions', () => {
+			expect( Array.isArray( commonIcons ) ).toBe( true );
+			expect( commonIcons.length ).toBeGreaterThan( 0 );
+		} );
+
+		it( 'contains icon definitions with id, alt, and src', () => {
+			commonIcons.forEach( ( icon ) => {
+				expect( icon ).toHaveProperty( 'id' );
+				expect( icon ).toHaveProperty( 'alt' );
+				expect( icon ).toHaveProperty( 'src' );
+				expect( typeof icon.id ).toBe( 'string' );
+				expect( typeof icon.alt ).toBe( 'string' );
+				expect( typeof icon.src ).toBe( 'string' );
+			} );
+		} );
+
+		it( 'includes expected payment method icons', () => {
+			const ids = commonIcons.map( ( icon ) => icon.id );
+			expect( ids ).toContain( 'visa' );
+			expect( ids ).toContain( 'mastercard' );
+			expect( ids ).toContain( 'amex' );
+		} );
+	} );
+
+	describe( 'getCommonIconProps', () => {
+		it( 'returns the matching icon props for a known id', () => {
+			const result = getCommonIconProps( 'visa' );
+			expect( result ).toEqual(
+				expect.objectContaining( {
+					id: 'visa',
+					alt: 'Visa',
+				} )
+			);
+			expect( typeof ( result as { src: string } ).src ).toBe(
+				'string'
+			);
+		} );
+
+		it( 'returns an empty object for an unknown id', () => {
+			const result = getCommonIconProps( 'unknown-brand' );
+			expect( result ).toEqual( {} );
+		} );
+
+		it( 'returns an empty object for an empty string', () => {
+			const result = getCommonIconProps( '' );
+			expect( result ).toEqual( {} );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/index.ts
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/index.ts
@@ -16,3 +16,7 @@ export {
 export { default as TextInput } from '../../components/text-input/text-input';
 export { default as ValidationInputError } from '../../components/validation-input-error';
 export { default as StoreNotice } from '../../components/store-notice';
+export {
+	commonIcons as paymentMethodCommonIcons,
+	getCommonIconProps,
+} from '../../assets/js/base/components/cart-checkout/payment-method-icons/common-icons';

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/index.ts
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/index.ts
@@ -19,4 +19,4 @@ export { default as StoreNotice } from '../../components/store-notice';
 export {
 	commonIcons as paymentMethodCommonIcons,
 	getCommonIconProps,
-} from '../../assets/js/base/components/cart-checkout/payment-method-icons/common-icons';
+} from '../../../assets/js/base/components/cart-checkout/payment-method-icons/common-icons';

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/test/exports.test.ts
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/test/exports.test.ts
@@ -5,6 +5,10 @@
  * paymentMethodCommonIcons and getCommonIconProps so that third-party
  * extensions can import them from the package entry point.
  */
+
+/**
+ * External dependencies
+ */
 import {
 	paymentMethodCommonIcons,
 	getCommonIconProps,

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/test/exports.test.ts
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/test/exports.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Smoke tests for @woocommerce/blocks-checkout public exports.
+ *
+ * These tests verify that the barrel file correctly re-exports
+ * paymentMethodCommonIcons and getCommonIconProps so that third-party
+ * extensions can import them from the package entry point.
+ */
+import {
+	paymentMethodCommonIcons,
+	getCommonIconProps,
+} from '@woocommerce/blocks-checkout';
+
+describe( '@woocommerce/blocks-checkout payment icon exports', () => {
+	it( 'exports paymentMethodCommonIcons as a non-empty array', () => {
+		expect( Array.isArray( paymentMethodCommonIcons ) ).toBe( true );
+		expect( paymentMethodCommonIcons.length ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'exports getCommonIconProps as a function', () => {
+		expect( typeof getCommonIconProps ).toBe( 'function' );
+	} );
+
+	it( 'getCommonIconProps returns Visa icon props from the package export', () => {
+		const result = getCommonIconProps( 'visa' );
+		expect( result ).toEqual(
+			expect.objectContaining( {
+				id: 'visa',
+				alt: 'Visa',
+			} )
+		);
+	} );
+
+	it( 'getCommonIconProps returns empty object for unknown brand from the package export', () => {
+		const result = getCommonIconProps( 'nonexistent' );
+		expect( result ).toEqual( {} );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

This PR exports the shared payment method icon definitions and helper from the `@woocommerce/blocks-checkout` package:

- `paymentMethodCommonIcons`
- `getCommonIconProps`

These already exist internally in the checkout codebase, but are not currently exposed through the package API. Exporting them allows third-party extensions to reuse WooCommerce's built-in payment method icons and lookup logic instead of duplicating asset definitions.

Closes #42154

### How to test the changes in this Pull Request:

1. Import from `@woocommerce/blocks-checkout` in an extension or test fixture:
   - `paymentMethodCommonIcons`
   - `getCommonIconProps`
2. Confirm both exports are available.
3. Verify `getCommonIconProps( "visa" )` returns the expected icon props.
4. Verify existing package exports continue to work as before.

### Testing that has already taken place:

- Verified the exports are re-exported from the package entrypoint via `components/index.ts`
- Confirmed the underlying shared icon module already exports both values
- Inspected the diff to ensure this is additive only

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Export shared payment method icons and `getCommonIconProps` from `@woocommerce/blocks-checkout`.

</details>
