### PR TITLE
fix: only hash filename for downloadable-product uploads

### DIFF
--- a/plugins/woocommerce/changelog/64638-ai-agent-rsmapgj-11-1777969641
+++ b/plugins/woocommerce/changelog/64638-ai-agent-rsmapgj-11-1777969641
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect conditional in WC_Admin_Upload_Downloadable_Product::update_filename so filename hashing only applies to downloadable-product uploads.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-upload-downloadable-product.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-upload-downloadable-product.php
@@ -64,19 +64,20 @@ class WC_Admin_Upload_Downloadable_Product {
 	 */
 	public function update_filename( $full_filename, $ext, $dir ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		if ( ! isset( $_POST['type'] ) || ! 'downloadable_product' === $_POST['type'] ) {
-			return $full_filename;
+		if ( isset( $_POST['type'] ) && 'downloadable_product' === $_POST['type'] ) {
+
+			if ( ! strpos( $dir, 'woocommerce_uploads' ) ) {
+				return $full_filename;
+			}
+
+			if ( 'no' === get_option( 'woocommerce_downloads_add_hash_to_filename' ) ) {
+				return $full_filename;
+			}
+
+			return $this->unique_filename( $full_filename, $ext );
 		}
 
-		if ( ! strpos( $dir, 'woocommerce_uploads' ) ) {
-			return $full_filename;
-		}
-
-		if ( 'no' === get_option( 'woocommerce_downloads_add_hash_to_filename' ) ) {
-			return $full_filename;
-		}
-
-		return $this->unique_filename( $full_filename, $ext );
+		return $full_filename;
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a PHP operator-precedence bug in `WC_Admin_Upload_Downloadable_Product::update_filename()`. The original guard `! 'downloadable_product' === $_POST['type']` is parsed as `(! 'downloadable_product') === $_POST['type']`, which always evaluates to `false === $_POST['type']`. Because that combined `||` short-circuit never returns early for non-downloadable uploads, the unique-filename hashing logic was running for any upload that reached this filter (including non-downloadable products), unintentionally mutating their filenames.

- Restructures the conditional so the unique-filename logic only runs when `isset( $_POST['type'] ) && 'downloadable_product' === $_POST['type']`.
- For all other upload types, the original `$full_filename` is returned unchanged — restoring the originally intended behavior.
- Scope is limited to a single method in `plugins/woocommerce/includes/admin/class-wc-admin-upload-downloadable-product.php`; no public API or filter signature changes.

Closes #62983

### Screenshots or screen recordings:

<!-- This PR was generated by the RSMAPGJ AI Coder pipeline. UI screenshots have not been captured by the agent. Reviewer should add before/after screenshots if the change has visible UI impact. -->

### How to test the changes in this Pull Request:

Reproduction steps and acceptance criteria are documented in the linked Linear ticket and the upstream issue. Recommended manual verification:

1. Apply the steps from the linked GitHub issue (woocommerce/woocommerce#62983).
2. Without this patch: upload a file via a non-downloadable upload path that hits `wp_handle_upload`'s filter chain — observe the filename gets the WooCommerce uniqueified hash applied.
3. With this patch: repeat the same non-downloadable upload — confirm the filename is returned unchanged.
4. Confirm downloadable-product uploads still receive the unique-filename treatment when `woocommerce_downloads_add_hash_to_filename` is enabled and the target dir is `woocommerce_uploads`.
5. Run the relevant unit/integration test suites for the admin upload area affected.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push (approved iter 1, 0 issues, per the batch report).
- Local: `php -l` passed on the changed file after a clean rebase onto current `origin/trunk`.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix incorrect conditional in WC_Admin_Upload_Downloadable_Product::update_filename so filename hashing only applies to downloadable-product uploads.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-11
