### PR TITLE
fix: guard mb_list_encodings() call with function_exists() in product CSV import

### DIFF
--- a/plugins/woocommerce/changelog/64649-ai-agent-rsmapgj-100-1778059297
+++ b/plugins/woocommerce/changelog/64649-ai-agent-rsmapgj-100-1778059297
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Guard `mb_list_encodings()` call in product CSV import form with `function_exists()` to prevent fatal error on servers without mbstring.

--- a/plugins/woocommerce/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/plugins/woocommerce/includes/admin/importers/views/html-product-csv-import-form.php
@@ -83,7 +83,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<td><select id="woocommerce-importer-character-encoding" name="character_encoding">
 							<option value="" selected><?php esc_html_e( 'Autodetect', 'woocommerce' ); ?></option>
 							<?php
-							$encodings = mb_list_encodings();
+							$encodings = function_exists( 'mb_list_encodings' ) ? mb_list_encodings() : array();
 							sort( $encodings, SORT_NATURAL );
 							foreach ( $encodings as $encoding ) {
 								echo '<option>' . esc_html( $encoding ) . '</option>';


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The product CSV import form crashes with a fatal PHP error (`Call to undefined function mb_list_encodings()`) on PHP installations where the `mbstring` extension is not enabled. This silently breaks the importer UI — no "Continue" button appears.

The fix wraps the call in a `function_exists()` guard with an empty-array fallback:

```php
// Before (broken on sites without mbstring):
$encodings = mb_list_encodings();

// After (safe regardless of mbstring availability):
$encodings = function_exists( 'mb_list_encodings' ) ? mb_list_encodings() : array();
```

When `mbstring` is unavailable the encoding selector renders with no options, which is a graceful degradation — the importer form still loads and the user can proceed.

Closes #38541

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. Leave this section empty unless the operator explicitly asks for visual evidence. -->

### How to test the changes in this Pull Request:

1. On a PHP environment without the `mbstring` extension (or by temporarily renaming the call to a non-existent function), navigate to **WooCommerce → Products → Import**.
2. Confirm the import form loads without a fatal error and the "Continue" button is visible.
3. On an environment with `mbstring` enabled, confirm the character-encoding selector still populates normally.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Guard `mb_list_encodings()` call in product CSV import form with `function_exists()` to prevent fatal error on servers without mbstring.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-100
