### PR TITLE
RSM: Fix iAPI hydration mismatch on shopper-collection variation span

### DIFF
--- a/plugins/woocommerce/changelog/64771-fix-shopper-collection-variation-hydration
+++ b/plugins/woocommerce/changelog/64771-fix-shopper-collection-variation-hydration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Interactivity API hydration warning on shopper-collection rows for items without product variations.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -428,9 +428,16 @@ final class ShopperCollection extends AbstractBlock {
 				>
 					<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
 				</button>
-				<?php if ( '' !== $variation_label ) : ?>
-					<span class="wc-block-shopper-collection-item__variation"><?php echo esc_html( $variation_label ); ?></span>
-				<?php endif; ?>
+				<span
+					class="wc-block-shopper-collection-item__variation"
+					data-wp-bind--hidden="!state.currentItemVariationLabel"
+					data-wp-text="state.currentItemVariationLabel"
+					<?php
+					if ( '' === $variation_label ) {
+						echo 'hidden';
+					}
+					?>
+				><?php echo esc_html( $variation_label ); ?></span>
 			</div>
 			<?php
 			// Render the decoded display name as plain text so the SSR


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The shopper-collection block renders one row per saved item using a JS `<template data-wp-each>` that always declares a variation `<span>`. The PHP SSR path only emitted that span when the item had a non-empty variation label, so rows for non-variation products triggered the Interactivity API hydration walker's `Expected a DOM node of type "span" but found ""` warning and aborted hydration of the subtree.

Always emit the variation `<span>` server-side and toggle visibility with the inline `hidden` attribute plus `data-wp-bind--hidden`, mirroring the pattern already used by the adjacent price wrapper and Move-to-cart button. The `data-wp-text` directive is added so post-hydration context changes still update the text reactively.

Bug introduced in PR #64651.

### How to test the changes in this Pull Request:

1. Enable the "Save for Later in Cart" experimental feature (`WooCommerce → Settings → Advanced → Features`, or `wp option update woocommerce_cart_save_for_later_enabled yes`).
2. Make sure the `woocommerce/shopper-collection` block is on the cart page (it auto-injects after the cart block when the feature is on).
3. As a logged-in shopper, save at least one **simple** product (no attributes) and one **variable** product to your saved-for-later list from the cart.
4. Reload the cart page and open the browser devtools console.
5. **Before the fix:** the console logs `Expected a DOM node of type "span" but found "" as available DOM-node(s)` with a `Directives → span` stack.
6. **After the fix:** no such warning. Variation rows still display attribute labels (e.g. `Color: Blue, Size: M`); simple-product rows render with no visible variation slot.

### Testing that has already taken place:

Reproduced the hydration warning locally on a cart page containing a saved-for-later list with a simple (non-variation) product; confirmed the warning is gone after this change, and that variation labels still render correctly for variable products. PHPStan clean for the modified file.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Fix Interactivity API hydration warning on shopper-collection rows for items without product variations.

</details>