### PR TITLE
fix: register wc_no_js via wp_add_inline_script to allow CSP nonce injection

### DIFF
--- a/plugins/woocommerce/changelog/61141-register-wc-no-js-via-wp-add-inline-script
+++ b/plugins/woocommerce/changelog/61141-register-wc-no-js-via-wp-add-inline-script
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Register wc_no_js script via wp_add_inline_script() to allow CSP nonce injection through the wp_inline_script_attributes() filter.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -386,28 +386,13 @@ function wc_body_class( $classes ) {
 
 	$classes[] = 'woocommerce-no-js';
 
-	add_action( 'wp_footer', 'wc_no_js' );
+	wp_add_inline_script(
+		'woocommerce',
+		'(function(){var c=document.body.className;c=c.replace(/woocommerce-no-js/,"woocommerce-js");document.body.className=c;})()',
+		'after'
+	);
 
 	return array_unique( $classes );
-}
-
-/**
- * NO JS handling.
- *
- * @since 3.4.0
- * @return void
- */
-function wc_no_js() {
-	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
-	?>
-	<script<?php echo $type_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-		(function () {
-			var c = document.body.className;
-			c = c.replace(/woocommerce-no-js/, 'woocommerce-js');
-			document.body.className = c;
-		})();
-	</script>
-	<?php
 }
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `wc_no_js` inline script is currently output directly inside a `wp_footer` action callback, bypassing the WordPress script API. Because it is not registered via `wp_add_inline_script()`, the `wp_inline_script_attributes()` filter cannot inject a CSP nonce, so sites enforcing a nonce-based Content Security Policy must add `unsafe-inline` as a workaround to avoid the script being blocked.

The fix registers the inline script using `wp_add_inline_script()` attached to an existing WooCommerce script handle, enabling nonce injection through the standard WordPress filter.

Closes #61141

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Enable a Content Security Policy with a nonce-based `script-src` directive (no `unsafe-inline`).
2. Load any WooCommerce frontend page.
3. Confirm the `wc_no_js` script is rendered with the correct nonce attribute and is not blocked by the browser CSP.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog file already present on the branch: `plugins/woocommerce/changelog/61141-register-wc-no-js-via-wp-add-inline-script` (added by the AI Coder fixer).

---

Generated by the RSMAPGJ AI Coder pipeline. The fixer's quality reviewer agent approved this diff before push. Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-16
