### PR TITLE
fix: update children cache after create_all_product_variations to prevent stale get_children() results

### DIFF
--- a/plugins/woocommerce/changelog/61113-fix-children-cache-after-create-all-product-variations
+++ b/plugins/woocommerce/changelog/61113-fix-children-cache-after-create-all-product-variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix stale children cache on variable product after calling create_all_product_variations

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1549,11 +1549,11 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 *
 	 * @since  3.6.0
 	 * @todo   Add to interface in 4.0.
-	 * @param  WC_Product $product Variable product.
-	 * @param  int        $limit Limit the number of created variations.
-	 * @param  array      $default_values Key value pairs to set on created variations.
-	 * @param  array      $metadata Key value pairs to set as meta data on created variations.
-	 * @return int        Number of created variations.
+	 * @param  WC_Product_Variable $product Variable product.
+	 * @param  int                 $limit Limit the number of created variations.
+	 * @param  array               $default_values Key value pairs to set on created variations.
+	 * @param  array               $metadata Key value pairs to set as meta data on created variations.
+	 * @return int                 Number of created variations.
 	 */
 	public function create_all_product_variations( $product, $limit = -1, $default_values = array(), $metadata = array() ) {
 		$count = 0;
@@ -1585,6 +1585,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$possible_attributes = array_reverse( wc_array_cartesian( $attributes ) );
 		$product_id          = $product->get_id();
+		$new_variation_ids   = array();
 
 		foreach ( $possible_attributes as $possible_attribute ) {
 			// Allow any order if key/values -- do not use strict mode.
@@ -1600,6 +1601,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$variation->set_attributes( $possible_attribute );
 			$variation_id = $variation->save();
 
+			$new_variation_ids[] = $variation_id;
+
 			do_action( 'product_variation_linked', $variation_id );
 
 			++$count;
@@ -1607,6 +1610,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			if ( $limit > 0 && $count >= $limit ) {
 				break;
 			}
+		}
+
+		// Update the children cache on the product instance so subsequent calls to
+		// get_children() reflect the newly created variations. Without this, the
+		// get_children() call above sets $children to [] (empty array, not null),
+		// causing later get_children() calls to return stale empty results.
+		if ( ! empty( $new_variation_ids ) ) {
+			$product->set_children( array_merge( $child_ids, $new_variation_ids ) );
 		}
 
 		return $count;

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -1101,6 +1101,36 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that create_all_product_variations updates the children cache on the product instance.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/61113
+	 */
+	public function test_variable_create_all_product_variations_updates_children_cache() {
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Test Variable Product' );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'color' );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+		$attribute->set_options( array( 'red', 'blue' ) );
+
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$count      = $data_store->create_all_product_variations( $product );
+
+		$this->assertEquals( 2, $count );
+
+		// get_children() on the same product instance should return the newly
+		// created variation IDs, not the stale empty array that was cached
+		// before the variations were created.
+		$children = $product->get_children();
+		$this->assertCount( 2, $children, 'get_children() must reflect variations created in the same call' );
+	}
+
+	/**
 	 * Test find_matching_product_variation.
 	 *
 	 * @return void


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Product_Data_Store_CPT::create_all_product_variations` internally queries for existing variations before creating new ones. This query sets the `children` property on the product instance to an empty array (`[]`), which is the sentinel used by `WC_Product_Variable::get_children()` to skip the DB fetch. As a result, any subsequent call to `get_children()` on the same instance returns stale empty results even after new variations were created.

The fix ensures the product's `children` cache is updated (or invalidated) after variations are created, so `get_children()` returns the correct set of variation IDs.

Closes #61113

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Create a variable product with multiple attributes set to variation-enabled.
2. Call `$data_store->create_all_product_variations($product)`.
3. Immediately call `$product->get_children()` and confirm it returns the newly created variation IDs (not an empty array).

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog file already present on the branch: `plugins/woocommerce/changelog/61113-fix-children-cache-after-create-all-product-variations` (added by the AI Coder fixer).

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-17
