### PR TITLE
Remove the SKU field helper text

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-sku-remove-description
+++ b/packages/js/experimental-products-app/changelog/update-sku-remove-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove the helper text under the SKU field in the experimental products edit panel.

--- a/packages/js/experimental-products-app/src/fields/sku/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/sku/field.tsx
@@ -13,10 +13,6 @@ import type { ProductEntityRecord } from '../types';
 const fieldDefinition = {
 	type: 'text',
 	label: __( 'SKU', 'woocommerce' ),
-	description: __(
-		'Give your product a unique code to help identify it in orders and fulfilment.',
-		'woocommerce'
-	),
 	enableSorting: false,
 	filterBy: false,
 } satisfies Partial< Field< ProductEntityRecord > >;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Removes the `description` from the SKU field in the experimental products app, so the edit/quick-edit panel no longer renders the "Give your product a unique code to help identify it in orders and fulfilment." helper text below the SKU input.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| SKU input followed by helper text | SKU input only |

### How to test the changes in this Pull Request:

1. Enable the feature flags `product-data-views` and `gutenberg-editor-inspector-use-dataform`.
2. Navigate to **WooCommerce → Products (new)**.
3. Open any product via Quick edit (or Edit).
4. Confirm the **SKU** field renders without the helper text below it.

### Testing that has already taken place:

- Manual smoke check; no behavior change beyond the removed copy.

### Changelog entry

`packages/js/experimental-products-app/changelog/update-sku-remove-description` — patch / update.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**