### PR TITLE
Render the Stock column as a Badge

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-stock-column-badge
+++ b/packages/js/experimental-products-app/changelog/update-stock-column-badge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Render the Stock column in the products list as a Badge, with intents reflecting in stock, out of stock, and on backorder states.

--- a/packages/js/experimental-products-app/src/fields/stock/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/stock/field.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import type { Field } from '@wordpress/dataviews';
 
 /**
@@ -10,11 +11,22 @@ import type { Field } from '@wordpress/dataviews';
  */
 import type { ProductEntityRecord } from '../types';
 
-function isValidStockStatus( value: string ) {
+type StockStatus = 'instock' | 'outofstock' | 'onbackorder';
+
+function isValidStockStatus( value: string ): value is StockStatus {
 	return (
 		value === 'instock' || value === 'outofstock' || value === 'onbackorder'
 	);
 }
+
+const stockStatusBadgeIntent: Record<
+	StockStatus,
+	React.ComponentProps< typeof Badge >[ 'intent' ]
+> = {
+	instock: 'none',
+	outofstock: 'high',
+	onbackorder: 'draft',
+};
 
 const fieldDefinition = {
 	label: __( 'Stock', 'woocommerce' ),
@@ -40,21 +52,22 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 		const match = field?.elements?.find(
 			( status ) => status.value === item.stock_status
 		);
-		return match ? (
+
+		if ( ! match || ! isValidStockStatus( match.value ) ) {
+			return item.stock_status;
+		}
+
+		return (
 			<div className="woocommerce-fields-field__stock">
-				<span
-					className={ `woocommerce-fields-field__stock-label woocommerce-fields-field__stock-label--${ match.value }` }
-				>
+				<Badge intent={ stockStatusBadgeIntent[ match.value ] }>
 					{ match.label }
-				</span>
+				</Badge>
 				{ item.stock_quantity && item.stock_quantity > 0 && (
 					<span className="woocommerce-fields-field__stock-quantity">
 						({ item.stock_quantity })
 					</span>
 				) }
 			</div>
-		) : (
-			item.stock_status
 		);
 	},
 	Edit: ( { data, onChange, field } ) => (

--- a/packages/js/experimental-products-app/src/fields/stock/style.scss
+++ b/packages/js/experimental-products-app/src/fields/stock/style.scss
@@ -1,14 +1,5 @@
 .woocommerce-fields-field__stock {
 	display: flex;
+	align-items: center;
 	gap: 5px;
-
-	.woocommerce-fields-field__stock-label {
-		&--outofstock {
-			color: #cc1818;
-		}
-
-		&--onbackorder {
-			color: #ffa500;
-		}
-	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Replace the plain coloured-text stock label in the experimental All Products list with the `Badge` component from `@wordpress/ui`, matching the visual treatment used elsewhere in the products app (e.g. the product status badge).

Intent mapping:

| Stock status   | Intent  |
| -------------- | ------- |
| In stock       | `none`  |
| Out of stock   | `high`  |
| On backorder   | `draft` |

The trailing stock quantity (e.g. `(5)`) is preserved next to the badge.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Coloured text label ("In stock", red "Out of stock", orange "On backorder") | Badge with semantic intents |

### How to test the changes in this Pull Request:

1. Enable the feature flags `product-data-views` and `gutenberg-editor-inspector-use-dataform`.
2. Navigate to **WooCommerce → Products (new)**.
3. Make sure the **Stock** column is visible (it's in the default layout).
4. Confirm products render the stock status as a Badge with the correct intent:
   - In-stock products → neutral badge.
   - Out-of-stock products → high-intent (red) badge.
   - On-backorder products → draft (yellow) badge.
5. For products with `manage_stock` enabled (where stock_quantity is shown), confirm the quantity (e.g. `(12)`) still appears next to the badge.

### Testing that has already taken place:

- `npx tsc --noEmit --project packages/js/experimental-products-app/tsconfig.json` — clean.

### Changelog entry

`packages/js/experimental-products-app/changelog/update-stock-column-badge` — minor / update.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**