### PR TITLE
fix: WC_Order_Data_Store_CPT::get_unpaid_orders returns orders before date instead of after

### DIFF
--- a/plugins/woocommerce/changelog/64635-ai-agent-rsmapgj-118-1777972056
+++ b/plugins/woocommerce/changelog/64635-ai-agent-rsmapgj-118-1777972056
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WC_Order_Data_Store_CPT::get_unpaid_orders returning orders modified before the given date instead of after.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -559,7 +559,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				FROM {$wpdb->posts} AS posts
 				WHERE   posts.post_type   IN ('" . implode( "','", wc_get_order_types() ) . "')
 				AND     posts.post_status = '" . OrderInternalStatus::PENDING . "'
-				AND     posts.post_modified < %s",
+				AND     posts.post_modified > %s",
 				// @codingStandardsIgnoreEnd
 				gmdate( 'Y-m-d H:i:s', absint( $date ) )
 			)


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Order_Data_Store_CPT::get_unpaid_orders( $date )` is documented as returning unpaid orders **after** a given date, but its SQL query used `posts.post_modified < %s`, returning orders modified **before** the given date instead. Callers passing a timestamp expecting "orders modified after this date" received an empty array (or stale orders), which silently breaks any cleanup/reminder routine relying on this helper.

This PR flips the comparison operator from `<` to `>` so the SQL matches the docblock and the method name's intent.

- Root cause: incorrect SQL comparison operator in `WC_Order_Data_Store_CPT::get_unpaid_orders()`.
- Fix: change `posts.post_modified < %s` to `posts.post_modified > %s` in `plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php`.

Closes #35675

### Screenshots or screen recordings:

<!-- This PR was generated by the RSMAPGJ AI Coder pipeline. UI screenshots have not been captured by the agent. Reviewer should add before/after screenshots if the change has visible UI impact. This change has no UI surface — it affects a backend data-store query only. -->

### How to test the changes in this Pull Request:

Reproduction steps and acceptance criteria are documented in the linked Linear ticket and the upstream issue. Recommended manual verification:

1. Create a pending (unpaid) order in the WooCommerce admin.
2. From a snippet/mu-plugin or REPL, call:
   ```php
   $date_one_year_ago = ( new DateTime( 'now - 1 year' ) )->getTimestamp();
   $cpt = new WC_Order_Data_Store_CPT();
   $unpaid = $cpt->get_unpaid_orders( $date_one_year_ago );
   var_dump( $unpaid );
   ```
3. Before this fix: `$unpaid` is an empty array. After this fix: `$unpaid` contains the new pending order's ID, because the order was modified **after** "one year ago".
4. Run the order data-store unit test suite for the area touched: `pnpm --filter='@woocommerce/plugin-woocommerce' test:php -- --filter Order_Data_Store_CPT`.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff (iter 2; one non-blocking comment from iter 1). PHP lint clean for the modified file.
- Manual: none yet. Human verification recommended before merge given this changes a SQL query's semantics.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix WC_Order_Data_Store_CPT::get_unpaid_orders returning orders modified before the given date instead of after.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-118
