### PR TITLE
fix: use field_name instead of id when retrieving option values in WC_Admin_Settings

### DIFF
--- a/plugins/woocommerce/changelog/64653-ai-agent-rsmapgj-65-1778062421
+++ b/plugins/woocommerce/changelog/64653-ai-agent-rsmapgj-65-1778062421
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WC_Admin_Settings retrieving option values using field ID instead of field_name, restoring correct behavior for array-keyed settings fields.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -291,7 +291,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					$value['suffix'] = '';
 				}
 				if ( ! isset( $value['value'] ) ) {
-					$value['value'] = self::get_option( $value['id'], $value['default'] );
+					$value['value'] = self::get_option( $value['field_name'], $value['default'] );
 				}
 
 				if ( ! is_null( $value['fixed_value'] ?? null ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Admin_Settings::get_saved_settings_fields()` was calling `self::get_option( $value['id'], $value['default'] )` to retrieve each field's stored value. When a field's `field_name` uses array notation (e.g. `option_name[key]`) but `id` is set to a different string, the lookup fails silently and the field always shows its default value. The fix is a single substitution: pass `$value['field_name']` instead of `$value['id']` so the correct option key is used. For standard fields where `id` and `field_name` are identical, behaviour is unchanged.

**Before:**
```php
$value['value'] = self::get_option( $value['id'], $value['default'] );
```

**After:**
```php
$value['value'] = self::get_option( $value['field_name'], $value['default'] );
```

Closes #48254

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Register a WooCommerce settings field where `field_name` uses array notation (e.g. `my_option[key]`) but `id` differs.
2. Save a known value for that option in the database.
3. Call `WC_Admin_Settings::get_saved_settings_fields()` and confirm the value is correctly retrieved.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix WC_Admin_Settings retrieving option values using field ID instead of field_name, restoring correct behavior for array-keyed settings fields.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-65
