### PR TITLE
Fix Catalog Sorting block assets returning 404

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6660-iapi-catalog-sorting-block-404-css-and-js
+++ b/plugins/woocommerce/changelog/wooplug-6660-iapi-catalog-sorting-block-404-css-and-js
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevent 404s for Catalog Sorting block assets.
+
+Catalog Sorting block: prevent 404s for non-existent JS and CSS asset files.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -51616,12 +51616,6 @@ parameters:
 			path: src/Blocks/BlockTypes/CatalogSorting.php
 
 		-
-			message: '#^Variable \$styles_and_classes on left side of \?\? is never defined\.$#'
-			identifier: nullCoalesce.variable
-			count: 1
-			path: src/Blocks/BlockTypes/CatalogSorting.php
-
-		-
 			message: '#^Cannot call method allocate_and_return_parsed_attributes\(\) on Automattic\\Block_Scanner\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -53804,7 +53798,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Blocks/BlockTypes/ProductFilterRating.php
-
 
 		-
 			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, Closure\(mixed\)\: \(0\|1\) given\.$#'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CatalogSorting.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CatalogSorting.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
  */
 class CatalogSorting extends AbstractBlock {
 
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CatalogSorting.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CatalogSorting.php
@@ -65,7 +65,7 @@ class CatalogSorting extends AbstractBlock {
 						]
 					)
 				),
-				'style' => esc_attr( $styles_and_classes['styles'] ?? '' ),
+				'style' => esc_attr( $classes_and_styles['styles'] ?? '' ),
 			)
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

Closes #64681
Closes WOOPLUG-6660

### Changes proposed in this Pull Request:

The Catalog Sorting block emits 404s for `catalog-sorting-frontend.js` and `catalog-sorting.css` on the frontend, caused by the following PR
- #62854

@luisherranz asked in the PR to remove

```
	protected function get_block_type_script( $key = null ) {
		return null;
	}
```

This removal caused the 404s. I added the trait `EnableBlockJsonAssetsTrait` which sets the following functions to return null
- `get_block_type_script`
- `get_block_type_style`
- `get_block_type_editor_style` 

### How to test the changes in this Pull Request:

1. Start wp-env and import products if there are nont
2. Visit the shop page
3. View the page on the storefront with DevTools → Network open.
4. Confirm there are no 404 requests for `catalog-sorting-frontend.js` or `catalog-sorting.css`.
5. Change the sort option in the dropdown and confirm the product list re-sorts (iAPI handler still works).

| Before | After |
|--------|--------|
| <img width="2518" height="1645" alt="image" src="https://github.com/user-attachments/assets/cd8db128-f5a4-4f62-b1ea-b7073e2c2015" /> | <img width="2518" height="1645" alt="image" src="https://github.com/user-attachments/assets/4ef21fed-0780-42c8-978d-b90f0188aa44" /> |

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was added manually at `plugins/woocommerce/changelog/wooplug-6660-iapi-catalog-sorting-block-404-css-and-js`.

</details>