### PR TITLE
Fix bulk quick edit behavior

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-quick-edit-bulk-selection
+++ b/packages/js/experimental-products-app/changelog/fix-quick-edit-bulk-selection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix quick edit bulk selection and hide unsupported SKU field in bulk edits.

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.test.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.test.tsx
@@ -87,6 +87,11 @@ describe( 'product list actions', () => {
 		status: 'draft',
 		name: 'Beanie',
 	} as ProductEntityRecord;
+	const hoodie = {
+		id: 34,
+		status: 'draft',
+		name: 'Hoodie',
+	} as ProductEntityRecord;
 
 	const deleteEntityRecord = jest.fn();
 	const invalidateResolution = jest.fn();
@@ -136,7 +141,11 @@ describe( 'product list actions', () => {
 
 		expect( quickEditProductAction ).toBeDefined();
 
-		getCallbackAction( quickEditProductAction! ).callback( [ product ], {
+		if ( ! quickEditProductAction ) {
+			throw new Error( 'Quick edit action not found.' );
+		}
+
+		getCallbackAction( quickEditProductAction ).callback( [ product ], {
 			onActionPerformed,
 		} );
 
@@ -155,6 +164,31 @@ describe( 'product list actions', () => {
 		expect( quickEditProductAction?.supportsBulk ).toBe( true );
 	} );
 
+	it( 'opens quick edit panel with all selected products when triggered as a bulk action', () => {
+		const { result } = renderHook( () => useProductActions() );
+		const quickEditProductAction = result.current.find(
+			( action ) => action.id === 'quick-edit-product'
+		);
+
+		expect( quickEditProductAction ).toBeDefined();
+
+		if ( ! quickEditProductAction ) {
+			throw new Error( 'Quick edit action not found.' );
+		}
+
+		getCallbackAction( quickEditProductAction ).callback(
+			[ product, hoodie ],
+			{
+				onActionPerformed,
+			}
+		);
+
+		expect( navigate ).toHaveBeenCalledWith(
+			'/products?activeView=draft&postId=12%2C34&quickEdit=true'
+		);
+		expect( onActionPerformed ).toHaveBeenCalledWith( [ product, hoodie ] );
+	} );
+
 	it( 'opens product editor when the Edit action is triggered', () => {
 		const { result } = renderHook( () => useProductActions() );
 		const editProductAction = result.current.find(
@@ -163,13 +197,17 @@ describe( 'product list actions', () => {
 
 		expect( editProductAction ).toBeDefined();
 
+		if ( ! editProductAction ) {
+			throw new Error( 'Edit action not found.' );
+		}
+
 		const originalLocation = window.location;
 		Object.defineProperty( window, 'location', {
 			writable: true,
 			value: { href: '' },
 		} );
 
-		getCallbackAction( editProductAction! ).callback( [ product ], {
+		getCallbackAction( editProductAction ).callback( [ product ], {
 			onActionPerformed,
 		} );
 

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
@@ -31,7 +31,7 @@ type EditActionOptions = {
 function getQuickEditPath(
 	path: string,
 	query: Record< string, string | undefined >,
-	productId: number
+	productIds: number[]
 ) {
 	const nextQuery = Object.entries( query ).reduce(
 		( acc, [ key, value ] ) => {
@@ -46,7 +46,7 @@ function getQuickEditPath(
 
 	return getProductListNavigationPath( path, {
 		...nextQuery,
-		postId: String( productId ),
+		postId: productIds.join( ',' ),
 		quickEdit: 'true',
 	} );
 }
@@ -132,10 +132,10 @@ export const quickEditAction = ( {
 		return product.status !== 'trash';
 	},
 	callback( items, { onActionPerformed } ) {
-		const product = items[ 0 ];
+		const productIds = items.map( ( product ) => product.id );
 
-		if ( product ) {
-			navigate( getQuickEditPath( path, query, product.id ) );
+		if ( productIds.length > 0 ) {
+			navigate( getQuickEditPath( path, query, productIds ) );
 		}
 
 		if ( onActionPerformed ) {

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -256,6 +256,9 @@ describe( 'product edit utils', () => {
 			'shipping_class',
 			'tax_status',
 		];
+		const bulkUniversalFieldIds = universalFieldIds.filter(
+			( fieldId ) => fieldId !== 'sku'
+		);
 
 		it( 'shows pricing, shipping, and linked product fields for simple physical products', () => {
 			const fieldIds = getVisibleFieldIds( [
@@ -418,6 +421,7 @@ describe( 'product edit utils', () => {
 			] );
 
 			expectFieldsHidden( fieldIds, priceFieldIds );
+			expectFieldsHidden( fieldIds, [ 'sku' ] );
 			expect( fieldIds ).toEqual(
 				expect.arrayContaining( [
 					'name',
@@ -428,9 +432,31 @@ describe( 'product edit utils', () => {
 					'featured',
 					'upsell_ids',
 					'cross_sell_ids',
-					...universalFieldIds,
+					...bulkUniversalFieldIds,
 				] )
 			);
+		} );
+
+		it( 'shows price but not SKU when bulk editing simple products', () => {
+			const fieldIds = getVisibleFieldIds( [
+				buildProduct( {
+					id: 1,
+					type: 'simple',
+					regular_price: '12',
+					price: '12',
+				} ),
+				buildProduct( {
+					id: 2,
+					type: 'simple',
+					regular_price: '15',
+					price: '15',
+				} ),
+			] );
+
+			expect( fieldIds ).toEqual(
+				expect.arrayContaining( [ 'price', 'regular_price' ] )
+			);
+			expectFieldsHidden( fieldIds, [ 'sku' ] );
 		} );
 
 		it( 'shows sellable instance fields for variations', () => {
@@ -482,12 +508,13 @@ describe( 'product edit utils', () => {
 			expect( fieldIds ).toEqual(
 				expect.arrayContaining( [
 					...priceFieldIds,
-					...universalFieldIds,
+					...bulkUniversalFieldIds,
 				] )
 			);
 			expectFieldsHidden( fieldIds, [
 				...parentOwnedFieldIds,
 				'downloadable',
+				'sku',
 			] );
 		} );
 
@@ -510,12 +537,13 @@ describe( 'product edit utils', () => {
 			] );
 
 			expect( fieldIds ).toEqual(
-				expect.arrayContaining( universalFieldIds )
+				expect.arrayContaining( bulkUniversalFieldIds )
 			);
 			expectFieldsHidden( fieldIds, [
 				...parentOwnedFieldIds,
 				...priceFieldIds,
 				'downloadable',
+				'sku',
 			] );
 		} );
 
@@ -546,12 +574,13 @@ describe( 'product edit utils', () => {
 			] );
 
 			expect( fieldIds ).toEqual(
-				expect.arrayContaining( universalFieldIds )
+				expect.arrayContaining( bulkUniversalFieldIds )
 			);
 			expectFieldsHidden( fieldIds, [
 				...parentOwnedFieldIds,
 				...priceFieldIds,
 				'downloadable',
+				'sku',
 			] );
 		} );
 

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -195,6 +195,9 @@ const SELLABLE_PRODUCT_EDIT_FIELD_ID_SET = new Set< ProductEditFieldId >( [
 	'date_on_sale_to',
 ] );
 
+const BULK_UNSUPPORTED_PRODUCT_EDIT_FIELD_ID_SET =
+	new Set< ProductEditFieldId >( [ 'sku' ] );
+
 function normalizeValue( value: unknown ) {
 	if ( value === undefined ) {
 		return '__undefined__';
@@ -435,9 +438,19 @@ export function getVisibleProductEditFields(
 ) {
 	const compatibleFieldIds =
 		getCommonProductTypeCompatibleFieldIds( products );
+	const isBulkEdit = products.length > 1;
 
 	return fields.reduce< ProductField[] >( ( visibleFields, field ) => {
 		if ( ! compatibleFieldIds.has( field.id ) ) {
+			return visibleFields;
+		}
+
+		if (
+			isBulkEdit &&
+			BULK_UNSUPPORTED_PRODUCT_EDIT_FIELD_ID_SET.has(
+				field.id as ProductEditFieldId
+			)
+		) {
 			return visibleFields;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Bulk quick edit was advertised as supported, but the action only passed the first selected product ID to the quick edit route. This keeps all selected product IDs in the route so the drawer edits the full bulk selection.

The PR also hides SKU from bulk quick edit because it is not supported for bulk editing, while keeping price fields available for compatible product selections. Mixed bulk values now surface placeholders across the quick edit field controls that support them.

### Screenshots or screen recordings:

Not included; this is a behavior and field availability change in the quick edit drawer.

### How to test the changes in this Pull Request:

1. Open the experimental products app.
2. Select at least two simple products from the product list.
3. Trigger the bulk action for Quick edit.
4. Confirm the drawer opens for all selected products.
5. Confirm price fields are available and the SKU field is not shown.
6. Confirm fields with mixed values show mixed-value placeholder text where applicable.
7. Edit a price field, save, and confirm the selected products are saved.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/dataviews-actions/actions.test.tsx`
-   `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/dataviews-actions/actions.tsx src/dataviews-actions/actions.test.tsx`
-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/product-edit/utils.test.ts`
-   `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/product-edit/utils.ts src/product-edit/utils.test.ts`
-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/fields/mixed-placeholders.test.tsx`
-   `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/fields/mixed-placeholders.test.tsx src/fields/description/field.tsx src/fields/short_description/field.tsx src/fields/tax_status/field.tsx src/fields/components/product-selector.tsx src/fields/upsell_ids/field.tsx src/fields/cross_sell_ids/field.tsx src/fields/images/field.tsx src/fields/downloadable/field.tsx`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Manual changelog entries were added:

-   `packages/js/experimental-products-app/changelog/fix-quick-edit-bulk-selection`
-   `packages/js/experimental-products-app/changelog/add-mixed-bulk-quick-edit-placeholders`

</details>
