### PR TITLE
Add ariaLabel to attribute, status, and taxonomy product filter items

### DIFF
--- a/plugins/woocommerce/changelog/64693-fix-product-filter-aria-labels
+++ b/plugins/woocommerce/changelog/64693-fix-product-filter-aria-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add ariaLabel to attribute, status, and taxonomy product filter items for improved screen reader accessibility

--- a/plugins/woocommerce/changelog/tangerine-d92da596
+++ b/plugins/woocommerce/changelog/tangerine-d92da596
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add ariaLabel to attribute, status, and taxonomy product filter items for improved screen reader accessibility

--- a/plugins/woocommerce/changelog/tangerine-d92da596
+++ b/plugins/woocommerce/changelog/tangerine-d92da596
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add ariaLabel to attribute, status, and taxonomy product filter items for improved screen reader accessibility

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -198,21 +198,11 @@ final class ProductFilterAttribute extends AbstractBlock {
 					$term          = (array) $term;
 					$term['count'] = $attribute_counts[ $term['term_id'] ] ?? 0;
 
-					$type       = 'attribute/' . str_replace( 'pa_', '', $product_attribute->slug );
-					$aria_label = $term['name'];
-					if ( $show_counts ) {
-						$aria_label = sprintf(
-							/* translators: %1$s: filter item label. %2$d: number of results. */
-							_n( '%1$s, %2$d result', '%1$s, %2$d results', $term['count'], 'woocommerce' ),
-							$term['name'],
-							$term['count']
-						);
-					}
-
+					$type = 'attribute/' . str_replace( 'pa_', '', $product_attribute->slug );
 					$item = array(
 						'id'                 => $type . '-' . $term['slug'],
 						'label'              => $term['name'],
-						'ariaLabel'          => $aria_label,
+						'ariaLabel'          => $term['name'],
 						'value'              => $term['slug'],
 						'selected'           => in_array( $term['slug'], $selected_terms, true ),
 						'type'               => $type,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -198,10 +198,21 @@ final class ProductFilterAttribute extends AbstractBlock {
 					$term          = (array) $term;
 					$term['count'] = $attribute_counts[ $term['term_id'] ] ?? 0;
 
-					$type = 'attribute/' . str_replace( 'pa_', '', $product_attribute->slug );
+					$type       = 'attribute/' . str_replace( 'pa_', '', $product_attribute->slug );
+					$aria_label = $term['name'];
+					if ( $show_counts ) {
+						$aria_label = sprintf(
+							/* translators: %1$s: filter item label. %2$d: number of results. */
+							_n( '%1$s, %2$d result', '%1$s, %2$d results', $term['count'], 'woocommerce' ),
+							$term['name'],
+							$term['count']
+						);
+					}
+
 					$item = array(
 						'id'                 => $type . '-' . $term['slug'],
 						'label'              => $term['name'],
+						'ariaLabel'          => $aria_label,
 						'value'              => $term['slug'],
 						'selected'           => in_array( $term['slug'], $selected_terms, true ),
 						'type'               => $type,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -111,21 +111,11 @@ final class ProductFilterStatus extends AbstractBlock {
 		$show_counts    = $attributes['showCounts'] ?? false;
 		$filter_options = array_map(
 			function ( $item ) use ( $stock_statuses, $selected_stock_statuses, $show_counts ) {
-				$label      = $stock_statuses[ $item['status'] ];
-				$aria_label = $label;
-				if ( $show_counts ) {
-					$aria_label = sprintf(
-						/* translators: %1$s: filter item label. %2$d: number of results. */
-						_n( '%1$s, %2$d result', '%1$s, %2$d results', $item['count'], 'woocommerce' ),
-						$label,
-						$item['count']
-					);
-				}
-
+				$label  = $stock_statuses[ $item['status'] ];
 				$option = array(
 					'id'        => 'status-' . $item['status'],
 					'label'     => $label,
-					'ariaLabel' => $aria_label,
+					'ariaLabel' => $label,
 					'value'     => $item['status'],
 					'selected'  => in_array( $item['status'], $selected_stock_statuses, true ),
 					'type'      => 'status',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -111,12 +111,24 @@ final class ProductFilterStatus extends AbstractBlock {
 		$show_counts    = $attributes['showCounts'] ?? false;
 		$filter_options = array_map(
 			function ( $item ) use ( $stock_statuses, $selected_stock_statuses, $show_counts ) {
+				$label      = $stock_statuses[ $item['status'] ];
+				$aria_label = $label;
+				if ( $show_counts ) {
+					$aria_label = sprintf(
+						/* translators: %1$s: filter item label. %2$d: number of results. */
+						_n( '%1$s, %2$d result', '%1$s, %2$d results', $item['count'], 'woocommerce' ),
+						$label,
+						$item['count']
+					);
+				}
+
 				$option = array(
-					'id'       => 'status-' . $item['status'],
-					'label'    => $stock_statuses[ $item['status'] ],
-					'value'    => $item['status'],
-					'selected' => in_array( $item['status'], $selected_stock_statuses, true ),
-					'type'     => 'status',
+					'id'        => 'status-' . $item['status'],
+					'label'     => $label,
+					'ariaLabel' => $aria_label,
+					'value'     => $item['status'],
+					'selected'  => in_array( $item['status'], $selected_stock_statuses, true ),
+					'type'      => 'status',
 				);
 
 				if ( $show_counts ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -244,13 +244,24 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 					$term          = (array) $term;
 					$term['count'] = $taxonomy_counts[ $term['term_id'] ] ?? 0;
 
-					$type   = 'taxonomy/' . $taxonomy;
+					$type       = 'taxonomy/' . $taxonomy;
+					$aria_label = $term['name'];
+					if ( $show_counts ) {
+						$aria_label = sprintf(
+							/* translators: %1$s: filter item label. %2$d: number of results. */
+							_n( '%1$s, %2$d result', '%1$s, %2$d results', $term['count'], 'woocommerce' ),
+							$term['name'],
+							$term['count']
+						);
+					}
+
 					$option = array(
-						'id'       => $type . '-' . $term['slug'],
-						'label'    => $term['name'],
-						'value'    => $term['slug'],
-						'selected' => in_array( $term['slug'], $selected_terms, true ),
-						'type'     => $type,
+						'id'        => $type . '-' . $term['slug'],
+						'label'     => $term['name'],
+						'ariaLabel' => $aria_label,
+						'value'     => $term['slug'],
+						'selected'  => in_array( $term['slug'], $selected_terms, true ),
+						'type'      => $type,
 					);
 
 					if ( $show_counts ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -244,21 +244,11 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 					$term          = (array) $term;
 					$term['count'] = $taxonomy_counts[ $term['term_id'] ] ?? 0;
 
-					$type       = 'taxonomy/' . $taxonomy;
-					$aria_label = $term['name'];
-					if ( $show_counts ) {
-						$aria_label = sprintf(
-							/* translators: %1$s: filter item label. %2$d: number of results. */
-							_n( '%1$s, %2$d result', '%1$s, %2$d results', $term['count'], 'woocommerce' ),
-							$term['name'],
-							$term['count']
-						);
-					}
-
+					$type   = 'taxonomy/' . $taxonomy;
 					$option = array(
 						'id'        => $type . '-' . $term['slug'],
 						'label'     => $term['name'],
-						'ariaLabel' => $aria_label,
+						'ariaLabel' => $term['name'],
 						'value'     => $term['slug'],
 						'selected'  => in_array( $term['slug'], $selected_terms, true ),
 						'type'      => $type,


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Add `ariaLabel` to item arrays in `ProductFilterAttribute`, `ProductFilterStatus`, `ProductFilterTaxonomy`. Matches existing `ProductFilterRating` pattern. Needed for swatch style where visible text is clipped — without `ariaLabel`, screen readers get no label.

### How to test the changes in this Pull Request:

1. Add Product Filters block with Attribute, Status, and Taxonomy filters.
2. Inspect rendered HTML — filter items should have `aria-label` matching label text.
3. Switch to swatch style, verify aria-label is the only accessible name.

### Testing that has already taken place:

- PHPStan: clean
- PHPCS: clean

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.