### PR TITLE
Mini-Cart block: add display style setting (icon only / text only / icon and text)

### DIFF
--- a/plugins/woocommerce/changelog/feat-issue-61653
+++ b/plugins/woocommerce/changelog/feat-issue-61653
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Mini-Cart block: add display style setting to show icon only, text only, or icon and text

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json
@@ -28,6 +28,10 @@
 			"type": "string",
 			"default": "cart"
 		},
+		"displayStyle": {
+			"type": "string",
+			"default": "icon_only"
+		},
 		"addToCartBehaviour": {
 			"type": "string",
 			"default": "none"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.tsx
@@ -21,7 +21,7 @@ import {
 	isNumber,
 } from '@woocommerce/types';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
-import { sprintf, _n } from '@wordpress/i18n';
+import { sprintf, _n, __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { CHECKOUT_URL } from '@woocommerce/block-settings';
 import type { ReactRootWithContainer } from '@woocommerce/base-utils';
@@ -30,6 +30,7 @@ import type { ReactRootWithContainer } from '@woocommerce/base-utils';
  * Internal dependencies
  */
 import type { BlockAttributes } from './types';
+import { DisplayStyle } from './types';
 import QuantityBadge from './quantity-badge';
 import { MiniCartContentsBlock } from './mini-cart-contents/block';
 import './style.scss';
@@ -54,6 +55,7 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 		colorClassNames,
 		contents = '',
 		miniCartIcon,
+		displayStyle = DisplayStyle.ICON_ONLY,
 		addToCartBehaviour = 'none',
 		onCartClickBehaviour = 'open_drawer',
 		hasHiddenPrice = true,
@@ -259,13 +261,20 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 				} }
 				aria-label={ ariaLabel }
 			>
-				<QuantityBadge
-					count={ cartItemsCount }
-					icon={ miniCartIcon }
-					iconColor={ iconColor }
-					productCountColor={ productCountColor }
-					productCountVisibility={ productCountVisibility }
-				/>
+				{ displayStyle !== DisplayStyle.TEXT_ONLY && (
+					<QuantityBadge
+						count={ cartItemsCount }
+						icon={ miniCartIcon }
+						iconColor={ iconColor }
+						productCountColor={ productCountColor }
+						productCountVisibility={ productCountVisibility }
+					/>
+				) }
+				{ displayStyle !== DisplayStyle.ICON_ONLY && (
+					<span className="wc-block-mini-cart__label">
+						{ __( 'Cart', 'woocommerce' ) }
+					</span>
+				) }
 				{ ! hasHiddenPrice && (
 					<span
 						className="wc-block-mini-cart__amount"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.tsx
@@ -268,6 +268,9 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 						iconColor={ iconColor }
 						productCountColor={ productCountColor }
 						productCountVisibility={ productCountVisibility }
+						{ ...( displayStyle === DisplayStyle.ICON_ONLY && {
+							ariaLabel: __( 'Cart', 'woocommerce' ),
+						} ) }
 					/>
 				) }
 				{ displayStyle !== DisplayStyle.ICON_ONLY && (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/component-frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/component-frontend.tsx
@@ -48,6 +48,7 @@ const renderMiniCartFrontend = () => {
 				colorClassNames,
 				style: el.dataset.style ? JSON.parse( el.dataset.style ) : {},
 				miniCartIcon: el.dataset.miniCartIcon,
+				displayStyle: el.dataset.displayStyle || 'icon_only',
 				addToCartBehaviour: el.dataset.addToCartBehaviour || 'none',
 				onCartClickBehaviour:
 					el.dataset.onCartClickBehaviour || 'open_drawer',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/edit.tsx
@@ -352,6 +352,9 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							productCountColor={ productCountColor }
 							icon={ miniCartIcon }
 							productCountVisibility={ productCountVisibility }
+							{ ...( displayStyle === DisplayStyle.ICON_ONLY && {
+								ariaLabel: __( 'Cart', 'woocommerce' ),
+							} ) }
 						/>
 					) }
 					{ displayStyle !== DisplayStyle.ICON_ONLY && (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/edit.tsx
@@ -31,11 +31,13 @@ import type { ColorPaletteOption } from '@woocommerce/editor-components/color-pa
 import QuantityBadge from './quantity-badge';
 import { defaultColorItem } from './utils/defaults';
 import { migrateAttributesToColorPanel } from './utils/data';
+import { DisplayStyle } from './types';
 import './editor.scss';
 import { useThemeColors } from '../../shared/hooks/use-theme-colors';
 
 export interface Attributes {
 	miniCartIcon: 'cart' | 'bag' | 'bag-alt';
+	displayStyle: DisplayStyle;
 	addToCartBehaviour: string;
 	onCartClickBehaviour: 'navigate_to_checkout' | 'open_drawer';
 	hasHiddenPrice: boolean;
@@ -65,6 +67,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 		iconColor = defaultColorItem,
 		productCountColor = defaultColorItem,
 		miniCartIcon,
+		displayStyle = DisplayStyle.ICON_ONLY,
 		productCountVisibility,
 	} = migrateAttributesToColorPanel( attributes );
 	const miniCartButtonRef = useRef< HTMLButtonElement >( null );
@@ -118,53 +121,74 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 		<div { ...blockProps }>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
-					<ToggleGroupControl
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-						className="wc-block-editor-mini-cart__cart-icon-toggle"
-						isBlock
-						label={ __( 'Cart Icon', 'woocommerce' ) }
-						value={ miniCartIcon }
-						onChange={ ( value: 'cart' | 'bag' | 'bag-alt' ) => {
-							setAttributes( {
-								miniCartIcon: value,
-							} );
-						} }
-					>
-						<ToggleGroupControlOption
-							value={ 'cart' }
-							label={ <Icon size={ 32 } icon={ cartOutline } /> }
-						/>
-						<ToggleGroupControlOption
-							value={ 'bag' }
-							label={ <Icon size={ 32 } icon={ bag } /> }
-						/>
-						<ToggleGroupControlOption
-							value={ 'bag-alt' }
-							label={ <Icon size={ 32 } icon={ bagAlt } /> }
-						/>
-					</ToggleGroupControl>
-					<BaseControl
-						__nextHasNoMarginBottom
-						id="wc-block-mini-cart__display-toggle"
-						label={ __( 'Display', 'woocommerce' ) }
-					>
-						<ToggleControl
+					<RadioControl
+						className="wc-block-mini-cart__display-style-radiocontrol"
+						label={ __( 'Icon options', 'woocommerce' ) }
+						selected={ displayStyle }
+						options={ [
+							{
+								label: __(
+									'Icon and text',
+									'woocommerce'
+								),
+								value: DisplayStyle.ICON_AND_TEXT,
+							},
+							{
+								label: __( 'Text only', 'woocommerce' ),
+								value: DisplayStyle.TEXT_ONLY,
+							},
+							{
+								label: __( 'Icon only', 'woocommerce' ),
+								value: DisplayStyle.ICON_ONLY,
+							},
+						] }
+						onChange={ ( value: DisplayStyle ) =>
+							setAttributes( { displayStyle: value } )
+						}
+					/>
+					{ displayStyle !== DisplayStyle.TEXT_ONLY && (
+						<ToggleGroupControl
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
-							label={ __( 'Display total price', 'woocommerce' ) }
-							help={ __(
-								'Toggle to display the total price of products in the shopping cart. If no products have been added, the price will not display.',
-								'woocommerce'
-							) }
-							checked={ ! hasHiddenPrice }
-							onChange={ () =>
+							className="wc-block-editor-mini-cart__cart-icon-toggle"
+							isBlock
+							label={ __( 'Icon display', 'woocommerce' ) }
+							value={ miniCartIcon }
+							onChange={ ( value: 'cart' | 'bag' | 'bag-alt' ) => {
 								setAttributes( {
-									hasHiddenPrice: ! hasHiddenPrice,
-								} )
-							}
-						/>
-					</BaseControl>
+									miniCartIcon: value,
+								} );
+							} }
+						>
+							<ToggleGroupControlOption
+								value={ 'cart' }
+								label={ <Icon size={ 32 } icon={ cartOutline } /> }
+							/>
+							<ToggleGroupControlOption
+								value={ 'bag' }
+								label={ <Icon size={ 32 } icon={ bag } /> }
+							/>
+							<ToggleGroupControlOption
+								value={ 'bag-alt' }
+								label={ <Icon size={ 32 } icon={ bagAlt } /> }
+							/>
+						</ToggleGroupControl>
+					) }
+					<ToggleControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ __( 'Display total price', 'woocommerce' ) }
+						help={ __(
+							'Shopper will only see it when having products in Cart.',
+							'woocommerce'
+						) }
+						checked={ ! hasHiddenPrice }
+						onChange={ () =>
+							setAttributes( {
+								hasHiddenPrice: ! hasHiddenPrice,
+							} )
+						}
+					/>
 					<BaseControl
 						__nextHasNoMarginBottom
 						id="wc-block-mini-cart__product-count-basecontrol"
@@ -321,13 +345,20 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 					ref={ miniCartButtonRef }
 					className="wc-block-mini-cart__button"
 				>
-					<QuantityBadge
-						count={ productCount }
-						iconColor={ iconColor }
-						productCountColor={ productCountColor }
-						icon={ miniCartIcon }
-						productCountVisibility={ productCountVisibility }
-					/>
+					{ displayStyle !== DisplayStyle.TEXT_ONLY && (
+						<QuantityBadge
+							count={ productCount }
+							iconColor={ iconColor }
+							productCountColor={ productCountColor }
+							icon={ miniCartIcon }
+							productCountVisibility={ productCountVisibility }
+						/>
+					) }
+					{ displayStyle !== DisplayStyle.ICON_ONLY && (
+						<span className="wc-block-mini-cart__label">
+							{ __( 'Cart', 'woocommerce' ) }
+						</span>
+					) }
 					{ ! hasHiddenPrice && (
 						<span
 							className="wc-block-mini-cart__amount"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/quantity-badge/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/quantity-badge/index.tsx
@@ -16,6 +16,7 @@ interface Props {
 	iconColor?: ColorItem | { color: undefined };
 	productCountColor?: ColorItem | { color: undefined };
 	productCountVisibility?: productCountVisibilityType;
+	ariaLabel?: string;
 }
 
 const QuantityBadge = ( {
@@ -24,6 +25,7 @@ const QuantityBadge = ( {
 	iconColor,
 	productCountColor,
 	productCountVisibility,
+	ariaLabel,
 }: Props ): JSX.Element => {
 	function getIcon( iconName?: 'cart' | 'bag' | 'bag-alt' ) {
 		switch ( iconName ) {
@@ -45,7 +47,10 @@ const QuantityBadge = ( {
 	const displayCount = shouldDisplayCount ? count : '';
 
 	return (
-		<span className="wc-block-mini-cart__quantity-badge">
+		<span
+			className="wc-block-mini-cart__quantity-badge"
+			{ ...( ariaLabel && { 'aria-label': ariaLabel } ) }
+		>
 			<Icon
 				className="wc-block-mini-cart__icon"
 				color={ iconColor?.color }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/types.ts
@@ -10,6 +10,12 @@ export type productCountVisibilityType =
 	| 'greater_than_zero'
 	| undefined;
 
+export enum DisplayStyle {
+	ICON_AND_TEXT = 'icon_and_text',
+	TEXT_ONLY = 'text_only',
+	ICON_ONLY = 'icon_only',
+}
+
 export interface ColorItem {
 	color: string;
 	name?: string;
@@ -24,6 +30,7 @@ export interface BlockAttributes {
 	style?: Record< string, Record< string, string > >;
 	contents: string;
 	miniCartIcon?: IconType;
+	displayStyle?: DisplayStyle;
 	addToCartBehaviour: string;
 	onCartClickBehaviour: string;
 	hasHiddenPrice: boolean;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -621,7 +621,7 @@ class MiniCart extends AbstractBlock {
 				>
 					<?php $iapi_display_style = isset( $attributes['displayStyle'] ) ? $attributes['displayStyle'] : 'icon_only'; ?>
 					<?php if ( 'text_only' !== $iapi_display_style ) : ?>
-					<span class="wc-block-mini-cart__quantity-badge">
+					<span class="wc-block-mini-cart__quantity-badge"<?php echo 'icon_only' === $iapi_display_style ? ' aria-label="' . esc_attr__( 'Cart', 'woocommerce' ) . '"' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 						<?php
 							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							echo $icon;
@@ -835,7 +835,8 @@ class MiniCart extends AbstractBlock {
 
 		$icon_markup = '';
 		if ( 'text_only' !== $display_style ) {
-			$icon_markup = '<span class="wc-block-mini-cart__quantity-badge">
+			$badge_aria_label = 'icon_only' === $display_style ? ' aria-label="' . esc_attr__( 'Cart', 'woocommerce' ) . '"' : '';
+			$icon_markup      = '<span class="wc-block-mini-cart__quantity-badge"' . $badge_aria_label . '>
 				' . $icon . '
 				' . ( 'never' !== $product_count_visibility ? '<span class="wc-block-mini-cart__badge" style="' . esc_attr( $styles ) . '"></span>' : '' ) . '
 			</span>';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -619,6 +619,8 @@ class MiniCart extends AbstractBlock {
 					class="wc-block-mini-cart__button"
 					<?php echo $button_role; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				>
+					<?php $iapi_display_style = isset( $attributes['displayStyle'] ) ? $attributes['displayStyle'] : 'icon_only'; ?>
+					<?php if ( 'text_only' !== $iapi_display_style ) : ?>
 					<span class="wc-block-mini-cart__quantity-badge">
 						<?php
 							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -636,6 +638,10 @@ class MiniCart extends AbstractBlock {
 							</span>
 						<?php endif; ?>
 					</span>
+					<?php endif; ?>
+					<?php if ( 'icon_only' !== $iapi_display_style ) : ?>
+					<span class="wc-block-mini-cart__label"><?php echo esc_html__( 'Cart', 'woocommerce' ); ?></span>
+					<?php endif; ?>
 					<?php if ( $cart_always_shows_price ) : ?>
 						<span data-wp-text="state.formattedSubtotal" class="wc-block-mini-cart__amount" style="<?php echo 'color:' . esc_attr( $price_color ); ?>">
 						</span>
@@ -825,12 +831,22 @@ class MiniCart extends AbstractBlock {
 		$icon                = MiniCartUtils::get_svg_icon( $attributes['miniCartIcon'] ?? '', $icon_color );
 
 		$product_count_visibility = isset( $attributes['productCountVisibility'] ) ? $attributes['productCountVisibility'] : 'greater_than_zero';
+		$display_style            = isset( $attributes['displayStyle'] ) ? $attributes['displayStyle'] : 'icon_only';
 
-		$button_html = '<span class="wc-block-mini-cart__quantity-badge">
-			' . $icon . '
-			' . ( 'never' !== $product_count_visibility ? '<span class="wc-block-mini-cart__badge" style="' . esc_attr( $styles ) . '"></span>' : '' ) . '
-		</span>
-		' . $this->get_cart_price_markup( $attributes );
+		$icon_markup = '';
+		if ( 'text_only' !== $display_style ) {
+			$icon_markup = '<span class="wc-block-mini-cart__quantity-badge">
+				' . $icon . '
+				' . ( 'never' !== $product_count_visibility ? '<span class="wc-block-mini-cart__badge" style="' . esc_attr( $styles ) . '"></span>' : '' ) . '
+			</span>';
+		}
+
+		$label_markup = '';
+		if ( 'icon_only' !== $display_style ) {
+			$label_markup = '<span class="wc-block-mini-cart__label">' . esc_html__( 'Cart', 'woocommerce' ) . '</span>';
+		}
+
+		$button_html = $icon_markup . $label_markup . $this->get_cart_price_markup( $attributes );
 
 		if ( is_cart() || is_checkout() ) {
 			if ( $this->should_not_render_mini_cart( $attributes ) ) {
@@ -845,7 +861,7 @@ class MiniCart extends AbstractBlock {
 
 		$template_part_contents = $this->get_template_part_contents();
 
-		return '<div class="' . esc_attr( $wrapper_classes ) . '" style="' . esc_attr( $wrapper_styles ) . '">
+		return '<div class="' . esc_attr( $wrapper_classes ) . '" style="' . esc_attr( $wrapper_styles ) . '" data-display-style="' . esc_attr( $display_style ) . '">
 			<button class="wc-block-mini-cart__button" aria-label="' . __( 'Cart', 'woocommerce' ) . '">' . $button_html . '</button>
 			<div class="is-loading wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
 				<div class="wc-block-mini-cart__drawer wc-block-components-drawer">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a `Display Style` setting to the Mini-Cart block, matching the pattern already used in the Customer Account block. Users can now choose between:

- Icon only (default — no change to existing blocks)
- Text only — shows "Cart" label, hides icon
- Icon and text — shows both

Closes #61653 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/0bde8ca0-9090-4b4c-82c0-c6e6ef7659b9

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add a Mini-Cart block to a page or open the Header template part in the Site Editor.
2. In the block sidebar under Settings, confirm a new "Icon options" radio control appears with three choices: Icon and text, Text only, Icon only.
3. Select Text only — the editor preview should show only the "Cart" label with no icon. The icon picker below should disappear.
4. Save the template and visit the frontend — confirm the icon is not rendered.
5. Repeat for Icon and text — both icon and label should appear in editor and on frontend.
6. Repeat for Icon only — only the icon badge should appear (default behavior, unaffected).
7. Confirm existing Mini-Cart blocks with no saved displayStyle still default to icon only.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
