### PR TITLE
fix: correct Zambian kwacha currency symbol from ZK to ZMW

### DIFF
--- a/plugins/woocommerce/changelog/64639-ai-agent-rsmapgj-216-1777969526
+++ b/plugins/woocommerce/changelog/64639-ai-agent-rsmapgj-216-1777969526
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Zambian kwacha currency symbol from ZK to ZMW to match ISO 4217 standard.

--- a/plugins/woocommerce/changelog/64639-ai-agent-rsmapgj-216-1777969526
+++ b/plugins/woocommerce/changelog/64639-ai-agent-rsmapgj-216-1777969526
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix Zambian kwacha currency symbol from ZK to ZMW to match ISO 4217 standard.

--- a/plugins/woocommerce/changelog/fix-zmw-currency-symbol
+++ b/plugins/woocommerce/changelog/fix-zmw-currency-symbol
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Zambian kwacha currency symbol from ZK to ZMW to match ISO 4217 standard.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -696,7 +696,7 @@ function get_woocommerce_currency_symbols() {
 			'XPF' => 'XPF',
 			'YER' => '&#xfdfc;',
 			'ZAR' => '&#82;',
-			'ZMW' => 'ZK',
+			'ZMW' => 'ZMW',
 		)
 	);
 

--- a/plugins/woocommerce/tests/e2e-pw/data/settings.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/settings.ts
@@ -169,7 +169,7 @@ export const currencies = {
 	XPF: 'CFP franc (XPF) — XPF',
 	YER: 'Yemeni rial (&#xfdfc;) — YER',
 	ZAR: 'South African rand (&#82;) — ZAR',
-	ZMW: 'Zambian kwacha (ZK) — ZMW',
+	ZMW: 'Zambian kwacha (ZMW) — ZMW',
 };
 
 export const externalCurrencies = {
@@ -334,7 +334,7 @@ export const externalCurrencies = {
 	XPF: 'CFP franc (Fr)',
 	YER: 'Yemeni rial (&#xfdfc;)',
 	ZAR: 'South African rand (&#82;)',
-	ZMW: 'Zambian kwacha (ZK)',
+	ZMW: 'Zambian kwacha (ZMW)',
 };
 
 export const stateOptions = {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/data/data-crud.test.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/data/data-crud.test.ts
@@ -8263,7 +8263,7 @@ test.describe( 'Data API tests', () => {
 				expect.objectContaining( {
 					code: 'ZMW',
 					name: 'Zambian kwacha',
-					symbol: 'ZK',
+					symbol: 'ZMW',
 					_links: {
 						self: [
 							{


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WooCommerce uses the incorrect currency abbreviation "ZK" for the Zambian kwacha in its currency symbol map. The ISO 4217 standard defines the official currency code for Zambia as "ZMW". This PR updates the displayed symbol from `ZK` to `ZMW` in `get_woocommerce_currency_symbols()` so the General Settings currency dropdown and any UI rendering the symbol use the correct abbreviation.

- Updates `ZMW` symbol in `plugins/woocommerce/includes/wc-core-functions.php` from `ZK` to `ZMW`.
- Updates the corresponding e2e test data fixtures in `plugins/woocommerce/tests/e2e-pw/data/settings.ts` and the data-crud API test expectation in `plugins/woocommerce/tests/e2e-pw/tests/api-tests/data/data-crud.test.ts` to match.

Closes #40931

### Screenshots or screen recordings:

<!-- This PR was generated by the RSMAPGJ AI Coder pipeline. UI screenshots have not been captured by the agent. Reviewer should add before/after screenshots if the change has visible UI impact. -->

### How to test the changes in this Pull Request:

Reproduction steps and acceptance criteria are documented in the linked Linear ticket and the upstream issue. Recommended manual verification:

1. With this branch checked out, navigate to **WooCommerce > Settings > General**.
2. Open the **Currency** dropdown and locate `Zambian kwacha`.
3. Confirm the displayed symbol/code is `ZMW`, not `ZK`.
4. Run the relevant e2e tests for the Settings/Currency area to confirm fixtures match.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push (approved iter 1, 0 issues from the batch report).
- PHP syntax check: `php -l` clean on changed PHP file.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix Zambian kwacha currency symbol from ZK to ZMW to match ISO 4217 standard.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-216
