### PR TITLE
fix: update the code to use variation id for variable products

### DIFF
--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -287,15 +287,28 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		$refunds = array();
 		foreach ( $order->get_refunds() as $refund ) {
 			foreach ( $refund->get_items() as $item ) {
-				$product_id = $item->get_product_id();
-				if ( array_key_exists( $product_id, $refunds ) ) {
-					$refunds[ $product_id ]['quantity'] += absint( $item->get_quantity() );
-					$refunds[ $product_id ]['total']    += abs( (float) $item->get_total() );
+				$product_id   = $item->get_product_id();
+				$variation_id = $item->get_variation_id();
+				if ( $variation_id ) {
+					if ( isset( $refunds[ $product_id ][ $variation_id ] ) ) {
+						$refunds[ $product_id ][ $variation_id ]['quantity'] += absint( $item->get_quantity() );
+						$refunds[ $product_id ][ $variation_id ]['total']    += abs( (float) $item->get_total() );
+					} else {
+						$refunds[ $product_id ][ $variation_id ] = array(
+							'quantity' => absint( $item->get_quantity() ),
+							'total'    => abs( (float) $item->get_total() ),
+						);
+					}
 				} else {
-					$refunds[ $product_id ] = array(
-						'quantity' => absint( $item->get_quantity() ),
-						'total'    => abs( (float) $item->get_total() ),
-					);
+					if ( isset( $refunds[ $product_id ] ) ) {
+						$refunds[ $product_id ]['quantity'] += absint( $item->get_quantity() );
+						$refunds[ $product_id ]['total']    += abs( (float) $item->get_total() );
+					} else {
+						$refunds[ $product_id ] = array(
+							'quantity' => absint( $item->get_quantity() ),
+							'total'    => abs( (float) $item->get_total() ),
+						);
+					}
 				}
 			}
 		}
@@ -306,6 +319,9 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			$product_object = is_callable( array( $item, 'get_product' ) ) ? $item->get_product() : null;
 			$row_class      = apply_filters( 'woocommerce_admin_html_order_preview_item_class', '', $item, $order );
 			$refund         = $refunds[ $item->get_product_id() ] ?? null;
+			$variation_id   = $item->get_variation_id();
+			$quantity       = 0 !== $variation_id ? $refund[ $variation_id ]['quantity'] : $refund['quantity'];
+			$total          = 0 !== $variation_id ? $refund[ $variation_id ]['total'] : $refund['total'];
 
 			$html .= '<tr class="wc-order-preview-table__item wc-order-preview-table__item--' . esc_attr( $item_id ) . ( $row_class ? ' ' . esc_attr( $row_class ) : '' ) . '">';
 
@@ -336,7 +352,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 					case 'quantity':
 						$html .= esc_html( $item->get_quantity() );
 						if ( $refund ) {
-							$html .= "<div><small class='refunded'>-" . $refund['quantity'] . '</small></div><br/>';
+							$html .= "<div><small class='refunded'>-" . $quantity . '</small></div><br/>';
 						}
 						break;
 					case 'tax':
@@ -345,7 +361,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 					case 'total':
 						$html .= wc_price( $item->get_total(), $price_args );
 						if ( $refund ) {
-							$html .= "<div><small class='refunded'>-" . wc_price( $refund['total'], $price_args ) . '</small></div><br/>';
+							$html .= "<div><small class='refunded'>-" . wc_price( $total, $price_args ) . '</small></div><br/>';
 						}
 						break;
 					default:

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -318,10 +318,15 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 			$product_object = is_callable( array( $item, 'get_product' ) ) ? $item->get_product() : null;
 			$row_class      = apply_filters( 'woocommerce_admin_html_order_preview_item_class', '', $item, $order );
-			$refund         = $refunds[ $item->get_product_id() ] ?? null;
 			$variation_id   = $item->get_variation_id();
-			$quantity       = 0 !== $variation_id ? $refund[ $variation_id ]['quantity'] : $refund['quantity'];
-			$total          = 0 !== $variation_id ? $refund[ $variation_id ]['total'] : $refund['total'];
+			
+			if ( $variation_id ) {
+				$refund = $refunds[ $item->get_product_id() ][ $variation_id ] ?? null;
+			} else {
+				$refund = $refunds[ $item->get_product_id() ] ?? null;
+			}
+			$quantity = $refund['quantity'] ?? 0;
+			$total    = $refund['total'] ?? 0;
 
 			$html .= '<tr class="wc-order-preview-table__item wc-order-preview-table__item--' . esc_attr( $item_id ) . ( $row_class ? ' ' . esc_attr( $row_class ) : '' ) . '">';
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

---

### Changes proposed in this Pull Request:

Fix refund quantity/total tracking in order preview to correctly handle product variations.

Previously, `get_order_preview_item_html()` stored refund data keyed only by `$product_id`, meaning that multiple variations of the same product would overwrite each other's refund quantities and totals. This PR restructures the refund aggregation logic to key by `$variation_id` when present, falling back to `$product_id` for simple products.

At the display layer, `$quantity` and `$total` variables are now resolved from the variation-aware refund structure before use, replacing direct array key access on `$refund['quantity']` and `$refund['total']`.

Closes https://github.com/woocommerce/woocommerce/issues/64323

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/57709

---

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|  <img width="736" height="505" alt="Screenshot 2026-05-07 at 1 51 21 AM" src="https://github.com/user-attachments/assets/0c9370af-5d2b-4886-8340-ec27f95840c3" /> | <img width="735" height="509" alt="Screenshot 2026-05-07 at 1 43 35 AM" src="https://github.com/user-attachments/assets/718c0a5a-d0f1-46c9-afd4-a08d52f8b367" /> |

---

### How to test the changes in this Pull Request:

1. Set up a WooCommerce store with a variable product (e.g. a t-shirt with Size: S / M / L variations).
2. Place an order containing **two different variations** of the same variable product (e.g. 1× Size S and 1× Size M).
3. Issue a partial refund on one of the variations (e.g. refund only the Size S item).
4. Open the order preview panel (hover the order in WooCommerce → Orders and click "Preview").
5. Verify that the refunded quantity and total shown in the preview match the refunded variation only — the non-refunded variation should show no refund badge.
6. Repeat with a simple (non-variable) product to confirm backward compatibility.

---

### Testing that has already taken place:

Manually tested on a local WP/WooCommerce environment with variable products containing 2–3 variations. Confirmed that:
- Refund quantity and total are correctly attributed per variation.
- Simple (non-variable) products continue to display refund data correctly.
- No JS console errors or PHP notices observed.



Changelog Entry Details

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Fix incorrect refund quantity/total display in order preview for variable products by keying refund data on variation ID when present.