### PR TITLE
Allow subscription orders through payment completion validation

### DIFF
--- a/plugins/woocommerce/changelog/fix-62761-payment-complete-subscriptions
+++ b/plugins/woocommerce/changelog/fix-62761-payment-complete-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow WooCommerce Subscriptions renewal orders to complete payment under checkout evidence validation.

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -152,7 +152,11 @@ class WC_Order extends WC_Abstract_Order {
 			 * @param WC_Order $order                     Order object.
 			 * @since 10.8.0
 			 */
-			$allowed_created_via_values = apply_filters( 'woocommerce_payment_complete_allowed_created_via_values', array( 'checkout', 'store-api', 'rest-api', 'admin', 'pos-rest-api' ), $this );
+			$allowed_created_via_values = apply_filters(
+				'woocommerce_payment_complete_allowed_created_via_values',
+				array( 'checkout', 'store-api', 'rest-api', 'admin', 'pos-rest-api', 'subscription' ),
+				$this
+			);
 
 			if ( ! empty( $created_via ) && in_array( $created_via, $allowed_created_via_values, true ) ) {
 				$has_checkout_evidence = true;

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -1187,6 +1187,22 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test: payment_complete allows orders with created_via subscription
+	 *
+	 * @testdox payment_complete allows order with created_via subscription.
+	 * @since 10.9.0
+	 */
+	public function test_payment_complete_allows_orders_with_created_via_subscription() {
+		$object = new WC_Order();
+		$object->set_created_via( 'subscription' );
+		$object->set_status( OrderStatus::PENDING );
+		$object->save();
+
+		$this->assertTrue( $object->payment_complete( '12345' ) );
+		$this->assertEquals( OrderStatus::COMPLETED, $object->get_status() );
+	}
+
+	/**
 	 * Test: payment_complete allows orders with cart_hash
 	 *
 	 * @testdox payment_complete allows order with cart_hash


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This proposes the core-side compatibility fix for the payment completion validation added in #62843, instead of relying on WooCommerce Subscriptions plugin changes that older installed versions may never receive.

- Adds `subscription` to the default `woocommerce_payment_complete_allowed_created_via_values` list.
- Adds regression coverage for `WC_Order::payment_complete()` accepting orders created via `subscription`.
- Adds a WooCommerce Core changelog entry.

Related to #62761 and #64674.

(For Bug Fixes) Bug introduced in PR #62843.

### Screenshots or screen recordings:

Not applicable; this is a backend compatibility fix.

### How to test the changes in this Pull Request:

1. In a test store with WooCommerce Subscriptions active, create or identify a pending renewal order generated by Subscriptions and confirm its `_created_via` value is `subscription`.
2. Trigger payment completion for that renewal order, for example through the normal renewal payment flow or with `wp eval '$order = wc_get_order( ORDER_ID ); var_dump( $order->payment_complete( "test-transaction-id" ) );'`.
3. Confirm `payment_complete()` returns `true` and the order transitions to the expected paid status.
4. Confirm a pending order with no checkout evidence, no `created_via`, and no `cart_hash` remains blocked by the checkout evidence validation.
5. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Tests_CRUD_Orders::test_payment_complete_allows_orders_with_created_via_subscription`.

### Testing that has already taken place:

- `git diff --check`
- `php -l plugins/woocommerce/includes/class-wc-order.php`
- `php -l plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php`

I also attempted the normal WooCommerce PHP test/lint commands locally, but this worktree does not currently have `pnpm`, `corepack`, `node_modules`, or the plugin vendor config needed to run them:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` failed with `pnpm: command not found`.
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Tests_CRUD_Orders::test_payment_complete_allows_orders_with_created_via_subscription` failed with `pnpm: command not found`.
- `composer exec -- phpstan analyse includes/class-wc-order.php --memory-limit=2G` from `plugins/woocommerce` failed because `phpstan` was not installed in this worktree.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

A manual changelog entry was added at `plugins/woocommerce/changelog/fix-62761-payment-complete-subscriptions`.
