### PR TITLE
RSM: Wire Shopper Collection block to shopper-lists API via iAPI store

### DIFF
--- a/plugins/woocommerce/changelog/add-shopper-collections-iapi-store
+++ b/plugins/woocommerce/changelog/add-shopper-collections-iapi-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Wire the Shopper Collection (Saved-for-later) block to the shopper-lists Store API via a private iAPI store, with server-side rendering of saved items, optimistic remove, and Move-to-cart for simple products.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -1,0 +1,288 @@
+/**
+ * External dependencies
+ */
+import { store } from '@wordpress/interactivity';
+import type { AsyncAction, TypeYield } from '@wordpress/interactivity';
+import type { CurrencyResponse } from '@woocommerce/types';
+
+/**
+ * Mirror of `Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListItemSchema::get_properties()`.
+ *
+ * Keep this in sync with the schema. State here must not include any UI-derived
+ * fields — display values belong in block-private stores or PHP SSR.
+ * TO DO: decide where UI-derived state lives
+ */
+export type ShopperListItemImage = {
+	id: number;
+	src: string;
+	thumbnail: string;
+	srcset: string;
+	sizes: string;
+	name: string;
+	alt: string;
+	thumbnail_srcset: string;
+	thumbnail_sizes: string;
+};
+
+export type ShopperListItemVariation = {
+	raw_attribute: string;
+	attribute: string;
+	value: string;
+};
+
+export type ShopperListItemPrices = CurrencyResponse & {
+	price: string;
+	regular_price: string;
+	sale_price: string;
+};
+
+export type RawShopperListItem = {
+	key: string;
+	id: number;
+	product_id: number;
+	variation_id: number;
+	quantity: number;
+	product_exists: boolean;
+	name: string;
+	permalink: string;
+	images: ShopperListItemImage[];
+	variation: ShopperListItemVariation[];
+	prices: ShopperListItemPrices | null;
+	date_added_gmt: string;
+};
+
+export type ShopperListState = {
+	items: RawShopperListItem[];
+	isLoading: boolean;
+	error: string | null;
+};
+
+export type AddItemPayload = {
+	product_id?: number;
+	cart_item_key?: string;
+	variation?: Array< { attribute: string; value: string } >;
+	quantity?: number;
+};
+
+export type Store = {
+	state: {
+		restUrl: string;
+		// TODO: revisit nonce handling when we look at authentication for
+		// the shopper-lists routes. Today PHP seeds this via
+		// `wp_create_nonce( 'wc_store_api' )` and we refresh it from
+		// response headers (see restRequest below). Likely changes once
+		// the routes start enforcing nonces server-side: align with the
+		// cart store's bootstrap-from-response-header pattern, share the
+		// cart's `state.nonce` instead of duplicating, or move to a
+		// caching-friendlier transport.
+		nonce: string;
+		lists: Record< string, ShopperListState >;
+	};
+	actions: {
+		loadList: ( slug: string ) => Promise< void >;
+		addItem: ( slug: string, payload: AddItemPayload ) => Promise< void >;
+		removeItem: ( slug: string, key: string ) => Promise< void >;
+	};
+};
+
+// Stores are locked to prevent 3PD usage until the API is stable.
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+const isShopperListItem = ( value: unknown ): value is RawShopperListItem =>
+	!! value &&
+	typeof value === 'object' &&
+	typeof ( value as { key?: unknown } ).key === 'string';
+
+const ensureListState = (
+	state: Store[ 'state' ],
+	slug: string
+): ShopperListState => {
+	let list = state.lists[ slug ];
+	if ( ! list ) {
+		list = { items: [], isLoading: false, error: null };
+		state.lists[ slug ] = list;
+	}
+	return list;
+};
+
+/**
+ * Send a Store API request following the cart store's auth shape:
+ * Nonce header, `wc_store_api` action on the server side, cookie auth via
+ * `credentials: 'include'`, and `cache: 'no-store'` so user-specific data is
+ * never cached.
+ *
+ * The starter nonce is seeded by PHP via `wp_interactivity_state` and
+ * refreshed from the `Nonce` response header on every subsequent request,
+ * so the server-side enforcement (landing in a follow-up PR) can be
+ * flipped on without rewriting the client.
+ */
+async function restRequest< T >(
+	state: Store[ 'state' ],
+	path: string,
+	init: RequestInit = {}
+): Promise< T | null > {
+	const headers = new Headers( init.headers );
+	headers.set( 'Content-Type', 'application/json' );
+	if ( state.nonce ) {
+		headers.set( 'Nonce', state.nonce );
+	}
+
+	const response = await fetch( `${ state.restUrl }${ path }`, {
+		...init,
+		headers,
+		cache: 'no-store',
+		credentials: 'include',
+	} );
+
+	const nextNonce = response.headers.get( 'Nonce' );
+	if ( nextNonce ) {
+		state.nonce = nextNonce;
+	}
+
+	if ( response.status === 204 ) {
+		return null;
+	}
+
+	const text = await response.text();
+	const contentType = response.headers.get( 'Content-Type' ) || '';
+	const json =
+		text && contentType.includes( 'json' ) ? JSON.parse( text ) : null;
+
+	if ( ! response.ok ) {
+		const message =
+			( json && typeof json === 'object' && 'message' in json
+				? String( ( json as { message: unknown } ).message )
+				: '' ) ||
+			response.statusText ||
+			'Request failed.';
+		throw new Error( message );
+	}
+
+	return json as T | null;
+}
+
+// Do NOT supply `nonce` / `restUrl` defaults here. iAPI's deep-merge has the
+// JS-supplied state win over the existing (PHP-seeded) state for primitives,
+// so an empty-string default would clobber the values seeded server-side via
+// `wp_interactivity_state`. State for those fields comes purely from PHP. Same
+// reason the cart store doesn't ship state defaults — see cart.ts.
+const { state } = store< Store >(
+	'woocommerce/shopper-lists',
+	{
+		actions: {
+			*loadList( slug: string ): AsyncAction< void > {
+				const list = ensureListState( state, slug );
+				list.isLoading = true;
+				list.error = null;
+
+				try {
+					const response = ( yield restRequest<
+						RawShopperListItem[]
+					>(
+						state,
+						`wc/store/v1/shopper-lists/${ encodeURIComponent(
+							slug
+						) }/items`,
+						{ method: 'GET' }
+					) ) as TypeYield<
+						typeof restRequest< RawShopperListItem[] >
+					>;
+
+					if ( ! Array.isArray( response ) ) {
+						throw new Error( 'Invalid shopper list response.' );
+					}
+
+					const items = response.filter( isShopperListItem );
+
+					// TODO: track in-flight mutation count and skip applying
+					// load results when mutations are pending, so a slow
+					// loadList cannot clobber a fresh add/remove.
+					list.items = items;
+				} catch ( error ) {
+					list.error = ( error as Error ).message;
+				} finally {
+					list.isLoading = false;
+				}
+			},
+
+			*addItem(
+				slug: string,
+				payload: AddItemPayload
+			): AsyncAction< void > {
+				const list = ensureListState( state, slug );
+				list.error = null;
+
+				try {
+					const item = ( yield restRequest< RawShopperListItem >(
+						state,
+						`wc/store/v1/shopper-lists/${ encodeURIComponent(
+							slug
+						) }/items`,
+						{
+							method: 'POST',
+							body: JSON.stringify( payload ),
+						}
+					) ) as TypeYield<
+						typeof restRequest< RawShopperListItem >
+					>;
+
+					if ( ! isShopperListItem( item ) ) {
+						throw new Error(
+							'Invalid shopper list item response.'
+						);
+					}
+
+					// Merge the returned item by key — replace if present,
+					// append otherwise. Re-saving the same product POSTs
+					// twice and the server merges quantity, so we mirror
+					// that behaviour locally.
+					const existingIndex = list.items.findIndex(
+						( i ) => i.key === item.key
+					);
+					if ( existingIndex >= 0 ) {
+						list.items[ existingIndex ] = item;
+					} else {
+						list.items.push( item );
+					}
+				} catch ( error ) {
+					list.error = ( error as Error ).message;
+				}
+			},
+
+			*removeItem( slug: string, key: string ): AsyncAction< void > {
+				const list = state.lists[ slug ];
+				if ( ! list ) {
+					return;
+				}
+
+				const removedIndex = list.items.findIndex(
+					( i ) => i.key === key
+				);
+				if ( removedIndex < 0 ) {
+					return;
+				}
+				const removed = list.items[ removedIndex ];
+
+				// Optimistic remove.
+				list.items.splice( removedIndex, 1 );
+				list.error = null;
+
+				try {
+					yield restRequest(
+						state,
+						`wc/store/v1/shopper-lists/${ encodeURIComponent(
+							slug
+						) }/items/${ encodeURIComponent( key ) }`,
+						{ method: 'DELETE' }
+					);
+				} catch ( error ) {
+					// Restore the row at its original position.
+					list.items.splice( removedIndex, 0, removed );
+					list.error = ( error as Error ).message;
+				}
+			},
+		},
+	},
+	{ lock: universalLock }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -48,6 +48,8 @@ export type RawShopperListItem = {
 	images: ShopperListItemImage[];
 	variation: ShopperListItemVariation[];
 	prices: ShopperListItemPrices | null;
+	price_html: string;
+	image_html: string;
 	date_added_gmt: string;
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
@@ -41,5 +41,6 @@
 		}
 	},
 	"viewScriptModule": "woocommerce/shopper-collection",
-	"style": "file:../woocommerce/shopper-collection-style.css"
+	"style": "file:../woocommerce/shopper-collection-style.css",
+	"editorStyle": "file:../woocommerce/shopper-collection-editor.css"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
@@ -1,0 +1,88 @@
+// The block IS the grid. supports.layout's `columnCount` attribute drives
+// our --wc-shopper-collection-columns CSS variable (set inline on the wrapper
+// in both editor preview and PHP render). No nested grids, no inner blocks.
+.wc-block-shopper-collection {
+	display: grid;
+	gap: var(--wp--style--block-gap, 1.5em);
+	grid-template-columns: repeat(
+		var(--wc-shopper-collection-columns, 3),
+		minmax(0, 1fr)
+	);
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wc-block-shopper-collection-item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em;
+
+	// Image and price visual styling come from the shared atomic classes
+	// (wc-block-components-product-image / -price) loaded by the global
+	// wc-blocks stylesheet — no per-element rules needed here.
+
+	// Title spacing/line-height matches Product Collection's default
+	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
+	// We target wp-block-post-title (core's post-title class) because the
+	// editor preview mirrors PC's editor render, which uses core/post-title.
+	.wp-block-post-title {
+		line-height: 1.4;
+		margin: 0 0 0.75rem;
+	}
+
+	// Variation and quantity have no atomic equivalent in Product Collection,
+	// so we own their styling. Center-aligned and small to mirror the rest
+	// of the row (price + button use the WP `has-small-font-size` preset).
+	&__variation,
+	&__quantity {
+		color: rgba(0, 0, 0, 0.7);
+		display: block;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		text-align: center;
+	}
+
+	// Remove button overlays the image (mirrors Product Collection's
+	// sale-badge slot — top-right corner inside the product-image wrapper).
+	// Positioned absolute with align-self: flex-end so the parent's
+	// __inner-container flex layout pushes it to the right edge.
+	&__remove {
+		align-self: flex-end;
+		appearance: none;
+		background: rgba(0, 0, 0, 0.65);
+		border: 0;
+		border-radius: 999px;
+		color: #fff;
+		cursor: pointer;
+		font-size: var(--wp--preset--font-size--small, 0.75em);
+		line-height: 1;
+		padding: 0.4em 0.75em;
+		z-index: 10;
+
+		&[disabled] {
+			cursor: not-allowed;
+			opacity: 0.7;
+		}
+
+		&:hover:not([disabled]) {
+			background: rgba(0, 0, 0, 0.85);
+		}
+	}
+}
+
+.wc-block-shopper-collection__empty {
+	color: rgba(0, 0, 0, 0.7);
+	grid-column: 1 / -1;
+	padding: 1em 0;
+	text-align: center;
+}
+
+// Error state spans every grid column so it reads as a single alert
+// rather than a badly-sized cell when the collection has a multi-column
+// layout. Same treatment as the empty state above for symmetry.
+.wc-block-shopper-collection__error {
+	color: #b91c1c;
+	grid-column: 1 / -1;
+	padding: 1em 0;
+	text-align: center;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -1,6 +1,289 @@
 /**
- * Side-effect import that boots the Shopper Collection iAPI store on the
- * frontend. The store itself will be wired in a follow-up that adds the
- * `@woocommerce/stores/woocommerce/shopper-lists` module.
+ * External dependencies
  */
-export {};
+import {
+	getConfig,
+	getContext,
+	store,
+	type AsyncAction,
+} from '@wordpress/interactivity';
+import '@woocommerce/stores/woocommerce/shopper-lists';
+import '@woocommerce/stores/woocommerce/cart';
+import type {
+	RawShopperListItem,
+	ShopperListItemPrices,
+	Store as ShopperListsStore,
+} from '@woocommerce/stores/woocommerce/shopper-lists';
+import type {
+	Store as WooCommerce,
+	WooCommerceConfig,
+} from '@woocommerce/stores/woocommerce/cart';
+
+/**
+ * Internal dependencies
+ */
+import {
+	formatPriceWithCurrency,
+	normalizeCurrencyResponse,
+} from '../../../../packages/prices/utils/currency';
+
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+type ShopperCollectionConfig = {
+	quantityLabelTemplate: string;
+	removeLabelTemplate: string;
+	moveToCartLabel: string;
+	emptyMessage: string;
+};
+
+type BlockContext = {
+	listSlug: string;
+	listItem?: RawShopperListItem;
+};
+
+type BlockStore = {
+	state: {
+		currentItems: RawShopperListItem[];
+		hasError: boolean;
+		errorMessage: string;
+		isEmpty: boolean;
+		isMoveToCartHidden: boolean;
+		isPriceHidden: boolean;
+		currentItemThumbnail: string;
+		currentItemAlt: string;
+		currentItemDisplayName: string;
+		currentItemQuantityLabel: string;
+		currentItemRemoveLabel: string;
+		currentItemFormattedPrice: string;
+		currentItemVariationLabel: string;
+	};
+	actions: {
+		onClickRemove: () => Generator< unknown, void >;
+		onClickMoveToCart: () => Generator< unknown, void >;
+	};
+};
+
+const { state: shopperListsState, actions: shopperListsActions } =
+	store< ShopperListsStore >(
+		'woocommerce/shopper-lists',
+		{},
+		{ lock: universalLock }
+	);
+
+const { state: cartState, actions: cartActions } = store< WooCommerce >(
+	'woocommerce',
+	{},
+	{ lock: universalLock }
+);
+
+const { placeholderImgSrc, currency: defaultCurrency } = getConfig(
+	'woocommerce'
+) as WooCommerceConfig;
+
+const decodeEntities = ( encoded: string ): string => {
+	const txt = document.createElement( 'textarea' );
+	txt.innerHTML = encoded;
+	return txt.value;
+};
+
+const formatPriceFromSchema = (
+	prices: ShopperListItemPrices | null | undefined
+): string => {
+	if ( ! prices || prices.price === '' || ! defaultCurrency ) {
+		return '';
+	}
+	const itemCurrency = normalizeCurrencyResponse( prices, defaultCurrency );
+	return formatPriceWithCurrency( prices.price, itemCurrency );
+};
+
+const formatVariationLabel = ( item: RawShopperListItem ): string => {
+	if ( ! item.variation || item.variation.length === 0 ) {
+		return '';
+	}
+	return item.variation
+		.map(
+			( v ) =>
+				`${ decodeEntities( v.attribute ) }: ${ decodeEntities(
+					v.value
+				) }`
+		)
+		.join( ', ' );
+};
+
+const getList = ( slug: string ) => shopperListsState.lists[ slug ] ?? null;
+
+store< BlockStore >(
+	'woocommerce/shopper-collection',
+	{
+		state: {
+			get currentItems(): RawShopperListItem[] {
+				const { listSlug } = getContext< BlockContext >();
+				return getList( listSlug )?.items ?? [];
+			},
+
+			get hasError(): boolean {
+				const { listSlug } = getContext< BlockContext >();
+				return !! getList( listSlug )?.error;
+			},
+
+			get errorMessage(): string {
+				const { listSlug } = getContext< BlockContext >();
+				return getList( listSlug )?.error ?? '';
+			},
+
+			get isEmpty(): boolean {
+				const { listSlug } = getContext< BlockContext >();
+				const list = getList( listSlug );
+				if ( ! list ) {
+					return true;
+				}
+				return ! list.isLoading && list.items.length === 0;
+			},
+
+			get hasVariation(): boolean {
+				const { listItem } = getContext< BlockContext >();
+				return !! listItem && listItem.variation.length > 0;
+			},
+
+			get isPriceHidden(): boolean {
+				const { listItem } = getContext< BlockContext >();
+				return ! listItem?.product_exists || ! listItem.prices;
+			},
+
+			get isMoveToCartHidden(): boolean {
+				const { listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return true;
+				}
+				// Tombstones never have a buyable product.
+				return ! listItem.product_exists;
+			},
+
+			get currentItemThumbnail(): string {
+				const { listItem } = getContext< BlockContext >();
+				return (
+					listItem?.images?.[ 0 ]?.thumbnail ||
+					placeholderImgSrc ||
+					''
+				);
+			},
+
+			get currentItemAlt(): string {
+				const { listItem } = getContext< BlockContext >();
+				return listItem ? decodeEntities( listItem.name ) : '';
+			},
+
+			// `data-wp-text` writes its argument as text-content without
+			// running entity decoding, so a name returned by the schema as
+			// `Tom &amp; Jerry` would render literally that way. Bind
+			// templates and SSR text spans to this getter instead of the
+			// raw context field so what the browser shows matches what
+			// PHP wrote on first paint.
+			get currentItemDisplayName(): string {
+				const { listItem } = getContext< BlockContext >();
+				return listItem ? decodeEntities( listItem.name ) : '';
+			},
+
+			get currentItemQuantityLabel(): string {
+				const { listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return '';
+				}
+				const { quantityLabelTemplate } = getConfig(
+					'woocommerce/shopper-collection'
+				) as ShopperCollectionConfig;
+				return quantityLabelTemplate.replace(
+					'%d',
+					String( listItem.quantity )
+				);
+			},
+
+			get currentItemRemoveLabel(): string {
+				const { listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return '';
+				}
+				const { removeLabelTemplate } = getConfig(
+					'woocommerce/shopper-collection'
+				) as ShopperCollectionConfig;
+				return removeLabelTemplate.replace(
+					'%s',
+					decodeEntities( listItem.name )
+				);
+			},
+
+			get currentItemFormattedPrice(): string {
+				const { listItem } = getContext< BlockContext >();
+				return formatPriceFromSchema( listItem?.prices );
+			},
+
+			get currentItemVariationLabel(): string {
+				const { listItem } = getContext< BlockContext >();
+				return listItem ? formatVariationLabel( listItem ) : '';
+			},
+		},
+
+		actions: {
+			*onClickRemove(): AsyncAction< void > {
+				const { listSlug, listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return;
+				}
+				yield shopperListsActions.removeItem( listSlug, listItem.key );
+			},
+
+			*onClickMoveToCart(): AsyncAction< void > {
+				const { listSlug, listItem } = getContext< BlockContext >();
+				if ( ! listItem || ! listItem.product_exists ) {
+					return;
+				}
+
+				// Map the schema's `variation` shape to the cart's
+				// SelectedAttributes shape. The schema returns the
+				// slug-form attribute under `raw_attribute` (e.g.
+				// `attribute_pa_color`) plus a display label under
+				// `attribute` (e.g. "Color"); the cart matches by the
+				// slug-form, so override `attribute` with `raw_attribute`.
+				// Same swap mini-cart's `changeQuantity` does. Empty for
+				// simple products.
+				const variation = listItem.variation.map(
+					( { raw_attribute: rawAttribute, value, attribute } ) => ( {
+						attribute: rawAttribute || attribute,
+						value,
+					} )
+				);
+				const isVariation = listItem.variation_id > 0;
+
+				// `cartActions.addCartItem` catches its own errors and
+				// surfaces them as store notices, so the yield resolves
+				// the same way on success and failure. Snapshot the
+				// matching line's quantity, run the add, then only remove
+				// from the saved list if it actually grew.
+				const lookup = {
+					id: listItem.id,
+					...( isVariation && { variation } ),
+				};
+				const beforeItem = cartState.findItemInCart( lookup );
+				const beforeQuantity = beforeItem?.quantity ?? 0;
+
+				yield cartActions.addCartItem( {
+					id: listItem.id,
+					quantityToAdd: listItem.quantity,
+					type: isVariation ? 'variation' : 'simple',
+					...( isVariation && { variation } ),
+				} );
+
+				const afterItem = cartState.findItemInCart( lookup );
+				const afterQuantity = afterItem?.quantity ?? 0;
+
+				if ( afterQuantity <= beforeQuantity ) {
+					return;
+				}
+
+				yield shopperListsActions.removeItem( listSlug, listItem.key );
+			},
+		},
+	},
+	{ lock: universalLock }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -4,6 +4,7 @@
 import {
 	getConfig,
 	getContext,
+	getElement,
 	store,
 	type AsyncAction,
 } from '@wordpress/interactivity';
@@ -11,21 +12,10 @@ import '@woocommerce/stores/woocommerce/shopper-lists';
 import '@woocommerce/stores/woocommerce/cart';
 import type {
 	RawShopperListItem,
-	ShopperListItemPrices,
 	Store as ShopperListsStore,
 } from '@woocommerce/stores/woocommerce/shopper-lists';
-import type {
-	Store as WooCommerce,
-	WooCommerceConfig,
-} from '@woocommerce/stores/woocommerce/cart';
-
-/**
- * Internal dependencies
- */
-import {
-	formatPriceWithCurrency,
-	normalizeCurrencyResponse,
-} from '../../../../packages/prices/utils/currency';
+import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
+import { sanitizeHTML } from '@woocommerce/sanitize';
 
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
@@ -33,13 +23,12 @@ const universalLock =
 type ShopperCollectionConfig = {
 	quantityLabelTemplate: string;
 	removeLabelTemplate: string;
-	moveToCartLabel: string;
-	emptyMessage: string;
 };
 
 type BlockContext = {
 	listSlug: string;
 	listItem?: RawShopperListItem;
+	htmlField?: 'price_html' | 'image_html';
 };
 
 type BlockStore = {
@@ -50,19 +39,57 @@ type BlockStore = {
 		isEmpty: boolean;
 		isMoveToCartHidden: boolean;
 		isPriceHidden: boolean;
-		currentItemThumbnail: string;
-		currentItemAlt: string;
 		currentItemDisplayName: string;
 		currentItemQuantityLabel: string;
 		currentItemRemoveLabel: string;
-		currentItemFormattedPrice: string;
 		currentItemVariationLabel: string;
 	};
 	actions: {
 		onClickRemove: () => Generator< unknown, void >;
 		onClickMoveToCart: () => Generator< unknown, void >;
 	};
+	callbacks: {
+		updateInnerHtml: () => void;
+	};
 };
+
+// Allow-list for sanitizing the schema's preformatted strings on innerHTML
+// swap. Covers what `wc_price` (sale/discount markup, currency symbol) and
+// `wp_get_attachment_image` / `wc_placeholder_img` emit (responsive image
+// + dimensions + lazy loading).
+const ALLOWED_TAGS = [
+	'a',
+	'b',
+	'em',
+	'i',
+	'strong',
+	'p',
+	'br',
+	'span',
+	'bdi',
+	'del',
+	'ins',
+	'img',
+	'picture',
+	'source',
+];
+const ALLOWED_ATTR = [
+	'class',
+	'target',
+	'href',
+	'rel',
+	'name',
+	'download',
+	'aria-hidden',
+	'src',
+	'srcset',
+	'sizes',
+	'alt',
+	'width',
+	'height',
+	'loading',
+	'decoding',
+];
 
 const { state: shopperListsState, actions: shopperListsActions } =
 	store< ShopperListsStore >(
@@ -77,24 +104,10 @@ const { state: cartState, actions: cartActions } = store< WooCommerce >(
 	{ lock: universalLock }
 );
 
-const { placeholderImgSrc, currency: defaultCurrency } = getConfig(
-	'woocommerce'
-) as WooCommerceConfig;
-
 const decodeEntities = ( encoded: string ): string => {
 	const txt = document.createElement( 'textarea' );
 	txt.innerHTML = encoded;
 	return txt.value;
-};
-
-const formatPriceFromSchema = (
-	prices: ShopperListItemPrices | null | undefined
-): string => {
-	if ( ! prices || prices.price === '' || ! defaultCurrency ) {
-		return '';
-	}
-	const itemCurrency = normalizeCurrencyResponse( prices, defaultCurrency );
-	return formatPriceWithCurrency( prices.price, itemCurrency );
 };
 
 const formatVariationLabel = ( item: RawShopperListItem ): string => {
@@ -141,14 +154,9 @@ store< BlockStore >(
 				return ! list.isLoading && list.items.length === 0;
 			},
 
-			get hasVariation(): boolean {
-				const { listItem } = getContext< BlockContext >();
-				return !! listItem && listItem.variation.length > 0;
-			},
-
 			get isPriceHidden(): boolean {
 				const { listItem } = getContext< BlockContext >();
-				return ! listItem?.product_exists || ! listItem.prices;
+				return ! listItem?.price_html;
 			},
 
 			get isMoveToCartHidden(): boolean {
@@ -158,20 +166,6 @@ store< BlockStore >(
 				}
 				// Tombstones never have a buyable product.
 				return ! listItem.product_exists;
-			},
-
-			get currentItemThumbnail(): string {
-				const { listItem } = getContext< BlockContext >();
-				return (
-					listItem?.images?.[ 0 ]?.thumbnail ||
-					placeholderImgSrc ||
-					''
-				);
-			},
-
-			get currentItemAlt(): string {
-				const { listItem } = getContext< BlockContext >();
-				return listItem ? decodeEntities( listItem.name ) : '';
 			},
 
 			// `data-wp-text` writes its argument as text-content without
@@ -211,11 +205,6 @@ store< BlockStore >(
 					'%s',
 					decodeEntities( listItem.name )
 				);
-			},
-
-			get currentItemFormattedPrice(): string {
-				const { listItem } = getContext< BlockContext >();
-				return formatPriceFromSchema( listItem?.prices );
 			},
 
 			get currentItemVariationLabel(): string {
@@ -282,6 +271,33 @@ store< BlockStore >(
 				}
 
 				yield shopperListsActions.removeItem( listSlug, listItem.key );
+			},
+		},
+
+		callbacks: {
+			// Single shared innerHTML-swap callback for any slot whose
+			// content is one of the schema's preformatted HTML fields.
+			// Mirrors the atomic product-elements `updateValue` callback:
+			// the watched element carries `data-wp-context='{"htmlField":"price_html"}'`
+			// (or `"image_html"`), and this callback reads that field
+			// off the row's `listItem` and pastes its sanitized HTML into
+			// `element.ref`. PHP renders the same HTML server-side, so
+			// hydration is a no-op when the row's listItem hasn't changed,
+			// and a clean swap when it has (e.g. after Remove shifts the
+			// next item into this slot).
+			updateInnerHtml: () => {
+				const { ref } = getElement();
+				const { listItem, htmlField } = getContext< BlockContext >();
+				if ( ! ref || ! listItem || ! htmlField ) {
+					return;
+				}
+				const html = listItem[ htmlField ];
+				if ( typeof html === 'string' ) {
+					ref.innerHTML = sanitizeHTML( html, {
+						tags: ALLOWED_TAGS,
+						attr: ALLOWED_ATTR,
+					} );
+				}
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -1,6 +1,31 @@
-// The block IS the grid. supports.layout's `columnCount` attribute drives
-// our --wc-shopper-collection-columns CSS variable (set inline on the wrapper
-// in both editor preview and PHP render). No nested grids, no inner blocks.
+// Frontend stylesheet for the Shopper Collection block.
+// Diverges from `editor.scss` because the editor canvas loads the
+// WooCommerce atomic block stylesheet for free (which provides image
+// sizing, the relative/absolute positioning for the remove-button
+// overlay, etc.); the frontend only ships this block's CSS, so anything
+// the layout depends on has to live here. If we add pieces to
+// editor.scss that the frontend also needs, mirror them here too —
+// keep the visual result aligned.
+// TODO: revisit how this block depends on atomic-block CSS. We currently
+// borrow `.wc-block-components-product-image` / `__inner-container` from
+// the product-image atomic block. Product Collection avoids this problem
+// by *rendering* the atomic blocks as inner blocks, so WordPress
+// auto-enqueues their stylesheets — we don't, so we have to handle it
+// ourselves. Three options:
+//   1. (current) Duplicate the rules we need into this file.
+//      Self-contained but drifts if atomic styles change upstream.
+//   2. Enqueue the atomic image stylesheet from ShopperCollection.php
+//      (e.g. `wp_enqueue_style( 'wc-block-product-elements-image' )` —
+//      verify the actual handle in the build). Zero duplication, but
+//      pulls in the whole atomic stylesheet for a few rules.
+//   3. Stop borrowing atomic classes — give our markup its own
+//      block-local classes (e.g. `wc-block-shopper-collection-item__image`,
+//      `__image-link`) and own all the styling. Cleanest ownership, but
+//      requires a small template rewrite.
+// Option 1 is the lightest while we only borrow two classes; switch to
+// option 2 if we end up borrowing more, or option 3 if a future
+// variation needs different image/overlay behaviour.
+
 .wc-block-shopper-collection {
 	display: grid;
 	gap: var(--wp--style--block-gap, 1.5em);
@@ -18,9 +43,34 @@
 	flex-direction: column;
 	gap: 0.25em;
 
-	// Image and price visual styling come from the shared atomic classes
-	// (wc-block-components-product-image / -price) loaded by the global
-	// wc-blocks stylesheet — no per-element rules needed here.
+	// `.wc-block-components-product-image` is normally styled by the
+	// atomic-block stylesheet. Reproduce just enough here so the
+	// image fills its column track and acts as a positioning anchor
+	// for the remove-button overlay.
+	.wc-block-components-product-image {
+		display: block;
+		margin: 0;
+		position: relative;
+
+		img {
+			display: block;
+			height: auto;
+			max-width: 100%;
+			width: 100%;
+		}
+	}
+
+	// The remove button lives inside `__inner-container` which the
+	// atomic stylesheet positions absolutely in the top-right of the
+	// image. Replicate that here so the button overlays rather than
+	// stacking below the thumbnail.
+	.wc-block-components-product-image__inner-container {
+		padding: 0.5em;
+		position: absolute;
+		right: 0;
+		top: 0;
+		z-index: 10;
+	}
 
 	// Title spacing/line-height matches Product Collection's default
 	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
@@ -42,12 +92,10 @@
 		text-align: center;
 	}
 
-	// Remove button overlays the image (mirrors Product Collection's
-	// sale-badge slot — top-right corner inside the product-image wrapper).
-	// Positioned absolute with align-self: flex-end so the parent's
-	// __inner-container flex layout pushes it to the right edge.
+	// The remove button is centered inside `__inner-container`, which is
+	// itself absolutely positioned over the image. No alignment hacks
+	// needed here; just style the pill.
 	&__remove {
-		align-self: flex-end;
 		appearance: none;
 		background: rgba(0, 0, 0, 0.65);
 		border: 0;
@@ -57,7 +105,6 @@
 		font-size: var(--wp--preset--font-size--small, 0.75em);
 		line-height: 1;
 		padding: 0.4em 0.75em;
-		z-index: 10;
 
 		&[disabled] {
 			cursor: not-allowed;
@@ -72,6 +119,17 @@
 
 .wc-block-shopper-collection__empty {
 	color: rgba(0, 0, 0, 0.7);
+	grid-column: 1 / -1;
+	padding: 1em 0;
+	text-align: center;
+}
+
+// Error state spans every grid column so it reads as a single alert
+// rather than a badly-sized cell when the collection has a multi-column
+// layout. Same treatment as the empty state above for symmetry.
+.wc-block-shopper-collection__error {
+	color: #b91c1c;
+	grid-column: 1 / -1;
 	padding: 1em 0;
 	text-align: center;
 }

--- a/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
@@ -46,6 +46,8 @@ const entries = {
 		'./assets/js/base/stores/store-notices.ts',
 	'@woocommerce/stores/woocommerce/products':
 		'./assets/js/base/stores/woocommerce/products.ts',
+	'@woocommerce/stores/woocommerce/shopper-lists':
+		'./assets/js/base/stores/woocommerce/shopper-lists.ts',
 };
 
 module.exports = {

--- a/plugins/woocommerce/client/blocks/tsconfig.base.json
+++ b/plugins/woocommerce/client/blocks/tsconfig.base.json
@@ -124,6 +124,9 @@
 			"@woocommerce/stores/woocommerce/products": [
 				"assets/js/base/stores/woocommerce/products"
 			],
+			"@woocommerce/stores/woocommerce/shopper-lists": [
+				"assets/js/base/stores/woocommerce/shopper-lists"
+			],
 			"@woocommerce/type-defs/*": [
 				"assets/js/types/type-defs/*"
 			],

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -192,7 +192,12 @@ final class ShopperCollection extends AbstractBlock {
 		if ( $response->is_error() ) {
 			$error   = $response->as_error();
 			$message = $error instanceof \WP_Error ? $error->get_error_message() : 'Unknown error';
-			wc_get_logger()->warning(
+			// Logged at debug level on purpose: prefetch failures are
+			// often transient (network blips, auth refresh races) and
+			// the user-visible behaviour is the empty state — nothing
+			// for ops to act on. Anyone investigating a regression can
+			// flip the WC logger to debug to surface them.
+			wc_get_logger()->debug(
 				sprintf( 'Shopper Collection prefetch failed: %s', $message ),
 				array(
 					'source' => 'shopper-collection',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -23,13 +23,6 @@ final class ShopperCollection extends AbstractBlock {
 	protected $block_name = 'shopper-collection';
 
 	/**
-	 * Memoised placeholder image URL — looked up at most once per request.
-	 *
-	 * @var string|null
-	 */
-	private ?string $placeholder_img_src = null;
-
-	/**
 	 * Render the block.
 	 *
 	 * @param array     $attributes Block attributes.
@@ -238,10 +231,15 @@ final class ShopperCollection extends AbstractBlock {
 				// Single anchor for both live products and tombstones. For
 				// tombstones `permalink` is empty, so iAPI removes the `href`
 				// attribute and the anchor degrades to non-clickable.
+				// Image and price markup come pre-formatted from the schema
+				// (`image_html`, `price_html`) — `data-wp-watch` callbacks
+				// swap each slot's innerHTML on hydrate / state change so we
+				// don't reimplement WC's `wc_price` / `wp_get_attachment_image`
+				// in JS.
 				?>
 				<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
 					<a data-wp-bind--href="context.listItem.permalink">
-						<img data-wp-bind--src="state.currentItemThumbnail" data-wp-bind--alt="state.currentItemAlt" />
+						<span class="wc-block-shopper-collection-item__image-slot" data-wp-context='{"htmlField":"image_html"}' data-wp-watch="callbacks.updateInnerHtml"></span>
 					</a>
 					<div class="wc-block-components-product-image__inner-container">
 						<button
@@ -258,9 +256,7 @@ final class ShopperCollection extends AbstractBlock {
 					<a data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"></a>
 				</h2>
 				<span class="wc-block-shopper-collection-item__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
-				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="state.isPriceHidden">
-					<span class="wc-block-components-product-price__value" data-wp-text="state.currentItemFormattedPrice"></span>
-				</div>
+				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="state.isPriceHidden" data-wp-context='{"htmlField":"price_html"}' data-wp-watch="callbacks.updateInnerHtml"></div>
 				<span class="wc-block-shopper-collection-item__quantity" data-wp-text="state.currentItemQuantityLabel"></span>
 				<?php if ( ! empty( $variation['showAction'] ) ) : ?>
 					<div class="wp-block-button wc-block-components-product-button" data-wp-bind--hidden="state.isMoveToCartHidden">
@@ -307,14 +303,15 @@ final class ShopperCollection extends AbstractBlock {
 		$name            = (string) ( $item['name'] ?? '' );
 		$permalink       = (string) ( $item['permalink'] ?? '' );
 		$quantity        = (int) ( $item['quantity'] ?? 1 );
-		$thumbnail       = $this->get_item_thumbnail( $item );
 		$alt             = html_entity_decode( $name, ENT_QUOTES, 'UTF-8' );
-		$prices          = $product_exists && ! empty( $item['prices'] ) && is_array( $item['prices'] ) ? $item['prices'] : null;
-		$formatted_price = $prices ? $this->format_price_with_currency( $prices ) : '';
+		$image_html      = (string) ( $item['image_html'] ?? '' );
+		$price_html      = (string) ( $item['price_html'] ?? '' );
 		$variation_label = $this->get_variation_label( $item );
 
 		$quantity_label = sprintf( $variation['quantityLabelTemplate'], $quantity );
 		$remove_aria    = sprintf( $variation['removeLabelTemplate'], $alt );
+
+		$is_price_hidden = '' === $price_html;
 
 		$item_class = sprintf(
 			'wc-block-shopper-collection-item wc-block-shopper-collection-item--%s',
@@ -334,15 +331,25 @@ final class ShopperCollection extends AbstractBlock {
 			<?php echo wp_interactivity_data_wp_context( $context ); ?>
 		>
 			<?php
-			// Emit the same single-anchor structure as the `<template>`
-			// so iAPI hydration is a no-op diff. For tombstones the
-			// href is omitted entirely (the anchor degrades to
-			// non-clickable rather than self-linking back to the
-			// current page).
+			// Emit the same structure as the `<template>` so iAPI
+			// hydration is a no-op diff. For tombstones the anchor's
+			// href is omitted (the anchor degrades to non-clickable
+			// rather than self-linking back to the current page).
+			// Image and price markup come pre-formatted from the
+			// schema (`image_html`, `price_html`) and are echoed into
+			// the watcher slots — the JS-side `updateInnerHtml`
+			// callback takes over after hydration to swap the slot's
+			// innerHTML when the row's context.listItem changes.
 			?>
 			<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
 				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink">
-					<img src="<?php echo esc_url( $thumbnail ); ?>" alt="<?php echo esc_attr( $alt ); ?>" data-wp-bind--src="state.currentItemThumbnail" data-wp-bind--alt="state.currentItemAlt" />
+					<span
+						class="wc-block-shopper-collection-item__image-slot"
+						data-wp-context='{"htmlField":"image_html"}'
+						data-wp-watch="callbacks.updateInnerHtml"
+					>
+						<?php echo wp_kses_post( $image_html ); ?>
+					</span>
 				</a>
 				<div class="wc-block-components-product-image__inner-container">
 					<button
@@ -370,11 +377,19 @@ final class ShopperCollection extends AbstractBlock {
 			<?php if ( '' !== $variation_label ) : ?>
 				<span class="wc-block-shopper-collection-item__variation"><?php echo esc_html( $variation_label ); ?></span>
 			<?php endif; ?>
-			<?php if ( null !== $prices ) : ?>
-				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size">
-					<span class="wc-block-components-product-price__value"><?php echo esc_html( $formatted_price ); ?></span>
-				</div>
-			<?php endif; ?>
+			<div
+				class="price wc-block-components-product-price has-text-align-center has-small-font-size"
+				data-wp-bind--hidden="state.isPriceHidden"
+				data-wp-context='{"htmlField":"price_html"}'
+				data-wp-watch="callbacks.updateInnerHtml"
+				<?php
+				if ( $is_price_hidden ) {
+					echo 'hidden';
+				}
+				?>
+			>
+				<?php echo wp_kses_post( $price_html ); ?>
+			</div>
 			<span class="wc-block-shopper-collection-item__quantity"><?php echo esc_html( $quantity_label ); ?></span>
 			<?php if ( ! empty( $variation['showAction'] ) ) : ?>
 				<?php
@@ -441,25 +456,6 @@ final class ShopperCollection extends AbstractBlock {
 	}
 
 	/**
-	 * Resolve the thumbnail URL for an item, falling back to the
-	 * configured placeholder when no image is available (live products
-	 * with no image and tombstones both use the placeholder).
-	 *
-	 * @param array<string, mixed> $item Schema-shape item.
-	 * @return string
-	 */
-	private function get_item_thumbnail( array $item ): string {
-		$images = $item['images'] ?? array();
-		if ( is_array( $images ) && isset( $images[0]['thumbnail'] ) && is_string( $images[0]['thumbnail'] ) && '' !== $images[0]['thumbnail'] ) {
-			return $images[0]['thumbnail'];
-		}
-		if ( null === $this->placeholder_img_src ) {
-			$this->placeholder_img_src = (string) wc_placeholder_img_src( 'woocommerce_thumbnail' );
-		}
-		return $this->placeholder_img_src;
-	}
-
-	/**
 	 * Build a comma-separated variation label like "Color: Blue, Size: M".
 	 *
 	 * @param array<string, mixed> $item Schema-shape item.
@@ -483,46 +479,6 @@ final class ShopperCollection extends AbstractBlock {
 			$parts[] = $attribute . ': ' . $value;
 		}
 		return implode( ', ', $parts );
-	}
-
-	/**
-	 * Format a schema `prices` object the same way the JS-side
-	 * `formatPriceWithCurrency` does, so SSR output matches what the
-	 * client would render after hydration.
-	 *
-	 * @param array<string, mixed> $prices Schema `prices` object.
-	 * @return string
-	 */
-	private function format_price_with_currency( array $prices ): string {
-		$price_str = isset( $prices['price'] ) ? (string) $prices['price'] : '';
-		if ( '' === $price_str ) {
-			return '';
-		}
-
-		$minor_unit       = isset( $prices['currency_minor_unit'] ) && is_int( $prices['currency_minor_unit'] ) ? $prices['currency_minor_unit'] : 0;
-		$prefix           = isset( $prices['currency_prefix'] ) ? (string) $prices['currency_prefix'] : '';
-		$suffix           = isset( $prices['currency_suffix'] ) ? (string) $prices['currency_suffix'] : '';
-		$decimal_sep      = isset( $prices['currency_decimal_separator'] ) ? (string) $prices['currency_decimal_separator'] : '.';
-		$thousand_sep     = isset( $prices['currency_thousand_separator'] ) ? (string) $prices['currency_thousand_separator'] : ',';
-		$price_int        = (int) $price_str;
-		$divisor          = $minor_unit > 0 ? (int) pow( 10, $minor_unit ) : 1;
-		$decimal_value    = $minor_unit > 0 ? $price_int / $divisor : (float) $price_int;
-		$as_string        = $minor_unit > 0
-			? number_format( $decimal_value, $minor_unit, '.', '' )
-			: (string) $price_int;
-		$parts            = explode( '.', $as_string );
-		$before           = $parts[0];
-		$after            = $parts[1] ?? '';
-		$before_separated = (string) preg_replace( '/\B(?=(\d{3})+(?!\d))/', $thousand_sep, $before );
-
-		$decimal_part = '';
-		if ( '' !== $after ) {
-			$decimal_part = $decimal_sep . str_pad( $after, $minor_unit, '0' );
-		} elseif ( $minor_unit > 0 ) {
-			$decimal_part = $decimal_sep . str_repeat( '0', $minor_unit );
-		}
-
-		return html_entity_decode( $prefix . $before_separated . $decimal_part . $suffix, ENT_QUOTES, 'UTF-8' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -4,13 +4,15 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+
 /**
  * Shopper Collection block.
  *
- * Renders a collection curated by the shopper (e.g. Saved for Later). The data
- * source and frontend interactivity are wired in follow-up tasks; this class
- * is the structural backbone that registers the block and outputs the
- * server-side container the iAPI store will hydrate.
+ * Renders a collection curated by the shopper (e.g. Saved for Later) wired to
+ * the `shopper-lists` Store API endpoints via the shared `woocommerce/shopper-lists`
+ * iAPI store. PHP prefetches the active list so the first paint is already
+ * populated; JS then takes over for adds, removes, and Move-to-cart.
  */
 final class ShopperCollection extends AbstractBlock {
 	/**
@@ -21,6 +23,13 @@ final class ShopperCollection extends AbstractBlock {
 	protected $block_name = 'shopper-collection';
 
 	/**
+	 * Memoised placeholder image URL — looked up at most once per request.
+	 *
+	 * @var string|null
+	 */
+	private ?string $placeholder_img_src = null;
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array     $attributes Block attributes.
@@ -29,36 +38,491 @@ final class ShopperCollection extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		$list_slug = isset( $attributes['listName'] ) && is_string( $attributes['listName'] ) && '' !== $attributes['listName']
+			? sanitize_title( $attributes['listName'] )
+			: 'saved-for-later';
+
 		$column_count = isset( $attributes['layout']['columnCount'] ) && is_numeric( $attributes['layout']['columnCount'] )
 			? max( 1, (int) $attributes['layout']['columnCount'] )
 			: 3;
 
+		$variation = $this->get_variation_config( $list_slug );
+
+		wp_enqueue_script_module( $this->get_full_block_name() );
+
+		$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
+		BlocksSharedState::load_store_config( $consent );
+		BlocksSharedState::load_placeholder_image( $consent );
+		// `Move to cart` calls into the shared cart store, which expects
+		// `state.cart.items` and friends. Without this load the cart store
+		// would have no hydrated cart and the action would throw on the
+		// first click.
+		BlocksSharedState::load_cart_state( $consent );
+
+		$items = $this->prefetch_list_items( $list_slug );
+
+		// Seed the shared shopper-lists store with the rest URL, the
+		// pre-fetched items, and a starter nonce. The starter nonce is
+		// what the cart store also seeds via `state.nonce` — the JS layer
+		// keeps it fresh by reading the `Nonce` response header on every
+		// subsequent request, so this is just the bootstrap value (and
+		// avoids deadlocking mutations that await `isNonceReady` before
+		// any GET has fired).
+		wp_interactivity_state(
+			'woocommerce/shopper-lists',
+			array(
+				'restUrl' => get_rest_url(),
+				'nonce'   => wp_create_nonce( 'wc_store_api' ),
+				'lists'   => array(
+					$list_slug => array(
+						'items'     => $items,
+						'isLoading' => false,
+						'error'     => null,
+					),
+				),
+			)
+		);
+
+		// Only the templates the JS getters consume need to flow through
+		// `wp_interactivity_config`. Visible strings (empty / error /
+		// action label) are rendered server-side and toggled with
+		// directives, so no need to duplicate them here.
+		// NOTE: this config is global per namespace, so multiple
+		// shopper-collection blocks on the same page would clobber each
+		// other's labels. v1 ships with one collection per page; if we
+		// later need multi-instance, move these into per-block context.
+		// TODO: scope these labels per list type once a second variation
+		// (Wishlist, etc.) lands. Two shopper-collection blocks on the
+		// same page would otherwise share one set of templates — the
+		// last one rendered wins, so a Wishlist row would say
+		// "Quantity: 3" using Saved-for-later's wording (or the other
+		// way around). Move into `data-wp-context` keyed by listSlug,
+		// or namespace the config keys (e.g.
+		// `quantityLabelTemplate.{slug}`) and update the JS getters to
+		// pick the right one off the per-row context.
+		wp_interactivity_config(
+			'woocommerce/shopper-collection',
+			array(
+				'quantityLabelTemplate' => $variation['quantityLabelTemplate'],
+				'removeLabelTemplate'   => $variation['removeLabelTemplate'],
+			)
+		);
+
+		$wrapper_class = sprintf(
+			'wc-block-shopper-collection wc-block-shopper-collection--%s',
+			$variation['modifierSlug']
+		);
+
 		$wrapper_attributes = array(
-			'class'               => 'wc-block-shopper-collection',
-			'data-wp-interactive' => 'woocommerce/shopper-collections',
-			'data-wp-context'     => '{}',
-			'data-wp-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),
+			'class'               => $wrapper_class,
+			'data-wp-interactive' => 'woocommerce/shopper-collection',
+			'data-wp-context'     => (string) wp_json_encode( array( 'listSlug' => $list_slug ) ),
+			// Deterministic key derived from the list slug so iAPI router
+			// navigations land on the same block identity across renders.
+			'data-wp-key'         => $this->get_full_block_name() . '-' . $list_slug,
 			'style'               => sprintf( '--wc-shopper-collection-columns:%d;', $column_count ),
 		);
 
+		$is_empty = empty( $items );
+
 		return sprintf(
-			'<ul %1$s>%2$s</ul>',
+			'<ul %1$s>%2$s%3$s%4$s%5$s</ul>',
 			get_block_wrapper_attributes( $wrapper_attributes ),
-			$this->get_placeholder_markup()
+			$this->render_template_markup( $variation ),
+			$this->render_items_markup( $items, $variation ),
+			$this->render_empty_markup( $is_empty, $variation ),
+			$this->render_error_markup( $variation )
 		);
 	}
 
 	/**
-	 * Placeholder markup for the rendered block. The real `data-wp-each` template
-	 * over `state.currentListItems` will be added once the iAPI store lands.
+	 * Per-list-type rendering config. Centralises every string and
+	 * behaviour switch that differs across list types so the renderer
+	 * stays generic.
 	 *
+	 * Adding a new list type = add a new entry here. Future variations
+	 * that need behaviours the existing JS actions don't cover should
+	 * also add a new `actions.onClickXyz` in `frontend.ts` and point
+	 * `actionDirective` at it.
+	 *
+	 * Unknown slugs fall back to `saved-for-later` so the block still
+	 * renders, with a generic copy.
+	 *
+	 * @param string $list_slug The list slug.
+	 * @return array<string, mixed>
+	 */
+	private function get_variation_config( string $list_slug ): array {
+		$variations = array(
+			'saved-for-later' => array(
+				'modifierSlug'          => 'saved-for-later',
+				'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
+				'errorMessage'          => __( 'Something went wrong — please try again.', 'woocommerce' ),
+				'removeButtonLabel'     => __( 'Remove', 'woocommerce' ),
+				/* translators: %s: product name. */
+				'removeLabelTemplate'   => __( 'Remove %s from saved items', 'woocommerce' ),
+				/* translators: %d: quantity of saved items. */
+				'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
+				'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
+				'actionDirective'       => 'actions.onClickMoveToCart',
+				'showAction'            => true,
+			),
+		);
+
+		return $variations[ $list_slug ] ?? $variations['saved-for-later'];
+	}
+
+	/**
+	 * Prefetch the items in a list via `rest_do_request()`. Logged-out users
+	 * short-circuit to an empty list — the route requires authentication and
+	 * we don't want to fire an API call that's only going to 401.
+	 *
+	 * @param string $list_slug The list slug.
+	 * @return array<int, array<string, mixed>> Items in the schema response shape.
+	 */
+	private function prefetch_list_items( string $list_slug ): array {
+		if ( ! is_user_logged_in() ) {
+			return array();
+		}
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/shopper-lists/' . $list_slug . '/items' );
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			$error   = $response->as_error();
+			$message = $error instanceof \WP_Error ? $error->get_error_message() : 'Unknown error';
+			wc_get_logger()->warning(
+				sprintf( 'Shopper Collection prefetch failed: %s', $message ),
+				array(
+					'source' => 'shopper-collection',
+					'data'   => array( 'slug' => $list_slug ),
+				)
+			);
+			return array();
+		}
+
+		$data = $response->get_data();
+		if ( ! is_array( $data ) && ! is_object( $data ) ) {
+			return array();
+		}
+
+		// The schema casts `prices` and image entries to stdClass so the
+		// JSON response renders objects, not arrays. Round-trip through
+		// JSON encode/decode to normalise everything to nested arrays so
+		// the SSR markup helpers below can treat fields uniformly.
+		$decoded = json_decode( (string) wp_json_encode( $data ), true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * The `<template data-wp-each>` describing how each item is rendered on
+	 * the client. Pre-rendered children sit alongside as `data-wp-each-child`
+	 * elements so first paint is populated.
+	 *
+	 * @param array<string, mixed> $variation Per-list-type rendering config.
 	 * @return string
 	 */
-	private function get_placeholder_markup(): string {
-		return sprintf(
-			'<li class="wc-block-shopper-collection__empty">%s</li>',
-			esc_html__( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' )
+	private function render_template_markup( array $variation ): string {
+		$item_class = sprintf(
+			'wc-block-shopper-collection-item wc-block-shopper-collection-item--%s',
+			$variation['modifierSlug']
 		);
+
+		ob_start();
+		?>
+		<template
+			data-wp-each--list-item="state.currentItems"
+			data-wp-each-key="context.listItem.key"
+		>
+			<li class="<?php echo esc_attr( $item_class ); ?>">
+				<?php
+				// Single anchor for both live products and tombstones. For
+				// tombstones `permalink` is empty, so iAPI removes the `href`
+				// attribute and the anchor degrades to non-clickable.
+				?>
+				<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+					<a data-wp-bind--href="context.listItem.permalink">
+						<img data-wp-bind--src="state.currentItemThumbnail" data-wp-bind--alt="state.currentItemAlt" />
+					</a>
+					<div class="wc-block-components-product-image__inner-container">
+						<button
+							type="button"
+							class="wc-block-shopper-collection-item__remove"
+							data-wp-on--click="actions.onClickRemove"
+							data-wp-bind--aria-label="state.currentItemRemoveLabel"
+						>
+							<?php echo esc_html( $variation['removeButtonLabel'] ); ?>
+						</button>
+					</div>
+				</div>
+				<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
+					<a data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"></a>
+				</h2>
+				<span class="wc-block-shopper-collection-item__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
+				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="state.isPriceHidden">
+					<span class="wc-block-components-product-price__value" data-wp-text="state.currentItemFormattedPrice"></span>
+				</div>
+				<span class="wc-block-shopper-collection-item__quantity" data-wp-text="state.currentItemQuantityLabel"></span>
+				<?php if ( ! empty( $variation['showAction'] ) ) : ?>
+					<div class="wp-block-button wc-block-components-product-button" data-wp-bind--hidden="state.isMoveToCartHidden">
+						<button
+							type="button"
+							class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+							data-wp-on--click="<?php echo esc_attr( $variation['actionDirective'] ); ?>"
+						>
+							<?php echo esc_html( $variation['actionLabel'] ); ?>
+						</button>
+					</div>
+				<?php endif; ?>
+			</li>
+		</template>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Render the SSR markup for each item. JS will reconcile these via
+	 * `data-wp-each-child` after hydration.
+	 *
+	 * @param array<int, array<string, mixed>> $items     Schema-shape items.
+	 * @param array<string, mixed>             $variation Per-list-type rendering config.
+	 * @return string
+	 */
+	private function render_items_markup( array $items, array $variation ): string {
+		$markup = '';
+		foreach ( $items as $item ) {
+			$markup .= $this->render_item_markup( $item, $variation );
+		}
+		return $markup;
+	}
+
+	/**
+	 * Render a single SSR item.
+	 *
+	 * @param array<string, mixed> $item      Schema-shape item.
+	 * @param array<string, mixed> $variation Per-list-type rendering config.
+	 * @return string
+	 */
+	private function render_item_markup( array $item, array $variation ): string {
+		$product_exists  = ! empty( $item['product_exists'] );
+		$name            = (string) ( $item['name'] ?? '' );
+		$permalink       = (string) ( $item['permalink'] ?? '' );
+		$quantity        = (int) ( $item['quantity'] ?? 1 );
+		$thumbnail       = $this->get_item_thumbnail( $item );
+		$alt             = html_entity_decode( $name, ENT_QUOTES, 'UTF-8' );
+		$prices          = $product_exists && ! empty( $item['prices'] ) && is_array( $item['prices'] ) ? $item['prices'] : null;
+		$formatted_price = $prices ? $this->format_price_with_currency( $prices ) : '';
+		$variation_label = $this->get_variation_label( $item );
+
+		$quantity_label = sprintf( $variation['quantityLabelTemplate'], $quantity );
+		$remove_aria    = sprintf( $variation['removeLabelTemplate'], $alt );
+
+		$item_class = sprintf(
+			'wc-block-shopper-collection-item wc-block-shopper-collection-item--%s',
+			$variation['modifierSlug']
+		);
+
+		$context = array(
+			'listItem' => $item,
+		);
+
+		ob_start();
+		?>
+		<li
+			class="<?php echo esc_attr( $item_class ); ?>"
+			data-wp-each-child
+			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<?php echo wp_interactivity_data_wp_context( $context ); ?>
+		>
+			<?php
+			// Emit the same single-anchor structure as the `<template>`
+			// so iAPI hydration is a no-op diff. For tombstones the
+			// href is omitted entirely (the anchor degrades to
+			// non-clickable rather than self-linking back to the
+			// current page).
+			?>
+			<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink">
+					<img src="<?php echo esc_url( $thumbnail ); ?>" alt="<?php echo esc_attr( $alt ); ?>" data-wp-bind--src="state.currentItemThumbnail" data-wp-bind--alt="state.currentItemAlt" />
+				</a>
+				<div class="wc-block-components-product-image__inner-container">
+					<button
+						type="button"
+						class="wc-block-shopper-collection-item__remove"
+						aria-label="<?php echo esc_attr( $remove_aria ); ?>"
+						data-wp-on--click="actions.onClickRemove"
+						data-wp-bind--aria-label="state.currentItemRemoveLabel"
+					>
+						<?php echo esc_html( $variation['removeButtonLabel'] ); ?>
+					</button>
+				</div>
+			</div>
+			<?php
+			// Render the decoded display name as plain text so the SSR
+			// output matches what `data-wp-text="state.currentItemDisplayName"`
+			// will write after hydration. Names like "Tom &amp; Jerry"
+			// must show as "Tom & Jerry" both before and after JS.
+			// Same single-anchor pattern as the image — href omitted
+			// for tombstones.
+			?>
+			<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
+				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
+			</h2>
+			<?php if ( '' !== $variation_label ) : ?>
+				<span class="wc-block-shopper-collection-item__variation"><?php echo esc_html( $variation_label ); ?></span>
+			<?php endif; ?>
+			<?php if ( null !== $prices ) : ?>
+				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size">
+					<span class="wc-block-components-product-price__value"><?php echo esc_html( $formatted_price ); ?></span>
+				</div>
+			<?php endif; ?>
+			<span class="wc-block-shopper-collection-item__quantity"><?php echo esc_html( $quantity_label ); ?></span>
+			<?php if ( ! empty( $variation['showAction'] ) ) : ?>
+				<?php
+				// Always emit the wrapper with the same `data-wp-bind--hidden`
+				// the template uses, and start it hidden when the SSR-side
+				// rule (the row is a tombstone) says so. That way a state
+				// change after hydration (e.g. the product is later flagged
+				// as deleted) hides the button without iAPI having to swap
+				// the entire row out.
+				$is_move_to_cart_hidden = ! $product_exists;
+				?>
+			<div
+				class="wp-block-button wc-block-components-product-button"
+				data-wp-bind--hidden="state.isMoveToCartHidden"
+				<?php
+				if ( $is_move_to_cart_hidden ) {
+					echo 'hidden';
+				}
+				?>
+			>
+				<button
+					type="button"
+					class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+					data-wp-on--click="<?php echo esc_attr( $variation['actionDirective'] ); ?>"
+				>
+					<?php echo esc_html( $variation['actionLabel'] ); ?>
+				</button>
+			</div>
+			<?php endif; ?>
+		</li>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Render the empty-state markup. Always present in the DOM so JS can
+	 * toggle it on once the last item is removed.
+	 *
+	 * @param bool                 $is_empty  Whether the list is empty on initial paint.
+	 * @param array<string, mixed> $variation Per-list-type rendering config.
+	 * @return string
+	 */
+	private function render_empty_markup( bool $is_empty, array $variation ): string {
+		$hidden_attr = $is_empty ? '' : ' hidden';
+		return sprintf(
+			'<li class="wc-block-shopper-collection__empty" data-wp-bind--hidden="!state.isEmpty"%1$s>%2$s</li>',
+			$hidden_attr,
+			esc_html( $variation['emptyMessage'] )
+		);
+	}
+
+	/**
+	 * Render the error-state markup. Hidden on initial paint and toggled on
+	 * by the JS-side `state.hasError` getter when a request fails.
+	 *
+	 * @param array<string, mixed> $variation Per-list-type rendering config.
+	 * @return string
+	 */
+	private function render_error_markup( array $variation ): string {
+		return sprintf(
+			'<li class="wc-block-shopper-collection__error" role="alert" data-wp-bind--hidden="!state.hasError" data-wp-text="state.errorMessage" hidden>%s</li>',
+			esc_html( $variation['errorMessage'] )
+		);
+	}
+
+	/**
+	 * Resolve the thumbnail URL for an item, falling back to the
+	 * configured placeholder when no image is available (live products
+	 * with no image and tombstones both use the placeholder).
+	 *
+	 * @param array<string, mixed> $item Schema-shape item.
+	 * @return string
+	 */
+	private function get_item_thumbnail( array $item ): string {
+		$images = $item['images'] ?? array();
+		if ( is_array( $images ) && isset( $images[0]['thumbnail'] ) && is_string( $images[0]['thumbnail'] ) && '' !== $images[0]['thumbnail'] ) {
+			return $images[0]['thumbnail'];
+		}
+		if ( null === $this->placeholder_img_src ) {
+			$this->placeholder_img_src = (string) wc_placeholder_img_src( 'woocommerce_thumbnail' );
+		}
+		return $this->placeholder_img_src;
+	}
+
+	/**
+	 * Build a comma-separated variation label like "Color: Blue, Size: M".
+	 *
+	 * @param array<string, mixed> $item Schema-shape item.
+	 * @return string
+	 */
+	private function get_variation_label( array $item ): string {
+		$variation = $item['variation'] ?? array();
+		if ( ! is_array( $variation ) || empty( $variation ) ) {
+			return '';
+		}
+		$parts = array();
+		foreach ( $variation as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$attribute = isset( $entry['attribute'] ) ? html_entity_decode( (string) $entry['attribute'], ENT_QUOTES, 'UTF-8' ) : '';
+			$value     = isset( $entry['value'] ) ? html_entity_decode( (string) $entry['value'], ENT_QUOTES, 'UTF-8' ) : '';
+			if ( '' === $attribute && '' === $value ) {
+				continue;
+			}
+			$parts[] = $attribute . ': ' . $value;
+		}
+		return implode( ', ', $parts );
+	}
+
+	/**
+	 * Format a schema `prices` object the same way the JS-side
+	 * `formatPriceWithCurrency` does, so SSR output matches what the
+	 * client would render after hydration.
+	 *
+	 * @param array<string, mixed> $prices Schema `prices` object.
+	 * @return string
+	 */
+	private function format_price_with_currency( array $prices ): string {
+		$price_str = isset( $prices['price'] ) ? (string) $prices['price'] : '';
+		if ( '' === $price_str ) {
+			return '';
+		}
+
+		$minor_unit       = isset( $prices['currency_minor_unit'] ) && is_int( $prices['currency_minor_unit'] ) ? $prices['currency_minor_unit'] : 0;
+		$prefix           = isset( $prices['currency_prefix'] ) ? (string) $prices['currency_prefix'] : '';
+		$suffix           = isset( $prices['currency_suffix'] ) ? (string) $prices['currency_suffix'] : '';
+		$decimal_sep      = isset( $prices['currency_decimal_separator'] ) ? (string) $prices['currency_decimal_separator'] : '.';
+		$thousand_sep     = isset( $prices['currency_thousand_separator'] ) ? (string) $prices['currency_thousand_separator'] : ',';
+		$price_int        = (int) $price_str;
+		$divisor          = $minor_unit > 0 ? (int) pow( 10, $minor_unit ) : 1;
+		$decimal_value    = $minor_unit > 0 ? $price_int / $divisor : (float) $price_int;
+		$as_string        = $minor_unit > 0
+			? number_format( $decimal_value, $minor_unit, '.', '' )
+			: (string) $price_int;
+		$parts            = explode( '.', $as_string );
+		$before           = $parts[0];
+		$after            = $parts[1] ?? '';
+		$before_separated = (string) preg_replace( '/\B(?=(\d{3})+(?!\d))/', $thousand_sep, $before );
+
+		$decimal_part = '';
+		if ( '' !== $after ) {
+			$decimal_part = $decimal_sep . str_pad( $after, $minor_unit, '0' );
+		} elseif ( $minor_unit > 0 ) {
+			$decimal_part = $decimal_sep . str_repeat( '0', $minor_unit );
+		}
+
+		return html_entity_decode( $prefix . $before_separated . $decimal_part . $suffix, ENT_QUOTES, 'UTF-8' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -134,7 +134,7 @@ final class ShopperCollection extends AbstractBlock {
 			$this->render_template_markup( $variation ),
 			$this->render_items_markup( $items, $variation ),
 			$this->render_empty_markup( $is_empty, $variation ),
-			$this->render_error_markup( $variation )
+			$this->render_error_markup()
 		);
 	}
 
@@ -159,7 +159,6 @@ final class ShopperCollection extends AbstractBlock {
 			'saved-for-later' => array(
 				'modifierSlug'          => 'saved-for-later',
 				'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
-				'errorMessage'          => __( 'Something went wrong — please try again.', 'woocommerce' ),
 				'removeButtonLabel'     => __( 'Remove', 'woocommerce' ),
 				/* translators: %s: product name. */
 				'removeLabelTemplate'   => __( 'Remove %s from saved items', 'woocommerce' ),
@@ -453,16 +452,22 @@ final class ShopperCollection extends AbstractBlock {
 
 	/**
 	 * Render the error-state markup. Hidden on initial paint and toggled on
-	 * by the JS-side `state.hasError` getter when a request fails.
+	 * by the JS-side `state.hasError` getter when a request fails. The text
+	 * content is left empty here on purpose: errors only happen post-hydration,
+	 * and `data-wp-text="state.errorMessage"` writes the actual server-supplied
+	 * message — surfacing that is more useful than a generic fallback.
 	 *
-	 * @param array<string, mixed> $variation Per-list-type rendering config.
+	 * TODO: replace this in-list error row with a `store-notices` notice
+	 * rendered above the list. Mini-cart's pattern (cart.ts → showNoticeError →
+	 * `@woocommerce/stores/store-notices`) is the right reference: dispatch
+	 * the server message there from the JS catch blocks in shopper-lists.ts
+	 * instead of holding it on `list.error`. That gives users a dismissible,
+	 * stylistically-aligned notice rather than a row tucked into the grid.
+	 *
 	 * @return string
 	 */
-	private function render_error_markup( array $variation ): string {
-		return sprintf(
-			'<li class="wc-block-shopper-collection__error" role="alert" data-wp-bind--hidden="!state.hasError" data-wp-text="state.errorMessage" hidden>%s</li>',
-			esc_html( $variation['errorMessage'] )
-		);
+	private function render_error_markup(): string {
+		return '<li class="wc-block-shopper-collection__error" role="alert" data-wp-bind--hidden="!state.hasError" data-wp-text="state.errorMessage" hidden></li>';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -94,6 +94,7 @@ final class ShopperCollection extends AbstractBlock {
 		// shopper-collection blocks on the same page would clobber each
 		// other's labels. v1 ships with one collection per page; if we
 		// later need multi-instance, move these into per-block context.
+		// phpcs:disable Generic.Commenting.Todo.TaskFound
 		// TODO: scope these labels per list type once a second variation
 		// (Wishlist, etc.) lands. Two shopper-collection blocks on the
 		// same page would otherwise share one set of templates — the
@@ -103,6 +104,7 @@ final class ShopperCollection extends AbstractBlock {
 		// or namespace the config keys (e.g.
 		// `quantityLabelTemplate.{slug}`) and update the JS getters to
 		// pick the right one off the per-row context.
+		// phpcs:enable Generic.Commenting.Todo.TaskFound
 		wp_interactivity_config(
 			'woocommerce/shopper-collection',
 			array(
@@ -456,12 +458,16 @@ final class ShopperCollection extends AbstractBlock {
 	 * and `data-wp-text="state.errorMessage"` writes the actual server-supplied
 	 * message — surfacing that is more useful than a generic fallback.
 	 *
+	 * phpcs:disable Generic.Commenting.Todo.TaskFound
+	 *
 	 * TODO: replace this in-list error row with a `store-notices` notice
 	 * rendered above the list. Mini-cart's pattern (cart.ts → showNoticeError →
 	 * `@woocommerce/stores/store-notices`) is the right reference: dispatch
 	 * the server message there from the JS catch blocks in shopper-lists.ts
 	 * instead of holding it on `list.error`. That gives users a dismissible,
 	 * stylistically-aligned notice rather than a row tucked into the grid.
+	 *
+	 * phpcs:enable Generic.Commenting.Todo.TaskFound
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -49,7 +49,7 @@ final class ShopperCollection extends AbstractBlock {
 		// `layout` comes from `supports.layout`, not a declared attribute, so WP doesn't guarantee every nested key is set — `??` covers a partial layout object.
 		$column_count = max( 1, (int) ( $attributes['layout']['columnCount'] ?? 3 ) );
 
-		$variation = $this->get_variation_config( $list_slug );
+		$variation = $this->get_variation_config();
 
 		wp_enqueue_script_module( $this->get_full_block_name() );
 
@@ -143,34 +143,28 @@ final class ShopperCollection extends AbstractBlock {
 	 * behaviour switch that differs across list types so the renderer
 	 * stays generic.
 	 *
-	 * Adding a new list type = add a new entry here. Future variations
-	 * that need behaviours the existing JS actions don't cover should
-	 * also add a new `actions.onClickXyz` in `frontend.ts` and point
-	 * `actionDirective` at it.
+	 * Today only `saved-for-later` exists, so the config is returned
+	 * verbatim. When a second list type lands (Wishlist, Recently
+	 * Viewed, etc.), turn this into a lookup keyed by the list slug
+	 * and add the slug as a parameter. Unknown slugs in that future
+	 * lookup should render the empty state or surface an error rather
+	 * than silently borrow another list type's copy.
 	 *
-	 * Unknown slugs fall back to `saved-for-later` so the block still
-	 * renders, with a generic copy.
-	 *
-	 * @param string $list_slug The list slug.
 	 * @return array<string, mixed>
 	 */
-	private function get_variation_config( string $list_slug ): array {
-		$variations = array(
-			'saved-for-later' => array(
-				'modifierSlug'          => 'saved-for-later',
-				'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
-				'removeButtonLabel'     => __( 'Remove', 'woocommerce' ),
-				/* translators: %s: product name. */
-				'removeLabelTemplate'   => __( 'Remove %s from saved items', 'woocommerce' ),
-				/* translators: %d: quantity of saved items. */
-				'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
-				'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
-				'actionDirective'       => 'actions.onClickMoveToCart',
-				'showAction'            => true,
-			),
+	private function get_variation_config(): array {
+		return array(
+			'modifierSlug'          => 'saved-for-later',
+			'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
+			'removeButtonLabel'     => __( 'Remove', 'woocommerce' ),
+			/* translators: %s: product name. */
+			'removeLabelTemplate'   => __( 'Remove %s from saved items', 'woocommerce' ),
+			/* translators: %d: quantity of saved items. */
+			'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
+			'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
+			'actionDirective'       => 'actions.onClickMoveToCart',
+			'showAction'            => true,
 		);
-
-		return $variations[ $list_slug ] ?? $variations['saved-for-later'];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -31,13 +31,23 @@ final class ShopperCollection extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$list_slug = isset( $attributes['listName'] ) && is_string( $attributes['listName'] ) && '' !== $attributes['listName']
-			? sanitize_title( $attributes['listName'] )
-			: 'saved-for-later';
+		// `listName` is declared with a default in block.json, so WP core's
+		// `prepare_attributes_for_render` guarantees it's set as a string by
+		// the time we get here. `sanitize_title` is *not* redundant though:
+		// the schema only enforces `type: string`, and the block editor's
+		// "Edit as HTML" path lets anyone override the attribute with an
+		// arbitrary string. The slug then flows into a REST URL, into the
+		// `data-wp-context` JSON, into `data-wp-key`, and into the
+		// `wc-block-shopper-collection--{slug}` CSS modifier class — so we
+		// normalize it to `[a-z0-9_-]+` here. Empty result falls back to the
+		// declared default.
+		$list_slug = sanitize_title( $attributes['listName'] );
+		if ( '' === $list_slug ) {
+			$list_slug = 'saved-for-later';
+		}
 
-		$column_count = isset( $attributes['layout']['columnCount'] ) && is_numeric( $attributes['layout']['columnCount'] )
-			? max( 1, (int) $attributes['layout']['columnCount'] )
-			: 3;
+		// `layout` comes from `supports.layout`, not a declared attribute, so WP doesn't guarantee every nested key is set — `??` covers a partial layout object.
+		$column_count = max( 1, (int) ( $attributes['layout']['columnCount'] ?? 3 ) );
 
 		$variation = $this->get_variation_config( $list_slug );
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -180,6 +180,18 @@ class ShopperListItemSchema extends AbstractSchema {
 					)
 				),
 			),
+			'price_html'     => array(
+				'description' => __( 'Live product price as HTML, formatted via wc_price including sale/discount markup. Empty when the product no longer exists.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'image_html'     => array(
+				'description' => __( 'Product thumbnail as a fully-formed <img> element with srcset, sizes, alt, and lazy-loading attributes. Falls back to the configured placeholder image when the product has no image or no longer exists.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
 			'date_added_gmt' => array(
 				'description' => __( 'The date the item was saved, as GMT.', 'woocommerce' ),
 				'type'        => 'string',
@@ -215,17 +227,21 @@ class ShopperListItemSchema extends AbstractSchema {
 		$variation_data = isset( $item['variation'] ) && is_array( $item['variation'] ) ? $item['variation'] : array();
 
 		if ( $has_product ) {
-			$response['name']      = $this->get_name( $product );
-			$response['permalink'] = $product->get_permalink();
-			$response['images']    = $this->get_images( $product );
-			$response['variation'] = $this->format_variation_data( $variation_data, $product );
-			$response['prices']    = (object) $this->get_prices( $product );
+			$response['name']       = $this->get_name( $product );
+			$response['permalink']  = $product->get_permalink();
+			$response['images']     = $this->get_images( $product );
+			$response['variation']  = $this->format_variation_data( $variation_data, $product );
+			$response['prices']     = (object) $this->get_prices( $product );
+			$response['price_html'] = (string) $product->get_price_html();
+			$response['image_html'] = $this->get_image_html( $product );
 		} else {
-			$response['name']      = $this->prepare_html_response( (string) ( $item['product_title_at_save'] ?? '' ) );
-			$response['permalink'] = '';
-			$response['images']    = array();
-			$response['variation'] = array();
-			$response['prices']    = null;
+			$response['name']       = $this->prepare_html_response( (string) ( $item['product_title_at_save'] ?? '' ) );
+			$response['permalink']  = '';
+			$response['images']     = array();
+			$response['variation']  = array();
+			$response['prices']     = null;
+			$response['price_html'] = '';
+			$response['image_html'] = $this->get_image_html( null );
 		}//end if
 
 		return $response;
@@ -259,6 +275,26 @@ class ShopperListItemSchema extends AbstractSchema {
 
 		$image = $this->image_attachment_schema->get_item_response( $image_id );
 		return $image ? array( $image ) : array();
+	}
+
+	/**
+	 * Get the thumbnail image HTML for a shopper list item, falling back to the
+	 * WooCommerce placeholder when the product has no image or has been deleted.
+	 *
+	 * Pre-formatting on the server lets renderers (PHP SSR + JS hydration)
+	 * consume one canonical string instead of each side composing the markup
+	 * from the structured `images` array. Mirrors the pattern WC uses in
+	 * `ProductSchema::price_html` / `ProductImage::render`.
+	 *
+	 * @param \WC_Product|null $product Live product instance, or null for tombstones.
+	 * @return string
+	 */
+	private function get_image_html( ?\WC_Product $product ): string {
+		$image_id = $product instanceof \WC_Product ? (int) $product->get_image_id() : 0;
+		if ( $image_id > 0 ) {
+			return (string) wp_get_attachment_image( $image_id, 'woocommerce_thumbnail' );
+		}
+		return (string) wc_placeholder_img( 'woocommerce_thumbnail' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -107,6 +107,68 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should expose price_html for live products and an empty string for tombstones.
+	 */
+	public function test_price_html_is_populated_for_live_products(): void {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Priced T-Shirt',
+				'regular_price' => 19.99,
+			)
+		);
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertArrayHasKey( 'price_html', $response, 'price_html must be present on the response' );
+		$this->assertIsString( $response['price_html'] );
+		$this->assertNotSame( '', $response['price_html'], 'price_html must be non-empty for a live priced product' );
+		$this->assertStringContainsString( 'woocommerce-Price-amount', $response['price_html'], 'price_html should be the formatted markup from wc_price' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should expose image_html with the configured product thumbnail when one is set.
+	 */
+	public function test_image_html_uses_product_thumbnail_when_available(): void {
+		$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$product       = \WC_Helper_Product::create_simple_product( true, array( 'name' => 'Imaged T-Shirt' ) );
+		$product->set_image_id( $attachment_id );
+		$product->save();
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertArrayHasKey( 'image_html', $response, 'image_html must be present on the response' );
+		$this->assertIsString( $response['image_html'] );
+		$this->assertStringContainsString( '<img', $response['image_html'], 'image_html must be a fully-formed <img> element' );
+		$this->assertStringContainsString( 'srcset=', $response['image_html'], 'image_html must carry the responsive srcset attribute' );
+
+		$product->delete( true );
+		wp_delete_attachment( $attachment_id, true );
+	}
+
+	/**
+	 * @testdox Should expose image_html using the WooCommerce placeholder when the product has no image.
+	 */
+	public function test_image_html_falls_back_to_placeholder_when_product_has_no_image(): void {
+		$product = \WC_Helper_Product::create_simple_product( true, array( 'name' => 'No-Image T-Shirt' ) );
+		$product->set_image_id( 0 );
+		$product->save();
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertArrayHasKey( 'image_html', $response );
+		$this->assertSame(
+			(string) wc_placeholder_img( 'woocommerce_thumbnail' ),
+			$response['image_html'],
+			'image_html for an image-less product must equal the configured placeholder markup'
+		);
+
+		$product->delete( true );
+	}
+
+	/**
 	 * @testdox Should fall back to at-save snapshot data when the product no longer exists.
 	 */
 	public function test_falls_back_to_snapshot_when_product_missing(): void {
@@ -123,5 +185,32 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );
 		$this->assertNull( $response['prices'], 'Live prices should be null for missing products' );
 		$this->assertArrayNotHasKey( 'product_title_at_save', $response, 'Internal at-save title snapshot should not leak into the public response' );
+	}
+
+	/**
+	 * @testdox Should expose an empty price_html and the placeholder image_html for tombstones.
+	 */
+	public function test_tombstone_returns_empty_price_html_and_placeholder_image_html(): void {
+		$product    = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Going Away',
+				'regular_price' => 24.99,
+			)
+		);
+		$product_id = $product->get_id();
+		$item       = $this->build_item( $product_id, 0, array(), 'Going Away' );
+		wp_delete_post( $product_id, true );
+
+		$response = $this->sut->get_item_response( $item );
+
+		$this->assertArrayHasKey( 'price_html', $response );
+		$this->assertSame( '', $response['price_html'], 'Tombstones must not advertise a price' );
+		$this->assertArrayHasKey( 'image_html', $response );
+		$this->assertSame(
+			(string) wc_placeholder_img( 'woocommerce_thumbnail' ),
+			$response['image_html'],
+			'Tombstones must use the placeholder image markup'
+		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Wires the Shopper Collection (Saved-for-later variation) end-to-end against the shopper-lists Store API endpoints introduced in #64472. PHP prefetches the active list and seeds initial state so first paint shows real items; JS hydrates and takes over for Remove and Move-to-cart.

**Files and roles:**

- `assets/js/base/stores/woocommerce/shopper-lists.ts` — new shared, locked iAPI store at namespace `woocommerce/shopper-lists`. Mirrors `ShopperListItemSchema` field-for-field (no UI-derived fields), exposes `loadList` / `addItem` / `removeItem` actions. Follows the cart store's auth shape: `Nonce` header, `cache: 'no-store'`, `credentials: 'include'`, nonce refreshed from response headers per request.
- `assets/js/blocks/shopper-collection/frontend.ts` — block-private iAPI store at `woocommerce/shopper-collection`. Hosts derived display getters (formatted price, decoded name, thumbnail with placeholder fallback, etc.) and the click handlers (`onClickRemove`, `onClickMoveToCart`). Side-effect imports both shared stores.
- `src/Blocks/BlockTypes/ShopperCollection.php` — SSR via `rest_do_request()` (logged-out short-circuits), seeds `wp_interactivity_state` with the prefetched items + nonce + restUrl, renders both the `<template data-wp-each>` and pre-rendered `data-wp-each-child` rows so first paint matches what iAPI hydrates against. Centralises per-list-type strings/classes/behaviour in a `get_variation_config()` map so adding Wishlist/etc. is one new entry.
- `assets/js/blocks/shopper-collection/{style,editor}.scss` — diverged on purpose: `style.scss` is self-contained for the frontend (the WC atomic-block stylesheet doesn't auto-load there), while `editor.scss` relies on the editor canvas's global CSS.
- `tsconfig.base.json`, `webpack-config-interactive-blocks.js` — register the new shared-store path alias and module entry.

**Key decisions:**

- **Two stores, not one.** The shared store stays schema-pure (mirror only); display-derived state and click handlers live in the block-private store. Future variations (Wishlist, Recently viewed) reuse the same shared store and most of the block-private getters; only the action button behaviour diverges (configurable via the variation map's `actionDirective`).
- **SSR + `<template>` together.** Mini-cart renders items JS-only (drawer, no first-paint requirement); Product Collection renders PHP-only (no in-place reactivity needed). Shopper Collection needs both — first-paint completeness and reactive Remove/Move-to-cart — so it pays the parallel-implementation cost (PHP `format_price_with_currency` ↔ JS `formatPriceFromSchema`, etc.). TODO in the renderer flags moving to schema-supplied `price_html` / `image_html` once #64472 grows those fields.
- **PHP-seeded nonce.** Diverges from the cart store's bootstrap-from-response-header pattern; required because shopper-lists doesn't auto-fire a request on hydrate (SSR already populated state). Marked with a TODO to revisit alongside server-side authentication enforcement.
- **Move-to-cart is two requests, not one.** Calls cart's `addCartItem`, then on success calls `removeItem`. Detects success by snapshotting the matching cart line's quantity before/after the add — cart store catches its own errors, so the yield resolves the same way on success and failure.

### How to test the changes in this Pull Request:

1. Check out this branch on top of \`feature/shopper-collections\`. Run \`pnpm --filter=@woocommerce/block-library build\`.
2. Log in as a shopper. Add a few products to cart, including at least one variable product (Hoodie + Color + Size).
3. Hit \`POST /wp-json/wc/store/v1/shopper-lists/saved-for-later/items\` with \`{"cart_item_key": "<key>"}\` (or \`{"product_id": N}\`) for each item you want saved.
4. Add the **Saved for Later** block to a page (Block Inserter → Saved for Later).
5. Visit the page. Verify:
    - Logged-in: items appear on first paint with thumbnail, name, variation label (where applicable), formatted price, quantity, Remove pill on the image, and Move to cart button.
    - Logged-out: empty state renders, no console errors, no API calls in the network tab.
6. Click **Remove** on a row → row disappears immediately, persists across reload.
7. Block requests in DevTools (or kill the network), click Remove → row reappears with an error notice.
8. Click **Move to cart** on a simple product → item enters cart, row disappears from saved list.
9. Click **Move to cart** on a variable product → variation lands in cart with the right attributes, row disappears from saved list.
10. \`wp post delete <product_id> --force\` for one of the saved products → reload page → that row renders with the placeholder image, no price, no Move to cart button (only Remove).
11. POST the same product twice via the API → reload → single row shows the merged quantity, no duplicate row.

### Testing that has already taken place:

- PHPStan (clean), PHPCS (clean), \`wp-scripts lint-js\` (clean), Stylelint (clean) on all touched files.
- \`pnpm --filter=@woocommerce/block-library ts:check\` — the two pre-existing errors in \`edit.tsx\` / \`index.tsx\` predate this branch.
- Manual browser verification of: SSR first paint, Remove (success path), Move to cart (simple + variation), tombstones (deleted product fallback), re-saving merges quantity.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry.

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog already added manually at \`plugins/woocommerce/changelog/add-shopper-collections-iapi-store\` (Significance: minor, Type: add).

</details>