### PR TITLE
Add prev/next order navigation to Order detail page header

### DIFF
--- a/plugins/woocommerce/changelog/max-width-order-detail-page
+++ b/plugins/woocommerce/changelog/max-width-order-detail-page
@@ -1,4 +1,4 @@
-Significance: patch
-Type: tweak
+Significance: minor
+Type: add
 
-Cap the admin Order edit screen at 1200px max-width and center it on wide displays.
+Add the `order-detail-redesign` feature flag (default off). When enabled, caps the admin Order edit screen at 1200px on wide displays.

--- a/plugins/woocommerce/changelog/max-width-order-detail-page
+++ b/plugins/woocommerce/changelog/max-width-order-detail-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Cap the admin Order edit screen at 1200px max-width and center it on wide displays.

--- a/plugins/woocommerce/changelog/order-detail-prev-next-nav
+++ b/plugins/woocommerce/changelog/order-detail-prev-next-nav
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add prev/next order navigation in the Order detail page header (behind the `order-detail-redesign` feature flag).

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -44,6 +44,7 @@
 		"launch-your-store": true,
 		"product-editor-template-system": false,
 		"use-wp-horizon": false,
-		"rest-api-v4": false
+		"rest-api-v4": false,
+		"order-detail-redesign": false
 	}
 }

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -44,6 +44,7 @@
 		"launch-your-store": true,
 		"product-editor-template-system": false,
 		"use-wp-horizon": false,
-		"rest-api-v4": false
+		"rest-api-v4": false,
+		"order-detail-redesign": false
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3009,6 +3009,13 @@ ul.wc_coupon_list_block {
 
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
+	// Cap the admin Order edit/new screen content at 1200px and center it.
+	// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
+	.wrap:has(#poststuff) {
+		max-width: 1200px;
+		margin-inline: auto;
+	}
+
 	.tablenav .one-page .displaying-num {
 		display: none;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3014,71 +3014,69 @@ ul.wc_coupon_list_block {
 	&.woocommerce-feature-enabled-order-detail-redesign .wrap:has(#poststuff) {
 		max-width: 1200px;
 		margin-inline: auto;
+	}
 
-		// Make the H1 row a flex container so the prev/next nav can right-align via margin-inline-start: auto.
-		// Wraps below the title on narrow viewports.
-		display: flex;
-		flex-wrap: wrap;
+	// Float the prev/next nav to the right of the H1 row. The `<hr class="wp-header-end">`
+	// that follows the title row clears this float, so the metabox columns below are unaffected.
+	// On narrow viewports where the nav can't fit beside the title, the float wraps to the next line.
+	&.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav {
+		float: right;
+		display: inline-flex;
 		align-items: center;
-		column-gap: 8px;
+		gap: 8px;
+		margin-top: 4px;
+		font-size: 13px;
+		line-height: 1.4;
+	}
 
-		> h1.wp-heading-inline {
-			margin-right: 0;
-		}
-
-		.woocommerce-order-list-nav {
-			display: inline-flex;
-			align-items: center;
-			gap: 8px;
-			margin-inline-start: auto;
-			font-size: 13px;
-			line-height: 1.4;
-		}
-
-		.woocommerce-order-list-nav__count {
-			.is-current {
-				color: $gray-900;
-			}
-
-			.is-muted {
-				color: $gray-700;
-			}
-		}
-
-		.woocommerce-order-list-nav__chevron {
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			width: 32px;
-			height: 32px;
-			border-radius: $radius-s;
+	&.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav__count {
+		.is-current {
 			color: $gray-900;
-			text-decoration: none;
-			transition: background-color 0.1s ease-in-out;
+		}
 
-			&:hover,
-			&:focus-visible {
-				background-color: rgba(0, 0, 0, 0.06);
-			}
-
-			&:focus-visible {
-				outline: var(--wp-admin-border-width-focus) solid currentColor;
-				outline-offset: 1px;
-			}
-
-			&[aria-disabled="true"] {
-				opacity: 0.4;
-				cursor: default;
-				pointer-events: none;
-			}
-
-			.woocommerce-order-list-nav__icon {
-				fill: currentColor;
-			}
+		.is-muted {
+			color: $gray-700;
 		}
 	}
 
-	// Mirror the chevron icons in RTL so "previous" still reads as "back".
+	&.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav__chevron {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: $radius-s;
+		color: $gray-900;
+		text-decoration: none;
+		transition: background-color 0.1s ease-in-out;
+
+		&:hover,
+		&:focus-visible {
+			background-color: rgba(0, 0, 0, 0.06);
+		}
+
+		&:focus-visible {
+			outline: var(--wp-admin-border-width-focus) solid currentColor;
+			outline-offset: 1px;
+		}
+
+		&[aria-disabled="true"] {
+			opacity: 0.4;
+			cursor: default;
+			pointer-events: none;
+		}
+
+		.woocommerce-order-list-nav__icon {
+			fill: currentColor;
+		}
+	}
+
+	// Mirror the chevron icons in RTL so the visual direction still matches position-number direction.
+	&.woocommerce-feature-enabled-order-detail-redesign[dir="rtl"] .woocommerce-order-list-nav,
+	[dir="rtl"] &.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav {
+		float: left;
+	}
+
 	&.woocommerce-feature-enabled-order-detail-redesign[dir="rtl"] .woocommerce-order-list-nav__icon,
 	[dir="rtl"] &.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav__icon {
 		transform: scaleX(-1);

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3009,8 +3009,9 @@ ul.wc_coupon_list_block {
 
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
+	// Gated behind the `order-detail-redesign` feature flag (body class added by OrderDetailRedesign\Init).
 	// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
-	.wrap:has(#poststuff) {
+	&.woocommerce-feature-enabled-order-detail-redesign .wrap:has(#poststuff) {
 		max-width: 1200px;
 		margin-inline: auto;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3009,7 +3009,6 @@ ul.wc_coupon_list_block {
 
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
-	// Cap the admin Order edit/new screen content at 1200px and center it.
 	// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
 	.wrap:has(#poststuff) {
 		max-width: 1200px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3014,6 +3014,74 @@ ul.wc_coupon_list_block {
 	&.woocommerce-feature-enabled-order-detail-redesign .wrap:has(#poststuff) {
 		max-width: 1200px;
 		margin-inline: auto;
+
+		// Make the H1 row a flex container so the prev/next nav can right-align via margin-inline-start: auto.
+		// Wraps below the title on narrow viewports.
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		column-gap: 8px;
+
+		> h1.wp-heading-inline {
+			margin-right: 0;
+		}
+
+		.woocommerce-order-list-nav {
+			display: inline-flex;
+			align-items: center;
+			gap: 8px;
+			margin-inline-start: auto;
+			font-size: 13px;
+			line-height: 1.4;
+		}
+
+		.woocommerce-order-list-nav__count {
+			.is-current {
+				color: $gray-900;
+			}
+
+			.is-muted {
+				color: $gray-700;
+			}
+		}
+
+		.woocommerce-order-list-nav__chevron {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 32px;
+			height: 32px;
+			border-radius: $radius-s;
+			color: $gray-900;
+			text-decoration: none;
+			transition: background-color 0.1s ease-in-out;
+
+			&:hover,
+			&:focus-visible {
+				background-color: rgba(0, 0, 0, 0.06);
+			}
+
+			&:focus-visible {
+				outline: var(--wp-admin-border-width-focus) solid currentColor;
+				outline-offset: 1px;
+			}
+
+			&[aria-disabled="true"] {
+				opacity: 0.4;
+				cursor: default;
+				pointer-events: none;
+			}
+
+			.woocommerce-order-list-nav__icon {
+				fill: currentColor;
+			}
+		}
+	}
+
+	// Mirror the chevron icons in RTL so "previous" still reads as "back".
+	&.woocommerce-feature-enabled-order-detail-redesign[dir="rtl"] .woocommerce-order-list-nav__icon,
+	[dir="rtl"] &.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav__icon {
+		transform: scaleX(-1);
 	}
 
 	.tablenav .one-page .displaying-num {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3023,28 +3023,17 @@ ul.wc_coupon_list_block {
 		float: right;
 		display: inline-flex;
 		align-items: center;
-		gap: 8px;
+		gap: 4px;
 		margin-top: 4px;
 		font-size: 13px;
 		line-height: 1.4;
 	}
 
-	&.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav__count {
-		.is-current {
-			color: $gray-900;
-		}
-
-		.is-muted {
-			color: $gray-700;
-		}
-	}
-
-	&.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav__chevron {
+	&.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav__link {
 		display: inline-flex;
 		align-items: center;
-		justify-content: center;
-		width: 32px;
-		height: 32px;
+		gap: 4px;
+		padding: 4px 8px;
 		border-radius: $radius-s;
 		color: $gray-900;
 		text-decoration: none;
@@ -3053,6 +3042,7 @@ ul.wc_coupon_list_block {
 		&:hover,
 		&:focus-visible {
 			background-color: rgba(0, 0, 0, 0.06);
+			color: $gray-900;
 		}
 
 		&:focus-visible {
@@ -3071,12 +3061,13 @@ ul.wc_coupon_list_block {
 		}
 	}
 
-	// Mirror the chevron icons in RTL so the visual direction still matches position-number direction.
+	// In RTL, float the nav to the left so it still hugs the inline-end edge.
 	&.woocommerce-feature-enabled-order-detail-redesign[dir="rtl"] .woocommerce-order-list-nav,
 	[dir="rtl"] &.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav {
 		float: left;
 	}
 
+	// Mirror the chevron icons in RTL so the visual direction still matches the reading direction.
 	&.woocommerce-feature-enabled-order-detail-redesign[dir="rtl"] .woocommerce-order-list-nav__icon,
 	[dir="rtl"] &.woocommerce-feature-enabled-order-detail-redesign .woocommerce-order-list-nav__icon {
 		transform: scaleX(-1);

--- a/plugins/woocommerce/src/Admin/Features/OrderDetailRedesign/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/OrderDetailRedesign/Init.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WooCommerce Order Detail Redesign feature loader.
+ *
+ * @package WooCommerce
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\OrderDetailRedesign;
+
+/**
+ * Loads support for the redesigned WooCommerce order detail page.
+ *
+ * Auto-instantiated by `Features::load_features()` when the
+ * `order-detail-redesign` feature flag is enabled (see
+ * `client/admin/config/core.json`).
+ *
+ * @since 10.9.0
+ */
+class Init {
+
+	const FEATURE_ID = 'order-detail-redesign';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		add_filter( 'admin_body_class', array( $this, 'handle_admin_body_class' ) );
+	}
+
+	/**
+	 * Adds the feature body class on the order edit/new screens.
+	 *
+	 * The framework's auto-added `woocommerce-feature-enabled-*` body class
+	 * (in `Features::add_admin_body_classes()`) only fires on wc-admin and
+	 * embedded pages; the HPOS order edit screen and the legacy `shop_order`
+	 * CPT edit screen are neither, so the class is added here for those
+	 * screens.
+	 *
+	 * @internal
+	 *
+	 * @param string $classes Existing space-separated body classes.
+	 * @return string
+	 */
+	public function handle_admin_body_class( string $classes ): string {
+		if ( ! self::is_order_edit_screen() ) {
+			return $classes;
+		}
+
+		return $classes . ' woocommerce-feature-enabled-' . self::FEATURE_ID;
+	}
+
+	/**
+	 * Returns true on the HPOS order edit/new screen or the legacy `shop_order` CPT edit/new screen.
+	 *
+	 * @return bool
+	 */
+	private static function is_order_edit_screen(): bool {
+		// HPOS edit/new: admin.php?page=wc-orders&action=edit|new.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['page'] ) && 'wc-orders' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) {
+			$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
+			if ( in_array( $action, array( 'edit', 'new' ), true ) ) {
+				return true;
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		// Legacy CPT shop_order edit/new screens.
+		$screen = get_current_screen();
+		if ( $screen && 'shop_order' === $screen->id && 'post' === $screen->base ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/OrderDetailRedesign/OrderListNav.php
+++ b/plugins/woocommerce/src/Admin/Features/OrderDetailRedesign/OrderListNav.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * Order list navigation for the Order detail page.
+ *
+ * @package WooCommerce
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\OrderDetailRedesign;
+
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use WC_Order;
+
+/**
+ * Renders a `< 1 / 23 >` previous/next nav next to the H1 on the HPOS Order edit page.
+ *
+ * Position and total reflect the orders-list filter set the user came from
+ * (read once from the referer, then carried forward via URL params on
+ * prev/next links). When no list context is available, falls back to all
+ * shop_orders sorted by `date_created` DESC.
+ *
+ * @since 10.9.0
+ */
+class OrderListNav {
+
+	/**
+	 * URL params forwarded between the orders list and the prev/next links.
+	 */
+	private const ALLOWED_LIST_PARAMS = array(
+		'status',
+		's',
+		'm',
+		'_customer_user',
+	);
+
+	/**
+	 * SVG path for the chevron-left icon, sourced from `@wordpress/icons`.
+	 */
+	private const CHEVRON_LEFT_PATH = 'M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z';
+
+	/**
+	 * SVG path for the chevron-right icon, sourced from `@wordpress/icons`.
+	 */
+	private const CHEVRON_RIGHT_PATH = 'M10.6 6L9.4 7l5 5-5 5 1.2 1 6.4-6z';
+
+	/**
+	 * Outputs the navigation markup for the given order.
+	 *
+	 * @param WC_Order $order Order being edited.
+	 *
+	 * @since 10.9.0
+	 */
+	public function render( WC_Order $order ): void {
+		if ( 'shop_order' !== $order->get_type() ) {
+			return;
+		}
+
+		$data = $this->get_navigation_data( $order );
+
+		if ( $data['total'] < 1 ) {
+			return;
+		}
+
+		$prev_url = $data['prev_id'] ? $this->build_edit_url( $data['prev_id'], $data['list_query'] ) : null;
+		$next_url = $data['next_id'] ? $this->build_edit_url( $data['next_id'], $data['list_query'] ) : null;
+
+		$count_label = sprintf(
+			/* translators: 1: position of the current order in the list, 2: total orders in the list. */
+			__( 'Order %1$s of %2$s', 'woocommerce' ),
+			number_format_i18n( $data['position'] ),
+			number_format_i18n( $data['total'] )
+		);
+
+		?>
+		<nav class="woocommerce-order-list-nav" aria-label="<?php esc_attr_e( 'Order navigation', 'woocommerce' ); ?>">
+			<?php $this->render_chevron( $prev_url, __( 'Previous order', 'woocommerce' ), self::CHEVRON_LEFT_PATH ); ?>
+			<span class="woocommerce-order-list-nav__count" aria-label="<?php echo esc_attr( $count_label ); ?>">
+				<span class="is-current"><?php echo esc_html( number_format_i18n( $data['position'] ) ); ?></span><span class="is-muted"> / <?php echo esc_html( number_format_i18n( $data['total'] ) ); ?></span>
+			</span>
+			<?php $this->render_chevron( $next_url, __( 'Next order', 'woocommerce' ), self::CHEVRON_RIGHT_PATH ); ?>
+		</nav>
+		<?php
+	}
+
+	/**
+	 * Computes the position/total/prev_id/next_id for the given order.
+	 *
+	 * @param WC_Order $order Order being edited.
+	 * @return array{position:int,total:int,prev_id:?int,next_id:?int,list_query:array<string,string>}
+	 *
+	 * @since 10.9.0
+	 */
+	public function get_navigation_data( WC_Order $order ): array {
+		$list_query = $this->get_list_query_from_request();
+		$query_args = $this->build_query_args( $list_query );
+
+		$position_data = $this->compute_position_and_total( $order, $query_args );
+
+		// If the current order doesn't match the active filters, drop the filters and
+		// recompute against the unfiltered set so the nav stays useful.
+		if ( ! $position_data['in_set'] && ! empty( $list_query ) ) {
+			$list_query    = array();
+			$query_args    = $this->build_query_args( $list_query );
+			$position_data = $this->compute_position_and_total( $order, $query_args );
+		}
+
+		$boundaries = $this->compute_prev_next_ids( $order, $query_args );
+
+		return array(
+			'position'   => $position_data['position'],
+			'total'      => $position_data['total'],
+			'prev_id'    => $boundaries['prev_id'],
+			'next_id'    => $boundaries['next_id'],
+			'list_query' => $list_query,
+		);
+	}
+
+	/**
+	 * Renders a single chevron — as a link when navigable, or a disabled span at boundaries.
+	 *
+	 * @param string|null $url       Destination URL, or null when disabled.
+	 * @param string      $label     Accessible label.
+	 * @param string      $svg_path  Inline SVG `d` attribute.
+	 */
+	private function render_chevron( ?string $url, string $label, string $svg_path ): void {
+		$svg = sprintf(
+			'<svg class="woocommerce-order-list-nav__icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="%s"></path></svg>',
+			esc_attr( $svg_path )
+		);
+
+		if ( null === $url ) {
+			printf(
+				'<span class="woocommerce-order-list-nav__chevron" aria-disabled="true" aria-label="%s">%s</span>',
+				esc_attr( $label ),
+				$svg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- inline SVG built from constant + escaped attr.
+			);
+			return;
+		}
+
+		printf(
+			'<a href="%s" class="woocommerce-order-list-nav__chevron" aria-label="%s">%s</a>',
+			esc_url( $url ),
+			esc_attr( $label ),
+			$svg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- inline SVG built from constant + escaped attr.
+		);
+	}
+
+	/**
+	 * Extracts forwarded list filter params from the request.
+	 *
+	 * Precedence: current URL params first (already forwarded by a prior prev/next click),
+	 * then params parsed from the orders-list referer on first arrival.
+	 *
+	 * @return array<string,string>
+	 */
+	private function get_list_query_from_request(): array {
+		$params = $this->extract_allowed_params( $_GET ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( ! empty( $params ) ) {
+			return $params;
+		}
+
+		$referer = wp_get_referer();
+		if ( ! $referer ) {
+			return array();
+		}
+
+		$parsed = wp_parse_url( $referer );
+		if ( empty( $parsed['query'] ) ) {
+			return array();
+		}
+
+		$referer_params = array();
+		wp_parse_str( $parsed['query'], $referer_params );
+
+		$is_orders_list = 'wc-orders' === ( $referer_params['page'] ?? '' )
+			&& empty( $referer_params['action'] );
+
+		if ( ! $is_orders_list ) {
+			return array();
+		}
+
+		return $this->extract_allowed_params( $referer_params );
+	}
+
+	/**
+	 * Picks whitelisted params from the given source and sanitizes them.
+	 *
+	 * @param array<int|string,mixed> $source Raw param source.
+	 * @return array<string,string>
+	 */
+	private function extract_allowed_params( array $source ): array {
+		$out = array();
+		foreach ( self::ALLOWED_LIST_PARAMS as $key ) {
+			if ( ! isset( $source[ $key ] ) || ! is_scalar( $source[ $key ] ) ) {
+				continue;
+			}
+			$value = (string) $source[ $key ];
+			if ( '' === $value || 'all' === $value ) {
+				continue;
+			}
+			$out[ $key ] = sanitize_text_field( wp_unslash( $value ) );
+		}
+		return $out;
+	}
+
+	/**
+	 * Translates orders-list URL params into `wc_get_orders` arguments.
+	 *
+	 * @param array<string,string> $list_query Whitelisted list params.
+	 * @return array<string,mixed>
+	 */
+	private function build_query_args( array $list_query ): array {
+		$args = array(
+			'type'    => 'shop_order',
+			'orderby' => 'date',
+			'order'   => 'DESC',
+		);
+
+		if ( isset( $list_query['status'] ) ) {
+			$args['status'] = $list_query['status'];
+		} else {
+			$args['status'] = $this->get_default_visible_statuses();
+		}
+
+		if ( isset( $list_query['s'] ) ) {
+			$args['s'] = $list_query['s'];
+		}
+
+		if ( isset( $list_query['_customer_user'] ) && (int) $list_query['_customer_user'] > 0 ) {
+			$args['customer'] = (int) $list_query['_customer_user'];
+		}
+
+		if ( isset( $list_query['m'] ) && preg_match( '/^[0-9]{6}$/', $list_query['m'] ) ) {
+			$year      = substr( $list_query['m'], 0, 4 );
+			$month     = substr( $list_query['m'], 4, 2 );
+			$timestamp = strtotime( "{$year}-{$month}-01" );
+			if ( false !== $timestamp ) {
+				$last_day             = gmdate( 'Y-m-t', $timestamp );
+				$args['date_created'] = "{$year}-{$month}-01...{$last_day}";
+			}
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Mirrors the orders list table's default visible-status set.
+	 *
+	 * @return string[]
+	 */
+	private function get_default_visible_statuses(): array {
+		return array_values(
+			array_intersect(
+				array_keys( wc_get_order_statuses() ),
+				get_post_stati( array( 'show_in_admin_all_list' => true ), 'names' )
+			)
+		);
+	}
+
+	/**
+	 * Computes total count + position via two paginated count queries.
+	 *
+	 * Position is one-based. `in_set` is false when the current order doesn't match
+	 * the active filters (e.g. the user filtered to status=completed but is viewing
+	 * a processing order).
+	 *
+	 * @param WC_Order            $order      Current order.
+	 * @param array<string,mixed> $query_args Base query args (type/status/etc).
+	 * @return array{position:int,total:int,in_set:bool}
+	 */
+	private function compute_position_and_total( WC_Order $order, array $query_args ): array {
+		$total_query = wc_get_orders(
+			array_merge(
+				$query_args,
+				array(
+					'limit'    => 1,
+					'paginate' => true,
+					'return'   => 'ids',
+				)
+			)
+		);
+		$total       = isset( $total_query->total ) ? (int) $total_query->total : 0;
+
+		if ( $total < 1 ) {
+			return array(
+				'position' => 0,
+				'total'    => 0,
+				'in_set'   => false,
+			);
+		}
+
+		$timestamp   = $order->get_date_created() ? $order->get_date_created()->getTimestamp() : time();
+		$newer_query = wc_get_orders(
+			array_merge(
+				$query_args,
+				array(
+					'date_created' => '>' . $timestamp,
+					'limit'        => 1,
+					'paginate'     => true,
+					'return'       => 'ids',
+				)
+			)
+		);
+		$newer_count = isset( $newer_query->total ) ? (int) $newer_query->total : 0;
+		$position    = $newer_count + 1;
+
+		return array(
+			'position' => $position,
+			'total'    => $total,
+			'in_set'   => $position <= $total,
+		);
+	}
+
+	/**
+	 * Finds the IDs of the prev (older) and next (newer) orders matching the same filters.
+	 *
+	 * @param WC_Order            $order      Current order.
+	 * @param array<string,mixed> $query_args Base query args.
+	 * @return array{prev_id:?int,next_id:?int}
+	 */
+	private function compute_prev_next_ids( WC_Order $order, array $query_args ): array {
+		$timestamp = $order->get_date_created() ? $order->get_date_created()->getTimestamp() : time();
+
+		$prev_ids = wc_get_orders(
+			array_merge(
+				$query_args,
+				array(
+					'date_created' => '<' . $timestamp,
+					'orderby'      => 'date',
+					'order'        => 'DESC',
+					'limit'        => 1,
+					'return'       => 'ids',
+				)
+			)
+		);
+
+		$next_ids = wc_get_orders(
+			array_merge(
+				$query_args,
+				array(
+					'date_created' => '>' . $timestamp,
+					'orderby'      => 'date',
+					'order'        => 'ASC',
+					'limit'        => 1,
+					'return'       => 'ids',
+				)
+			)
+		);
+
+		return array(
+			'prev_id' => $this->first_id( $prev_ids ),
+			'next_id' => $this->first_id( $next_ids ),
+		);
+	}
+
+	/**
+	 * Extracts the first ID from a `wc_get_orders( return => 'ids' )` result.
+	 *
+	 * @param mixed $result Result of wc_get_orders with `return=ids`.
+	 */
+	private function first_id( $result ): ?int {
+		if ( ! is_array( $result ) || empty( $result ) ) {
+			return null;
+		}
+		$first = $result[0];
+		return is_numeric( $first ) ? (int) $first : null;
+	}
+
+	/**
+	 * Builds the HPOS Order edit URL with forwarded list filters.
+	 *
+	 * @param int                  $order_id   Target order ID.
+	 * @param array<string,string> $list_query Forwarded list params.
+	 */
+	private function build_edit_url( int $order_id, array $list_query ): string {
+		$base = OrderUtil::get_order_admin_edit_url( $order_id );
+		return $list_query ? add_query_arg( $list_query, $base ) : $base;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/OrderDetailRedesign/OrderListNav.php
+++ b/plugins/woocommerce/src/Admin/Features/OrderDetailRedesign/OrderListNav.php
@@ -314,7 +314,12 @@ class OrderListNav {
 	}
 
 	/**
-	 * Finds the IDs of the prev (older) and next (newer) orders matching the same filters.
+	 * Finds the IDs of the orders at position-1 (left chevron) and position+1 (right chevron).
+	 *
+	 * The orders list defaults to date DESC, so position 1 is the newest order. Decrementing
+	 * the position number means moving to a newer order; incrementing means moving to an older
+	 * one. `prev_id` (left chevron) therefore points to the newer order; `next_id` (right
+	 * chevron) points to the older one.
 	 *
 	 * @param WC_Order            $order      Current order.
 	 * @param array<string,mixed> $query_args Base query args.
@@ -323,26 +328,28 @@ class OrderListNav {
 	private function compute_prev_next_ids( WC_Order $order, array $query_args ): array {
 		$timestamp = $order->get_date_created() ? $order->get_date_created()->getTimestamp() : time();
 
+		// Left chevron: decrement position → newer order.
 		$prev_ids = wc_get_orders(
-			array_merge(
-				$query_args,
-				array(
-					'date_created' => '<' . $timestamp,
-					'orderby'      => 'date',
-					'order'        => 'DESC',
-					'limit'        => 1,
-					'return'       => 'ids',
-				)
-			)
-		);
-
-		$next_ids = wc_get_orders(
 			array_merge(
 				$query_args,
 				array(
 					'date_created' => '>' . $timestamp,
 					'orderby'      => 'date',
 					'order'        => 'ASC',
+					'limit'        => 1,
+					'return'       => 'ids',
+				)
+			)
+		);
+
+		// Right chevron: increment position → older order.
+		$next_ids = wc_get_orders(
+			array_merge(
+				$query_args,
+				array(
+					'date_created' => '<' . $timestamp,
+					'orderby'      => 'date',
+					'order'        => 'DESC',
 					'limit'        => 1,
 					'return'       => 'ids',
 				)

--- a/plugins/woocommerce/src/Admin/Features/OrderDetailRedesign/OrderListNav.php
+++ b/plugins/woocommerce/src/Admin/Features/OrderDetailRedesign/OrderListNav.php
@@ -13,12 +13,13 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
 
 /**
- * Renders a `< 1 / 23 >` previous/next nav next to the H1 on the HPOS Order edit page.
+ * Renders a `< Prev   Next >` previous/next nav next to the H1 on the HPOS Order edit page.
  *
- * Position and total reflect the orders-list filter set the user came from
- * (read once from the referer, then carried forward via URL params on
- * prev/next links). When no list context is available, falls back to all
- * shop_orders sorted by `date_created` DESC.
+ * Direction follows list-traversal semantics, not chronological: the orders list defaults
+ * to date DESC, so "Prev" (left) goes to the newer order (the one above in the list) and
+ * "Next" (right) goes to the older order (the one below). Filters are read once from the
+ * orders-list referer and carried forward on each link. When no list context is available,
+ * falls back to all shop_orders sorted by `date_created` DESC.
  *
  * @since 10.9.0
  */
@@ -58,36 +59,33 @@ class OrderListNav {
 
 		$data = $this->get_navigation_data( $order );
 
-		if ( $data['total'] < 1 ) {
-			return;
-		}
-
 		$prev_url = $data['prev_id'] ? $this->build_edit_url( $data['prev_id'], $data['list_query'] ) : null;
 		$next_url = $data['next_id'] ? $this->build_edit_url( $data['next_id'], $data['list_query'] ) : null;
 
-		$count_label = sprintf(
-			/* translators: 1: position of the current order in the list, 2: total orders in the list. */
-			__( 'Order %1$s of %2$s', 'woocommerce' ),
-			number_format_i18n( $data['position'] ),
-			number_format_i18n( $data['total'] )
-		);
+		// Nothing to navigate to in either direction — there's only one order in the set.
+		if ( null === $prev_url && null === $next_url ) {
+			return;
+		}
 
 		?>
 		<nav class="woocommerce-order-list-nav" aria-label="<?php esc_attr_e( 'Order navigation', 'woocommerce' ); ?>">
-			<?php $this->render_chevron( $prev_url, __( 'Previous order', 'woocommerce' ), self::CHEVRON_LEFT_PATH ); ?>
-			<span class="woocommerce-order-list-nav__count" aria-label="<?php echo esc_attr( $count_label ); ?>">
-				<span class="is-current"><?php echo esc_html( number_format_i18n( $data['position'] ) ); ?></span><span class="is-muted"> / <?php echo esc_html( number_format_i18n( $data['total'] ) ); ?></span>
-			</span>
-			<?php $this->render_chevron( $next_url, __( 'Next order', 'woocommerce' ), self::CHEVRON_RIGHT_PATH ); ?>
+			<?php
+			$this->render_link( $prev_url, __( 'Prev', 'woocommerce' ), self::CHEVRON_LEFT_PATH, true );
+			$this->render_link( $next_url, __( 'Next', 'woocommerce' ), self::CHEVRON_RIGHT_PATH, false );
+			?>
 		</nav>
 		<?php
 	}
 
 	/**
-	 * Computes the position/total/prev_id/next_id for the given order.
+	 * Computes the prev_id / next_id / forwarded list filters for the given order.
+	 *
+	 * If the current order is excluded by the active filters (e.g. the user filtered the
+	 * orders list to status=completed but is now viewing a processing order), the filters
+	 * are silently dropped so the nav still shows usable links.
 	 *
 	 * @param WC_Order $order Order being edited.
-	 * @return array{position:int,total:int,prev_id:?int,next_id:?int,list_query:array<string,string>}
+	 * @return array{prev_id:?int,next_id:?int,list_query:array<string,string>}
 	 *
 	 * @since 10.9.0
 	 */
@@ -95,21 +93,14 @@ class OrderListNav {
 		$list_query = $this->get_list_query_from_request();
 		$query_args = $this->build_query_args( $list_query );
 
-		$position_data = $this->compute_position_and_total( $order, $query_args );
-
-		// If the current order doesn't match the active filters, drop the filters and
-		// recompute against the unfiltered set so the nav stays useful.
-		if ( ! $position_data['in_set'] && ! empty( $list_query ) ) {
-			$list_query    = array();
-			$query_args    = $this->build_query_args( $list_query );
-			$position_data = $this->compute_position_and_total( $order, $query_args );
+		if ( ! empty( $list_query ) && ! $this->order_matches_filters( $order, $query_args ) ) {
+			$list_query = array();
+			$query_args = $this->build_query_args( $list_query );
 		}
 
 		$boundaries = $this->compute_prev_next_ids( $order, $query_args );
 
 		return array(
-			'position'   => $position_data['position'],
-			'total'      => $position_data['total'],
 			'prev_id'    => $boundaries['prev_id'],
 			'next_id'    => $boundaries['next_id'],
 			'list_query' => $list_query,
@@ -117,32 +108,36 @@ class OrderListNav {
 	}
 
 	/**
-	 * Renders a single chevron — as a link when navigable, or a disabled span at boundaries.
+	 * Renders a single Prev / Next link — chevron + label, or a disabled span at boundaries.
 	 *
-	 * @param string|null $url       Destination URL, or null when disabled.
-	 * @param string      $label     Accessible label.
-	 * @param string      $svg_path  Inline SVG `d` attribute.
+	 * @param string|null $url        Destination URL, or null when disabled.
+	 * @param string      $label      Visible link text (e.g. "Prev", "Next").
+	 * @param string      $svg_path   Inline SVG `d` attribute for the chevron.
+	 * @param bool        $icon_first Whether the chevron renders before the label (true for Prev, false for Next).
 	 */
-	private function render_chevron( ?string $url, string $label, string $svg_path ): void {
-		$svg = sprintf(
+	private function render_link( ?string $url, string $label, string $svg_path, bool $icon_first ): void {
+		$svg             = sprintf(
 			'<svg class="woocommerce-order-list-nav__icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="%s"></path></svg>',
 			esc_attr( $svg_path )
 		);
+		$text            = sprintf( '<span class="woocommerce-order-list-nav__label">%s</span>', esc_html( $label ) );
+		$inner           = $icon_first ? $svg . $text : $text . $svg;
+		$direction_class = $icon_first ? 'is-prev' : 'is-next';
 
 		if ( null === $url ) {
 			printf(
-				'<span class="woocommerce-order-list-nav__chevron" aria-disabled="true" aria-label="%s">%s</span>',
-				esc_attr( $label ),
-				$svg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- inline SVG built from constant + escaped attr.
+				'<span class="woocommerce-order-list-nav__link %s" aria-disabled="true">%s</span>',
+				esc_attr( $direction_class ),
+				$inner // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- inline SVG built from constant + escaped label.
 			);
 			return;
 		}
 
 		printf(
-			'<a href="%s" class="woocommerce-order-list-nav__chevron" aria-label="%s">%s</a>',
+			'<a href="%s" class="woocommerce-order-list-nav__link %s">%s</a>',
 			esc_url( $url ),
-			esc_attr( $label ),
-			$svg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- inline SVG built from constant + escaped attr.
+			esc_attr( $direction_class ),
+			$inner // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- inline SVG built from constant + escaped label.
 		);
 	}
 
@@ -260,57 +255,26 @@ class OrderListNav {
 	}
 
 	/**
-	 * Computes total count + position via two paginated count queries.
+	 * Whether the given order matches the active filter set (i.e. would appear in that list view).
 	 *
-	 * Position is one-based. `in_set` is false when the current order doesn't match
-	 * the active filters (e.g. the user filtered to status=completed but is viewing
-	 * a processing order).
+	 * Used to decide whether to drop the filters before computing prev/next, so the nav still
+	 * shows usable links when the user has navigated to an order outside their filtered view.
 	 *
-	 * @param WC_Order            $order      Current order.
-	 * @param array<string,mixed> $query_args Base query args (type/status/etc).
-	 * @return array{position:int,total:int,in_set:bool}
+	 * @param WC_Order            $order      Order being edited.
+	 * @param array<string,mixed> $query_args Filter set as `wc_get_orders` args.
 	 */
-	private function compute_position_and_total( WC_Order $order, array $query_args ): array {
-		$total_query = wc_get_orders(
+	private function order_matches_filters( WC_Order $order, array $query_args ): bool {
+		$match = wc_get_orders(
 			array_merge(
 				$query_args,
 				array(
+					'post__in' => array( $order->get_id() ),
 					'limit'    => 1,
-					'paginate' => true,
 					'return'   => 'ids',
 				)
 			)
 		);
-		$total       = isset( $total_query->total ) ? (int) $total_query->total : 0;
-
-		if ( $total < 1 ) {
-			return array(
-				'position' => 0,
-				'total'    => 0,
-				'in_set'   => false,
-			);
-		}
-
-		$timestamp   = $order->get_date_created() ? $order->get_date_created()->getTimestamp() : time();
-		$newer_query = wc_get_orders(
-			array_merge(
-				$query_args,
-				array(
-					'date_created' => '>' . $timestamp,
-					'limit'        => 1,
-					'paginate'     => true,
-					'return'       => 'ids',
-				)
-			)
-		);
-		$newer_count = isset( $newer_query->total ) ? (int) $newer_query->total : 0;
-		$position    = $newer_count + 1;
-
-		return array(
-			'position' => $position,
-			'total'    => $total,
-			'in_set'   => $position <= $total,
-		);
+		return is_array( $match ) && ! empty( $match );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -5,6 +5,9 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
+use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\Features\OrderDetailRedesign\Init as OrderDetailRedesignInit;
+use Automattic\WooCommerce\Admin\Features\OrderDetailRedesign\OrderListNav;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
@@ -435,6 +438,10 @@ class Edit {
 		<?php
 		if ( 'edit_order' === $this->current_action ) {
 			echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new ) . '</a>';
+		}
+
+		if ( 'edit_order' === $this->current_action && Features::is_enabled( OrderDetailRedesignInit::FEATURE_ID ) ) {
+			wc_get_container()->get( OrderListNav::class )->render( $this->order );
 		}
 		?>
 		<hr class="wp-header-end">

--- a/plugins/woocommerce/tests/php/src/Admin/Features/OrderDetailRedesign/OrderListNavTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/OrderDetailRedesign/OrderListNavTest.php
@@ -1,0 +1,182 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\Features\OrderDetailRedesign;
+
+use Automattic\WooCommerce\Admin\Features\OrderDetailRedesign\OrderListNav;
+use WC_Helper_Order;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the OrderListNav class.
+ */
+class OrderListNavTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var OrderListNav
+	 */
+	private $sut;
+
+	/**
+	 * IDs of orders created in setUp, oldest → newest.
+	 *
+	 * @var int[]
+	 */
+	private $order_ids = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new OrderListNav();
+
+		$_GET    = array();
+		$_SERVER = array_merge( $_SERVER, array( 'HTTP_REFERER' => '' ) );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->order_ids as $order_id ) {
+			$order = wc_get_order( $order_id );
+			if ( $order ) {
+				$order->delete( true );
+			}
+		}
+		$this->order_ids = array();
+
+		$_GET = array();
+		unset( $_SERVER['HTTP_REFERER'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Creates N processing orders with strictly-increasing `date_created` values.
+	 *
+	 * @param int $count Number of orders.
+	 * @return int[] Order IDs in chronological order (oldest first).
+	 */
+	private function create_orders( int $count ): array {
+		$base_time = time() - ( $count * 3600 );
+		$ids       = array();
+		for ( $i = 0; $i < $count; $i++ ) {
+			$order = WC_Helper_Order::create_order();
+			$order->set_status( 'processing' );
+			$order->set_date_created( $base_time + ( $i * 3600 ) );
+			$order->save();
+			$ids[] = $order->get_id();
+		}
+		$this->order_ids = array_merge( $this->order_ids, $ids );
+		return $ids;
+	}
+
+	/**
+	 * @testdox Should render nothing for non-shop_order types.
+	 */
+	public function test_render_skips_refunds(): void {
+		$order             = WC_Helper_Order::create_order();
+		$refund            = wc_create_refund(
+			array(
+				'amount'   => 1,
+				'order_id' => $order->get_id(),
+			)
+		);
+		$this->order_ids[] = $order->get_id();
+
+		ob_start();
+		$this->sut->render( $refund );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output, 'Refund should not produce nav markup.' );
+	}
+
+	/**
+	 * @testdox Should report position 1 / N for the newest order in the set.
+	 */
+	public function test_position_is_one_for_newest_order(): void {
+		$ids   = $this->create_orders( 5 );
+		$order = wc_get_order( end( $ids ) );
+
+		$data = $this->sut->get_navigation_data( $order );
+
+		$this->assertSame( 1, $data['position'], 'Newest order should be position 1.' );
+		$this->assertSame( 5, $data['total'], 'Total should reflect all 5 orders.' );
+		$this->assertNull( $data['next_id'], 'No next link from newest order.' );
+		$this->assertSame( $ids[3], $data['prev_id'], 'Prev should be the second-newest order.' );
+	}
+
+	/**
+	 * @testdox Should report position N / N for the oldest order in the set.
+	 */
+	public function test_position_is_total_for_oldest_order(): void {
+		$ids   = $this->create_orders( 5 );
+		$order = wc_get_order( $ids[0] );
+
+		$data = $this->sut->get_navigation_data( $order );
+
+		$this->assertSame( 5, $data['position'], 'Oldest order should be at position equal to total.' );
+		$this->assertSame( 5, $data['total'], 'Total should reflect all 5 orders.' );
+		$this->assertNull( $data['prev_id'], 'No prev link from oldest order.' );
+		$this->assertSame( $ids[1], $data['next_id'], 'Next should be the second-oldest order.' );
+	}
+
+	/**
+	 * @testdox Should narrow position and total to the active status filter.
+	 */
+	public function test_status_filter_narrows_the_set(): void {
+		$ids = $this->create_orders( 5 );
+
+		$completed_order = wc_get_order( $ids[2] );
+		$completed_order->set_status( 'completed' );
+		$completed_order->save();
+
+		$_GET['status'] = 'completed';
+
+		$data = $this->sut->get_navigation_data( $completed_order );
+
+		$this->assertSame( 1, $data['position'], 'The single completed order should be at position 1 within its filter.' );
+		$this->assertSame( 1, $data['total'], 'Total should reflect the filtered set (1 completed order).' );
+		$this->assertNull( $data['prev_id'], 'No prev order matches the filter.' );
+		$this->assertNull( $data['next_id'], 'No next order matches the filter.' );
+		$this->assertSame( array( 'status' => 'completed' ), $data['list_query'], 'Filter should be carried forward.' );
+	}
+
+	/**
+	 * @testdox Should fall back to unfiltered set when current order does not match the active filter.
+	 */
+	public function test_falls_back_when_filter_excludes_current_order(): void {
+		$ids = $this->create_orders( 3 );
+
+		$_GET['status'] = 'completed';
+
+		$processing_order = wc_get_order( $ids[1] );
+		$data             = $this->sut->get_navigation_data( $processing_order );
+
+		$this->assertSame( 3, $data['total'], 'Total should reflect the unfiltered set after fallback.' );
+		$this->assertSame( 2, $data['position'], 'Position should reflect the unfiltered set (middle of 3).' );
+		$this->assertSame( array(), $data['list_query'], 'Filter should be dropped after fallback.' );
+	}
+
+	/**
+	 * @testdox Should drop unknown URL params from the forwarded list query.
+	 */
+	public function test_unknown_params_are_dropped(): void {
+		$ids   = $this->create_orders( 2 );
+		$order = wc_get_order( $ids[0] );
+
+		$_GET['status']     = 'processing';
+		$_GET['evil']       = 'should-be-dropped';
+		$_GET['javascript'] = 'alert(1)';
+
+		$data = $this->sut->get_navigation_data( $order );
+
+		$this->assertArrayHasKey( 'status', $data['list_query'], 'Whitelisted param should be kept.' );
+		$this->assertArrayNotHasKey( 'evil', $data['list_query'], 'Unknown param should be dropped.' );
+		$this->assertArrayNotHasKey( 'javascript', $data['list_query'], 'Unknown param should be dropped.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/Features/OrderDetailRedesign/OrderListNavTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/OrderDetailRedesign/OrderListNavTest.php
@@ -96,37 +96,33 @@ class OrderListNavTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should report position 1 / N for the newest order in the set.
+	 * @testdox Should disable Prev (left) at the newest order in the set.
 	 */
-	public function test_position_is_one_for_newest_order(): void {
+	public function test_no_prev_at_newest_order(): void {
 		$ids   = $this->create_orders( 5 );
 		$order = wc_get_order( end( $ids ) );
 
 		$data = $this->sut->get_navigation_data( $order );
 
-		$this->assertSame( 1, $data['position'], 'Newest order should be position 1.' );
-		$this->assertSame( 5, $data['total'], 'Total should reflect all 5 orders.' );
-		$this->assertNull( $data['prev_id'], 'No previous-position link at position 1.' );
-		$this->assertSame( $ids[3], $data['next_id'], 'Next-position link should be the second-newest order.' );
+		$this->assertNull( $data['prev_id'], 'Prev link should be disabled at the newest order.' );
+		$this->assertSame( $ids[3], $data['next_id'], 'Next link should point at the second-newest order.' );
 	}
 
 	/**
-	 * @testdox Should report position N / N for the oldest order in the set.
+	 * @testdox Should disable Next (right) at the oldest order in the set.
 	 */
-	public function test_position_is_total_for_oldest_order(): void {
+	public function test_no_next_at_oldest_order(): void {
 		$ids   = $this->create_orders( 5 );
 		$order = wc_get_order( $ids[0] );
 
 		$data = $this->sut->get_navigation_data( $order );
 
-		$this->assertSame( 5, $data['position'], 'Oldest order should be at position equal to total.' );
-		$this->assertSame( 5, $data['total'], 'Total should reflect all 5 orders.' );
-		$this->assertNull( $data['next_id'], 'No next-position link at the last position.' );
-		$this->assertSame( $ids[1], $data['prev_id'], 'Previous-position link should be the second-oldest order.' );
+		$this->assertNull( $data['next_id'], 'Next link should be disabled at the oldest order.' );
+		$this->assertSame( $ids[1], $data['prev_id'], 'Prev link should point at the second-oldest order.' );
 	}
 
 	/**
-	 * @testdox Should narrow position and total to the active status filter.
+	 * @testdox Should narrow prev/next to the active status filter.
 	 */
 	public function test_status_filter_narrows_the_set(): void {
 		$ids = $this->create_orders( 5 );
@@ -139,11 +135,10 @@ class OrderListNavTest extends WC_Unit_Test_Case {
 
 		$data = $this->sut->get_navigation_data( $completed_order );
 
-		$this->assertSame( 1, $data['position'], 'The single completed order should be at position 1 within its filter.' );
-		$this->assertSame( 1, $data['total'], 'Total should reflect the filtered set (1 completed order).' );
 		$this->assertNull( $data['prev_id'], 'No prev order matches the filter.' );
 		$this->assertNull( $data['next_id'], 'No next order matches the filter.' );
-		$this->assertSame( array( 'status' => 'completed' ), $data['list_query'], 'Filter should be carried forward.' );
+		$this->assertArrayHasKey( 'status', $data['list_query'] );
+		$this->assertSame( 'completed', $data['list_query']['status'], 'Filter should be carried forward.' );
 	}
 
 	/**
@@ -157,8 +152,8 @@ class OrderListNavTest extends WC_Unit_Test_Case {
 		$processing_order = wc_get_order( $ids[1] );
 		$data             = $this->sut->get_navigation_data( $processing_order );
 
-		$this->assertSame( 3, $data['total'], 'Total should reflect the unfiltered set after fallback.' );
-		$this->assertSame( 2, $data['position'], 'Position should reflect the unfiltered set (middle of 3).' );
+		$this->assertSame( $ids[2], $data['prev_id'], 'Prev should walk the unfiltered set after fallback.' );
+		$this->assertSame( $ids[0], $data['next_id'], 'Next should walk the unfiltered set after fallback.' );
 		$this->assertSame( array(), $data['list_query'], 'Filter should be dropped after fallback.' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Admin/Features/OrderDetailRedesign/OrderListNavTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/OrderDetailRedesign/OrderListNavTest.php
@@ -106,8 +106,8 @@ class OrderListNavTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 1, $data['position'], 'Newest order should be position 1.' );
 		$this->assertSame( 5, $data['total'], 'Total should reflect all 5 orders.' );
-		$this->assertNull( $data['next_id'], 'No next link from newest order.' );
-		$this->assertSame( $ids[3], $data['prev_id'], 'Prev should be the second-newest order.' );
+		$this->assertNull( $data['prev_id'], 'No previous-position link at position 1.' );
+		$this->assertSame( $ids[3], $data['next_id'], 'Next-position link should be the second-newest order.' );
 	}
 
 	/**
@@ -121,8 +121,8 @@ class OrderListNavTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 5, $data['position'], 'Oldest order should be at position equal to total.' );
 		$this->assertSame( 5, $data['total'], 'Total should reflect all 5 orders.' );
-		$this->assertNull( $data['prev_id'], 'No prev link from oldest order.' );
-		$this->assertSame( $ids[1], $data['next_id'], 'Next should be the second-oldest order.' );
+		$this->assertNull( $data['next_id'], 'No next-position link at the last position.' );
+		$this->assertSame( $ids[1], $data['prev_id'], 'Previous-position link should be the second-oldest order.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a right-aligned `< 1 / 23 >` previous/next order navigation to the H1 row of the HPOS Order edit screen, behind the `order-detail-redesign` feature flag. Position and total reflect the orders-list filter set the user came from (read once from the referer, then carried forward in URL params on prev/next links). Falls back to all `shop_orders` by `date_created DESC` when no list context is known.

> **Stacked on #64669.** This PR contains the four `order-detail-redesign` flag-scaffolding commits from #64669 so the new code can resolve `OrderDetailRedesign\Init`. Once #64669 merges to trunk, those commits drop out of this diff automatically.

Visual tokens come from the WP 7.0 SCSS variables already in `client/legacy/css/_variables.scss`: `$gray-900` (#1e1e1e) for the current position number, `$gray-700` (#757575) for the separator and total. Chevron icons are inline SVGs sourced from `@wordpress/icons` (`chevronLeft` / `chevronRight`).

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

**Pre-requisites:** install [WooCommerce Beta Tester](https://github.com/woocommerce/woocommerce-beta-tester) and have ~25 orders across multiple statuses.

**With the flag OFF (default):**

1. Visit any order at `?page=wc-orders&action=edit&id=N`. Expected: no nav appears next to the H1; identical to trunk.

**With the flag ON** (toggle via WooCommerce Beta Tester → Tools → WCA Test Helper → Features):

2. Go to **WooCommerce → Orders** and click any order. Expected: a right-aligned `< 1 / 23 >` nav renders next to the H1, with the current position number in dark grey and the ` / 23` separator + total in lighter grey.
3. Click the right (Next) chevron. Expected: navigates to the next-newer order; the nav re-renders with the new position; the URL keeps any list filter params.
4. From the orders list, filter to **Processing** (e.g. ~5 orders), then click an order. Expected: total reads `5`; prev/next walks only processing orders.
5. From step 4, click "Previous" until you reach the oldest processing order. Expected: the left chevron renders disabled (faded, no tab focus, no link).
6. Open an order via direct URL paste (no orders-list referer). Expected: nav still renders with the all-orders fallback; total reflects every order.
7. Filter to **Completed**, then directly visit the URL of a `processing` order. Expected: nav renders using the unfiltered fallback (the Completed filter is dropped because the current order doesn't match it).
8. Visit `?page=wc-orders&action=new`. Expected: no nav (no current order).
9. Open a refund detail page from an order that has a refund. Expected: no nav (refunds are out of scope).
10. Resize the browser to ~600px wide. Expected: the nav wraps below the title; remains usable.
11. Switch the site to a RTL locale (e.g. Hebrew). Expected: the chevrons flip; "Previous" still navigates to the older order.
12. Tab through the page. Expected: focus ring on chevrons matches WP admin focus styling; disabled chevrons are skipped in tab order; aria-labels read "Previous order" / "Next order" / "Order N of M" via screen reader.

### Testing that has already taken place:

- PHPCS (`vendor/bin/phpcs`) on the new files: clean.
- PHPStan (`composer exec -- phpstan analyse src/Admin/Features/OrderDetailRedesign/OrderListNav.php src/Admin/Features/OrderDetailRedesign/Init.php src/Internal/Admin/Orders/Edit.php`): no errors, baseline unchanged.
- SCSS build (`pnpm --filter=@woocommerce/classic-assets run build:project:assets`): succeeds; compiled `admin.css` and `admin-rtl.css` contain the new `.woocommerce-order-list-nav*` rules with `$gray-900` / `$gray-700` colors and the RTL flip rule.
- PHP unit tests (`OrderListNavTest`) cover position math at boundaries, status-filter narrowing, fallback when filter excludes current order, unknown-param dropping, and refund no-op. Run via CI's wp-env.
- Manual visual verification on a Studio site is pending the screenshots above.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was added manually as `plugins/woocommerce/changelog/order-detail-prev-next-nav` (Significance: minor, Type: add).

</details>