### PR TITLE
Fix unauthenticated access to guest order fulfillments via V4 REST API

### DIFF
--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Fulfillments/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Fulfillments/Controller.php
@@ -370,9 +370,10 @@ class Controller extends AbstractController {
 		}
 
 		// Check if the order exists, and if the current user is the owner of the order, and the request is a read request.
-		// We allow this because we need to render the order fulfillments on the customer's order details and order tracking pages.
-		// But they will be only able to view them, not edit.
-		if ( get_current_user_id() === $order->get_customer_id() && WP_REST_Server::READABLE === $request->get_method() ) {
+		// Guest order fulfillments are rendered server-side via templates, so they don't need REST API access.
+		// The get_current_user_id() > 0 check prevents unauthenticated users from accessing guest orders
+		// where both get_current_user_id() and get_customer_id() would return 0.
+		if ( get_current_user_id() > 0 && get_current_user_id() === $order->get_customer_id() && WP_REST_Server::READABLE === $request->get_method() ) {
 			return true;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Fulfillments/ControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Fulfillments/ControllerTest.php
@@ -405,6 +405,32 @@ class ControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Regression test for WOO13-227: an unauthenticated request must not be
+	 * able to read a guest order's fulfillments. The owner-read check compares
+	 * get_current_user_id() to $order->get_customer_id(); for guest orders
+	 * both are 0, so the check needs a `get_current_user_id() > 0` guard.
+	 */
+	public function test_permission_check_unauthenticated_cannot_read_guest_order_fulfillments() {
+		$guest_order       = WC_Helper_Order::create_order( 0 );
+		$guest_fulfillment = FulfillmentsHelper::create_fulfillment(
+			array( 'entity_id' => $guest_order->get_id() )
+		);
+
+		wp_set_current_user( 0 );
+
+		$list_request = new WP_REST_Request( 'GET', '/wc/v4/fulfillments' );
+		$list_request->set_param( 'order_id', $guest_order->get_id() );
+		$list_response = rest_get_server()->dispatch( $list_request );
+		$this->assertSame( 401, $list_response->get_status() );
+
+		$get_request  = new WP_REST_Request( 'GET', '/wc/v4/fulfillments/' . $guest_fulfillment->get_id() );
+		$get_response = rest_get_server()->dispatch( $get_request );
+		$this->assertSame( 401, $get_response->get_status() );
+
+		WC_Helper_Order::delete_order( $guest_order->get_id() );
+	}
+
+	/**
 	 * Test permission check - customer accessing other's order
 	 */
 	public function test_permission_check_customer_other_order() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Follow-up to #64130. The V3 admin fulfillments controller was patched in #64130, but the parallel V4 controller (`src/Internal/RestApi/Routes/V4/Fulfillments/Controller.php`) repeated the same unsafe owner-check shape:

```php
if ( get_current_user_id() === $order->get_customer_id() && WP_REST_Server::READABLE === $request->get_method() ) {
    return true;
}
```

For guest orders both sides evaluate to `0`, so `0 === 0` grants any unauthenticated request read access to guest-order fulfillment data (status, tracking number, items).

This PR mirrors the V3 fix by adding the `get_current_user_id() > 0` guard so the customer-ownership branch only applies to authenticated users. Guest order fulfillments are still rendered server-side via PHP templates (gated by the order tracking form).

A regression test (`test_permission_check_unauthenticated_cannot_read_guest_order_fulfillments`) covers both the collection (`GET /wc/v4/fulfillments?order_id=<guest>`) and item (`GET /wc/v4/fulfillments/<id>`) routes and asserts a `401` response on both.

Linear: [WOO13-227](https://linear.app/a8c/issue/WOO13-227)

(For Bug Fixes) Bug introduced in PR #60205.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the fulfillments feature flag (`woocommerce_feature_fulfillments_enabled` = `yes`).
2. Enable the V4 REST API (`rest-api-v4` in the WooCommerce feature list).
3. Create a guest order (place an order without logging in) and, as an admin, add a fulfillment to it.
4. In a private/incognito browser (not logged in), request `GET /wp-json/wc/v4/fulfillments?order_id=<guest_order_id>` and `GET /wp-json/wc/v4/fulfillments/<fulfillment_id>`.
5. Verify both return a **401 Unauthorized** response instead of the fulfillment data.
6. As an admin, verify you can still list and read fulfillments normally via V4.
7. As a logged-in customer on their own order, verify the existing read path still works.

The repro script from the issue (`.docs/scripts/repro-64130-v4-fulfillments-auth.sh`) can also be used: V4 should now return `401` to match V3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHP linting (`phpcs-changed`) passes with no warnings.
- PHPStan analysis passes on the modified source file.
- Regression test added; full PHPUnit suite will be run by CI (the local wp-env in this worktree shares a port with the in-flight branch in the main checkout, so the test was not executed locally).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix for API v4 exposing fulfillment data on guest orders via API
</details>
