### PR TITLE
fix: update order date_modified when line items change in CPT data store

### DIFF
--- a/plugins/woocommerce/changelog/fix-34798-order-date-modified-not-updated-on-item-changes
+++ b/plugins/woocommerce/changelog/fix-34798-order-date-modified-not-updated-on-item-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order date_modified not being updated when order items (quantity, totals) are changed.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -226,6 +226,14 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		$changes = $order->get_changes();
 
+		// Always update date_modified when the order is updated, unless it was explicitly set.
+		// This mirrors the behaviour of the HPOS data store and ensures date_modified is updated
+		// when order items or other related data (e.g. totals) change.
+		if ( ! isset( $changes['date_modified'] ) ) {
+			$order->set_date_modified( current_time( 'mysql' ) );
+			$changes = $order->get_changes();
+		}
+
 		// Only update the post when the post data changes.
 		if ( array_intersect( array( 'date_created', 'date_modified', 'status', 'parent_id', 'post_excerpt' ), array_keys( $changes ) ) ) {
 			$post_data = array(

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1339,6 +1339,53 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Saving an order with meta changes (e.g. totals) updates date_modified.
+	 */
+	public function test_saving_order_with_meta_changes_updates_date_modified(): void {
+		$order = WC_Helper_Order::create_order();
+
+		// Set date_modified to a known past time so we can assert it changes.
+		$order->set_date_modified( '2020-01-01 00:00:00' );
+		$order->save();
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertEquals( strtotime( '2020-01-01 00:00:00' ), $order->get_date_modified( 'edit' )->getTimestamp(), 'Initial date_modified should be the value we explicitly set.' );
+
+		// Update a meta field (e.g. order total), mirroring what calculate_totals() does.
+		$order->set_total( 999.99 );
+		$order->save();
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertNotEquals( strtotime( '2020-01-01 00:00:00' ), $order->get_date_modified( 'edit' )->getTimestamp(), 'date_modified should be updated when order meta changes.' );
+	}
+
+	/**
+	 * @testdox Updating order items (quantity) via calculate_totals updates the order date_modified.
+	 */
+	public function test_order_item_update_updates_order_date_modified(): void {
+		$order = WC_Helper_Order::create_order();
+
+		// Set date_modified to a known past time so we can assert it changes.
+		$order->set_date_modified( '2020-01-01 00:00:00' );
+		$order->save();
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertEquals( strtotime( '2020-01-01 00:00:00' ), $order->get_date_modified( 'edit' )->getTimestamp(), 'Initial date_modified should be the value we explicitly set.' );
+
+		// Update a line item quantity (mirroring a REST API PUT request).
+		$items = $order->get_items();
+		$item  = reset( $items );
+		$item->set_quantity( 5 );
+		$item->save();
+
+		// calculate_totals() recalculates order totals and calls save() — this is the path used by the REST API.
+		$order->calculate_totals();
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertNotEquals( strtotime( '2020-01-01 00:00:00' ), $order->get_date_modified( 'edit' )->getTimestamp(), 'date_modified should be updated when order items are changed.' );
+	}
+
+	/**
 	 * @testdox CPT cache priming populates order item meta caches so item access does not trigger additional queries.
 	 */
 	public function test_prime_caches_for_orders_primes_item_meta(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When an order's line items (quantity, totals) are updated via the REST API, the CPT data store's `update()` method was not updating the order's `date_modified` timestamp. This is because item changes do not register as changes on the order object itself, so the existing check for `date_modified` in the order's `$changes` array was never triggered.

The fix mirrors the behaviour already implemented in the HPOS data store: at the start of `update()`, if `date_modified` has not been explicitly changed by the caller, it is set to the current time unconditionally. This ensures that any save operation — including those triggered by `calculate_totals()` after item edits — always bumps `date_modified`, keeping it consistent with HPOS and making REST API `modified_after` filters work correctly.

Two new PHPUnit tests are added to the CPT data store test class to cover:
1. Saving an order with meta changes (e.g. order total) updates `date_modified`.
2. Updating order items (quantity) via `calculate_totals()` updates `date_modified`.

Closes #34798

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Create an order via the REST API and note its `date_modified` value.
2. Send a `PUT /wp-json/wc/v3/orders/{id}` request that updates a line item quantity (e.g. `"line_items": [{"id": <item_id>, "quantity": 5}]`).
3. Fetch the order again and confirm that `date_modified` has been updated to a more recent timestamp.

### Testing that has already taken place:

- Automated: the RSMAPGJ AI Coder pipeline's quality reviewer agent approved this diff before push.
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix order date_modified not being updated when order items (quantity, totals) are changed.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline. Opened as **draft** so a human reviewer can verify the fix before promotion to ready-for-review.

Linear: https://linear.app/a8c/issue/RSMAPGJ-228
