### PR TITLE
Add PR release communication workflow 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -114,3 +114,23 @@ Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce
 #### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
 
 </details>
+
+### Release Communication
+
+<!-- release-communication-section -->
+Select if this PR needs a generated summary for release notes:
+
+- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
+- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
+
+<details>
+<summary>When to use each?</summary>
+
+**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
+- Example: "New bulk editing for products", "Improved checkout performance"
+
+**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
+- Example: "Hook signature change", "Deprecated filter", "REST API field removed"
+
+An AI will analyze your PR and post a draft comment for you to review and edit.
+</details>

--- a/.github/workflows/pr-release-communication.yml
+++ b/.github/workflows/pr-release-communication.yml
@@ -64,6 +64,27 @@ jobs:
             1. gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body
             2. gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
 
+            ANALYSIS GUIDELINES
+
+            Title:
+            - Keep to 1-3 sentences
+            - Lead with the user/merchant impact
+            - Avoid internal implementation details (file names, test coverage, etc.)
+            - Write as if for a changelog or newsletter audience
+            - Focus on "what's different now" not "what code changed"
+
+            What Changed:
+            - Describe behavior changes, not file modifications
+            - Focus on what users will see or experience differently
+            - Avoid listing specific files, classes, or internal components
+
+            User Impact:
+            - Think from the merchant's perspective
+            - What problem does this solve for them?
+            - Do they need to take any action?
+            - Will they notice anything different in the admin or frontend?
+            - Consider performance, UX, and workflow impacts
+
             TONE: Clear, accessible, focus on user benefits
 
       - name: Post Feature Highlight Comment
@@ -171,6 +192,33 @@ jobs:
             METHOD
             1. gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body
             2. gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+
+            ANALYSIS GUIDELINES
+
+            Title:
+            - Keep to 1-3 sentences
+            - Lead with the developer impact
+            - Avoid internal implementation details (file names, test coverage, etc.)
+            - Write as if for a developer changelog audience
+            - Focus on "what's different now" not "what code changed"
+
+            What Changed:
+            - Describe behavior changes, not file modifications
+            - Focus on third-party developers building extensions/plugins
+            - Always mention new or changed hooks/filters with their exact names
+            - Highlight API changes, new endpoints, or data structure changes
+            - Call out breaking changes prominently
+            - Note deprecations and migration paths
+
+            How to Detect:
+            - Help developers identify if their code is affected
+            - Reference specific hook/filter names to search for
+            - Mention affected APIs or class methods
+
+            Actions Needed:
+            - Provide clear migration steps
+            - Identify new extension points they might want to use
+            - Note any deprecation timelines
 
             FOCUS ON:
             - Hook changes (added, removed, signature changes)

--- a/.github/workflows/pr-release-communication.yml
+++ b/.github/workflows/pr-release-communication.yml
@@ -1,0 +1,235 @@
+name: PR Release Communication
+
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: release-comm-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # ─────────────────────────────────────────────────────────────
+  # JOB 1: Feature Highlights (for users/merchants)
+  # ─────────────────────────────────────────────────────────────
+  feature-highlight:
+    name: Generate Feature Highlight
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.body, '[x] **Feature Highlight**')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Add Feature Highlight label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['feature highlight']
+            });
+
+      - name: Generate Feature Highlight
+        id: highlight
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: >
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --json-schema '{"type":"object","properties":{"title":{"type":"string"},"what_changed":{"type":"string"},"user_impact":{"type":"string"}},"required":["title","what_changed","user_impact"]}'
+          prompt: |
+            Feature Highlight Generator for WooCommerce
+
+            REPO: ${{ github.repository }}
+            PR: #${{ github.event.pull_request.number }}
+
+            OBJECTIVE
+            Generate a feature highlight for release notes and announcements.
+
+            OUTPUT FORMAT (JSON)
+            - title: Short, catchy title (5-10 words)
+            - what_changed: 2-3 sentences describing the changes
+            - user_impact: 2-3 sentences explaining benefits for store owners/merchants
+
+            METHOD
+            1. gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body
+            2. gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+
+            TONE: Clear, accessible, focus on user benefits
+
+      - name: Post Feature Highlight Comment
+        if: steps.highlight.outputs.structured_output
+        uses: actions/github-script@v7
+        env:
+          OUTPUT: ${{ steps.highlight.outputs.structured_output }}
+        with:
+          script: |
+            const data = JSON.parse(process.env.OUTPUT);
+            const marker = '<!-- feature-highlight-comment -->';
+
+            const body = `${marker}
+            ## ✨ Feature Highlight (Draft)
+
+            **${data.title}**
+
+            ### What Changed
+            ${data.what_changed}
+
+            ### User Impact
+            ${data.user_impact}
+
+            ---
+            *🤖 Auto-generated. Please review and edit.*
+
+            cc @woocommerce/developer-advocacy`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
+
+  # ─────────────────────────────────────────────────────────────
+  # JOB 2: Developer Advisory (for developers/extenders)
+  # ─────────────────────────────────────────────────────────────
+  developer-advisory:
+    name: Generate Developer Advisory
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.body, '[x] **Developer Advisory**')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Add Developer Advisory label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['developer advisory']
+            });
+
+      - name: Generate Developer Advisory
+        id: advisory
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: >
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --json-schema '{"type":"object","properties":{"title":{"type":"string"},"what_changed":{"type":"string"},"how_to_detect":{"type":"string"},"actions_needed":{"type":"string"}},"required":["title","what_changed","how_to_detect","actions_needed"]}'
+          prompt: |
+            Developer Advisory Generator for WooCommerce
+
+            REPO: ${{ github.repository }}
+            PR: #${{ github.event.pull_request.number }}
+
+            OBJECTIVE
+            Generate a developer advisory for changes that affect plugins, themes, or extensions.
+
+            OUTPUT FORMAT (JSON)
+            - title: Clear title describing the change (5-15 words)
+            - what_changed: 2-3 sentences describing the technical changes (hooks, APIs, classes, etc.)
+            - how_to_detect: 2-3 sentences explaining how developers can tell if their code is affected
+            - actions_needed: 2-3 sentences describing what developers need to do to adapt
+
+            METHOD
+            1. gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body
+            2. gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+
+            FOCUS ON:
+            - Hook changes (added, removed, signature changes)
+            - Class/method changes (deprecations, removals, renames)
+            - Filter/action changes
+            - REST API changes
+            - Database/option key changes
+
+            TONE: Technical but clear, actionable
+
+      - name: Post Developer Advisory Comment
+        if: steps.advisory.outputs.structured_output
+        uses: actions/github-script@v7
+        env:
+          OUTPUT: ${{ steps.advisory.outputs.structured_output }}
+        with:
+          script: |
+            const data = JSON.parse(process.env.OUTPUT);
+            const marker = '<!-- developer-advisory-comment -->';
+
+            const body = `${marker}
+            ## ⚠️ Developer Advisory (Draft)
+
+            **${data.title}**
+
+            ### What Changed
+            ${data.what_changed}
+
+            ### How to Detect if You're Affected
+            ${data.how_to_detect}
+
+            ### Actions Needed
+            ${data.actions_needed}
+
+            ---
+            *🤖 Auto-generated. Please review and edit.*
+
+            cc @woocommerce/developer-advocacy`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }


### PR DESCRIPTION
Add PR release communication workflow with feature highlights and developer advisories

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a new section to the PR template for "Release Communications". Developers can check the box to request that Claude generate a Feature Highlight or Developer Advisory for their PR, which is then tagged to the @woocommerce/developer-advocacy team for review and publication.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
