### PR TITLE
Fix Add to Cart + Options button being disabled when a grouped product child quantity changes to 0

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-button-disabled
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-button-disabled
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Add to Cart + Options button being disabled when a grouped product child quantity changed to 0
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -202,7 +202,11 @@ const { actions } = store< MergedAddToCartWithOptionsStores >(
 					};
 				}
 
-				if ( productsState.mainProductInContext?.type === 'grouped' ) {
+				const parentProduct = productsState.findProduct( {
+					id: productsState.productId,
+					selectedAttributes: context.selectedAttributes,
+				} );
+				if ( parentProduct?.type === 'grouped' ) {
 					actions.validateGroupedProductQuantity();
 				} else {
 					actions.validateQuantity( productId, value );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -593,12 +593,12 @@ test.describe( 'Add to Cart + Options Block', () => {
 				.getByLabel( 'Reduce quantity of Beanie' );
 			await reduceBeanieQuantityButton.click();
 
-			const addToCartButton = page.getByRole( 'button', {
+			const addedToCartButton = page.getByRole( 'button', {
 				name: 'Added to cart',
 				exact: true,
 			} );
 
-			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
+			await expect( addedToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 
 			const reduceTShirtQuantityButton = page
 				.locator(
@@ -618,7 +618,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( tShirtQuantityInput ).toHaveValue( '0' );
 			await expect( reduceBeanieQuantityButton ).toBeDisabled();
 			await expect( reduceTShirtQuantityButton ).toBeDisabled();
-			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
+			await expect( addedToCartButton ).toHaveClass( /\bdisabled\b/ );
 		} );
 
 		await test.step( 'products sold individually can be added to cart', async () => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -551,16 +551,21 @@ test.describe( 'Add to Cart + Options Block', () => {
 		} );
 
 		await test.step( 'successfully adds to cart when child products are selected', async () => {
-			const increaseQuantityButton = page
+			const increaseBeanieQuantityButton = page
 				.locator(
 					'[data-block-name="woocommerce/add-to-cart-with-options"]'
 				)
 				.getByLabel( 'Increase quantity of Beanie' );
-			await increaseQuantityButton.click();
+			await increaseBeanieQuantityButton.click();
 
 			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 
-			await increaseQuantityButton.click();
+			const increaseTShirtQuantityButton = page
+				.locator(
+					'[data-block-name="woocommerce/add-to-cart-with-options"]'
+				)
+				.getByLabel( 'Increase quantity of T-Shirt' );
+			await increaseTShirtQuantityButton.click();
 
 			await addToCartButton.click();
 
@@ -581,28 +586,39 @@ test.describe( 'Add to Cart + Options Block', () => {
 		} );
 
 		await test.step( 'child simple product quantities can be decreased down to 0', async () => {
-			const reduceQuantityButton = page
+			const reduceBeanieQuantityButton = page
 				.locator(
 					'[data-block-name="woocommerce/add-to-cart-with-options-grouped-product-item-selector"]'
 				)
 				.getByLabel( 'Reduce quantity of Beanie' );
-			await reduceQuantityButton.click();
-			await reduceQuantityButton.click();
+			await reduceBeanieQuantityButton.click();
 
-			const quantityInput = page.getByRole( 'spinbutton', {
-				name: 'Beanie',
+			const addToCartButton = page.getByRole( 'button', {
+				name: 'Added to cart',
+				exact: true,
 			} );
 
-			await expect( quantityInput ).toHaveValue( '0' );
+			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 
-			await expect( reduceQuantityButton ).toBeDisabled();
+			const reduceTShirtQuantityButton = page
+				.locator(
+					'[data-block-name="woocommerce/add-to-cart-with-options-grouped-product-item-selector"]'
+				)
+				.getByLabel( 'Reduce quantity of T-Shirt' );
+			await reduceTShirtQuantityButton.click();
 
-			await expect(
-				page.getByRole( 'button', {
-					name: 'Added to cart',
-					exact: true,
-				} )
-			).toHaveClass( /\bdisabled\b/ );
+			const beanieQuantityInput = page.getByRole( 'spinbutton', {
+				name: 'Beanie',
+			} );
+			const tShirtQuantityInput = page.getByRole( 'spinbutton', {
+				name: 'T-Shirt',
+			} );
+
+			await expect( beanieQuantityInput ).toHaveValue( '0' );
+			await expect( tShirtQuantityInput ).toHaveValue( '0' );
+			await expect( reduceBeanieQuantityButton ).toBeDisabled();
+			await expect( reduceTShirtQuantityButton ).toBeDisabled();
+			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
 		} );
 
 		await test.step( 'products sold individually can be added to cart', async () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WC 10.8 has a regression that causes the 'Add to cart' button to change to the disabled state when only one of a grouped product's children is set to 0. Instead, the button should look disabled only when all product quantities are set to 0.

This PR fixes that and updates the tests to catch this kind of issues in the future.

### How to test the changes in this Pull Request:

1. Visit the product page of a grouped product.
2. Increase the quantity of two of its children.
3. Set back the quantity of one of them to 0.
4. Verify the 'Add to cart' button doesn't look disabled and clicking on it correctly adds products to the cart.

Before:

https://github.com/user-attachments/assets/b8f2c418-67ea-486b-ab93-0e3d1a580286

After:

https://github.com/user-attachments/assets/26d23883-225e-405b-baa9-ec5436f32d7c
