### PR TITLE
Limit reviewer assignment workflow to trunk and release branches

### DIFF
--- a/.github/workflows/automate-team-review-assignment.yml
+++ b/.github/workflows/automate-team-review-assignment.yml
@@ -73,7 +73,7 @@ jobs:
               token: ${{ secrets.PR_ASSIGN_TOKEN }}
 
         - name: Assign reviewers for a teams PR
-          if: ${{ steps.check.outputs.contributor == 'no' && github.event.pull_request.draft == false && ! contains( github.event.pull_request.labels.*.name, 'Release' ) }}
+          if: ${{ steps.check.outputs.contributor == 'no' && github.event.pull_request.draft == false && ! contains( github.event.pull_request.labels.*.name, 'Release' ) && ( github.event.pull_request.base.ref == 'trunk' || startsWith( github.event.pull_request.base.ref, 'release/' ) ) }}
           continue-on-error: ${{ ( github.event.pull_request.head.repo.fork && 'true' ) || 'false' }}
           uses: acq688/Request-Reviewer-For-Team-Action@fca1c60fd0504aef59bdc925f3902c8a2d8bce62 # v1.1
           with:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Gate the "Assign reviewers for a teams PR" step in `automate-team-review-assignment.yml` to PRs whose base ref is `trunk` or `release/*`. PRs targeting working/feature branches no longer auto-request team reviewers to avoid authors having to spend time removing reviewers on every PR. The relevant teams will be requested anyway when the work eventually lands in a PR targeting `trunk`.

> [!IMPORTANT]
> I'm not sure if anyone is actually relying on this for getting reviews in temporary or feature branches, so I'd defer to Flux/HoG for actual approval, but it seems to me that it's unnecessary and adds noise because those reviewers get pinged for things that they don't really need to review at that point.
> In cases where you belong to more than one team, even more reviewers get pinged 😸 

### How to test the changes in this Pull Request:

`pull_request_target` workflows run from the base branch, so this only takes effect after merge. Then:

1. Open a PR (non draft!) targeting a working branch (for example `feature/shopper-collections`) and confirm the "Assign reviewers for a teams PR" step is **skipped** and no team reviewers are requested.
2. Open a non-draft PR targeting `trunk`: confirm the step **runs** and team reviewers are requested as before.