### PR TITLE
Add MCP adapter compatibility checks

### DIFF
--- a/plugins/woocommerce/changelog/dev-mcp-adapter-compatibility-checks
+++ b/plugins/woocommerce/changelog/dev-mcp-adapter-compatibility-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add MCP adapter compatibility checks and note the temporary Abilities API polyfill.

--- a/plugins/woocommerce/changelog/rsm-1335-domain-abilities
+++ b/plugins/woocommerce/changelog/rsm-1335-domain-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add canonical WooCommerce domain abilities for product and order management.

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesCategories.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesCategories.php
@@ -40,6 +40,16 @@ class AbilitiesCategories {
 			return;
 		}
 
+		if ( ! function_exists( 'wp_has_ability_category' ) || ! wp_has_ability_category( 'woocommerce' ) ) {
+			wp_register_ability_category(
+				'woocommerce',
+				array(
+					'label'       => __( 'WooCommerce', 'woocommerce' ),
+					'description' => __( 'Canonical WooCommerce store management abilities backed by WooCommerce domain APIs.', 'woocommerce' ),
+				)
+			);
+		}
+
 		wp_register_ability_category(
 			'woocommerce-rest',
 			array(

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRegistry.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRegistry.php
@@ -28,6 +28,7 @@ class AbilitiesRegistry {
 	 * Initialize all WooCommerce abilities.
 	 */
 	private function init_abilities(): void {
+		// TODO: Remove the wordpress/abilities-api Composer polyfill when WooCommerce requires WordPress 6.9+.
 		AbilitiesCategories::init();
 		DomainAbilities::init();
 		AbilitiesRestBridge::init();

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRegistry.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRegistry.php
@@ -29,6 +29,7 @@ class AbilitiesRegistry {
 	 */
 	private function init_abilities(): void {
 		AbilitiesCategories::init();
+		DomainAbilities::init();
 		AbilitiesRestBridge::init();
 	}
 

--- a/plugins/woocommerce/src/Internal/Abilities/DomainAbilities.php
+++ b/plugins/woocommerce/src/Internal/Abilities/DomainAbilities.php
@@ -18,6 +18,8 @@ class DomainAbilities {
 	 * Initialize ability registration.
 	 *
 	 * @internal
+	 *
+	 * @since 10.9.0
 	 */
 	final public static function init(): void {
 		/*
@@ -30,6 +32,8 @@ class DomainAbilities {
 
 	/**
 	 * Register canonical domain abilities.
+	 *
+	 * @since 10.9.0
 	 */
 	public static function register_abilities(): void {
 		if ( ! function_exists( 'wp_register_ability' ) ) {
@@ -65,7 +69,7 @@ class DomainAbilities {
 				'input_schema'        => self::get_products_query_input_schema(),
 				'output_schema'       => self::get_collection_output_schema( 'products' ),
 				'execute_callback'    => array( __CLASS__, 'execute_products_query' ),
-				'permission_callback' => array( __CLASS__, 'can_query_woocommerce' ),
+				'permission_callback' => array( __CLASS__, 'can_query_products' ),
 				'meta'                => self::get_domain_meta( 'query', true, true, false ),
 			)
 		);
@@ -91,7 +95,7 @@ class DomainAbilities {
 				'input_schema'        => self::get_product_create_input_schema(),
 				'output_schema'       => self::get_entity_output_schema( 'product' ),
 				'execute_callback'    => array( __CLASS__, 'execute_product_create' ),
-				'permission_callback' => array( __CLASS__, 'can_manage_products' ),
+				'permission_callback' => array( __CLASS__, 'can_create_product' ),
 				'meta'                => self::get_domain_meta( 'create', false, false, false ),
 			)
 		);
@@ -117,7 +121,7 @@ class DomainAbilities {
 				'input_schema'        => self::get_product_update_input_schema(),
 				'output_schema'       => self::get_entity_output_schema( 'product' ),
 				'execute_callback'    => array( __CLASS__, 'execute_product_update' ),
-				'permission_callback' => array( __CLASS__, 'can_manage_products' ),
+				'permission_callback' => array( __CLASS__, 'can_update_product' ),
 				'meta'                => self::get_domain_meta( 'update', false, false, true ),
 			)
 		);
@@ -143,7 +147,7 @@ class DomainAbilities {
 				'input_schema'        => self::get_product_delete_input_schema(),
 				'output_schema'       => self::get_delete_output_schema(),
 				'execute_callback'    => array( __CLASS__, 'execute_product_delete' ),
-				'permission_callback' => array( __CLASS__, 'can_manage_products' ),
+				'permission_callback' => array( __CLASS__, 'can_delete_product' ),
 				'meta'                => self::get_domain_meta( 'delete', false, false, true ),
 			)
 		);
@@ -169,7 +173,7 @@ class DomainAbilities {
 				'input_schema'        => self::get_orders_query_input_schema(),
 				'output_schema'       => self::get_collection_output_schema( 'orders' ),
 				'execute_callback'    => array( __CLASS__, 'execute_orders_query' ),
-				'permission_callback' => array( __CLASS__, 'can_query_woocommerce' ),
+				'permission_callback' => array( __CLASS__, 'can_query_orders' ),
 				'meta'                => self::get_domain_meta( 'query', true, true, false ),
 			)
 		);
@@ -232,6 +236,8 @@ class DomainAbilities {
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
+	 *
+	 * @since 10.9.0
 	 */
 	public static function execute_products_query( array $input ) {
 		if ( ! empty( $input['id'] ) ) {
@@ -289,6 +295,8 @@ class DomainAbilities {
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
+	 *
+	 * @since 10.9.0
 	 */
 	public static function execute_product_create( array $input ) {
 		$type    = sanitize_key( $input['type'] ?? 'simple' );
@@ -315,6 +323,8 @@ class DomainAbilities {
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
+	 *
+	 * @since 10.9.0
 	 */
 	public static function execute_product_update( array $input ) {
 		$product = self::get_product_from_input( $input );
@@ -336,6 +346,8 @@ class DomainAbilities {
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
+	 *
+	 * @since 10.9.0
 	 */
 	public static function execute_product_delete( array $input ) {
 		$product = self::get_product_from_input( $input );
@@ -358,6 +370,8 @@ class DomainAbilities {
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
+	 *
+	 * @since 10.9.0
 	 */
 	public static function execute_orders_query( array $input ) {
 		$include_line_items = (bool) ( $input['include_line_items'] ?? false );
@@ -431,6 +445,8 @@ class DomainAbilities {
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
+	 *
+	 * @since 10.9.0
 	 */
 	public static function execute_order_update_status( array $input ) {
 		if ( empty( $input['id'] ) ) {
@@ -474,6 +490,8 @@ class DomainAbilities {
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
+	 *
+	 * @since 10.9.0
 	 */
 	public static function execute_order_add_note( array $input ) {
 		if ( empty( $input['id'] ) ) {
@@ -514,30 +532,85 @@ class DomainAbilities {
 	}
 
 	/**
-	 * Check read access for WooCommerce data.
+	 * Check product read access.
 	 *
+	 * @param mixed $input Ability input.
 	 * @return bool
+	 *
+	 * @since 10.9.0
 	 */
-	public static function can_query_woocommerce(): bool {
-		return current_user_can( 'manage_woocommerce' ) || current_user_can( 'view_woocommerce_reports' );
+	public static function can_query_products( $input = array() ): bool {
+		$product_id = self::get_input_id( $input );
+
+		return wc_rest_check_post_permissions( 'product', 'read', $product_id );
 	}
 
 	/**
-	 * Check product management access.
+	 * Check product creation access.
 	 *
+	 * @param mixed $input Ability input.
 	 * @return bool
+	 *
+	 * @since 10.9.0
 	 */
-	public static function can_manage_products(): bool {
-		return current_user_can( 'manage_woocommerce' ) || current_user_can( 'edit_products' );
+	public static function can_create_product( $input = array() ): bool {
+		return wc_rest_check_post_permissions( 'product', 'create' );
+	}
+
+	/**
+	 * Check product update access.
+	 *
+	 * @param mixed $input Ability input.
+	 * @return bool
+	 *
+	 * @since 10.9.0
+	 */
+	public static function can_update_product( $input = array() ): bool {
+		$product_id = self::get_input_id( $input );
+
+		return $product_id > 0 && wc_rest_check_post_permissions( 'product', 'edit', $product_id );
+	}
+
+	/**
+	 * Check product deletion access.
+	 *
+	 * @param mixed $input Ability input.
+	 * @return bool
+	 *
+	 * @since 10.9.0
+	 */
+	public static function can_delete_product( $input = array() ): bool {
+		$product_id = self::get_input_id( $input );
+
+		return $product_id > 0 && wc_rest_check_post_permissions( 'product', 'delete', $product_id );
+	}
+
+	/**
+	 * Check order read access.
+	 *
+	 * @param mixed $input Ability input.
+	 * @return bool
+	 *
+	 * @since 10.9.0
+	 */
+	public static function can_query_orders( $input = array() ): bool {
+		$order_id = self::get_input_id( $input );
+
+		return wc_rest_check_post_permissions( 'shop_order', 'read', $order_id );
 	}
 
 	/**
 	 * Check order management access.
 	 *
+	 * @param mixed $input Ability input.
 	 * @return bool
+	 *
+	 * @since 10.9.0
 	 */
-	public static function can_manage_orders(): bool {
-		return current_user_can( 'manage_woocommerce' ) || current_user_can( 'edit_shop_orders' );
+	public static function can_manage_orders( $input = array() ): bool {
+		$order_id = self::get_input_id( $input );
+
+		return $order_id > 0 && wc_rest_check_post_permissions( 'shop_order', 'edit', $order_id );
 	}
 
 	/**
@@ -959,6 +1032,16 @@ class DomainAbilities {
 	 */
 	private static function format_datetime( ?\WC_DateTime $datetime ): ?string {
 		return $datetime ? $datetime->date( DATE_ATOM ) : null;
+	}
+
+	/**
+	 * Get an ID value from ability input.
+	 *
+	 * @param mixed $input Ability input.
+	 * @return int
+	 */
+	private static function get_input_id( $input ): int {
+		return is_array( $input ) && ! empty( $input['id'] ) ? absint( $input['id'] ) : 0;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Abilities/DomainAbilities.php
+++ b/plugins/woocommerce/src/Internal/Abilities/DomainAbilities.php
@@ -1,0 +1,798 @@
+<?php
+/**
+ * Domain Abilities class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers canonical WooCommerce abilities backed by WooCommerce domain APIs.
+ */
+class DomainAbilities {
+
+	/**
+	 * Initialize ability registration.
+	 *
+	 * @internal
+	 */
+	final public static function init(): void {
+		/*
+		 * Register abilities when Abilities API is ready.
+		 * Support both old (pre-6.9) and new (6.9+) action names.
+		 */
+		add_action( 'abilities_api_init', array( __CLASS__, 'register_abilities' ) );
+		add_action( 'wp_abilities_api_init', array( __CLASS__, 'register_abilities' ) );
+	}
+
+	/**
+	 * Register canonical domain abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		self::register_products_query();
+		self::register_products_manage();
+		self::register_orders_query();
+		self::register_orders_manage();
+	}
+
+	/**
+	 * Register the product query ability.
+	 */
+	private static function register_products_query(): void {
+		if ( self::has_ability( 'woocommerce/products-query' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'woocommerce/products-query',
+			array(
+				'label'               => __( 'Query Products', 'woocommerce' ),
+				'description'         => __(
+					'Find WooCommerce products by ID or common catalog filters using WooCommerce product APIs.',
+					'woocommerce'
+				),
+				'category'            => 'woocommerce',
+				'input_schema'        => self::get_products_query_input_schema(),
+				'output_schema'       => self::get_collection_output_schema( 'products' ),
+				'execute_callback'    => array( __CLASS__, 'execute_products_query' ),
+				'permission_callback' => array( __CLASS__, 'can_query_woocommerce' ),
+				'meta'                => self::get_domain_meta( 'query', true, true, false ),
+			)
+		);
+	}
+
+	/**
+	 * Register the product management ability.
+	 */
+	private static function register_products_manage(): void {
+		if ( self::has_ability( 'woocommerce/products-manage' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'woocommerce/products-manage',
+			array(
+				'label'               => __( 'Manage Products', 'woocommerce' ),
+				'description'         => __(
+					'Create, update, or delete WooCommerce products using WooCommerce product APIs.',
+					'woocommerce'
+				),
+				'category'            => 'woocommerce',
+				'input_schema'        => self::get_products_manage_input_schema(),
+				'output_schema'       => self::get_entity_output_schema( 'product' ),
+				'execute_callback'    => array( __CLASS__, 'execute_products_manage' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_products' ),
+				'meta'                => self::get_domain_meta( 'manage', false, false, true ),
+			)
+		);
+	}
+
+	/**
+	 * Register the order query ability.
+	 */
+	private static function register_orders_query(): void {
+		if ( self::has_ability( 'woocommerce/orders-query' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'woocommerce/orders-query',
+			array(
+				'label'               => __( 'Query Orders', 'woocommerce' ),
+				'description'         => __(
+					'Find WooCommerce orders by ID or common order filters using WooCommerce order APIs.',
+					'woocommerce'
+				),
+				'category'            => 'woocommerce',
+				'input_schema'        => self::get_orders_query_input_schema(),
+				'output_schema'       => self::get_collection_output_schema( 'orders' ),
+				'execute_callback'    => array( __CLASS__, 'execute_orders_query' ),
+				'permission_callback' => array( __CLASS__, 'can_query_woocommerce' ),
+				'meta'                => self::get_domain_meta( 'query', true, true, false ),
+			)
+		);
+	}
+
+	/**
+	 * Register the order management ability.
+	 */
+	private static function register_orders_manage(): void {
+		if ( self::has_ability( 'woocommerce/orders-manage' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'woocommerce/orders-manage',
+			array(
+				'label'               => __( 'Manage Orders', 'woocommerce' ),
+				'description'         => __(
+					'Update WooCommerce order status or add order notes using WooCommerce order APIs.',
+					'woocommerce'
+				),
+				'category'            => 'woocommerce',
+				'input_schema'        => self::get_orders_manage_input_schema(),
+				'output_schema'       => self::get_entity_output_schema( 'order' ),
+				'execute_callback'    => array( __CLASS__, 'execute_orders_manage' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_orders' ),
+				'meta'                => self::get_domain_meta( 'manage', false, false, true ),
+			)
+		);
+	}
+
+	/**
+	 * Query products.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function execute_products_query( array $input ) {
+		if ( ! empty( $input['id'] ) ) {
+			$product = wc_get_product( absint( $input['id'] ) );
+
+			if ( ! $product ) {
+				return new \WP_Error(
+					'woocommerce_product_not_found',
+					__( 'Product not found.', 'woocommerce' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			return array(
+				'products' => array( self::format_product( $product ) ),
+				'total'    => 1,
+				'page'     => 1,
+				'per_page' => 1,
+			);
+		}
+
+		$page     = max( 1, absint( $input['page'] ?? 1 ) );
+		$per_page = self::sanitize_per_page( $input['per_page'] ?? 10 );
+		$args     = array(
+			'limit'    => $per_page,
+			'page'     => $page,
+			'paginate' => true,
+			'return'   => 'objects',
+		);
+
+		foreach ( array( 'status', 'type', 'sku', 'stock_status' ) as $field ) {
+			if ( ! empty( $input[ $field ] ) ) {
+				$args[ $field ] = wc_clean( wp_unslash( $input[ $field ] ) );
+			}
+		}
+
+		if ( ! empty( $input['search'] ) ) {
+			$args['s'] = wc_clean( wp_unslash( $input['search'] ) );
+		}
+
+		$results  = wc_get_products( $args );
+		$products = is_object( $results ) && isset( $results->products ) ? $results->products : array();
+		$total    = is_object( $results ) && isset( $results->total ) ? (int) $results->total : count( $products );
+
+		return array(
+			'products' => array_map( array( __CLASS__, 'format_product' ), $products ),
+			'total'    => $total,
+			'page'     => $page,
+			'per_page' => $per_page,
+		);
+	}
+
+	/**
+	 * Manage products.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function execute_products_manage( array $input ) {
+		$action = sanitize_key( $input['action'] ?? '' );
+
+		switch ( $action ) {
+			case 'create':
+				$type    = sanitize_key( $input['type'] ?? 'simple' );
+				$product = wc_get_product_object( $type );
+
+				if ( ! $product ) {
+					return new \WP_Error(
+						'woocommerce_invalid_product_type',
+						__( 'Invalid product type.', 'woocommerce' ),
+						array( 'status' => 400 )
+					);
+				}
+
+				self::set_product_props( $product, $input );
+				$product->save();
+
+				return array(
+					'action'  => 'create',
+					'product' => self::format_product( $product ),
+				);
+
+			case 'update':
+				$product = self::get_product_from_input( $input );
+
+				if ( is_wp_error( $product ) ) {
+					return $product;
+				}
+
+				self::set_product_props( $product, $input );
+				$product->save();
+
+				return array(
+					'action'  => 'update',
+					'product' => self::format_product( $product ),
+				);
+
+			case 'delete':
+				$product = self::get_product_from_input( $input );
+
+				if ( is_wp_error( $product ) ) {
+					return $product;
+				}
+
+				$product_id = $product->get_id();
+				$deleted    = $product->delete( (bool) ( $input['force'] ?? false ) );
+
+				return array(
+					'action'  => 'delete',
+					'deleted' => (bool) $deleted,
+					'id'      => $product_id,
+				);
+		}
+
+		return new \WP_Error(
+			'woocommerce_invalid_product_action',
+			__( 'Invalid product management action.', 'woocommerce' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	/**
+	 * Query orders.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function execute_orders_query( array $input ) {
+		$include_line_items = (bool) ( $input['include_line_items'] ?? false );
+
+		if ( ! empty( $input['id'] ) ) {
+			$order = wc_get_order( absint( $input['id'] ) );
+
+			if ( ! $order ) {
+				return new \WP_Error(
+					'woocommerce_order_not_found',
+					__( 'Order not found.', 'woocommerce' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			return array(
+				'orders'   => array( self::format_order( $order, $include_line_items ) ),
+				'total'    => 1,
+				'page'     => 1,
+				'per_page' => 1,
+			);
+		}
+
+		$page     = max( 1, absint( $input['page'] ?? 1 ) );
+		$per_page = self::sanitize_per_page( $input['per_page'] ?? 10 );
+		$args     = array(
+			'limit'    => $per_page,
+			'page'     => $page,
+			'paginate' => true,
+			'return'   => 'objects',
+		);
+
+		foreach ( array( 'status', 'billing_email' ) as $field ) {
+			if ( ! empty( $input[ $field ] ) ) {
+				$args[ $field ] = wc_clean( wp_unslash( $input[ $field ] ) );
+			}
+		}
+
+		if ( ! empty( $input['customer_id'] ) ) {
+			$args['customer_id'] = absint( $input['customer_id'] );
+		}
+
+		$results = wc_get_orders( $args );
+		$orders  = is_object( $results ) && isset( $results->orders ) ? $results->orders : array();
+		$total   = is_object( $results ) && isset( $results->total ) ? (int) $results->total : count( $orders );
+
+		return array(
+			'orders'   => array_map(
+				static function ( $order ) use ( $include_line_items ) {
+					return self::format_order( $order, $include_line_items );
+				},
+				$orders
+			),
+			'total'    => $total,
+			'page'     => $page,
+			'per_page' => $per_page,
+		);
+	}
+
+	/**
+	 * Manage orders.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function execute_orders_manage( array $input ) {
+		if ( empty( $input['id'] ) ) {
+			return new \WP_Error(
+				'woocommerce_order_id_required',
+				__( 'Order ID is required.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$order = wc_get_order( absint( $input['id'] ) );
+
+		if ( ! $order ) {
+			return new \WP_Error(
+				'woocommerce_order_not_found',
+				__( 'Order not found.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$action = sanitize_key( $input['action'] ?? '' );
+
+		switch ( $action ) {
+			case 'update_status':
+				if ( empty( $input['status'] ) ) {
+					return new \WP_Error(
+						'woocommerce_order_status_required',
+						__( 'Order status is required.', 'woocommerce' ),
+						array( 'status' => 400 )
+					);
+				}
+
+				$order->update_status(
+					sanitize_key( $input['status'] ),
+					isset( $input['note'] ) ? wc_clean( wp_unslash( $input['note'] ) ) : ''
+				);
+
+				return array(
+					'action' => 'update_status',
+					'order'  => self::format_order( $order, false ),
+				);
+
+			case 'add_note':
+				if ( empty( $input['note'] ) ) {
+					return new \WP_Error(
+						'woocommerce_order_note_required',
+						__( 'Order note is required.', 'woocommerce' ),
+						array( 'status' => 400 )
+					);
+				}
+
+				$note_id = $order->add_order_note(
+					wc_clean( wp_unslash( $input['note'] ) ),
+					(bool) ( $input['customer_note'] ?? false )
+				);
+
+				return array(
+					'action'  => 'add_note',
+					'note_id' => (int) $note_id,
+					'order'   => self::format_order( $order, false ),
+				);
+		}
+
+		return new \WP_Error(
+			'woocommerce_invalid_order_action',
+			__( 'Invalid order management action.', 'woocommerce' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	/**
+	 * Check read access for WooCommerce data.
+	 *
+	 * @return bool
+	 */
+	public static function can_query_woocommerce(): bool {
+		return current_user_can( 'manage_woocommerce' ) || current_user_can( 'view_woocommerce_reports' );
+	}
+
+	/**
+	 * Check product management access.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_products(): bool {
+		return current_user_can( 'manage_woocommerce' ) || current_user_can( 'edit_products' );
+	}
+
+	/**
+	 * Check order management access.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_orders(): bool {
+		return current_user_can( 'manage_woocommerce' ) || current_user_can( 'edit_shop_orders' );
+	}
+
+	/**
+	 * Get common domain metadata.
+	 *
+	 * @param string $operation   Operation group.
+	 * @param bool   $is_readonly Whether the ability is readonly.
+	 * @param bool   $idempotent  Whether the ability is idempotent.
+	 * @param bool   $destructive Whether the ability can mutate data.
+	 * @return array
+	 */
+	private static function get_domain_meta( string $operation, bool $is_readonly, bool $idempotent, bool $destructive ): array {
+		return array(
+			'show_in_rest'                  => true,
+			'mcp'                           => array(
+				'public' => true,
+				'type'   => 'tool',
+			),
+				'woocommerce_ability_source'    => 'domain-api',
+				'woocommerce_ability_operation' => $operation,
+			'annotations'                   => array(
+				'readonly'    => $is_readonly,
+				'idempotent'  => $idempotent,
+				'destructive' => $destructive,
+			),
+		);
+	}
+
+	/**
+	 * Get the products query input schema.
+	 *
+	 * @return array
+	 */
+	private static function get_products_query_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'           => array( 'type' => 'integer' ),
+				'search'       => array( 'type' => 'string' ),
+				'sku'          => array( 'type' => 'string' ),
+				'status'       => array( 'type' => 'string' ),
+				'type'         => array( 'type' => 'string' ),
+				'stock_status' => array( 'type' => 'string' ),
+				'page'         => array(
+					'type'    => 'integer',
+					'default' => 1,
+					'minimum' => 1,
+				),
+				'per_page'     => array(
+					'type'    => 'integer',
+					'default' => 10,
+					'minimum' => 1,
+					'maximum' => 100,
+				),
+			),
+			'additionalProperties' => false,
+			'default'              => array(),
+		);
+	}
+
+	/**
+	 * Get the products manage input schema.
+	 *
+	 * @return array
+	 */
+	private static function get_products_manage_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'action'            => array(
+					'type' => 'string',
+					'enum' => array( 'create', 'update', 'delete' ),
+				),
+				'id'                => array( 'type' => 'integer' ),
+				'type'              => array( 'type' => 'string' ),
+				'name'              => array( 'type' => 'string' ),
+				'sku'               => array( 'type' => 'string' ),
+				'regular_price'     => array( 'type' => 'string' ),
+				'sale_price'        => array( 'type' => 'string' ),
+				'description'       => array( 'type' => 'string' ),
+				'short_description' => array( 'type' => 'string' ),
+				'status'            => array( 'type' => 'string' ),
+				'manage_stock'      => array( 'type' => 'boolean' ),
+				'stock_quantity'    => array( 'type' => 'integer' ),
+				'stock_status'      => array( 'type' => 'string' ),
+				'virtual'           => array( 'type' => 'boolean' ),
+				'downloadable'      => array( 'type' => 'boolean' ),
+				'force'             => array( 'type' => 'boolean' ),
+			),
+			'required'             => array( 'action' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Get the orders query input schema.
+	 *
+	 * @return array
+	 */
+	private static function get_orders_query_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'                 => array( 'type' => 'integer' ),
+				'status'             => array( 'type' => 'string' ),
+				'customer_id'        => array( 'type' => 'integer' ),
+				'billing_email'      => array( 'type' => 'string' ),
+				'include_line_items' => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+				'page'               => array(
+					'type'    => 'integer',
+					'default' => 1,
+					'minimum' => 1,
+				),
+				'per_page'           => array(
+					'type'    => 'integer',
+					'default' => 10,
+					'minimum' => 1,
+					'maximum' => 100,
+				),
+			),
+			'additionalProperties' => false,
+			'default'              => array(),
+		);
+	}
+
+	/**
+	 * Get the orders manage input schema.
+	 *
+	 * @return array
+	 */
+	private static function get_orders_manage_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'action'        => array(
+					'type' => 'string',
+					'enum' => array( 'update_status', 'add_note' ),
+				),
+				'id'            => array( 'type' => 'integer' ),
+				'status'        => array( 'type' => 'string' ),
+				'note'          => array( 'type' => 'string' ),
+				'customer_note' => array( 'type' => 'boolean' ),
+			),
+			'required'             => array( 'action', 'id' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Get a collection output schema.
+	 *
+	 * @param string $collection_key Collection property key.
+	 * @return array
+	 */
+	private static function get_collection_output_schema( string $collection_key ): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				$collection_key => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'                 => 'object',
+						'additionalProperties' => true,
+					),
+				),
+				'total'         => array( 'type' => 'integer' ),
+				'page'          => array( 'type' => 'integer' ),
+				'per_page'      => array( 'type' => 'integer' ),
+			),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Get an entity output schema.
+	 *
+	 * @param string $entity_key Entity property key.
+	 * @return array
+	 */
+	private static function get_entity_output_schema( string $entity_key ): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'action'    => array( 'type' => 'string' ),
+				$entity_key => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'deleted'   => array( 'type' => 'boolean' ),
+				'id'        => array( 'type' => 'integer' ),
+				'note_id'   => array( 'type' => 'integer' ),
+			),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Get a product from ability input.
+	 *
+	 * @param array $input Ability input.
+	 * @return \WC_Product|\WP_Error
+	 */
+	private static function get_product_from_input( array $input ) {
+		if ( empty( $input['id'] ) ) {
+			return new \WP_Error(
+				'woocommerce_product_id_required',
+				__( 'Product ID is required.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$product = wc_get_product( absint( $input['id'] ) );
+
+		if ( ! $product ) {
+			return new \WP_Error(
+				'woocommerce_product_not_found',
+				__( 'Product not found.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $product;
+	}
+
+	/**
+	 * Set supported product properties from ability input.
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @param array       $input   Ability input.
+	 */
+	private static function set_product_props( \WC_Product $product, array $input ): void {
+		$setters = array(
+			'name'              => 'set_name',
+			'sku'               => 'set_sku',
+			'regular_price'     => 'set_regular_price',
+			'sale_price'        => 'set_sale_price',
+			'description'       => 'set_description',
+			'short_description' => 'set_short_description',
+			'status'            => 'set_status',
+			'manage_stock'      => 'set_manage_stock',
+			'stock_quantity'    => 'set_stock_quantity',
+			'stock_status'      => 'set_stock_status',
+			'virtual'           => 'set_virtual',
+			'downloadable'      => 'set_downloadable',
+		);
+
+		foreach ( $setters as $field => $setter ) {
+			if ( array_key_exists( $field, $input ) && is_callable( array( $product, $setter ) ) ) {
+				$value = $input[ $field ];
+
+				if ( is_string( $value ) ) {
+					$value = wc_clean( wp_unslash( $value ) );
+				}
+
+				$product->{$setter}( $value );
+			}
+		}
+	}
+
+	/**
+	 * Format a product for ability output.
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @return array
+	 */
+	private static function format_product( \WC_Product $product ): array {
+		return array(
+			'id'             => $product->get_id(),
+			'name'           => $product->get_name(),
+			'slug'           => $product->get_slug(),
+			'permalink'      => $product->get_permalink(),
+			'type'           => $product->get_type(),
+			'status'         => $product->get_status(),
+			'sku'            => $product->get_sku(),
+			'price'          => $product->get_price(),
+			'regular_price'  => $product->get_regular_price(),
+			'sale_price'     => $product->get_sale_price(),
+			'stock_status'   => $product->get_stock_status(),
+			'stock_quantity' => null === $product->get_stock_quantity() ? null : (int) $product->get_stock_quantity(),
+			'manage_stock'   => (bool) $product->get_manage_stock(),
+			'virtual'        => (bool) $product->get_virtual(),
+			'downloadable'   => (bool) $product->get_downloadable(),
+			'date_created'   => self::format_datetime( $product->get_date_created() ),
+			'date_modified'  => self::format_datetime( $product->get_date_modified() ),
+		);
+	}
+
+	/**
+	 * Format an order for ability output.
+	 *
+	 * @param \WC_Order $order              Order object.
+	 * @param bool      $include_line_items Whether to include line items.
+	 * @return array
+	 */
+	private static function format_order( \WC_Order $order, bool $include_line_items ): array {
+		$data = array(
+			'id'                   => $order->get_id(),
+			'status'               => $order->get_status(),
+			'currency'             => $order->get_currency(),
+			'total'                => $order->get_total(),
+			'customer_id'          => $order->get_customer_id(),
+			'billing_email'        => $order->get_billing_email(),
+			'payment_method'       => $order->get_payment_method(),
+			'payment_method_title' => $order->get_payment_method_title(),
+			'date_created'         => self::format_datetime( $order->get_date_created() ),
+			'date_modified'        => self::format_datetime( $order->get_date_modified() ),
+		);
+
+		if ( $include_line_items ) {
+			$data['line_items'] = array();
+
+			foreach ( $order->get_items() as $item ) {
+				$data['line_items'][] = array(
+					'id'           => $item->get_id(),
+					'name'         => $item->get_name(),
+					'product_id'   => $item->get_product_id(),
+					'variation_id' => $item->get_variation_id(),
+					'quantity'     => $item->get_quantity(),
+					'subtotal'     => $item->get_subtotal(),
+					'total'        => $item->get_total(),
+				);
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Format a WooCommerce datetime.
+	 *
+	 * @param \WC_DateTime|null $datetime Date/time value.
+	 * @return string|null
+	 */
+	private static function format_datetime( ?\WC_DateTime $datetime ): ?string {
+		return $datetime ? $datetime->date( DATE_ATOM ) : null;
+	}
+
+	/**
+	 * Sanitize a per-page value.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return int
+	 */
+	private static function sanitize_per_page( $value ): int {
+		return min( 100, max( 1, absint( $value ) ) );
+	}
+
+	/**
+	 * Check whether an ability is already registered.
+	 *
+	 * @param string $ability_id Ability ID.
+	 * @return bool
+	 */
+	private static function has_ability( string $ability_id ): bool {
+		return function_exists( 'wp_has_ability' ) && wp_has_ability( $ability_id );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Abilities/DomainAbilities.php
+++ b/plugins/woocommerce/src/Internal/Abilities/DomainAbilities.php
@@ -454,8 +454,8 @@ class DomainAbilities {
 				'public' => true,
 				'type'   => 'tool',
 			),
-				'woocommerce_ability_source'    => 'domain-api',
-				'woocommerce_ability_operation' => $operation,
+			'woocommerce_ability_source'    => 'domain-api',
+			'woocommerce_ability_operation' => $operation,
 			'annotations'                   => array(
 				'readonly'    => $is_readonly,
 				'idempotent'  => $idempotent,

--- a/plugins/woocommerce/src/Internal/Abilities/DomainAbilities.php
+++ b/plugins/woocommerce/src/Internal/Abilities/DomainAbilities.php
@@ -37,9 +37,12 @@ class DomainAbilities {
 		}
 
 		self::register_products_query();
-		self::register_products_manage();
+		self::register_product_create();
+		self::register_product_update();
+		self::register_product_delete();
 		self::register_orders_query();
-		self::register_orders_manage();
+		self::register_order_update_status();
+		self::register_order_add_note();
 	}
 
 	/**
@@ -69,27 +72,79 @@ class DomainAbilities {
 	}
 
 	/**
-	 * Register the product management ability.
+	 * Register the product creation ability.
 	 */
-	private static function register_products_manage(): void {
-		if ( self::has_ability( 'woocommerce/products-manage' ) ) {
+	private static function register_product_create(): void {
+		if ( self::has_ability( 'woocommerce/product-create' ) ) {
 			return;
 		}
 
 		wp_register_ability(
-			'woocommerce/products-manage',
+			'woocommerce/product-create',
 			array(
-				'label'               => __( 'Manage Products', 'woocommerce' ),
+				'label'               => __( 'Create Product', 'woocommerce' ),
 				'description'         => __(
-					'Create, update, or delete WooCommerce products using WooCommerce product APIs.',
+					'Create a WooCommerce product using WooCommerce product APIs.',
 					'woocommerce'
 				),
 				'category'            => 'woocommerce',
-				'input_schema'        => self::get_products_manage_input_schema(),
+				'input_schema'        => self::get_product_create_input_schema(),
 				'output_schema'       => self::get_entity_output_schema( 'product' ),
-				'execute_callback'    => array( __CLASS__, 'execute_products_manage' ),
+				'execute_callback'    => array( __CLASS__, 'execute_product_create' ),
 				'permission_callback' => array( __CLASS__, 'can_manage_products' ),
-				'meta'                => self::get_domain_meta( 'manage', false, false, true ),
+				'meta'                => self::get_domain_meta( 'create', false, false, false ),
+			)
+		);
+	}
+
+	/**
+	 * Register the product update ability.
+	 */
+	private static function register_product_update(): void {
+		if ( self::has_ability( 'woocommerce/product-update' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'woocommerce/product-update',
+			array(
+				'label'               => __( 'Update Product', 'woocommerce' ),
+				'description'         => __(
+					'Update an existing WooCommerce product using WooCommerce product APIs.',
+					'woocommerce'
+				),
+				'category'            => 'woocommerce',
+				'input_schema'        => self::get_product_update_input_schema(),
+				'output_schema'       => self::get_entity_output_schema( 'product' ),
+				'execute_callback'    => array( __CLASS__, 'execute_product_update' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_products' ),
+				'meta'                => self::get_domain_meta( 'update', false, false, true ),
+			)
+		);
+	}
+
+	/**
+	 * Register the product delete ability.
+	 */
+	private static function register_product_delete(): void {
+		if ( self::has_ability( 'woocommerce/product-delete' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'woocommerce/product-delete',
+			array(
+				'label'               => __( 'Delete Product', 'woocommerce' ),
+				'description'         => __(
+					'Delete a WooCommerce product using WooCommerce product APIs.',
+					'woocommerce'
+				),
+				'category'            => 'woocommerce',
+				'input_schema'        => self::get_product_delete_input_schema(),
+				'output_schema'       => self::get_delete_output_schema(),
+				'execute_callback'    => array( __CLASS__, 'execute_product_delete' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_products' ),
+				'meta'                => self::get_domain_meta( 'delete', false, false, true ),
 			)
 		);
 	}
@@ -121,27 +176,53 @@ class DomainAbilities {
 	}
 
 	/**
-	 * Register the order management ability.
+	 * Register the order status update ability.
 	 */
-	private static function register_orders_manage(): void {
-		if ( self::has_ability( 'woocommerce/orders-manage' ) ) {
+	private static function register_order_update_status(): void {
+		if ( self::has_ability( 'woocommerce/order-update-status' ) ) {
 			return;
 		}
 
 		wp_register_ability(
-			'woocommerce/orders-manage',
+			'woocommerce/order-update-status',
 			array(
-				'label'               => __( 'Manage Orders', 'woocommerce' ),
+				'label'               => __( 'Update Order Status', 'woocommerce' ),
 				'description'         => __(
-					'Update WooCommerce order status or add order notes using WooCommerce order APIs.',
+					'Update a WooCommerce order status using WooCommerce order APIs.',
 					'woocommerce'
 				),
 				'category'            => 'woocommerce',
-				'input_schema'        => self::get_orders_manage_input_schema(),
+				'input_schema'        => self::get_order_update_status_input_schema(),
 				'output_schema'       => self::get_entity_output_schema( 'order' ),
-				'execute_callback'    => array( __CLASS__, 'execute_orders_manage' ),
+				'execute_callback'    => array( __CLASS__, 'execute_order_update_status' ),
 				'permission_callback' => array( __CLASS__, 'can_manage_orders' ),
-				'meta'                => self::get_domain_meta( 'manage', false, false, true ),
+				'meta'                => self::get_domain_meta( 'update-status', false, false, true ),
+			)
+		);
+	}
+
+	/**
+	 * Register the order note creation ability.
+	 */
+	private static function register_order_add_note(): void {
+		if ( self::has_ability( 'woocommerce/order-add-note' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'woocommerce/order-add-note',
+			array(
+				'label'               => __( 'Add Order Note', 'woocommerce' ),
+				'description'         => __(
+					'Add a note to a WooCommerce order using WooCommerce order APIs.',
+					'woocommerce'
+				),
+				'category'            => 'woocommerce',
+				'input_schema'        => self::get_order_add_note_input_schema(),
+				'output_schema'       => self::get_order_note_output_schema(),
+				'execute_callback'    => array( __CLASS__, 'execute_order_add_note' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_orders' ),
+				'meta'                => self::get_domain_meta( 'add-note', false, false, false ),
 			)
 		);
 	}
@@ -204,71 +285,71 @@ class DomainAbilities {
 	}
 
 	/**
-	 * Manage products.
+	 * Create a product.
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
 	 */
-	public static function execute_products_manage( array $input ) {
-		$action = sanitize_key( $input['action'] ?? '' );
+	public static function execute_product_create( array $input ) {
+		$type    = sanitize_key( $input['type'] ?? 'simple' );
+		$product = wc_get_product_object( $type );
 
-		switch ( $action ) {
-			case 'create':
-				$type    = sanitize_key( $input['type'] ?? 'simple' );
-				$product = wc_get_product_object( $type );
-
-				if ( ! $product ) {
-					return new \WP_Error(
-						'woocommerce_invalid_product_type',
-						__( 'Invalid product type.', 'woocommerce' ),
-						array( 'status' => 400 )
-					);
-				}
-
-				self::set_product_props( $product, $input );
-				$product->save();
-
-				return array(
-					'action'  => 'create',
-					'product' => self::format_product( $product ),
-				);
-
-			case 'update':
-				$product = self::get_product_from_input( $input );
-
-				if ( is_wp_error( $product ) ) {
-					return $product;
-				}
-
-				self::set_product_props( $product, $input );
-				$product->save();
-
-				return array(
-					'action'  => 'update',
-					'product' => self::format_product( $product ),
-				);
-
-			case 'delete':
-				$product = self::get_product_from_input( $input );
-
-				if ( is_wp_error( $product ) ) {
-					return $product;
-				}
-
-				$product_id = $product->get_id();
-				$deleted    = $product->delete( (bool) ( $input['force'] ?? false ) );
-
-				return array(
-					'action'  => 'delete',
-					'deleted' => (bool) $deleted,
-					'id'      => $product_id,
-				);
+		if ( ! $product ) {
+			return new \WP_Error(
+				'woocommerce_invalid_product_type',
+				__( 'Invalid product type.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
 		}
 
-		return new \WP_Error(
-			'woocommerce_invalid_product_action',
-			__( 'Invalid product management action.', 'woocommerce' ),
-			array( 'status' => 400 )
+		self::set_product_props( $product, $input );
+		$product->save();
+
+		return array(
+			'product' => self::format_product( $product ),
+		);
+	}
+
+	/**
+	 * Update a product.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function execute_product_update( array $input ) {
+		$product = self::get_product_from_input( $input );
+
+		if ( is_wp_error( $product ) ) {
+			return $product;
+		}
+
+		self::set_product_props( $product, $input );
+		$product->save();
+
+		return array(
+			'product' => self::format_product( $product ),
+		);
+	}
+
+	/**
+	 * Delete a product.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function execute_product_delete( array $input ) {
+		$product = self::get_product_from_input( $input );
+
+		if ( is_wp_error( $product ) ) {
+			return $product;
+		}
+
+		$product_id = $product->get_id();
+		$deleted    = $product->delete( (bool) ( $input['force'] ?? false ) );
+
+		return array(
+			'deleted' => (bool) $deleted,
+			'id'      => $product_id,
 		);
 	}
 
@@ -284,7 +365,7 @@ class DomainAbilities {
 		if ( ! empty( $input['id'] ) ) {
 			$order = wc_get_order( absint( $input['id'] ) );
 
-			if ( ! $order ) {
+			if ( ! $order instanceof \WC_Order ) {
 				return new \WP_Error(
 					'woocommerce_order_not_found',
 					__( 'Order not found.', 'woocommerce' ),
@@ -307,6 +388,7 @@ class DomainAbilities {
 			'page'     => $page,
 			'paginate' => true,
 			'return'   => 'objects',
+			'type'     => 'shop_order',
 		);
 
 		foreach ( array( 'status', 'billing_email' ) as $field ) {
@@ -321,6 +403,14 @@ class DomainAbilities {
 
 		$results = wc_get_orders( $args );
 		$orders  = is_object( $results ) && isset( $results->orders ) ? $results->orders : array();
+		$orders  = array_values(
+			array_filter(
+				$orders,
+				static function ( $order ): bool {
+					return $order instanceof \WC_Order;
+				}
+			)
+		);
 		$total   = is_object( $results ) && isset( $results->total ) ? (int) $results->total : count( $orders );
 
 		return array(
@@ -337,12 +427,12 @@ class DomainAbilities {
 	}
 
 	/**
-	 * Manage orders.
+	 * Update an order status.
 	 *
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
 	 */
-	public static function execute_orders_manage( array $input ) {
+	public static function execute_order_update_status( array $input ) {
 		if ( empty( $input['id'] ) ) {
 			return new \WP_Error(
 				'woocommerce_order_id_required',
@@ -353,7 +443,7 @@ class DomainAbilities {
 
 		$order = wc_get_order( absint( $input['id'] ) );
 
-		if ( ! $order ) {
+		if ( ! $order instanceof \WC_Order ) {
 			return new \WP_Error(
 				'woocommerce_order_not_found',
 				__( 'Order not found.', 'woocommerce' ),
@@ -361,53 +451,65 @@ class DomainAbilities {
 			);
 		}
 
-		$action = sanitize_key( $input['action'] ?? '' );
-
-		switch ( $action ) {
-			case 'update_status':
-				if ( empty( $input['status'] ) ) {
-					return new \WP_Error(
-						'woocommerce_order_status_required',
-						__( 'Order status is required.', 'woocommerce' ),
-						array( 'status' => 400 )
-					);
-				}
-
-				$order->update_status(
-					sanitize_key( $input['status'] ),
-					isset( $input['note'] ) ? wc_clean( wp_unslash( $input['note'] ) ) : ''
-				);
-
-				return array(
-					'action' => 'update_status',
-					'order'  => self::format_order( $order, false ),
-				);
-
-			case 'add_note':
-				if ( empty( $input['note'] ) ) {
-					return new \WP_Error(
-						'woocommerce_order_note_required',
-						__( 'Order note is required.', 'woocommerce' ),
-						array( 'status' => 400 )
-					);
-				}
-
-				$note_id = $order->add_order_note(
-					wc_clean( wp_unslash( $input['note'] ) ),
-					(bool) ( $input['customer_note'] ?? false )
-				);
-
-				return array(
-					'action'  => 'add_note',
-					'note_id' => (int) $note_id,
-					'order'   => self::format_order( $order, false ),
-				);
+		if ( empty( $input['status'] ) ) {
+			return new \WP_Error(
+				'woocommerce_order_status_required',
+				__( 'Order status is required.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
 		}
 
-		return new \WP_Error(
-			'woocommerce_invalid_order_action',
-			__( 'Invalid order management action.', 'woocommerce' ),
-			array( 'status' => 400 )
+		$order->update_status(
+			sanitize_key( $input['status'] ),
+			isset( $input['note'] ) ? self::sanitize_string( $input['note'] ) : ''
+		);
+
+		return array(
+			'order' => self::format_order( $order, false ),
+		);
+	}
+
+	/**
+	 * Add an order note.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function execute_order_add_note( array $input ) {
+		if ( empty( $input['id'] ) ) {
+			return new \WP_Error(
+				'woocommerce_order_id_required',
+				__( 'Order ID is required.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$order = wc_get_order( absint( $input['id'] ) );
+
+		if ( ! $order instanceof \WC_Order ) {
+			return new \WP_Error(
+				'woocommerce_order_not_found',
+				__( 'Order not found.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( empty( $input['note'] ) ) {
+			return new \WP_Error(
+				'woocommerce_order_note_required',
+				__( 'Order note is required.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$note_id = $order->add_order_note(
+			self::sanitize_string( $input['note'] ),
+			( (bool) ( $input['customer_note'] ?? false ) ) ? 1 : 0
+		);
+
+		return array(
+			'note_id' => (int) $note_id,
+			'order'   => self::format_order( $order, false ),
 		);
 	}
 
@@ -497,19 +599,14 @@ class DomainAbilities {
 	}
 
 	/**
-	 * Get the products manage input schema.
+	 * Get the product create input schema.
 	 *
 	 * @return array
 	 */
-	private static function get_products_manage_input_schema(): array {
+	private static function get_product_create_input_schema(): array {
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'action'            => array(
-					'type' => 'string',
-					'enum' => array( 'create', 'update', 'delete' ),
-				),
-				'id'                => array( 'type' => 'integer' ),
 				'type'              => array( 'type' => 'string' ),
 				'name'              => array( 'type' => 'string' ),
 				'sku'               => array( 'type' => 'string' ),
@@ -523,9 +620,46 @@ class DomainAbilities {
 				'stock_status'      => array( 'type' => 'string' ),
 				'virtual'           => array( 'type' => 'boolean' ),
 				'downloadable'      => array( 'type' => 'boolean' ),
-				'force'             => array( 'type' => 'boolean' ),
 			),
-			'required'             => array( 'action' ),
+			'required'             => array( 'name' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Get the product update input schema.
+	 *
+	 * @return array
+	 */
+	private static function get_product_update_input_schema(): array {
+		$schema               = self::get_product_create_input_schema();
+		$schema['properties'] = array_merge(
+			array(
+				'id' => array( 'type' => 'integer' ),
+			),
+			$schema['properties']
+		);
+		$schema['required']   = array( 'id' );
+
+		return $schema;
+	}
+
+	/**
+	 * Get the product delete input schema.
+	 *
+	 * @return array
+	 */
+	private static function get_product_delete_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'    => array( 'type' => 'integer' ),
+				'force' => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+			),
+			'required'             => array( 'id' ),
 			'additionalProperties' => false,
 		);
 	}
@@ -565,24 +699,40 @@ class DomainAbilities {
 	}
 
 	/**
-	 * Get the orders manage input schema.
+	 * Get the order status update input schema.
 	 *
 	 * @return array
 	 */
-	private static function get_orders_manage_input_schema(): array {
+	private static function get_order_update_status_input_schema(): array {
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'action'        => array(
-					'type' => 'string',
-					'enum' => array( 'update_status', 'add_note' ),
-				),
-				'id'            => array( 'type' => 'integer' ),
-				'status'        => array( 'type' => 'string' ),
-				'note'          => array( 'type' => 'string' ),
-				'customer_note' => array( 'type' => 'boolean' ),
+				'id'     => array( 'type' => 'integer' ),
+				'status' => array( 'type' => 'string' ),
+				'note'   => array( 'type' => 'string' ),
 			),
-			'required'             => array( 'action', 'id' ),
+			'required'             => array( 'id', 'status' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Get the order note input schema.
+	 *
+	 * @return array
+	 */
+	private static function get_order_add_note_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'            => array( 'type' => 'integer' ),
+				'note'          => array( 'type' => 'string' ),
+				'customer_note' => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+			),
+			'required'             => array( 'id', 'note' ),
 			'additionalProperties' => false,
 		);
 	}
@@ -622,14 +772,45 @@ class DomainAbilities {
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'action'    => array( 'type' => 'string' ),
 				$entity_key => array(
 					'type'                 => 'object',
 					'additionalProperties' => true,
 				),
-				'deleted'   => array( 'type' => 'boolean' ),
-				'id'        => array( 'type' => 'integer' ),
-				'note_id'   => array( 'type' => 'integer' ),
+			),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Get a delete output schema.
+	 *
+	 * @return array
+	 */
+	private static function get_delete_output_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'deleted' => array( 'type' => 'boolean' ),
+				'id'      => array( 'type' => 'integer' ),
+			),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Get an order note output schema.
+	 *
+	 * @return array
+	 */
+	private static function get_order_note_output_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'note_id' => array( 'type' => 'integer' ),
+				'order'   => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
 			),
 			'additionalProperties' => false,
 		);
@@ -751,6 +932,10 @@ class DomainAbilities {
 			$data['line_items'] = array();
 
 			foreach ( $order->get_items() as $item ) {
+				if ( ! $item instanceof \WC_Order_Item_Product ) {
+					continue;
+				}
+
 				$data['line_items'][] = array(
 					'id'           => $item->get_id(),
 					'name'         => $item->get_name(),
@@ -784,6 +969,22 @@ class DomainAbilities {
 	 */
 	private static function sanitize_per_page( $value ): int {
 		return min( 100, max( 1, absint( $value ) ) );
+	}
+
+	/**
+	 * Sanitize a scalar string input value.
+	 *
+	 * @param mixed $value Raw input value.
+	 * @return string
+	 */
+	private static function sanitize_string( $value ): string {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		$clean = wc_clean( wp_unslash( (string) $value ) );
+
+		return is_string( $clean ) ? $clean : '';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -36,6 +36,32 @@ class MCPAdapterProvider {
 	const MCP_ROUTE = 'mcp';
 
 	/**
+	 * MCP adapter class name.
+	 *
+	 * @var string
+	 */
+	private const MCP_ADAPTER_CLASS = 'WP\MCP\Core\McpAdapter';
+
+	/**
+	 * Number of arguments WooCommerce passes to McpAdapter::create_server().
+	 *
+	 * @var int
+	 */
+	private const CREATE_SERVER_ARGUMENT_COUNT = 10;
+
+	/**
+	 * MCP adapter classes WooCommerce needs at runtime.
+	 *
+	 * @var array<string, string>
+	 */
+	private const REQUIRED_MCP_ADAPTER_CLASSES = array(
+		'WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler'       => 'MCP error handler',
+		'WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler'  => 'MCP observability handler',
+		'WP\MCP\Transport\HttpTransport'                                   => 'MCP HTTP transport',
+		'WP\MCP\Transport\Infrastructure\McpTransportContext'              => 'MCP transport context',
+	);
+
+	/**
 	 * Whether MCP adapter is initialized.
 	 *
 	 * @var bool
@@ -68,28 +94,151 @@ class MCPAdapterProvider {
 			return;
 		}
 
-		$this->initialize_mcp_adapter();
+		if ( ! $this->initialize_mcp_adapter() ) {
+			return;
+		}
+
 		$this->register_hooks();
 		$this->initialized = true;
 	}
 
 	/**
 	 * Initialize the MCP adapter.
+	 *
+	 * @return bool Whether the MCP adapter was initialized.
 	 */
-	private function initialize_mcp_adapter(): void {
-		// Check if MCP adapter class exists (should be autoloaded by WooCommerce's composer).
-		if ( ! class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
-			if ( function_exists( 'wc_get_logger' ) ) {
-				wc_get_logger()->warning(
-					'MCP adapter class not found. Skipping MCP initialization.',
-					array( 'source' => 'woocommerce-mcp' )
-				);
-			}
-			return;
+	private function initialize_mcp_adapter(): bool {
+		$compatibility_errors = self::get_mcp_adapter_compatibility_errors();
+
+		if ( ! empty( $compatibility_errors ) ) {
+			$this->log_mcp_adapter_compatibility_errors( $compatibility_errors );
+			return false;
 		}
 
 		// Initialize the MCP adapter instance - this triggers the rest_api_init hook registration.
 		\WP\MCP\Core\McpAdapter::instance();
+
+		return true;
+	}
+
+	/**
+	 * Get MCP adapter compatibility errors for the loaded runtime.
+	 *
+	 * @return array Compatibility error messages.
+	 */
+	public static function get_mcp_adapter_compatibility_errors(): array {
+		return self::get_mcp_adapter_compatibility_errors_for(
+			self::MCP_ADAPTER_CLASS,
+			self::REQUIRED_MCP_ADAPTER_CLASSES,
+			self::CREATE_SERVER_ARGUMENT_COUNT
+		);
+	}
+
+	/**
+	 * Get MCP adapter compatibility errors for a specific adapter API shape.
+	 *
+	 * @param string $adapter_class                MCP adapter class name.
+	 * @param array  $required_classes             Required class names keyed by class and labelled by dependency role.
+	 * @param int    $create_server_argument_count Number of arguments WooCommerce passes to create_server().
+	 * @return array Compatibility error messages.
+	 */
+	private static function get_mcp_adapter_compatibility_errors_for( string $adapter_class, array $required_classes, int $create_server_argument_count ): array {
+		$errors = array();
+
+		if ( ! class_exists( $adapter_class ) ) {
+			$errors[] = sprintf(
+				'MCP adapter class %s was not found.',
+				$adapter_class
+			);
+		} else {
+			$errors = array_merge(
+				$errors,
+				self::get_mcp_adapter_method_compatibility_errors( $adapter_class, $create_server_argument_count )
+			);
+		}
+
+		foreach ( $required_classes as $class_name => $class_description ) {
+			if ( ! class_exists( $class_name ) ) {
+				$errors[] = sprintf(
+					'Required %1$s class %2$s was not found.',
+					$class_description,
+					$class_name
+				);
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Get compatibility errors for the MCP adapter methods WooCommerce calls.
+	 *
+	 * @param string $adapter_class                MCP adapter class name.
+	 * @param int    $create_server_argument_count Number of arguments WooCommerce passes to create_server().
+	 * @return array Compatibility error messages.
+	 */
+	private static function get_mcp_adapter_method_compatibility_errors( string $adapter_class, int $create_server_argument_count ): array {
+		$errors = array();
+
+		if ( ! method_exists( $adapter_class, 'instance' ) ) {
+			$errors[] = sprintf(
+				'MCP adapter class %s is missing the instance() method.',
+				$adapter_class
+			);
+		} else {
+			$instance_method = new \ReflectionMethod( $adapter_class, 'instance' );
+			if ( ! $instance_method->isPublic() || ! $instance_method->isStatic() ) {
+				$errors[] = sprintf(
+					'MCP adapter class %s must provide a public static instance() method.',
+					$adapter_class
+				);
+			}
+		}
+
+		if ( ! method_exists( $adapter_class, 'create_server' ) ) {
+			$errors[] = sprintf(
+				'MCP adapter class %s is missing the create_server() method.',
+				$adapter_class
+			);
+			return $errors;
+		}
+
+		$create_server_method = new \ReflectionMethod( $adapter_class, 'create_server' );
+		if ( ! $create_server_method->isPublic() ) {
+			$errors[] = sprintf(
+				'MCP adapter class %s must provide a public create_server() method.',
+				$adapter_class
+			);
+		}
+
+		if (
+			$create_server_method->getNumberOfRequiredParameters() > $create_server_argument_count ||
+			$create_server_method->getNumberOfParameters() < $create_server_argument_count
+		) {
+			$errors[] = sprintf(
+				'MCP adapter class %1$s has an incompatible create_server() signature for WooCommerce. Expected support for %2$d arguments.',
+				$adapter_class,
+				$create_server_argument_count
+			);
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Log MCP adapter compatibility errors.
+	 *
+	 * @param array $compatibility_errors Compatibility error messages.
+	 */
+	private function log_mcp_adapter_compatibility_errors( array $compatibility_errors ): void {
+		if ( ! function_exists( 'wc_get_logger' ) ) {
+			return;
+		}
+
+		wc_get_logger()->warning(
+			'MCP adapter compatibility check failed. Skipping MCP initialization. ' . implode( ' ', $compatibility_errors ),
+			array( 'source' => 'woocommerce-mcp' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Abilities/DomainAbilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Abilities/DomainAbilitiesTest.php
@@ -179,7 +179,7 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test querying products by SKU.
+	 * @testdox Should query products by SKU.
 	 */
 	public function test_products_query_by_sku(): void {
 		$product                     = \WC_Helper_Product::create_simple_product(
@@ -258,7 +258,47 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test querying orders by billing email.
+	 * @testdox Should reject product mutations without operation-specific product caps.
+	 */
+	public function test_product_mutations_require_operation_specific_product_caps(): void {
+		$product                     = \WC_Helper_Product::create_simple_product();
+		$this->created_product_ids[] = $product->get_id();
+
+		wp_set_current_user( $this->create_user_with_caps( array( 'read', 'edit_products' ) ) );
+
+		$created = wp_get_ability( 'woocommerce/product-create' )->execute(
+			array(
+				'type' => 'simple',
+				'name' => 'Disallowed Product',
+			)
+		);
+
+		$this->assertWPError( $created );
+		$this->assertSame( 'ability_invalid_permissions', $created->get_error_code() );
+
+		$updated = wp_get_ability( 'woocommerce/product-update' )->execute(
+			array(
+				'id'   => $product->get_id(),
+				'name' => 'Disallowed Product Update',
+			)
+		);
+
+		$this->assertWPError( $updated );
+		$this->assertSame( 'ability_invalid_permissions', $updated->get_error_code() );
+
+		$deleted = wp_get_ability( 'woocommerce/product-delete' )->execute(
+			array(
+				'id'    => $product->get_id(),
+				'force' => true,
+			)
+		);
+
+		$this->assertWPError( $deleted );
+		$this->assertSame( 'ability_invalid_permissions', $deleted->get_error_code() );
+	}
+
+	/**
+	 * @testdox Should query orders by billing email.
 	 */
 	public function test_orders_query_by_billing_email(): void {
 		$order = \WC_Helper_Order::create_order();
@@ -278,6 +318,25 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 		$this->assertSame( $order->get_id(), $result['orders'][0]['id'] );
 		$this->assertSame( 'domain-order-query@example.com', $result['orders'][0]['billing_email'] );
 		$this->assertNotEmpty( $result['orders'][0]['line_items'] );
+	}
+
+	/**
+	 * @testdox Should reject order queries without order read caps.
+	 */
+	public function test_orders_query_requires_order_read_caps(): void {
+		$order                     = \WC_Helper_Order::create_order();
+		$this->created_order_ids[] = $order->get_id();
+
+		wp_set_current_user( $this->create_user_with_caps( array( 'read', 'view_woocommerce_reports' ) ) );
+
+		$result = wp_get_ability( 'woocommerce/orders-query' )->execute(
+			array(
+				'id' => $order->get_id(),
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
 	}
 
 	/**
@@ -348,5 +407,24 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 		add_action( 'wp_abilities_api_init', $callback );
 		do_action( 'wp_abilities_api_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
 		remove_action( 'wp_abilities_api_init', $callback );
+	}
+
+	/**
+	 * Create a user with the given primitive capabilities.
+	 *
+	 * @param array $caps Capabilities to grant.
+	 * @return int User ID.
+	 */
+	private function create_user_with_caps( array $caps ): int {
+		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$user    = get_user_by( 'id', $user_id );
+
+		$this->assertNotFalse( $user );
+
+		foreach ( $caps as $cap ) {
+			$user->add_cap( $cap );
+		}
+
+		return $user_id;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Abilities/DomainAbilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Abilities/DomainAbilitiesTest.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * DomainAbilitiesTest class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Abilities;
+
+use Automattic\WooCommerce\Internal\Abilities\DomainAbilities;
+
+/**
+ * Tests for canonical WooCommerce domain abilities.
+ */
+class DomainAbilitiesTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * Ability IDs registered by these tests.
+	 *
+	 * @var array
+	 */
+	private $registered_ability_ids = array(
+		'woocommerce/products-query',
+		'woocommerce/products-manage',
+		'woocommerce/orders-query',
+		'woocommerce/orders-manage',
+	);
+
+	/**
+	 * Category IDs registered by these tests.
+	 *
+	 * @var array
+	 */
+	private $registered_category_ids = array();
+
+	/**
+	 * Product IDs created by these tests.
+	 *
+	 * @var array
+	 */
+	private $created_product_ids = array();
+
+	/**
+	 * Order IDs created by these tests.
+	 *
+	 * @var array
+	 */
+	private $created_order_ids = array();
+
+	/**
+	 * Original value of $wp_actions['wp_abilities_api_init'] to restore in tearDown.
+	 *
+	 * @var int|null
+	 */
+	private $original_abilities_init_action_count;
+
+	/**
+	 * Original value of $wp_actions['wp_abilities_api_categories_init'] to restore in tearDown.
+	 *
+	 * @var int|null
+	 */
+	private $original_categories_init_action_count;
+
+	/**
+	 * Set up each test.
+	 */
+	public function setUp(): void {
+		global $wp_actions;
+
+		parent::setUp();
+
+		$this->original_abilities_init_action_count  = $wp_actions['wp_abilities_api_init'] ?? null;
+		$this->original_categories_init_action_count = $wp_actions['wp_abilities_api_categories_init'] ?? null;
+
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			$abilities_bootstrap = WP_PLUGIN_DIR . '/woocommerce/vendor/wordpress/abilities-api/includes/bootstrap.php';
+			if ( file_exists( $abilities_bootstrap ) ) {
+				require_once $abilities_bootstrap;
+			}
+		}
+
+		wp_set_current_user(
+			$this->factory->user->create(
+				array(
+					'role' => 'administrator',
+				)
+			)
+		);
+
+		$this->register_woocommerce_category();
+		$this->register_domain_abilities();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		global $wp_actions;
+
+		foreach ( $this->created_order_ids as $order_id ) {
+			$order = wc_get_order( $order_id );
+
+			if ( $order ) {
+				$order->delete( true );
+			}
+		}
+
+		foreach ( $this->created_product_ids as $product_id ) {
+			$product = wc_get_product( $product_id );
+
+			if ( $product ) {
+				$product->delete( true );
+			}
+		}
+
+		foreach ( $this->registered_ability_ids as $ability_id ) {
+			if ( function_exists( 'wp_has_ability' ) && wp_has_ability( $ability_id ) ) {
+				wp_unregister_ability( $ability_id );
+			}
+		}
+
+		foreach ( $this->registered_category_ids as $category_id ) {
+			if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( $category_id ) ) {
+				wp_unregister_ability_category( $category_id );
+			}
+		}
+
+		if ( null !== $this->original_abilities_init_action_count ) {
+			$wp_actions['wp_abilities_api_init'] = $this->original_abilities_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $wp_actions['wp_abilities_api_init'] ) ) {
+			unset( $wp_actions['wp_abilities_api_init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		if ( null !== $this->original_categories_init_action_count ) {
+			$wp_actions['wp_abilities_api_categories_init'] = $this->original_categories_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $wp_actions['wp_abilities_api_categories_init'] ) ) {
+			unset( $wp_actions['wp_abilities_api_categories_init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test canonical abilities register with MCP metadata for the upstream adapter.
+	 */
+	public function test_canonical_abilities_register_with_mcp_metadata(): void {
+		foreach ( $this->registered_ability_ids as $ability_id ) {
+			$ability = wp_get_ability( $ability_id );
+
+			$this->assertNotNull( $ability, "{$ability_id} should be registered." );
+			$this->assertSame( 'woocommerce', $ability->get_category() );
+
+			$meta = $ability->get_meta();
+			$this->assertTrue( $meta['show_in_rest'] );
+			$this->assertSame( 'domain-api', $meta['woocommerce_ability_source'] );
+			$this->assertTrue( $meta['mcp']['public'] );
+			$this->assertSame( 'tool', $meta['mcp']['type'] );
+		}
+	}
+
+	/**
+	 * Test querying products by SKU.
+	 */
+	public function test_products_query_by_sku(): void {
+		$product                     = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Domain Query Product',
+				'sku'  => 'domain-query-product',
+			)
+		);
+		$this->created_product_ids[] = $product->get_id();
+
+		$result = wp_get_ability( 'woocommerce/products-query' )->execute(
+			array(
+				'sku' => 'domain-query-product',
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( $product->get_id(), $result['products'][0]['id'] );
+		$this->assertSame( 'Domain Query Product', $result['products'][0]['name'] );
+	}
+
+	/**
+	 * Test creating and updating a product.
+	 */
+	public function test_products_manage_create_and_update(): void {
+		$created = wp_get_ability( 'woocommerce/products-manage' )->execute(
+			array(
+				'action'        => 'create',
+				'type'          => 'simple',
+				'name'          => 'Domain Managed Product',
+				'sku'           => 'domain-managed-product',
+				'regular_price' => '19.99',
+			)
+		);
+
+		$this->assertNotWPError( $created );
+		$product_id                  = $created['product']['id'];
+		$this->created_product_ids[] = $product_id;
+
+		$this->assertSame( 'create', $created['action'] );
+		$this->assertSame( 'Domain Managed Product', $created['product']['name'] );
+		$this->assertSame( '19.99', $created['product']['regular_price'] );
+
+		$updated = wp_get_ability( 'woocommerce/products-manage' )->execute(
+			array(
+				'action'        => 'update',
+				'id'            => $product_id,
+				'name'          => 'Domain Managed Product Updated',
+				'regular_price' => '24.99',
+			)
+		);
+
+		$this->assertNotWPError( $updated );
+		$this->assertSame( 'update', $updated['action'] );
+		$this->assertSame( 'Domain Managed Product Updated', $updated['product']['name'] );
+		$this->assertSame( '24.99', $updated['product']['regular_price'] );
+	}
+
+	/**
+	 * Test querying orders by billing email.
+	 */
+	public function test_orders_query_by_billing_email(): void {
+		$order = \WC_Helper_Order::create_order();
+		$order->set_billing_email( 'domain-order-query@example.com' );
+		$order->save();
+		$this->created_order_ids[] = $order->get_id();
+
+		$result = wp_get_ability( 'woocommerce/orders-query' )->execute(
+			array(
+				'billing_email'      => 'domain-order-query@example.com',
+				'include_line_items' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( $order->get_id(), $result['orders'][0]['id'] );
+		$this->assertSame( 'domain-order-query@example.com', $result['orders'][0]['billing_email'] );
+		$this->assertNotEmpty( $result['orders'][0]['line_items'] );
+	}
+
+	/**
+	 * Test updating order status and adding an order note.
+	 */
+	public function test_orders_manage_update_status_and_add_note(): void {
+		$order                     = \WC_Helper_Order::create_order();
+		$this->created_order_ids[] = $order->get_id();
+
+		$updated = wp_get_ability( 'woocommerce/orders-manage' )->execute(
+			array(
+				'action' => 'update_status',
+				'id'     => $order->get_id(),
+				'status' => 'processing',
+			)
+		);
+
+		$this->assertNotWPError( $updated );
+		$this->assertSame( 'update_status', $updated['action'] );
+		$this->assertSame( 'processing', $updated['order']['status'] );
+
+		$note = wp_get_ability( 'woocommerce/orders-manage' )->execute(
+			array(
+				'action' => 'add_note',
+				'id'     => $order->get_id(),
+				'note'   => 'Domain ability order note.',
+			)
+		);
+
+		$this->assertNotWPError( $note );
+		$this->assertSame( 'add_note', $note['action'] );
+		$this->assertGreaterThan( 0, $note['note_id'] );
+	}
+
+	/**
+	 * Register the WooCommerce ability category for this test.
+	 */
+	private function register_woocommerce_category(): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
+			return;
+		}
+
+		if ( wp_has_ability_category( 'woocommerce' ) ) {
+			return;
+		}
+
+		$category = null;
+		$callback = function () use ( &$category ) {
+			$category = wp_register_ability_category(
+				'woocommerce',
+				array(
+					'label'       => 'WooCommerce',
+					'description' => 'Canonical WooCommerce store management abilities.',
+				)
+			);
+		};
+
+		add_action( 'wp_abilities_api_categories_init', $callback );
+		do_action( 'wp_abilities_api_categories_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		remove_action( 'wp_abilities_api_categories_init', $callback );
+
+		$this->assertNotNull( $category, 'WooCommerce ability category should register.' );
+		$this->registered_category_ids[] = 'woocommerce';
+	}
+
+	/**
+	 * Register canonical domain abilities for this test.
+	 */
+	private function register_domain_abilities(): void {
+		$callback = array( DomainAbilities::class, 'register_abilities' );
+
+		add_action( 'wp_abilities_api_init', $callback );
+		do_action( 'wp_abilities_api_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		remove_action( 'wp_abilities_api_init', $callback );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Abilities/DomainAbilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Abilities/DomainAbilitiesTest.php
@@ -21,9 +21,12 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 	 */
 	private $registered_ability_ids = array(
 		'woocommerce/products-query',
-		'woocommerce/products-manage',
+		'woocommerce/product-create',
+		'woocommerce/product-update',
+		'woocommerce/product-delete',
 		'woocommerce/orders-query',
-		'woocommerce/orders-manage',
+		'woocommerce/order-update-status',
+		'woocommerce/order-add-note',
 	);
 
 	/**
@@ -143,9 +146,19 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test canonical abilities register with MCP metadata for the upstream adapter.
+	 * @testdox Should register canonical abilities with MCP metadata for the upstream adapter.
 	 */
 	public function test_canonical_abilities_register_with_mcp_metadata(): void {
+		$expected_operations = array(
+			'woocommerce/products-query'      => 'query',
+			'woocommerce/product-create'      => 'create',
+			'woocommerce/product-update'      => 'update',
+			'woocommerce/product-delete'      => 'delete',
+			'woocommerce/orders-query'        => 'query',
+			'woocommerce/order-update-status' => 'update-status',
+			'woocommerce/order-add-note'      => 'add-note',
+		);
+
 		foreach ( $this->registered_ability_ids as $ability_id ) {
 			$ability = wp_get_ability( $ability_id );
 
@@ -155,8 +168,13 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 			$meta = $ability->get_meta();
 			$this->assertTrue( $meta['show_in_rest'] );
 			$this->assertSame( 'domain-api', $meta['woocommerce_ability_source'] );
+			$this->assertSame( $expected_operations[ $ability_id ], $meta['woocommerce_ability_operation'] );
 			$this->assertTrue( $meta['mcp']['public'] );
 			$this->assertSame( 'tool', $meta['mcp']['type'] );
+			$this->assertArrayHasKey( 'readonly', $meta['annotations'] );
+			$this->assertArrayHasKey( 'destructive', $meta['annotations'] );
+			$this->assertArrayHasKey( 'idempotent', $meta['annotations'] );
+			$this->assertArrayNotHasKey( 'expose_in_deprecated_woocommerce_mcp', $meta );
 		}
 	}
 
@@ -186,12 +204,11 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test creating and updating a product.
+	 * @testdox Should create and update a product.
 	 */
-	public function test_products_manage_create_and_update(): void {
-		$created = wp_get_ability( 'woocommerce/products-manage' )->execute(
+	public function test_product_create_and_update(): void {
+		$created = wp_get_ability( 'woocommerce/product-create' )->execute(
 			array(
-				'action'        => 'create',
 				'type'          => 'simple',
 				'name'          => 'Domain Managed Product',
 				'sku'           => 'domain-managed-product',
@@ -203,13 +220,11 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 		$product_id                  = $created['product']['id'];
 		$this->created_product_ids[] = $product_id;
 
-		$this->assertSame( 'create', $created['action'] );
 		$this->assertSame( 'Domain Managed Product', $created['product']['name'] );
 		$this->assertSame( '19.99', $created['product']['regular_price'] );
 
-		$updated = wp_get_ability( 'woocommerce/products-manage' )->execute(
+		$updated = wp_get_ability( 'woocommerce/product-update' )->execute(
 			array(
-				'action'        => 'update',
 				'id'            => $product_id,
 				'name'          => 'Domain Managed Product Updated',
 				'regular_price' => '24.99',
@@ -217,9 +232,29 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertNotWPError( $updated );
-		$this->assertSame( 'update', $updated['action'] );
 		$this->assertSame( 'Domain Managed Product Updated', $updated['product']['name'] );
 		$this->assertSame( '24.99', $updated['product']['regular_price'] );
+	}
+
+	/**
+	 * @testdox Should delete a product.
+	 */
+	public function test_product_delete(): void {
+		$product                     = \WC_Helper_Product::create_simple_product();
+		$this->created_product_ids[] = $product->get_id();
+
+		$deleted = wp_get_ability( 'woocommerce/product-delete' )->execute(
+			array(
+				'id'    => $product->get_id(),
+				'force' => true,
+			)
+		);
+
+		$this->assertNotWPError( $deleted );
+		$this->assertTrue( $deleted['deleted'] );
+		$this->assertSame( $product->get_id(), $deleted['id'] );
+
+		$this->created_product_ids = array_diff( $this->created_product_ids, array( $product->get_id() ) );
 	}
 
 	/**
@@ -246,34 +281,30 @@ class DomainAbilitiesTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test updating order status and adding an order note.
+	 * @testdox Should update order status and add an order note.
 	 */
-	public function test_orders_manage_update_status_and_add_note(): void {
+	public function test_order_update_status_and_add_note(): void {
 		$order                     = \WC_Helper_Order::create_order();
 		$this->created_order_ids[] = $order->get_id();
 
-		$updated = wp_get_ability( 'woocommerce/orders-manage' )->execute(
+		$updated = wp_get_ability( 'woocommerce/order-update-status' )->execute(
 			array(
-				'action' => 'update_status',
 				'id'     => $order->get_id(),
 				'status' => 'processing',
 			)
 		);
 
 		$this->assertNotWPError( $updated );
-		$this->assertSame( 'update_status', $updated['action'] );
 		$this->assertSame( 'processing', $updated['order']['status'] );
 
-		$note = wp_get_ability( 'woocommerce/orders-manage' )->execute(
+		$note = wp_get_ability( 'woocommerce/order-add-note' )->execute(
 			array(
-				'action' => 'add_note',
-				'id'     => $order->get_id(),
-				'note'   => 'Domain ability order note.',
+				'id'   => $order->get_id(),
+				'note' => 'Domain ability order note.',
 			)
 		);
 
 		$this->assertNotWPError( $note );
-		$this->assertSame( 'add_note', $note['action'] );
 		$this->assertGreaterThan( 0, $note['note_id'] );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/Fixtures/CompatibleMcpAdapterForTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/Fixtures/CompatibleMcpAdapterForTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * CompatibleMcpAdapterForTest class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MCP\Fixtures;
+
+/**
+ * Compatible MCP adapter test fixture.
+ */
+class CompatibleMcpAdapterForTest {
+
+	/**
+	 * Get the adapter instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		return new self();
+	}
+
+	/**
+	 * Create a server.
+	 *
+	 * @param mixed $server_id Server ID.
+	 * @param mixed $server_route_namespace Server route namespace.
+	 * @param mixed $server_route Server route.
+	 * @param mixed $server_name Server name.
+	 * @param mixed $server_description Server description.
+	 * @param mixed $server_version Server version.
+	 * @param mixed $mcp_transports MCP transports.
+	 * @param mixed $error_handler Error handler.
+	 * @param mixed $observability_handler Observability handler.
+	 * @param mixed $tools Tools.
+	 * @return self
+	 */
+	public function create_server( $server_id, $server_route_namespace, $server_route, $server_name, $server_description, $server_version, $mcp_transports, $error_handler, $observability_handler, $tools ) {
+		return $this;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/Fixtures/IncompatibleCreateServerMcpAdapterForTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/Fixtures/IncompatibleCreateServerMcpAdapterForTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * IncompatibleCreateServerMcpAdapterForTest class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MCP\Fixtures;
+
+/**
+ * MCP adapter test fixture with an incompatible create_server() signature.
+ */
+class IncompatibleCreateServerMcpAdapterForTest {
+
+	/**
+	 * Get the adapter instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		return new self();
+	}
+
+	/**
+	 * Create a server.
+	 *
+	 * @param mixed $server_id Server ID.
+	 * @param mixed $server_route_namespace Server route namespace.
+	 * @param mixed $server_route Server route.
+	 * @param mixed $server_name Server name.
+	 * @param mixed $server_description Server description.
+	 * @param mixed $server_version Server version.
+	 * @param mixed $mcp_transports MCP transports.
+	 * @param mixed $error_handler Error handler.
+	 * @param mixed $observability_handler Observability handler.
+	 * @param mixed $tools Tools.
+	 * @param mixed $resources Resources.
+	 * @return self
+	 */
+	public function create_server( $server_id, $server_route_namespace, $server_route, $server_name, $server_description, $server_version, $mcp_transports, $error_handler, $observability_handler, $tools, $resources ) {
+		return $this;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/Fixtures/MissingCreateServerMcpAdapterForTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/Fixtures/MissingCreateServerMcpAdapterForTest.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * MissingCreateServerMcpAdapterForTest class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MCP\Fixtures;
+
+/**
+ * MCP adapter test fixture missing create_server().
+ */
+class MissingCreateServerMcpAdapterForTest {
+
+	/**
+	 * Get the adapter instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		return new self();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -9,6 +9,9 @@ namespace Automattic\WooCommerce\Tests\Internal\MCP;
 
 use Automattic\WooCommerce\Internal\MCP\MCPAdapterProvider;
 use Automattic\WooCommerce\Internal\Abilities\AbilitiesRegistry;
+use Automattic\WooCommerce\Tests\Internal\MCP\Fixtures\CompatibleMcpAdapterForTest;
+use Automattic\WooCommerce\Tests\Internal\MCP\Fixtures\IncompatibleCreateServerMcpAdapterForTest;
+use Automattic\WooCommerce\Tests\Internal\MCP\Fixtures\MissingCreateServerMcpAdapterForTest;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
@@ -228,6 +231,59 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should report no MCP adapter compatibility errors for the loaded adapter.
+	 */
+	public function test_mcp_adapter_compatibility_check_passes_for_loaded_adapter() {
+		$errors = MCPAdapterProvider::get_mcp_adapter_compatibility_errors();
+
+		$this->assertEquals( array(), $errors, 'Loaded MCP adapter should provide the API surface WooCommerce requires' );
+	}
+
+	/**
+	 * @testdox Should report missing MCP adapter dependency classes.
+	 */
+	public function test_mcp_adapter_compatibility_check_reports_missing_dependency_classes() {
+		$errors = $this->get_mcp_adapter_compatibility_errors_for(
+			CompatibleMcpAdapterForTest::class,
+			array(
+				'Automattic\\WooCommerce\\Tests\\Internal\\MCP\\MissingMcpDependencyForTest' => 'test dependency',
+			)
+		);
+
+		$this->assertContains(
+			'Required test dependency class Automattic\\WooCommerce\\Tests\\Internal\\MCP\\MissingMcpDependencyForTest was not found.',
+			$errors,
+			'Missing MCP adapter dependency classes should be reported'
+		);
+	}
+
+	/**
+	 * @testdox Should report missing MCP adapter methods.
+	 */
+	public function test_mcp_adapter_compatibility_check_reports_missing_methods() {
+		$errors = $this->get_mcp_adapter_compatibility_errors_for( MissingCreateServerMcpAdapterForTest::class );
+
+		$this->assertContains(
+			'MCP adapter class ' . MissingCreateServerMcpAdapterForTest::class . ' is missing the create_server() method.',
+			$errors,
+			'Missing create_server() should be reported'
+		);
+	}
+
+	/**
+	 * @testdox Should report incompatible MCP adapter method signatures.
+	 */
+	public function test_mcp_adapter_compatibility_check_reports_incompatible_create_server_signature() {
+		$errors = $this->get_mcp_adapter_compatibility_errors_for( IncompatibleCreateServerMcpAdapterForTest::class );
+
+		$this->assertStringContainsString(
+			'incompatible create_server() signature',
+			implode( ' ', $errors ),
+			'Incompatible create_server() signatures should be reported'
+		);
+	}
+
+	/**
 	 * Test initialization state tracking.
 	 */
 	public function test_is_initialized_tracks_state() {
@@ -316,6 +372,25 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			),
 			array_values( $result ),
 			'Should maintain correct values after re-indexing'
+		);
+	}
+
+	/**
+	 * Get MCP adapter compatibility errors for a test adapter API shape.
+	 *
+	 * @param string $adapter_class    MCP adapter class name.
+	 * @param array  $required_classes Required class names keyed by class and labelled by dependency role.
+	 * @return array Compatibility error messages.
+	 */
+	private function get_mcp_adapter_compatibility_errors_for( string $adapter_class, array $required_classes = array() ): array {
+		$method = new \ReflectionMethod( MCPAdapterProvider::class, 'get_mcp_adapter_compatibility_errors_for' );
+		$method->setAccessible( true );
+
+		return $method->invoke(
+			null,
+			$adapter_class,
+			$required_classes,
+			10
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The MCP adapter dependency can be loaded by more than one WordPress plugin, so WooCommerce should avoid initializing MCP when another loaded adapter does not provide the API surface WooCommerce expects.

This adds runtime compatibility checks for the MCP adapter class, required support classes, and `create_server()` signature before registering WooCommerce MCP hooks. It also adds a TODO noting that the Abilities API Composer polyfill should be removed once WooCommerce requires WordPress 6.9+.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. From `plugins/woocommerce`, run `WP_ENV_PORT=8890 WP_ENV_TESTS_PORT=8087 pnpm run test:php:env -- --filter MCPAdapterProviderTest`.
3. Confirm the MCP adapter provider test suite passes.
4. Run `pnpm run lint:php:changes`.
5. Run `composer exec -- phpstan analyse src/Internal/MCP/MCPAdapterProvider.php src/Internal/Abilities/AbilitiesRegistry.php --memory-limit=2G`.

### Testing that has already taken place:

- `WP_ENV_PORT=8890 WP_ENV_TESTS_PORT=8087 pnpm run test:php:env -- --filter MCPAdapterProviderTest` passed with 14 tests and 16 assertions.
- `pnpm run lint:php:changes` passed.
- `composer exec -- phpstan analyse src/Internal/MCP/MCPAdapterProvider.php src/Internal/Abilities/AbilitiesRegistry.php --memory-limit=2G` passed.
- `git diff --check` passed.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Manual changelog entry included: `plugins/woocommerce/changelog/dev-mcp-adapter-compatibility-checks`.

</details>
