### PR TITLE
Add prev/next order navigation to Order detail page header

### DIFF
--- a/plugins/woocommerce/changelog/order-detail-redesign-prev-next-nav
+++ b/plugins/woocommerce/changelog/order-detail-redesign-prev-next-nav
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Order detail redesign: add prev/next order navigation in the Order edit page header so users can walk between adjacent orders without going back to the list. No-op when the order-detail-redesign feature flag is off.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3046,10 +3046,64 @@ ul.wc_coupon_list_block {
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
 	// Gated behind the `order-detail-redesign` feature flag (body class added by OrderDetailRedesign\Init).
-	// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
-	&.woocommerce-feature-enabled-order-detail-redesign .wrap:has(#poststuff) {
-		max-width: 1200px;
-		margin-inline: auto;
+	&.woocommerce-feature-enabled-order-detail-redesign {
+		// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
+		.wrap:has(#poststuff) {
+			max-width: 1200px;
+			margin-inline: auto;
+		}
+
+		// Prev/next order navigation in the H1 row. Floats right so it sits
+		// on the opposite side of the title + "Add new" action.
+		.woocommerce-order-list-nav {
+			display: inline-flex;
+			align-items: center;
+			gap: 4px;
+			float: right;
+			margin-top: 4px;
+		}
+
+		.woocommerce-order-list-nav__button {
+			display: inline-flex;
+			align-items: center;
+			gap: 2px;
+			padding: 4px 8px;
+			border-radius: 2px; // --wpds-border-radius-xs
+			color: #1e1e1e; // --wpds-color-fg-content-neutral
+			font-size: 13px;
+			line-height: 1.4;
+			text-decoration: none;
+
+			&:hover {
+				background: rgba(0, 0, 0, 0.06);
+				color: #1e1e1e;
+			}
+
+			&:focus-visible {
+				outline: 2px solid;
+				outline-offset: 1px;
+			}
+
+			&[aria-disabled="true"] {
+				color: #757575; // --wpds-color-fg-content-neutral-weak
+				cursor: default;
+				pointer-events: none;
+			}
+
+			svg {
+				flex-shrink: 0;
+			}
+		}
+
+		// Mirror the chevrons in RTL contexts so "Prev" still points to older orders.
+		html[dir="rtl"] & .woocommerce-order-list-nav__button svg {
+			transform: scaleX(-1);
+		}
+
+		// Keep the form content from wrapping around the floated nav.
+		.wp-header-end {
+			clear: right;
+		}
 	}
 
 	.tablenav .one-page .displaying-num {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3051,16 +3051,23 @@ ul.wc_coupon_list_block {
 		.wrap:has(#poststuff) {
 			max-width: 1200px;
 			margin-inline: auto;
+			// Anchor for the absolutely-positioned prev/next nav below.
+			position: relative;
 		}
 
-		// Prev/next order navigation in the H1 row. Floats right so it sits
-		// on the opposite side of the title + "Add new" action.
+		// Prev/next order navigation in the H1 row. Absolutely positioned so
+		// it sits on the opposite side of the title + "Add new" action and
+		// stays vertically centered with the H1 text regardless of H1 height.
+		// `right: 20px` matches WP admin's standard right gutter so the nav
+		// aligns with the right edge of the postbox column (not the .wrap edge).
 		.woocommerce-order-list-nav {
 			display: inline-flex;
 			align-items: center;
 			gap: 4px;
-			float: right;
-			margin-top: 4px;
+			position: absolute;
+			right: 20px;
+			top: 24px;
+			transform: translateY(-50%);
 		}
 
 		.woocommerce-order-list-nav__button {
@@ -3098,11 +3105,6 @@ ul.wc_coupon_list_block {
 		// Mirror the chevrons in RTL contexts so "Prev" still points to older orders.
 		html[dir="rtl"] & .woocommerce-order-list-nav__button svg {
 			transform: scaleX(-1);
-		}
-
-		// Keep the form content from wrapping around the floated nav.
-		.wp-header-end {
-			clear: right;
 		}
 	}
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3070,29 +3070,19 @@ ul.wc_coupon_list_block {
 			transform: translateY(-50%);
 		}
 
+		// Layout-only overrides on top of .components-button.is-tertiary.
+		// Color, hover, focus ring, padding, font, and radius all come from
+		// the design system; we only keep what the component doesn't supply.
 		.woocommerce-order-list-nav__button {
-			display: inline-flex;
-			align-items: center;
 			gap: 2px;
-			padding: 4px 8px;
-			border-radius: 2px; // --wpds-border-radius-xs
-			color: #1e1e1e; // --wpds-color-fg-content-neutral
-			font-size: 13px;
-			line-height: 1.4;
 			text-decoration: none;
 
-			&:hover {
-				background: rgba(0, 0, 0, 0.06);
-				color: #1e1e1e;
-			}
-
-			&:focus-visible {
-				outline: 2px solid;
-				outline-offset: 1px;
-			}
-
 			&[aria-disabled="true"] {
-				color: #757575; // --wpds-color-fg-content-neutral-weak
+				// .components-button.is-tertiary's disabled handling only
+				// fires on the real :disabled pseudo-class. The inactive
+				// nav variant renders as <span aria-disabled="true">, so we
+				// still need to mute color and lock interactions here.
+				color: var(--wpds-color-fg-interactive-neutral-disabled, #757575);
 				cursor: default;
 				pointer-events: none;
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\TaxonomiesMetaBox;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\Features\OrderDetailRedesign\OrderListNav;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
 
@@ -435,6 +437,10 @@ class Edit {
 		<?php
 		if ( 'edit_order' === $this->current_action ) {
 			echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new ) . '</a>';
+		}
+
+		if ( 'edit_order' === $this->current_action && FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+			OrderListNav::render( $this->order );
 		}
 		?>
 		<hr class="wp-header-end">

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
+use Automattic\WooCommerce\Admin\Features\Features as AdminFeatures;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
@@ -439,7 +440,12 @@ class Edit {
 			echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new ) . '</a>';
 		}
 
-		if ( 'edit_order' === $this->current_action && FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+		// Note: using the wc-admin features API (`AdminFeatures::is_enabled`) rather than
+		// `FeaturesUtil::feature_is_enabled` because `order-detail-redesign` is registered in
+		// `client/admin/config/core.json` only and is not bridged to the core `FeaturesController`,
+		// so `FeaturesUtil::feature_is_enabled` always returns false for this feature. See PR
+		// description for the broader bug that needs fixing in #64669 / #64678 follow-ups.
+		if ( 'edit_order' === $this->current_action && AdminFeatures::is_enabled( 'order-detail-redesign' ) ) {
 			OrderListNav::render( $this->order );
 		}
 		?>

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Renders prev/next order navigation in the Order detail page header.
+ *
+ * @package WooCommerce
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Features\OrderDetailRedesign;
+
+use WC_Order;
+
+/**
+ * Outputs the `< Prev   Next >` navigation that lets users walk between
+ * adjacent orders without going back to the list. Server-rendered;
+ * neighbours are resolved against the orders-list filter set the user
+ * came from (carried via `wp_get_referer()` and forwarded in subsequent
+ * links).
+ *
+ * Gated behind the `order-detail-redesign` feature flag — caller checks
+ * `FeaturesUtil::feature_is_enabled( 'order-detail-redesign' )` before invoking.
+ *
+ * @since 10.9.0
+ */
+class OrderListNav {
+
+	/**
+	 * Chevron-left path data, sourced from @wordpress/icons (24×24 viewBox).
+	 */
+	private const CHEVRON_LEFT_PATH = 'M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z';
+
+	/**
+	 * Chevron-right path data, sourced from @wordpress/icons (24×24 viewBox).
+	 */
+	private const CHEVRON_RIGHT_PATH = 'M10.6 6 9.4 7.1 14.3 12l-4.9 4.9 1.2 1.1 6-6z';
+
+	/**
+	 * URL params from the orders list page that we forward to keep the
+	 * prev/next walk scoped to the user's filter set.
+	 */
+	private const FILTER_WHITELIST = array( 'status', 's', '_customer_user', '_created_via' );
+
+	/**
+	 * Outputs the navigation markup for the given order.
+	 *
+	 * No-op for non-`shop_order` types (e.g. refunds).
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order The current order.
+	 * @return void
+	 */
+	public static function render( WC_Order $order ): void {
+		if ( 'shop_order' !== $order->get_type() ) {
+			return;
+		}
+
+		$data       = self::get_navigation_data( $order );
+		$list_query = $data['list_query'];
+
+		$prev_url = self::build_order_url( $data['prev_id'], $list_query );
+		$next_url = self::build_order_url( $data['next_id'], $list_query );
+
+		?>
+		<nav class="woocommerce-order-list-nav" aria-label="<?php esc_attr_e( 'Order navigation', 'woocommerce' ); ?>">
+			<?php
+			self::render_button(
+				$prev_url,
+				__( 'Prev', 'woocommerce' ),
+				__( 'Previous order', 'woocommerce' ),
+				self::CHEVRON_LEFT_PATH,
+				'is-prev'
+			);
+			self::render_button(
+				$next_url,
+				__( 'Next', 'woocommerce' ),
+				__( 'Next order', 'woocommerce' ),
+				self::CHEVRON_RIGHT_PATH,
+				'is-next'
+			);
+			?>
+		</nav>
+		<?php
+	}
+
+	/**
+	 * Resolves the prev/next order IDs for the order within the current
+	 * orders-list filter set.
+	 *
+	 * Falls back to the unfiltered set (all orders by date DESC) if the
+	 * filters exclude the current order.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order The current order.
+	 * @return array{prev_id: int|null, next_id: int|null, list_query: array<string, mixed>}
+	 */
+	public static function get_navigation_data( WC_Order $order ): array {
+		$list_query = self::get_list_query_from_request();
+
+		$result = self::compute_neighbors( $order, $list_query );
+		if ( null === $result ) {
+			$list_query = array();
+			$result     = self::compute_neighbors( $order, array() );
+		}
+
+		if ( null === $result ) {
+			$result = array(
+				'prev_id' => null,
+				'next_id' => null,
+			);
+		}
+
+		$result['list_query'] = $list_query;
+		return $result;
+	}
+
+	/**
+	 * Renders a single prev/next button — either an active link or a disabled span.
+	 *
+	 * @param string|null $url       URL for the button, or null when disabled.
+	 * @param string      $text      Visible text ("Prev" / "Next").
+	 * @param string      $aria      Accessible label ("Previous order" / "Next order").
+	 * @param string      $svg_path  SVG path data for the chevron.
+	 * @param string      $variant   "is-prev" (icon before text) or "is-next" (icon after text).
+	 */
+	private static function render_button( ?string $url, string $text, string $aria, string $svg_path, string $variant ): void {
+		$svg     = '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="' . esc_attr( $svg_path ) . '"></path></svg>';
+		$content = 'is-prev' === $variant
+			? $svg . '<span class="woocommerce-order-list-nav__label">' . esc_html( $text ) . '</span>'
+			: '<span class="woocommerce-order-list-nav__label">' . esc_html( $text ) . '</span>' . $svg;
+		$class   = 'woocommerce-order-list-nav__button ' . esc_attr( $variant );
+
+		if ( null === $url ) {
+			?>
+			<span class="<?php echo esc_attr( $class ); ?>" aria-disabled="true" aria-label="<?php echo esc_attr( $aria ); ?>"><?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static SVG markup with escaped path; text node is escaped above. ?></span>
+			<?php
+		} else {
+			?>
+			<a href="<?php echo esc_url( $url ); ?>" class="<?php echo esc_attr( $class ); ?>" aria-label="<?php echo esc_attr( $aria ); ?>"><?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static SVG markup with escaped path; text node is escaped above. ?></a>
+			<?php
+		}
+	}
+
+	/**
+	 * Resolves the prev/next order IDs against the given filter set.
+	 *
+	 * Returns null when the order is not in the filter set, signaling a
+	 * fallback to the unfiltered set is needed.
+	 *
+	 * @param WC_Order             $order      Current order.
+	 * @param array<string, mixed> $list_query Filter args (already mapped to wc_get_orders keys).
+	 * @return array{prev_id: int|null, next_id: int|null}|null
+	 */
+	private static function compute_neighbors( WC_Order $order, array $list_query ): ?array {
+		$date = $order->get_date_created();
+		if ( null === $date ) {
+			return null;
+		}
+		$timestamp = $date->getTimestamp();
+
+		$base_args = array_merge( $list_query, array( 'type' => 'shop_order' ) );
+
+		if ( ! empty( $list_query ) && ! self::order_matches_filters( $order, $base_args ) ) {
+			return null;
+		}
+
+		$prev_ids = wc_get_orders(
+			array_merge(
+				$base_args,
+				array(
+					'date_created' => '<' . $timestamp,
+					'orderby'      => 'date',
+					'order'        => 'DESC',
+					'limit'        => 1,
+					'return'       => 'ids',
+				)
+			)
+		);
+		$next_ids = wc_get_orders(
+			array_merge(
+				$base_args,
+				array(
+					'date_created' => '>' . $timestamp,
+					'orderby'      => 'date',
+					'order'        => 'ASC',
+					'limit'        => 1,
+					'return'       => 'ids',
+				)
+			)
+		);
+
+		return array(
+			'prev_id' => self::first_id( $prev_ids ),
+			'next_id' => self::first_id( $next_ids ),
+		);
+	}
+
+	/**
+	 * Returns the first ID from a `wc_get_orders( …, 'return' => 'ids' )` result, or null if empty.
+	 *
+	 * @param mixed $result wc_get_orders return value when called with `return=ids`.
+	 * @return int|null
+	 */
+	private static function first_id( $result ): ?int {
+		if ( ! is_array( $result ) || empty( $result ) ) {
+			return null;
+		}
+		$first = reset( $result );
+		return is_numeric( $first ) ? (int) $first : null;
+	}
+
+	/**
+	 * Returns true when the given order matches the supplied filter args.
+	 *
+	 * @param WC_Order             $order Order to check.
+	 * @param array<string, mixed> $args  Filter args (must include `type`).
+	 * @return bool
+	 */
+	private static function order_matches_filters( WC_Order $order, array $args ): bool {
+		$matches = wc_get_orders(
+			array_merge(
+				$args,
+				array(
+					'id'     => $order->get_id(),
+					'limit'  => 1,
+					'return' => 'ids',
+				)
+			)
+		);
+
+		return is_array( $matches ) && ! empty( $matches );
+	}
+
+	/**
+	 * Reads filter params from the current request, falling back to the
+	 * referer when the current URL has none. Returns args mapped to
+	 * wc_get_orders parameter names.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function get_list_query_from_request(): array {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current = self::extract_whitelisted_params( $_GET );
+		if ( ! empty( $current ) ) {
+			return self::map_to_query_args( $current );
+		}
+
+		$referer = wp_get_referer();
+		if ( ! $referer || ! self::is_orders_list_url( $referer ) ) {
+			return array();
+		}
+
+		$query = wp_parse_url( $referer, PHP_URL_QUERY );
+		if ( ! is_string( $query ) || '' === $query ) {
+			return array();
+		}
+
+		$parsed = array();
+		wp_parse_str( $query, $parsed );
+
+		return self::map_to_query_args( self::extract_whitelisted_params( $parsed ) );
+	}
+
+	/**
+	 * Pulls and sanitizes whitelisted params from a query array.
+	 *
+	 * @param array<int|string, mixed> $params Raw params (e.g. `$_GET` or `wp_parse_str` output).
+	 * @return array<string, mixed>
+	 */
+	private static function extract_whitelisted_params( array $params ): array {
+		$result = array();
+
+		foreach ( self::FILTER_WHITELIST as $key ) {
+			if ( ! isset( $params[ $key ] ) ) {
+				continue;
+			}
+			$value = $params[ $key ];
+			if ( is_string( $value ) ) {
+				$value = wp_unslash( $value );
+			}
+
+			$sanitized = self::sanitize_param( $key, $value );
+			if ( null !== $sanitized ) {
+				$result[ $key ] = $sanitized;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Sanitizes a single param value. Returns null when the value should
+	 * be ignored (empty, "all", trash, etc.).
+	 *
+	 * @param string $key   Param name.
+	 * @param mixed  $value Raw value.
+	 * @return mixed|null
+	 */
+	private static function sanitize_param( string $key, $value ) {
+		switch ( $key ) {
+			case 'status':
+				if ( ! is_string( $value ) ) {
+					return null;
+				}
+				$value = sanitize_text_field( $value );
+				if ( '' === $value || 'all' === $value || 'trash' === $value ) {
+					return null;
+				}
+				return $value;
+
+			case 's':
+				$value = is_string( $value ) ? sanitize_text_field( $value ) : '';
+				return '' === $value ? null : $value;
+
+			case '_customer_user':
+				$value = absint( $value );
+				return $value > 0 ? $value : null;
+
+			case '_created_via':
+				if ( is_array( $value ) ) {
+					$value = array_map( 'sanitize_text_field', array_map( 'wp_unslash', $value ) );
+					$value = array_values( array_filter( $value ) );
+					return ! empty( $value ) ? $value : null;
+				}
+				$value = is_string( $value ) ? sanitize_text_field( $value ) : '';
+				return '' === $value ? null : array( $value );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Maps URL param names to wc_get_orders arg names.
+	 *
+	 * @param array<string, mixed> $params Whitelisted, sanitized URL params.
+	 * @return array<string, mixed>
+	 */
+	private static function map_to_query_args( array $params ): array {
+		$args = array();
+
+		if ( isset( $params['status'] ) ) {
+			$args['status'] = $params['status'];
+		}
+		if ( isset( $params['s'] ) ) {
+			$args['s'] = $params['s'];
+		}
+		if ( isset( $params['_customer_user'] ) ) {
+			$args['customer'] = $params['_customer_user'];
+		}
+		if ( isset( $params['_created_via'] ) ) {
+			$args['created_via'] = $params['_created_via'];
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Returns true when the URL points at the orders list page (not the order edit/new screen).
+	 *
+	 * @param string $url URL to test.
+	 * @return bool
+	 */
+	private static function is_orders_list_url( string $url ): bool {
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+		if ( ! is_string( $query ) || '' === $query ) {
+			return false;
+		}
+
+		$parsed = array();
+		wp_parse_str( $query, $parsed );
+
+		if ( 'wc-orders' !== ( $parsed['page'] ?? null ) ) {
+			return false;
+		}
+
+		$action = $parsed['action'] ?? '';
+		return ! in_array( $action, array( 'edit', 'new' ), true );
+	}
+
+	/**
+	 * Builds the order edit URL, carrying forward the list filter params.
+	 *
+	 * @param int|null             $order_id   Target order ID, or null to disable the chevron.
+	 * @param array<string, mixed> $list_query Filter args (in wc_get_orders form).
+	 * @return string|null
+	 */
+	private static function build_order_url( ?int $order_id, array $list_query ): ?string {
+		if ( null === $order_id ) {
+			return null;
+		}
+
+		$args = array_merge(
+			array(
+				'page'   => 'wc-orders',
+				'action' => 'edit',
+				'id'     => $order_id,
+			),
+			self::query_args_to_url_params( $list_query )
+		);
+
+		return admin_url( add_query_arg( $args, 'admin.php' ) );
+	}
+
+	/**
+	 * Maps wc_get_orders args back to URL param names for the link href.
+	 *
+	 * @param array<string, mixed> $args wc_get_orders args.
+	 * @return array<string, mixed>
+	 */
+	private static function query_args_to_url_params( array $args ): array {
+		$params = array();
+		if ( isset( $args['status'] ) ) {
+			$params['status'] = $args['status'];
+		}
+		if ( isset( $args['s'] ) ) {
+			$params['s'] = $args['s'];
+		}
+		if ( isset( $args['customer'] ) ) {
+			$params['_customer_user'] = $args['customer'];
+		}
+		if ( isset( $args['created_via'] ) ) {
+			$created_via            = (array) $args['created_via'];
+			$params['_created_via'] = 1 === count( $created_via ) ? $created_via[0] : $created_via;
+		}
+		return $params;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
@@ -19,7 +19,7 @@ use WC_Order;
  * links).
  *
  * Gated behind the `order-detail-redesign` feature flag — caller checks
- * `FeaturesUtil::feature_is_enabled( 'order-detail-redesign' )` before invoking.
+ * `Admin\Features\Features::is_enabled( 'order-detail-redesign' )` before invoking.
  *
  * @since 10.9.0
  */

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
@@ -130,7 +130,7 @@ class OrderListNav {
 		$content = 'is-prev' === $variant
 			? $svg . '<span class="woocommerce-order-list-nav__label">' . esc_html( $text ) . '</span>'
 			: '<span class="woocommerce-order-list-nav__label">' . esc_html( $text ) . '</span>' . $svg;
-		$class   = 'woocommerce-order-list-nav__button ' . esc_attr( $variant );
+		$class   = 'components-button is-tertiary woocommerce-order-list-nav__button ' . esc_attr( $variant );
 
 		if ( null === $url ) {
 			?>

--- a/plugins/woocommerce/tests/php/src/Internal/Features/OrderDetailRedesign/OrderListNavTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/OrderDetailRedesign/OrderListNavTest.php
@@ -1,0 +1,251 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Features\OrderDetailRedesign;
+
+use Automattic\WooCommerce\Internal\Features\OrderDetailRedesign\OrderListNav;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use WC_Order;
+
+/**
+ * Tests for OrderListNav.
+ *
+ * @testdox OrderListNav
+ * @since 10.9.0
+ */
+class OrderListNavTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * Orders created for the test, ordered newest → oldest.
+	 *
+	 * @var WC_Order[]
+	 */
+	private array $orders = array();
+
+	/**
+	 * Set up each test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$_SERVER['HTTP_REFERER'] = '';
+		unset( $_GET['status'], $_GET['s'], $_GET['_customer_user'], $_GET['_created_via'] );
+	}
+
+	/**
+	 * Tear down each test case.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->orders as $order ) {
+			$order->delete( true );
+		}
+		$this->orders = array();
+
+		unset( $_SERVER['HTTP_REFERER'] );
+		unset( $_GET['status'], $_GET['s'], $_GET['_customer_user'], $_GET['_created_via'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Creates `$count` orders with strictly decreasing `date_created` so
+	 * `$this->orders[0]` is the newest. Optionally tags each order with a
+	 * status to enable filter-based tests.
+	 *
+	 * @param int           $count    Number of orders to create.
+	 * @param string[]|null $statuses One status per order (newest first), or null for default.
+	 * @return WC_Order[]
+	 */
+	private function create_orders( int $count, ?array $statuses = null ): array {
+		$base = time() - ( DAY_IN_SECONDS * $count );
+		$out  = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$order = OrderHelper::create_order();
+			$order->set_date_created( $base + ( ( $count - $i ) * DAY_IN_SECONDS ) );
+			if ( null !== $statuses ) {
+				$order->set_status( $statuses[ $i ] );
+			}
+			$order->save();
+			$out[] = $order;
+		}
+
+		$this->orders = $out;
+		return $out;
+	}
+
+	/**
+	 * @testdox Should return no prev when called on the newest order.
+	 */
+	public function test_returns_no_prev_for_newest_order(): void {
+		$orders = $this->create_orders( 5 );
+
+		$data = OrderListNav::get_navigation_data( $orders[0] );
+
+		$this->assertNull( $data['prev_id'], 'Newest order has no previous' );
+		$this->assertSame( $orders[1]->get_id(), $data['next_id'], 'Next is the second-newest order' );
+	}
+
+	/**
+	 * @testdox Should return correct neighbours for an order in the middle.
+	 */
+	public function test_returns_correct_neighbours_for_middle_order(): void {
+		$orders = $this->create_orders( 5 );
+
+		$data = OrderListNav::get_navigation_data( $orders[2] );
+
+		$this->assertSame( $orders[3]->get_id(), $data['prev_id'], 'Previous is the next-older order' );
+		$this->assertSame( $orders[1]->get_id(), $data['next_id'], 'Next is the next-newer order' );
+	}
+
+	/**
+	 * @testdox Should return no next when called on the oldest order.
+	 */
+	public function test_returns_no_next_for_oldest_order(): void {
+		$orders = $this->create_orders( 5 );
+
+		$data = OrderListNav::get_navigation_data( end( $orders ) );
+
+		$this->assertSame( $orders[3]->get_id(), $data['prev_id'], 'Previous is the second-oldest order' );
+		$this->assertNull( $data['next_id'], 'Oldest order has no next' );
+	}
+
+	/**
+	 * @testdox Should restrict the walk to orders matching the status filter.
+	 */
+	public function test_restricts_walk_to_status_filter(): void {
+		$orders = $this->create_orders(
+			5,
+			array( 'completed', 'processing', 'completed', 'processing', 'completed' )
+		);
+
+		$_GET['status'] = 'processing';
+
+		$data = OrderListNav::get_navigation_data( $orders[1] );
+
+		$this->assertSame( $orders[3]->get_id(), $data['prev_id'], 'Walk skips completed orders' );
+		$this->assertNull( $data['next_id'], 'No newer processing order' );
+		$this->assertArrayHasKey( 'status', $data['list_query'], 'Filter is preserved in list_query' );
+		$this->assertSame( 'processing', $data['list_query']['status'] );
+	}
+
+	/**
+	 * @testdox Should fall back to unfiltered set when filter excludes the current order.
+	 */
+	public function test_falls_back_when_filter_excludes_current_order(): void {
+		$orders = $this->create_orders(
+			3,
+			array( 'completed', 'completed', 'completed' )
+		);
+
+		$_GET['status'] = 'processing';
+
+		$data = OrderListNav::get_navigation_data( $orders[1] );
+
+		$this->assertSame( $orders[0]->get_id(), $data['next_id'], 'Falls back to walking the unfiltered set' );
+		$this->assertSame( $orders[2]->get_id(), $data['prev_id'], 'Falls back to walking the unfiltered set' );
+		$this->assertSame( array(), $data['list_query'], 'Filters dropped after fallback' );
+	}
+
+	/**
+	 * @testdox Should drop unrecognised query params and ignore the all/trash status keywords.
+	 */
+	public function test_drops_unknown_params_and_ignores_pseudo_statuses(): void {
+		$orders = $this->create_orders( 2 );
+
+		$_GET['unknown_param'] = 'value';
+		$_GET['status']        = 'all';
+
+		$data = OrderListNav::get_navigation_data( $orders[0] );
+
+		$this->assertSame( array(), $data['list_query'], 'Unknown params and status=all are dropped' );
+		$this->assertSame( $orders[1]->get_id(), $data['next_id'], 'Walk still works without filters' );
+	}
+
+	/**
+	 * @testdox Should sanitize bogus _customer_user values down to an empty filter.
+	 */
+	public function test_sanitizes_invalid_customer_user(): void {
+		$orders = $this->create_orders( 2 );
+
+		$_GET['_customer_user'] = 'not-a-number';
+
+		$data = OrderListNav::get_navigation_data( $orders[0] );
+
+		$this->assertArrayNotHasKey( 'customer', $data['list_query'], 'Bogus customer ID dropped' );
+	}
+
+	/**
+	 * @testdox Should pull filter params from the referer when the current URL has none.
+	 */
+	public function test_pulls_filter_from_referer_when_request_is_empty(): void {
+		$orders = $this->create_orders(
+			3,
+			array( 'completed', 'processing', 'processing' )
+		);
+
+		$_SERVER['HTTP_REFERER'] = admin_url( 'admin.php?page=wc-orders&status=processing' );
+
+		$data = OrderListNav::get_navigation_data( $orders[1] );
+
+		$this->assertArrayHasKey( 'status', $data['list_query'], 'Status pulled from referer' );
+		$this->assertSame( 'processing', $data['list_query']['status'] );
+		$this->assertSame( $orders[2]->get_id(), $data['prev_id'], 'Walk only includes processing orders from referer filter' );
+		$this->assertNull( $data['next_id'], 'Newer-than-current is completed, so excluded from filtered walk' );
+	}
+
+	/**
+	 * @testdox Should ignore referers that point at the order edit screen, not the list.
+	 */
+	public function test_ignores_referer_when_it_is_an_edit_screen(): void {
+		$orders = $this->create_orders( 2 );
+
+		$_SERVER['HTTP_REFERER'] = admin_url( 'admin.php?page=wc-orders&action=edit&id=1&status=processing' );
+
+		$data = OrderListNav::get_navigation_data( $orders[0] );
+
+		$this->assertSame( array(), $data['list_query'], 'Edit-screen referer does not bleed filters in' );
+	}
+
+	/**
+	 * @testdox Should produce no output when render() is called with a refund.
+	 */
+	public function test_render_is_noop_for_refund(): void {
+		$order          = OrderHelper::create_order();
+		$this->orders[] = $order;
+
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 5,
+				'reason'   => 'Test refund',
+			)
+		);
+
+		$this->assertNotInstanceOf( \WP_Error::class, $refund, 'Refund creation must succeed' );
+
+		ob_start();
+		OrderListNav::render( $refund );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output, 'render() must not emit markup for non-shop_order types' );
+	}
+
+	/**
+	 * @testdox Should emit the nav markup for a shop_order.
+	 */
+	public function test_render_emits_markup_for_shop_order(): void {
+		$orders = $this->create_orders( 3 );
+
+		ob_start();
+		OrderListNav::render( $orders[1] );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'woocommerce-order-list-nav', $output );
+		$this->assertStringContainsString( 'aria-label="Order navigation"', $output );
+		$this->assertStringContainsString( '>Prev<', $output, 'Visible "Prev" label is present' );
+		$this->assertStringContainsString( '>Next<', $output, 'Visible "Next" label is present' );
+		$this->assertStringContainsString( 'aria-label="Previous order"', $output );
+		$this->assertStringContainsString( 'aria-label="Next order"', $output );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a \`< Prev   Next >\` control to the right of the Order edit page H1 so users can walk between adjacent orders without going back to the list. This has been highly requested through the [X post](https://x.com/designatwoo/status/2052046286782631965). List filters (status, search, customer, channel) carry over from the orders-list referer and are forwarded in the prev/next URLs so the walk stays scoped to the user's filter set. Falls back to all orders by date DESC when no list context is known, or when the active filter excludes the current order.

Gated behind the \`order-detail-redesign\` feature flag introduced in #64669 — when the flag is off the nav does not render. Stacked on top of #64678 (submit block split).

### Screenshots or screen recordings:

### BEFORE
<img width="3600" height="2086" alt="AFTER2" src="https://github.com/user-attachments/assets/a8dab497-2420-4468-91b3-35b1de21b7b9" />

### AFTER
<img width="3600" height="2086" alt="AFTER-NAV" src="https://github.com/user-attachments/assets/8443d260-b3de-4463-b87e-779414f0ac7d" />

### AFTER PR #64643 is merged
<img width="3600" height="2086" alt="AFTER AFTER" src="https://github.com/user-attachments/assets/08b12966-994b-44c2-8d50-e7f30c289122" />

### How to test the changes in this Pull Request:

Pre-req: enable the **Order detail redesign** feature flag in WooCommerce → Settings → Advanced → Features (or via WooCommerce Beta Tester). Have ~10+ orders with mixed statuses.

1. With the flag **off**, visit any order at \`?page=wc-orders&action=edit&id=N\`. Confirm: no nav renders.
2. Toggle the flag **on**. From the orders list at \`?page=wc-orders\`, click an order. Confirm: a \`< Prev    Next >\` control sits to the right of the title in the header.
3. Click "Next". Confirm: navigates to the next-newer order; URL retains list filter params.
4. Filter the orders list to \`status=processing\`. Click an order. Confirm: prev/next walk only includes processing orders.
5. Walk to the oldest order in the filtered set. Confirm: "Next" becomes disabled (muted color, no link, skipped on tab).
6. Open an order via direct URL (no referer). Confirm: nav renders and walks all orders by date.
7. Filter to \`status=completed\`, then directly visit a \`processing\` order. Confirm: nav still renders using the unfiltered fallback.
8. Visit \`?page=wc-orders&action=new\`. Confirm: no nav renders.
9. Open a refund detail page. Confirm: no nav renders.
10. Tab through the page. Confirm: focus ring matches WP admin; disabled state is skipped.
11. Switch site to RTL (e.g. Hebrew). Confirm: chevrons flip; "Prev" still goes to the older order.

### Testing that has already taken place:

- \`phpcs\` clean on new and modified files.
- \`phpstan\` (level 8) clean on \`OrderListNav.php\` and \`Edit.php\`.
- \`pnpm build\` clean; new SCSS compiled into \`admin.css\`.
- Unit tests written (\`OrderListNavTest.php\`) covering filter whitelist, sanitization, referer extraction, prev/next neighbor lookup, fallback behavior, refund no-op, and rendered markup.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry already added manually at \`plugins/woocommerce/changelog/order-detail-redesign-prev-next-nav\` (significance: minor, type: add).

</details>