### PR TITLE
fix: make WC_Product_Variation::set_name() persist through save()

### DIFF
--- a/plugins/woocommerce/changelog/64661-ai-agent-rsmapgj-230-1778065508
+++ b/plugins/woocommerce/changelog/64661-ai-agent-rsmapgj-230-1778065508
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `WC_Product_Variation::set_name()` being overwritten on save by persisting custom variation names via a `_variation_title_is_custom` meta flag.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -29,6 +29,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	protected function exclude_internal_meta_keys( $meta ) {
 		$internal_meta_keys   = $this->internal_meta_keys;
 		$internal_meta_keys[] = '_cogs_value_is_additive';
+		$internal_meta_keys[] = '_variation_title_is_custom';
 
 		return ! in_array( $meta->meta_key, $internal_meta_keys, true ) && 0 !== stripos( $meta->meta_key, 'attribute_' ) && 0 !== stripos( $meta->meta_key, 'wp_' );
 	}
@@ -90,12 +91,15 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$updates = array();
 		/**
 		 * If a variation title is not in sync with the parent e.g. saved prior to 3.0, or if the parent title has changed, detect here and update.
+		 * Skip auto-sync when the variation has a custom title explicitly set by the caller.
 		 */
-		$new_title = $this->generate_product_title( $product );
+		if ( ! get_post_meta( $product->get_id(), '_variation_title_is_custom', true ) ) {
+			$new_title = $this->generate_product_title( $product );
 
-		if ( $post_object->post_title !== $new_title ) {
-			$product->set_name( $new_title );
-			$updates = array_merge( $updates, array( 'post_title' => $new_title ) );
+			if ( $post_object->post_title !== $new_title ) {
+				$product->set_name( $new_title );
+				$updates = array_merge( $updates, array( 'post_title' => $new_title ) );
+			}
 		}
 
 		if ( ! empty( $updates ) ) {
@@ -118,9 +122,10 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$product->set_date_created( time() );
 		}
 
-		$new_title = $this->generate_product_title( $product );
+		$name_explicitly_set = isset( $product->get_changes()['name'] );
+		$new_title           = $this->generate_product_title( $product );
 
-		if ( $product->get_name( 'edit' ) !== $new_title ) {
+		if ( ! $name_explicitly_set && $product->get_name( 'edit' ) !== $new_title ) {
 			$product->set_name( $new_title );
 		}
 
@@ -157,6 +162,10 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		if ( $id && ! is_wp_error( $id ) ) {
 			$product->set_id( $id );
 
+			if ( $name_explicitly_set && $product->get_name( 'edit' ) !== $new_title ) {
+				update_post_meta( $id, '_variation_title_is_custom', '1' );
+			}
+
 			$this->update_post_meta( $product, true );
 			$this->update_terms( $product, true );
 			$this->update_visibility( $product, true );
@@ -188,10 +197,24 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$product->set_date_created( time() );
 		}
 
-		$new_title = $this->generate_product_title( $product );
+		// Snapshot changes before any auto-title modification so we can detect explicit name changes.
+		$pre_changes         = $product->get_changes();
+		$name_explicitly_set = isset( $pre_changes['name'] );
+		$new_title           = $this->generate_product_title( $product );
 
-		if ( $product->get_name( 'edit' ) !== $new_title ) {
-			$product->set_name( $new_title );
+		if ( $name_explicitly_set ) {
+			// The caller explicitly set the name; respect it and track whether it is a custom value.
+			if ( $product->get_name( 'edit' ) !== $new_title ) {
+				update_post_meta( $product->get_id(), '_variation_title_is_custom', '1' );
+			} else {
+				// Name was set to the auto-generated value; clear the custom flag.
+				delete_post_meta( $product->get_id(), '_variation_title_is_custom' );
+			}
+		} elseif ( ! get_post_meta( $product->get_id(), '_variation_title_is_custom', true ) ) {
+			// No explicit name change and no custom name flag; auto-sync the title.
+			if ( $product->get_name( 'edit' ) !== $new_title ) {
+				$product->set_name( $new_title );
+			}
 		}
 
 		// The post parent is not a valid variable product so we should prevent this.

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variations-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variations-data-store-cpt-test.php
@@ -296,6 +296,98 @@ class WC_Product_Variation_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox set_name() on a variation persists after save() and is returned by get_name() on a fresh fetch.
+	 */
+	public function test_set_name_persists_after_save_and_refetch() {
+		$variation = $this->get_variation();
+		$variation->set_name( 'My Custom Variation Name' );
+		$variation->save();
+
+		$refetched = wc_get_product( $variation->get_id() );
+
+		$this->assertEquals( 'My Custom Variation Name', $refetched->get_name() );
+	}
+
+	/**
+	 * @testdox Custom variation name set via set_name() persists across multiple saves without re-setting the name.
+	 */
+	public function test_custom_name_persists_across_subsequent_saves() {
+		$variation = $this->get_variation();
+		$variation->set_name( 'Persistent Custom Name' );
+		$variation->save();
+
+		// Save again without changing the name.
+		$variation2 = wc_get_product( $variation->get_id() );
+		$variation2->set_regular_price( '99.99' );
+		$variation2->save();
+
+		$refetched = wc_get_product( $variation->get_id() );
+
+		$this->assertEquals( 'Persistent Custom Name', $refetched->get_name() );
+	}
+
+	/**
+	 * @testdox Setting the name back to the auto-generated title via set_name() removes the custom name flag.
+	 */
+	public function test_setting_name_to_auto_generated_removes_custom_flag() {
+		$variation = $this->get_variation();
+		$variation->set_name( 'My Custom Name' );
+		$variation->save();
+
+		$this->assertEquals( '1', get_post_meta( $variation->get_id(), '_variation_title_is_custom', true ) );
+
+		// Now set it back to the auto-generated title.
+		$data_store = new WC_Product_Variation_Data_Store_CPT();
+		$auto_title = $data_store->get_attribute_summary( $variation );
+
+		$variation2 = wc_get_product( $variation->get_id() );
+		// The parent product name is used in the auto-generated title; derive it.
+		$parent     = wc_get_product( $variation2->get_parent_id() );
+		$auto_title = $parent->get_name();
+
+		$variation2->set_name( $auto_title );
+		$variation2->save();
+
+		$this->assertEmpty( get_post_meta( $variation->get_id(), '_variation_title_is_custom', true ) );
+	}
+
+	/**
+	 * @testdox Custom variation name set on create() persists after the first save and a subsequent fetch.
+	 */
+	public function test_set_name_on_new_variation_persists() {
+		$parent = WC_Helper_Product::create_variation_product();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $parent->get_id() );
+		$variation->set_name( 'Brand New Custom Name' );
+		$variation->set_status( 'publish' );
+		$variation->save();
+
+		$refetched = wc_get_product( $variation->get_id() );
+
+		$this->assertEquals( 'Brand New Custom Name', $refetched->get_name() );
+	}
+
+	/**
+	 * @testdox _variation_title_is_custom meta is excluded from the variation's public meta data.
+	 */
+	public function test_variation_title_is_custom_meta_is_internal() {
+		$variation = $this->get_variation();
+		$variation->set_name( 'Custom Name For Meta Test' );
+		$variation->save();
+
+		$meta_data = $variation->get_meta_data();
+		$keys      = array_map(
+			function ( $m ) {
+				return $m->key;
+			},
+			$meta_data
+		);
+
+		$this->assertNotContains( '_variation_title_is_custom', $keys );
+	}
+
+	/**
 	 * Create a variable product and return one of its variations.
 	 *
 	 * @return WC_Product_Variation The variation created.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Product_Variation::set_name()` was silently overwritten on every `save()` call because `WC_Product_Variation_Data_Store_CPT` unconditionally regenerated and applied the auto-generated title (parent product name + attribute summary) during both `create()` and `update()`. The fix introduces a `_variation_title_is_custom` post-meta flag that is set whenever `save()` detects the caller explicitly changed the name to a value different from the auto-generated title, and clears the flag if the name is set back to the auto-generated value. Both the `create()` and `update()` paths skip the auto-title sync when this flag is present, so a custom name set via `set_name()` now persists across multiple saves. The meta key is added to the internal meta keys list so it is never exposed in public meta data.

Closes #33333

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Create a variable product with at least one variation. Call `$variation->set_name( 'My Custom Name' )` followed by `$variation->save()`, then re-fetch with `wc_get_product( $id )` and assert that `get_name()` returns `'My Custom Name'` (not the auto-generated title).
2. Save the variation a second time without calling `set_name()` again (e.g. update the price) and re-fetch; verify the custom name is still returned by `get_name()`.
3. Call `set_name()` with the auto-generated title (parent name) on the variation and save; confirm the `_variation_title_is_custom` meta is cleared and that the title reverts to normal auto-sync behaviour on future saves.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix `WC_Product_Variation::set_name()` being overwritten on save by persisting custom variation names via a `_variation_title_is_custom` meta flag.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. Opened as **draft** so a human reviewer can verify the fix before promotion to ready-for-review.

Linear: https://linear.app/a8c/issue/RSMAPGJ-230
