### PR TITLE
Remove nofollow from internal product links in WooCommerce Blocks

### DIFF
--- a/plugins/woocommerce/changelog/64619-fix-43097-remove-nofollow-from-product-links
+++ b/plugins/woocommerce/changelog/64619-fix-43097-remove-nofollow-from-product-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove `rel="nofollow"` from internal product permalink links in WooCommerce Blocks.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
@@ -161,7 +161,6 @@ const AddToCartButton = ( {
 		};
 	} else if ( ! allowAddToCart ) {
 		buttonProps.href = permalink;
-		buttonProps.rel = 'nofollow';
 		buttonProps.onClick = () => {
 			dispatchStoreEvent( 'product-view-link', {
 				product,


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the WooCommerce Contributing Guidelines and WordPress Coding Standards.
- [x] I have checked to ensure there aren't other open Pull Requests for the same change.
- [x] I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

This PR removes `rel="nofollow"` from product button links in WooCommerce Blocks when the button links to the product permalink instead of adding directly to cart.

That fallback link is an internal navigational link to the product page, not a cart or checkout action. Marking it as `nofollow` is unnecessary and not ideal for internal site navigation.

The `nofollow` attribute is still preserved for cart links in the cart contents case.

Closes #43097

### How to test the changes in this Pull Request:

1. Use a product/button block configuration where the button links to the product page instead of adding directly to cart.
2. Inspect the rendered anchor element.
3. Before this change: the product permalink link includes `rel="nofollow"`.
4. After this change: the product permalink link no longer includes `rel="nofollow"`.
5. Verify cart-content links still behave as before.

### Testing that has already taken place:

- Verified the change only affects the fallback product permalink path
- Confirmed cart-content links still retain their existing `nofollow` behavior
- Inspected the resulting diff to ensure this is a minimal, targeted change

### Milestone

- [x] Automatically assign milestone for the next WooCommerce version

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Remove `rel="nofollow"` from internal product permalink links in WooCommerce Blocks.

</details>
