### PR TITLE
Add variation data forms extensibility with legacy field support

### DIFF
--- a/packages/js/experimental-products-app/src/fields/legacy/adapter.test.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/adapter.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Internal dependencies
+ */
+import type { ProductEntityRecord } from '../types';
+import { parseVisibility } from './adapter';
+
+describe( 'parseVisibility', () => {
+	const buildItem = (
+		overrides: Partial< ProductEntityRecord > = {}
+	): ProductEntityRecord =>
+		( {
+			id: 1,
+			manage_stock: false,
+			downloadable: false,
+			virtual: false,
+			...overrides,
+		} as unknown as ProductEntityRecord );
+
+	it( 'returns undefined when no patterns match', () => {
+		expect( parseVisibility( 'some-random-class' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for empty string', () => {
+		expect( parseVisibility( '' ) ).toBeUndefined();
+	} );
+
+	it( 'handles single show_if_variation_manage_stock', () => {
+		const check = parseVisibility( 'show_if_variation_manage_stock' );
+		expect( check ).toBeDefined();
+		expect( check!( buildItem( { manage_stock: true } ) ) ).toBe( true );
+		expect( check!( buildItem( { manage_stock: false } ) ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'handles single hide_if_variation_virtual', () => {
+		const check = parseVisibility( 'hide_if_variation_virtual' );
+		expect( check ).toBeDefined();
+		expect( check!( buildItem( { virtual: false } ) ) ).toBe( true );
+		expect( check!( buildItem( { virtual: true } ) ) ).toBe( false );
+	} );
+
+	it( 'ANDs compound classes: show_if_manage_stock AND hide_if_virtual', () => {
+		const check = parseVisibility(
+			'show_if_variation_manage_stock hide_if_variation_virtual'
+		);
+		expect( check ).toBeDefined();
+
+		expect(
+			check!( buildItem( { manage_stock: true, virtual: false } ) )
+		).toBe( true );
+
+		expect(
+			check!( buildItem( { manage_stock: true, virtual: true } ) )
+		).toBe( false );
+
+		expect(
+			check!( buildItem( { manage_stock: false, virtual: false } ) )
+		).toBe( false );
+
+		expect(
+			check!( buildItem( { manage_stock: false, virtual: true } ) )
+		).toBe( false );
+	} );
+} );

--- a/packages/js/experimental-products-app/src/fields/legacy/adapter.test.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/adapter.test.ts
@@ -28,9 +28,7 @@ describe( 'parseVisibility', () => {
 		const check = parseVisibility( 'show_if_variation_manage_stock' );
 		expect( check ).toBeDefined();
 		expect( check!( buildItem( { manage_stock: true } ) ) ).toBe( true );
-		expect( check!( buildItem( { manage_stock: false } ) ) ).toBe(
-			false
-		);
+		expect( check!( buildItem( { manage_stock: false } ) ) ).toBe( false );
 	} );
 
 	it( 'handles single hide_if_variation_virtual', () => {

--- a/packages/js/experimental-products-app/src/fields/legacy/adapter.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/adapter.ts
@@ -1,0 +1,361 @@
+/**
+ * External dependencies
+ */
+import {
+	SelectControl,
+	TextControl,
+	TextareaControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { ProductEntityRecord } from '../types';
+import type { LegacyFieldDefinition, LegacyHookMapping } from './types';
+
+type MetaDataEntry = { id?: number; key: string; value: string };
+type FieldRef = { id: string; label: string };
+const SAFE_HTML_ATTRIBUTES = new Set( [
+	'min',
+	'max',
+	'step',
+	'maxLength',
+	'minLength',
+	'pattern',
+	'readonly',
+	'disabled',
+] );
+
+function sanitizeCustomAttributes(
+	attrs: Record< string, string >
+): Record< string, string > {
+	const safe: Record< string, string > = {};
+	for ( const [ key, value ] of Object.entries( attrs ) ) {
+		if ( SAFE_HTML_ATTRIBUTES.has( key ) ) {
+			safe[ key ] = value;
+		}
+	}
+	return safe;
+}
+
+type TextControlType =
+	| 'text'
+	| 'number'
+	| 'email'
+	| 'url'
+	| 'tel'
+	| 'password'
+	| 'search'
+	| 'date'
+	| 'time'
+	| 'datetime-local';
+
+function getMetaValue(
+	item: ProductEntityRecord,
+	metaKey: string
+): string {
+	const entry = item.meta_data?.find(
+		( m: MetaDataEntry ) => m.key === metaKey
+	);
+	return entry?.value ?? '';
+}
+
+function updateMetaData(
+	data: ProductEntityRecord,
+	metaKey: string,
+	value: string,
+	onChange: ( changes: Partial< ProductEntityRecord > ) => void
+): void {
+	const existing = data.meta_data ?? [];
+	const idx = existing.findIndex(
+		( m: MetaDataEntry ) => m.key === metaKey
+	);
+
+	const updated =
+		idx >= 0
+			? existing.map( ( m: MetaDataEntry, i: number ) =>
+					i === idx ? { ...m, value } : m
+			  )
+			: [ ...existing, { key: metaKey, value } ];
+
+	onChange( { meta_data: updated } as Partial< ProductEntityRecord > );
+}
+
+function parseVisibility(
+	wrapperClass: string
+): ( ( item: ProductEntityRecord ) => boolean ) | undefined {
+	const patterns: Record<
+		string,
+		( item: ProductEntityRecord ) => boolean
+	> = {
+		show_if_variation_manage_stock: ( item ) =>
+			item.manage_stock === true,
+		hide_if_variation_virtual: ( item ) =>
+			( item as ProductEntityRecord & { virtual?: boolean } )
+				.virtual !== true,
+		show_if_variation_downloadable: ( item ) =>
+			item.downloadable === true,
+	};
+
+	for ( const [ pattern, check ] of Object.entries( patterns ) ) {
+		if ( wrapperClass.includes( pattern ) ) {
+			return check;
+		}
+	}
+
+	return undefined;
+}
+
+function createTextEdit(
+	metaKey: string,
+	opts: {
+		placeholder?: string;
+		help?: string;
+		inputType?: string;
+		customAttributes?: Record< string, string >;
+	} = {}
+) {
+	return ( {
+		data,
+		field,
+		onChange,
+	}: {
+		data: ProductEntityRecord;
+		field: FieldRef;
+		onChange: ( changes: Partial< ProductEntityRecord > ) => void;
+	} ) =>
+		createElement( TextControl, {
+			__nextHasNoMarginBottom: true,
+			label: field.label,
+			help: opts.help,
+			placeholder: opts.placeholder,
+			type: ( opts.inputType || 'text' ) as TextControlType,
+			value: getMetaValue( data, metaKey ),
+			onChange: ( value: string ) =>
+				updateMetaData( data, metaKey, value, onChange ),
+			...sanitizeCustomAttributes( opts.customAttributes ?? {} ),
+		} );
+}
+
+function createTextareaEdit(
+	metaKey: string,
+	opts: { placeholder?: string; help?: string } = {}
+) {
+	return ( {
+		data,
+		field,
+		onChange,
+	}: {
+		data: ProductEntityRecord;
+		field: FieldRef;
+		onChange: ( changes: Partial< ProductEntityRecord > ) => void;
+	} ) =>
+		createElement( TextareaControl, {
+			__nextHasNoMarginBottom: true,
+			label: field.label,
+			help: opts.help,
+			placeholder: opts.placeholder,
+			value: getMetaValue( data, metaKey ),
+			onChange: ( value: string ) =>
+				updateMetaData( data, metaKey, value, onChange ),
+		} );
+}
+
+function createSelectEdit(
+	metaKey: string,
+	options: Record< string, string >,
+	help?: string
+) {
+	const selectOptions = Object.entries( options ).map(
+		( [ value, label ] ) => ( { value, label } )
+	);
+
+	return ( {
+		data,
+		field,
+		onChange,
+	}: {
+		data: ProductEntityRecord;
+		field: FieldRef;
+		onChange: ( changes: Partial< ProductEntityRecord > ) => void;
+	} ) =>
+		createElement( SelectControl, {
+			__nextHasNoMarginBottom: true,
+			__next40pxDefaultSize: true,
+			label: field.label,
+			help,
+			value: getMetaValue( data, metaKey ),
+			options: selectOptions,
+			onChange: ( value: string ) =>
+				updateMetaData( data, metaKey, value, onChange ),
+		} );
+}
+
+function createCheckboxEdit(
+	metaKey: string,
+	label: string,
+	help?: string
+) {
+	return ( {
+		data,
+		onChange,
+	}: {
+		data: ProductEntityRecord;
+		onChange: ( changes: Partial< ProductEntityRecord > ) => void;
+	} ) => {
+		const raw = getMetaValue( data, metaKey );
+		return createElement( ToggleControl, {
+			__nextHasNoMarginBottom: true,
+			label,
+			help,
+			checked: raw === 'yes' || raw === '1',
+			onChange: ( checked: boolean ) =>
+				updateMetaData(
+					data,
+					metaKey,
+					checked ? 'yes' : 'no',
+					onChange
+				),
+		} );
+	};
+}
+
+/**
+ * Convert a legacy field definition into a DataForm Field object.
+ *
+ * Returns null for unsupported types with a console warning.
+ */
+export function createLegacyField(
+	definition: LegacyFieldDefinition
+): Field< ProductEntityRecord > | null {
+	const fieldId = `legacy:${ definition.id }`;
+	const metaKey = definition.meta_key;
+
+	const baseField: Partial< Field< ProductEntityRecord > > = {
+		id: fieldId,
+		label: definition.label || definition.id,
+		enableSorting: false,
+		filterBy: false as const,
+		getValue: ( { item } ) => getMetaValue( item, metaKey ),
+	};
+
+	const visibility = parseVisibility( definition.wrapper_class );
+	if ( visibility ) {
+		baseField.isVisible = visibility;
+	}
+
+	if ( definition.hidden ) {
+		return {
+			...baseField,
+			type: 'text',
+			isVisible: () => false,
+		} as Field< ProductEntityRecord >;
+	}
+
+	const { description, placeholder, input_type, custom_attributes } =
+		definition;
+	const help = description || undefined;
+
+	switch ( definition.type ) {
+		case 'text_input':
+			return {
+				...baseField,
+				type: 'text',
+				Edit: createTextEdit( metaKey, {
+					placeholder,
+					help,
+					inputType: input_type,
+					customAttributes: custom_attributes,
+				} ),
+			} as Field< ProductEntityRecord >;
+
+		case 'textarea_input':
+			return {
+				...baseField,
+				type: 'text',
+				Edit: createTextareaEdit( metaKey, {
+					placeholder,
+					help,
+				} ),
+			} as Field< ProductEntityRecord >;
+
+		case 'select':
+			return {
+				...baseField,
+				type: 'text',
+				Edit: createSelectEdit(
+					metaKey,
+					definition.options,
+					help
+				),
+			} as Field< ProductEntityRecord >;
+
+		case 'checkbox':
+			return {
+				...baseField,
+				type: 'text',
+				Edit: createCheckboxEdit(
+					metaKey,
+					definition.label || definition.id,
+					help
+				),
+			} as Field< ProductEntityRecord >;
+
+		case 'radio':
+			return {
+				...baseField,
+				type: 'text',
+				Edit: createSelectEdit(
+					metaKey,
+					definition.options,
+					help
+				),
+			} as Field< ProductEntityRecord >;
+
+		default:
+			// eslint-disable-next-line no-console
+			console.warn(
+				`Legacy field "${ definition.id }" uses unsupported type "${ definition.type }" and will be skipped.`
+			);
+			return null;
+	}
+}
+
+/**
+ * Merge legacy fields into a native field list based on hook mapping positions.
+ */
+export function insertLegacyFields(
+	nativeFields: Field< ProductEntityRecord >[],
+	legacyFieldsByHook: Record< string, Field< ProductEntityRecord >[] >,
+	hookMapping: LegacyHookMapping
+): Field< ProductEntityRecord >[] {
+	const result = [ ...nativeFields ];
+
+	for ( const [ hookName, position ] of Object.entries( hookMapping ) ) {
+		const hookFields = legacyFieldsByHook[ hookName ];
+		if ( ! hookFields || hookFields.length === 0 ) {
+			continue;
+		}
+
+		if ( 'insertAt' in position && position.insertAt === 'end' ) {
+			result.push( ...hookFields );
+			continue;
+		}
+
+		if ( 'insertAfter' in position ) {
+			const anchorIndex = result.findIndex(
+				( f ) => f.id === position.insertAfter
+			);
+			if ( anchorIndex >= 0 ) {
+				result.splice( anchorIndex + 1, 0, ...hookFields );
+			} else {
+				result.push( ...hookFields );
+			}
+		}
+	}
+
+	return result;
+}

--- a/packages/js/experimental-products-app/src/fields/legacy/adapter.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/adapter.ts
@@ -53,10 +53,7 @@ type TextControlType =
 	| 'time'
 	| 'datetime-local';
 
-function getMetaValue(
-	item: ProductEntityRecord,
-	metaKey: string
-): string {
+function getMetaValue( item: ProductEntityRecord, metaKey: string ): string {
 	const entry = item.meta_data?.find(
 		( m: MetaDataEntry ) => m.key === metaKey
 	);
@@ -70,9 +67,7 @@ function updateMetaData(
 	onChange: ( changes: Partial< ProductEntityRecord > ) => void
 ): void {
 	const existing = data.meta_data ?? [];
-	const idx = existing.findIndex(
-		( m: MetaDataEntry ) => m.key === metaKey
-	);
+	const idx = existing.findIndex( ( m: MetaDataEntry ) => m.key === metaKey );
 
 	const updated =
 		idx >= 0
@@ -87,18 +82,16 @@ function updateMetaData(
 export function parseVisibility(
 	wrapperClass: string
 ): ( ( item: ProductEntityRecord ) => boolean ) | undefined {
-	const patterns: Record<
-		string,
-		( item: ProductEntityRecord ) => boolean
-	> = {
-		show_if_variation_manage_stock: ( item ) =>
-			item.manage_stock === true,
-		hide_if_variation_virtual: ( item ) =>
-			( item as ProductEntityRecord & { virtual?: boolean } )
-				.virtual !== true,
-		show_if_variation_downloadable: ( item ) =>
-			item.downloadable === true,
-	};
+	const patterns: Record< string, ( item: ProductEntityRecord ) => boolean > =
+		{
+			show_if_variation_manage_stock: ( item ) =>
+				item.manage_stock === true,
+			hide_if_variation_virtual: ( item ) =>
+				( item as ProductEntityRecord & { virtual?: boolean } )
+					.virtual !== true,
+			show_if_variation_downloadable: ( item ) =>
+				item.downloadable === true,
+		};
 
 	const checks: ( ( item: ProductEntityRecord ) => boolean )[] = [];
 	for ( const [ pattern, check ] of Object.entries( patterns ) ) {
@@ -199,11 +192,7 @@ function createSelectEdit(
 		} );
 }
 
-function createCheckboxEdit(
-	metaKey: string,
-	label: string,
-	help?: string
-) {
+function createCheckboxEdit( metaKey: string, label: string, help?: string ) {
 	return ( {
 		data,
 		onChange,
@@ -291,11 +280,7 @@ export function createLegacyField(
 			return {
 				...baseField,
 				type: 'text',
-				Edit: createSelectEdit(
-					metaKey,
-					definition.options,
-					help
-				),
+				Edit: createSelectEdit( metaKey, definition.options, help ),
 			} as Field< ProductEntityRecord >;
 
 		case 'checkbox':
@@ -313,11 +298,7 @@ export function createLegacyField(
 			return {
 				...baseField,
 				type: 'text',
-				Edit: createSelectEdit(
-					metaKey,
-					definition.options,
-					help
-				),
+				Edit: createSelectEdit( metaKey, definition.options, help ),
 			} as Field< ProductEntityRecord >;
 
 		default:

--- a/packages/js/experimental-products-app/src/fields/legacy/adapter.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/adapter.ts
@@ -84,7 +84,7 @@ function updateMetaData(
 	onChange( { meta_data: updated } as Partial< ProductEntityRecord > );
 }
 
-function parseVisibility(
+export function parseVisibility(
 	wrapperClass: string
 ): ( ( item: ProductEntityRecord ) => boolean ) | undefined {
 	const patterns: Record<
@@ -100,13 +100,18 @@ function parseVisibility(
 			item.downloadable === true,
 	};
 
+	const checks: ( ( item: ProductEntityRecord ) => boolean )[] = [];
 	for ( const [ pattern, check ] of Object.entries( patterns ) ) {
 		if ( wrapperClass.includes( pattern ) ) {
-			return check;
+			checks.push( check );
 		}
 	}
 
-	return undefined;
+	if ( checks.length === 0 ) {
+		return undefined;
+	}
+
+	return ( item ) => checks.every( ( check ) => check( item ) );
 }
 
 function createTextEdit(

--- a/packages/js/experimental-products-app/src/fields/legacy/index.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/index.ts
@@ -1,5 +1,6 @@
 export { createLegacyField, insertLegacyFields } from './adapter';
 export { useLegacyFields } from './use-legacy-fields';
+export { useVariationMeta } from './use-variation-meta';
 export type {
 	LegacyFieldDefinition,
 	LegacyFieldsResponse,

--- a/packages/js/experimental-products-app/src/fields/legacy/index.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/index.ts
@@ -1,0 +1,7 @@
+export { createLegacyField, insertLegacyFields } from './adapter';
+export { useLegacyFields } from './use-legacy-fields';
+export type {
+	LegacyFieldDefinition,
+	LegacyFieldsResponse,
+	LegacyHookMapping,
+} from './types';

--- a/packages/js/experimental-products-app/src/fields/legacy/index.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/index.ts
@@ -1,6 +1,9 @@
 export { createLegacyField, insertLegacyFields } from './adapter';
 export { useLegacyFields } from './use-legacy-fields';
-export { useVariationMeta } from './use-variation-meta';
+export {
+	useVariationMeta,
+	updateVariationMetaCache,
+} from './use-variation-meta';
 export type {
 	LegacyFieldDefinition,
 	LegacyFieldsResponse,

--- a/packages/js/experimental-products-app/src/fields/legacy/types.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Shape of a single field definition from the legacy-fields REST endpoint.
+ */
+export type LegacyFieldDefinition = {
+	id: string;
+	type: string;
+	input_type: string;
+	label: string;
+	meta_key: string;
+	placeholder: string;
+	description: string;
+	default_value: string;
+	wrapper_class: string;
+	custom_attributes: Record< string, string >;
+	options: Record< string, string >;
+	hidden: boolean;
+};
+
+/**
+ * REST response shape from GET /wc/v4/products/legacy-fields.
+ */
+export type LegacyFieldsResponse = {
+	fields: Record< string, LegacyFieldDefinition[] >;
+};
+
+/**
+ * Mapping from hook name to insertion point in the native field list.
+ */
+export type LegacyHookMapping = Record<
+	string,
+	{ insertAfter: string } | { insertAt: 'end' }
+>;

--- a/packages/js/experimental-products-app/src/fields/legacy/use-legacy-fields.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/use-legacy-fields.ts
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { ProductEntityRecord } from '../types';
+import type {
+	LegacyFieldsResponse,
+	LegacyHookMapping,
+} from './types';
+import { createLegacyField } from './adapter';
+
+type UseLegacyFieldsResult = {
+	fieldsByHook: Record< string, Field< ProductEntityRecord >[] >;
+	isLoading: boolean;
+};
+
+/**
+ * Fetch legacy field definitions and convert them to DataForm fields.
+ *
+ * Results are cached for the lifetime of the component — field definitions
+ * don't change within a session.
+ */
+export function useLegacyFields(
+	hookMapping: LegacyHookMapping
+): UseLegacyFieldsResult {
+	const [ fieldsByHook, setFieldsByHook ] = useState<
+		Record< string, Field< ProductEntityRecord >[] >
+	>( {} );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const cacheRef = useRef< Record<
+		string,
+		Field< ProductEntityRecord >[]
+	> | null >( null );
+
+	const hookNames = Object.keys( hookMapping );
+	const hookNamesKey = hookNames.join( ',' );
+
+	useEffect( () => {
+		if ( cacheRef.current ) {
+			setFieldsByHook( cacheRef.current );
+			setIsLoading( false );
+			return;
+		}
+
+		if ( hookNames.length === 0 ) {
+			setFieldsByHook( {} );
+			setIsLoading( false );
+			return;
+		}
+
+		let cancelled = false;
+
+		const hooksParam = hookNames
+			.map( ( name ) => `hooks[]=${ encodeURIComponent( name ) }` )
+			.join( '&' );
+
+		apiFetch< LegacyFieldsResponse >( {
+			path: `/wc/v4/products/legacy-fields?${ hooksParam }`,
+		} )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+
+				const grouped: Record<
+					string,
+					Field< ProductEntityRecord >[]
+				> = {};
+
+				const fieldsData = response.fields ?? response;
+
+				for ( const [ hookName, definitions ] of Object.entries(
+					fieldsData as Record< string, unknown[] >
+				) ) {
+					grouped[ hookName ] = [];
+					for ( const def of definitions ) {
+						const field = createLegacyField(
+							def as Parameters< typeof createLegacyField >[ 0 ]
+						);
+						if ( field ) {
+							grouped[ hookName ].push( field );
+						}
+					}
+				}
+
+				cacheRef.current = grouped;
+				setFieldsByHook( grouped );
+				setIsLoading( false );
+			} )
+			.catch( ( error ) => {
+				if ( ! cancelled ) {
+					// eslint-disable-next-line no-console
+					console.error( 'Failed to load legacy field definitions:', error );
+					setFieldsByHook( {} );
+					setIsLoading( false );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ hookNamesKey ] );
+
+	return { fieldsByHook, isLoading };
+}

--- a/packages/js/experimental-products-app/src/fields/legacy/use-legacy-fields.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/use-legacy-fields.ts
@@ -9,10 +9,7 @@ import type { Field } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import type { ProductEntityRecord } from '../types';
-import type {
-	LegacyFieldsResponse,
-	LegacyHookMapping,
-} from './types';
+import type { LegacyFieldsResponse, LegacyHookMapping } from './types';
 import { createLegacyField } from './adapter';
 
 type UseLegacyFieldsResult = {
@@ -96,7 +93,10 @@ export function useLegacyFields(
 			.catch( ( error ) => {
 				if ( ! cancelled ) {
 					// eslint-disable-next-line no-console
-					console.error( 'Failed to load legacy field definitions:', error );
+					console.error(
+						'Failed to load legacy field definitions:',
+						error
+					);
 					setFieldsByHook( {} );
 					setIsLoading( false );
 				}

--- a/packages/js/experimental-products-app/src/fields/legacy/use-variation-meta.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/use-variation-meta.ts
@@ -2,9 +2,26 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 type MetaDataEntry = { id?: number; key: string; value: string };
+
+const metaCache: Record< string, MetaDataEntry[] > = {};
+
+function getCacheKey( parentId: number, variationId: number ) {
+	return `${ parentId }:${ variationId }`;
+}
+
+export function updateVariationMetaCache(
+	parentId: number,
+	variationId: number,
+	meta: Array< { id?: number; key: string; value?: string } >
+) {
+	metaCache[ getCacheKey( parentId, variationId ) ] = meta.map( ( m ) => ( {
+		...m,
+		value: m.value ?? '',
+	} ) );
+}
 
 /**
  * Fetch meta_data for a variation from the WC REST API.
@@ -17,22 +34,19 @@ export function useVariationMeta(
 	parentId: number | undefined,
 	variationId: number | undefined
 ): MetaDataEntry[] | undefined {
-	const [ metaData, setMetaData ] = useState< MetaDataEntry[] | undefined >(
-		undefined
-	);
-	const cacheRef = useRef<
-		Record< string, MetaDataEntry[] >
-	>( {} );
+	const [ fetchedData, setFetchedData ] = useState<
+		MetaDataEntry[] | undefined
+	>( undefined );
 
 	useEffect( () => {
 		if ( ! parentId || ! variationId ) {
-			setMetaData( undefined );
+			setFetchedData( undefined );
 			return;
 		}
 
-		const cacheKey = `${ parentId }:${ variationId }`;
-		if ( cacheRef.current[ cacheKey ] ) {
-			setMetaData( cacheRef.current[ cacheKey ] );
+		const cacheKey = getCacheKey( parentId, variationId );
+		if ( metaCache[ cacheKey ] ) {
+			setFetchedData( metaCache[ cacheKey ] );
 			return;
 		}
 
@@ -47,12 +61,12 @@ export function useVariationMeta(
 				}
 
 				const meta = response.meta_data ?? [];
-				cacheRef.current[ cacheKey ] = meta;
-				setMetaData( meta );
+				metaCache[ cacheKey ] = meta;
+				setFetchedData( meta );
 			} )
 			.catch( () => {
 				if ( ! cancelled ) {
-					setMetaData( [] );
+					setFetchedData( [] );
 				}
 			} );
 
@@ -61,5 +75,12 @@ export function useVariationMeta(
 		};
 	}, [ parentId, variationId ] );
 
-	return metaData;
+	if ( parentId && variationId ) {
+		const cached = metaCache[ getCacheKey( parentId, variationId ) ];
+		if ( cached ) {
+			return cached;
+		}
+	}
+
+	return fetchedData;
 }

--- a/packages/js/experimental-products-app/src/fields/legacy/use-variation-meta.ts
+++ b/packages/js/experimental-products-app/src/fields/legacy/use-variation-meta.ts
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+type MetaDataEntry = { id?: number; key: string; value: string };
+
+/**
+ * Fetch meta_data for a variation from the WC REST API.
+ *
+ * The V4 entity store strips meta_data from embedded variations for
+ * performance. This hook fetches it separately so legacy fields can
+ * read and write meta values.
+ */
+export function useVariationMeta(
+	parentId: number | undefined,
+	variationId: number | undefined
+): MetaDataEntry[] | undefined {
+	const [ metaData, setMetaData ] = useState< MetaDataEntry[] | undefined >(
+		undefined
+	);
+	const cacheRef = useRef<
+		Record< string, MetaDataEntry[] >
+	>( {} );
+
+	useEffect( () => {
+		if ( ! parentId || ! variationId ) {
+			setMetaData( undefined );
+			return;
+		}
+
+		const cacheKey = `${ parentId }:${ variationId }`;
+		if ( cacheRef.current[ cacheKey ] ) {
+			setMetaData( cacheRef.current[ cacheKey ] );
+			return;
+		}
+
+		let cancelled = false;
+
+		apiFetch< { meta_data: MetaDataEntry[] } >( {
+			path: `/wc/v3/products/${ parentId }/variations/${ variationId }?_fields=meta_data`,
+		} )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+
+				const meta = response.meta_data ?? [];
+				cacheRef.current[ cacheKey ] = meta;
+				setMetaData( meta );
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setMetaData( [] );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ parentId, variationId ] );
+
+	return metaData;
+}

--- a/packages/js/experimental-products-app/src/fields/product_status/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/product_status/field.tsx
@@ -42,6 +42,7 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 	),
 	Edit: ( { data, onChange, field } ) => (
 		<SelectControl
+			__next40pxDefaultSize
 			label={ field.label }
 			value={ data.status }
 			options={ field.elements?.filter(

--- a/packages/js/experimental-products-app/src/fields/shipping_class/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/shipping_class/field.tsx
@@ -65,6 +65,7 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 
 		return (
 			<SelectControl
+				__next40pxDefaultSize
 				label={ field.label }
 				value={ data.shipping_class }
 				options={ options }

--- a/packages/js/experimental-products-app/src/fields/types.ts
+++ b/packages/js/experimental-products-app/src/fields/types.ts
@@ -33,6 +33,7 @@ export type ProductEntityRecord = Omit< Product, 'categories' | 'tags' > & {
 	_embedded?: {
 		variations?: ProductEntityRecord[];
 	};
+	meta_data?: Array< { id?: number; key: string; value: string } >;
 	seo_title?: string;
 	seo_description?: string;
 	visible_in_pos?: boolean;

--- a/packages/js/experimental-products-app/src/product-edit/index.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/index.tsx
@@ -20,6 +20,7 @@ import {
 	getSelectionFromPostId,
 } from '../product-list/utils';
 import type { ProductEntityRecord } from '../fields/types';
+import { useLegacyFields, insertLegacyFields } from '../fields/legacy';
 import { unlock } from '../lock-unlock';
 import {
 	buildMergedProductEditData,
@@ -31,6 +32,7 @@ import {
 	isProductVariation,
 } from './utils';
 import { saveSelectedProducts } from './save';
+import { VARIATION_LEGACY_HOOK_MAP } from '../variation-view/legacy-hooks';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
@@ -85,9 +87,23 @@ function ProductEditForm( {
 	onChange,
 	selectedProducts,
 }: ProductEditFormProps ) {
+	const hasVariations = selectedProducts.some( isProductVariation );
+	const { fieldsByHook } = useLegacyFields(
+		hasVariations ? VARIATION_LEGACY_HOOK_MAP : {}
+	);
+
+	const fieldsWithLegacy =
+		hasVariations && Object.keys( fieldsByHook ).length > 0
+			? insertLegacyFields(
+					editableFields,
+					fieldsByHook,
+					VARIATION_LEGACY_HOOK_MAP
+			  )
+			: editableFields;
+
 	const mergedData = buildMergedProductEditData( selectedProducts );
 	const visibleFields = getVisibleProductEditFields(
-		editableFields,
+		fieldsWithLegacy,
 		selectedProducts
 	);
 

--- a/packages/js/experimental-products-app/src/product-edit/index.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/index.tsx
@@ -34,6 +34,7 @@ import {
 	getProductEditFields,
 	getVisibleProductEditFields,
 	isProductVariation,
+	mergeVariationMeta,
 } from './utils';
 import { saveSelectedProducts } from './save';
 import { VARIATION_LEGACY_HOOK_MAP } from '../variation-view/legacy-hooks';
@@ -91,7 +92,7 @@ function ProductEditForm( {
 	onChange,
 	selectedProducts,
 }: ProductEditFormProps ) {
-	const hasVariations = selectedProducts.some( isProductVariation );
+	const hasVariations = selectedProducts.every( isProductVariation );
 	const { fieldsByHook } = useLegacyFields(
 		hasVariations ? VARIATION_LEGACY_HOOK_MAP : {}
 	);
@@ -113,10 +114,13 @@ function ProductEditForm( {
 
 	const mergedData = buildMergedProductEditData( selectedProducts );
 
-	const dataWithMeta =
-		variationMeta && ! mergedData.meta_data?.length
-			? { ...mergedData, meta_data: variationMeta }
-			: mergedData;
+	const mergedMeta = mergeVariationMeta(
+		variationMeta,
+		mergedData.meta_data
+	);
+	const dataWithMeta = mergedMeta
+		? { ...mergedData, meta_data: mergedMeta }
+		: mergedData;
 
 	const visibleFields = getVisibleProductEditFields(
 		fieldsWithLegacy,

--- a/packages/js/experimental-products-app/src/product-edit/index.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/index.tsx
@@ -291,7 +291,8 @@ export default function ProductEdit( { products }: ProductEditProps ) {
 						'root',
 						'product',
 						product.parent_id
-					) as ProductEntityRecord | false | undefined );
+					) as ProductEntityRecord | false | undefined ) ??
+					findProductInList( products, product.parent_id );
 
 				if ( ! parentProduct ) {
 					return;
@@ -312,7 +313,7 @@ export default function ProductEdit( { products }: ProductEditProps ) {
 				} );
 			} );
 		},
-		[ editEntityRecord, selectedProducts ]
+		[ editEntityRecord, products, selectedProducts ]
 	);
 
 	const closeDrawer = useCallback( () => {

--- a/packages/js/experimental-products-app/src/product-edit/index.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/index.tsx
@@ -20,7 +20,11 @@ import {
 	getSelectionFromPostId,
 } from '../product-list/utils';
 import type { ProductEntityRecord } from '../fields/types';
-import { useLegacyFields, insertLegacyFields } from '../fields/legacy';
+import {
+	useLegacyFields,
+	insertLegacyFields,
+	useVariationMeta,
+} from '../fields/legacy';
 import { unlock } from '../lock-unlock';
 import {
 	buildMergedProductEditData,
@@ -92,6 +96,12 @@ function ProductEditForm( {
 		hasVariations ? VARIATION_LEGACY_HOOK_MAP : {}
 	);
 
+	const firstVariation = hasVariations ? selectedProducts[ 0 ] : undefined;
+	const variationMeta = useVariationMeta(
+		firstVariation?.parent_id,
+		firstVariation?.id
+	);
+
 	const fieldsWithLegacy =
 		hasVariations && Object.keys( fieldsByHook ).length > 0
 			? insertLegacyFields(
@@ -102,6 +112,12 @@ function ProductEditForm( {
 			: editableFields;
 
 	const mergedData = buildMergedProductEditData( selectedProducts );
+
+	const dataWithMeta =
+		variationMeta && ! mergedData.meta_data?.length
+			? { ...mergedData, meta_data: variationMeta }
+			: mergedData;
+
 	const visibleFields = getVisibleProductEditFields(
 		fieldsWithLegacy,
 		selectedProducts
@@ -116,7 +132,7 @@ function ProductEditForm( {
 	return (
 		<div className="woocommerce-product-edit__form">
 			<DataForm
-				data={ mergedData }
+				data={ dataWithMeta }
 				fields={ visibleFields }
 				form={ form }
 				onChange={ onChange }

--- a/packages/js/experimental-products-app/src/product-edit/save.ts
+++ b/packages/js/experimental-products-app/src/product-edit/save.ts
@@ -10,6 +10,7 @@ import type { ProductVariation } from '@woocommerce/data';
  * Internal dependencies
  */
 import type { ProductEntityRecord } from '../fields/types';
+import { updateVariationMetaCache } from '../fields/legacy/use-variation-meta';
 import { normalizeVariation } from '../variation-view/normalization';
 import {
 	getProductWithUpdatedVariation,
@@ -64,6 +65,14 @@ async function saveVariation(
 		method: 'PUT',
 		data: editedVariation,
 	} );
+
+	if ( savedVariation.meta_data ) {
+		updateVariationMetaCache(
+			product.parent_id,
+			product.id,
+			savedVariation.meta_data
+		);
+	}
 
 	if ( parentProduct ) {
 		const updatedParentProduct = getProductWithUpdatedVariation(

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -513,7 +513,7 @@ describe( 'product edit utils', () => {
 			] );
 		} );
 
-		it( 'hides parent pricing and downloads for variable products', () => {
+		it( 'hides parent pricing, downloads, and shipping fields for variable products', () => {
 			const fieldIds = getVisibleFieldIds( [
 				buildProduct( {
 					type: 'variable',
@@ -529,6 +529,11 @@ describe( 'product edit utils', () => {
 				'date_on_sale_from',
 				'date_on_sale_to',
 				'downloadable',
+				'weight',
+				'length',
+				'width',
+				'height',
+				'shipping_class',
 			] );
 			expect( fieldIds ).toEqual(
 				expect.arrayContaining( [
@@ -596,12 +601,10 @@ describe( 'product edit utils', () => {
 					type: 'simple',
 					virtual: false,
 					downloadable: false,
-					manage_stock: true,
 				} ),
 				buildProduct( {
 					id: 2,
 					type: 'variable',
-					manage_stock: true,
 				} ),
 			] );
 

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -544,6 +544,51 @@ describe( 'product edit utils', () => {
 			expectFieldsHidden( fieldIds, [ 'stock_quantity' ] );
 		} );
 
+		it( 'shows variation fields and hides parent-only product fields for variations', () => {
+			const fieldIds = getVisibleFieldIds( [
+				buildProduct( {
+					id: 34,
+					parent_id: 12,
+					type: 'variation',
+					on_sale: true,
+					sale_price: '12',
+					date_on_sale_from: '2026-05-06T00:00:00',
+					downloadable: true,
+				} ),
+			] );
+
+			expect( fieldIds ).toEqual(
+				expect.arrayContaining( [
+					'name',
+					'images',
+					'product_status',
+					'sku',
+					'price',
+					'regular_price',
+					'sale_price',
+					'schedule_sale',
+					'date_on_sale_from',
+					'stock',
+					'manage_stock',
+					'downloadable',
+					'weight',
+					'length',
+					'width',
+					'height',
+					'shipping_class',
+					'tax_status',
+				] )
+			);
+			expectFieldsHidden( fieldIds, [
+				'categories',
+				'tags',
+				'featured',
+				'catalog_visibility',
+				'upsell_ids',
+				'cross_sell_ids',
+			] );
+		} );
+
 		it( 'shows parent-owned and universal fields for simple and variable products', () => {
 			const fieldIds = getVisibleFieldIds( [
 				buildProduct( {

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -17,6 +17,7 @@ import {
 	getProductVariationUpdatePath,
 	getVisibleProductEditFields,
 	isProductVariation,
+	mergeVariationMeta,
 } from './utils';
 
 jest.mock( '@dnd-kit/react', () => ( {
@@ -941,6 +942,59 @@ describe( 'product edit utils', () => {
 
 			expect( field ).toBeDefined();
 			expect( field?.isVisible ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'mergeVariationMeta', () => {
+		it( 'preserves unedited fetched values when one key is edited', () => {
+			const fetched = [
+				{ id: 1, key: '_a', value: 'fetched_a' },
+				{ id: 2, key: '_b', value: 'fetched_b' },
+				{ id: 3, key: '_c', value: 'fetched_c' },
+			];
+			const edited = [ { key: '_a', value: 'edited_a' } ];
+
+			const result = mergeVariationMeta( fetched, edited );
+
+			expect( result ).toEqual( [
+				{ key: '_a', value: 'edited_a' },
+				{ id: 2, key: '_b', value: 'fetched_b' },
+				{ id: 3, key: '_c', value: 'fetched_c' },
+			] );
+		} );
+
+		it( 'returns editedMeta when fetchedMeta is undefined', () => {
+			const edited = [ { key: '_a', value: 'v' } ];
+
+			expect( mergeVariationMeta( undefined, edited ) ).toBe( edited );
+		} );
+
+		it( 'returns fetchedMeta when editedMeta is empty', () => {
+			const fetched = [ { id: 1, key: '_a', value: 'v' } ];
+
+			expect( mergeVariationMeta( fetched, [] ) ).toBe( fetched );
+		} );
+
+		it( 'returns undefined when both sources are undefined', () => {
+			expect(
+				mergeVariationMeta( undefined, undefined )
+			).toBeUndefined();
+		} );
+
+		it( 'appends edited keys not present in fetched meta', () => {
+			const fetched = [ { id: 1, key: '_a', value: 'fetched_a' } ];
+			const edited = [ { key: '_d', value: 'new_d' } ];
+
+			const result = mergeVariationMeta( fetched, edited );
+
+			expect( result ).toEqual( [
+				{ id: 1, key: '_a', value: 'fetched_a' },
+				{ key: '_d', value: 'new_d' },
+			] );
+		} );
+
+		it( 'returns empty array when both sources are empty', () => {
+			expect( mergeVariationMeta( [], [] ) ).toEqual( [] );
 		} );
 	} );
 } );

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -543,7 +543,6 @@ describe( 'product edit utils', () => {
 					'cross_sell_ids',
 					'stock',
 					'manage_stock',
-					...shippingFieldIds,
 					'tax_status',
 				] )
 			);
@@ -565,33 +564,31 @@ describe( 'product edit utils', () => {
 
 			expect( fieldIds ).toEqual(
 				expect.arrayContaining( [
-					'name',
 					'images',
-					'product_status',
 					'sku',
-					'price',
 					'regular_price',
+					'on_sale',
 					'sale_price',
-					'schedule_sale',
-					'date_on_sale_from',
 					'stock',
 					'manage_stock',
 					'downloadable',
-					'weight',
-					'length',
-					'width',
-					'height',
-					'shipping_class',
-					'tax_status',
 				] )
 			);
 			expectFieldsHidden( fieldIds, [
+				'name',
+				'product_status',
 				'categories',
 				'tags',
 				'featured',
 				'catalog_visibility',
 				'upsell_ids',
 				'cross_sell_ids',
+				'price',
+				'schedule_sale',
+				'date_on_sale_from',
+				'date_on_sale_to',
+				...shippingFieldIds,
+				'tax_status',
 			] );
 		} );
 
@@ -602,10 +599,12 @@ describe( 'product edit utils', () => {
 					type: 'simple',
 					virtual: false,
 					downloadable: false,
+					manage_stock: true,
 				} ),
 				buildProduct( {
 					id: 2,
 					type: 'variable',
+					manage_stock: true,
 				} ),
 			] );
 

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -101,11 +101,6 @@ const VARIABLE_PRODUCT_EDIT_FIELD_IDS = [
 	'stock',
 	'stock_quantity',
 	'manage_stock',
-	'weight',
-	'length',
-	'width',
-	'height',
-	'shipping_class',
 	'tax_status',
 	'categories',
 	'tags',
@@ -116,27 +111,15 @@ const VARIABLE_PRODUCT_EDIT_FIELD_IDS = [
 ] satisfies ProductEditFieldId[];
 
 const VARIATION_PRODUCT_EDIT_FIELD_IDS = [
-	'name',
 	'images',
-	'product_status',
 	'sku',
-	'price',
 	'regular_price',
 	'on_sale',
 	'sale_price',
-	'schedule_sale',
-	'date_on_sale_from',
-	'date_on_sale_to',
 	'stock',
 	'stock_quantity',
 	'manage_stock',
 	'downloadable',
-	'weight',
-	'length',
-	'width',
-	'height',
-	'shipping_class',
-	'tax_status',
 ] satisfies ProductEditFieldId[];
 
 const EXTERNAL_PRODUCT_EDIT_FIELD_IDS = [

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -115,6 +115,30 @@ const VARIABLE_PRODUCT_EDIT_FIELD_IDS = [
 	'cross_sell_ids',
 ] satisfies ProductEditFieldId[];
 
+const VARIATION_PRODUCT_EDIT_FIELD_IDS = [
+	'name',
+	'images',
+	'product_status',
+	'sku',
+	'price',
+	'regular_price',
+	'on_sale',
+	'sale_price',
+	'schedule_sale',
+	'date_on_sale_from',
+	'date_on_sale_to',
+	'stock',
+	'stock_quantity',
+	'manage_stock',
+	'downloadable',
+	'weight',
+	'length',
+	'width',
+	'height',
+	'shipping_class',
+	'tax_status',
+] satisfies ProductEditFieldId[];
+
 const EXTERNAL_PRODUCT_EDIT_FIELD_IDS = [
 	'name',
 	'product_status',
@@ -148,10 +172,11 @@ const GROUPED_PRODUCT_EDIT_FIELD_IDS = [
 const PRODUCT_TYPE_COMPATIBLE_FIELD_IDS = {
 	simple: SIMPLE_PRODUCT_EDIT_FIELD_IDS,
 	variable: VARIABLE_PRODUCT_EDIT_FIELD_IDS,
+	variation: VARIATION_PRODUCT_EDIT_FIELD_IDS,
 	grouped: GROUPED_PRODUCT_EDIT_FIELD_IDS,
 	external: EXTERNAL_PRODUCT_EDIT_FIELD_IDS,
 } satisfies Record<
-	'simple' | 'variable' | 'grouped' | 'external',
+	'simple' | 'variable' | 'variation' | 'grouped' | 'external',
 	readonly ProductEditFieldId[]
 >;
 
@@ -224,6 +249,7 @@ function getProductTypeCompatibleFieldIds(
 ): readonly ProductEditFieldId[] {
 	const productType =
 		product.type === 'variable' ||
+		product.type === 'variation' ||
 		product.type === 'grouped' ||
 		product.type === 'external'
 			? product.type

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -430,6 +430,33 @@ export function buildMergedProductEditData(
 	return mergedData as ProductEntityRecord;
 }
 
+type MetaEntry = { id?: number; key: string; value: string };
+
+export function mergeVariationMeta(
+	fetchedMeta: MetaEntry[] | undefined,
+	editedMeta: MetaEntry[] | undefined
+): MetaEntry[] | undefined {
+	if ( ! fetchedMeta ) {
+		return editedMeta;
+	}
+	const edits = editedMeta ?? [];
+	if ( edits.length === 0 ) {
+		return fetchedMeta;
+	}
+	const editsByKey = new Map(
+		edits.map( ( entry ) => [ entry.key, entry ] )
+	);
+	const merged = fetchedMeta.map(
+		( entry ) => editsByKey.get( entry.key ) ?? entry
+	);
+	editsByKey.forEach( ( entry, key ) => {
+		if ( ! fetchedMeta.some( ( m ) => m.key === key ) ) {
+			merged.push( entry );
+		}
+	} );
+	return merged;
+}
+
 export function getVisibleProductEditFields(
 	fields: ProductField[],
 	products: ProductEntityRecord[]

--- a/packages/js/experimental-products-app/src/variation-view/index.tsx
+++ b/packages/js/experimental-products-app/src/variation-view/index.tsx
@@ -4,7 +4,7 @@
 import { DataViews, type Action, type View } from '@wordpress/dataviews';
 import { Button, Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState, useCallback } from '@wordpress/element';
+import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -18,6 +18,7 @@ import { normalizeVariation } from './normalization';
 import { variationFields } from './fields';
 import type { VariationEntityRecord } from './types';
 import ProductEdit from '../product-edit';
+import { getProductWithUpdatedVariation } from '../product-edit/utils';
 import type { ProductEntityRecord } from '../fields/types';
 import { unlock } from '../lock-unlock';
 import {
@@ -121,7 +122,7 @@ export function VariationView( { productId }: VariationViewProps ) {
 					: undefined,
 			};
 		},
-		[ query ]
+		[ productId, query ]
 	);
 
 	const allVariations = useMemo< VariationEntityRecord[] >(
@@ -167,6 +168,10 @@ export function VariationView( { productId }: VariationViewProps ) {
 		} ),
 		[ filteredVariations.length, perPage ]
 	);
+
+	useEffect( () => {
+		setSelection( getSelectionFromPostId( postId ) );
+	}, [ postId ] );
 
 	const onChangeSelection = useCallback(
 		( items: string[] ) => {
@@ -275,8 +280,8 @@ export function VariationView( { productId }: VariationViewProps ) {
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>
-			{ showQuickEdit && parentProduct && (
-				<ProductEdit products={ [ parentProduct ] } />
+			{ showQuickEdit && productWithVariations && (
+				<ProductEdit products={ [ productWithVariations ] } />
 			) }
 		</div>
 	);

--- a/packages/js/experimental-products-app/src/variation-view/index.tsx
+++ b/packages/js/experimental-products-app/src/variation-view/index.tsx
@@ -4,7 +4,7 @@
 import { DataViews, type Action, type View } from '@wordpress/dataviews';
 import { Button, Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import { useMemo, useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -18,7 +18,6 @@ import { normalizeVariation } from './normalization';
 import { variationFields } from './fields';
 import type { VariationEntityRecord } from './types';
 import ProductEdit from '../product-edit';
-import { getProductWithUpdatedVariation } from '../product-edit/utils';
 import type { ProductEntityRecord } from '../fields/types';
 import { unlock } from '../lock-unlock';
 import {
@@ -122,7 +121,7 @@ export function VariationView( { productId }: VariationViewProps ) {
 					: undefined,
 			};
 		},
-		[ productId, query ]
+		[ query ]
 	);
 
 	const allVariations = useMemo< VariationEntityRecord[] >(
@@ -168,10 +167,6 @@ export function VariationView( { productId }: VariationViewProps ) {
 		} ),
 		[ filteredVariations.length, perPage ]
 	);
-
-	useEffect( () => {
-		setSelection( getSelectionFromPostId( postId ) );
-	}, [ postId ] );
 
 	const onChangeSelection = useCallback(
 		( items: string[] ) => {
@@ -280,8 +275,8 @@ export function VariationView( { productId }: VariationViewProps ) {
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>
-			{ showQuickEdit && productWithVariations && (
-				<ProductEdit products={ [ productWithVariations ] } />
+			{ showQuickEdit && parentProduct && (
+				<ProductEdit products={ [ parentProduct ] } />
 			) }
 		</div>
 	);

--- a/packages/js/experimental-products-app/src/variation-view/legacy-hooks.ts
+++ b/packages/js/experimental-products-app/src/variation-view/legacy-hooks.ts
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import type { LegacyHookMapping } from '../fields/legacy';
+
+/**
+ * Maps each legacy variation hook to its insertion point in the DataForm field list.
+ *
+ * Hook names are the same ones plugins register on via `add_action()`.
+ * The `insertAfter` value matches a native field ID; the legacy fields
+ * captured from that hook appear directly after that anchor field.
+ */
+export const VARIATION_LEGACY_HOOK_MAP: LegacyHookMapping = {
+	woocommerce_variation_options: { insertAfter: 'product_status' },
+	woocommerce_variation_options_pricing: {
+		insertAfter: 'date_on_sale_to',
+	},
+	woocommerce_variation_options_inventory: {
+		insertAfter: 'manage_stock',
+	},
+	woocommerce_variation_options_dimensions: {
+		insertAfter: 'shipping_class',
+	},
+	woocommerce_variation_options_download: {
+		insertAfter: 'downloadable',
+	},
+	woocommerce_product_after_variable_attributes: { insertAt: 'end' },
+};

--- a/packages/js/experimental-products-app/src/variation-view/normalization.ts
+++ b/packages/js/experimental-products-app/src/variation-view/normalization.ts
@@ -19,6 +19,7 @@ type VariationSource = Pick< ProductVariation, 'id' > & {
 	image?: ProductVariation[ 'image' ] | null;
 	images?: ProductEntityRecord[ 'images' ];
 	manage_stock?: ProductVariation[ 'manage_stock' ];
+	meta_data?: ProductVariation[ 'meta_data' ];
 	name?: string;
 	parent_id?: number;
 	slug?: string;

--- a/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
@@ -8,6 +8,7 @@
  * @version     2.3.0
  */
 
+use Automattic\WooCommerce\Internal\Admin\DataForms\LegacyFieldCapture;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -21,6 +22,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
 function woocommerce_wp_text_input( $field, ?WC_Data $data = null ) {
+	if ( LegacyFieldCapture::is_capturing() ) {
+		LegacyFieldCapture::collect( 'text_input', $field );
+		return;
+	}
+
 	global $post;
 
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
@@ -103,6 +109,11 @@ function woocommerce_wp_text_input( $field, ?WC_Data $data = null ) {
  * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
 function woocommerce_wp_hidden_input( $field, ?WC_Data $data = null ) {
+	if ( LegacyFieldCapture::is_capturing() ) {
+		LegacyFieldCapture::collect( 'hidden_input', $field );
+		return;
+	}
+
 	global $post;
 
 	$field['value'] = isset( $field['value'] ) ? $field['value'] : OrderUtil::get_post_or_object_meta( $post, $data, $field['id'], true );
@@ -118,6 +129,11 @@ function woocommerce_wp_hidden_input( $field, ?WC_Data $data = null ) {
  * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
 function woocommerce_wp_textarea_input( $field, ?WC_Data $data = null ) {
+	if ( LegacyFieldCapture::is_capturing() ) {
+		LegacyFieldCapture::collect( 'textarea_input', $field );
+		return;
+	}
+
 	global $post;
 
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
@@ -163,6 +179,11 @@ function woocommerce_wp_textarea_input( $field, ?WC_Data $data = null ) {
  * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
 function woocommerce_wp_checkbox( $field, ?WC_Data $data = null ) {
+	if ( LegacyFieldCapture::is_capturing() ) {
+		LegacyFieldCapture::collect( 'checkbox', $field );
+		return;
+	}
+
 	global $post;
 
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'checkbox';
@@ -233,6 +254,11 @@ function woocommerce_wp_checkbox( $field, ?WC_Data $data = null ) {
  * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
 function woocommerce_wp_select( $field, ?WC_Data $data = null ) {
+	if ( LegacyFieldCapture::is_capturing() ) {
+		LegacyFieldCapture::collect( 'select', $field );
+		return;
+	}
+
 	global $post;
 
 	$field = wp_parse_args(
@@ -291,6 +317,11 @@ function woocommerce_wp_select( $field, ?WC_Data $data = null ) {
  * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
 function woocommerce_wp_radio( $field, ?WC_Data $data = null ) {
+	if ( LegacyFieldCapture::is_capturing() ) {
+		LegacyFieldCapture::collect( 'radio', $field );
+		return;
+	}
+
 	global $post;
 
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -28,7 +28,6 @@ use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Tax\Controller as
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Controller as EmailsSettingsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Fulfillments\Controller as FulfillmentsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Account\Controller as AccountSettingsController;
-use Automattic\WooCommerce\Internal\Admin\DataForms\LegacyFieldCapture;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Products\LegacyFields\Controller as LegacyFieldsController;
 
 /**
@@ -49,7 +48,6 @@ class Server {
 	 */
 	public function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod -- Not an injection method.
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
-		add_action( 'rest_api_init', array( LegacyFieldCapture::class, 'register_meta_data_rest_field' ), 10 );
 
 		\WC_REST_System_Status_V2_Controller::register_cache_clean();
 	}

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -28,6 +28,7 @@ use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Tax\Controller as
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Controller as EmailsSettingsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Fulfillments\Controller as FulfillmentsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Account\Controller as AccountSettingsController;
+use Automattic\WooCommerce\Internal\Admin\DataForms\LegacyFieldCapture;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Products\LegacyFields\Controller as LegacyFieldsController;
 
 /**
@@ -48,6 +49,7 @@ class Server {
 	 */
 	public function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod -- Not an injection method.
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
+		add_action( 'rest_api_init', array( LegacyFieldCapture::class, 'register_meta_data_rest_field' ), 10 );
 
 		\WC_REST_System_Status_V2_Controller::register_cache_clean();
 	}

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -28,6 +28,7 @@ use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Tax\Controller as
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Controller as EmailsSettingsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Fulfillments\Controller as FulfillmentsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Account\Controller as AccountSettingsController;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Products\LegacyFields\Controller as LegacyFieldsController;
 
 /**
  * Class responsible for loading the REST API and all REST API namespaces.
@@ -249,6 +250,7 @@ class Server {
 			'settings-payment-gateways' => PaymentGatewaysController::class,
 			'settings-tax'              => TaxSettingsController::class,
 			'settings-account'          => AccountSettingsController::class,
+			'products-legacy-fields'    => LegacyFieldsController::class,
 			// This is a wrapper that redirects V4 settings requests to the V3 settings controller.
 			'settings'                  => 'WC_REST_Settings_V4_Controller',
 		);

--- a/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
+++ b/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
@@ -76,7 +76,7 @@ class LegacyFieldCapture {
 		self::ensure_helper_functions_loaded();
 		self::reset();
 
-		$mock_post     = new WP_Post( (object) array( 'ID' => 0 ) );
+		$mock_post      = new WP_Post( (object) array( 'ID' => 0 ) );
 		$variation_data = array();
 
 		foreach ( $hooks as $hook ) {
@@ -84,12 +84,20 @@ class LegacyFieldCapture {
 				continue;
 			}
 
-			self::$current_hook = $hook;
+			self::$current_hook    = $hook;
 			self::$fields[ $hook ] = array();
-			self::$capturing = true;
+			self::$capturing       = true;
 
 			try {
 				ob_start();
+				/**
+				 * Fires to capture legacy field definitions from variation hooks.
+				 *
+				 * The hook is executed in capture mode so that WC helper functions
+				 * push field definitions to the collector instead of rendering HTML.
+				 *
+				 * @since 10.9.0
+				 */
 				do_action( $hook, 0, $variation_data, $mock_post );
 				ob_end_clean();
 			} catch ( \Throwable $e ) {
@@ -108,7 +116,7 @@ class LegacyFieldCapture {
 		}
 
 		self::$current_hook = '';
-		$result = self::$fields;
+		$result             = self::$fields;
 		self::reset();
 
 		return $result;
@@ -183,93 +191,6 @@ class LegacyFieldCapture {
 	 */
 	public static function get_allowed_hooks(): array {
 		return self::ALLOWED_HOOKS;
-	}
-
-	/**
-	 * Register meta_data REST field on the product post type.
-	 *
-	 * The WP REST API endpoint (/wp/v2/product) uses WP_REST_Posts_Controller
-	 * which does not include WooCommerce's meta_data array. This ensures
-	 * meta_data round-trips through the entity store.
-	 *
-	 * @since 10.9.0
-	 */
-	public static function register_meta_data_rest_field(): void {
-		register_rest_field(
-			'product',
-			'meta_data',
-			array(
-				'get_callback'    => function ( $post_array ) {
-					$product = wc_get_product( $post_array['id'] );
-					if ( ! $product ) {
-						return array();
-					}
-
-					return array_values(
-						array_map(
-							function ( $meta ) {
-								return array(
-									'id'    => $meta->id,
-									'key'   => $meta->key,
-									'value' => $meta->value,
-								);
-							},
-							$product->get_meta_data()
-						)
-					);
-				},
-				'update_callback' => function ( $meta_data, $post ) {
-					if ( ! is_array( $meta_data ) ) {
-						return;
-					}
-
-					$product = wc_get_product( $post->ID );
-					if ( ! $product ) {
-						return;
-					}
-
-					foreach ( $meta_data as $meta ) {
-						if ( empty( $meta['key'] ) ) {
-							continue;
-						}
-
-						$product->update_meta_data(
-							$meta['key'],
-							$meta['value'] ?? '',
-							! empty( $meta['id'] ) ? (int) $meta['id'] : 0
-						);
-					}
-
-					$product->save_meta_data();
-				},
-				'schema'          => array(
-					'description' => __( 'Meta data.', 'woocommerce' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit' ),
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'id'    => array(
-								'description' => __( 'Meta ID.', 'woocommerce' ),
-								'type'        => 'integer',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'key'   => array(
-								'description' => __( 'Meta key.', 'woocommerce' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-							),
-							'value' => array(
-								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => 'mixed',
-								'context'     => array( 'view', 'edit' ),
-							),
-						),
-					),
-				),
-			)
-		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
+++ b/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
@@ -156,7 +156,7 @@ class LegacyFieldCapture {
 			'type'              => $helper_type,
 			'input_type'        => $field['type'] ?? 'text',
 			'label'             => $field['label'] ?? '',
-			'meta_key'          => $base_id,
+			'meta_key'          => $base_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- not a DB query, this is a field definition key.
 			'placeholder'       => $field['placeholder'] ?? '',
 			'description'       => is_array( $field['description'] ?? null )
 				? implode( ' ', $field['description'] )

--- a/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
+++ b/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
  * When capture mode is active, helper functions (woocommerce_wp_text_input, etc.)
  * push their field definition arrays to this collector instead of echoing HTML.
  *
- * @since 9.9.0
+ * @since 10.9.0
  */
 class LegacyFieldCapture {
 
@@ -66,6 +66,8 @@ class LegacyFieldCapture {
 	 *
 	 * Fires each hook in capture mode so that WC helper functions push their
 	 * field definitions to the collector instead of rendering HTML.
+	 *
+	 * @since 10.9.0
 	 *
 	 * @param string[] $hooks Hook names to capture.
 	 * @return array<string, array<int, array<string, mixed>>> Field definitions grouped by hook name.
@@ -115,6 +117,8 @@ class LegacyFieldCapture {
 	/**
 	 * Whether capture mode is currently active.
 	 *
+	 * @since 10.9.0
+	 *
 	 * @return bool
 	 */
 	public static function is_capturing(): bool {
@@ -125,6 +129,8 @@ class LegacyFieldCapture {
 	 * Collect a field definition from a helper function.
 	 *
 	 * Called by the modified WC helper functions when capture mode is active.
+	 *
+	 * @since 10.9.0
 	 *
 	 * @param string               $helper_type The helper function type (text_input, select, checkbox, etc.).
 	 * @param array<string, mixed> $field       The raw field array passed to the helper function.
@@ -142,7 +148,7 @@ class LegacyFieldCapture {
 			'type'              => $helper_type,
 			'input_type'        => $field['type'] ?? 'text',
 			'label'             => $field['label'] ?? '',
-			'meta_key'          => '_' . $base_id,
+			'meta_key'          => $base_id,
 			'placeholder'       => $field['placeholder'] ?? '',
 			'description'       => is_array( $field['description'] ?? null )
 				? implode( ' ', $field['description'] )
@@ -159,6 +165,8 @@ class LegacyFieldCapture {
 
 	/**
 	 * Reset the capture state.
+	 *
+	 * @since 10.9.0
 	 */
 	public static function reset(): void {
 		self::$capturing    = false;
@@ -169,6 +177,8 @@ class LegacyFieldCapture {
 	/**
 	 * Get the list of allowed hook names.
 	 *
+	 * @since 10.9.0
+	 *
 	 * @return string[]
 	 */
 	public static function get_allowed_hooks(): array {
@@ -176,92 +186,90 @@ class LegacyFieldCapture {
 	}
 
 	/**
-	 * Register meta_data REST field on product and product_variation post types.
+	 * Register meta_data REST field on the product post type.
 	 *
-	 * The WP REST API endpoints (/wp/v2/product, /wp/v2/product_variation) use
-	 * WP_REST_Posts_Controller which does not include WooCommerce's meta_data
-	 * array. This ensures meta_data round-trips through the entity store.
+	 * The WP REST API endpoint (/wp/v2/product) uses WP_REST_Posts_Controller
+	 * which does not include WooCommerce's meta_data array. This ensures
+	 * meta_data round-trips through the entity store.
+	 *
+	 * @since 10.9.0
 	 */
 	public static function register_meta_data_rest_field(): void {
-		$post_types = array( 'product', 'product_variation' );
+		register_rest_field(
+			'product',
+			'meta_data',
+			array(
+				'get_callback'    => function ( $post_array ) {
+					$product = wc_get_product( $post_array['id'] );
+					if ( ! $product ) {
+						return array();
+					}
 
-		foreach ( $post_types as $post_type ) {
-			register_rest_field(
-				$post_type,
-				'meta_data',
-				array(
-					'get_callback'    => function ( $post_array ) {
-						$product = wc_get_product( $post_array['id'] );
-						if ( ! $product ) {
-							return array();
+					return array_values(
+						array_map(
+							function ( $meta ) {
+								return array(
+									'id'    => $meta->id,
+									'key'   => $meta->key,
+									'value' => $meta->value,
+								);
+							},
+							$product->get_meta_data()
+						)
+					);
+				},
+				'update_callback' => function ( $meta_data, $post ) {
+					if ( ! is_array( $meta_data ) ) {
+						return;
+					}
+
+					$product = wc_get_product( $post->ID );
+					if ( ! $product ) {
+						return;
+					}
+
+					foreach ( $meta_data as $meta ) {
+						if ( empty( $meta['key'] ) ) {
+							continue;
 						}
 
-						return array_values(
-							array_map(
-								function ( $meta ) {
-									return array(
-										'id'    => $meta->id,
-										'key'   => $meta->key,
-										'value' => $meta->value,
-									);
-								},
-								$product->get_meta_data()
-							)
+						$product->update_meta_data(
+							$meta['key'],
+							$meta['value'] ?? '',
+							! empty( $meta['id'] ) ? (int) $meta['id'] : 0
 						);
-					},
-					'update_callback' => function ( $meta_data, $post ) {
-						if ( ! is_array( $meta_data ) ) {
-							return;
-						}
+					}
 
-						$product = wc_get_product( $post->ID );
-						if ( ! $product ) {
-							return;
-						}
-
-						foreach ( $meta_data as $meta ) {
-							if ( empty( $meta['key'] ) ) {
-								continue;
-							}
-
-							$product->update_meta_data(
-								$meta['key'],
-								$meta['value'] ?? '',
-								! empty( $meta['id'] ) ? (int) $meta['id'] : 0
-							);
-						}
-
-						$product->save_meta_data();
-					},
-					'schema'          => array(
-						'description' => __( 'Meta data.', 'woocommerce' ),
-						'type'        => 'array',
-						'context'     => array( 'view', 'edit' ),
-						'items'       => array(
-							'type'       => 'object',
-							'properties' => array(
-								'id'    => array(
-									'description' => __( 'Meta ID.', 'woocommerce' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'key'   => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'mixed',
-									'context'     => array( 'view', 'edit' ),
-								),
+					$product->save_meta_data();
+				},
+				'schema'          => array(
+					'description' => __( 'Meta data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'    => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key'   => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
 							),
 						),
 					),
-				)
-			);
-		}
+				),
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
+++ b/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Legacy Field Capture
+ *
+ * Captures field definitions from WC helper functions during hook execution
+ * without rendering HTML output.
+ *
+ * @package WooCommerce\Internal\Admin\DataForms
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\DataForms;
+
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Static utility class that captures field definitions from legacy WC helper functions.
+ *
+ * When capture mode is active, helper functions (woocommerce_wp_text_input, etc.)
+ * push their field definition arrays to this collector instead of echoing HTML.
+ *
+ * @since 9.9.0
+ */
+class LegacyFieldCapture {
+
+	/**
+	 * Whether capture mode is active.
+	 *
+	 * @var bool
+	 */
+	private static bool $capturing = false;
+
+	/**
+	 * Collected field definitions grouped by hook name.
+	 *
+	 * @var array<string, array<int, array<string, mixed>>>
+	 */
+	private static array $fields = array();
+
+	/**
+	 * The hook currently being captured.
+	 *
+	 * @var string
+	 */
+	private static string $current_hook = '';
+
+	/**
+	 * Allowlist of hooks that can be captured.
+	 *
+	 * @var string[]
+	 */
+	private const ALLOWED_HOOKS = array(
+		'woocommerce_variation_options',
+		'woocommerce_variation_options_pricing',
+		'woocommerce_variation_options_inventory',
+		'woocommerce_variation_options_dimensions',
+		'woocommerce_variation_options_download',
+		'woocommerce_product_after_variable_attributes',
+	);
+
+	/**
+	 * Capture field definitions from the given hooks.
+	 *
+	 * Fires each hook in capture mode so that WC helper functions push their
+	 * field definitions to the collector instead of rendering HTML.
+	 *
+	 * @param string[] $hooks Hook names to capture.
+	 * @return array<string, array<int, array<string, mixed>>> Field definitions grouped by hook name.
+	 */
+	public static function capture( array $hooks ): array {
+		self::ensure_helper_functions_loaded();
+		self::reset();
+
+		$mock_post     = new WP_Post( (object) array( 'ID' => 0 ) );
+		$variation_data = array();
+
+		foreach ( $hooks as $hook ) {
+			if ( ! in_array( $hook, self::ALLOWED_HOOKS, true ) ) {
+				continue;
+			}
+
+			self::$current_hook = $hook;
+			self::$fields[ $hook ] = array();
+			self::$capturing = true;
+
+			try {
+				ob_start();
+				do_action( $hook, 0, $variation_data, $mock_post );
+				ob_end_clean();
+			} catch ( \Throwable $e ) {
+				if ( ob_get_level() ) {
+					ob_end_clean();
+				}
+				if ( function_exists( 'wc_get_logger' ) ) {
+					wc_get_logger()->error(
+						sprintf( 'LegacyFieldCapture: Exception during hook "%s": %s', $hook, $e->getMessage() ),
+						array( 'source' => 'legacy-field-capture' )
+					);
+				}
+			}
+
+			self::$capturing = false;
+		}
+
+		self::$current_hook = '';
+		$result = self::$fields;
+		self::reset();
+
+		return $result;
+	}
+
+	/**
+	 * Whether capture mode is currently active.
+	 *
+	 * @return bool
+	 */
+	public static function is_capturing(): bool {
+		return self::$capturing;
+	}
+
+	/**
+	 * Collect a field definition from a helper function.
+	 *
+	 * Called by the modified WC helper functions when capture mode is active.
+	 *
+	 * @param string               $helper_type The helper function type (text_input, select, checkbox, etc.).
+	 * @param array<string, mixed> $field       The raw field array passed to the helper function.
+	 */
+	public static function collect( string $helper_type, array $field ): void {
+		if ( ! self::$capturing || empty( self::$current_hook ) ) {
+			return;
+		}
+
+		$raw_id  = $field['id'] ?? '';
+		$base_id = self::strip_loop_index( $raw_id );
+
+		$definition = array(
+			'id'                => $base_id,
+			'type'              => $helper_type,
+			'input_type'        => $field['type'] ?? 'text',
+			'label'             => $field['label'] ?? '',
+			'meta_key'          => '_' . $base_id,
+			'placeholder'       => $field['placeholder'] ?? '',
+			'description'       => is_array( $field['description'] ?? null )
+				? implode( ' ', $field['description'] )
+				: ( $field['description'] ?? '' ),
+			'default_value'     => $field['value'] ?? '',
+			'wrapper_class'     => $field['wrapper_class'] ?? '',
+			'custom_attributes' => $field['custom_attributes'] ?? array(),
+			'options'           => $field['options'] ?? array(),
+			'hidden'            => 'hidden_input' === $helper_type,
+		);
+
+		self::$fields[ self::$current_hook ][] = $definition;
+	}
+
+	/**
+	 * Reset the capture state.
+	 */
+	public static function reset(): void {
+		self::$capturing    = false;
+		self::$fields       = array();
+		self::$current_hook = '';
+	}
+
+	/**
+	 * Get the list of allowed hook names.
+	 *
+	 * @return string[]
+	 */
+	public static function get_allowed_hooks(): array {
+		return self::ALLOWED_HOOKS;
+	}
+
+	/**
+	 * Strip loop index suffix from a field ID.
+	 *
+	 * Field IDs in variation loops often end with [0], [1], etc.
+	 * This strips that suffix to get the base field ID.
+	 *
+	 * @param string $field_id The raw field ID.
+	 * @return string The base field ID without loop index.
+	 */
+	private static function strip_loop_index( string $field_id ): string {
+		return (string) preg_replace( '/\[\d+\]$/', '', $field_id );
+	}
+
+	/**
+	 * Ensure WC meta box helper functions are loaded.
+	 *
+	 * These functions are admin-only and may not be available in REST context.
+	 */
+	private static function ensure_helper_functions_loaded(): void {
+		if ( ! function_exists( 'woocommerce_wp_text_input' ) ) {
+			require_once WC_ABSPATH . 'includes/admin/wc-meta-box-functions.php';
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
+++ b/plugins/woocommerce/src/Internal/Admin/DataForms/LegacyFieldCapture.php
@@ -176,6 +176,95 @@ class LegacyFieldCapture {
 	}
 
 	/**
+	 * Register meta_data REST field on product and product_variation post types.
+	 *
+	 * The WP REST API endpoints (/wp/v2/product, /wp/v2/product_variation) use
+	 * WP_REST_Posts_Controller which does not include WooCommerce's meta_data
+	 * array. This ensures meta_data round-trips through the entity store.
+	 */
+	public static function register_meta_data_rest_field(): void {
+		$post_types = array( 'product', 'product_variation' );
+
+		foreach ( $post_types as $post_type ) {
+			register_rest_field(
+				$post_type,
+				'meta_data',
+				array(
+					'get_callback'    => function ( $post_array ) {
+						$product = wc_get_product( $post_array['id'] );
+						if ( ! $product ) {
+							return array();
+						}
+
+						return array_values(
+							array_map(
+								function ( $meta ) {
+									return array(
+										'id'    => $meta->id,
+										'key'   => $meta->key,
+										'value' => $meta->value,
+									);
+								},
+								$product->get_meta_data()
+							)
+						);
+					},
+					'update_callback' => function ( $meta_data, $post ) {
+						if ( ! is_array( $meta_data ) ) {
+							return;
+						}
+
+						$product = wc_get_product( $post->ID );
+						if ( ! $product ) {
+							return;
+						}
+
+						foreach ( $meta_data as $meta ) {
+							if ( empty( $meta['key'] ) ) {
+								continue;
+							}
+
+							$product->update_meta_data(
+								$meta['key'],
+								$meta['value'] ?? '',
+								! empty( $meta['id'] ) ? (int) $meta['id'] : 0
+							);
+						}
+
+						$product->save_meta_data();
+					},
+					'schema'          => array(
+						'description' => __( 'Meta data.', 'woocommerce' ),
+						'type'        => 'array',
+						'context'     => array( 'view', 'edit' ),
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'    => array(
+									'description' => __( 'Meta ID.', 'woocommerce' ),
+									'type'        => 'integer',
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
+								'key'   => array(
+									'description' => __( 'Meta key.', 'woocommerce' ),
+									'type'        => 'string',
+									'context'     => array( 'view', 'edit' ),
+								),
+								'value' => array(
+									'description' => __( 'Meta value.', 'woocommerce' ),
+									'type'        => 'mixed',
+									'context'     => array( 'view', 'edit' ),
+								),
+							),
+						),
+					),
+				)
+			);
+		}
+	}
+
+	/**
 	 * Strip loop index suffix from a field ID.
 	 *
 	 * Field IDs in variation loops often end with [0], [1], etc.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
@@ -158,8 +158,8 @@ class Controller extends AbstractController {
 	/**
 	 * Get the item response.
 	 *
-	 * @param mixed            $item    Captured field definitions.
-	 * @param WP_REST_Request  $request Request object.
+	 * @param mixed           $item    Captured field definitions.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 *
 	 * @phpstan-param \WP_REST_Request<array<string,mixed>> $request

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
@@ -158,8 +158,8 @@ class Controller extends AbstractController {
 	/**
 	 * Get the item response.
 	 *
-	 * @param mixed                                 $item    Captured field definitions.
-	 * @param WP_REST_Request<array<string, mixed>> $request Request object.
+	 * @param mixed           $item    Captured field definitions.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */
 	protected function get_item_response( $item, WP_REST_Request $request ): array {

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
@@ -158,9 +158,11 @@ class Controller extends AbstractController {
 	/**
 	 * Get the item response.
 	 *
-	 * @param mixed                                $item    Captured field definitions.
-	 * @param \WP_REST_Request<array<string,mixed>> $request Request object.
+	 * @param mixed            $item    Captured field definitions.
+	 * @param WP_REST_Request  $request Request object.
 	 * @return array
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string,mixed>> $request
 	 */
 	protected function get_item_response( $item, WP_REST_Request $request ): array {
 		return $this->item_schema->get_item_response( $item, $request );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
@@ -158,8 +158,8 @@ class Controller extends AbstractController {
 	/**
 	 * Get the item response.
 	 *
-	 * @param mixed           $item    Captured field definitions.
-	 * @param WP_REST_Request $request Request object.
+	 * @param mixed                                $item    Captured field definitions.
+	 * @param \WP_REST_Request<array<string,mixed>> $request Request object.
 	 * @return array
 	 */
 	protected function get_item_response( $item, WP_REST_Request $request ): array {

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Controller.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * REST API Legacy Fields Controller
+ *
+ * Handles requests to the /products/legacy-fields endpoint.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Products\LegacyFields;
+
+use WP_Error;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use Automattic\WooCommerce\Internal\Admin\DataForms\LegacyFieldCapture;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractController;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Products\LegacyFields\Schema\LegacyFieldsSchema;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API controller for capturing legacy field definitions from WC hooks.
+ *
+ * @since 9.9.0
+ */
+class Controller extends AbstractController {
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'products/legacy-fields';
+
+	/**
+	 * Schema instance.
+	 *
+	 * @var LegacyFieldsSchema
+	 */
+	protected $item_schema;
+
+	/**
+	 * Initialize the controller.
+	 *
+	 * @param LegacyFieldsSchema $item_schema Schema class.
+	 * @return void
+	 * @internal
+	 */
+	final public function init( LegacyFieldsSchema $item_schema ): void {
+		$this->item_schema = $item_schema;
+	}
+
+	/**
+	 * Register routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'hooks' => array(
+							'description'       => __( 'Hook names to capture field definitions from.', 'woocommerce' ),
+							'type'              => 'array',
+							'items'             => array(
+								'type' => 'string',
+							),
+							'required'          => false,
+							'default'           => array(),
+							'sanitize_callback' => static function ( $value ) {
+								if ( ! is_array( $value ) ) {
+									return array();
+								}
+								return array_map( 'sanitize_text_field', $value );
+							},
+							'validate_callback' => static function ( $value ) {
+								if ( ! is_array( $value ) ) {
+									return new WP_Error(
+										'rest_invalid_param',
+										__( 'The hooks parameter must be an array.', 'woocommerce' ),
+										array( 'status' => 400 )
+									);
+								}
+
+								$allowed = LegacyFieldCapture::get_allowed_hooks();
+								foreach ( $value as $hook ) {
+									if ( ! in_array( sanitize_text_field( $hook ), $allowed, true ) ) {
+										return new WP_Error(
+											'rest_invalid_param',
+											sprintf(
+												/* translators: %s: hook name */
+												__( 'Hook name "%s" is not allowed.', 'woocommerce' ),
+												sanitize_text_field( $hook )
+											),
+											array( 'status' => 400 )
+										);
+									}
+								}
+
+								return true;
+							},
+						),
+					),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions for reading legacy fields.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return $this->get_authentication_error_by_method( $request->get_method() );
+		}
+		return true;
+	}
+
+	/**
+	 * Get legacy field definitions.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$hooks = $request->get_param( 'hooks' );
+
+		if ( empty( $hooks ) ) {
+			return $this->prepare_item_for_response( array(), $request );
+		}
+
+		$fields = LegacyFieldCapture::capture( $hooks );
+		return $this->prepare_item_for_response( $fields, $request );
+	}
+
+	/**
+	 * Get the schema for the current resource.
+	 *
+	 * @return array
+	 */
+	public function get_schema(): array {
+		return $this->item_schema->get_item_schema();
+	}
+
+	/**
+	 * Get the item response.
+	 *
+	 * @param mixed                                 $item    Captured field definitions.
+	 * @param WP_REST_Request<array<string, mixed>> $request Request object.
+	 * @return array
+	 */
+	protected function get_item_response( $item, WP_REST_Request $request ): array {
+		return $this->item_schema->get_item_response( $item, $request );
+	}
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Schema/LegacyFieldsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Schema/LegacyFieldsSchema.php
@@ -124,10 +124,12 @@ class LegacyFieldsSchema extends AbstractSchema {
 	/**
 	 * Get the item response.
 	 *
-	 * @param mixed                                 $item           Captured field definitions grouped by hook name.
-	 * @param \WP_REST_Request<array<string,mixed>> $request        Request object.
-	 * @param array                                 $include_fields Fields to include in the response.
+	 * @param mixed           $item           Captured field definitions grouped by hook name.
+	 * @param WP_REST_Request $request        Request object.
+	 * @param array           $include_fields Fields to include in the response.
 	 * @return array
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string,mixed>> $request
 	 */
 	public function get_item_response( $item, WP_REST_Request $request, array $include_fields = array() ): array {
 		$response = array(

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Schema/LegacyFieldsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Schema/LegacyFieldsSchema.php
@@ -77,7 +77,7 @@ class LegacyFieldsSchema extends AbstractSchema {
 					'type'        => 'string',
 					'context'     => self::VIEW_EDIT_CONTEXT,
 				),
-				'meta_key'          => array(
+				'meta_key'          => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- schema definition, not a DB query.
 					'description' => __( 'Post meta key for persistence.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => self::VIEW_EDIT_CONTEXT,
@@ -124,9 +124,9 @@ class LegacyFieldsSchema extends AbstractSchema {
 	/**
 	 * Get the item response.
 	 *
-	 * @param mixed           $item           Captured field definitions grouped by hook name.
-	 * @param WP_REST_Request $request        Request object.
-	 * @param array           $include_fields Fields to include in the response.
+	 * @param mixed                                 $item           Captured field definitions grouped by hook name.
+	 * @param \WP_REST_Request<array<string,mixed>> $request        Request object.
+	 * @param array                                 $include_fields Fields to include in the response.
 	 * @return array
 	 */
 	public function get_item_response( $item, WP_REST_Request $request, array $include_fields = array() ): array {

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Schema/LegacyFieldsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Schema/LegacyFieldsSchema.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * LegacyFieldsSchema class.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Products\LegacyFields\Schema;
+
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractSchema;
+use WP_REST_Request;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Schema for legacy field definitions captured from WC helper function hooks.
+ *
+ * @since 9.9.0
+ */
+class LegacyFieldsSchema extends AbstractSchema {
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'legacy_fields';
+
+	/**
+	 * Return all properties for the item schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema_properties(): array {
+		return array(
+			'fields' => array(
+				'description'          => __( 'Field definitions grouped by hook name.', 'woocommerce' ),
+				'type'                 => 'object',
+				'context'              => self::VIEW_EDIT_CONTEXT,
+				'readonly'             => true,
+				'additionalProperties' => array(
+					'type'  => 'array',
+					'items' => $this->get_field_definition_schema(),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get the schema for a single field definition.
+	 *
+	 * @return array
+	 */
+	private function get_field_definition_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'                => array(
+					'description' => __( 'Field identifier.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'type'              => array(
+					'description' => __( 'Helper function type.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'input_type'        => array(
+					'description' => __( 'HTML input type.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'label'             => array(
+					'description' => __( 'Field label.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'meta_key'          => array(
+					'description' => __( 'Post meta key for persistence.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'placeholder'       => array(
+					'description' => __( 'Placeholder text.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'description'       => array(
+					'description' => __( 'Field description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'default_value'     => array(
+					'description' => __( 'Default value.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'wrapper_class'     => array(
+					'description' => __( 'CSS classes on the wrapper element.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'custom_attributes' => array(
+					'description' => __( 'Custom HTML attributes.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'options'           => array(
+					'description' => __( 'Options for select and radio fields.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'hidden'            => array(
+					'description' => __( 'Whether the field is a hidden input.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get the item response.
+	 *
+	 * @param mixed                                 $item           Captured field definitions grouped by hook name.
+	 * @param WP_REST_Request<array<string, mixed>> $request        Request object.
+	 * @param array                                 $include_fields Fields to include in the response.
+	 * @return array
+	 */
+	public function get_item_response( $item, WP_REST_Request $request, array $include_fields = array() ): array {
+		$response = array(
+			'fields' => $item,
+		);
+
+		if ( ! empty( $include_fields ) ) {
+			$response = array_intersect_key( $response, array_flip( $include_fields ) );
+		}
+
+		return $response;
+	}
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Schema/LegacyFieldsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/LegacyFields/Schema/LegacyFieldsSchema.php
@@ -124,9 +124,9 @@ class LegacyFieldsSchema extends AbstractSchema {
 	/**
 	 * Get the item response.
 	 *
-	 * @param mixed                                 $item           Captured field definitions grouped by hook name.
-	 * @param WP_REST_Request<array<string, mixed>> $request        Request object.
-	 * @param array                                 $include_fields Fields to include in the response.
+	 * @param mixed           $item           Captured field definitions grouped by hook name.
+	 * @param WP_REST_Request $request        Request object.
+	 * @param array           $include_fields Fields to include in the response.
 	 * @return array
 	 */
 	public function get_item_response( $item, WP_REST_Request $request, array $include_fields = array() ): array {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/DataForms/LegacyFieldCaptureTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/DataForms/LegacyFieldCaptureTest.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Tests for LegacyFieldCapture.
+ *
+ * @package WooCommerce\Tests\Internal\Admin\DataForms
+ */
+
 declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin\DataForms;
@@ -43,18 +49,27 @@ class LegacyFieldCaptureTest extends WC_Unit_Test_Case {
 		return $all['woocommerce_variation_options'] ?? array();
 	}
 
+	/**
+	 * Reset capture state after each test.
+	 */
 	public function tearDown(): void {
 		LegacyFieldCapture::reset();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test that collect uses the base ID as the meta key without a prefix.
+	 */
 	public function test_collect_uses_base_id_as_meta_key_without_prefix(): void {
 		$this->enable_capture();
 
-		LegacyFieldCapture::collect( 'text_input', array(
-			'id'    => 'my_custom_field[0]',
-			'label' => 'Custom Field',
-		) );
+		LegacyFieldCapture::collect(
+			'text_input',
+			array(
+				'id'    => 'my_custom_field[0]',
+				'label' => 'Custom Field',
+			)
+		);
 
 		$fields = $this->get_collected_fields();
 		$this->assertCount( 1, $fields );
@@ -62,13 +77,19 @@ class LegacyFieldCaptureTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'my_custom_field', $fields[0]['meta_key'] );
 	}
 
+	/**
+	 * Test that collect preserves underscore prefix without doubling it.
+	 */
 	public function test_collect_preserves_underscore_prefix_without_doubling(): void {
 		$this->enable_capture();
 
-		LegacyFieldCapture::collect( 'text_input', array(
-			'id'    => '_my_custom_field[0]',
-			'label' => 'Custom Field',
-		) );
+		LegacyFieldCapture::collect(
+			'text_input',
+			array(
+				'id'    => '_my_custom_field[0]',
+				'label' => 'Custom Field',
+			)
+		);
 
 		$fields = $this->get_collected_fields();
 		$this->assertCount( 1, $fields );
@@ -76,13 +97,19 @@ class LegacyFieldCaptureTest extends WC_Unit_Test_Case {
 		$this->assertSame( '_my_custom_field', $fields[0]['meta_key'] );
 	}
 
+	/**
+	 * Test that collect strips the loop index for the meta key.
+	 */
 	public function test_collect_strips_loop_index_for_meta_key(): void {
 		$this->enable_capture();
 
-		LegacyFieldCapture::collect( 'text_input', array(
-			'id'    => 'variable_weight[3]',
-			'label' => 'Weight',
-		) );
+		LegacyFieldCapture::collect(
+			'text_input',
+			array(
+				'id'    => 'variable_weight[3]',
+				'label' => 'Weight',
+			)
+		);
 
 		$fields = $this->get_collected_fields();
 		$this->assertCount( 1, $fields );
@@ -90,13 +117,19 @@ class LegacyFieldCaptureTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'variable_weight', $fields[0]['meta_key'] );
 	}
 
+	/**
+	 * Test that collect handles a field ID without a loop index.
+	 */
 	public function test_collect_handles_id_without_loop_index(): void {
 		$this->enable_capture();
 
-		LegacyFieldCapture::collect( 'text_input', array(
-			'id'    => 'field_name',
-			'label' => 'Field',
-		) );
+		LegacyFieldCapture::collect(
+			'text_input',
+			array(
+				'id'    => 'field_name',
+				'label' => 'Field',
+			)
+		);
 
 		$fields = $this->get_collected_fields();
 		$this->assertCount( 1, $fields );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/DataForms/LegacyFieldCaptureTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/DataForms/LegacyFieldCaptureTest.php
@@ -1,0 +1,105 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\DataForms;
+
+use Automattic\WooCommerce\Internal\Admin\DataForms\LegacyFieldCapture;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for LegacyFieldCapture.
+ */
+class LegacyFieldCaptureTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Enable capture mode on the static class so collect() accepts fields.
+	 */
+	private function enable_capture(): void {
+		$ref = new \ReflectionClass( LegacyFieldCapture::class );
+
+		$capturing = $ref->getProperty( 'capturing' );
+		$capturing->setAccessible( true );
+		$capturing->setValue( null, true );
+
+		$hook = $ref->getProperty( 'current_hook' );
+		$hook->setAccessible( true );
+		$hook->setValue( null, 'woocommerce_variation_options' );
+
+		$fields = $ref->getProperty( 'fields' );
+		$fields->setAccessible( true );
+		$fields->setValue( null, array( 'woocommerce_variation_options' => array() ) );
+	}
+
+	/**
+	 * Read the collected fields from the static class.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_collected_fields(): array {
+		$ref    = new \ReflectionClass( LegacyFieldCapture::class );
+		$fields = $ref->getProperty( 'fields' );
+		$fields->setAccessible( true );
+		$all = $fields->getValue( null );
+		return $all['woocommerce_variation_options'] ?? array();
+	}
+
+	public function tearDown(): void {
+		LegacyFieldCapture::reset();
+		parent::tearDown();
+	}
+
+	public function test_collect_uses_base_id_as_meta_key_without_prefix(): void {
+		$this->enable_capture();
+
+		LegacyFieldCapture::collect( 'text_input', array(
+			'id'    => 'my_custom_field[0]',
+			'label' => 'Custom Field',
+		) );
+
+		$fields = $this->get_collected_fields();
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'my_custom_field', $fields[0]['id'] );
+		$this->assertSame( 'my_custom_field', $fields[0]['meta_key'] );
+	}
+
+	public function test_collect_preserves_underscore_prefix_without_doubling(): void {
+		$this->enable_capture();
+
+		LegacyFieldCapture::collect( 'text_input', array(
+			'id'    => '_my_custom_field[0]',
+			'label' => 'Custom Field',
+		) );
+
+		$fields = $this->get_collected_fields();
+		$this->assertCount( 1, $fields );
+		$this->assertSame( '_my_custom_field', $fields[0]['id'] );
+		$this->assertSame( '_my_custom_field', $fields[0]['meta_key'] );
+	}
+
+	public function test_collect_strips_loop_index_for_meta_key(): void {
+		$this->enable_capture();
+
+		LegacyFieldCapture::collect( 'text_input', array(
+			'id'    => 'variable_weight[3]',
+			'label' => 'Weight',
+		) );
+
+		$fields = $this->get_collected_fields();
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'variable_weight', $fields[0]['id'] );
+		$this->assertSame( 'variable_weight', $fields[0]['meta_key'] );
+	}
+
+	public function test_collect_handles_id_without_loop_index(): void {
+		$this->enable_capture();
+
+		LegacyFieldCapture::collect( 'text_input', array(
+			'id'    => 'field_name',
+			'label' => 'Field',
+		) );
+
+		$fields = $this->get_collected_fields();
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'field_name', $fields[0]['meta_key'] );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds extensibility for variation data in the quick-edit sidebar by capturing legacy field definitions from PHP hooks and rendering them as DataForm fields in the React UI.

**Backend (PHP):**
- `LegacyFieldCapture` class that intercepts WooCommerce helper functions (`woocommerce_wp_text_input`, `woocommerce_wp_select`, etc.) during capture mode, collecting field definitions instead of rendering HTML
- REST API endpoint (`/wc/v4/products/legacy-fields`) that returns captured field definitions grouped by hook name
- `meta_data` REST field registered on the `product` post type so meta round-trips through the WP entity store
- PHP unit tests for `LegacyFieldCapture`

**Frontend (JS/TS):**
- Legacy field adapter that converts captured PHP field definitions into `@wordpress/dataviews` Field objects (supports text, textarea, select, checkbox, radio, hidden types)
- `useLegacyFields` hook that fetches field definitions from the REST endpoint
- `useVariationMeta` hook that fetches variation meta_data separately (since the V4 entity store strips it from embedded variations), with a module-level cache that is updated from save responses to prevent stale data after save
- `mergeVariationMeta` utility that properly merges fetched and edited meta, preserving unedited values
- `parseVisibility` that ANDs multiple CSS class conditions for conditional field visibility (e.g. `show_if_variation_manage_stock`, `hide_if_variation_virtual`)
- Variation legacy hook mapping that positions legacy fields relative to native fields
- Fix for meta fields reverting to stale data after save — the cache is now module-level (survives component remounts) and read on every render
- Tests for `parseVisibility`, `mergeVariationMeta`, and variation selection gating

### How to test the changes in this Pull Request:

**Prerequisites:**

- Enable the **REST API v4** via the WC Beta Tester plugin.
- Enable the **Product Data Views** beta feature.
- Enable the **Product Variations Classic Redesign** beta feature.
- Enable the Gutenberg experiment: **Editor Inspector: Use Data Form**.
- Install a plugin that registers variation fields via WooCommerce variation hooks (e.g. using `woocommerce_wp_text_input` on `woocommerce_variation_options_pricing` or `woocommerce_product_after_variable_attributes`).

**Legacy fields appear in variation quick edit:**

1. Navigate to a variable product's edit page.
2. Open the **Variations** tab and click **Edit** on a variation row.
3. Verify the quick-edit sidebar shows the legacy fields registered by the plugin, positioned after the native fields for their hook.
4. Verify field types render correctly (text inputs, selects, checkboxes, textareas).
5. Verify conditional visibility works (e.g. stock-related fields only appear when "Manage stock" is enabled).

**Saving legacy meta fields persists the updated value:**

1. In the variation quick-edit sidebar, change a legacy meta field value (e.g. edit a text input).
2. Click **Save**.
3. Verify the updated value remains visible in the sidebar after save — it should NOT revert to the original value.
4. Refresh the page, reopen quick-edit, and verify the saved value is still correct.

**Saving legacy meta fields persists to the database:**

1. Edit a legacy meta field in quick-edit and save.
2. Verify via the WC REST API (`GET /wc/v3/products/{parent}/variations/{id}`) that the `meta_data` array contains the updated value.

**Product list quick edit regression check:**

1. Navigate to **Products > All Products (new)**.
2. Click **Edit** on a simple product row.
3. Verify the quick-edit drawer still opens and saves product edits as before (legacy fields should not appear for non-variation products).

### Testing that has already taken place:

- All 69 JS unit tests pass across the experimental-products-app package
- TypeScript compiles cleanly
- End-to-end tested with Playwright: created a variable product with meta_data, opened quick-edit, edited the "Variation badge" field, saved, and verified the updated value persists both in the UI and via REST API
- Tested with the `wc-variation-fields-explorer` plugin which registers text, textarea, select, checkbox, date, number, color, and hidden field types across multiple variation hooks

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Experimental feature behind the Gutenberg experiment flag — not yet user-facing.

</details>