### PR TITLE
Require Store API nonce on shopper-lists item writes

### DIFF
--- a/plugins/woocommerce/changelog/rsm-shopper-collections-nonce-stopgap
+++ b/plugins/woocommerce/changelog/rsm-shopper-collections-nonce-stopgap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Require a wc_store_api Nonce header on shopper-lists item writes.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -9,6 +9,9 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * GET / POST on /shopper-lists/{slug}/items.
+ *
+ * GET returns the items in a list.
+ * POST saves an item to the list either from an existing cart line or from direct item payload fields.
  */
 class ShopperListItems extends AbstractRoute {
 	// Stopgap CSRF guard, replaced once the upstream trait lands on trunk.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -9,11 +9,11 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * GET / POST on /shopper-lists/{slug}/items.
- *
- * GET returns the items in a list.
- * POST saves an item to the list either from an existing cart line or from direct item payload fields.
  */
 class ShopperListItems extends AbstractRoute {
+	// Stopgap CSRF guard, replaced once the upstream trait lands on trunk.
+	use ShopperListsNonceCheck;
+
 	/**
 	 * Route identifier.
 	 *

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -10,6 +10,9 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
  * DELETE /shopper-lists/{slug}/items/{key}.
  */
 class ShopperListItemsByKey extends AbstractRoute {
+	// Stopgap CSRF guard, replaced once the upstream trait lands on trunk.
+	use ShopperListsNonceCheck;
+
 	/**
 	 * Route identifier.
 	 *

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
@@ -1,0 +1,80 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+/**
+ * Stopgap CSRF guard for the write-capable shopper-lists routes.
+ *
+ * Enforces a `wc_store_api` Nonce header on writes and refreshes the
+ * client nonce via response headers on every reply. Same shape as the
+ * cart's existing flow, scoped to the nonce concern.
+ *
+ * To be replaced by a reusable Store API-wide nonce trait once that
+ * lands on trunk.
+ *
+ * @internal
+ */
+trait ShopperListsNonceCheck {
+	/**
+	 * @param \WP_REST_Request $request Request object.
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 * @return \WP_REST_Response
+	 */
+	public function get_response( \WP_REST_Request $request ) {
+		if ( $this->is_write_request( $request ) ) {
+			$nonce_check = $this->check_store_api_nonce( $request );
+			if ( is_wp_error( $nonce_check ) ) {
+				return $this->add_nonce_response_headers( $this->error_to_response( $nonce_check ) );
+			}
+		}
+
+		$response = parent::get_response( $request );
+
+		return $this->add_nonce_response_headers( $response );
+	}
+
+	/**
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 */
+	private function is_write_request( \WP_REST_Request $request ): bool {
+		return in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true );
+	}
+
+	/**
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 * @return true|\WP_Error
+	 */
+	private function check_store_api_nonce( \WP_REST_Request $request ) {
+		/** This filter is documented in src/StoreApi/Routes/V1/AbstractCartRoute.php. */
+		if ( apply_filters( 'woocommerce_store_api_disable_nonce_check', false ) ) {
+			return true;
+		}
+
+		$nonce = $request->get_header( 'Nonce' );
+		if ( null === $nonce || '' === $nonce ) {
+			return new \WP_Error(
+				'woocommerce_rest_missing_nonce',
+				__( 'Missing the Nonce header. This endpoint requires a valid nonce.', 'woocommerce' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		if ( ! wp_verify_nonce( $nonce, 'wc_store_api' ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_invalid_nonce',
+				__( 'Nonce is invalid.', 'woocommerce' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	private function add_nonce_response_headers( \WP_REST_Response $response ): \WP_REST_Response {
+		$response->header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$response->header( 'Nonce-Timestamp', (string) time() );
+
+		return $response;
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
@@ -17,6 +17,9 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
  */
 trait ShopperListsNonceCheck {
 	/**
+	 * Override of {@see AbstractRoute::get_response} that enforces the
+	 * `wc_store_api` Nonce header on writes and refreshes it on every reply.
+	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
 	 * @return \WP_REST_Response
@@ -35,18 +38,25 @@ trait ShopperListsNonceCheck {
 	}
 
 	/**
+	 * Whether the request mutates state. Mirrors `AbstractCartRoute::is_update_request`.
+	 *
+	 * @param \WP_REST_Request $request Request object.
 	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 * @return bool
 	 */
 	private function is_write_request( \WP_REST_Request $request ): bool {
 		return in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true );
 	}
 
 	/**
+	 * Verify the `Nonce` request header against the `wc_store_api` action.
+	 *
+	 * @param \WP_REST_Request $request Request object.
 	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
-	 * @return true|\WP_Error
+	 * @return true|\WP_Error True on success, WP_Error on missing/invalid nonce.
 	 */
 	private function check_store_api_nonce( \WP_REST_Request $request ) {
-		/** This filter is documented in src/StoreApi/Routes/V1/AbstractCartRoute.php. */
+		// This filter is documented in src/StoreApi/Routes/V1/AbstractCartRoute.php.
 		if ( apply_filters( 'woocommerce_store_api_disable_nonce_check', false ) ) {
 			return true;
 		}
@@ -71,6 +81,12 @@ trait ShopperListsNonceCheck {
 		return true;
 	}
 
+	/**
+	 * Attach a fresh `wc_store_api` nonce to the response.
+	 *
+	 * @param \WP_REST_Response $response Response object.
+	 * @return \WP_REST_Response
+	 */
 	private function add_nonce_response_headers( \WP_REST_Response $response ): \WP_REST_Response {
 		$response->header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$response->header( 'Nonce-Timestamp', (string) time() );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
@@ -56,7 +56,15 @@ trait ShopperListsNonceCheck {
 	 * @return true|\WP_Error True on success, WP_Error on missing/invalid nonce.
 	 */
 	private function check_store_api_nonce( \WP_REST_Request $request ) {
-		// This filter is documented in src/StoreApi/Routes/V1/AbstractCartRoute.php.
+		/**
+		 * Filters whether to disable the Store API nonce check.
+		 *
+		 * This filter is documented in src/StoreApi/Routes/V1/AbstractCartRoute.php.
+		 *
+		 * @since 4.5.0
+		 *
+		 * @param bool $disable_nonce_check If true, nonce checks will be disabled.
+		 */
 		if ( apply_filters( 'woocommerce_store_api_disable_nonce_check', false ) ) {
 			return true;
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
@@ -35,7 +35,7 @@ trait ShopperListsNonceCheck {
 		if ( $this->is_write_request( $request ) ) {
 			$nonce_check = $this->check_store_api_nonce( $request );
 			if ( is_wp_error( $nonce_check ) ) {
-				return $this->add_nonce_response_headers( rest_ensure_response( $this->error_to_response( $nonce_check ) ) );
+				return $this->add_nonce_response_headers( $this->error_to_response( $nonce_check ) );
 			}
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
@@ -17,6 +17,13 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
  */
 trait ShopperListsNonceCheck {
 	/**
+	 * Nonce action used to sign and verify Store API write requests.
+	 *
+	 * @var string
+	 */
+	private static $store_api_nonce_action = 'wc_store_api';
+
+	/**
 	 * Override of {@see AbstractRoute::get_response} that enforces the
 	 * `wc_store_api` Nonce header on writes and refreshes it on every reply.
 	 *
@@ -28,13 +35,13 @@ trait ShopperListsNonceCheck {
 		if ( $this->is_write_request( $request ) ) {
 			$nonce_check = $this->check_store_api_nonce( $request );
 			if ( is_wp_error( $nonce_check ) ) {
-				return $this->add_nonce_response_headers( $this->error_to_response( $nonce_check ) );
+				return $this->add_nonce_response_headers( rest_ensure_response( $this->error_to_response( $nonce_check ) ) );
 			}
 		}
 
 		$response = parent::get_response( $request );
 
-		return $this->add_nonce_response_headers( $response );
+		return $this->add_nonce_response_headers( rest_ensure_response( $response ) );
 	}
 
 	/**
@@ -71,18 +78,18 @@ trait ShopperListsNonceCheck {
 
 		$nonce = $request->get_header( 'Nonce' );
 		if ( null === $nonce || '' === $nonce ) {
-			return new \WP_Error(
+			return $this->get_route_error_response(
 				'woocommerce_rest_missing_nonce',
 				__( 'Missing the Nonce header. This endpoint requires a valid nonce.', 'woocommerce' ),
-				array( 'status' => 401 )
+				401
 			);
 		}
 
-		if ( ! wp_verify_nonce( $nonce, 'wc_store_api' ) ) {
-			return new \WP_Error(
+		if ( ! wp_verify_nonce( $nonce, self::$store_api_nonce_action ) ) {
+			return $this->get_route_error_response(
 				'woocommerce_rest_invalid_nonce',
 				__( 'Nonce is invalid.', 'woocommerce' ),
-				array( 'status' => 403 )
+				403
 			);
 		}
 
@@ -96,8 +103,9 @@ trait ShopperListsNonceCheck {
 	 * @return \WP_REST_Response
 	 */
 	private function add_nonce_response_headers( \WP_REST_Response $response ): \WP_REST_Response {
-		$response->header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$response->header( 'Nonce', wp_create_nonce( self::$store_api_nonce_action ) );
 		$response->header( 'Nonce-Timestamp', (string) time() );
+		$response->header( 'Cache-Control', 'no-store' );
 
 		return $response;
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -364,6 +364,11 @@ class ShopperLists extends ControllerTestCase {
 	 *           ["POST", "not-a-valid-nonce", 403, "woocommerce_rest_invalid_nonce"]
 	 *           ["DELETE", "", 401, "woocommerce_rest_missing_nonce"]
 	 *           ["DELETE", "not-a-valid-nonce", 403, "woocommerce_rest_invalid_nonce"]
+	 *
+	 * @param string $method              HTTP method.
+	 * @param string $nonce               Nonce header value.
+	 * @param int    $expected_status     Expected HTTP status code.
+	 * @param string $expected_error_code Expected WP_Error code.
 	 */
 	public function test_write_nonce_enforcement( string $method, string $nonce, int $expected_status, string $expected_error_code ) {
 		wp_set_current_user( $this->customer_id );
@@ -385,6 +390,9 @@ class ShopperLists extends ControllerTestCase {
 	 *
 	 * @testWith [null, 201]
 	 *           ["", 401]
+	 *
+	 * @param string|null $nonce           Nonce header value, or null to auto-attach a valid one.
+	 * @param int         $expected_status Expected HTTP status code.
 	 */
 	public function test_response_refreshes_nonce_headers( ?string $nonce, int $expected_status ) {
 		wp_set_current_user( $this->customer_id );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -87,16 +87,30 @@ class ShopperLists extends ControllerTestCase {
 	/**
 	 * Helper: dispatch a request and return the response.
 	 *
-	 * @param string $method HTTP method.
-	 * @param string $route Route path.
-	 * @param array  $params Body params.
+	 * On writes, `$nonce` defaults to a valid `wc_store_api` nonce. Pass `''`
+	 * to omit the header, or any other string to send a bad one.
+	 *
+	 * @param string      $method HTTP method.
+	 * @param string      $route  Route path.
+	 * @param array       $params Body params.
+	 * @param string|null $nonce  Nonce override.
 	 * @return \WP_REST_Response
 	 */
-	private function dispatch( string $method, string $route, array $params = array() ): \WP_REST_Response {
+	private function dispatch( string $method, string $route, array $params = array(), ?string $nonce = null ): \WP_REST_Response {
 		$request = new \WP_REST_Request( $method, $route );
 		foreach ( $params as $key => $value ) {
 			$request->set_param( $key, $value );
 		}
+
+		$is_write = in_array( $method, array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true );
+		if ( $is_write ) {
+			if ( null === $nonce ) {
+				$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+			} elseif ( '' !== $nonce ) {
+				$request->set_header( 'Nonce', $nonce );
+			}
+		}
+
 		return rest_get_server()->dispatch( $request );
 	}
 
@@ -341,5 +355,72 @@ class ShopperLists extends ControllerTestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 0, $response->get_data(), 'Other user should not see the first user\'s items.' );
+	}
+
+	/**
+	 * Test writes without (or with invalid) Nonce header are rejected.
+	 *
+	 * @testWith ["POST", "", 401, "woocommerce_rest_missing_nonce"]
+	 *           ["POST", "not-a-valid-nonce", 403, "woocommerce_rest_invalid_nonce"]
+	 *           ["DELETE", "", 401, "woocommerce_rest_missing_nonce"]
+	 *           ["DELETE", "not-a-valid-nonce", 403, "woocommerce_rest_invalid_nonce"]
+	 */
+	public function test_write_nonce_enforcement( string $method, string $nonce, int $expected_status, string $expected_error_code ) {
+		wp_set_current_user( $this->customer_id );
+
+		$is_post = 'POST' === $method;
+		$path    = $is_post
+			? '/wc/store/v1/shopper-lists/saved-for-later/items'
+			: '/wc/store/v1/shopper-lists/saved-for-later/items/' . str_repeat( 'a', 32 );
+		$params  = $is_post ? array( 'product_id' => $this->product->get_id() ) : array();
+
+		$response = $this->dispatch( $method, $path, $params, $nonce );
+
+		$this->assertEquals( $expected_status, $response->get_status() );
+		$this->assertSame( $expected_error_code, $response->get_data()['code'] );
+	}
+
+	/**
+	 * Test every response (success or auth failure) refreshes the Nonce headers.
+	 *
+	 * @testWith [null, 201]
+	 *           ["", 401]
+	 */
+	public function test_response_refreshes_nonce_headers( ?string $nonce, int $expected_status ) {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/saved-for-later/items',
+			array( 'product_id' => $this->product->get_id() ),
+			$nonce
+		);
+		$headers  = $response->get_headers();
+
+		$this->assertEquals( $expected_status, $response->get_status() );
+		$this->assertArrayHasKey( 'Nonce', $headers );
+		$this->assertArrayHasKey( 'Nonce-Timestamp', $headers );
+		$this->assertTrue( (bool) wp_verify_nonce( $headers['Nonce'], 'wc_store_api' ) );
+	}
+
+	/**
+	 * Test the `woocommerce_store_api_disable_nonce_check` filter bypass.
+	 */
+	public function test_disable_nonce_check_filter_bypasses_enforcement() {
+		wp_set_current_user( $this->customer_id );
+
+		add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
+		try {
+			$response = $this->dispatch(
+				'POST',
+				'/wc/store/v1/shopper-lists/saved-for-later/items',
+				array( 'product_id' => $this->product->get_id() ),
+				''
+			);
+		} finally {
+			remove_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
+		}
+
+		$this->assertEquals( 201, $response->get_status() );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The shopper-lists Store API routes added in #64472 rely on `is_user_logged_in()` alone for write authorization. The Store API short-circuits WP's built-in `rest_cookie_check_errors` (the `X-WP-Nonce` flow) via `Authentication::check_authentication`, so without our own check we'd be leaning entirely on browser `SameSite=Lax` defaults to block cross-origin form-POST CSRF, which is default on modern browsers but fragile elsewhere.

This PR adds a private `ShopperListsNonceCheck` trait scoped to `Routes/V1/`. It mirrors `AbstractCartRoute`'s `wc_store_api` Nonce flow with writes (POST/DELETE) requiring a valid `Nonce` header and every response refreshing the nonce via `Nonce` / `Nonce-Timestamp` response headers.

> [!NOTE]
> The new trait is `@internal` and tagged as a stopgap, with the intention of being replaced by a reusable Store API-wide nonce trait targeting trunk in a separate PR.


### How to test the changes in this Pull Request:

1. Ensure you're not running with `woocommerce_store_api_disable_nonce_check` disabled.
1. Enable **Save for Later in Cart** in **Settings > Advanced > Features**.
1. Log in as a customer and add a couple of products to the cart on the canonical cart page.
1. Click **Save for later** on a cart line moving the item into the "Saved For later" block below the cart.
1. Click the trash icon on a saved item and confirm it disappears and the deletion persists after a page reload.
1. To confirm the server-side enforcement, grab a valid product ID for a simple product from your store and run the code below in the browser's console while logged in:
    ```js
    (async () => {
      const r = await fetch('/wp-json/wc/store/v1/shopper-lists/saved-for-later/items?product_id=123', { method: 'POST' });
      console.log(r.status, await r.json());
    })();
    ```

    - On this branch you should get a 401 error indicating the nonce is missing.
    - On `feature/shopper-collections` (parent branch) the request succeeds and silently adds an item.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**