### PR TITLE
RSM: Gate cart Save for later link on login, feature flag, and block presence

### DIFF
--- a/plugins/woocommerce/changelog/64776-fix-cart-save-for-later-visibility
+++ b/plugins/woocommerce/changelog/64776-fix-cart-save-for-later-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Hide the cart "Save for later" link when the user is logged out, the `cart_save_for_later` feature is disabled, or the cart page has no `woocommerce/shopper-collection` block.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -20,8 +20,8 @@ import {
 } from '@woocommerce/blocks-checkout';
 import { forwardRef, useMemo } from '@wordpress/element';
 import type { CartItem } from '@woocommerce/types';
-import { objectHasProp, Currency } from '@woocommerce/types';
-import { getSetting } from '@woocommerce/settings';
+import { isBoolean, objectHasProp, Currency } from '@woocommerce/types';
+import { getSetting, getSettingWithCoercion } from '@woocommerce/settings';
 import { Icon, trash } from '@wordpress/icons';
 import { calculateSaleAmount } from '@woocommerce/base-utils';
 import { dinero, transformScale, toSnapshot, type Dinero } from 'dinero.js';
@@ -121,6 +121,28 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 		const { saveForLater, isSaving: isSavingForLater } = useSaveForLater();
 		const { dispatchStoreEvent } = useStoreEvents();
 		const isUserLoggedIn = !! getSetting< number >( 'currentUserId', 0 );
+		const isSaveForLaterFeatureEnabled = getSettingWithCoercion(
+			'experimentalCartSaveForLater',
+			false,
+			isBoolean
+		);
+		const cartPageHasSavedForLater = getSettingWithCoercion(
+			'cartPageHasSavedForLater',
+			false,
+			isBoolean
+		);
+		// Three signals, each catching a distinct failure mode.
+		// Disabling the `cart_save_for_later` feature unregisters the
+		// shopper-collection block but leaves any prior insertion in the
+		// cart page's post content (the editor renders it as an
+		// "unsupported block" notice) — so presence alone could render
+		// this link with no working destination. Inversely, the feature
+		// can be enabled on cart pages that never inserted the block.
+		// And the REST endpoints behind the click are auth-only.
+		const showSaveForLater =
+			isUserLoggedIn &&
+			isSaveForLaterFeatureEnabled &&
+			cartPageHasSavedForLater;
 
 		// Prepare props to pass to the applyCheckoutFilter filter.
 		// We need to pluck out receiveCart.
@@ -342,7 +364,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 								</button>
 							) }
 						</div>
-						{ isUserLoggedIn && (
+						{ showSaveForLater && (
 							<div className="wc-block-cart-item__save-for-later">
 								<button
 									type="button"

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/test/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/test/cart-line-item-row.tsx
@@ -1,0 +1,247 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import type { CartItem } from '@woocommerce/types';
+import { getSetting, getSettingWithCoercion } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import CartLineItemRow from '../cart-line-item-row';
+
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	// Default implementations return the provided defaultValue so module-load
+	// time calls (e.g. `getSetting( 'wcBlocksConfig', { pluginUrl: '', ... } )`
+	// in the settings constants module) still receive a usable shape. Per-test
+	// overrides via `setSettings` below replace these implementations.
+	getSetting: jest.fn(
+		( _key: string, defaultValue: unknown ) => defaultValue
+	),
+	getSettingWithCoercion: jest.fn(
+		( _key: string, defaultValue: unknown ) => defaultValue
+	),
+} ) );
+
+jest.mock( '@woocommerce/base-context/hooks', () => ( {
+	...jest.requireActual( '@woocommerce/base-context/hooks' ),
+	useStoreCartItemQuantity: jest.fn( () => ( {
+		quantity: 1,
+		setItemQuantity: jest.fn(),
+		removeItem: jest.fn(),
+		isPendingDelete: false,
+	} ) ),
+	useStoreEvents: jest.fn( () => ( {
+		dispatchStoreEvent: jest.fn(),
+	} ) ),
+	useStoreCart: jest.fn( () => ( {
+		receiveCart: jest.fn(),
+		cartItems: [],
+	} ) ),
+	useSaveForLater: jest.fn( () => ( {
+		saveForLater: jest.fn(),
+		isSaving: false,
+	} ) ),
+} ) );
+
+jest.mock( '@woocommerce/blocks-checkout', () => ( {
+	...jest.requireActual( '@woocommerce/blocks-checkout' ),
+	applyCheckoutFilter: jest.fn( ( { defaultValue } ) => defaultValue ),
+	productPriceValidation: jest.fn(),
+} ) );
+
+const mockGetSetting = getSetting as jest.Mock;
+const mockGetSettingWithCoercion = getSettingWithCoercion as jest.Mock;
+
+/**
+ * Minimal CartItem shape — only the fields the row actually reads. Using an
+ * inline fixture instead of `previewCart` keeps this test free of the
+ * preview module's transitive imports (which expect `wcBlocksConfig` to be
+ * populated at module-load time).
+ */
+const buildLineItem = (): CartItem =>
+	( {
+		key: 'test-key',
+		id: 1,
+		type: 'simple',
+		quantity: 1,
+		catalog_visibility: 'visible',
+		name: 'Test product',
+		short_description: '',
+		description: '',
+		sku: 'test-sku',
+		permalink: 'https://example.org',
+		low_stock_remaining: null,
+		backorders_allowed: false,
+		show_backorder_badge: false,
+		sold_individually: false,
+		quantity_limits: {
+			minimum: 1,
+			maximum: 99,
+			multiple_of: 1,
+			editable: true,
+		},
+		images: [],
+		variation: [],
+		item_data: [],
+		prices: {
+			currency_code: 'USD',
+			currency_minor_unit: 2,
+			currency_symbol: '$',
+			currency_prefix: '$',
+			currency_suffix: '',
+			currency_decimal_separator: '.',
+			currency_thousand_separator: ',',
+			price: '1000',
+			regular_price: '1000',
+			sale_price: '1000',
+			price_range: null,
+			raw_prices: {
+				precision: 6,
+				price: '10000000',
+				regular_price: '10000000',
+				sale_price: '10000000',
+			},
+		},
+		totals: {
+			currency_code: 'USD',
+			currency_minor_unit: 2,
+			currency_symbol: '$',
+			currency_prefix: '$',
+			currency_suffix: '',
+			currency_decimal_separator: '.',
+			currency_thousand_separator: ',',
+			line_subtotal: '1000',
+			line_subtotal_tax: '0',
+			line_total: '1000',
+			line_total_tax: '0',
+		},
+		extensions: {},
+	} as unknown as CartItem );
+
+/**
+ * Configure `getSetting` and `getSettingWithCoercion` mocks for the three
+ * signals the cart row reads when deciding whether to render the
+ * "Save for later" button. Any setting not explicitly provided falls back to
+ * the default supplied by the caller (same behaviour as the production
+ * helpers).
+ */
+const setSettings = ( {
+	currentUserId = 0,
+	experimentalCartSaveForLater,
+	cartPageHasSavedForLater,
+}: {
+	currentUserId?: number;
+	experimentalCartSaveForLater?: boolean;
+	cartPageHasSavedForLater?: boolean;
+} ) => {
+	mockGetSetting.mockImplementation(
+		( key: string, defaultValue: unknown ) => {
+			if ( key === 'currentUserId' ) {
+				return currentUserId;
+			}
+			return defaultValue;
+		}
+	);
+	mockGetSettingWithCoercion.mockImplementation(
+		( key: string, defaultValue: unknown ) => {
+			if (
+				key === 'experimentalCartSaveForLater' &&
+				experimentalCartSaveForLater !== undefined
+			) {
+				return experimentalCartSaveForLater;
+			}
+			if (
+				key === 'cartPageHasSavedForLater' &&
+				cartPageHasSavedForLater !== undefined
+			) {
+				return cartPageHasSavedForLater;
+			}
+			return defaultValue;
+		}
+	);
+};
+
+const renderRow = () => {
+	// Wrap in a table so the row's <td>s render in a valid context.
+	return render(
+		<table>
+			<tbody>
+				<CartLineItemRow lineItem={ buildLineItem() } />
+			</tbody>
+		</table>
+	);
+};
+
+describe( 'CartLineItemRow — Save for later visibility', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'shows the Save for later button when user is logged in, feature is enabled, and the page has a saved-for-later block', () => {
+		setSettings( {
+			currentUserId: 42,
+			experimentalCartSaveForLater: true,
+			cartPageHasSavedForLater: true,
+		} );
+
+		renderRow();
+
+		expect(
+			screen.getByRole( 'button', { name: /save for later/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'hides the Save for later button when the user is logged out', () => {
+		setSettings( {
+			currentUserId: 0,
+			experimentalCartSaveForLater: true,
+			cartPageHasSavedForLater: true,
+		} );
+
+		renderRow();
+
+		expect(
+			screen.queryByRole( 'button', { name: /save for later/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the Save for later button when the page has no saved-for-later block', () => {
+		setSettings( {
+			currentUserId: 42,
+			experimentalCartSaveForLater: true,
+			cartPageHasSavedForLater: false,
+		} );
+
+		renderRow();
+
+		expect(
+			screen.queryByRole( 'button', { name: /save for later/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the Save for later button when the feature flag is disabled', () => {
+		setSettings( {
+			currentUserId: 42,
+			experimentalCartSaveForLater: false,
+			cartPageHasSavedForLater: true,
+		} );
+
+		renderRow();
+
+		expect(
+			screen.queryByRole( 'button', { name: /save for later/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the Save for later button when none of the signals are set (defaults)', () => {
+		setSettings( {} );
+
+		renderRow();
+
+		expect(
+			screen.queryByRole( 'button', { name: /save for later/i } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\Assets;
 
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Automattic\WooCommerce\Internal\Logging\RemoteLogger;
 use Exception;
@@ -252,8 +253,9 @@ class AssetDataRegistry {
 			);
 		}
 
-		$core_data                            = $this->get_core_data();
-		$core_data['experimentalWcRestApiV4'] = Features::is_enabled( 'rest-api-v4' );
+		$core_data                                 = $this->get_core_data();
+		$core_data['experimentalWcRestApiV4']      = Features::is_enabled( 'rest-api-v4' );
+		$core_data['experimentalCartSaveForLater'] = FeaturesUtil::feature_is_enabled( 'cart_save_for_later' );
 		// note this WILL wipe any data already registered to these keys because they are protected.
 		$this->data = array_replace_recursive( $settings, $core_data );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Tests\Blocks\Assets;
 
 use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AssetDataRegistryMock;
 use Automattic\WooCommerce\Blocks\Package;
 use InvalidArgumentException;
@@ -85,5 +86,43 @@ class AssetDataRegistry extends \WP_UnitTestCase {
 		$original_data['cheeseburger'] = 'fries';
 		$this->assertEquals( $original_data, $data );
 		remove_filter( 'woocommerce_shared_settings', [ self::class, 'ndcallback' ] );
+	}
+
+	/**
+	 * @testdox `experimentalCartSaveForLater` is registered as true when the `cart_save_for_later` feature is enabled.
+	 */
+	public function test_experimental_cart_save_for_later_setting_is_true_when_feature_enabled() {
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		$original_enabled    = $features_controller->feature_is_enabled( 'cart_save_for_later' );
+
+		$features_controller->change_feature_enable( 'cart_save_for_later', true );
+		try {
+			$this->registry->initialize_core_data();
+			$data = $this->registry->get();
+
+			$this->assertArrayHasKey( 'experimentalCartSaveForLater', $data );
+			$this->assertTrue( $data['experimentalCartSaveForLater'] );
+		} finally {
+			$features_controller->change_feature_enable( 'cart_save_for_later', $original_enabled );
+		}
+	}
+
+	/**
+	 * @testdox `experimentalCartSaveForLater` is registered as false when the `cart_save_for_later` feature is disabled.
+	 */
+	public function test_experimental_cart_save_for_later_setting_is_false_when_feature_disabled() {
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		$original_enabled    = $features_controller->feature_is_enabled( 'cart_save_for_later' );
+
+		$features_controller->change_feature_enable( 'cart_save_for_later', false );
+		try {
+			$this->registry->initialize_core_data();
+			$data = $this->registry->get();
+
+			$this->assertArrayHasKey( 'experimentalCartSaveForLater', $data );
+			$this->assertFalse( $data['experimentalCartSaveForLater'] );
+		} finally {
+			$features_controller->change_feature_enable( 'cart_save_for_later', $original_enabled );
+		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The cart's "Save for later" link previously only checked the user's login state. It still rendered (and called into the auth-gated Store API) when the `cart_save_for_later` feature was off, or when the cart page didn't actually contain a `woocommerce/shopper-collection` block to receive the saved item. Each of those is a real path to a broken click — disabling the feature unregisters the shopper-collection block but leaves any prior insertion in the cart page's post content (the editor renders it as an "unsupported block" notice), and the feature can be enabled on cart pages that never inserted the block.

This PR adds the two missing primitives and combines all three at the consumer:

- `AssetDataRegistry::initialize_core_data()` emits a new global `experimentalCartSaveForLater` setting reflecting `FeaturesUtil::feature_is_enabled( 'cart_save_for_later' )`. Placed alongside the existing `experimentalWcRestApiV4` line and following the same `experimental*` naming convention.
- `cart-line-item-row.tsx` reads the three primitives (`currentUserId`, `experimentalCartSaveForLater`, `cartPageHasSavedForLater`) and ANDs them at the consumer. `Cart.php` keeps `cartPageHasSavedForLater` as pure block-presence (no policy).

Server emits facts; consumer applies the gate. Means each primitive stays reusable, and any future consumer (e.g. mini-cart) gets the feature flag for free off the global setting.

### How to test the changes in this Pull Request:

Prerequisite: enable the experimental feature (`wp option update woocommerce_cart_save_for_later_enabled yes`, or via `WooCommerce → Settings → Advanced → Features`). Add the `woocommerce/shopper-collection` block to the cart page (auto-injection ships with the feature).

1. **All gates pass.** Logged in, feature on, shopper-collection on the cart page → visit cart, **expect** a "Save for later" button on every cart line item. Click it and confirm the item moves out of the cart and into the saved-for-later list below.
2. **Logged out.** Log out and reload the cart → **expect** no "Save for later" button.
3. **Feature disabled.** Re-login, then `wp option update woocommerce_cart_save_for_later_enabled no` and reload the cart → **expect** no "Save for later" button (the shopper-collection block also won't render — that's existing behavior).
4. **Block removed.** Re-enable the feature, edit the cart page to remove the `woocommerce/shopper-collection` block from the post content, save, reload → **expect** no "Save for later" button on the cart rows.

### Testing that has already taken place:

- **5 Jest tests** in `cart-line-item-row.tsx` covering each individual gate failing + the all-true case + the all-defaults case. All pass.
- **2 PHPUnit tests** in `AssetDataRegistry` confirming the new setting reflects the feature flag (true when enabled, false when disabled), using `FeaturesController::change_feature_enable` with try/finally state restoration. All pass.
- Manual: reproduced the four cases above locally on a Studio site with `cart_save_for_later` toggled.
- PHPStan clean on both modified PHP files. Branch-level PHPCS clean.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Update - Update existing functionality

#### Message

Hide the cart "Save for later" link when the user is logged out, the `cart_save_for_later` feature is disabled, or the cart page has no `woocommerce/shopper-collection` block.

</details>