### PR TITLE
Polish Order detail Items meta box typography, icons, and layout

### DIFF
--- a/plugins/woocommerce/changelog/order-detail-items-polish
+++ b/plugins/woocommerce/changelog/order-detail-items-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Polish Order detail Items meta box typography, icons, and layout when the order-detail-redesign feature is enabled.

--- a/plugins/woocommerce/changelog/order-detail-redesign-actions-split
+++ b/plugins/woocommerce/changelog/order-detail-redesign-actions-split
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Order detail redesign: split the Order actions metabox so the Update and Move-to-trash buttons sit in a dedicated chrome-less block above the action dropdown. No-op when the order-detail-redesign feature flag is off.

--- a/plugins/woocommerce/changelog/order-detail-redesign-prev-next-nav
+++ b/plugins/woocommerce/changelog/order-detail-redesign-prev-next-nav
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Order detail redesign: add prev/next order navigation in the Order edit page header so users can walk between adjacent orders without going back to the list. No-op when the order-detail-redesign feature flag is off.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3006,10 +3006,46 @@ ul.wc_coupon_list_block {
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
 	// Gated behind the `order-detail-redesign` feature flag (body class added by OrderDetailRedesign\Init).
-	// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
-	&.woocommerce-feature-enabled-order-detail-redesign .wrap:has(#poststuff) {
-		max-width: 1200px;
-		margin-inline: auto;
+	&.woocommerce-feature-enabled-order-detail-redesign {
+		// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
+		.wrap:has(#poststuff) {
+			max-width: 1200px;
+			margin-inline: auto;
+		}
+
+		// Strip postbox chrome from the redesigned submit block so the
+		// Update/Trash CTAs read as primary controls rather than a meta box.
+		#woocommerce-order-submit {
+			background: transparent;
+			border: 0;
+			box-shadow: none;
+
+			.postbox-header,
+			.handle-actions {
+				display: none;
+			}
+
+			.inside {
+				padding: 0;
+				margin: 0;
+			}
+		}
+
+		.wc-order-submit {
+			display: flex;
+			// Update order (DOM-first) renders on the right so it remains the
+			// first tab stop while the destructive action sits on the left.
+			flex-direction: row-reverse;
+			gap: 12px;
+
+			.button {
+				flex: 1;
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 36px;
+			}
+		}
 	}
 
 	.tablenav .one-page .displaying-num {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3046,6 +3046,58 @@ ul.wc_coupon_list_block {
 				min-height: 36px;
 			}
 		}
+
+		// Prev/next order navigation in the H1 row. Floats right so it sits
+		// on the opposite side of the title + "Add new" action.
+		.woocommerce-order-list-nav {
+			display: inline-flex;
+			align-items: center;
+			gap: 4px;
+			float: right;
+			margin-top: 4px;
+		}
+
+		.woocommerce-order-list-nav__button {
+			display: inline-flex;
+			align-items: center;
+			gap: 2px;
+			padding: 4px 8px;
+			border-radius: 2px; // --wpds-border-radius-xs
+			color: #1e1e1e; // --wpds-color-fg-content-neutral
+			font-size: 13px;
+			line-height: 1.4;
+			text-decoration: none;
+
+			&:hover {
+				background: rgba(0, 0, 0, 0.06);
+				color: #1e1e1e;
+			}
+
+			&:focus-visible {
+				outline: 2px solid;
+				outline-offset: 1px;
+			}
+
+			&[aria-disabled="true"] {
+				color: #757575; // --wpds-color-fg-content-neutral-weak
+				cursor: default;
+				pointer-events: none;
+			}
+
+			svg {
+				flex-shrink: 0;
+			}
+		}
+
+		// Mirror the chevrons in RTL contexts so "Prev" still points to older orders.
+		html[dir="rtl"] & .woocommerce-order-list-nav__button svg {
+			transform: scaleX(-1);
+		}
+
+		// Keep the form content from wrapping around the floated nav.
+		.wp-header-end {
+			clear: right;
+		}
 	}
 
 	.tablenav .one-page .displaying-num {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3011,6 +3011,8 @@ ul.wc_coupon_list_block {
 		.wrap:has(#poststuff) {
 			max-width: 1200px;
 			margin-inline: auto;
+			// Anchor for the absolutely-positioned prev/next nav below.
+			position: relative;
 		}
 
 		// Strip postbox chrome from the redesigned submit block so the
@@ -3047,14 +3049,19 @@ ul.wc_coupon_list_block {
 			}
 		}
 
-		// Prev/next order navigation in the H1 row. Floats right so it sits
-		// on the opposite side of the title + "Add new" action.
+		// Prev/next order navigation in the H1 row. Absolutely positioned so
+		// it sits on the opposite side of the title + "Add new" action and
+		// stays vertically centered with the H1 text regardless of H1 height.
+		// `right: 20px` matches WP admin's standard right gutter so the nav
+		// aligns with the right edge of the postbox column (not the .wrap edge).
 		.woocommerce-order-list-nav {
 			display: inline-flex;
 			align-items: center;
 			gap: 4px;
-			float: right;
-			margin-top: 4px;
+			position: absolute;
+			right: 20px;
+			top: 24px;
+			transform: translateY(-50%);
 		}
 
 		.woocommerce-order-list-nav__button {
@@ -3092,11 +3099,6 @@ ul.wc_coupon_list_block {
 		// Mirror the chevrons in RTL contexts so "Prev" still points to older orders.
 		html[dir="rtl"] & .woocommerce-order-list-nav__button svg {
 			transform: scaleX(-1);
-		}
-
-		// Keep the form content from wrapping around the floated nav.
-		.wp-header-end {
-			clear: right;
 		}
 	}
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3149,8 +3149,8 @@ ul.wc_coupon_list_block {
 						font-size: var(--wpds-typography-font-size-md, 14px);
 						font-weight: var(--wpds-typography-font-weight-medium, 500);
 						line-height: var(--wpds-typography-line-height-md, 1.4);
-						color: var(--wpds-color-fg-content-neutral, #1d2327);
-						text-decoration: none;
+						color: var(--wpds-color-fg-interactive-brand, var(--wp-admin-theme-color, #2271b1));
+						text-decoration: underline;
 					}
 
 					.wc-order-item-sku,

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3131,7 +3131,7 @@ ul.wc_coupon_list_block {
 					font-size: var(--wpds-typography-font-size-xs, 12px);
 					font-weight: var(--wpds-typography-font-weight-regular, 400);
 					line-height: var(--wpds-typography-line-height-xs, 1.4);
-					color: var(--wpds-color-fg-content-neutral-weak, #757575);
+					color: var(--wpds-color-fg-content-neutral-weak, #707070);
 				}
 
 				// Center the icon thumb with the row label on rows that have a
@@ -3165,11 +3165,11 @@ ul.wc_coupon_list_block {
 						margin-top: 0.4em;
 						font-size: var(--wpds-typography-font-size-sm, 12px) !important;
 						line-height: var(--wpds-typography-line-height-sm, 1.4);
-						color: var(--wpds-color-fg-content-neutral-weak, #757575);
+						color: var(--wpds-color-fg-content-neutral-weak, #707070);
 
 						strong {
 							font-weight: var(--wpds-typography-font-weight-regular, 400);
-							color: var(--wpds-color-fg-content-neutral-weak, #757575);
+							color: var(--wpds-color-fg-content-neutral-weak, #707070);
 						}
 					}
 				}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3100,6 +3100,112 @@ ul.wc_coupon_list_block {
 		html[dir="rtl"] & .woocommerce-order-list-nav__button svg {
 			transform: scaleX(-1);
 		}
+
+		// Items meta box polish — typography, WP DS icons, action bar, alignment.
+		// All rules use `var(--wpds-…, fallback)` so they remain correct when WP DS
+		// tokens aren't loaded.
+		#woocommerce-order-items {
+			.add-items {
+				display: flex;
+				align-items: center;
+				flex-wrap: wrap;
+				gap: var(--wpds-dimension-gap-sm, 8px);
+
+				.button {
+					float: none;
+					margin-right: 0;
+				}
+
+				.button-primary {
+					margin-left: auto;
+					float: none;
+				}
+			}
+
+			.woocommerce_order_items_wrapper small.refunded {
+				color: var(--wpds-color-fg-content-error-weak, #cc1818);
+			}
+
+			table.woocommerce_order_items {
+				thead th {
+					font-size: var(--wpds-typography-font-size-xs, 12px);
+					font-weight: var(--wpds-typography-font-weight-regular, 400);
+					line-height: var(--wpds-typography-line-height-xs, 1.4);
+					color: var(--wpds-color-fg-content-neutral-weak, #757575);
+				}
+
+				// Center the icon thumb with the row label on rows that have a
+				// single line of label content. Product rows stack name + SKU +
+				// variation and stay top-aligned via the inherited rule.
+				tbody#order_shipping_line_items td,
+				tbody#order_fee_line_items td,
+				tbody#order_refunds td {
+					vertical-align: middle;
+				}
+
+				td.name {
+					.wc-order-item-name {
+						display: block;
+						font-size: var(--wpds-typography-font-size-md, 14px);
+						font-weight: var(--wpds-typography-font-weight-medium, 500);
+						line-height: var(--wpds-typography-line-height-md, 1.4);
+						color: var(--wpds-color-fg-content-neutral, #1d2327);
+						text-decoration: none;
+					}
+
+					.wc-order-item-sku,
+					.wc-order-item-variation {
+						margin-top: 0.4em;
+						font-size: var(--wpds-typography-font-size-sm, 12px) !important;
+						line-height: var(--wpds-typography-line-height-sm, 1.4);
+						color: var(--wpds-color-fg-content-neutral-weak, #757575);
+
+						strong {
+							font-weight: var(--wpds-typography-font-weight-regular, 400);
+							color: var(--wpds-color-fg-content-neutral-weak, #757575);
+						}
+					}
+				}
+
+				// Replace the WC custom-font glyph on shipping / fee / refund
+				// thumb cells with a WP DS icon painted via mask-image. Suppress
+				// the original `::before` glyph so only the WP DS icon shows.
+				tr.shipping .thumb div,
+				tr.fee .thumb div,
+				tr.refund .thumb div {
+					width: 38px;
+					height: 38px;
+					font-size: 0;
+					border: 0;
+					background-color: var(--wpds-color-fg-content-neutral-weak, #757575);
+					-webkit-mask-repeat: no-repeat;
+					mask-repeat: no-repeat;
+					-webkit-mask-position: center;
+					mask-position: center;
+					-webkit-mask-size: 24px 24px;
+					mask-size: 24px 24px;
+
+					&::before {
+						content: none;
+					}
+				}
+
+				tr.shipping .thumb div {
+					-webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M3 6.75C3 5.784 3.784 5 4.75 5H15V7.313l.05.027 5.056 2.73.394.212v3.468a1.75 1.75 0 01-1.75 1.75h-.012a2.5 2.5 0 11-4.975 0H9.737a2.5 2.5 0 11-4.975 0H3V6.75zM13.5 14V6.5H4.75a.25.25 0 00-.25.25V14h.965a2.493 2.493 0 011.785-.75c.7 0 1.332.287 1.785.75H13.5zm4.535 0h.715a.25.25 0 00.25-.25v-2.573l-4-2.16v4.568a2.487 2.487 0 011.25-.335c.7 0 1.332.287 1.785.75zM6.282 15.5a1.002 1.002 0 00.968 1.25 1 1 0 10-.968-1.25zm9 0a1 1 0 101.937.498 1 1 0 00-1.938-.498z'/></svg>");
+					mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M3 6.75C3 5.784 3.784 5 4.75 5H15V7.313l.05.027 5.056 2.73.394.212v3.468a1.75 1.75 0 01-1.75 1.75h-.012a2.5 2.5 0 11-4.975 0H9.737a2.5 2.5 0 11-4.975 0H3V6.75zM13.5 14V6.5H4.75a.25.25 0 00-.25.25V14h.965a2.493 2.493 0 011.785-.75c.7 0 1.332.287 1.785.75H13.5zm4.535 0h.715a.25.25 0 00.25-.25v-2.573l-4-2.16v4.568a2.487 2.487 0 011.25-.335c.7 0 1.332.287 1.785.75zM6.282 15.5a1.002 1.002 0 00.968 1.25 1 1 0 10-.968-1.25zm9 0a1 1 0 101.937.498 1 1 0 00-1.938-.498z'/></svg>");
+				}
+
+				tr.fee .thumb div {
+					-webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M10.7 9.6c.3-.2.8-.4 1.3-.4s1 .2 1.3.4c.3.2.4.5.4.6 0 .4.3.8.8.8s.8-.3.8-.8c0-.8-.5-1.4-1.1-1.9-.4-.3-.9-.5-1.4-.6v-.3c0-.4-.3-.8-.8-.8s-.8.3-.8.8v.3c-.5 0-1 .3-1.4.6-.6.4-1.1 1.1-1.1 1.9s.5 1.4 1.1 1.9c.6.4 1.4.6 2.2.6h.2c.5 0 .9.2 1.1.4.3.2.4.5.4.6s0 .4-.4.6c-.3.2-.8.4-1.3.4s-1-.2-1.3-.4c-.3-.2-.4-.5-.4-.6 0-.4-.3-.8-.8-.8s-.8.3-.8.8c0 .8.5 1.4 1.1 1.9.4.3.9.5 1.4.6v.3c0 .4.3.8.8.8s.8-.3.8-.8v-.3c.5 0 1-.3 1.4-.6.6-.4 1.1-1.1 1.1-1.9s-.5-1.4-1.1-1.9c-.5-.4-1.2-.6-1.9-.6H12c-.6 0-1-.2-1.3-.4-.3-.2-.4-.5-.4-.6s0-.4.4-.6ZM12 4c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8Zm0 14.5c-3.6 0-6.5-2.9-6.5-6.5S8.4 5.5 12 5.5s6.5 2.9 6.5 6.5-2.9 6.5-6.5 6.5Z'/></svg>");
+					mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M10.7 9.6c.3-.2.8-.4 1.3-.4s1 .2 1.3.4c.3.2.4.5.4.6 0 .4.3.8.8.8s.8-.3.8-.8c0-.8-.5-1.4-1.1-1.9-.4-.3-.9-.5-1.4-.6v-.3c0-.4-.3-.8-.8-.8s-.8.3-.8.8v.3c-.5 0-1 .3-1.4.6-.6.4-1.1 1.1-1.1 1.9s.5 1.4 1.1 1.9c.6.4 1.4.6 2.2.6h.2c.5 0 .9.2 1.1.4.3.2.4.5.4.6s0 .4-.4.6c-.3.2-.8.4-1.3.4s-1-.2-1.3-.4c-.3-.2-.4-.5-.4-.6 0-.4-.3-.8-.8-.8s-.8.3-.8.8c0 .8.5 1.4 1.1 1.9.4.3.9.5 1.4.6v.3c0 .4.3.8.8.8s.8-.3.8-.8v-.3c.5 0 1-.3 1.4-.6.6-.4 1.1-1.1 1.1-1.9s-.5-1.4-1.1-1.9c-.5-.4-1.2-.6-1.9-.6H12c-.6 0-1-.2-1.3-.4-.3-.2-.4-.5-.4-.6s0-.4.4-.6ZM12 4c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8Zm0 14.5c-3.6 0-6.5-2.9-6.5-6.5S8.4 5.5 12 5.5s6.5 2.9 6.5 6.5-2.9 6.5-6.5 6.5Z'/></svg>");
+				}
+
+				tr.refund .thumb div {
+					-webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M18.3 11.7c-.6-.6-1.4-.9-2.3-.9H6.7l2.9-3.3-1.1-1-4.5 5L8.5 16l1-1-2.7-2.7H16c.5 0 .9.2 1.3.5 1 1 1 3.4 1 4.5v.3h1.5v-.2c0-1.5 0-4.3-1.5-5.7z'/></svg>");
+					mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M18.3 11.7c-.6-.6-1.4-.9-2.3-.9H6.7l2.9-3.3-1.1-1-4.5 5L8.5 16l1-1-2.7-2.7H16c.5 0 .9.2 1.3.5 1 1 1 3.4 1 4.5v.3h1.5v-.2c0-1.5 0-4.3-1.5-5.7z'/></svg>");
+				}
+			}
+		}
 	}
 
 	.tablenav .one-page .displaying-num {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3149,6 +3149,13 @@ ul.wc_coupon_list_block {
 						font-size: var(--wpds-typography-font-size-md, 14px);
 						font-weight: var(--wpds-typography-font-weight-medium, 500);
 						line-height: var(--wpds-typography-line-height-md, 1.4);
+					}
+
+					// Scope the link affordance to the anchor variant. The template
+					// renders `.wc-order-item-name` as a <div> when the product no
+					// longer exists, so the underline + brand color must not apply
+					// to that variant.
+					a.wc-order-item-name {
 						color: var(--wpds-color-fg-interactive-brand, var(--wp-admin-theme-color, #2271b1));
 						text-decoration: underline;
 					}

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -11,6 +11,7 @@
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -58,25 +59,27 @@ class WC_Meta_Box_Order_Actions {
 				<button class="button wc-reload"><span><?php esc_html_e( 'Apply', 'woocommerce' ); ?></span></button>
 			</li>
 
-			<li class="wide">
-				<div id="delete-action">
-					<?php
-					if ( current_user_can( 'delete_post', $order_id ) ) {
+			<?php if ( ! FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) : ?>
+				<li class="wide">
+					<div id="delete-action">
+						<?php
+						if ( current_user_can( 'delete_post', $order_id ) ) {
 
-						if ( ! EMPTY_TRASH_DAYS ) {
-							$delete_text = __( 'Delete permanently', 'woocommerce' );
-						} else {
-							$delete_text = __( 'Move to Trash', 'woocommerce' );
+							if ( ! EMPTY_TRASH_DAYS ) {
+								$delete_text = __( 'Delete permanently', 'woocommerce' );
+							} else {
+								$delete_text = __( 'Move to Trash', 'woocommerce' );
+							}
+							?>
+							<a class="submitdelete deletion" href="<?php echo esc_url( self::get_trash_or_delete_order_link( $order_id ) ); ?>"><?php echo esc_html( $delete_text ); ?></a>
+							<?php
 						}
 						?>
-						<a class="submitdelete deletion" href="<?php echo esc_url( self::get_trash_or_delete_order_link( $order_id ) ); ?>"><?php echo esc_html( $delete_text ); ?></a>
-						<?php
-					}
-					?>
-				</div>
+					</div>
 
-				<button type="submit" class="button save_order button-primary" name="save" value="<?php echo OrderStatus::AUTO_DRAFT === $order->get_status() ? esc_attr__( 'Create', 'woocommerce' ) : esc_attr__( 'Update', 'woocommerce' ); ?>"><?php echo OrderStatus::AUTO_DRAFT === $order->get_status() ? esc_html__( 'Create', 'woocommerce' ) : esc_html__( 'Update', 'woocommerce' ); ?></button>
-			</li>
+					<button type="submit" class="button save_order button-primary" name="save" value="<?php echo OrderStatus::AUTO_DRAFT === $order->get_status() ? esc_attr__( 'Create', 'woocommerce' ) : esc_attr__( 'Update', 'woocommerce' ); ?>"><?php echo OrderStatus::AUTO_DRAFT === $order->get_status() ? esc_html__( 'Create', 'woocommerce' ) : esc_html__( 'Update', 'woocommerce' ); ?></button>
+				</li>
+			<?php endif; ?>
 
 			<?php
 			/**

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-submit.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-submit.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Order Submit
+ *
+ * Renders the redesigned Update/Create + Trash submit block for an order in
+ * the side column, gated behind the `order-detail-redesign` feature flag.
+ *
+ * @package WooCommerce\Admin\Meta Boxes
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Meta_Box_Order_Submit Class.
+ *
+ * @internal
+ */
+class WC_Meta_Box_Order_Submit {
+
+	/**
+	 * Output the metabox.
+	 *
+	 * @param WP_Post|WC_Order $post Post or order object.
+	 */
+	public static function output( $post ): void {
+		// Render nothing when the redesign is not active. The empty meta box
+		// is hidden entirely by CSS rules scoped to the redesign body class,
+		// so it leaves no visible artifact when the flag is off.
+		if ( ! FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+			return;
+		}
+
+		global $theorder;
+
+		OrderUtil::init_theorder_object( $post );
+		$order = $theorder;
+
+		$order_id     = $order->get_id();
+		$is_new_order = OrderStatus::AUTO_DRAFT === $order->get_status();
+		$submit_label = $is_new_order
+			? __( 'Create order', 'woocommerce' )
+			: __( 'Update order', 'woocommerce' );
+
+		?>
+		<div class="wc-order-submit">
+			<button
+				type="submit"
+				class="button save_order button-primary"
+				name="save"
+				value="<?php echo esc_attr( $submit_label ); ?>"
+			><?php echo esc_html( $submit_label ); ?></button>
+
+			<?php if ( current_user_can( 'delete_post', $order_id ) ) : ?>
+				<?php
+				$delete_text = ! EMPTY_TRASH_DAYS
+					? __( 'Delete permanently', 'woocommerce' )
+					: __( 'Move to trash', 'woocommerce' );
+				?>
+				<a
+					class="button button-secondary"
+					href="<?php echo esc_url( self::get_trash_or_delete_order_link( $order_id ) ); ?>"
+				><?php echo esc_html( $delete_text ); ?></a>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Forms a trash/delete order URL.
+	 *
+	 * Mirrors WC_Meta_Box_Order_Actions::get_trash_or_delete_order_link() so
+	 * this class doesn't depend on a private helper of another class. To be
+	 * consolidated when the order detail redesign exits the feature flag.
+	 *
+	 * @param int $order_id The order ID for which we want a trash/delete URL.
+	 * @return string
+	 */
+	private static function get_trash_or_delete_order_link( int $order_id ): string {
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order ) {
+				return '';
+			}
+			$order_list_url  = wc_get_container()->get( PageController::class )->get_base_page_url( $order->get_type() );
+			$trash_order_url = add_query_arg(
+				array(
+					'action'           => 'trash',
+					'id'               => array( $order_id ),
+					'_wp_http_referer' => $order_list_url,
+				),
+				$order_list_url
+			);
+
+			return wp_nonce_url( $trash_order_url, 'bulk-orders' );
+		}
+
+		return get_delete_post_link( $order_id ) ?? '';
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\TaxonomiesMetaBox;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
 
@@ -80,6 +81,9 @@ class Edit {
 		/* Translators: %s order type name. */
 		add_meta_box( 'woocommerce-order-notes', sprintf( __( '%s notes', 'woocommerce' ), $title ), 'WC_Meta_Box_Order_Notes::output', $screen_id, 'side', 'default' );
 		add_meta_box( 'woocommerce-order-downloads', __( 'Downloadable product permissions', 'woocommerce' ) . wc_help_tip( __( 'Note: Permissions for order items will automatically be granted when the order status changes to processing/completed.', 'woocommerce' ) ), 'WC_Meta_Box_Order_Downloads::output', $screen_id, 'normal', 'default' );
+		if ( FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+			add_meta_box( 'woocommerce-order-submit', __( 'Save', 'woocommerce' ), 'WC_Meta_Box_Order_Submit::output', $screen_id, 'side', 'high' );
+		}
 		/* Translators: %s order type name. */
 		add_meta_box( 'woocommerce-order-actions', sprintf( __( '%s actions', 'woocommerce' ), $title ), 'WC_Meta_Box_Order_Actions::output', $screen_id, 'side', 'high' );
 		self::maybe_register_order_attribution( $screen_id, $title );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\TaxonomiesMetaBox;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\Features\OrderDetailRedesign\OrderListNav;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
@@ -439,6 +440,10 @@ class Edit {
 		<?php
 		if ( 'edit_order' === $this->current_action ) {
 			echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new ) . '</a>';
+		}
+
+		if ( 'edit_order' === $this->current_action && FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+			OrderListNav::render( $this->order );
 		}
 		?>
 		<hr class="wp-header-end">

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
+use Automattic\WooCommerce\Admin\Features\Features as AdminFeatures;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
@@ -442,7 +443,12 @@ class Edit {
 			echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new ) . '</a>';
 		}
 
-		if ( 'edit_order' === $this->current_action && FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+		// Note: using the wc-admin features API (`AdminFeatures::is_enabled`) rather than
+		// `FeaturesUtil::feature_is_enabled` because `order-detail-redesign` is registered in
+		// `client/admin/config/core.json` only and is not bridged to the core `FeaturesController`,
+		// so `FeaturesUtil::feature_is_enabled` always returns false for this feature. See PR
+		// description for the broader bug that needs fixing in #64669 / #64678 follow-ups.
+		if ( 'edit_order' === $this->current_action && AdminFeatures::is_enabled( 'order-detail-redesign' ) ) {
 			OrderListNav::render( $this->order );
 		}
 		?>

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Renders prev/next order navigation in the Order detail page header.
+ *
+ * @package WooCommerce
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Features\OrderDetailRedesign;
+
+use WC_Order;
+
+/**
+ * Outputs the `< Prev   Next >` navigation that lets users walk between
+ * adjacent orders without going back to the list. Server-rendered;
+ * neighbours are resolved against the orders-list filter set the user
+ * came from (carried via `wp_get_referer()` and forwarded in subsequent
+ * links).
+ *
+ * Gated behind the `order-detail-redesign` feature flag — caller checks
+ * `FeaturesUtil::feature_is_enabled( 'order-detail-redesign' )` before invoking.
+ *
+ * @since 10.9.0
+ */
+class OrderListNav {
+
+	/**
+	 * Chevron-left path data, sourced from @wordpress/icons (24×24 viewBox).
+	 */
+	private const CHEVRON_LEFT_PATH = 'M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z';
+
+	/**
+	 * Chevron-right path data, sourced from @wordpress/icons (24×24 viewBox).
+	 */
+	private const CHEVRON_RIGHT_PATH = 'M10.6 6 9.4 7.1 14.3 12l-4.9 4.9 1.2 1.1 6-6z';
+
+	/**
+	 * URL params from the orders list page that we forward to keep the
+	 * prev/next walk scoped to the user's filter set.
+	 */
+	private const FILTER_WHITELIST = array( 'status', 's', '_customer_user', '_created_via' );
+
+	/**
+	 * Outputs the navigation markup for the given order.
+	 *
+	 * No-op for non-`shop_order` types (e.g. refunds).
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order The current order.
+	 * @return void
+	 */
+	public static function render( WC_Order $order ): void {
+		if ( 'shop_order' !== $order->get_type() ) {
+			return;
+		}
+
+		$data       = self::get_navigation_data( $order );
+		$list_query = $data['list_query'];
+
+		$prev_url = self::build_order_url( $data['prev_id'], $list_query );
+		$next_url = self::build_order_url( $data['next_id'], $list_query );
+
+		?>
+		<nav class="woocommerce-order-list-nav" aria-label="<?php esc_attr_e( 'Order navigation', 'woocommerce' ); ?>">
+			<?php
+			self::render_button(
+				$prev_url,
+				__( 'Prev', 'woocommerce' ),
+				__( 'Previous order', 'woocommerce' ),
+				self::CHEVRON_LEFT_PATH,
+				'is-prev'
+			);
+			self::render_button(
+				$next_url,
+				__( 'Next', 'woocommerce' ),
+				__( 'Next order', 'woocommerce' ),
+				self::CHEVRON_RIGHT_PATH,
+				'is-next'
+			);
+			?>
+		</nav>
+		<?php
+	}
+
+	/**
+	 * Resolves the prev/next order IDs for the order within the current
+	 * orders-list filter set.
+	 *
+	 * Falls back to the unfiltered set (all orders by date DESC) if the
+	 * filters exclude the current order.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order The current order.
+	 * @return array{prev_id: int|null, next_id: int|null, list_query: array<string, mixed>}
+	 */
+	public static function get_navigation_data( WC_Order $order ): array {
+		$list_query = self::get_list_query_from_request();
+
+		$result = self::compute_neighbors( $order, $list_query );
+		if ( null === $result ) {
+			$list_query = array();
+			$result     = self::compute_neighbors( $order, array() );
+		}
+
+		if ( null === $result ) {
+			$result = array(
+				'prev_id' => null,
+				'next_id' => null,
+			);
+		}
+
+		$result['list_query'] = $list_query;
+		return $result;
+	}
+
+	/**
+	 * Renders a single prev/next button — either an active link or a disabled span.
+	 *
+	 * @param string|null $url       URL for the button, or null when disabled.
+	 * @param string      $text      Visible text ("Prev" / "Next").
+	 * @param string      $aria      Accessible label ("Previous order" / "Next order").
+	 * @param string      $svg_path  SVG path data for the chevron.
+	 * @param string      $variant   "is-prev" (icon before text) or "is-next" (icon after text).
+	 */
+	private static function render_button( ?string $url, string $text, string $aria, string $svg_path, string $variant ): void {
+		$svg     = '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="' . esc_attr( $svg_path ) . '"></path></svg>';
+		$content = 'is-prev' === $variant
+			? $svg . '<span class="woocommerce-order-list-nav__label">' . esc_html( $text ) . '</span>'
+			: '<span class="woocommerce-order-list-nav__label">' . esc_html( $text ) . '</span>' . $svg;
+		$class   = 'woocommerce-order-list-nav__button ' . esc_attr( $variant );
+
+		if ( null === $url ) {
+			?>
+			<span class="<?php echo esc_attr( $class ); ?>" aria-disabled="true" aria-label="<?php echo esc_attr( $aria ); ?>"><?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static SVG markup with escaped path; text node is escaped above. ?></span>
+			<?php
+		} else {
+			?>
+			<a href="<?php echo esc_url( $url ); ?>" class="<?php echo esc_attr( $class ); ?>" aria-label="<?php echo esc_attr( $aria ); ?>"><?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static SVG markup with escaped path; text node is escaped above. ?></a>
+			<?php
+		}
+	}
+
+	/**
+	 * Resolves the prev/next order IDs against the given filter set.
+	 *
+	 * Returns null when the order is not in the filter set, signaling a
+	 * fallback to the unfiltered set is needed.
+	 *
+	 * @param WC_Order             $order      Current order.
+	 * @param array<string, mixed> $list_query Filter args (already mapped to wc_get_orders keys).
+	 * @return array{prev_id: int|null, next_id: int|null}|null
+	 */
+	private static function compute_neighbors( WC_Order $order, array $list_query ): ?array {
+		$date = $order->get_date_created();
+		if ( null === $date ) {
+			return null;
+		}
+		$timestamp = $date->getTimestamp();
+
+		$base_args = array_merge( $list_query, array( 'type' => 'shop_order' ) );
+
+		if ( ! empty( $list_query ) && ! self::order_matches_filters( $order, $base_args ) ) {
+			return null;
+		}
+
+		$prev_ids = wc_get_orders(
+			array_merge(
+				$base_args,
+				array(
+					'date_created' => '<' . $timestamp,
+					'orderby'      => 'date',
+					'order'        => 'DESC',
+					'limit'        => 1,
+					'return'       => 'ids',
+				)
+			)
+		);
+		$next_ids = wc_get_orders(
+			array_merge(
+				$base_args,
+				array(
+					'date_created' => '>' . $timestamp,
+					'orderby'      => 'date',
+					'order'        => 'ASC',
+					'limit'        => 1,
+					'return'       => 'ids',
+				)
+			)
+		);
+
+		return array(
+			'prev_id' => self::first_id( $prev_ids ),
+			'next_id' => self::first_id( $next_ids ),
+		);
+	}
+
+	/**
+	 * Returns the first ID from a `wc_get_orders( …, 'return' => 'ids' )` result, or null if empty.
+	 *
+	 * @param mixed $result wc_get_orders return value when called with `return=ids`.
+	 * @return int|null
+	 */
+	private static function first_id( $result ): ?int {
+		if ( ! is_array( $result ) || empty( $result ) ) {
+			return null;
+		}
+		$first = reset( $result );
+		return is_numeric( $first ) ? (int) $first : null;
+	}
+
+	/**
+	 * Returns true when the given order matches the supplied filter args.
+	 *
+	 * @param WC_Order             $order Order to check.
+	 * @param array<string, mixed> $args  Filter args (must include `type`).
+	 * @return bool
+	 */
+	private static function order_matches_filters( WC_Order $order, array $args ): bool {
+		$matches = wc_get_orders(
+			array_merge(
+				$args,
+				array(
+					'id'     => $order->get_id(),
+					'limit'  => 1,
+					'return' => 'ids',
+				)
+			)
+		);
+
+		return is_array( $matches ) && ! empty( $matches );
+	}
+
+	/**
+	 * Reads filter params from the current request, falling back to the
+	 * referer when the current URL has none. Returns args mapped to
+	 * wc_get_orders parameter names.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function get_list_query_from_request(): array {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current = self::extract_whitelisted_params( $_GET );
+		if ( ! empty( $current ) ) {
+			return self::map_to_query_args( $current );
+		}
+
+		$referer = wp_get_referer();
+		if ( ! $referer || ! self::is_orders_list_url( $referer ) ) {
+			return array();
+		}
+
+		$query = wp_parse_url( $referer, PHP_URL_QUERY );
+		if ( ! is_string( $query ) || '' === $query ) {
+			return array();
+		}
+
+		$parsed = array();
+		wp_parse_str( $query, $parsed );
+
+		return self::map_to_query_args( self::extract_whitelisted_params( $parsed ) );
+	}
+
+	/**
+	 * Pulls and sanitizes whitelisted params from a query array.
+	 *
+	 * @param array<int|string, mixed> $params Raw params (e.g. `$_GET` or `wp_parse_str` output).
+	 * @return array<string, mixed>
+	 */
+	private static function extract_whitelisted_params( array $params ): array {
+		$result = array();
+
+		foreach ( self::FILTER_WHITELIST as $key ) {
+			if ( ! isset( $params[ $key ] ) ) {
+				continue;
+			}
+			$value = $params[ $key ];
+			if ( is_string( $value ) ) {
+				$value = wp_unslash( $value );
+			}
+
+			$sanitized = self::sanitize_param( $key, $value );
+			if ( null !== $sanitized ) {
+				$result[ $key ] = $sanitized;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Sanitizes a single param value. Returns null when the value should
+	 * be ignored (empty, "all", trash, etc.).
+	 *
+	 * @param string $key   Param name.
+	 * @param mixed  $value Raw value.
+	 * @return mixed|null
+	 */
+	private static function sanitize_param( string $key, $value ) {
+		switch ( $key ) {
+			case 'status':
+				if ( ! is_string( $value ) ) {
+					return null;
+				}
+				$value = sanitize_text_field( $value );
+				if ( '' === $value || 'all' === $value || 'trash' === $value ) {
+					return null;
+				}
+				return $value;
+
+			case 's':
+				$value = is_string( $value ) ? sanitize_text_field( $value ) : '';
+				return '' === $value ? null : $value;
+
+			case '_customer_user':
+				$value = absint( $value );
+				return $value > 0 ? $value : null;
+
+			case '_created_via':
+				if ( is_array( $value ) ) {
+					$value = array_map( 'sanitize_text_field', array_map( 'wp_unslash', $value ) );
+					$value = array_values( array_filter( $value ) );
+					return ! empty( $value ) ? $value : null;
+				}
+				$value = is_string( $value ) ? sanitize_text_field( $value ) : '';
+				return '' === $value ? null : array( $value );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Maps URL param names to wc_get_orders arg names.
+	 *
+	 * @param array<string, mixed> $params Whitelisted, sanitized URL params.
+	 * @return array<string, mixed>
+	 */
+	private static function map_to_query_args( array $params ): array {
+		$args = array();
+
+		if ( isset( $params['status'] ) ) {
+			$args['status'] = $params['status'];
+		}
+		if ( isset( $params['s'] ) ) {
+			$args['s'] = $params['s'];
+		}
+		if ( isset( $params['_customer_user'] ) ) {
+			$args['customer'] = $params['_customer_user'];
+		}
+		if ( isset( $params['_created_via'] ) ) {
+			$args['created_via'] = $params['_created_via'];
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Returns true when the URL points at the orders list page (not the order edit/new screen).
+	 *
+	 * @param string $url URL to test.
+	 * @return bool
+	 */
+	private static function is_orders_list_url( string $url ): bool {
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+		if ( ! is_string( $query ) || '' === $query ) {
+			return false;
+		}
+
+		$parsed = array();
+		wp_parse_str( $query, $parsed );
+
+		if ( 'wc-orders' !== ( $parsed['page'] ?? null ) ) {
+			return false;
+		}
+
+		$action = $parsed['action'] ?? '';
+		return ! in_array( $action, array( 'edit', 'new' ), true );
+	}
+
+	/**
+	 * Builds the order edit URL, carrying forward the list filter params.
+	 *
+	 * @param int|null             $order_id   Target order ID, or null to disable the chevron.
+	 * @param array<string, mixed> $list_query Filter args (in wc_get_orders form).
+	 * @return string|null
+	 */
+	private static function build_order_url( ?int $order_id, array $list_query ): ?string {
+		if ( null === $order_id ) {
+			return null;
+		}
+
+		$args = array_merge(
+			array(
+				'page'   => 'wc-orders',
+				'action' => 'edit',
+				'id'     => $order_id,
+			),
+			self::query_args_to_url_params( $list_query )
+		);
+
+		return admin_url( add_query_arg( $args, 'admin.php' ) );
+	}
+
+	/**
+	 * Maps wc_get_orders args back to URL param names for the link href.
+	 *
+	 * @param array<string, mixed> $args wc_get_orders args.
+	 * @return array<string, mixed>
+	 */
+	private static function query_args_to_url_params( array $args ): array {
+		$params = array();
+		if ( isset( $args['status'] ) ) {
+			$params['status'] = $args['status'];
+		}
+		if ( isset( $args['s'] ) ) {
+			$params['s'] = $args['s'];
+		}
+		if ( isset( $args['customer'] ) ) {
+			$params['_customer_user'] = $args['customer'];
+		}
+		if ( isset( $args['created_via'] ) ) {
+			$created_via            = (array) $args['created_via'];
+			$params['_created_via'] = 1 === count( $created_via ) ? $created_via[0] : $created_via;
+		}
+		return $params;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/OrderListNav.php
@@ -19,7 +19,7 @@ use WC_Order;
  * links).
  *
  * Gated behind the `order-detail-redesign` feature flag — caller checks
- * `FeaturesUtil::feature_is_enabled( 'order-detail-redesign' )` before invoking.
+ * `Admin\Features\Features::is_enabled( 'order-detail-redesign' )` before invoking.
  *
  * @since 10.9.0
  */

--- a/plugins/woocommerce/tests/php/src/Internal/Features/OrderDetailRedesign/OrderListNavTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/OrderDetailRedesign/OrderListNavTest.php
@@ -1,0 +1,251 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Features\OrderDetailRedesign;
+
+use Automattic\WooCommerce\Internal\Features\OrderDetailRedesign\OrderListNav;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use WC_Order;
+
+/**
+ * Tests for OrderListNav.
+ *
+ * @testdox OrderListNav
+ * @since 10.9.0
+ */
+class OrderListNavTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * Orders created for the test, ordered newest → oldest.
+	 *
+	 * @var WC_Order[]
+	 */
+	private array $orders = array();
+
+	/**
+	 * Set up each test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$_SERVER['HTTP_REFERER'] = '';
+		unset( $_GET['status'], $_GET['s'], $_GET['_customer_user'], $_GET['_created_via'] );
+	}
+
+	/**
+	 * Tear down each test case.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->orders as $order ) {
+			$order->delete( true );
+		}
+		$this->orders = array();
+
+		unset( $_SERVER['HTTP_REFERER'] );
+		unset( $_GET['status'], $_GET['s'], $_GET['_customer_user'], $_GET['_created_via'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Creates `$count` orders with strictly decreasing `date_created` so
+	 * `$this->orders[0]` is the newest. Optionally tags each order with a
+	 * status to enable filter-based tests.
+	 *
+	 * @param int           $count    Number of orders to create.
+	 * @param string[]|null $statuses One status per order (newest first), or null for default.
+	 * @return WC_Order[]
+	 */
+	private function create_orders( int $count, ?array $statuses = null ): array {
+		$base = time() - ( DAY_IN_SECONDS * $count );
+		$out  = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$order = OrderHelper::create_order();
+			$order->set_date_created( $base + ( ( $count - $i ) * DAY_IN_SECONDS ) );
+			if ( null !== $statuses ) {
+				$order->set_status( $statuses[ $i ] );
+			}
+			$order->save();
+			$out[] = $order;
+		}
+
+		$this->orders = $out;
+		return $out;
+	}
+
+	/**
+	 * @testdox Should return no prev when called on the newest order.
+	 */
+	public function test_returns_no_prev_for_newest_order(): void {
+		$orders = $this->create_orders( 5 );
+
+		$data = OrderListNav::get_navigation_data( $orders[0] );
+
+		$this->assertNull( $data['prev_id'], 'Newest order has no previous' );
+		$this->assertSame( $orders[1]->get_id(), $data['next_id'], 'Next is the second-newest order' );
+	}
+
+	/**
+	 * @testdox Should return correct neighbours for an order in the middle.
+	 */
+	public function test_returns_correct_neighbours_for_middle_order(): void {
+		$orders = $this->create_orders( 5 );
+
+		$data = OrderListNav::get_navigation_data( $orders[2] );
+
+		$this->assertSame( $orders[3]->get_id(), $data['prev_id'], 'Previous is the next-older order' );
+		$this->assertSame( $orders[1]->get_id(), $data['next_id'], 'Next is the next-newer order' );
+	}
+
+	/**
+	 * @testdox Should return no next when called on the oldest order.
+	 */
+	public function test_returns_no_next_for_oldest_order(): void {
+		$orders = $this->create_orders( 5 );
+
+		$data = OrderListNav::get_navigation_data( end( $orders ) );
+
+		$this->assertSame( $orders[3]->get_id(), $data['prev_id'], 'Previous is the second-oldest order' );
+		$this->assertNull( $data['next_id'], 'Oldest order has no next' );
+	}
+
+	/**
+	 * @testdox Should restrict the walk to orders matching the status filter.
+	 */
+	public function test_restricts_walk_to_status_filter(): void {
+		$orders = $this->create_orders(
+			5,
+			array( 'completed', 'processing', 'completed', 'processing', 'completed' )
+		);
+
+		$_GET['status'] = 'processing';
+
+		$data = OrderListNav::get_navigation_data( $orders[1] );
+
+		$this->assertSame( $orders[3]->get_id(), $data['prev_id'], 'Walk skips completed orders' );
+		$this->assertNull( $data['next_id'], 'No newer processing order' );
+		$this->assertArrayHasKey( 'status', $data['list_query'], 'Filter is preserved in list_query' );
+		$this->assertSame( 'processing', $data['list_query']['status'] );
+	}
+
+	/**
+	 * @testdox Should fall back to unfiltered set when filter excludes the current order.
+	 */
+	public function test_falls_back_when_filter_excludes_current_order(): void {
+		$orders = $this->create_orders(
+			3,
+			array( 'completed', 'completed', 'completed' )
+		);
+
+		$_GET['status'] = 'processing';
+
+		$data = OrderListNav::get_navigation_data( $orders[1] );
+
+		$this->assertSame( $orders[0]->get_id(), $data['next_id'], 'Falls back to walking the unfiltered set' );
+		$this->assertSame( $orders[2]->get_id(), $data['prev_id'], 'Falls back to walking the unfiltered set' );
+		$this->assertSame( array(), $data['list_query'], 'Filters dropped after fallback' );
+	}
+
+	/**
+	 * @testdox Should drop unrecognised query params and ignore the all/trash status keywords.
+	 */
+	public function test_drops_unknown_params_and_ignores_pseudo_statuses(): void {
+		$orders = $this->create_orders( 2 );
+
+		$_GET['unknown_param'] = 'value';
+		$_GET['status']        = 'all';
+
+		$data = OrderListNav::get_navigation_data( $orders[0] );
+
+		$this->assertSame( array(), $data['list_query'], 'Unknown params and status=all are dropped' );
+		$this->assertSame( $orders[1]->get_id(), $data['next_id'], 'Walk still works without filters' );
+	}
+
+	/**
+	 * @testdox Should sanitize bogus _customer_user values down to an empty filter.
+	 */
+	public function test_sanitizes_invalid_customer_user(): void {
+		$orders = $this->create_orders( 2 );
+
+		$_GET['_customer_user'] = 'not-a-number';
+
+		$data = OrderListNav::get_navigation_data( $orders[0] );
+
+		$this->assertArrayNotHasKey( 'customer', $data['list_query'], 'Bogus customer ID dropped' );
+	}
+
+	/**
+	 * @testdox Should pull filter params from the referer when the current URL has none.
+	 */
+	public function test_pulls_filter_from_referer_when_request_is_empty(): void {
+		$orders = $this->create_orders(
+			3,
+			array( 'completed', 'processing', 'processing' )
+		);
+
+		$_SERVER['HTTP_REFERER'] = admin_url( 'admin.php?page=wc-orders&status=processing' );
+
+		$data = OrderListNav::get_navigation_data( $orders[1] );
+
+		$this->assertArrayHasKey( 'status', $data['list_query'], 'Status pulled from referer' );
+		$this->assertSame( 'processing', $data['list_query']['status'] );
+		$this->assertSame( $orders[2]->get_id(), $data['prev_id'], 'Walk only includes processing orders from referer filter' );
+		$this->assertNull( $data['next_id'], 'Newer-than-current is completed, so excluded from filtered walk' );
+	}
+
+	/**
+	 * @testdox Should ignore referers that point at the order edit screen, not the list.
+	 */
+	public function test_ignores_referer_when_it_is_an_edit_screen(): void {
+		$orders = $this->create_orders( 2 );
+
+		$_SERVER['HTTP_REFERER'] = admin_url( 'admin.php?page=wc-orders&action=edit&id=1&status=processing' );
+
+		$data = OrderListNav::get_navigation_data( $orders[0] );
+
+		$this->assertSame( array(), $data['list_query'], 'Edit-screen referer does not bleed filters in' );
+	}
+
+	/**
+	 * @testdox Should produce no output when render() is called with a refund.
+	 */
+	public function test_render_is_noop_for_refund(): void {
+		$order          = OrderHelper::create_order();
+		$this->orders[] = $order;
+
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 5,
+				'reason'   => 'Test refund',
+			)
+		);
+
+		$this->assertNotInstanceOf( \WP_Error::class, $refund, 'Refund creation must succeed' );
+
+		ob_start();
+		OrderListNav::render( $refund );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output, 'render() must not emit markup for non-shop_order types' );
+	}
+
+	/**
+	 * @testdox Should emit the nav markup for a shop_order.
+	 */
+	public function test_render_emits_markup_for_shop_order(): void {
+		$orders = $this->create_orders( 3 );
+
+		ob_start();
+		OrderListNav::render( $orders[1] );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'woocommerce-order-list-nav', $output );
+		$this->assertStringContainsString( 'aria-label="Order navigation"', $output );
+		$this->assertStringContainsString( '>Prev<', $output, 'Visible "Prev" label is present' );
+		$this->assertStringContainsString( '>Next<', $output, 'Visible "Next" label is present' );
+		$this->assertStringContainsString( 'aria-label="Previous order"', $output );
+		$this->assertStringContainsString( 'aria-label="Next order"', $output );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Items meta box on the Order edit screen renders the product name at the same visual hierarchy as the SKU and Variation ID meta lines, and uses a custom WooCommerce icon font for the shipping/fee/refund row glyphs. This PR introduces a CSS-only polish that lifts the product name one typography step above the meta, applies WP Design System typography and color tokens with safe fallbacks, swaps the icon-font glyphs for the matching `@wordpress/icons` SVGs (shipping → `shipping`, fee → `currency-dollar`, refund → `undo`) painted via `mask-image`, tightens the bottom action bar to flexbox with the primary "Recalculate" pushed right, and vertically centers the icon thumb with the row label on shipping/fee/refund rows.

All rules are scoped to `.woocommerce-feature-enabled-order-detail-redesign` so orders without the `order-detail-redesign` feature enabled see no change. Each token-using rule uses `var(--wpds-…, fallback)` so the design holds even where WP DS tokens aren't loaded.

### Screenshots or screen recordings:

### BEFORE
<img width="3600" height="2086" alt="BEFORE-ITEMS" src="https://github.com/user-attachments/assets/37cf8ae1-7d53-4454-b312-2418184e7779" />

### AFTER
<img width="3600" height="2086" alt="AFTER-ITEMS" src="https://github.com/user-attachments/assets/91112899-8d7d-4416-b4b9-b926353dcc6c" />


### How to test the changes in this Pull Request:

1. Enable the `order-detail-redesign` feature flag (Tools → Features in wp-admin, or set it in the database).
2. Open an existing order on the Order edit screen with at least one product line item (preferably with a SKU and a variation), one shipping line, one fee line, and one refund row.
3. Confirm the product name reads visually heavier than `SKU:` / `Variation ID:`, and the meta labels are no longer bold.
4. Confirm the shipping row shows the WP DS truck icon, the fee row shows the `$`-in-circle icon, and the refund row shows the curved undo arrow.
5. Confirm the icon thumb on shipping/fee/refund rows is vertically centered with the row label.
6. Confirm column headers (Item / Cost / Qty / Total) render in the lighter, smaller WP DS-aligned style.
7. Confirm the bottom action bar groups Add item(s) / Apply coupon / Refund on the left and pushes Recalculate flush right, with even spacing.
8. Disable the feature flag and reload — every change above should disappear and the legacy rendering should return.

### Testing that has already taken place:

Manually verified on a local Studio site against an order containing product items, a shipping line, and a fee. Visual diff confirmed the new typography hierarchy and WP DS icon set. CSS rebuilt via `pnpm build:classic-assets`; compiled `assets/css/admin.css` confirmed every new token and selector is prefixed by `.woocommerce-feature-enabled-order-detail-redesign`.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry.

The changelog file was created manually at `plugins/woocommerce/changelog/order-detail-items-polish`.