### PR TITLE
fix: remove stripslashes() call that produces invalid JSON in LogHandlerFileV2 backtrace context

### DIFF
--- a/plugins/woocommerce/changelog/64655-ai-agent-rsmapgj-12-1778062820
+++ b/plugins/woocommerce/changelog/64655-ai-agent-rsmapgj-12-1778062820
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix LogHandlerFileV2 producing invalid JSON log context when backtrace is enabled by removing erroneous stripslashes() call.

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -91,7 +91,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 
 		if ( ! empty( $context_for_entry ) ) {
 			$formatted_context = wp_json_encode( $context_for_entry, JSON_UNESCAPED_UNICODE );
-			$message          .= stripslashes( " CONTEXT: $formatted_context" );
+			$message          .= " CONTEXT: $formatted_context";
 		}
 
 		$entry = "$time_string $level_string $message";

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
@@ -192,7 +192,7 @@ MESSAGE;
 				'multibyte'   => '中文字',
 				'backslashes' => 'C:\MS-DOS\\',
 			),
-			$context_delineator . '{"multibyte":"中文字","backslashes":"C:\MS-DOS\"}',
+			$context_delineator . '{"multibyte":"中文字","backslashes":"C:\\\\MS-DOS\\\\"}',
 		);
 		yield 'backtrace boolean only' => array(
 			array( 'backtrace' => true ),


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When logging with `backtrace` enabled, `LogHandlerFileV2` calls `stripslashes()` on the JSON-encoded context string. This strips the backslashes used as namespace separators (e.g. `Automattic\\WooCommerce` becomes `Automattic\WooCommerce`), producing invalid JSON that the Admin Status Logs viewer cannot parse.

The fix removes the `stripslashes()` call from the context-formatting path, ensuring the JSON output remains valid regardless of the logged data.

```php
// Before (corrupts JSON when context contains backslashes):
$context = stripslashes( json_encode( $context ) );

// After (valid JSON preserved):
$context = json_encode( $context );
```

Closes #62830

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Log a message with `backtrace => true` and context containing backslash-heavy values (e.g. PHP namespace strings): `wc_get_logger()->info('test', ['source' => 'test', 'backtrace' => true, 'data' => ['class' => 'Automattic\\WooCommerce\\SomeClass']])`.
2. Navigate to **WooCommerce → Status → Logs** and open the log file.
3. Confirm the CONTEXT field displays valid, parseable JSON with backslashes intact.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix LogHandlerFileV2 producing invalid JSON log context when backtrace is enabled by removing erroneous stripslashes() call.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-12
