### PR TITLE
Split admin Order edit submit buttons from the Order actions metabox

### DIFF
--- a/plugins/woocommerce/changelog/order-detail-redesign-actions-split
+++ b/plugins/woocommerce/changelog/order-detail-redesign-actions-split
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Order detail redesign: split the Order actions metabox so the Update and Move-to-trash buttons sit in a dedicated chrome-less block above the action dropdown. No-op when the order-detail-redesign feature flag is off.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3046,6 +3046,18 @@ ul.wc_coupon_list_block {
 				min-height: 36px;
 			}
 		}
+
+		// `.submitdelete` is kept on the trash link so existing admin scripts
+		// continue to recognize it as a delete action, but WP's
+		// `#poststuff a.submitdelete` rule would otherwise strip the
+		// button-secondary appearance. Restore the button look here.
+		#woocommerce-order-submit a.submitdelete {
+			background: #f6f7f7;
+			border: 1px solid #2271b1;
+			color: #2271b1;
+			padding: 0 10px;
+			text-decoration: none;
+		}
 	}
 
 	.tablenav .one-page .displaying-num {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3006,10 +3006,46 @@ ul.wc_coupon_list_block {
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
 	// Gated behind the `order-detail-redesign` feature flag (body class added by OrderDetailRedesign\Init).
-	// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
-	&.woocommerce-feature-enabled-order-detail-redesign .wrap:has(#poststuff) {
-		max-width: 1200px;
-		margin-inline: auto;
+	&.woocommerce-feature-enabled-order-detail-redesign {
+		// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
+		.wrap:has(#poststuff) {
+			max-width: 1200px;
+			margin-inline: auto;
+		}
+
+		// Strip postbox chrome from the redesigned submit block so the
+		// Update/Trash CTAs read as primary controls rather than a meta box.
+		#woocommerce-order-submit {
+			background: transparent;
+			border: 0;
+			box-shadow: none;
+
+			.postbox-header,
+			.handle-actions {
+				display: none;
+			}
+
+			.inside {
+				padding: 0;
+				margin: 0;
+			}
+		}
+
+		.wc-order-submit {
+			display: flex;
+			// Update order (DOM-first) renders on the right so it remains the
+			// first tab stop while the destructive action sits on the left.
+			flex-direction: row-reverse;
+			gap: 12px;
+
+			.button {
+				flex: 1;
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 36px;
+			}
+		}
 	}
 
 	.tablenav .one-page .displaying-num {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3053,8 +3053,8 @@ ul.wc_coupon_list_block {
 		// button-secondary appearance. Restore the button look here.
 		#woocommerce-order-submit a.submitdelete {
 			background: #f6f7f7;
-			border: 1px solid #2271b1;
-			color: #2271b1;
+			border: 1px solid var(--wp-admin-theme-color, #2271b1);
+			color: var(--wp-admin-theme-color, #2271b1);
 			padding: 0 10px;
 			text-decoration: none;
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -210,6 +210,10 @@ class WC_Admin_Post_Types {
 			),
 			10 => __( 'Order draft updated.', 'woocommerce' ),
 			11 => __( 'Order updated and sent.', 'woocommerce' ),
+			12 => __( 'Order details sent to customer.', 'woocommerce' ),
+			13 => __( 'New order notification resent.', 'woocommerce' ),
+			14 => __( 'Download permissions regenerated.', 'woocommerce' ),
+			15 => __( 'Order action applied.', 'woocommerce' ),
 		);
 
 		return $messages;

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -11,6 +11,7 @@
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -58,25 +59,27 @@ class WC_Meta_Box_Order_Actions {
 				<button class="button wc-reload"><span><?php esc_html_e( 'Apply', 'woocommerce' ); ?></span></button>
 			</li>
 
-			<li class="wide">
-				<div id="delete-action">
-					<?php
-					if ( current_user_can( 'delete_post', $order_id ) ) {
+			<?php if ( ! FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) : ?>
+				<li class="wide">
+					<div id="delete-action">
+						<?php
+						if ( current_user_can( 'delete_post', $order_id ) ) {
 
-						if ( ! EMPTY_TRASH_DAYS ) {
-							$delete_text = __( 'Delete permanently', 'woocommerce' );
-						} else {
-							$delete_text = __( 'Move to Trash', 'woocommerce' );
+							if ( ! EMPTY_TRASH_DAYS ) {
+								$delete_text = __( 'Delete permanently', 'woocommerce' );
+							} else {
+								$delete_text = __( 'Move to Trash', 'woocommerce' );
+							}
+							?>
+							<a class="submitdelete deletion" href="<?php echo esc_url( self::get_trash_or_delete_order_link( $order_id ) ); ?>"><?php echo esc_html( $delete_text ); ?></a>
+							<?php
 						}
 						?>
-						<a class="submitdelete deletion" href="<?php echo esc_url( self::get_trash_or_delete_order_link( $order_id ) ); ?>"><?php echo esc_html( $delete_text ); ?></a>
-						<?php
-					}
-					?>
-				</div>
+					</div>
 
-				<button type="submit" class="button save_order button-primary" name="save" value="<?php echo OrderStatus::AUTO_DRAFT === $order->get_status() ? esc_attr__( 'Create', 'woocommerce' ) : esc_attr__( 'Update', 'woocommerce' ); ?>"><?php echo OrderStatus::AUTO_DRAFT === $order->get_status() ? esc_html__( 'Create', 'woocommerce' ) : esc_html__( 'Update', 'woocommerce' ); ?></button>
-			</li>
+					<button type="submit" class="button save_order button-primary" name="save" value="<?php echo OrderStatus::AUTO_DRAFT === $order->get_status() ? esc_attr__( 'Create', 'woocommerce' ) : esc_attr__( 'Update', 'woocommerce' ); ?>"><?php echo OrderStatus::AUTO_DRAFT === $order->get_status() ? esc_html__( 'Create', 'woocommerce' ) : esc_html__( 'Update', 'woocommerce' ); ?></button>
+				</li>
+			<?php endif; ?>
 
 			<?php
 			/**

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -204,7 +204,7 @@ class WC_Meta_Box_Order_Actions {
 				}
 			} elseif ( ! did_action( 'woocommerce_order_action_' . sanitize_title( $action ) ) ) {
 
-					do_action( 'woocommerce_order_action_' . sanitize_title( $action ), $order );
+				do_action( 'woocommerce_order_action_' . sanitize_title( $action ), $order );
 
 				if ( $redesign ) {
 					self::set_redirect_message_id( 15 );

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -56,7 +56,7 @@ class WC_Meta_Box_Order_Actions {
 						<option value="<?php echo esc_attr( $action ); ?>"><?php echo esc_html( $title ); ?></option>
 					<?php } ?>
 				</select>
-				<button class="button wc-reload"><span><?php esc_html_e( 'Apply', 'woocommerce' ); ?></span></button>
+				<button type="submit" name="wc_order_action_submit" value="1" class="button wc-reload"><span><?php esc_html_e( 'Apply', 'woocommerce' ); ?></span></button>
 			</li>
 
 			<?php if ( ! FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) : ?>
@@ -132,6 +132,18 @@ class WC_Meta_Box_Order_Actions {
 
 		// Handle button actions.
 		if ( ! empty( $_POST['wc_order_action'] ) ) { // @codingStandardsIgnoreLine
+
+			// When the order detail redesign is enabled, only run the
+			// selected order action if the Apply button was the submitter —
+			// not the primary Update order button in the dedicated submit
+			// metabox. The Apply button posts `wc_order_action_submit`; the
+			// Update order button posts only `save`.
+			if (
+				FeaturesUtil::feature_is_enabled( 'order-detail-redesign' )
+				&& empty( $_POST['wc_order_action_submit'] )
+			) {
+				return;
+			}
 
 			$action = wc_clean( wp_unslash( $_POST['wc_order_action'] ) ); // @codingStandardsIgnoreLine
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -145,7 +145,8 @@ class WC_Meta_Box_Order_Actions {
 				return;
 			}
 
-			$action = wc_clean( wp_unslash( $_POST['wc_order_action'] ) ); // @codingStandardsIgnoreLine
+			$action   = wc_clean( wp_unslash( $_POST['wc_order_action'] ) ); // @codingStandardsIgnoreLine
+			$redesign = FeaturesUtil::feature_is_enabled( 'order-detail-redesign' );
 
 			if ( 'send_order_details' === $action ) {
 				/**
@@ -170,9 +171,11 @@ class WC_Meta_Box_Order_Actions {
 				 */
 				do_action( 'woocommerce_after_resend_order_email', $order, 'customer_invoice' );
 
-				// Change the post saved message.
-				add_filter( 'redirect_post_location', array( __CLASS__, 'set_email_sent_message' ) );
-
+				if ( $redesign ) {
+					self::set_redirect_message_id( 12 );
+				} else {
+					add_filter( 'redirect_post_location', array( __CLASS__, 'set_email_sent_message' ) );
+				}
 			} elseif ( 'send_order_details_admin' === $action ) {
 
 				do_action( 'woocommerce_before_resend_order_emails', $order, 'new_order' );
@@ -185,20 +188,49 @@ class WC_Meta_Box_Order_Actions {
 
 				do_action( 'woocommerce_after_resend_order_email', $order, 'new_order' );
 
-				// Change the post saved message.
-				add_filter( 'redirect_post_location', array( __CLASS__, 'set_email_sent_message' ) );
-
+				if ( $redesign ) {
+					self::set_redirect_message_id( 13 );
+				} else {
+					add_filter( 'redirect_post_location', array( __CLASS__, 'set_email_sent_message' ) );
+				}
 			} elseif ( 'regenerate_download_permissions' === $action ) {
 
 				$data_store = WC_Data_Store::load( 'customer-download' );
 				$data_store->delete_by_order_id( $post_id );
 				wc_downloadable_product_permissions( $post_id, true );
 
+				if ( $redesign ) {
+					self::set_redirect_message_id( 14 );
+				}
 			} elseif ( ! did_action( 'woocommerce_order_action_' . sanitize_title( $action ) ) ) {
 
 					do_action( 'woocommerce_order_action_' . sanitize_title( $action ), $order );
+
+				if ( $redesign ) {
+					self::set_redirect_message_id( 15 );
+				}
 			}
 		}
+	}
+
+	/**
+	 * Adds redirect-location filters that change the post-update message ID
+	 * to the given value.
+	 *
+	 * Filters both `redirect_post_location` (legacy CPT save flow) and
+	 * `woocommerce_redirect_order_location` (HPOS save flow) so the order
+	 * edit screen shows the same confirmation message regardless of which
+	 * order storage backend is active.
+	 *
+	 * @param int $message_id Message ID registered in
+	 *                        WC_Admin_Post_Types::order_updated_messages().
+	 */
+	private static function set_redirect_message_id( int $message_id ): void {
+		$filter = function ( $location ) use ( $message_id ) {
+			return add_query_arg( 'message', $message_id, $location );
+		};
+		add_filter( 'redirect_post_location', $filter );
+		add_filter( 'woocommerce_redirect_order_location', $filter );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -10,6 +10,7 @@
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\Utilities\Users;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -685,6 +686,16 @@ class WC_Meta_Box_Order_Data {
 	 */
 	public static function save( $order_id ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
+
+		// When the order detail redesign is on and the user clicked Apply
+		// in the Order actions metabox (not Update order), skip the order
+		// data save — Apply is for running the selected action only.
+		if (
+			FeaturesUtil::feature_is_enabled( 'order-detail-redesign' )
+			&& ! empty( $_POST['wc_order_action_submit'] )
+		) {
+			return;
+		}
 
 		if ( ! isset( $_POST['order_status'] ) ) {
 			throw new Exception( __( 'Order status is missing.', 'woocommerce' ), 400 );

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
@@ -6,6 +6,8 @@
  * @version     2.1.0
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -93,6 +95,16 @@ class WC_Meta_Box_Order_Downloads {
 	 * @param WP_Post $post Post object.
 	 */
 	public static function save( $post_id, $post ) {
+		// When the order detail redesign is on and the user clicked Apply
+		// in the Order actions metabox (not Update order), skip the
+		// downloads save — Apply is for running the selected action only.
+		if (
+			FeaturesUtil::feature_is_enabled( 'order-detail-redesign' )
+			&& ! empty( $_POST['wc_order_action_submit'] )
+		) {
+			return;
+		}
+
 		if ( isset( $_POST['permission_id'] ) ) {
 			$permission_ids      = $_POST['permission_id'];
 			$downloads_remaining = $_POST['downloads_remaining'];

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -10,6 +10,7 @@
  * @version     2.1.0
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -46,6 +47,16 @@ class WC_Meta_Box_Order_Items {
 	 * @param int $post_id
 	 */
 	public static function save( $post_id ) {
+		// When the order detail redesign is on and the user clicked Apply
+		// in the Order actions metabox (not Update order), skip the order
+		// items save — Apply is for running the selected action only.
+		if (
+			FeaturesUtil::feature_is_enabled( 'order-detail-redesign' )
+			&& ! empty( $_POST['wc_order_action_submit'] )
+		) {
+			return;
+		}
+
 		/**
 		 * This $_POST variable's data has been validated and escaped
 		 * inside `wc_save_order_items()` function.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-submit.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-submit.php
@@ -64,7 +64,7 @@ class WC_Meta_Box_Order_Submit {
 					: __( 'Move to trash', 'woocommerce' );
 				?>
 				<a
-					class="button button-secondary"
+					class="button button-secondary submitdelete deletion"
 					href="<?php echo esc_url( self::get_trash_or_delete_order_link( $order_id ) ); ?>"
 				><?php echo esc_html( $delete_text ); ?></a>
 			<?php endif; ?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-submit.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-submit.php
@@ -30,9 +30,9 @@ class WC_Meta_Box_Order_Submit {
 	 * @param WP_Post|WC_Order $post Post or order object.
 	 */
 	public static function output( $post ): void {
-		// Render nothing when the redesign is not active. The empty meta box
-		// is hidden entirely by CSS rules scoped to the redesign body class,
-		// so it leaves no visible artifact when the flag is off.
+		// Defense in depth: the meta box is only registered when the flag is on
+		// (see `Edit::add_order_meta_boxes()`), but guard the callback too in
+		// case it is invoked directly from custom code.
 		if ( ! FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
 			return;
 		}
@@ -76,8 +76,10 @@ class WC_Meta_Box_Order_Submit {
 	 * Forms a trash/delete order URL.
 	 *
 	 * Mirrors WC_Meta_Box_Order_Actions::get_trash_or_delete_order_link() so
-	 * this class doesn't depend on a private helper of another class. To be
-	 * consolidated when the order detail redesign exits the feature flag.
+	 * this class doesn't depend on a private helper of another class.
+	 *
+	 * TODO: Consolidate with WC_Meta_Box_Order_Actions::get_trash_or_delete_order_link()
+	 * when the order-detail-redesign feature flag exits experimental status.
 	 *
 	 * @param int $order_id The order ID for which we want a trash/delete URL.
 	 * @return string

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-submit.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-submit.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Order Submit
+ *
+ * Renders the redesigned Update/Create + Trash submit block for an order in
+ * the side column, gated behind the `order-detail-redesign` feature flag.
+ *
+ * @package WooCommerce\Admin\Meta Boxes
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Meta_Box_Order_Submit Class.
+ *
+ * @internal
+ */
+class WC_Meta_Box_Order_Submit {
+
+	/**
+	 * Output the metabox.
+	 *
+	 * @param WP_Post|WC_Order $post Post or order object.
+	 */
+	public static function output( $post ): void {
+		// Render nothing when the redesign is not active. The empty meta box
+		// is hidden entirely by CSS rules scoped to the redesign body class,
+		// so it leaves no visible artifact when the flag is off.
+		if ( ! FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+			return;
+		}
+
+		global $theorder;
+
+		OrderUtil::init_theorder_object( $post );
+		$order = $theorder;
+
+		$order_id     = $order->get_id();
+		$is_new_order = OrderStatus::AUTO_DRAFT === $order->get_status();
+		$submit_label = $is_new_order
+			? __( 'Create order', 'woocommerce' )
+			: __( 'Update order', 'woocommerce' );
+
+		?>
+		<div class="wc-order-submit">
+			<button
+				type="submit"
+				class="button save_order button-primary"
+				name="save"
+				value="<?php echo esc_attr( $submit_label ); ?>"
+			><?php echo esc_html( $submit_label ); ?></button>
+
+			<?php if ( current_user_can( 'delete_post', $order_id ) ) : ?>
+				<?php
+				$delete_text = ! EMPTY_TRASH_DAYS
+					? __( 'Delete permanently', 'woocommerce' )
+					: __( 'Move to trash', 'woocommerce' );
+				?>
+				<a
+					class="button button-secondary"
+					href="<?php echo esc_url( self::get_trash_or_delete_order_link( $order_id ) ); ?>"
+				><?php echo esc_html( $delete_text ); ?></a>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Forms a trash/delete order URL.
+	 *
+	 * Mirrors WC_Meta_Box_Order_Actions::get_trash_or_delete_order_link() so
+	 * this class doesn't depend on a private helper of another class. To be
+	 * consolidated when the order detail redesign exits the feature flag.
+	 *
+	 * @param int $order_id The order ID for which we want a trash/delete URL.
+	 * @return string
+	 */
+	private static function get_trash_or_delete_order_link( int $order_id ): string {
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order ) {
+				return '';
+			}
+			$order_list_url  = wc_get_container()->get( PageController::class )->get_base_page_url( $order->get_type() );
+			$trash_order_url = add_query_arg(
+				array(
+					'action'           => 'trash',
+					'id'               => array( $order_id ),
+					'_wp_http_referer' => $order_list_url,
+				),
+				$order_list_url
+			);
+
+			return wp_nonce_url( $trash_order_url, 'bulk-orders' );
+		}
+
+		return get_delete_post_link( $order_id ) ?? '';
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\TaxonomiesMetaBox;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
 
@@ -80,6 +81,9 @@ class Edit {
 		/* Translators: %s order type name. */
 		add_meta_box( 'woocommerce-order-notes', sprintf( __( '%s notes', 'woocommerce' ), $title ), 'WC_Meta_Box_Order_Notes::output', $screen_id, 'side', 'default' );
 		add_meta_box( 'woocommerce-order-downloads', __( 'Downloadable product permissions', 'woocommerce' ) . wc_help_tip( __( 'Note: Permissions for order items will automatically be granted when the order status changes to processing/completed.', 'woocommerce' ) ), 'WC_Meta_Box_Order_Downloads::output', $screen_id, 'normal', 'default' );
+		if ( FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+			add_meta_box( 'woocommerce-order-submit', __( 'Save', 'woocommerce' ), 'WC_Meta_Box_Order_Submit::output', $screen_id, 'side', 'high' );
+		}
 		/* Translators: %s order type name. */
 		add_meta_box( 'woocommerce-order-actions', sprintf( __( '%s actions', 'woocommerce' ), $title ), 'WC_Meta_Box_Order_Actions::output', $screen_id, 'side', 'high' );
 		self::maybe_register_order_attribution( $screen_id, $title );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -500,7 +500,10 @@ class FeaturesController {
 				),
 				'enabled_by_default'           => false,
 				'is_experimental'              => true,
-				'disable_ui'                   => false,
+				// Hide from WC Settings > Advanced > Features while this redesign
+				// is still being built. The flag stays toggleable from the WCA
+				// Test Helper plugin and from WP-CLI / direct option flips.
+				'disable_ui'                   => true,
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -492,6 +492,18 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_experimental'              => false,
 			),
+			'order-detail-redesign'              => array(
+				'name'                         => __( 'Order detail page redesign', 'woocommerce' ),
+				'description'                  => __(
+					'Try the redesigned order detail and edit page in the admin (experimental).',
+					'woocommerce'
+				),
+				'enabled_by_default'           => false,
+				'is_experimental'              => true,
+				'disable_ui'                   => false,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+			),
 			'block_email_editor'                 => array(
 				'name'                         => __( 'Block Email Editor (alpha)', 'woocommerce' ),
 				'description'                  => __(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Part of the order detail redesign. Today the side-column "Order actions" metabox bundles three unrelated controls: an action dropdown for auxiliary actions (e.g. "Send order details to customer"), the primary Update/Create button, and a Move to Trash link. The bundling makes the primary save action feel weighted equal to the dropdown.

This PR extracts Update order (or Create order on auto-draft) and Move to trash into a new chrome-less "Save" metabox that sits at the top of the side column, rendered as side-by-side primary/secondary buttons. The original Order actions metabox is stripped down to just the dropdown + Apply. Everything is gated behind the \`order-detail-redesign\` feature flag — when off, the screen is bit-for-bit identical to today.

Stacked on top of #64669 (which adds the feature flag and the max-width cap). Once #64669 merges, this PR's base will retarget to \`trunk\`.

### Screenshots or screen recordings:

### BEFORE
<img width="3600" height="2086" alt="AFTER" src="https://github.com/user-attachments/assets/6f37af46-7289-4910-8137-059f244890a1" />

### AFTER
<img width="3600" height="2086" alt="AFTER2" src="https://github.com/user-attachments/assets/edc2c905-1658-4c37-a048-b793d297be7e" />

### How to test the changes in this Pull Request:

1. Pull this branch and run \`pnpm --filter='@woocommerce/plugin-woocommerce' build:classic-assets\` to compile SCSS.
2. With the \`order-detail-redesign\` feature flag **off** (default in production): visit any order at **WooCommerce → Orders → (order) → Edit**. Confirm the Order actions metabox in the side column is unchanged — single box bundling the dropdown, Update, and Move to Trash. Confirm clicking Update saves. Confirm the dropdown's "Send order details to customer" still works.
3. Enable the \`order-detail-redesign\` feature flag (it is enabled by default in dev builds via \`client/admin/config/development.json\`).
4. Reload the order edit screen. Confirm a new chrome-less block appears at the top of the side column with **Move to trash** on the left (secondary) and **Update order** on the right (primary), side-by-side and equal width.
5. Click **Update order** — confirm the order saves.
6. Pick a dropdown action (e.g. "Regenerate download permissions") and click Apply — confirm the action runs.
7. Visit **WooCommerce → Orders → Add order**. The new block's primary button should read **Create order** instead of Update.
8. Add \`define( 'EMPTY_TRASH_DAYS', 0 );\` to \`wp-config.php\`. Reload the edit screen — the secondary button should read **Delete permanently**. Restore after testing.
9. As a user that lacks the \`delete_post\` capability for the order, confirm the Move to trash button is hidden and the Update order button is still visible.
10. Resize the browser below 782px. Confirm the side column stacks below the main column and the new Save block sits at the top of the stacked sidebar (above Order actions).
11. Repeat steps 4–10 on the legacy CPT order edit screen (when HPOS is disabled).

### Testing that has already taken place:

- Manual verification on macOS Studio with HPOS enabled across the matrix above.
- \`pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes\` — clean.
- PHPStan on all four touched PHP files — clean (\`[OK] No errors\`), no new baseline entries.
- \`pnpm --filter=@woocommerce/plugin-woocommerce build:classic-assets\` — SCSS compiles cleanly.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually at \`plugins/woocommerce/changelog/order-detail-redesign-actions-split\`.

</details>