### PR TITLE
Remove the Categories field helper text

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-categories-remove-description
+++ b/packages/js/experimental-products-app/changelog/update-categories-remove-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove the helper text under the Categories field in the experimental products edit panel.

--- a/packages/js/experimental-products-app/src/fields/categories/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/categories/field.tsx
@@ -33,10 +33,6 @@ type ProductCategory = {
 const fieldDefinition = {
 	type: 'array',
 	label: __( 'Categories', 'woocommerce' ),
-	description: __(
-		'Add one or more categories to help customers find this product on your store.',
-		'woocommerce'
-	),
 	enableSorting: false,
 	filterBy: {
 		operators: [ 'isAny', 'isNone' ],


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Removes the `description` from the Categories field in the experimental products app, so the edit/quick-edit panel no longer renders the "Add one or more categories to help customers find this product on your store." helper text below the categories input.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Categories input followed by helper text | Categories input only |

### How to test the changes in this Pull Request:

1. Enable the feature flags `product-data-views` and `gutenberg-editor-inspector-use-dataform`.
2. Navigate to **WooCommerce → Products (new)**.
3. Open any product via Quick edit (or Edit).
4. Confirm the **Categories** field renders without the helper text below it.

### Testing that has already taken place:

- Manual smoke check; no behavior change beyond the removed copy.

### Changelog entry

`packages/js/experimental-products-app/changelog/update-categories-remove-description` — patch / update.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**