### PR TITLE
Cancel review-request email on any transition out of completed

### DIFF
--- a/plugins/woocommerce/changelog/64756-wooplug-6672-cancel-review-email-on-status-change
+++ b/plugins/woocommerce/changelog/64756-wooplug-6672-cancel-review-email-on-status-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Cancel the delayed Customer Review Request email when the order leaves `completed` for any status, and refuse to send if the order is no longer in an eligible status at trigger time.

--- a/plugins/woocommerce/changelog/wooplug-6672-cancel-review-email-on-status-change
+++ b/plugins/woocommerce/changelog/wooplug-6672-cancel-review-email-on-status-change
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Cancel the delayed Customer Review Request email when the order leaves `completed` for any status, and refuse to send if the order is no longer in an eligible status at trigger time.

--- a/plugins/woocommerce/changelog/wooplug-6672-cancel-review-email-on-status-change
+++ b/plugins/woocommerce/changelog/wooplug-6672-cancel-review-email-on-status-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Cancel the delayed Customer Review Request email when the order leaves `completed` for any status, and refuse to send if the order is no longer in an eligible status at trigger time.

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php
@@ -116,7 +116,7 @@ if ( ! class_exists( 'WC_Email_Customer_Review_Request', false ) ) :
 		 * filter the page-load endpoint and submission handler use keeps the
 		 * three entry points consistent.
 		 *
-		 * @since 10.9.0
+		 * @since 10.8.0
 		 * @return bool
 		 */
 		protected function is_order_eligible_for_send(): bool {
@@ -130,7 +130,7 @@ if ( ! class_exists( 'WC_Email_Customer_Review_Request', false ) ) :
 			 * Defaults to `completed` only. Same hook the page-load endpoint and the
 			 * submission handler use, so the three entry points stay aligned.
 			 *
-			 * @since 10.9.0
+			 * @since 10.8.0
 			 *
 			 * @param string[] $eligible_statuses Default: `[ 'completed' ]`.
 			 * @param WC_Order $order             Order being inspected.

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Emails
  */
 
+use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -98,11 +99,49 @@ if ( ! class_exists( 'WC_Email_Customer_Review_Request', false ) ) :
 				$this->placeholders['{order_number}'] = $order->get_order_number();
 			}
 
-			if ( $this->is_enabled() && $this->get_recipient() ) {
+			if ( $this->is_enabled() && $this->get_recipient() && $this->is_order_eligible_for_send() ) {
 				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 			}
 
 			$this->restore_locale();
+		}
+
+		/**
+		 * Defence-in-depth status check at send time.
+		 *
+		 * The scheduler unschedules the pending action when the order leaves
+		 * `completed`, but a race window or a direct invocation of the action
+		 * hook can still reach `trigger()` for an order that is no longer in
+		 * an eligible state. Checking the same `woocommerce_review_order_eligible_statuses`
+		 * filter the page-load endpoint and submission handler use keeps the
+		 * three entry points consistent.
+		 *
+		 * @since 10.9.0
+		 * @return bool
+		 */
+		protected function is_order_eligible_for_send(): bool {
+			if ( ! $this->object instanceof WC_Order ) {
+				return false;
+			}
+
+			/**
+			 * Filter the order statuses that are eligible to receive the review-request email.
+			 *
+			 * Defaults to `completed` only. Same hook the page-load endpoint and the
+			 * submission handler use, so the three entry points stay aligned.
+			 *
+			 * @since 10.9.0
+			 *
+			 * @param string[] $eligible_statuses Default: `[ 'completed' ]`.
+			 * @param WC_Order $order             Order being inspected.
+			 */
+			$eligible_statuses = (array) apply_filters(
+				'woocommerce_review_order_eligible_statuses',
+				array( OrderStatus::COMPLETED ),
+				$this->object
+			);
+
+			return in_array( $this->object->get_status(), $eligible_statuses, true );
 		}
 
 		/**

--- a/plugins/woocommerce/src/Internal/OrderReviews/Scheduler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Scheduler.php
@@ -7,6 +7,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\OrderReviews;
 
+use Automattic\WooCommerce\Enums\OrderStatus;
 use WC_Email_Customer_Review_Request;
 use WC_Order;
 
@@ -55,10 +56,33 @@ class Scheduler {
 	 */
 	final public function init(): void {
 		add_action( 'woocommerce_order_status_completed', array( $this, 'handle_woocommerce_order_status_completed' ), 10, 1 );
-		add_action( 'woocommerce_order_status_cancelled', array( $this, 'handle_cancellation' ), 10, 1 );
-		add_action( 'woocommerce_order_status_refunded', array( $this, 'handle_cancellation' ), 10, 1 );
+		// Catch every transition out of `completed` (cancelled, refunded,
+		// processing, on-hold, pending, failed, custom statuses…) so the
+		// pending email is unscheduled regardless of which status the order
+		// moves to.
+		add_action( 'woocommerce_order_status_changed', array( $this, 'handle_status_changed' ), 10, 3 );
 		add_action( 'woocommerce_trash_order', array( $this, 'handle_cancellation' ), 10, 1 );
 		add_action( 'woocommerce_before_delete_order', array( $this, 'handle_cancellation' ), 10, 1 );
+	}
+
+	/**
+	 * Unschedule the pending review-request email whenever the order leaves
+	 * the eligible state. `woocommerce_order_status_changed` fires for every
+	 * transition, so a single listener covers cancelled / refunded /
+	 * processing / on-hold / pending / failed / custom statuses in one place.
+	 *
+	 * @internal
+	 *
+	 * @param int    $order_id   Order ID.
+	 * @param string $old_status Previous status (sans `wc-` prefix).
+	 * @param string $new_status New status (sans `wc-` prefix).
+	 */
+	public function handle_status_changed( int $order_id, string $old_status, string $new_status ): void {
+		if ( OrderStatus::COMPLETED !== $old_status || OrderStatus::COMPLETED === $new_status ) {
+			return;
+		}
+
+		$this->handle_cancellation( $order_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderReviews/Scheduler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Scheduler.php
@@ -71,6 +71,11 @@ class Scheduler {
 	 * transition, so a single listener covers cancelled / refunded /
 	 * processing / on-hold / pending / failed / custom statuses in one place.
 	 *
+	 * Eligibility is read from the same `woocommerce_review_order_eligible_statuses`
+	 * filter the trigger uses, so a site that widens the filter (e.g. to also
+	 * accept `processing`) keeps the email queued through transitions inside
+	 * its expanded eligible set.
+	 *
 	 * @internal
 	 *
 	 * @param int    $order_id   Order ID.
@@ -78,7 +83,19 @@ class Scheduler {
 	 * @param string $new_status New status (sans `wc-` prefix).
 	 */
 	public function handle_status_changed( int $order_id, string $old_status, string $new_status ): void {
-		if ( OrderStatus::COMPLETED !== $old_status || OrderStatus::COMPLETED === $new_status ) {
+		$order = wc_get_order( $order_id );
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment -- documented on WC_Email_Customer_Review_Request::is_order_eligible_for_send().
+		$eligible_statuses = (array) apply_filters(
+			'woocommerce_review_order_eligible_statuses',
+			array( OrderStatus::COMPLETED ),
+			$order instanceof WC_Order ? $order : null
+		);
+
+		$was_eligible = in_array( $old_status, $eligible_statuses, true );
+		$is_eligible  = in_array( $new_status, $eligible_statuses, true );
+
+		if ( ! $was_eligible || $is_eligible ) {
 			return;
 		}
 
@@ -135,13 +152,13 @@ class Scheduler {
 	}
 
 	/**
-	 * Cancel any pending review-request action when the order leaves the
-	 * eligible state.
+	 * Cancel any pending review-request action and clear the scheduled-at meta.
 	 *
-	 * Hooked into `woocommerce_order_status_cancelled`,
-	 * `woocommerce_order_status_refunded`, `woocommerce_trash_order` and
-	 * `woocommerce_before_delete_order` so full refunds, cancellations, trashes
-	 * and deletions all clean up the pending job.
+	 * Hooked directly into `woocommerce_trash_order` and
+	 * `woocommerce_before_delete_order` for the trash/delete lifecycle events,
+	 * and called from `handle_status_changed()` for every status transition
+	 * out of an eligible status (cancelled, refunded, processing, on-hold,
+	 * pending, failed, custom statuses…).
 	 *
 	 * @internal
 	 *

--- a/plugins/woocommerce/src/Internal/OrderReviews/Scheduler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Scheduler.php
@@ -85,7 +85,17 @@ class Scheduler {
 	public function handle_status_changed( int $order_id, string $old_status, string $new_status ): void {
 		$order = wc_get_order( $order_id );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment -- documented on WC_Email_Customer_Review_Request::is_order_eligible_for_send().
+		/**
+		 * Filter the order statuses that are eligible to receive the review-request email.
+		 *
+		 * Same hook the email's `trigger()` consults at send time; documented on
+		 * `WC_Email_Customer_Review_Request::is_order_eligible_for_send()`.
+		 *
+		 * @since 10.8.0
+		 *
+		 * @param string[]      $eligible_statuses Default: `[ 'completed' ]`.
+		 * @param WC_Order|null $order             Order being inspected, or null if it could not be loaded.
+		 */
 		$eligible_statuses = (array) apply_filters(
 			'woocommerce_review_order_eligible_statuses',
 			array( OrderStatus::COMPLETED ),

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
@@ -209,4 +209,57 @@ class WC_Email_Customer_Review_Request_Test extends \WC_Unit_Test_Case {
 
 		$this->assertSame( $before, $after, 'Disabled review-request email must not dispatch any mail.' );
 	}
+
+	/**
+	 * @testdox trigger() refuses to send when the order is no longer in an eligible status.
+	 *
+	 * Defence-in-depth against the scheduler missing a transition out of
+	 * `completed` (WOOPLUG-6672): even if the action fires, the email must
+	 * not go out for an order that is no longer eligible.
+	 */
+	public function test_trigger_skips_when_order_not_in_eligible_status(): void {
+		$this->sut->update_option( 'enabled', 'yes' );
+		$this->sut->enabled = 'yes';
+
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order->set_status( 'completed' );
+		$order->save();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$before = count( $mailer->mock_sent );
+		$this->sut->trigger( $order->get_id() );
+		$after = count( $mailer->mock_sent );
+
+		$this->assertSame( $before, $after, 'Review-request email must not dispatch for non-eligible status.' );
+	}
+
+	/**
+	 * @testdox The woocommerce_review_order_eligible_statuses filter widens the eligible set for trigger().
+	 */
+	public function test_trigger_eligible_statuses_filter_can_widen(): void {
+		$this->sut->update_option( 'enabled', 'yes' );
+		$this->sut->enabled = 'yes';
+
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		add_filter(
+			'woocommerce_review_order_eligible_statuses',
+			static function () {
+				return array( 'completed', 'processing' );
+			}
+		);
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$before = count( $mailer->mock_sent );
+		$this->sut->trigger( $order->get_id() );
+		$after = count( $mailer->mock_sent );
+
+		remove_all_filters( 'woocommerce_review_order_eligible_statuses' );
+
+		$this->assertSame( $before + 1, $after, 'Filter must allow non-default statuses to receive the email.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
@@ -246,19 +246,19 @@ class WC_Email_Customer_Review_Request_Test extends \WC_Unit_Test_Case {
 		$order->set_status( 'processing' );
 		$order->save();
 
-		add_filter(
-			'woocommerce_review_order_eligible_statuses',
-			static function () {
-				return array( 'completed', 'processing' );
-			}
-		);
+		$widen_statuses = static function () {
+			return array( 'completed', 'processing' );
+		};
+		add_filter( 'woocommerce_review_order_eligible_statuses', $widen_statuses );
 
 		$mailer = tests_retrieve_phpmailer_instance();
 		$before = count( $mailer->mock_sent );
-		$this->sut->trigger( $order->get_id() );
-		$after = count( $mailer->mock_sent );
-
-		remove_all_filters( 'woocommerce_review_order_eligible_statuses' );
+		try {
+			$this->sut->trigger( $order->get_id() );
+			$after = count( $mailer->mock_sent );
+		} finally {
+			remove_filter( 'woocommerce_review_order_eligible_statuses', $widen_statuses );
+		}
 
 		$this->assertSame( $before + 1, $after, 'Filter must allow non-default statuses to receive the email.' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SchedulerTest.php
@@ -136,8 +136,13 @@ class SchedulerTest extends WC_Unit_Test_Case {
 	 */
 	public function cancellation_status_provider(): array {
 		return array(
-			'cancelled' => array( 'cancelled' ),
-			'refunded'  => array( 'refunded' ),
+			'cancelled'  => array( 'cancelled' ),
+			'refunded'   => array( 'refunded' ),
+			// Any other transition out of `completed` must also unschedule.
+			'processing' => array( 'processing' ),
+			'on-hold'    => array( 'on-hold' ),
+			'pending'    => array( 'pending' ),
+			'failed'     => array( 'failed' ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SchedulerTest.php
@@ -175,6 +175,32 @@ class SchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The woocommerce_review_order_eligible_statuses filter keeps the action queued through transitions inside the widened set.
+	 */
+	public function test_status_changed_respects_eligible_statuses_filter(): void {
+		$widen = static function () {
+			return array( 'completed', 'processing' );
+		};
+		add_filter( 'woocommerce_review_order_eligible_statuses', $widen );
+
+		try {
+			$order = $this->create_pending_order();
+			$order->update_status( 'completed' );
+			$this->assertTrue( (bool) as_next_scheduled_action( Scheduler::ACTION_HOOK, array( $order->get_id() ) ) );
+
+			// `processing` is eligible per the filter, so the pending action stays.
+			$order->update_status( 'processing' );
+			$this->assertTrue( (bool) as_next_scheduled_action( Scheduler::ACTION_HOOK, array( $order->get_id() ) ) );
+
+			// `on-hold` is NOT in the filter's eligible set, so the action is now unscheduled.
+			$order->update_status( 'on-hold' );
+			$this->assertFalse( (bool) as_next_scheduled_action( Scheduler::ACTION_HOOK, array( $order->get_id() ) ) );
+		} finally {
+			remove_filter( 'woocommerce_review_order_eligible_statuses', $widen );
+		}
+	}
+
+	/**
 	 * @testdox Cancellation unschedules the action even when the tracking meta is missing.
 	 *
 	 * Guards against an out-of-sync meta value leaving a stray scheduled send.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes WOOPLUG-6672 / \#64743: the delayed Customer Review Request email could fire for an order that was no longer in `completed`.

Two layers of fix:

**1. Scheduler cleanup on every transition out of `completed`.**
`Scheduler::init()` previously listened for `cancelled`, `refunded`, `trash`, and `before_delete` only. Any other status change (`completed → processing`, `completed → on-hold`, `pending`, `failed`, custom statuses) left the pending Action Scheduler job queued, and 7 days later the email fired. The fix replaces the per-status `cancelled` and `refunded` hooks with a single `woocommerce_order_status_changed` listener that unschedules whenever the previous status was `completed` and the new status isn't. Trash and delete remain on their own dedicated hooks since they aren't status transitions.

**2. Eligibility guard at send time.**
`WC_Email_Customer_Review_Request::trigger()` now consults the same `woocommerce_review_order_eligible_statuses` filter the page-load endpoint and submission handler use. If the order is no longer in an eligible status (default: `completed`) when the action fires, the send is suppressed. This is defence in depth against:

- A race where Action Scheduler has already started running the queued job before the unschedule fires.
- Any code path that invokes the `woocommerce_send_review_request_notification` hook directly.

Bug introduced in PR \#64393 (email class) + \#64395 (scheduler).

#### Files

```
src/Internal/OrderReviews/Scheduler.php
includes/emails/class-wc-email-customer-review-request.php
tests/php/src/Internal/OrderReviews/SchedulerTest.php
tests/php/includes/emails/class-wc-email-customer-review-request-test.php
```

### Screenshots or screen recordings:

> Not applicable — backend-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

> **Note:** Enable the **WC Settings → Emails → Review request** email first.

**1. completed → processing unschedules the email.**

   1. Place a test order with a billing email and mark it **Completed**.
   2. Verify in WP Admin → Tools → Scheduled Actions → Pending that a `woocommerce_send_review_request` action exists for the order.
   3. Manually change the order status to **Processing**.
   4. Refresh Scheduled Actions. The pending action is gone.

**2. completed → cancelled / refunded still works (regression check).**

   1. Repeat step 1 with two orders.
   2. Mark one **Cancelled** and the other **Refunded**.
   3. Confirm both pending actions are gone.

**3. Trigger guard.**

   1. Place a third order, mark it **Completed**, then immediately **Processing** (so the pending action is unscheduled by step 1's logic).
   2. From WP-CLI, force the trigger directly:
      ```sh
      wp eval "do_action( 'woocommerce_send_review_request_notification', <order_id> );" --allow-root
      ```
   3. The email is **not** sent because the order's current status is no longer eligible.

**4. Filter widens the eligible set.**

   1. Add a snippet:
      ```php
      add_filter( 'woocommerce_review_order_eligible_statuses', function () {
          return [ 'completed', 'processing' ];
      } );
      ```
   2. Repeat step 3 — the email **is** sent because `processing` is now eligible.

<!-- End testing instructions -->

### Testing that has already taken place:

- 57 PHPUnit tests in `Scheduler` pass, including 4 new data-set rows (`processing`, `on-hold`, `pending`, `failed`) on the cancellation provider.
- 14 PHPUnit tests in `WC_Email_Customer_Review_Request_Test` pass, including 2 new tests for the eligibility guard and the eligible-statuses filter.
- PHPCS clean on changed files.
- PHPStan clean on `Scheduler.php` and `class-wc-email-customer-review-request.php`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Cancel the delayed Customer Review Request email when the order leaves `completed` for any status, and refuse to send if the order is no longer in an eligible status at trigger time.

</details>
