### PR TITLE
Auto-inject saved for later block after cart on cart page

### DIFF
--- a/plugins/woocommerce/changelog/add-shopper-collections-cart-hook
+++ b/plugins/woocommerce/changelog/add-shopper-collections-cart-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Auto-inject the Shopper Collection block on the cart page when the shopper lists feature is enabled.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -47,8 +47,11 @@ final class ShopperCollection extends AbstractBlock {
 			return $hooked_block_types;
 		}
 
-		$cart_page_id = absint( wc_get_page_id( 'cart' ) );
-		if ( ! $cart_page_id || ! ( $context instanceof \WP_Post ) || (int) $context->ID !== $cart_page_id ) {
+		// `wc_get_page_id()` returns -1 when the page option isn't set —
+		// don't wrap it in `absint()`, which would turn that sentinel into a
+		// real-looking ID of 1 and false-match a post with that ID.
+		$cart_page_id = (int) wc_get_page_id( 'cart' );
+		if ( $cart_page_id <= 0 || ! ( $context instanceof \WP_Post ) || (int) $context->ID !== $cart_page_id ) {
 			return $hooked_block_types;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -47,19 +47,14 @@ final class ShopperCollection extends AbstractBlock {
 			return $hooked_block_types;
 		}
 
-		// `wc_get_page_id()` returns -1 when the page option isn't set —
-		// don't wrap it in `absint()`, which would turn that sentinel into a
-		// real-looking ID of 1 and false-match a post with that ID.
+		// `wc_get_page_id()` returns -1 when the page option isn't set.
 		$cart_page_id = (int) wc_get_page_id( 'cart' );
 		if ( $cart_page_id <= 0 || ! ( $context instanceof \WP_Post ) || (int) $context->ID !== $cart_page_id ) {
 			return $hooked_block_types;
 		}
 
 		// Don't double-inject if the block is already in the cart page
-		// content (e.g. a merchant added it manually before the feature
-		// flag was flipped, or after). `has_block()` parses the content
-		// rather than substring-matching, so it won't false-positive on
-		// the block name appearing inside attribute strings or comments.
+		// content.
 		if ( has_block( $this->get_full_block_name(), $context ) ) {
 			return $hooked_block_types;
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -23,6 +23,69 @@ final class ShopperCollection extends AbstractBlock {
 	protected $block_name = 'shopper-collection';
 
 	/**
+	 * Initialize this block type.
+	 */
+	protected function initialize(): void {
+		parent::initialize();
+
+		// We do not use `BlockHooksTrait` currently as it has issues with PHPStan.
+		add_filter( 'hooked_block_types', array( $this, 'register_hooked_block' ), 9, 4 );
+		add_filter( 'hooked_block_woocommerce/shopper-collection', array( $this, 'set_hooked_block_attributes' ), 10, 4 );
+	}
+
+	/**
+	 * Auto-inject this block after `woocommerce/cart`, scoped to the cart page.
+	 *
+	 * @param array                                  $hooked_block_types Block names hooked at this position.
+	 * @param string                                 $relative_position  Position of the insertion point.
+	 * @param string                                 $anchor_block_type  Anchor block name.
+	 * @param array|\WP_Post|\WP_Block_Template|null $context            Where the block is being embedded.
+	 * @return array
+	 */
+	public function register_hooked_block( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+		if ( 'after' !== $relative_position || 'woocommerce/cart' !== $anchor_block_type ) {
+			return $hooked_block_types;
+		}
+
+		$cart_page_id = absint( wc_get_page_id( 'cart' ) );
+		if ( ! $cart_page_id || ! ( $context instanceof \WP_Post ) || (int) $context->ID !== $cart_page_id ) {
+			return $hooked_block_types;
+		}
+
+		// Don't double-inject if the block is already in the cart page
+		// content (e.g. a merchant added it manually before the feature
+		// flag was flipped, or after). `has_block()` parses the content
+		// rather than substring-matching, so it won't false-positive on
+		// the block name appearing inside attribute strings or comments.
+		if ( has_block( $this->get_full_block_name(), $context ) ) {
+			return $hooked_block_types;
+		}
+
+		$hooked_block_types[] = $this->get_full_block_name();
+		return $hooked_block_types;
+	}
+
+	/**
+	 * Set the `listName` attribute on the auto-injected block.
+	 *
+	 * @param array|null $parsed_hooked_block The parsed hooked block array, or null to suppress insertion.
+	 * @param string     $hooked_block_type   The hooked block type name.
+	 * @param string     $relative_position   Position of the insertion point.
+	 * @param array      $parsed_anchor_block The anchor block, in parsed block array format.
+	 * @return array|null
+	 */
+	public function set_hooked_block_attributes( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block ) {
+		if ( null === $parsed_hooked_block || 'after' !== $relative_position ) {
+			return $parsed_hooked_block;
+		}
+		if ( ! isset( $parsed_anchor_block['blockName'] ) || 'woocommerce/cart' !== $parsed_anchor_block['blockName'] ) {
+			return $parsed_hooked_block;
+		}
+		$parsed_hooked_block['attrs']['listName'] = 'saved-for-later';
+		return $parsed_hooked_block;
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array     $attributes Block attributes.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -1,0 +1,120 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the ShopperCollection block type.
+ */
+class ShopperCollectionTests extends WP_UnitTestCase {
+
+	/**
+	 * System under test. Constructing it registers the block-hook filters via `initialize()`.
+	 *
+	 * @var ShopperCollection
+	 */
+	private ShopperCollection $sut;
+
+	/**
+	 * Instantiate the block.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new ShopperCollection(
+			Package::container()->get( Api::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry()
+		);
+	}
+
+	/**
+	 * Remove the registered filters so other tests aren't affected.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'hooked_block_types', array( $this->sut, 'register_hooked_block' ), 9 );
+		remove_filter( 'hooked_block_woocommerce/shopper-collection', array( $this->sut, 'set_hooked_block_attributes' ), 10 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return array<string, array{string, string, bool, bool}>
+	 */
+	public function provider_register_hooked_block(): array {
+		$cart_only         = '<!-- wp:woocommerce/cart /-->';
+		$cart_with_shopper = '<!-- wp:woocommerce/cart /--><!-- wp:woocommerce/shopper-collection {"listName":"saved-for-later"} /-->';
+
+		return array(
+			// label                                => array( cart_page_content, anchor, context_is_cart_page, expected_hooked ).
+			'hooked after cart on cart page'        => array( $cart_only, 'woocommerce/cart', true, true ),
+			'not hooked after non-cart anchor'      => array( $cart_only, 'core/paragraph', true, false ),
+			'not hooked when context is other page' => array( $cart_only, 'woocommerce/cart', false, false ),
+			'not hooked when already present'       => array( $cart_with_shopper, 'woocommerce/cart', true, false ),
+		);
+	}
+
+	/**
+	 * `register_hooked_block` only adds the block when the anchor is `woocommerce/cart`,
+	 * the context is the cart page, and the cart page doesn't already contain the block.
+	 *
+	 * @dataProvider provider_register_hooked_block
+	 *
+	 * @param string $cart_page_content    Initial content of the cart page.
+	 * @param string $anchor               Anchor block name passed to the filter.
+	 * @param bool   $context_is_cart_page Whether the filter context is the cart page or some other page.
+	 * @param bool   $expected_hooked      Whether the block should end up in the hooked list.
+	 */
+	public function test_register_hooked_block( string $cart_page_content, string $anchor, bool $context_is_cart_page, bool $expected_hooked ): void {
+		$cart_page_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => $cart_page_content,
+			)
+		);
+		update_option( 'woocommerce_cart_page_id', $cart_page_id );
+
+		$context_id = $context_is_cart_page
+			? $cart_page_id
+			: self::factory()->post->create( array( 'post_type' => 'page', 'post_status' => 'publish' ) );
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
+		$hooked = apply_filters( 'hooked_block_types', array(), 'after', $anchor, get_post( $context_id ) );
+
+		if ( $expected_hooked ) {
+			$this->assertContains( 'woocommerce/shopper-collection', $hooked );
+		} else {
+			$this->assertNotContains( 'woocommerce/shopper-collection', $hooked );
+		}
+	}
+
+	/**
+	 * The auto-injected block has its `listName` attribute set to `saved-for-later`.
+	 */
+	public function test_hooked_block_attributes_set_list_name(): void {
+		$parsed_hooked_block = array(
+			'blockName' => 'woocommerce/shopper-collection',
+			'attrs'     => array(),
+		);
+		$parsed_anchor_block = array( 'blockName' => 'woocommerce/cart' );
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
+		$result = apply_filters(
+			'hooked_block_woocommerce/shopper-collection',
+			$parsed_hooked_block,
+			'woocommerce/shopper-collection',
+			'after',
+			$parsed_anchor_block
+		);
+
+		$this->assertSame( 'saved-for-later', $result['attrs']['listName'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -97,6 +97,27 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When the cart page option is unset, `wc_get_page_id()` returns -1 — the filter
+	 * must treat that as "no cart page" rather than letting it match a real post ID.
+	 */
+	public function test_register_hooked_block_skips_when_cart_page_unset(): void {
+		delete_option( 'woocommerce_cart_page_id' );
+
+		$context_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:woocommerce/cart /-->',
+			)
+		);
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
+		$hooked = apply_filters( 'hooked_block_types', array(), 'after', 'woocommerce/cart', get_post( $context_id ) );
+
+		$this->assertNotContains( 'woocommerce/shopper-collection', $hooked );
+	}
+
+	/**
 	 * The auto-injected block has its `listName` attribute set to `saved-for-later`.
 	 */
 	public function test_hooked_block_attributes_set_list_name(): void {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -4,10 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
-use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Blocks\Assets\Api;
-use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
-use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+use ReflectionClass;
 use WP_UnitTestCase;
 
 /**
@@ -16,33 +13,25 @@ use WP_UnitTestCase;
 class ShopperCollectionTests extends WP_UnitTestCase {
 
 	/**
-	 * System under test. Constructing it registers the block-hook filters via `initialize()`.
+	 * System under test.
+	 *
+	 * Constructed via reflection so `AbstractBlock::__construct` doesn't run
+	 * `parent::initialize()` and re-register the block (the test bootstrap
+	 * has already registered it). The filter callbacks under test only read
+	 * `$this->namespace` and `$this->block_name`, both class defaults.
 	 *
 	 * @var ShopperCollection
 	 */
 	private ShopperCollection $sut;
 
 	/**
-	 * Instantiate the block.
+	 * Instantiate the block without invoking its constructor.
 	 */
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->sut = new ShopperCollection(
-			Package::container()->get( Api::class ),
-			Package::container()->get( AssetDataRegistry::class ),
-			new IntegrationRegistry()
-		);
-	}
-
-	/**
-	 * Remove the registered filters so other tests aren't affected.
-	 */
-	public function tearDown(): void {
-		remove_filter( 'hooked_block_types', array( $this->sut, 'register_hooked_block' ), 9 );
-		remove_filter( 'hooked_block_woocommerce/shopper-collection', array( $this->sut, 'set_hooked_block_attributes' ), 10 );
-
-		parent::tearDown();
+		$reflection = new ReflectionClass( ShopperCollection::class );
+		$this->sut  = $reflection->newInstanceWithoutConstructor();
 	}
 
 	/**
@@ -84,10 +73,14 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 
 		$context_id = $context_is_cart_page
 			? $cart_page_id
-			: self::factory()->post->create( array( 'post_type' => 'page', 'post_status' => 'publish' ) );
+			: self::factory()->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+				)
+			);
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
-		$hooked = apply_filters( 'hooked_block_types', array(), 'after', $anchor, get_post( $context_id ) );
+		$hooked = $this->sut->register_hooked_block( array(), 'after', $anchor, get_post( $context_id ) );
 
 		if ( $expected_hooked ) {
 			$this->assertContains( 'woocommerce/shopper-collection', $hooked );
@@ -111,8 +104,7 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 			)
 		);
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
-		$hooked = apply_filters( 'hooked_block_types', array(), 'after', 'woocommerce/cart', get_post( $context_id ) );
+		$hooked = $this->sut->register_hooked_block( array(), 'after', 'woocommerce/cart', get_post( $context_id ) );
 
 		$this->assertNotContains( 'woocommerce/shopper-collection', $hooked );
 	}
@@ -127,9 +119,7 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 		);
 		$parsed_anchor_block = array( 'blockName' => 'woocommerce/cart' );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
-		$result = apply_filters(
-			'hooked_block_woocommerce/shopper-collection',
+		$result = $this->sut->set_hooked_block_attributes(
 			$parsed_hooked_block,
 			'woocommerce/shopper-collection',
 			'after',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Wires `woocommerce/shopper-collection` into the Block Hooks API so that, when the `cart_save_for_later` feature flag is on, the block is auto-injected after `woocommerce/cart` on the canonical cart page.

> [!NOTE]
> This PR depends on `jorgeatorres/shopper-collections-settings`. The base branch will need to be changed if PR #64700 gets merged first.

### How to test the changes in this Pull Request:

1. In **WooCommerce > Settings > Advanced > Features**, enable the experimental **Cart save for later** flag.
2. As a logged-in shopper, visit the **Cart** page. The "saved for later" block should render directly after the cart block.
3. Open the cart page in the editor and confirm the appended block is there and that markup is `<!-- wp:woocommerce/shopper-collection {"listName":"saved-for-later"} /-->`.
4. Create a different page that contains a `woocommerce/cart` block and confirm the saved for later block is **not** auto-injected there.
5. Disable the feature flag and confirm the block stops being injected on the cart page.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->