### PR TITLE
Gate "saved for later" behind feature flag

### DIFF
--- a/plugins/woocommerce/changelog/add-shopper-collections-feature-flag
+++ b/plugins/woocommerce/changelog/add-shopper-collections-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Gate shopper lists behind a new experimental flag.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -264,6 +264,10 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'isBlockTheme', wp_is_block_theme() );
 		$this->asset_data_registry->add( 'shippingMethodsExist', CartCheckoutUtils::shipping_methods_exist() > 0 );
 
+		if ( has_block( 'woocommerce/shopper-collection' ) ) {
+			$this->asset_data_registry->add( 'cartPageHasSavedForLater', true );
+		}
+
 		$is_block_editor = $this->is_block_editor();
 
 		// Check `current_user_can` so we can show notices about incompatible extensions in the front-end to admins too.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
 use Automattic\WooCommerce\Blocks\BlockTypes\Checkout;
 use Automattic\WooCommerce\Blocks\BlockTypes\MiniCartContents;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * BlockTypesController class.
@@ -506,7 +507,6 @@ final class BlockTypesController {
 			'ReviewsByCategory',
 			'ReviewsByProduct',
 			'RelatedProducts',
-			'ShopperCollection',
 			'SingleProduct',
 			'StockFilter',
 			'PageContentWrapper',
@@ -553,6 +553,10 @@ final class BlockTypesController {
 			Checkout::get_checkout_block_types(),
 			MiniCartContents::get_mini_cart_block_types()
 		);
+
+		if ( FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
+			$block_types[] = 'ShopperCollection';
+		}
 
 		if ( wp_is_block_theme() ) {
 			$block_types[] = 'AddToCartWithOptions\AddToCartWithOptions';

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -602,6 +602,19 @@ class FeaturesController {
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
+			'cart_save_for_later'                => array(
+				'name'                         => __( 'Save for Later in Cart', 'woocommerce' ),
+				'description'                  => __(
+					'Let shoppers save cart items to a list to purchase later.',
+					'woocommerce'
+				),
+				'is_experimental'              => true,
+				'enabled_by_default'           => false,
+				// Custom option_key as we expect this setting to move out of features to
+				// a cart/checkout settings section.
+				'option_key'                   => 'woocommerce_cart_save_for_later_enabled',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+			),
 			ProductCacheController::FEATURE_NAME => array(
 				'name'                         => __( 'Cache Product Objects', 'woocommerce' ),
 				'description'                  => __(

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -39,7 +39,7 @@ class RoutesController {
 	public function __construct( SchemaController $schema_controller ) {
 		$this->schema_controller = $schema_controller;
 		$this->routes            = [
-			'v1'      => [
+			'v1'            => [
 				Routes\V1\Batch::IDENTIFIER              => Routes\V1\Batch::class,
 				Routes\V1\Cart::IDENTIFIER               => Routes\V1\Cart::class,
 				Routes\V1\CartAddItem::IDENTIFIER        => Routes\V1\CartAddItem::class,
@@ -70,16 +70,19 @@ class RoutesController {
 				Routes\V1\Products::IDENTIFIER           => Routes\V1\Products::class,
 				Routes\V1\ProductsById::IDENTIFIER       => Routes\V1\ProductsById::class,
 				Routes\V1\ProductsBySlug::IDENTIFIER     => Routes\V1\ProductsBySlug::class,
+			],
+			'private'       => [
+				// This route should be moved outside of the Store API namespace.
+				Routes\V1\Patterns::IDENTIFIER => Routes\V1\Patterns::class,
+			],
+			'shopper_lists' => [
+				// Gated behind the `cart_save_for_later` feature flag.
 				Routes\V1\ShopperLists::IDENTIFIER       => Routes\V1\ShopperLists::class,
 				Routes\V1\ShopperListsBySlug::IDENTIFIER => Routes\V1\ShopperListsBySlug::class,
 				Routes\V1\ShopperListItems::IDENTIFIER   => Routes\V1\ShopperListItems::class,
 				Routes\V1\ShopperListItemsByKey::IDENTIFIER => Routes\V1\ShopperListItemsByKey::class,
 			],
-			'private' => [
-				// This route should be moved outside of the Store API namespace.
-				Routes\V1\Patterns::IDENTIFIER => Routes\V1\Patterns::class,
-			],
-			'agentic' => [
+			'agentic'       => [
 				// Agentic Commerce Protocol endpoints.
 				Routes\V1\Agentic\CheckoutSessions::IDENTIFIER         => Routes\V1\Agentic\CheckoutSessions::class,
 				Routes\V1\Agentic\CheckoutSessionsUpdate::IDENTIFIER   => Routes\V1\Agentic\CheckoutSessionsUpdate::class,
@@ -95,6 +98,10 @@ class RoutesController {
 		$this->register_routes( 'v1', self::$api_namespace );
 		$this->register_routes( 'v1', self::$api_namespace . '/v1' );
 		$this->register_routes( 'private', 'wc/private' );
+
+		if ( FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
+			$this->register_routes( 'shopper_lists', self::$api_namespace . '/v1' );
+		}
 
 		if ( FeaturesUtil::feature_is_enabled( 'agentic_checkout' ) ) {
 			$this->register_routes( 'agentic', 'wc/agentic/v1' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -39,6 +39,11 @@ class ShopperLists extends ControllerTestCase {
 	 * Setup test data.
 	 */
 	protected function setUp(): void {
+		// The shopper-lists routes are gated behind the `cart_save_for_later`
+		// feature flag, which is read inside `do_action( 'rest_api_init' )`
+		// fired by parent::setUp(). The option must be in place before then.
+		update_option( 'woocommerce_cart_save_for_later_enabled', 'yes' );
+
 		parent::setUp();
 
 		$fixtures      = new FixtureData();
@@ -75,6 +80,8 @@ class ShopperLists extends ControllerTestCase {
 		if ( $this->other_customer_id ) {
 			wp_delete_user( $this->other_customer_id );
 		}
+
+		delete_option( 'woocommerce_cart_save_for_later_enabled' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a new experimental **Save for Later in Cart** feature flag (`cart_save_for_later`) and gates the shopper collection block and related StoreApi routes behind it.

Also exposes a `cartHasSaveForLater` boolean to JS via `AssetDataRegistry` (`wcSettings.cartHasSaveForLater`). It is `true` only when the user is logged in, the feature flag is enabled, and the cart page contains a `woocommerce/shopper-collection` block. Checks are ordered cheapest-first so PHP can short-circuit before loading the cart page and parsing its blocks.

Closes WOOPRD-3507

### How to test the changes in this Pull Request:

1. Visit **WooCommerce → Settings → Advanced → Features** and confirm the new **Save for Later in Cart** toggle is shown (experimental, off by default).
    <img width="635" height="81" alt="Screenshot 2026-05-07 at 14 51 34" src="https://github.com/user-attachments/assets/116454c1-2239-45c3-8096-8f7878076c94" />
3. With the toggle **off**: confirm the Shopper Collection block does not appear in the block inserter and `GET /wp-json/wc/store/v1/shopper-lists` returns a 404.
4. Enable the toggle: confirm the block is available in the inserter and the `/wc/store/v1/shopper-lists*` endpoints respond as expected.
5. With the toggle **on**, place the Shopper Collection block on the cart page and log in as a customer. Visit the cart, open the browser console, and confirm `wcSettings.cartHasSaveForLater === true`. Then toggle each precondition off in turn — log out, disable the feature, remove the block from the cart page — and confirm the value flips to `false` on each.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->