### PR TITLE
Install JS dependencies in woocommerce-analytics build-package.sh

### DIFF
--- a/packages/php/woocommerce-analytics/tasks/build-package.sh
+++ b/packages/php/woocommerce-analytics/tasks/build-package.sh
@@ -19,6 +19,11 @@ if [ -d "$BUILD_DIR" ]; then
     rm -rf "$BUILD_DIR"
 fi
 
+# Install JS dependencies. The mirror workflow does not run `pnpm install`
+# before invoking us, so node_modules may be missing.
+echo "Installing JS dependencies..."
+pnpm install --filter "@automattic/woocommerce-analytics" --frozen-lockfile
+
 # Build JS assets first
 echo "Building JS assets..."
 pnpm run build-production


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes the **Mirror a PHP package for releasing it on Packagist.org** workflow for `@automattic/woocommerce-analytics`. The workflow currently fails during `bash tasks/build-package.sh` with:

```
[webpack-cli] Failed to load '.../woocommerce-analytics/webpack.config.js' config
ESM (`import`) failed:
  Cannot find module '@wordpress/dependency-extraction-webpack-plugin'
```

**Root cause:** `package-php-mirror.yml` calls the `setup-woocommerce-monorepo` action without `install: true`, so `pnpm install` never runs before `build:composer-package` is invoked. `email-editor` (the only other PHP package using this workflow) gets away with this because its `build-package.sh` is pure file-copy — no JS build. `woocommerce-analytics` has a JS client (`src/client/`) and runs webpack from inside `build-package.sh`, which needs `node_modules`.

Fix: install the package's own deps inside `build-package.sh` so the script is self-contained and works regardless of whether the caller pre-installed.

```diff
+# Install JS dependencies. The mirror workflow does not run `pnpm install`
+# before invoking us, so node_modules may be missing.
+echo "Installing JS dependencies..."
+pnpm install --filter "@automattic/woocommerce-analytics" --frozen-lockfile
+
 # Build JS assets first
 echo "Building JS assets..."
 pnpm run build-production
```

`--frozen-lockfile` keeps CI deterministic and is a no-op for local runs where `node_modules` is already in sync.

### How to test the changes in this Pull Request:

1. Pull this branch locally.
2. From the monorepo root, run:
   ```sh
   pnpm --filter "@automattic/woocommerce-analytics" build:composer-package
   ```
   Should complete with `Build completed successfully!` and produce `packages/php/woocommerce-analytics/build/Automattic/woocommerce-analytics/` containing `src/`, `build/`, `composer.json`, `CHANGELOG.md`, etc.
3. After this PR merges, trigger [Mirror a PHP package workflow](https://github.com/woocommerce/woocommerce/actions/workflows/package-php-mirror.yml) with `package: @automattic/woocommerce-analytics`. The previously failing run (`Build package for mirroring` step) should now succeed end-to-end and push to the mirror repo, where the autotagger will tag `v0.16.4`.

### Testing that has already taken place:

- Ran `pnpm --filter "@automattic/woocommerce-analytics" build:composer-package` locally — completes successfully, webpack output unchanged, all files copied correctly to the mirror directory.
- Verified composer.json/CHANGELOG.md in the build output match source.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [x] This Pull Request does not require a changelog entry.

#### Comment

Pure CI/release-tooling fix. No runtime, source, or user-visible changes. Unblocks publishing `woocommerce-analytics` 0.16.4 to Packagist via the mirror workflow.
