### PR TITLE
Fix analytics crash when customer-effort-score-tracks feature is disabled

### DIFF
--- a/packages/js/customer-effort-score/changelog/fix-ces-disabled-analytics-crash
+++ b/packages/js/customer-effort-score/changelog/fix-ces-disabled-analytics-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix analytics crash when customer-effort-score-tracks feature is disabled by adding null safety checks to useDispatch returns in CustomerEffortScoreModalContainer.

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
@@ -16,8 +16,8 @@ import { ADMIN_INSTALL_TIMESTAMP_OPTION_NAME } from '../../constants';
 import store from '../../store';
 
 export const CustomerEffortScoreModalContainer = () => {
-	const { createSuccessNotice } = useDispatch( 'core/notices' );
-	const { hideCesModal } = useDispatch( store );
+	const coreNoticesDispatch = useDispatch( 'core/notices' );
+	const cesDispatch = useDispatch( store );
 	const {
 		storeAgeInWeeks,
 		resolving: isLoading,
@@ -41,6 +41,16 @@ export const CustomerEffortScoreModalContainer = () => {
 			resolving,
 		};
 	}, [] );
+
+	// When the customer-effort-score-tracks feature is disabled,
+	// the store may not be registered, causing useDispatch to return null.
+	// Return null early to prevent destructuring crashes.
+	if ( ! coreNoticesDispatch || ! cesDispatch ) {
+		return null;
+	}
+
+	const { createSuccessNotice } = coreNoticesDispatch;
+	const { hideCesModal } = cesDispatch;
 
 	const recordScore = (
 		score: number,


### PR DESCRIPTION
## Description

When the `customer-effort-score-tracks` feature flag is disabled via `apply_filters('woocommerce_admin_get_feature_config')`, all WooCommerce Analytics pages crash with:

```
TypeError: Cannot destructure property 'createSuccessNotice' of '(0 , i.useDispatch)(...)' as it is null.
```

The error originates from `CustomerEffortScoreModalContainer` in `@woocommerce/customer-effort-score`. When the CES feature is disabled, the `wc/customer-effort-score` Redux store is not registered, causing `useDispatch(store)` to return `null`. The subsequent destructuring `{ hideCesModal } = useDispatch(store)` then throws a TypeError.

## Changes

In `packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx`:

- Store `useDispatch` return values in variables instead of immediately destructuring
- After all React hooks are called (to comply with rules-of-hooks), check if either dispatch is null/undefined
- If null, return `null` early from the component before any destructuring occurs
- Destructuring only happens after the null guard passes

This ensures the component gracefully handles the disabled feature flag instead of crashing.

## How to Reproduce

1. Disable the `customer-effort-score-tracks` feature via filter:
   ```php
   add_filter( 'woocommerce_admin_get_feature_config', function( $features ) {
       $features['customer-effort-score-tracks'] = false;
       return $features;
   } );
   ```
2. Navigate to any Analytics page (e.g., WooCommerce → Analytics → Overview)
3. Page crashes with TypeError

## Testing Instructions

1. Apply the filter above to disable `customer-effort-score-tracks`
2. Verify Analytics pages load correctly without crashing
3. Verify that when the feature is enabled (default), CES modals still function normally
4. Run `pnpm lint:lang:js` in `packages/js/customer-effort-score` — no new errors

## Changelog Entry

> Fix analytics crash when customer-effort-score-tracks feature is disabled by adding null safety checks to useDispatch returns in CustomerEffortScoreModalContainer.