### PR TITLE
fix: WC_Countries locale cache not refreshed on locale switch

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-countries-locale-cache-refresh
+++ b/plugins/woocommerce/changelog/fix-wc-countries-locale-cache-refresh
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix WC_Countries caching country/state/continent names without refreshing on locale switch; add flush_country_name_cache() and hook it to change_locale action.

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -40,6 +40,37 @@ class WC_Countries {
 	private $geo_cache = array();
 
 	/**
+	 * Constructor.
+	 *
+	 * Registers a hook to flush the country/state/continent name cache whenever
+	 * the active locale is switched, ensuring that translated names always
+	 * reflect the current locale.
+	 *
+	 * @since 10.9.0
+	 */
+	public function __construct() {
+		add_action( 'change_locale', array( $this, 'flush_country_name_cache' ) );
+	}
+
+	/**
+	 * Flush the cache of country, state, and continent names.
+	 *
+	 * Called automatically when the locale changes (via switch_to_locale() or
+	 * restore_current_locale()) so that subsequent calls to get_countries(),
+	 * get_states(), and get_continents() return correctly translated names for
+	 * the active locale.
+	 *
+	 * This method is also public so callers can trigger a manual cache flush
+	 * when needed.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function flush_country_name_cache() {
+		unset( $this->geo_cache['countries'], $this->geo_cache['states'], $this->geo_cache['continents'] );
+	}
+
+	/**
 	 * Auto-load in-accessible properties on demand.
 	 *
 	 * @param  mixed $key Key.

--- a/plugins/woocommerce/tests/php/includes/class-wc-countries-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-countries-test.php
@@ -43,4 +43,51 @@ class WC_Countries_Test extends \WC_Unit_Test_Case {
 			),
 		);
 	}
+
+	/**
+	 * Tests that `flush_country_name_cache` clears the geo_cache so that
+	 * get_countries(), get_states(), and get_continents() reload their data.
+	 *
+	 * @return void
+	 */
+	public function test_flush_country_name_cache_clears_geo_cache() {
+		$countries = new WC_Countries();
+
+		// Warm the cache for all three data sets.
+		$countries->get_countries();
+		$countries->get_states();
+		$countries->get_continents();
+
+		// Inspect the private geo_cache via reflection.
+		$ref   = new ReflectionClass( $countries );
+		$prop  = $ref->getProperty( 'geo_cache' );
+		$prop->setAccessible( true );
+
+		$before = $prop->getValue( $countries );
+		$this->assertArrayHasKey( 'countries', $before, 'geo_cache[countries] should be populated after get_countries().' );
+		$this->assertArrayHasKey( 'states', $before, 'geo_cache[states] should be populated after get_states().' );
+		$this->assertArrayHasKey( 'continents', $before, 'geo_cache[continents] should be populated after get_continents().' );
+
+		$countries->flush_country_name_cache();
+
+		$after = $prop->getValue( $countries );
+		$this->assertArrayNotHasKey( 'countries', $after, 'geo_cache[countries] should be cleared by flush_country_name_cache().' );
+		$this->assertArrayNotHasKey( 'states', $after, 'geo_cache[states] should be cleared by flush_country_name_cache().' );
+		$this->assertArrayNotHasKey( 'continents', $after, 'geo_cache[continents] should be cleared by flush_country_name_cache().' );
+	}
+
+	/**
+	 * Tests that `flush_country_name_cache` is hooked to the `change_locale` action
+	 * so country names are refreshed when the locale switches.
+	 *
+	 * @return void
+	 */
+	public function test_flush_country_name_cache_hooked_to_change_locale() {
+		$countries = new WC_Countries();
+
+		$this->assertNotFalse(
+			has_action( 'change_locale', array( $countries, 'flush_country_name_cache' ) ),
+			'flush_country_name_cache() should be hooked to the change_locale action.'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a locale cache regression in `WC_Countries` where country, state, and continent names were cached without being invalidated when the active locale changed. Adds a `flush_country_name_cache()` method that clears the relevant `geo_cache` entries, and hooks it to the `change_locale` action so that translated names are always correct after a `switch_to_locale()` or `restore_current_locale()` call. Two unit tests are added to verify cache clearing and the hook registration.

Closes #42013

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Call `WC()->countries->get_countries()` to warm the cache, then call `switch_to_locale( 'fr_FR' )` — verify that `WC()->countries->get_countries()` now returns French country names instead of stale English ones.
2. Directly call `WC()->countries->flush_country_name_cache()` and confirm that subsequent calls to `get_countries()`, `get_states()`, and `get_continents()` reload fresh data (no stale cache entries remain).
3. Run the new PHPUnit tests in `plugins/woocommerce/tests/php/includes/class-wc-countries-test.php` and confirm both `test_flush_country_name_cache_clears_geo_cache` and `test_flush_country_name_cache_hooked_to_change_locale` pass.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix WC_Countries caching country/state/continent names without refreshing on locale switch; add flush_country_name_cache() and hook it to change_locale action.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. Opened as **draft** so a human reviewer can verify the fix before promotion to ready-for-review.

Linear: https://linear.app/a8c/issue/RSMAPGJ-214
