### PR TITLE
RSM: Add Save for later link to cart line items

### DIFF
--- a/plugins/woocommerce/changelog/add-cart-save-for-later-link
+++ b/plugins/woocommerce/changelog/add-cart-save-for-later-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a "Save for later" link beneath each cart line item that saves the item to the saved-for-later shopper list and removes it from the cart on success. The link is only shown to logged-in users and is hidden in the mini-cart.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -11,6 +11,7 @@ import {
 	useStoreCartItemQuantity,
 	useStoreEvents,
 	useStoreCart,
+	useSaveForLater,
 } from '@woocommerce/base-context/hooks';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import {
@@ -117,7 +118,9 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 
 		const { quantity, setItemQuantity, removeItem, isPendingDelete } =
 			useStoreCartItemQuantity( lineItem );
+		const { saveForLater, isSaving: isSavingForLater } = useSaveForLater();
 		const { dispatchStoreEvent } = useStoreEvents();
+		const isUserLoggedIn = !! getSetting< number >( 'currentUserId', 0 );
 
 		// Prepare props to pass to the applyCheckoutFilter filter.
 		// We need to pluck out receiveCart.
@@ -339,6 +342,59 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 								</button>
 							) }
 						</div>
+						{ isUserLoggedIn && (
+							<div className="wc-block-cart-item__save-for-later">
+								<button
+									type="button"
+									className="wc-block-cart-item__save-for-later-link"
+									onClick={ async () => {
+										const saved = await saveForLater(
+											lineItem.key
+										);
+										if ( ! saved ) {
+											return;
+										}
+										// removeItem surfaces its own errors
+										// via processErrorResponse; we still
+										// fire the analytics event and a11y
+										// announcement to mirror the regular
+										// remove flow.
+										await removeItem();
+										// TODO: consider a dedicated
+										// 'cart-save-for-later' store event so
+										// analytics can distinguish a save
+										// from a plain remove.
+										dispatchStoreEvent(
+											'cart-remove-item',
+											{
+												product: lineItem,
+												quantity,
+											}
+										);
+										speak(
+											sprintf(
+												/* translators: %s refers to the item name. */
+												__(
+													'%s has been saved for later and removed from your cart.',
+													'woocommerce'
+												),
+												name
+											)
+										);
+									} }
+									disabled={
+										isPendingDelete || isSavingForLater
+									}
+								>
+									{ isSavingForLater
+										? __( 'Saving…', 'woocommerce' )
+										: __(
+												'Save for later',
+												'woocommerce'
+										  ) }
+								</button>
+							</div>
+						) }
 					</div>
 				</td>
 				<td className="wc-block-cart-item__total">

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -96,6 +96,21 @@ table.wc-block-cart-items {
 				}
 			}
 		}
+		.wc-block-cart-item__save-for-later {
+			.wc-block-cart-item__save-for-later-link {
+				@include link-button();
+				@include hover-effect();
+				@include font-small-locked;
+
+				text-transform: none;
+				white-space: nowrap;
+
+				&:disabled {
+					cursor: default;
+					opacity: 0.5;
+				}
+			}
+		}
 		.wc-block-components-product-name {
 			@include font-small-locked;
 			display: block;
@@ -118,6 +133,10 @@ table.wc-block-cart-items {
 			pointer-events: none;
 			transition: opacity 200ms ease;
 		}
+	}
+
+	&.wc-block-mini-cart-items .wc-block-cart-item__save-for-later {
+		display: none;
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/index.ts
@@ -1,3 +1,4 @@
 export * from './use-store-cart';
 export * from './use-store-cart-coupons';
 export * from './use-store-cart-item-quantity';
+export * from './use-save-for-later';

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-save-for-later.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-save-for-later.ts
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { dispatch, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { cartStore } from '@woocommerce/block-data';
+
+/**
+ * Save a cart line item to the saved-for-later shopper list.
+ *
+ * Dispatches the wp.data cart store's `saveForLater` thunk, which POSTs the
+ * item and emits a `wc-blocks_store_sync_required` event. A Shopper
+ * Collection block on the same page picks up that event in its iAPI store
+ * and applies the new row reactively.
+ *
+ * Resolves to `true` on success so the caller can chain the cart removal;
+ * on failure surfaces an error notice in the cart context and resolves to
+ * `false`. The cart removal is the caller's responsibility — keep the two
+ * awaits separate so save and remove errors stay distinct.
+ */
+export const useSaveForLater = (): {
+	isSaving: boolean;
+	saveForLater: ( cartItemKey: string ) => Promise< boolean >;
+} => {
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { saveForLater: dispatchSaveForLater } = useDispatch( cartStore );
+
+	const saveForLater = useCallback(
+		async ( cartItemKey: string ): Promise< boolean > => {
+			if ( ! cartItemKey || isSaving ) {
+				return false;
+			}
+			setIsSaving( true );
+			try {
+				await dispatchSaveForLater( cartItemKey );
+				return true;
+			} catch ( error ) {
+				const message =
+					error &&
+					typeof error === 'object' &&
+					'message' in error &&
+					typeof ( error as { message: unknown } ).message ===
+						'string'
+						? ( error as { message: string } ).message
+						: __(
+								'There was a problem saving this item for later.',
+								'woocommerce'
+						  );
+				dispatch( noticesStore ).createNotice( 'error', message, {
+					context: 'wc/cart',
+					isDismissible: true,
+				} );
+				return false;
+			} finally {
+				setIsSaving( false );
+			}
+		},
+		[ isSaving, dispatchSaveForLater ]
+	);
+
+	return { isSaving, saveForLater };
+};

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -306,7 +306,11 @@ window.addEventListener( 'wc-blocks_store_sync_required', ( event: Event ) => {
 	if ( detail?.type !== 'shopper-list-item-added' ) {
 		return;
 	}
-	if ( ! detail.slug || ! isShopperListItem( detail.item ) ) {
+	if (
+		typeof detail.slug !== 'string' ||
+		detail.slug.trim().length === 0 ||
+		! isShopperListItem( detail.item )
+	) {
 		return;
 	}
 	const list = ensureListState( state, detail.slug );

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -169,7 +169,7 @@ async function restRequest< T >(
 // so an empty-string default would clobber the values seeded server-side via
 // `wp_interactivity_state`. State for those fields comes purely from PHP. Same
 // reason the cart store doesn't ship state defaults — see cart.ts.
-const { state } = store< Store >(
+const { state, actions } = store< Store >(
 	'woocommerce/shopper-lists',
 	{
 		actions: {
@@ -288,3 +288,18 @@ const { state } = store< Store >(
 	},
 	{ lock: universalLock }
 );
+
+// Listen for shopper-list mutations emitted from the wp.data side (e.g. the
+// cart store's saveForLater thunk). Mirrors the cart store's ping-and-refetch
+// pattern: the producer announces "this list changed" with no payload, and
+// this side refetches to reconcile. Keeps the discriminator contract in sync
+// with `assets/js/data/cart/thunks.ts::saveForLater`.
+window.addEventListener( 'wc-blocks_store_sync_required', ( event: Event ) => {
+	const detail = ( event as CustomEvent ).detail as
+		| { type?: string; slug?: string }
+		| undefined;
+	if ( detail?.type !== 'shopper-list-changed' || ! detail.slug ) {
+		return;
+	}
+	actions.loadList( detail.slug );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -169,7 +169,7 @@ async function restRequest< T >(
 // so an empty-string default would clobber the values seeded server-side via
 // `wp_interactivity_state`. State for those fields comes purely from PHP. Same
 // reason the cart store doesn't ship state defaults — see cart.ts.
-const { state, actions } = store< Store >(
+const { state } = store< Store >(
 	'woocommerce/shopper-lists',
 	{
 		actions: {
@@ -289,17 +289,33 @@ const { state, actions } = store< Store >(
 	{ lock: universalLock }
 );
 
-// Listen for shopper-list mutations emitted from the wp.data side (e.g. the
-// cart store's saveForLater thunk). Mirrors the cart store's ping-and-refetch
-// pattern: the producer announces "this list changed" with no payload, and
-// this side refetches to reconcile. Keeps the discriminator contract in sync
-// with `assets/js/data/cart/thunks.ts::saveForLater`.
+// Listen for shopper-list item additions emitted from the wp.data side (e.g.
+// the cart store's saveForLater thunk). Mirrors the cart's iAPI → wp.data
+// sync direction, which also ships a payload (`from_iAPI` carries
+// `quantityChanges`). The event carries the saved item directly so we can
+// splice it in without an extra GET — keeps the merge ordering deterministic
+// and avoids the loadList-vs-mutation race the iAPI store's loadList still
+// has a TODO about.
+//
+// Keeps the discriminator + payload contract in sync with
+// `assets/js/data/cart/thunks.ts::saveForLater`.
 window.addEventListener( 'wc-blocks_store_sync_required', ( event: Event ) => {
 	const detail = ( event as CustomEvent ).detail as
-		| { type?: string; slug?: string }
+		| { type?: string; slug?: string; item?: RawShopperListItem }
 		| undefined;
-	if ( detail?.type !== 'shopper-list-changed' || ! detail.slug ) {
+	if ( detail?.type !== 'shopper-list-item-added' ) {
 		return;
 	}
-	actions.loadList( detail.slug );
+	if ( ! detail.slug || ! isShopperListItem( detail.item ) ) {
+		return;
+	}
+	const list = ensureListState( state, detail.slug );
+	const item = detail.item;
+	const existingIndex = list.items.findIndex( ( i ) => i.key === item.key );
+	if ( existingIndex >= 0 ) {
+		list.items[ existingIndex ] = item;
+	} else {
+		list.items.push( item );
+	}
+	list.error = null;
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -485,6 +485,44 @@ export const removeItemFromCart =
 	};
 
 /**
+ * Saves a cart line item to the saved-for-later shopper list.
+ *
+ * On success, emits a `wc-blocks_store_sync_required` event with
+ * `detail.type === 'shopper-list-changed'` so a `woocommerce/shopper-lists`
+ * iAPI store on the same page (rendered by a Shopper Collection block)
+ * refetches and reconciles. Mirrors the ping-and-refetch pattern this store
+ * already uses to sync with the iAPI cart store — no payload on the wire,
+ * the listener owns the reconcile.
+ *
+ * Removing the item from the cart is the caller's responsibility — keep the
+ * two awaits separate so save and remove errors can be reported distinctly.
+ *
+ * @param {string} cartItemKey Cart item to save.
+ */
+export const saveForLater =
+	( cartItemKey: string ) => async (): Promise< { key: string } > => {
+		const { response } = await apiFetchWithHeaders< {
+			response: { key: string };
+		} >( {
+			path: '/wc/store/v1/shopper-lists/saved-for-later/items',
+			method: 'POST',
+			data: { cart_item_key: cartItemKey },
+			cache: 'no-store',
+		} );
+
+		window.dispatchEvent(
+			new CustomEvent( 'wc-blocks_store_sync_required', {
+				detail: {
+					type: 'shopper-list-changed',
+					slug: 'saved-for-later',
+				},
+			} )
+		);
+
+		return response;
+	};
+
+/**
  * Tracks AbortControllers per cart item for cancelling in-flight quantity requests.
  */
 const quantityAbortControllers = new Map< string, AbortController >();
@@ -698,6 +736,7 @@ export type Thunks =
 	| typeof removeCoupon
 	| typeof addItemToCart
 	| typeof removeItemFromCart
+	| typeof saveForLater
 	| typeof changeCartItemQuantity
 	| typeof selectShippingRate
 	| typeof updateCustomerData;

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -487,12 +487,14 @@ export const removeItemFromCart =
 /**
  * Saves a cart line item to the saved-for-later shopper list.
  *
- * On success, emits a `wc-blocks_store_sync_required` event with
- * `detail.type === 'shopper-list-changed'` so a `woocommerce/shopper-lists`
- * iAPI store on the same page (rendered by a Shopper Collection block)
- * refetches and reconciles. Mirrors the ping-and-refetch pattern this store
- * already uses to sync with the iAPI cart store — no payload on the wire,
- * the listener owns the reconcile.
+ * On success, emits a `wc-blocks_store_sync_required` event with the saved
+ * item in `detail.item` so a `woocommerce/shopper-lists` iAPI store on the
+ * same page (rendered by a Shopper Collection block) can splice the row
+ * into its local state — no extra GET, no race window between a slow
+ * refetch and concurrent mutations. Same envelope the cart's iAPI → wp.data
+ * sync uses to ship payloads (`detail.type === 'from_iAPI'` carries
+ * `quantityChanges`); this is the wp.data → iAPI direction of the same
+ * pattern.
  *
  * Removing the item from the cart is the caller's responsibility — keep the
  * two awaits separate so save and remove errors can be reported distinctly.
@@ -513,8 +515,9 @@ export const saveForLater =
 		window.dispatchEvent(
 			new CustomEvent( 'wc-blocks_store_sync_required', {
 				detail: {
-					type: 'shopper-list-changed',
+					type: 'shopper-list-item-added',
 					slug: 'saved-for-later',
+					item: response,
 				},
 			} )
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -21,6 +21,7 @@ import {
 	type ConfigOf,
 	type ActionCreatorsOf,
 } from '@wordpress/data/build-types/types';
+import { __ } from '@wordpress/i18n';
 import { cartStore } from '@woocommerce/block-data';
 
 /**
@@ -160,8 +161,8 @@ export const applyExtensionCartUpdate =
 
 			if ( ! includeShipping || ! includeBilling ) {
 				const {
-					shipping_address: _,
-					billing_address: __,
+					shipping_address: _shipping,
+					billing_address: _billing,
 					...responseWithoutAddresses
 				} = response;
 
@@ -503,6 +504,17 @@ export const removeItemFromCart =
  */
 export const saveForLater =
 	( cartItemKey: string ) => async (): Promise< { key: string } > => {
+		if (
+			typeof cartItemKey !== 'string' ||
+			cartItemKey.trim().length === 0
+		) {
+			throw new Error(
+				__(
+					'A cart item is required to save it for later.',
+					'woocommerce'
+				)
+			);
+		}
 		const { response } = await apiFetchWithHeaders< {
 			response: { key: string };
 		} >( {

--- a/plugins/woocommerce/client/blocks/assets/js/data/shared-controls.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/shared-controls.ts
@@ -130,6 +130,9 @@ const preventBatching = [
 	'/wc/store/v1/checkout',
 	'/wc/store/v1/checkout?__experimental_calc_totals=true',
 	'/wc/store/v1/cart/update-item',
+	// Shopper-lists routes don't declare allow_batch yet. Drop these once
+	// the routes opt into batching server-side.
+	'/wc/store/v1/shopper-lists/saved-for-later/items',
 ];
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Add a "Save for later" link beneath each cart line item that moves the item to the saved-for-later shopper list and removes it from the cart on success. The save is dispatched through a new `saveForLater` thunk on the wp.data cart store; on success it emits a `wc-blocks_store_sync_required` event with `detail.type === 'shopper-list-item-added'` and the saved row in `detail.item`. The iAPI shopper-lists store listens for that event and splices the row into its local state — no extra GET, no race window between a slow refetch and concurrent mutations. Mirrors the cart's `iAPI → wp.data` sync direction, which also ships a payload (`detail.type === 'from_iAPI'` carries `quantityChanges`).

The link does not depend on the Shopper Collection block being on the page — the thunk uses the cart's existing `apiFetchWithHeaders`, which already has the Store API nonce middleware loaded for any cart page. Same-page reactivity kicks in automatically when a Shopper Collection block happens to be rendered.

Inputs are validated at both boundaries: the thunk rejects non-string/whitespace `cartItemKey` before hitting the network, and the iAPI listener rejects malformed `detail.slug`/`detail.item` payloads before mutating state. Both boundaries are public (the thunk is dispatchable by any `useDispatch(cartStore)` caller, the event is window-level), so the guards are defense-in-depth.

Builds on top of #64472 (Store API endpoints) and #64651 (Shopper Collection iAPI store) — base branch is `feature/shopper-collections`.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Check out the branch and run the dev build.
2. On a regular page, insert a Shopper Collection block (Saved for Later variation) so it renders for logged-in users.
3. Log in as a customer and add a few items (mix of simple and variable products) to the cart.
4. Open the Cart block. Confirm a "Save for later" link appears under each line item's quantity selector.
5. Click "Save for later" on one item. Expected: the item disappears from the cart, totals update, and a screen-reader announcement is made.
6. Visit the page with the Shopper Collection block. Expected: the saved item appears in the collection. Repeat with a variation product and confirm the variation attributes are preserved.
7. Place the Cart and a Shopper Collection block on the same page; click "Save for later". Expected: the saved item appears in the collection without a page reload — the new row is spliced into the iAPI state via the sync event, no GET request is fired.
8. Log out and reload the cart. Expected: the "Save for later" link is hidden.
9. Open the mini-cart. Expected: the "Save for later" link does not appear there.
10. Force an error (e.g., block the POST in DevTools network conditions) and click "Save for later". Expected: the item stays in the cart and an error notice appears in the cart context.

### Testing that has already taken place:

Manual testing of the save → remove flow, error surfacing, guest hiding, mini-cart hiding, and same-page reactivity with the Shopper Collection block. ESLint and TypeScript pass for the changed files.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually at \`plugins/woocommerce/changelog/add-cart-save-for-later-link\`.

</details>