### PR TITLE
Fix duplicate AJAX requests in customer search

### DIFF
--- a/packages/js/components/changelog/fix-64014-customer-search-duplicate-requests
+++ b/packages/js/components/changelog/fix-64014-customer-search-duplicate-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add query deduplication and unmount cleanup to SelectControl to prevent duplicate AJAX requests in customer search (WooCommerce > Customers)

--- a/packages/js/components/src/select-control/index.tsx
+++ b/packages/js/components/src/select-control/index.tsx
@@ -222,6 +222,8 @@ export class SelectControl extends Component< Props, State > {
 	node: HTMLDivElement | null = null;
 	activePromise: Promise< void | Option[] > | null = null;
 	cacheSearchOptions: Option[] = [];
+	lastSearchQuery: string | null = null;
+	isUnmounted = false;
 
 	constructor( props: Props ) {
 		super( props );
@@ -257,6 +259,14 @@ export class SelectControl extends Component< Props, State > {
 		}
 	}
 
+	componentWillUnmount() {
+		this.isUnmounted = true;
+		// Cancel any pending debounced search to avoid requests after unmount.
+		( this.updateSearchOptions as {
+			cancel?: () => void;
+		} ).cancel?.();
+	}
+
 	bindNode( node: HTMLDivElement ) {
 		this.node = node;
 	}
@@ -264,6 +274,10 @@ export class SelectControl extends Component< Props, State > {
 	reset( selected: Selected | Option[] | undefined = this.getSelected() ) {
 		const { multiple, excludeSelectedOptions } = this.props;
 		const newState = { ...initialState };
+
+		// Reset the last search query so future searches with the same
+		// query are allowed (e.g., after selecting an option).
+		this.lastSearchQuery = null;
 		// Reset selectedIndex if single selection.
 		if (
 			! multiple &&
@@ -471,6 +485,18 @@ export class SelectControl extends Component< Props, State > {
 	}
 
 	search( query: string | null ) {
+		// Skip if the query hasn't changed to prevent duplicate API requests
+		// (e.g., from focus events re-triggering the same search).
+		if (
+			query === this.lastSearchQuery &&
+			query !== null &&
+			query !== ''
+		) {
+			return;
+		}
+
+		this.lastSearchQuery = query;
+
 		const cacheSearchOptions = this.cacheSearchOptions || [];
 		const searchOptions =
 			query !== null && ! query.length && ! this.props.hideBeforeSearch
@@ -503,6 +529,9 @@ export class SelectControl extends Component< Props, State > {
 		const promise = ( this.activePromise = Promise.resolve(
 			onSearch!( options, query )
 		).then( ( promiseOptions ) => {
+			if ( this.isUnmounted ) {
+				return;
+			}
 			if ( promise !== this.activePromise ) {
 				// Another promise has become active since this one was asked to resolve, so do nothing,
 				// or else we might end triggering a race condition updating the state.

--- a/plugins/woocommerce/changelog/fix-64014-customer-search-duplicate-requests
+++ b/plugins/woocommerce/changelog/fix-64014-customer-search-duplicate-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add query deduplication and unmount cleanup to SelectControl to prevent duplicate AJAX requests in customer search (WooCommerce > Customers)


### PR DESCRIPTION
## Summary

Fixes #64014

The customer search in WooCommerce > Customers triggers duplicate AJAX requests to `/wc-analytics/customers`. This PR adds query deduplication to the `SelectControl` component to prevent the same search query from firing multiple API requests.

## Changes

- **Query deduplication in `SelectControl.search()`**: Tracks the last search query and skips the search if the query has not changed. This prevents focus events from re-triggering the same search.
- **Unmount cleanup**: Cancels pending debounced search calls when the component unmounts, preventing stale requests.
- **Reset on selection**: Clears the last search query when `reset()` is called (e.g., after selecting an option), so future searches with the same query are still allowed.

## Files Changed

- `packages/js/components/src/select-control/index.tsx` — Core fix: deduplication + unmount cleanup
- `packages/js/components/changelog/fix-64014-customer-search-duplicate-requests` — Changelog entry
- `plugins/woocommerce/changelog/fix-64014-customer-search-duplicate-requests` — Changelog entry

## Testing Instructions

1. Create several customers in WooCommerce
2. Go to WooCommerce > Customers
3. Open browser DevTools Network tab
4. Type a search query (e.g., "user1000") quickly
5. **Before**: Multiple duplicate requests to `/wc-analytics/customers` with the same search parameter
6. **After**: Only one request per unique search query after the debounce window

Also test:
- Clicking on a search result → should still work correctly
- Clicking "All customers with names that include..." → should work as expected
- Re-focusing the search input with existing text → should not re-trigger the same search

## Changelog

> Add query deduplication and unmount cleanup to SelectControl to prevent duplicate AJAX requests in customer search (WooCommerce > Customers)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->