### PR TITLE
fix: Store API product filtering ignores taxonomies registered for multiple object types

### DIFF
--- a/plugins/woocommerce/changelog/64637-ai-agent-rsmapgj-208-1777970700
+++ b/plugins/woocommerce/changelog/64637-ai-agent-rsmapgj-208-1777970700
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure Store API product filtering recognises taxonomies registered for multiple object types (e.g. both `product` and `product-variation`).

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -107,11 +107,13 @@ class ProductQuery implements QueryClausesGenerator {
 		// Gets all registered product taxonomies and prefixes them with `tax_`.
 		// This is needed to avoid situations where a user registers a new product taxonomy with the same name as default field.
 		// eg an `sku` taxonomy will be mapped to `tax_sku`.
+		// Use get_object_taxonomies() instead of get_taxonomies() to include taxonomies registered for multiple object types
+		// (e.g. both 'product' and 'product-variation'), which get_taxonomies() with 'object_type' incorrectly excludes.
 		$all_product_taxonomies = array_map(
 			function ( $value ) {
 				return '_unstable_tax_' . $value;
 			},
-			get_taxonomies( array( 'object_type' => array( 'product' ) ), 'names' )
+			get_object_taxonomies( 'product', 'names' )
 		);
 
 		// Map between taxonomy name and arg key.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Store API's `ProductQuery::get_main_query_clauses()` builds a whitelist of product-related taxonomies for filtering using `get_taxonomies( array( 'object_type' => array( 'product' ) ), 'names' )`. That helper only returns taxonomies whose registered `object_type` array equals exactly `['product']` — so taxonomies registered against multiple object types (e.g. both `product` and `product-variation`) are silently dropped from the whitelist and their filters are ignored when querying the Store API products endpoint.

This PR swaps the call for `get_object_taxonomies( 'product', 'names' )`, which returns every taxonomy that includes `product` among its registered object types, regardless of how many other object types it is also attached to.

- Root cause: `get_taxonomies()` filters by exact `object_type` match, not membership.
- Fix: use `get_object_taxonomies( 'product', 'names' )`, which is the correct WordPress helper for "all taxonomies attached to the `product` post type."
- Scope: a single 1-line behaviour change inside `plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php` plus an explanatory comment.

Closes #44298

### Screenshots or screen recordings:

<!-- This PR was generated by the RSMAPGJ AI Coder pipeline. UI screenshots have not been captured by the agent. Reviewer should add before/after screenshots if the change has visible UI impact. The change is API-side only (Store API filtering); a network-tab capture of `/wp-json/wc/store/v1/products?<dual_tax>=<term>` before/after would be the relevant artifact. -->

### How to test the changes in this Pull Request:

Reproduction steps and acceptance criteria are documented in the linked Linear ticket and the upstream issue. Recommended manual verification:

1. Register a custom taxonomy associated with both `product` and `product-variation`, e.g. via an mu-plugin:

   ```php
   add_action( 'init', function () {
       register_taxonomy( 'dual_tax', array( 'product', 'product-variation' ), array(
           'label'        => 'Dual Tax',
           'public'       => true,
           'hierarchical' => false,
           'rewrite'      => array( 'slug' => 'dual-tax' ),
           'show_in_rest' => true,
       ) );
   }, 5 );
   ```
2. Create two simple products and assign each a different term in `dual_tax` (e.g. `alpha` and `beta`).
3. Hit `/wp-json/wc/store/v1/products?dual_tax=alpha`.
4. Without this fix: both products are returned (the `dual_tax` filter is silently dropped because the taxonomy is registered for more than one object type). With this fix: only the product tagged `alpha` is returned.
5. Run the relevant Store API test suites for the products endpoint.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff (approved iter 2, 1 blocking issue addressed in iter 1).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Ensure Store API product filtering recognises taxonomies registered for multiple object types (e.g. both `product` and `product-variation`).

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-208
