### PR TITLE
Move review order page DB update callback to 10.8.0-1 key

### DIFF
--- a/plugins/woocommerce/changelog/fix-review-order-page-update-key
+++ b/plugins/woocommerce/changelog/fix-review-order-page-update-key
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Ensure the review order page is created on upgrade from earlier 10.8 beta builds where the 10.8.0 DB updates have already been recorded.

--- a/plugins/woocommerce/changelog/fix-review-order-page-update-key
+++ b/plugins/woocommerce/changelog/fix-review-order-page-update-key
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Ensure the review order page is created on upgrade from earlier 10.8 beta builds where the 10.8.0 DB updates have already been recorded.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -47,7 +47,7 @@ class WC_Install {
 	 * @var array
 	 */
 	private static $db_updates = array(
-		'2.0.0'  => array(
+		'2.0.0'    => array(
 			'wc_update_200_file_paths',
 			'wc_update_200_permalinks',
 			'wc_update_200_subcat_display',
@@ -56,42 +56,42 @@ class WC_Install {
 			'wc_update_200_images',
 			'wc_update_200_db_version',
 		),
-		'2.0.9'  => array(
+		'2.0.9'    => array(
 			'wc_update_209_brazillian_state',
 			'wc_update_209_db_version',
 		),
-		'2.1.0'  => array(
+		'2.1.0'    => array(
 			'wc_update_210_remove_pages',
 			'wc_update_210_file_paths',
 			'wc_update_210_db_version',
 		),
-		'2.2.0'  => array(
+		'2.2.0'    => array(
 			'wc_update_220_shipping',
 			'wc_update_220_order_status',
 			'wc_update_220_variations',
 			'wc_update_220_attributes',
 			'wc_update_220_db_version',
 		),
-		'2.3.0'  => array(
+		'2.3.0'    => array(
 			'wc_update_230_options',
 			'wc_update_230_db_version',
 		),
-		'2.4.0'  => array(
+		'2.4.0'    => array(
 			'wc_update_240_options',
 			'wc_update_240_shipping_methods',
 			'wc_update_240_api_keys',
 			'wc_update_240_refunds',
 			'wc_update_240_db_version',
 		),
-		'2.4.1'  => array(
+		'2.4.1'    => array(
 			'wc_update_241_variations',
 			'wc_update_241_db_version',
 		),
-		'2.5.0'  => array(
+		'2.5.0'    => array(
 			'wc_update_250_currency',
 			'wc_update_250_db_version',
 		),
-		'2.6.0'  => array(
+		'2.6.0'    => array(
 			'wc_update_260_options',
 			'wc_update_260_termmeta',
 			'wc_update_260_zones',
@@ -99,26 +99,26 @@ class WC_Install {
 			'wc_update_260_refunds',
 			'wc_update_260_db_version',
 		),
-		'3.0.0'  => array(
+		'3.0.0'    => array(
 			'wc_update_300_grouped_products',
 			'wc_update_300_settings',
 			'wc_update_300_product_visibility',
 			'wc_update_300_db_version',
 		),
-		'3.1.0'  => array(
+		'3.1.0'    => array(
 			'wc_update_310_downloadable_products',
 			'wc_update_310_old_comments',
 			'wc_update_310_db_version',
 		),
-		'3.1.2'  => array(
+		'3.1.2'    => array(
 			'wc_update_312_shop_manager_capabilities',
 			'wc_update_312_db_version',
 		),
-		'3.2.0'  => array(
+		'3.2.0'    => array(
 			'wc_update_320_mexican_states',
 			'wc_update_320_db_version',
 		),
-		'3.3.0'  => array(
+		'3.3.0'    => array(
 			'wc_update_330_image_options',
 			'wc_update_330_webhooks',
 			'wc_update_330_product_stock_status',
@@ -127,48 +127,48 @@ class WC_Install {
 			'wc_update_330_set_paypal_sandbox_credentials',
 			'wc_update_330_db_version',
 		),
-		'3.4.0'  => array(
+		'3.4.0'    => array(
 			'wc_update_340_states',
 			'wc_update_340_state',
 			'wc_update_340_last_active',
 			'wc_update_340_db_version',
 		),
-		'3.4.3'  => array(
+		'3.4.3'    => array(
 			'wc_update_343_cleanup_foreign_keys',
 			'wc_update_343_db_version',
 		),
-		'3.4.4'  => array(
+		'3.4.4'    => array(
 			'wc_update_344_recreate_roles',
 			'wc_update_344_db_version',
 		),
-		'3.5.0'  => array(
+		'3.5.0'    => array(
 			'wc_update_350_reviews_comment_type',
 			'wc_update_350_db_version',
 		),
-		'3.5.2'  => array(
+		'3.5.2'    => array(
 			'wc_update_352_drop_download_log_fk',
 		),
-		'3.5.4'  => array(
+		'3.5.4'    => array(
 			'wc_update_354_modify_shop_manager_caps',
 			'wc_update_354_db_version',
 		),
-		'3.6.0'  => array(
+		'3.6.0'    => array(
 			'wc_update_360_product_lookup_tables',
 			'wc_update_360_term_meta',
 			'wc_update_360_downloadable_product_permissions_index',
 			'wc_update_360_db_version',
 		),
-		'3.7.0'  => array(
+		'3.7.0'    => array(
 			'wc_update_370_tax_rate_classes',
 			'wc_update_370_mro_std_currency',
 			'wc_update_370_db_version',
 		),
-		'3.9.0'  => array(
+		'3.9.0'    => array(
 			'wc_update_390_move_maxmind_database',
 			'wc_update_390_change_geolocation_database_update_cron',
 			'wc_update_390_db_version',
 		),
-		'4.0.0'  => array(
+		'4.0.0'    => array(
 			'wc_update_product_lookup_tables',
 			'wc_update_400_increase_size_of_column',
 			'wc_update_400_reset_action_scheduler_migration_status',
@@ -177,27 +177,27 @@ class WC_Install {
 			'wc_admin_update_0251_remove_unsnooze_action',
 			'wc_update_400_db_version',
 		),
-		'4.4.0'  => array(
+		'4.4.0'    => array(
 			'wc_update_440_insert_attribute_terms_for_variable_products',
 			'wc_admin_update_110_remove_facebook_note',
 			'wc_admin_update_130_remove_dismiss_action_from_tracking_opt_in_note',
 			'wc_update_440_db_version',
 		),
-		'4.5.0'  => array(
+		'4.5.0'    => array(
 			'wc_update_450_sanitize_coupons_code',
 			'wc_update_450_db_version',
 		),
-		'5.0.0'  => array(
+		'5.0.0'    => array(
 			'wc_update_500_fix_product_review_count',
 			'wc_admin_update_160_remove_facebook_note',
 			'wc_admin_update_170_homescreen_layout',
 			'wc_update_500_db_version',
 		),
-		'5.6.0'  => array(
+		'5.6.0'    => array(
 			'wc_update_560_create_refund_returns_page',
 			'wc_update_560_db_version',
 		),
-		'6.0.0'  => array(
+		'6.0.0'    => array(
 			'wc_update_600_migrate_rate_limit_options',
 			'wc_admin_update_270_delete_report_downloads',
 			'wc_admin_update_271_update_task_list_options',
@@ -206,129 +206,131 @@ class WC_Install {
 			'wc_admin_update_290_delete_default_homepage_layout_option',
 			'wc_update_600_db_version',
 		),
-		'6.3.0'  => array(
+		'6.3.0'    => array(
 			'wc_update_630_create_product_attributes_lookup_table',
 			'wc_admin_update_300_update_is_read_from_last_read',
 			'wc_update_630_db_version',
 		),
-		'6.4.0'  => array(
+		'6.4.0'    => array(
 			'wc_update_640_add_primary_key_to_product_attributes_lookup_table',
 			'wc_admin_update_340_remove_is_primary_from_note_action',
 			'wc_update_640_db_version',
 		),
-		'6.5.0'  => array(
+		'6.5.0'    => array(
 			'wc_update_650_approved_download_directories',
 		),
-		'6.5.1'  => array(
+		'6.5.1'    => array(
 			'wc_update_651_approved_download_directories',
 		),
-		'6.7.0'  => array(
+		'6.7.0'    => array(
 			'wc_update_670_purge_comments_count_cache',
 			'wc_update_670_delete_deprecated_remote_inbox_notifications_option',
 		),
-		'7.0.0'  => array(
+		'7.0.0'    => array(
 			'wc_update_700_remove_download_log_fk',
 			'wc_update_700_remove_recommended_marketing_plugins_transient',
 		),
-		'7.2.1'  => array(
+		'7.2.1'    => array(
 			'wc_update_721_adjust_new_zealand_states',
 			'wc_update_721_adjust_ukraine_states',
 		),
-		'7.2.2'  => array(
+		'7.2.2'    => array(
 			'wc_update_722_adjust_new_zealand_states',
 			'wc_update_722_adjust_ukraine_states',
 		),
-		'7.5.0'  => array(
+		'7.5.0'    => array(
 			'wc_update_750_add_columns_to_order_stats_table',
 			'wc_update_750_disable_new_product_management_experience',
 		),
-		'7.7.0'  => array(
+		'7.7.0'    => array(
 			'wc_update_770_remove_multichannel_marketing_feature_options',
 		),
-		'7.9.0'  => array(
+		'7.9.0'    => array(
 			'wc_update_790_blockified_product_grid_block',
 		),
-		'8.1.0'  => array(
+		'8.1.0'    => array(
 			'wc_update_810_migrate_transactional_metadata_for_hpos',
 		),
-		'8.3.0'  => array(
+		'8.3.0'    => array(
 			'wc_update_830_rename_checkout_template',
 			'wc_update_830_rename_cart_template',
 		),
-		'8.6.0'  => array(
+		'8.6.0'    => array(
 			'wc_update_860_remove_recommended_marketing_plugins_transient',
 		),
-		'8.7.0'  => array(
+		'8.7.0'    => array(
 			'wc_update_870_prevent_listing_of_transient_files_directory',
 		),
-		'8.9.0'  => array(
+		'8.9.0'    => array(
 			'wc_update_890_update_connect_to_woocommerce_note',
 			'wc_update_890_update_paypal_standard_load_eligibility',
 		),
-		'8.9.1'  => array(
+		'8.9.1'    => array(
 			'wc_update_891_create_plugin_autoinstall_history_option',
 		),
-		'9.1.0'  => array(
+		'9.1.0'    => array(
 			'wc_update_910_add_launch_your_store_tour_option',
 			'wc_update_910_remove_obsolete_user_meta',
 		),
-		'9.2.0'  => array(
+		'9.2.0'    => array(
 			'wc_update_920_add_wc_hooked_blocks_version_option',
 		),
-		'9.3.0'  => array(
+		'9.3.0'    => array(
 			'wc_update_930_add_woocommerce_coming_soon_option',
 			'wc_update_930_migrate_user_meta_for_launch_your_store_tour',
 		),
-		'9.4.0'  => array(
+		'9.4.0'    => array(
 			'wc_update_940_add_phone_to_order_address_fts_index',
 			'wc_update_940_remove_help_panel_highlight_shown',
 		),
-		'9.5.0'  => array(
+		'9.5.0'    => array(
 			'wc_update_950_tracking_option_autoload',
 		),
-		'9.6.1'  => array(
+		'9.6.1'    => array(
 			'wc_update_961_migrate_default_email_base_color',
 		),
-		'9.8.0'  => array(
+		'9.8.0'    => array(
 			'wc_update_980_remove_order_attribution_install_banner_dismissed_option',
 		),
-		'9.8.5'  => array(
+		'9.8.5'    => array(
 			'wc_update_985_enable_new_payments_settings_page_feature',
 		),
-		'9.9.0'  => array(
+		'9.9.0'    => array(
 			'wc_update_990_remove_wc_count_comments_transient',
 			'wc_update_990_remove_email_notes',
 		),
-		'10.0.0' => array(
+		'10.0.0'   => array(
 			'wc_update_1000_multisite_visibility_setting',
 			'wc_update_1000_remove_patterns_toolkit_transient',
 		),
-		'10.2.0' => array(
+		'10.2.0'   => array(
 			'wc_update_1020_add_old_refunded_order_items_to_product_lookup_table',
 		),
-		'10.3.0' => array(
+		'10.3.0'   => array(
 			'wc_update_1030_add_comments_date_type_index',
 		),
-		'10.4.0' => array(
+		'10.4.0'   => array(
 			'wc_update_1040_add_idx_date_paid_status_parent',
 			'wc_update_1040_cleanup_legacy_ptk_patterns_fetching',
 		),
-		'10.5.0' => array(
+		'10.5.0'   => array(
 			'wc_update_1050_migrate_brand_permalink_setting',
 			'wc_update_1050_enable_autoload_options',
 			'wc_update_1050_add_idx_user_email',
 			'wc_update_1050_remove_deprecated_marketplace_option',
 		),
-		'10.6.0' => array(
+		'10.6.0'   => array(
 			'wc_update_1060_add_woo_idx_comment_approved_type_index',
 		),
-		'10.7.0' => array(
+		'10.7.0'   => array(
 			'wc_update_1070_disable_hpos_sync_on_read',
 		),
-		'10.8.0' => array(
+		'10.8.0'   => array(
 			'wc_update_1080_migrate_analytics_import_option',
 			'wc_update_1080_slim_orders_meta_key_index',
 			'wc_update_1080_backfill_email_template_sync_meta',
+		),
+		'10.8.0-1' => array(
 			'wc_update_1080_create_review_order_page',
 		),
 	);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -171,7 +171,16 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_woocommerce_updated_action() {
-		$versions     = array_keys( WC_Install::get_db_update_callbacks() );
+		// DB update keys may include a suffix (e.g. "10.8.0-1") used to schedule extra updates
+		// for an already-released version, so normalize each key to its X.Y.Z form and dedupe
+		// before picking the previous one — otherwise count-2 can land on a sibling of the
+		// latest version that is not actually older than the running code.
+		$versions     = array_values( array_unique( array_map(
+			static function ( $v ) {
+				return preg_replace( '/-.*$/', '', $v );
+			},
+			array_keys( WC_Install::get_db_update_callbacks() )
+		) ) );
 		$prev_version = $versions[ count( $versions ) - 2 ];
 		update_option( 'woocommerce_version', $prev_version );
 		WC_Install::check_version();

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -175,12 +175,13 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 		// for an already-released version, so normalize each key to its X.Y.Z form and dedupe
 		// before picking the previous one — otherwise count-2 can land on a sibling of the
 		// latest version that is not actually older than the running code.
-		$versions     = array_values( array_unique( array_map(
+		$normalized   = array_map(
 			static function ( $v ) {
 				return preg_replace( '/-.*$/', '', $v );
 			},
 			array_keys( WC_Install::get_db_update_callbacks() )
-		) ) );
+		);
+		$versions     = array_values( array_unique( $normalized ) );
 		$prev_version = $versions[ count( $versions ) - 2 ];
 		update_option( 'woocommerce_version', $prev_version );
 		WC_Install::check_version();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Users who already ran 10.8.0 DB updates on a beta/RC build will not pick up the newly added `wc_update_1080_create_review_order_page` callback because the `10.8.0` version key has already been processed for them. This PR moves that callback into its own `10.8.0-1` key (per the convention documented in the file header) so it runs on upgrade regardless of which prior 10.8 build was installed.

### How to test the changes in this Pull Request:

1. Start from a site running an earlier 10.8 beta 1 where the previous `10.8.0` updates have already been recorded (i.e. `woocommerce_db_version` is at `10.8.0`).
2. Update to the build containing this change.
3. Run the DB update by running the A-S job manually (or `wp wc update`).
4. Confirm the Review Order page is created and that no other `10.8.0` callbacks re-run.

You can simulate the "already ran 10.8.0 updates" starting state with WP-CLI instead of installing an earlier beta:

```sh
wp option update woocommerce_version 10.8.0-beta.1
wp option update woocommerce_db_version 10.8.0
```

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->