### PR TITLE
fix: allow non-WooCommerce action hooks as webhook topics

### DIFF
--- a/plugins/woocommerce/changelog/64642-ai-agent-rsmapgj-370-1777971837
+++ b/plugins/woocommerce/changelog/64642-ai-agent-rsmapgj-370-1777971837
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Action" webhook topic not saving when a non-WooCommerce action hook (e.g. `wp_insert_comment`) is used.

--- a/plugins/woocommerce/changelog/fix-34442-webhook-action-topic-validation
+++ b/plugins/woocommerce/changelog/fix-34442-webhook-action-topic-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Action" webhook topic not saving due to overly restrictive topic validation rejecting non-WooCommerce action hooks.

--- a/plugins/woocommerce/changelog/fix-34442-webhook-action-topic-validation
+++ b/plugins/woocommerce/changelog/fix-34442-webhook-action-topic-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix "Action" webhook topic not saving due to overly restrictive topic validation rejecting non-WooCommerce action hooks.

--- a/plugins/woocommerce/includes/wc-webhook-functions.php
+++ b/plugins/woocommerce/includes/wc-webhook-functions.php
@@ -87,7 +87,7 @@ add_action( 'woocommerce_deliver_webhook_async', 'wc_deliver_webhook_async', 10,
 /**
  * Check if the given topic is a valid webhook topic, a topic is valid if:
  *
- * + starts with `action.woocommerce_` or `action.wc_`.
+ * + starts with `action.` followed by a non-empty action name.
  * + it has a valid resource & event.
  *
  * @since  2.2.0
@@ -105,8 +105,8 @@ function wc_is_webhook_valid_topic( $topic ) {
 		return false;
 	}
 
-	// Custom topics are prefixed with woocommerce_ or wc_ are valid.
-	if ( 0 === strpos( $topic, 'action.woocommerce_' ) || 0 === strpos( $topic, 'action.wc_' ) ) {
+	// Any action topic with a non-empty action name is valid.
+	if ( 0 === strpos( $topic, 'action.' ) && strlen( $topic ) > strlen( 'action.' ) ) {
 		return true;
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/webhooks/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/webhooks/functions.php
@@ -26,6 +26,9 @@ class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 		return array(
 			array( true, wc_is_webhook_valid_topic( 'action.woocommerce_add_to_cart' ) ),
 			array( true, wc_is_webhook_valid_topic( 'action.wc_add_to_cart' ) ),
+			array( true, wc_is_webhook_valid_topic( 'action.wp_insert_comment' ) ),
+			array( true, wc_is_webhook_valid_topic( 'action.save_post' ) ),
+			array( false, wc_is_webhook_valid_topic( 'action.' ) ),
 			array( true, wc_is_webhook_valid_topic( 'product.created' ) ),
 			array( true, wc_is_webhook_valid_topic( 'product.updated' ) ),
 			array( true, wc_is_webhook_valid_topic( 'product.deleted' ) ),


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When creating a webhook and selecting "Action" as the topic (e.g., `wp_insert_comment`), saving triggered the error "Webhook topic unknown. Please select a valid topic." The validation logic in `wc_is_webhook_valid_topic()` only accepted action topics prefixed with `action.woocommerce_` or `action.wc_`, rejecting any non-WooCommerce action hook even though the UI allows the user to enter arbitrary action names.

- Loosen the action-topic check in `wc_is_webhook_valid_topic()` so that any non-empty action name following `action.` is accepted, while still rejecting an empty `action.` topic.
- Update the inline doc comment to reflect the new rule.
- Extend the legacy unit-test data provider with positive cases for `action.wp_insert_comment` and `action.save_post`, and a negative case for the bare `action.` prefix.

Closes #34442

### Screenshots or screen recordings:

<!-- This PR was generated by the RSMAPGJ AI Coder pipeline. UI screenshots have not been captured by the agent. Reviewer should add before/after screenshots if the change has visible UI impact. -->

### How to test the changes in this Pull Request:

Reproduction steps and acceptance criteria are documented in the linked Linear ticket and the upstream issue. Recommended manual verification:

1. In a WooCommerce test environment, go to **WooCommerce > Settings > Advanced > Webhooks** and click **Add webhook**.
2. Set Topic to **Action**, enter `wp_insert_comment` in the Action field, fill the remaining required fields (name, delivery URL), and save.
3. Confirm the webhook saves successfully without the "Webhook topic unknown. Please select a valid topic." error.
4. Repeat with another non-WC action hook (e.g., `save_post`) to confirm arbitrary actions are accepted.
5. Run the legacy unit tests for webhook functions to confirm the new assertions pass:
   ```
   pnpm --filter='@woocommerce/plugin-woocommerce' test:php -- --filter WC_Tests_Webhook_Functions
   ```

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push (approved iter 1, 0 issues from the batch report).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix "Action" webhook topic not saving when a non-WooCommerce action hook (e.g. `wp_insert_comment`) is used.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-370
