### PR TITLE
Fix flaky review-order-url email test setUp

### DIFF
--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
@@ -25,7 +25,35 @@ class WC_Email_Customer_Review_Request_Test extends \WC_Unit_Test_Case {
 		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email.php';
 		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email-customer-review-request.php';
 
+		$this->ensure_review_order_page();
+
 		$this->sut = new WC_Email_Customer_Review_Request();
+	}
+
+	/**
+	 * Make sure the WC-managed Review Order page exists for tests that build a
+	 * URL through the endpoint. The bootstrap install seeds the page, but the
+	 * stored option can outlive the post across test runs, so re-create it
+	 * defensively if `woocommerce_review_order_page_id` doesn't resolve.
+	 */
+	private function ensure_review_order_page(): void {
+		$page_id = (int) get_option( 'woocommerce_review_order_page_id' );
+		if ( $page_id > 0 && get_post( $page_id ) instanceof \WP_Post ) {
+			return;
+		}
+
+		$new_page_id = wp_insert_post(
+			array(
+				'post_title'   => 'Review your order',
+				'post_name'    => 'review-order',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+				'post_content' => '<!-- wp:shortcode -->[woocommerce_review_order]<!-- /wp:shortcode -->',
+			)
+		);
+		if ( ! is_wp_error( $new_page_id ) && $new_page_id > 0 ) {
+			update_option( 'woocommerce_review_order_page_id', $new_page_id );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`WC_Email_Customer_Review_Request_Test::test_review_order_url_shape` fails on the 10.8 backport (#64628) with:

```
Failed asserting that '' matches PCRE pattern "#review-order[/=]1293#".
tests/php/includes/emails/class-wc-email-customer-review-request-test.php:96
```

Root cause: the bootstrap install seeds the WC-managed Review Order page, but across test runs the stored `woocommerce_review_order_page_id` option can outlive the actual post. When that happens `Endpoint::get_url()` resolves to an empty permalink because `get_post( $stale_id )` returns null and the URL build short-circuits.

Fix: defensively re-create the page in the test class's `setUp()` when the stored option doesn't resolve to a real post. Test-only change; production code untouched.

Lands on trunk first so the same fix can be backported to release/10.8 to unblock #64628.

Surfaced by PR #64628.

#### Files

```text
tests/php/includes/emails/class-wc-email-customer-review-request-test.php  setUp now ensures the Review Order page exists before each test
```

### Screenshots or screen recordings:

> Not applicable — test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out the branch into the WooCommerce monorepo.
2. From `plugins/woocommerce`, run:
   ```sh
   pnpm test:php:env -- --filter WC_Email_Customer_Review_Request_Test --testdox
   ```
3. All 12 tests in `WC_Email_Customer_Review_Request_Test` pass, including `test_review_order_url_shape`.

<!-- End testing instructions -->

### Testing that has already taken place:

- 12 PHPUnit tests in `WC_Email_Customer_Review_Request_Test` pass locally (PHP 8.1 / WP latest).
- PHPCS clean on the changed file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Test-only change; no production code or behaviour is modified.

</details>
