### PR TITLE
[Backport to release/10.8] Stamp three-way diff base meta and backfilled flag

### DIFF
--- a/plugins/woocommerce/changelog/64716-rsm-three-way-diff-base-meta-backport
+++ b/plugins/woocommerce/changelog/64716-rsm-three-way-diff-base-meta-backport
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Stamp the new `_wc_email_template_last_core_render` and `_wc_email_backfilled` post meta during email template sync so 10.9's three-way diff change-summary has a base reference on 10.8-era posts.

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetector.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateDivergenceDetector.php
@@ -72,6 +72,29 @@ class WCEmailTemplateDivergenceDetector {
 	public const LAST_SYNCED_AT_META_KEY = '_wc_email_last_synced_at';
 
 	/**
+	 * Post meta key for the canonical core render at the moment of the last
+	 * system write. Stamped by the generator and the RSM-149 backfill so that
+	 * the three-way diff change-summary shipping in 10.9 has a `base` reference
+	 * to compare against on existing 10.8-era posts. Forward-compatible: 10.8
+	 * has no consumer for this meta yet.
+	 *
+	 * @var string
+	 * @since 10.8.0
+	 */
+	public const LAST_CORE_RENDER_META_KEY = '_wc_email_template_last_core_render';
+
+	/**
+	 * Informational flag set to `true` by the RSM-149 backfill on every existing
+	 * `woo_email` post it stamps. Lets later release Tracks instrumentation
+	 * (RSM-145, shipping in 10.9) distinguish backfilled posts from natively
+	 * generated ones.
+	 *
+	 * @var string
+	 * @since 10.8.0
+	 */
+	public const BACKFILLED_META_KEY = '_wc_email_backfilled';
+
+	/**
 	 * Classification outcomes.
 	 */
 	public const STATUS_IN_SYNC                   = 'in_sync';

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateSyncBackfill.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailTemplateSyncBackfill.php
@@ -301,6 +301,15 @@ class WCEmailTemplateSyncBackfill {
 		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, $current_core_hash );
 		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, gmdate( 'Y-m-d H:i:s' ) );
 		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::STATUS_META_KEY, $status_for_stamp );
+		// Snapshot the canonical core render alongside the source hash so the
+		// three-way diff change-summary shipping in 10.9 has a `base` reference
+		// to compare against on existing 10.8-era posts. Forward-compatible:
+		// 10.8 has no consumer for this meta yet.
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::LAST_CORE_RENDER_META_KEY, $canonical_post_content );
+		// Mark the post as backfilled so later release Tracks instrumentation
+		// (RSM-145, shipping in 10.9) can distinguish backfilled posts from
+		// natively generated ones.
+		update_post_meta( $post_id, WCEmailTemplateDivergenceDetector::BACKFILLED_META_KEY, true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
@@ -404,9 +404,10 @@ class WCTransactionalEmailPostsGenerator {
 			if ( ! isset( $post_data['meta_input'] ) || ! is_array( $post_data['meta_input'] ) ) {
 				$post_data['meta_input'] = array();
 			}
-			$post_data['meta_input'][ WCEmailTemplateDivergenceDetector::VERSION_META_KEY ]        = (string) $sync_config['version'];
-			$post_data['meta_input'][ WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY ]    = sha1( (string) ( $post_data['post_content'] ?? '' ) );
-			$post_data['meta_input'][ WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY ] = gmdate( 'Y-m-d H:i:s' );
+			$post_data['meta_input'][ WCEmailTemplateDivergenceDetector::VERSION_META_KEY ]          = (string) $sync_config['version'];
+			$post_data['meta_input'][ WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY ]      = sha1( (string) ( $post_data['post_content'] ?? '' ) );
+			$post_data['meta_input'][ WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY ]   = gmdate( 'Y-m-d H:i:s' );
+			$post_data['meta_input'][ WCEmailTemplateDivergenceDetector::LAST_CORE_RENDER_META_KEY ] = (string) ( $post_data['post_content'] ?? '' );
 		}
 
 		$post_id = wp_insert_post( $post_data, true );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Backports just the meta-stamping bits from #64716 (commit `635b31f32e`) and #64675 (commit `59bd05c1`) onto `release/10.8`. The full three-way diff PR can't go on 10.8 because the consumers it talks to — change-summary, selective applier, auto-applier — don't exist on this release branch. They ship in 10.9.

What goes in:

- A new constant `LAST_CORE_RENDER_META_KEY` and a new constant `BACKFILLED_META_KEY` on `WCEmailTemplateDivergenceDetector`.
- The generator stamps `_wc_email_template_last_core_render` for every sync-eligible email when it creates the post.
- The RSM-149 backfill stamps `_wc_email_template_last_core_render` and sets `_wc_email_backfilled` to `true` on every legacy post it touches.

### Why this has to ship in 10.8 specifically:

The RSM-149 backfill is one-shot per site. It runs when the site picks up the 10.8 db-update, flips `woocommerce_email_template_sync_backfill_complete` to `yes`, and never runs again — including across future upgrades.

If we wait and only ship the new stamps in 10.9:

- Sites that ran the backfill on 10.8 will have the original four sync metas (`source_hash`, `version`, `last_synced_at`, `status`) but no `last_core_render` and no `backfilled`. The backfill won't re-run on 10.9 to stamp them.
- The 10.9 three-way diff will look up `_wc_email_template_last_core_render` on those legacy posts, find nothing, and fall back to the 2-way diff — which is exactly the inversion-buggy path #64716 was opened to replace.
- The 10.9 RSM-145 Tracks instrumentation has no way to tell backfilled posts apart from natively generated ones.

Stamping these metas on the 10.8 generator and backfill closes that gap before any 10.8 site picks up 10.9. Both metas are write-only on 10.8 — nothing reads them here — so the change is forward-compat plumbing only and safe on a patch release.

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install`.
2. Boot a fresh wp-env: `pnpm --filter=@woocommerce/plugin-woocommerce env:start`.
3. Confirm `WC_PLUGIN_FILE` reports the 10.8 series.
4. Visit the email editor at `/wp-admin/admin.php?page=wc-settings&tab=email` and let WooCommerce generate the default `woo_email` posts.
5. In `wp-cli`, pick a generated post (e.g. customer order email) and run:
   ```
   wp post meta list <post_id> --keys=_wc_email_template_last_core_render,_wc_email_template_source_hash,_wc_email_last_synced_at,_wc_email_template_version
   ```
   Expected: all four meta keys are present. `_wc_email_template_last_core_render` should equal the post's `post_content`.
6. To exercise the backfill, drop the four meta keys from the post and run the RSM-149 migration callback (`WCEmailTemplateSyncBackfill::run()`).
   ```
   wp eval 'Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncBackfill::run();'
   ```
   Expected: the four sync meta keys come back, plus `_wc_email_template_last_core_render` and `_wc_email_backfilled` (`1`).

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse` on all three modified files — `[OK] No errors`.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — PHP clean.
- PHPUnit not run on this worktree (the trunk worktree's wp-env was already bound to the standard ports). The patches are byte-identical to the merged trunk versions, which were exercised by #64716's test suite.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually as `plugins/woocommerce/changelog/64716-rsm-three-way-diff-base-meta-backport`.

</details>