### PR TITLE
fix: accept float order line item quantity in v3 REST API

### DIFF
--- a/plugins/woocommerce/changelog/64641-ai-agent-rsmapgj-367-1777970977
+++ b/plugins/woocommerce/changelog/64641-ai-agent-rsmapgj-367-1777970977
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow float values for order line item quantity in the v3 REST API to match core behavior and the GET order response.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -384,6 +384,8 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		$schema['properties']['coupon_lines']['items']['properties']['discount']['readonly'] = true;
 
+		$schema['properties']['line_items']['items']['properties']['quantity']['type'] = 'number';
+
 		$schema['properties']['manual_update'] = array(
 			'default'     => false,
 			'description' => __( 'Set the action as manual so that the order note registers as "added by user".', 'woocommerce' ),

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -926,6 +926,51 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Updating a line item quantity with a float value via the REST API is accepted.
+	 */
+	public function test_update_line_item_quantity_with_float_value(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders' );
+		$request->set_body_params(
+			array(
+				'status'     => 'processing',
+				'line_items' => array(
+					array(
+						'product_id' => $product->get_id(),
+						'quantity'   => 1,
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+
+		$order_data  = $response->get_data();
+		$order_id    = $order_data['id'];
+		$line_item   = $order_data['line_items'][0];
+		$line_item_id = $line_item['id'];
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order_id );
+		$request->set_body_params(
+			array(
+				'line_items' => array(
+					array(
+						'id'       => $line_item_id,
+						'quantity' => 1.52,
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'Float line item quantity should be accepted by the REST API.' );
+
+		$data = $response->get_data();
+		$this->assertEquals( 1.52, $data['line_items'][0]['quantity'] );
+	}
+
+	/**
 	 * @testdox Updating an order with incomplete meta_data entries does not cause errors.
 	 */
 	public function test_update_meta_data_with_incomplete_entries(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The WooCommerce REST API v3 update-order endpoint rejected float values for line item quantity (returning an `integer` validation error), even though the core system and admin UI both support float quantities and the GET order endpoint already returns float quantity values in its response.

This PR aligns the v3 controller's schema with that behavior: the `line_items[].quantity` property type is changed from `integer` to `number` so the REST API accepts float quantities the same way the core does.

- Root cause: schema validation on `line_items[].quantity` was declared as `integer` in `WC_REST_Orders_Controller::get_item_schema()`, contradicting the underlying line-item data model and the GET response shape.
- Fix: override the inherited schema entry to `number` for `line_items[].quantity` in the v3 controller.
- Tests: a new PHPUnit case in `class-wc-rest-orders-controller-tests.php` exercises updating an order line item with a float quantity (e.g. `1.52`) via the REST endpoint and asserts the float is accepted and persisted.

Closes #52198

### Screenshots or screen recordings:

<!-- This PR was generated by the RSMAPGJ AI Coder pipeline. UI screenshots have not been captured by the agent. Reviewer should add before/after screenshots if the change has visible UI impact (this fix is REST-API-only, so screenshots are not expected). -->

### How to test the changes in this Pull Request:

Reproduction steps and acceptance criteria are documented in the linked Linear ticket and the upstream issue (#52198). Recommended manual verification:

1. Create a simple product and an order with one line item (quantity = 1) on a local WooCommerce site.
2. Generate a REST API key with read/write permissions.
3. Send a `PUT /wp-json/wc/v3/orders/<order_id>` request with body `{ "line_items": [{ "id": <item_id>, "quantity": 1.52 }] }` using the API key as Basic auth.
4. Before this fix: the API returns a 400 with an `integer` validation error.
5. After this fix: the API accepts the float and the order line item is updated to `quantity = 1.52`.
6. Run the relevant PHPUnit suite for the REST orders controller:
   ```
   pnpm --filter='@woocommerce/plugin-woocommerce' test:php -- --filter WC_REST_Orders_Controller_Tests
   ```

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push (approved iter 1, 0 issues from the batch report).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Allow float values for order line item quantity in the v3 REST API to match core behavior and the GET order response.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-367
