### PR TITLE
fix: unregister taxonomy in wc_delete_attribute so the same slug can be re-created

### DIFF
--- a/plugins/woocommerce/changelog/38919-fix-wc-delete-attribute-unregister-taxonomy
+++ b/plugins/woocommerce/changelog/38919-fix-wc-delete-attribute-unregister-taxonomy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc_delete_attribute not unregistering the taxonomy, which prevented re-creating an attribute with the same slug in the same request.

--- a/plugins/woocommerce/changelog/38919-fix-wc-delete-attribute-unregister-taxonomy
+++ b/plugins/woocommerce/changelog/38919-fix-wc-delete-attribute-unregister-taxonomy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix wc_delete_attribute not unregistering the taxonomy, which prevented re-creating an attribute with the same slug in the same request.

--- a/plugins/woocommerce/changelog/64640-ai-agent-rsmapgj-219-1777970341
+++ b/plugins/woocommerce/changelog/64640-ai-agent-rsmapgj-219-1777970341
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc_delete_attribute not unregistering the taxonomy, which prevented re-creating an attribute with the same slug in the same request.

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -737,6 +737,7 @@ function wc_delete_attribute( $id ) {
 			foreach ( $terms as $term ) {
 				wp_delete_term( $term->term_id, $taxonomy );
 			}
+			unregister_taxonomy( $taxonomy );
 		}
 
 		/**

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -170,6 +170,32 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that wc_delete_attribute unregisters the taxonomy so the same slug can be re-created.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/38919
+	 */
+	public function test_wc_delete_attribute_unregisters_taxonomy() {
+		$id = wc_create_attribute( array( 'name' => 'ReproColor', 'slug' => 'reprocolor' ) );
+		$this->assertIsInt( $id, 'Attribute should be created successfully.' );
+
+		$taxonomy = wc_attribute_taxonomy_name( 'reprocolor' );
+
+		// Simulate WooCommerce registering the taxonomy at init (which would have happened in a real request).
+		register_taxonomy( $taxonomy, array( 'product' ) );
+		$this->assertTrue( taxonomy_exists( $taxonomy ), 'Taxonomy should be registered before deletion.' );
+
+		wc_delete_attribute( $id );
+
+		$this->assertFalse( taxonomy_exists( $taxonomy ), 'Taxonomy should be unregistered after wc_delete_attribute.' );
+
+		// Re-creating with the same slug should now succeed (not return a WP_Error).
+		$new_id = wc_create_attribute( array( 'name' => 'ReproColor', 'slug' => 'reprocolor' ) );
+		$this->assertIsInt( $new_id, 'Attribute should be re-creatable with the same slug after deletion.' );
+
+		wc_delete_attribute( $new_id );
+	}
+
+	/**
 	 * Describes the behavior of the wc_update_attribute() function.
 	 *
 	 * @return void


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`wc_delete_attribute()` performed several cleanup steps but did not unregister the attribute's taxonomy from the global `$wp_taxonomies` registry. The taxonomy entry remained dangling within the same request lifecycle, so a subsequent `wc_create_attribute()` call with the same slug failed with `WP_Error( 'invalid_product_attribute_slug_already_exists' )`.

- Call `unregister_taxonomy()` for the deleted attribute's taxonomy after its terms are removed, so the global registry no longer reports the slug as in use.
- Add a unit test (`test_wc_delete_attribute_unregisters_taxonomy`) that registers the taxonomy, deletes the attribute, and confirms the same slug can be re-created in the same request without error.

Closes #38919

### Screenshots or screen recordings:

<!-- This PR was generated by the RSMAPGJ AI Coder pipeline. UI screenshots have not been captured by the agent. Reviewer should add before/after screenshots if the change has visible UI impact. This is a backend-only change with no UI surface. -->

### How to test the changes in this Pull Request:

Reproduction steps and acceptance criteria are documented in the linked Linear ticket and the upstream issue (#38919). Recommended manual verification:

1. With this branch checked out, run a snippet that calls `wc_delete_attribute( $id )` for an existing attribute and immediately calls `wc_create_attribute()` with the same slug in the same request. Before the fix this returns a `WP_Error` with code `invalid_product_attribute_slug_already_exists`; after the fix it returns the new attribute id.
2. Run the new unit test:
   ```
   pnpm --filter='@woocommerce/plugin-woocommerce' test:php --filter test_wc_delete_attribute_unregisters_taxonomy
   ```
3. Run the broader attribute-functions test suite to confirm no regressions:
   ```
   pnpm --filter='@woocommerce/plugin-woocommerce' test:php tests/php/includes/wc-attribute-functions-test.php
   ```

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push (approved iter 1, 0 issues).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix wc_delete_attribute not unregistering the taxonomy, which prevented re-creating an attribute with the same slug in the same request.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-219
