### PR TITLE
Remove the Product type field from the quick edit panel

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-remove-type-from-quick-edit
+++ b/packages/js/experimental-products-app/changelog/update-remove-type-from-quick-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove the Product type field from the quick edit panel.

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -78,7 +78,6 @@ const COMMON_PRODUCT_EDIT_FIELD_IDS = [
 	'sku',
 	'categories',
 	'tags',
-	'type',
 	'featured',
 	'catalog_visibility',
 	'upsell_ids',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Removes the **Product type** field (Simple / Variable / Grouped / External) from the experimental quick edit panel. The field still exists and is editable in the full product editor; this only hides it from the side-panel quick edit form.

Implementation: drops `'type'` from `COMMON_PRODUCT_EDIT_FIELD_IDS` in `product-edit/utils.ts`. That list is spread into all per-type field arrays (simple/variable/grouped/external), so removing it from the common list removes it everywhere the quick edit form reads from.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Quick edit panel shows a Product type select | Quick edit panel no longer shows the Product type select |

### How to test the changes in this Pull Request:

1. Enable the feature flags `product-data-views` and `gutenberg-editor-inspector-use-dataform`.
2. Navigate to **WooCommerce → Products (new)**.
3. Open a product via **Quick edit** (try a few — simple, variable, external, grouped).
4. Confirm the **Product type** field is no longer rendered in the quick edit panel for any of them.
5. Open the same products via **Edit** (full editor) and confirm the Product type control is still available there.

### Testing that has already taken place:

- `npx jest packages/js/experimental-products-app/src/product-edit/utils.test.ts` — 12/12 pass.
- `npx tsc --noEmit --project packages/js/experimental-products-app/tsconfig.json` — clean.

### Changelog entry

`packages/js/experimental-products-app/changelog/update-remove-type-from-quick-edit` — patch / update.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**