### PR TITLE
Update REST API documentation links to new location

### DIFF
--- a/.github/workflows/pr-highlight-rest-api-changes.yml
+++ b/.github/workflows/pr-highlight-rest-api-changes.yml
@@ -52,5 +52,5 @@ jobs:
               issue_number: context.payload.pull_request.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ **API Documentation Reminder**\n\nHi @${{ github.event.pull_request.user.login }}! Your PR contains REST API changes. Please consider updating the [REST API documentation](https://github.com/woocommerce/woocommerce-rest-api-docs) if your changes affect the public API.\n\nChanged API files:\n```\n${{ join(fromJson(steps.filter.outputs.rest_files || '[]'), '\n') }}\n```'
+              body: '⚠️ **API Documentation Reminder**\n\nHi @${{ github.event.pull_request.user.login }}! Your PR contains REST API changes. Please consider updating the [REST API documentation](https://github.com/woocommerce/woocommerce/tree/trunk/docs/apis/rest-api) if your changes affect the public API.\n\nChanged API files:\n```\n${{ join(fromJson(steps.filter.outputs.rest_files || '[]'), '\n') }}\n```'
             });

--- a/packages/js/components/src/order-status/README.md
+++ b/packages/js/components/src/order-status/README.md
@@ -15,6 +15,6 @@ const order = { status: 'processing' }; // Use a real WooCommerce Order here.
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-`order` | Object | `null` | (required) The order to display a status for. See: https://woocommerce.github.io/woocommerce-rest-api-docs/#order-properties
+`order` | Object | `null` | (required) The order to display a status for. See: https://developer.woocommerce.com/docs/apis/rest-api/v3/orders/#order-properties
 `className` | String | `null` | Additional CSS classes
 `orderStatusMap` | Object | {} | A map of order status to human-friendly label.

--- a/packages/js/components/src/product-image/README.md
+++ b/packages/js/components/src/product-image/README.md
@@ -27,5 +27,5 @@ Name | Type | Default | Description
 `width` | Number | `60` | The width of image to display
 `height` | Number | `60` | The height of image to display
 `className` | String | `''` | Additional CSS classes
-`product` | Object | `null` | Product or variation object. The image to display will be pulled from `product.images` or `variation.image`. See https://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties and https://woocommerce.github.io/woocommerce-rest-api-docs/#product-variation-properties
+`product` | Object | `null` | Product or variation object. The image to display will be pulled from `product.images` or `variation.image`. See https://developer.woocommerce.com/docs/apis/rest-api/v3/products/#product-properties and https://developer.woocommerce.com/docs/apis/rest-api/v3/product-variations/#product-variation-properties
 `alt` | String | `null` | Text to use as the image alt attribute

--- a/packages/js/components/src/product-image/index.tsx
+++ b/packages/js/components/src/product-image/index.tsx
@@ -19,8 +19,8 @@ type ProductImageProps = {
 	/**
 	 * Product or variation object. The image to display will be pulled from
 	 * `product.images` or `variation.image`.
-	 * See https://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties
-	 * and https://woocommerce.github.io/woocommerce-rest-api-docs/#product-variation-properties
+	 * See https://developer.woocommerce.com/docs/apis/rest-api/v3/products/#product-properties
+	 * and https://developer.woocommerce.com/docs/apis/rest-api/v3/product-variations/#product-variation-properties
 	 */
 	product?: {
 		images?: Array< Image >;

--- a/packages/js/components/src/rating/README.md
+++ b/packages/js/components/src/rating/README.md
@@ -38,7 +38,7 @@ const product = { average_rating: 3.5 };
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-`product` | Object | `null` | (required) A product object containing a `average_rating`. See https://woocommerce.github.io/woocommerce-rest-api-docs/#products
+`product` | Object | `null` | (required) A product object containing a `average_rating`. See https://developer.woocommerce.com/docs/apis/rest-api/v3/products/
 
 
 ReviewRating
@@ -59,4 +59,4 @@ const review = { rating: 5 };
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-`review` | Object | `null` | (required) A review object containing a `rating`. See https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-product-reviews
+`review` | Object | `null` | (required) A review object containing a `rating`. See https://developer.woocommerce.com/docs/apis/rest-api/v3/product-reviews/#retrieve-a-product-review

--- a/packages/js/components/src/rating/review.tsx
+++ b/packages/js/components/src/rating/review.tsx
@@ -11,7 +11,7 @@ import Rating from './index';
 type ReviewRatingProps = {
 	/**
 	 * A review object containing a `rating`.
-	 * See https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-product-reviews.
+	 * See https://developer.woocommerce.com/docs/apis/rest-api/v3/product-reviews/#retrieve-a-product-review.
 	 */
 	review: {
 		rating?: number;

--- a/packages/js/data/src/product-categories/README.md
+++ b/packages/js/data/src/product-categories/README.md
@@ -1,6 +1,6 @@
 # Product Categories Data Store
 
-This data store provides functions to interact with the [Product Category REST endpoints](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-categories).
+This data store provides functions to interact with the [Product Category REST endpoints](https://developer.woocommerce.com/docs/apis/rest-api/v3/product-categories/).
 Under the hood this data store makes use of the [CRUD data store](../crud/README.md).
 
 **Note: This data store is listed as experimental still as it is still in active development.**

--- a/packages/js/data/src/product-shipping-classes/README.md
+++ b/packages/js/data/src/product-shipping-classes/README.md
@@ -1,6 +1,6 @@
 # Product Shipping Classes Data Store
 
-This data store provides functions to interact with the [Product Shipping Class REST endpoints](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-shipping-classes).
+This data store provides functions to interact with the [Product Shipping Class REST endpoints](https://developer.woocommerce.com/docs/apis/rest-api/v3/product-shipping-classes/).
 Under the hood this data store makes use of the [CRUD data store](../crud/README.md).
 
 **Note: This data store is listed as experimental still as it is still in active development.**

--- a/packages/js/data/src/shipping-zones/README.md
+++ b/packages/js/data/src/shipping-zones/README.md
@@ -1,6 +1,6 @@
 # Shipping Zones Data Store
 
-This data store provides functions to interact with the [Shipping Zones REST endpoints](https://woocommerce.github.io/woocommerce-rest-api-docs/#shipping-zones).
+This data store provides functions to interact with the [Shipping Zones REST endpoints](https://developer.woocommerce.com/docs/apis/rest-api/v3/shipping-zones/).
 Under the hood this data store makes use of the [CRUD data store](../crud/README.md).
 
 **Note: This data store is listed as experimental still as it is still in active development.**

--- a/plugins/woocommerce/README.md
+++ b/plugins/woocommerce/README.md
@@ -96,7 +96,7 @@ PHPStan configuration is stored in `phpstan.neon` at the root of the plugin dire
 -   [WooCommerce Documentation](https://woocommerce.com/)
 -   [WooCommerce Developer Documentation](https://github.com/woocommerce/woocommerce/wiki)
 -   [WooCommerce Code Reference](https://woocommerce.com/wc-apidocs/)
--   [WooCommerce REST API Docs](https://woocommerce.github.io/woocommerce-rest-api-docs/)
+-   [WooCommerce REST API Docs](https://developer.woocommerce.com/docs/apis/rest-api/)
 
 ## A Note for Extension Developers
 

--- a/plugins/woocommerce/client/admin/client/utils/admin-settings.js
+++ b/plugins/woocommerce/client/admin/client/utils/admin-settings.js
@@ -27,7 +27,7 @@ export const deprecatedAdminProperties = {
 		profile:
 			'Deprecated: wcSettings.admin.onboarding.profile is deprecated. It is planned to be released in WooCommerce 10.0.0. Please use `getProfileItems` from the onboarding store. See https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/data/src/onboarding for more information.',
 		euCountries:
-			'Deprecated: wcSettings.admin.onboarding.euCountries is deprecated. Please use `/wc/v3/data/continents/eu` from the REST API. See https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-continents for more information.',
+			'Deprecated: wcSettings.admin.onboarding.euCountries is deprecated. Please use `/wc/v3/data/continents/eu` from the REST API. See https://developer.woocommerce.com/docs/apis/rest-api/v3/data/#list-all-continents for more information.',
 		localInfo:
 			'Deprecated: wcSettings.admin.onboarding.localInfo is deprecated. Please use `include WC()->plugin_path() . "/i18n/locale-info.php"` instead.',
 		currencySymbols:

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -132,7 +132,7 @@ Yes, you can! Join in on our [GitHub repository](https://github.com/woocommerce/
 
 = Where can I find REST API documentation? =
 
-Extensive [WooCommerce REST API Documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/?utm_medium=referral&utm_source=wordpress.org&utm_campaign=wp_org_repo_listing) is available on GitHub.
+Extensive [WooCommerce REST API Documentation](https://developer.woocommerce.com/docs/apis/rest-api/?utm_medium=referral&utm_source=wordpress.org&utm_campaign=wp_org_repo_listing) is available.
 
 = My question is not listed here. Where can I find more answers? =
 

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -5,7 +5,7 @@
  * Handles requests to get and update options in the wp_options table.
  *
  * IMPORTANT: This API is for legacy support only. DO NOT add new options here. See p90Yrv-2vK-p2#comment-6482 for more details.
- * For new settings/options, use Settings REST API (https://woocommerce.github.io/woocommerce-rest-api-docs/#setting-option-properties) or create dedicated endpoints instead.
+ * For new settings/options, use Settings REST API (https://developer.woocommerce.com/docs/apis/rest-api/v3/setting-options/#setting-option-properties) or create dedicated endpoints instead.
  *
  * Example:
  * - Use register_rest_route() to create a new endpoint

--- a/plugins/woocommerce/tests/e2e-pw/data/coupon.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/coupon.ts
@@ -3,7 +3,7 @@
  *
  * For more details on a coupon's properties, see:
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#coupons
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/coupons/
  *
  */
 export const coupon = {

--- a/plugins/woocommerce/tests/e2e-pw/data/order.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/order.ts
@@ -12,7 +12,7 @@ import {
  *
  * For more details on the order properties, see:
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#order-properties
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/orders/#order-properties
  */
 export const order = {
 	payment_method: '',

--- a/plugins/woocommerce/tests/e2e-pw/data/products-crud.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/products-crud.ts
@@ -3,7 +3,7 @@
  *
  * For more details on the Product properties, see:
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#products
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/products/
  *
  */
 

--- a/plugins/woocommerce/tests/e2e-pw/data/refund.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/refund.ts
@@ -3,7 +3,7 @@
  *
  * For more details on the order refund properties, see:
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#order-refund-properties
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/order-refunds/#order-refund-properties
  *
  */
 export const refund = {

--- a/plugins/woocommerce/tests/e2e-pw/data/settings.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/settings.ts
@@ -3,7 +3,7 @@
  *
  * For more details on settings properties, see:
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#settings
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/settings/
  *
  */
 

--- a/plugins/woocommerce/tests/e2e-pw/data/shared/customer.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/shared/customer.ts
@@ -2,8 +2,8 @@
  * Customer billing object.
  *
  * Used in the following APIs:
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#customers
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#orders
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/customers/
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/orders/
  */
 export const customerBilling = {
 	first_name: 'John',
@@ -37,8 +37,8 @@ export const customerBillingSearchTest = {
  * Customer shipping object.
  *
  * Used in the following APIs:
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#customers
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#orders
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/customers/
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/orders/
  */
 export const customerShipping = {
 	first_name: 'Tim',

--- a/plugins/woocommerce/tests/e2e-pw/data/shared/error-response.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/shared/error-response.ts
@@ -1,7 +1,7 @@
 /**
  * API error response format
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#errors
+ * https://developer.woocommerce.com/docs/apis/rest-api/#errors
  */
 export const errorResponse = {
 	code: '',

--- a/plugins/woocommerce/tests/e2e-pw/data/shipping-zone.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/shipping-zone.ts
@@ -3,7 +3,7 @@
  *
  * For more details on shipping zone properties, see:
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#shipping-zone-properties
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/shipping-zones/#shipping-zone-properties
  *
  */
 const shippingZone = {

--- a/plugins/woocommerce/tests/e2e-pw/data/tax-rate.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/tax-rate.ts
@@ -3,7 +3,7 @@
  *
  * For more details on the tax rate properties, see:
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#tax-rate-properties
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/taxes/#tax-rate-properties
  *
  */
 const standardTaxRate = {

--- a/plugins/woocommerce/tests/e2e-pw/data/variation.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/variation.ts
@@ -3,7 +3,7 @@
  *
  * For more details on the product variation properties, see:
  *
- * https://woocommerce.github.io/woocommerce-rest-api-docs/#product-variations
+ * https://developer.woocommerce.com/docs/apis/rest-api/v3/product-variations/
  *
  */
 const variation = {

--- a/plugins/woocommerce/tests/e2e-pw/utils/api.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/api.ts
@@ -133,9 +133,9 @@ export const create = {
 	/**
 	 * Batch create product variations.
 	 *
-	 * @see {@link [Batch update product variations](https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-product-variations)}
+	 * @see {@link [Batch update product variations](https://developer.woocommerce.com/docs/apis/rest-api/v3/product-variations/#batch-update-product-variations)}
 	 * @param {number|string} productId  Product ID to add variations to
-	 * @param {object[]}      variations Array of variations to add. See [Product variation properties](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-variation-properties)
+	 * @param {object[]}      variations Array of variations to add. See [Product variation properties](https://developer.woocommerce.com/docs/apis/rest-api/v3/product-variations/#product-variation-properties)
 	 * @return {Promise<number[]>} Array of variation ID's.
 	 */
 	productVariations: async (

--- a/plugins/woocommerce/tests/e2e-pw/utils/variable-products.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/variable-products.ts
@@ -28,7 +28,7 @@ const productIds: number[] = [];
 /**
  * The `attributes` property to be used in the request payload for creating a variable product through the REST API.
  *
- * @see {@link [Product - Attributes properties](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-attributes-properties)}
+ * @see {@link [Product - Attributes properties](https://developer.woocommerce.com/docs/apis/rest-api/v3/products/#product---attributes-properties)}
  */
 const productAttributes = [
 	{
@@ -54,7 +54,7 @@ const productAttributes = [
 /**
  * Request payload for creating variations.
  *
- * @see {@link [Product variation properties](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-variation-properties)}
+ * @see {@link [Product variation properties](https://developer.woocommerce.com/docs/apis/rest-api/v3/product-variations/#product-variation-properties)}
  */
 const sampleVariations = [
 	{
@@ -113,7 +113,7 @@ const sampleVariations = [
 /**
  * Create a variable product using the WooCommerce REST API.
  *
- * @param {{ name: string, visible: boolean, variation: boolean, options: string[] }[]} attributes List of attributes. See [Product - Attributes properties](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-attributes-properties).
+ * @param {{ name: string, visible: boolean, variation: boolean, options: string[] }[]} attributes List of attributes. See [Product - Attributes properties](https://developer.woocommerce.com/docs/apis/rest-api/v3/products/#product---attributes-properties).
  * @return {Promise<number>} ID of the created variable product
  */
 async function createVariableProduct( attributes: ProductAttribute[] = [] ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The REST API documentation was migrated from `woocommerce.github.io/woocommerce-rest-api-docs` to `developer.woocommerce.com/docs/apis/rest-api/`. This PR updates all internal references to point to the new location, mapping old anchor links (e.g., `#products`, `#order-properties`) to their corresponding new page URLs (e.g., `/v3/products/`, `/v3/orders/#order-properties`).

Updates include READMEs, JSDoc comments, PHP docblocks, e2e test data files, and the PR automation workflow that reminds contributors to update API docs.