### PR TITLE
RSM: Add Remove icon and variation overlay to Shopper Collection items

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, SelectControl } from '@wordpress/components';
+import { Icon, trash } from '@wordpress/icons';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
 
 interface ShopperCollectionAttributes {
@@ -115,15 +116,26 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 							>
 								<img src={ PLACEHOLDER_IMG_SRC } alt="" />
 							</a>
-							<div className="wc-block-components-product-image__inner-container">
-								<button
-									type="button"
-									className="wc-block-shopper-collection-item__remove"
-									disabled
-								>
-									{ __( 'Remove', 'woocommerce' ) }
-								</button>
-							</div>
+							<button
+								type="button"
+								className="wc-block-shopper-collection-item__remove"
+								aria-label={ sprintf(
+									/* translators: %s: product name. */
+									__(
+										'Remove %s from Saved for later list',
+										'woocommerce'
+									),
+									item.name
+								) }
+								disabled
+							>
+								<Icon icon={ trash } size={ 24 } />
+							</button>
+							{ item.variation && (
+								<span className="wc-block-shopper-collection-item__variation">
+									{ item.variation }
+								</span>
+							) }
 						</div>
 						<h2 className="wp-block-post-title has-text-align-center has-medium-font-size">
 							<a
@@ -133,11 +145,6 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 								{ item.name }
 							</a>
 						</h2>
-						{ item.variation && (
-							<span className="wc-block-shopper-collection-item__variation">
-								{ item.variation }
-							</span>
-						) }
 						<div className="price wc-block-components-product-price has-text-align-center has-small-font-size">
 							<span className="wc-block-components-product-price__value">
 								{ item.price }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
@@ -31,10 +31,9 @@
 		margin: 0 0 0.75rem;
 	}
 
-	// Variation and quantity have no atomic equivalent in Product Collection,
-	// so we own their styling. Center-aligned and small to mirror the rest
-	// of the row (price + button use the WP `has-small-font-size` preset).
-	&__variation,
+	// Quantity has no atomic equivalent in Product Collection, so we own
+	// its styling. Center-aligned and small to mirror the rest of the row
+	// (price + button use the WP `has-small-font-size` preset).
 	&__quantity {
 		color: rgba(0, 0, 0, 0.7);
 		display: block;
@@ -42,30 +41,62 @@
 		text-align: center;
 	}
 
-	// Remove button overlays the image (mirrors Product Collection's
-	// sale-badge slot — top-right corner inside the product-image wrapper).
-	// Positioned absolute with align-self: flex-end so the parent's
-	// __inner-container flex layout pushes it to the right edge.
-	&__remove {
-		align-self: flex-end;
-		appearance: none;
-		background: rgba(0, 0, 0, 0.65);
-		border: 0;
-		border-radius: 999px;
-		color: #fff;
-		cursor: pointer;
-		font-size: var(--wp--preset--font-size--small, 0.75em);
-		line-height: 1;
-		padding: 0.4em 0.75em;
+	// Variation overlay sits at the bottom of the image and shares the
+	// remove badge's border/background/radius so the two corner overlays
+	// read as a pair. Spans the full image width (with the same 4px inset
+	// the remove badge uses on top/right) and is only rendered for
+	// variation products, so when absent the image isn't pushed around.
+	&__variation {
+		background: #fff;
+		border: 1px solid #43454b;
+		border-radius: 4px;
+		bottom: 4px;
+		box-sizing: border-box;
+		color: #43454b;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		left: 4px;
+		padding: 0.25em 0.75em;
+		position: absolute;
+		right: 4px;
+		text-align: center;
 		z-index: 10;
+	}
+
+	// Icon-only Remove button overlaying the image. Visually mirrors the
+	// `wc-block-components-product-sale-badge--align-right` overlay (same
+	// border, radius, colors, white fill, top-right inset over the image)
+	// so it reads as a corner badge. Symmetric padding keeps the hit
+	// area square. Hover inverts the colors for a clear affordance.
+	&__remove {
+		appearance: none;
+		background: #fff;
+		border: 1px solid #43454b;
+		border-radius: 4px;
+		box-sizing: border-box;
+		color: #43454b;
+		cursor: pointer;
+		display: block;
+		line-height: 0;
+		padding: 0.25em;
+		position: absolute;
+		right: 4px;
+		top: 4px;
+		transition: background-color 120ms ease, color 120ms ease;
+		z-index: 10;
+
+		svg {
+			display: block;
+			fill: currentColor;
+		}
+
+		&:hover:not([disabled]) {
+			background: #43454b;
+			color: #fff;
+		}
 
 		&[disabled] {
 			cursor: not-allowed;
 			opacity: 0.7;
-		}
-
-		&:hover:not([disabled]) {
-			background: rgba(0, 0, 0, 0.85);
 		}
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
@@ -70,7 +70,7 @@
 	&__remove {
 		appearance: none;
 		background: #fff;
-		border: 1px solid #43454b;
+		border: 1px solid #fff;
 		border-radius: 4px;
 		box-sizing: border-box;
 		color: #43454b;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
@@ -94,6 +94,17 @@
 			color: #fff;
 		}
 
+		// Keyboard focus indicator. The default :focus-visible ring would
+		// land on a transparent border against the white badge body and
+		// be invisible, so paint our own — outline (so it sits outside the
+		// border without nudging layout) plus a soft offset to keep it
+		// readable over both the badge body and the product image behind
+		// it. Not applied to :hover-only — pointer users keep the invert.
+		&:focus-visible:not([disabled]) {
+			outline: 2px solid #43454b;
+			outline-offset: 1px;
+		}
+
 		&[disabled] {
 			cursor: not-allowed;
 			opacity: 0.7;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -94,7 +94,7 @@
 	&__remove {
 		appearance: none;
 		background: #fff;
-		border: 1px solid #43454b;
+		border: 1px solid #fff;
 		border-radius: 4px;
 		box-sizing: border-box;
 		color: #43454b;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -118,6 +118,17 @@
 			color: #fff;
 		}
 
+		// Keyboard focus indicator. The default :focus-visible ring would
+		// land on a transparent border against the white badge body and
+		// be invisible, so paint our own — outline (so it sits outside the
+		// border without nudging layout) plus a soft offset to keep it
+		// readable over both the badge body and the product image behind
+		// it. Not applied to :hover-only — pointer users keep the invert.
+		&:focus-visible:not([disabled]) {
+			outline: 2px solid #43454b;
+			outline-offset: 1px;
+		}
+
 		&[disabled] {
 			cursor: not-allowed;
 			opacity: 0.7;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -1,30 +1,16 @@
 // Frontend stylesheet for the Shopper Collection block.
 // Diverges from `editor.scss` because the editor canvas loads the
 // WooCommerce atomic block stylesheet for free (which provides image
-// sizing, the relative/absolute positioning for the remove-button
-// overlay, etc.); the frontend only ships this block's CSS, so anything
-// the layout depends on has to live here. If we add pieces to
-// editor.scss that the frontend also needs, mirror them here too —
-// keep the visual result aligned.
+// sizing for the borrowed `.wc-block-components-product-image` class);
+// the frontend only ships this block's CSS, so anything the layout
+// depends on has to live here. If we add pieces to editor.scss that
+// the frontend also needs, mirror them here too — keep the visual
+// result aligned.
 // TODO: revisit how this block depends on atomic-block CSS. We currently
-// borrow `.wc-block-components-product-image` / `__inner-container` from
-// the product-image atomic block. Product Collection avoids this problem
-// by *rendering* the atomic blocks as inner blocks, so WordPress
-// auto-enqueues their stylesheets — we don't, so we have to handle it
-// ourselves. Three options:
-//   1. (current) Duplicate the rules we need into this file.
-//      Self-contained but drifts if atomic styles change upstream.
-//   2. Enqueue the atomic image stylesheet from ShopperCollection.php
-//      (e.g. `wp_enqueue_style( 'wc-block-product-elements-image' )` —
-//      verify the actual handle in the build). Zero duplication, but
-//      pulls in the whole atomic stylesheet for a few rules.
-//   3. Stop borrowing atomic classes — give our markup its own
-//      block-local classes (e.g. `wc-block-shopper-collection-item__image`,
-//      `__image-link`) and own all the styling. Cleanest ownership, but
-//      requires a small template rewrite.
-// Option 1 is the lightest while we only borrow two classes; switch to
-// option 2 if we end up borrowing more, or option 3 if a future
-// variation needs different image/overlay behaviour.
+// borrow `.wc-block-components-product-image` from the product-image
+// atomic block. Product Collection avoids this problem by *rendering*
+// the atomic blocks as inner blocks, so WordPress auto-enqueues their
+// stylesheets — we don't, so we have to handle it ourselves.
 
 .wc-block-shopper-collection {
 	display: grid;
@@ -46,7 +32,7 @@
 	// `.wc-block-components-product-image` is normally styled by the
 	// atomic-block stylesheet. Reproduce just enough here so the
 	// image fills its column track and acts as a positioning anchor
-	// for the remove-button overlay.
+	// for the remove-button badge overlay.
 	.wc-block-components-product-image {
 		display: block;
 		margin: 0;
@@ -60,18 +46,6 @@
 		}
 	}
 
-	// The remove button lives inside `__inner-container` which the
-	// atomic stylesheet positions absolutely in the top-right of the
-	// image. Replicate that here so the button overlays rather than
-	// stacking below the thumbnail.
-	.wc-block-components-product-image__inner-container {
-		padding: 0.5em;
-		position: absolute;
-		right: 0;
-		top: 0;
-		z-index: 10;
-	}
-
 	// Title spacing/line-height matches Product Collection's default
 	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
 	// We target wp-block-post-title (core's post-title class) because the
@@ -81,10 +55,9 @@
 		margin: 0 0 0.75rem;
 	}
 
-	// Variation and quantity have no atomic equivalent in Product Collection,
-	// so we own their styling. Center-aligned and small to mirror the rest
-	// of the row (price + button use the WP `has-small-font-size` preset).
-	&__variation,
+	// Quantity has no atomic equivalent in Product Collection, so we own
+	// its styling. Center-aligned and small to mirror the rest of the row
+	// (price + button use the WP `has-small-font-size` preset).
 	&__quantity {
 		color: rgba(0, 0, 0, 0.7);
 		display: block;
@@ -92,27 +65,62 @@
 		text-align: center;
 	}
 
-	// The remove button is centered inside `__inner-container`, which is
-	// itself absolutely positioned over the image. No alignment hacks
-	// needed here; just style the pill.
+	// Variation overlay sits at the bottom of the image and shares the
+	// remove badge's border/background/radius so the two corner overlays
+	// read as a pair. Spans the full image width (with the same 4px inset
+	// the remove badge uses on top/right) and is only rendered for
+	// variation products, so when absent the image isn't pushed around.
+	&__variation {
+		background: #fff;
+		border: 1px solid #43454b;
+		border-radius: 4px;
+		bottom: 4px;
+		box-sizing: border-box;
+		color: #43454b;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		left: 4px;
+		padding: 0.25em 0.75em;
+		position: absolute;
+		right: 4px;
+		text-align: center;
+		z-index: 10;
+	}
+
+	// Icon-only Remove button overlaying the image. Visually mirrors the
+	// `wc-block-components-product-sale-badge--align-right` overlay (same
+	// border, radius, colors, white fill, top-right inset over the image)
+	// so it reads as a corner badge. Symmetric padding keeps the hit
+	// area square. Hover inverts the colors for a clear affordance.
 	&__remove {
 		appearance: none;
-		background: rgba(0, 0, 0, 0.65);
-		border: 0;
-		border-radius: 999px;
-		color: #fff;
+		background: #fff;
+		border: 1px solid #43454b;
+		border-radius: 4px;
+		box-sizing: border-box;
+		color: #43454b;
 		cursor: pointer;
-		font-size: var(--wp--preset--font-size--small, 0.75em);
-		line-height: 1;
-		padding: 0.4em 0.75em;
+		display: block;
+		line-height: 0;
+		padding: 0.25em;
+		position: absolute;
+		right: 4px;
+		top: 4px;
+		transition: background-color 120ms ease, color 120ms ease;
+		z-index: 10;
+
+		svg {
+			display: block;
+			fill: currentColor;
+		}
+
+		&:hover:not([disabled]) {
+			background: #43454b;
+			color: #fff;
+		}
 
 		&[disabled] {
 			cursor: not-allowed;
 			opacity: 0.7;
-		}
-
-		&:hover:not([disabled]) {
-			background: rgba(0, 0, 0, 0.85);
 		}
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -158,9 +158,8 @@ final class ShopperCollection extends AbstractBlock {
 		return array(
 			'modifierSlug'          => 'saved-for-later',
 			'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
-			'removeButtonLabel'     => __( 'Remove', 'woocommerce' ),
 			/* translators: %s: product name. */
-			'removeLabelTemplate'   => __( 'Remove %s from saved items', 'woocommerce' ),
+			'removeLabelTemplate'   => __( 'Remove %s from Saved for later list', 'woocommerce' ),
 			/* translators: %d: quantity of saved items. */
 			'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
 			'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
@@ -251,21 +250,19 @@ final class ShopperCollection extends AbstractBlock {
 					<a data-wp-bind--href="context.listItem.permalink">
 						<span class="wc-block-shopper-collection-item__image-slot" data-wp-context='{"htmlField":"image_html"}' data-wp-watch="callbacks.updateInnerHtml"></span>
 					</a>
-					<div class="wc-block-components-product-image__inner-container">
-						<button
-							type="button"
-							class="wc-block-shopper-collection-item__remove"
-							data-wp-on--click="actions.onClickRemove"
-							data-wp-bind--aria-label="state.currentItemRemoveLabel"
-						>
-							<?php echo esc_html( $variation['removeButtonLabel'] ); ?>
-						</button>
-					</div>
+					<button
+						type="button"
+						class="wc-block-shopper-collection-item__remove"
+						data-wp-on--click="actions.onClickRemove"
+						data-wp-bind--aria-label="state.currentItemRemoveLabel"
+					>
+						<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
+					</button>
+					<span class="wc-block-shopper-collection-item__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
 				</div>
 				<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
 					<a data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"></a>
 				</h2>
-				<span class="wc-block-shopper-collection-item__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
 				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="state.isPriceHidden" data-wp-context='{"htmlField":"price_html"}' data-wp-watch="callbacks.updateInnerHtml"></div>
 				<span class="wc-block-shopper-collection-item__quantity" data-wp-text="state.currentItemQuantityLabel"></span>
 				<?php if ( ! empty( $variation['showAction'] ) ) : ?>
@@ -361,17 +358,18 @@ final class ShopperCollection extends AbstractBlock {
 						<?php echo wp_kses_post( $image_html ); ?>
 					</span>
 				</a>
-				<div class="wc-block-components-product-image__inner-container">
-					<button
-						type="button"
-						class="wc-block-shopper-collection-item__remove"
-						aria-label="<?php echo esc_attr( $remove_aria ); ?>"
-						data-wp-on--click="actions.onClickRemove"
-						data-wp-bind--aria-label="state.currentItemRemoveLabel"
-					>
-						<?php echo esc_html( $variation['removeButtonLabel'] ); ?>
-					</button>
-				</div>
+				<button
+					type="button"
+					class="wc-block-shopper-collection-item__remove"
+					aria-label="<?php echo esc_attr( $remove_aria ); ?>"
+					data-wp-on--click="actions.onClickRemove"
+					data-wp-bind--aria-label="state.currentItemRemoveLabel"
+				>
+					<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
+				</button>
+				<?php if ( '' !== $variation_label ) : ?>
+					<span class="wc-block-shopper-collection-item__variation"><?php echo esc_html( $variation_label ); ?></span>
+				<?php endif; ?>
 			</div>
 			<?php
 			// Render the decoded display name as plain text so the SSR
@@ -384,9 +382,6 @@ final class ShopperCollection extends AbstractBlock {
 			<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
 				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
 			</h2>
-			<?php if ( '' !== $variation_label ) : ?>
-				<span class="wc-block-shopper-collection-item__variation"><?php echo esc_html( $variation_label ); ?></span>
-			<?php endif; ?>
 			<div
 				class="price wc-block-components-product-price has-text-align-center has-small-font-size"
 				data-wp-bind--hidden="state.isPriceHidden"
@@ -473,6 +468,19 @@ final class ShopperCollection extends AbstractBlock {
 	 */
 	private function render_error_markup(): string {
 		return '<li class="wc-block-shopper-collection__error" role="alert" data-wp-bind--hidden="!state.hasError" data-wp-text="state.errorMessage" hidden></li>';
+	}
+
+	/**
+	 * Markup for the trash icon used in the remove-item button. Mirrors the
+	 * `trash` icon from `@wordpress/icons` that the cart line item uses for
+	 * `wc-block-cart-item__remove-link`, inlined here so SSR first paint
+	 * matches what JS would render after hydration. `currentColor` lets the
+	 * surrounding badge wrapper drive the fill.
+	 *
+	 * @return string
+	 */
+	private function get_remove_icon_svg(): string {
+		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"/></svg>';
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The default Shopper Collection item layout used a generic dark "Remove" pill and rendered variation attributes as a plain caption under the title, which read more like body copy than a product overlay. This PR aligns both with the surrounding atomic-block visual language by:

- Replacing the Remove button label with the same `trash` icon used by `wc-block-cart-item__remove-link` in cart line items, framed as a square white badge anchored top-right of the product image (same border, radius, and 4px inset as `wc-block-components-product-sale-badge--align-right`). The button inverts to a dark fill on hover. The aria-label now reads "Remove [product name] from Saved for later list".
- Moving variation attributes (e.g. "Color: Blue, Size: M") into a matching overlay anchored to the bottom of the product image, full image width with the same 4px inset, only rendered when the item is a variation.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|    <img width="789" height="323" alt="Screenshot 2026-05-08 at 16 35 29" src="https://github.com/user-attachments/assets/263189d3-6784-4d88-9221-0186150a384e" />  |  <img width="823" height="295" alt="Screenshot 2026-05-08 at 16 28 48" src="https://github.com/user-attachments/assets/7020fa8e-350f-4db4-8141-58e39acd21e9" />   |

### How to test the changes in this Pull Request:

1. Check out this branch and start the dev environment.
2. Sign in as a customer and add a few products to **Saved for later** from the cart — include at least one variation product (e.g. a T-shirt with size/color attributes) and at least one simple product.
3. Visit a page that contains the **Shopper Collection** block (Saved for Later variation).
4. Confirm that each item shows a square Remove icon button in the top-right corner of the product image, with a white fill, white border (visually edgeless against the badge body), and the trash icon rendered in dark grey.
5. Hover the Remove icon — the background should fill dark with the icon switching to white. The transition should be smooth.
6. Inspect the Remove button and verify its `aria-label` reads `Remove <product name> from Saved for later list`.
7. Click Remove on one of the items — the row should disappear without a page reload.
8. For the variation product, confirm a full-width pill with the variation attributes (e.g. "Color: Blue, Size: M") sits over the bottom of the product image, with the same border, radius, and 4px inset as the Remove badge.
9. For the simple product, confirm no variation overlay is rendered.
10. Resize the window down to a single-column layout and confirm both overlays remain anchored correctly to the image (still 4px from their respective edges) and don't overflow.

### Testing that has already taken place:

Manual: Local visual check on the editor preview and on a populated Saved for Later list with simple + variation products. Lint: `pnpm lint:css` and `phpcs-changed` clean on touched files; PHPStan clean on `ShopperCollection.php`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR targets the `feature/shopper-collections` feature branch, which already carries the `add-shopper-collections-iapi-store` and `rsm-shopper-collections-add-storeapi-endpoints` changelog entries. The visual refinements in this PR will ship under those entries when the feature branch is merged to trunk.

</details>