### PR TITLE
Add Shopper Collection Header block with editable heading and count

### DIFF
--- a/plugins/woocommerce/changelog/add-shopper-collection-header-block
+++ b/plugins/woocommerce/changelog/add-shopper-collection-header-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a Shopper Collection Header inner block that renders a section heading with a live item count above the saved-for-later list. Empty-state message is now visually hidden and announced via an `aria-live` region.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
@@ -12,20 +12,20 @@
 		"listName": {
 			"type": "string",
 			"default": "saved-for-later"
+		},
+		"columnCount": {
+			"type": "number",
+			"default": 3
 		}
 	},
+	"providesContext": {
+		"woocommerce/shopperListSlug": "listName"
+	},
 	"supports": {
-		 "align": [ "wide", "full" ],
+		"align": [ "wide", "full" ],
 		"interactivity": true,
 		"html": false,
 		"reusable": false,
-		"layout": {
-			"default": {
-				"type": "grid",
-				"columnCount": 3
-			},
-			"allowEditing": true
-		},
 		"spacing": {
 			"margin": true,
 			"padding": true,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
@@ -2,17 +2,31 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	RangeControl,
+	SelectControl,
+} from '@wordpress/components';
 import { Icon, trash } from '@wordpress/icons';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
 
+/**
+ * Internal dependencies
+ */
+import { PREVIEW_ITEMS } from './preview-items';
+
+const HEADER_TEMPLATE: [ string, Record< string, never > ][] = [
+	[ 'woocommerce/shopper-collection-header', {} ],
+];
+
 interface ShopperCollectionAttributes {
 	listName: string;
-	layout?: {
-		type?: string;
-		columnCount?: number;
-	};
+	columnCount: number;
 }
 
 interface EditProps {
@@ -22,63 +36,25 @@ interface EditProps {
 
 const DEFAULT_COLUMN_COUNT = 3;
 
-const PREVIEW_ITEMS = [
-	{
-		key: 'preview-1',
-		name: __( 'Sample product one', 'woocommerce' ),
-		variation: __( 'Size: M', 'woocommerce' ),
-		price: '$19.99',
-		quantity: __( 'Qty: 2', 'woocommerce' ),
-	},
-	{
-		key: 'preview-2',
-		name: __( 'Sample product two', 'woocommerce' ),
-		variation: __( 'Color: Blue', 'woocommerce' ),
-		price: '$29.99',
-		quantity: __( 'Qty: 1', 'woocommerce' ),
-	},
-	{
-		key: 'preview-3',
-		name: __( 'Sample product three', 'woocommerce' ),
-		variation: '',
-		price: '$9.99',
-		quantity: __( 'Qty: 3', 'woocommerce' ),
-	},
-	{
-		key: 'preview-4',
-		name: __( 'Sample product four', 'woocommerce' ),
-		variation: __( 'Size: L', 'woocommerce' ),
-		price: '$24.99',
-		quantity: __( 'Qty: 1', 'woocommerce' ),
-	},
-	{
-		key: 'preview-5',
-		name: __( 'Sample product five', 'woocommerce' ),
-		variation: '',
-		price: '$14.99',
-		quantity: __( 'Qty: 2', 'woocommerce' ),
-	},
-	{
-		key: 'preview-6',
-		name: __( 'Sample product six', 'woocommerce' ),
-		variation: __( 'Color: Red', 'woocommerce' ),
-		price: '$39.99',
-		quantity: __( 'Qty: 1', 'woocommerce' ),
-	},
-];
-
 const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
-	const { listName, layout } = attributes;
-	const columnCount =
-		typeof layout?.columnCount === 'number'
-			? layout.columnCount
-			: DEFAULT_COLUMN_COUNT;
+	const { listName, columnCount } = attributes;
 	const blockProps = useBlockProps( {
-		className: 'wc-block-shopper-collection',
+		className: 'wc-block-shopper-collection-wrapper',
 		style: {
 			'--wc-shopper-collection-columns': columnCount,
 		} as React.CSSProperties,
 	} );
+	// Locked to all so the header stays as the only child. Items in the
+	// list aren't editable blocks — they're rendered by iAPI from the
+	// shopper-lists store — so the header is the only thing the admin
+	// touches inside this block.
+	const innerBlocksProps = useInnerBlocksProps(
+		{ className: 'wc-block-shopper-collection-inner' },
+		{
+			template: HEADER_TEMPLATE,
+			templateLock: 'all',
+		}
+	);
 
 	return (
 		<>
@@ -101,70 +77,86 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 							setAttributes( { listName: value } )
 						}
 					/>
+					<RangeControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ __( 'Columns', 'woocommerce' ) }
+						value={ columnCount }
+						onChange={ ( value: number | undefined ) =>
+							setAttributes( {
+								columnCount: value ?? DEFAULT_COLUMN_COUNT,
+							} )
+						}
+						min={ 1 }
+						max={ 6 }
+					/>
 				</PanelBody>
 			</InspectorControls>
-			<ul { ...blockProps }>
-				{ PREVIEW_ITEMS.map( ( item ) => (
-					<li
-						key={ item.key }
-						className="wc-block-shopper-collection-item"
-					>
-						<div className="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
-							<a
-								href="#preview"
-								onClick={ ( e ) => e.preventDefault() }
-							>
-								<img src={ PLACEHOLDER_IMG_SRC } alt="" />
-							</a>
-							<button
-								type="button"
-								className="wc-block-shopper-collection-item__remove"
-								aria-label={ sprintf(
-									/* translators: %s: product name. */
-									__(
-										'Remove %s from Saved for later list',
-										'woocommerce'
-									),
-									item.name
+			<section { ...blockProps }>
+				<div { ...innerBlocksProps } />
+				<ul className="wc-block-shopper-collection">
+					{ PREVIEW_ITEMS.map( ( item ) => (
+						<li
+							key={ item.key }
+							className="wc-block-shopper-collection-item"
+						>
+							<div className="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+								<a
+									href="#preview"
+									onClick={ ( e ) => e.preventDefault() }
+								>
+									<img src={ PLACEHOLDER_IMG_SRC } alt="" />
+								</a>
+								<button
+									type="button"
+									className="wc-block-shopper-collection-item__remove"
+									aria-label={ sprintf(
+										/* translators: %s: product name. */
+										__(
+											'Remove %s from Saved for later list',
+											'woocommerce'
+										),
+										item.name
+									) }
+									disabled
+								>
+									<Icon icon={ trash } size={ 24 } />
+								</button>
+								{ item.variation && (
+									<span className="wc-block-shopper-collection-item__variation">
+										{ item.variation }
+									</span>
 								) }
-								disabled
-							>
-								<Icon icon={ trash } size={ 24 } />
-							</button>
-							{ item.variation && (
-								<span className="wc-block-shopper-collection-item__variation">
-									{ item.variation }
+							</div>
+							<h2 className="wp-block-post-title has-text-align-center has-medium-font-size">
+								<a
+									href="#preview"
+									onClick={ ( e ) => e.preventDefault() }
+								>
+									{ item.name }
+								</a>
+							</h2>
+							<div className="price wc-block-components-product-price has-text-align-center has-small-font-size">
+								<span className="wc-block-components-product-price__value">
+									{ item.price }
 								</span>
-							) }
-						</div>
-						<h2 className="wp-block-post-title has-text-align-center has-medium-font-size">
-							<a
-								href="#preview"
-								onClick={ ( e ) => e.preventDefault() }
-							>
-								{ item.name }
-							</a>
-						</h2>
-						<div className="price wc-block-components-product-price has-text-align-center has-small-font-size">
-							<span className="wc-block-components-product-price__value">
-								{ item.price }
+							</div>
+							<span className="wc-block-shopper-collection-item__quantity">
+								{ item.quantity }
 							</span>
-						</div>
-						<span className="wc-block-shopper-collection-item__quantity">
-							{ item.quantity }
-						</span>
-						<div className="wp-block-button wc-block-components-product-button">
-							<button
-								type="button"
-								className="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
-								disabled
-							>
-								{ __( 'Move to cart', 'woocommerce' ) }
-							</button>
-						</div>
-					</li>
-				) ) }
-			</ul>
+							<div className="wp-block-button wc-block-components-product-button">
+								<button
+									type="button"
+									className="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+									disabled
+								>
+									{ __( 'Move to cart', 'woocommerce' ) }
+								</button>
+							</div>
+						</li>
+					) ) }
+				</ul>
+			</section>
 		</>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
@@ -1,6 +1,30 @@
-// The block IS the grid. supports.layout's `columnCount` attribute drives
-// our --wc-shopper-collection-columns CSS variable (set inline on the wrapper
-// in both editor preview and PHP render). No nested grids, no inner blocks.
+// Outer section wraps the header inner block + items grid. The block's
+// own supports (color, typography, spacing) ride on this element via
+// `useBlockProps`. The grid is on the nested `<ul>` so the header isn't
+// forced into a grid cell alongside the items.
+.wc-block-shopper-collection-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wp--style--block-gap, 1em);
+}
+
+.wc-block-shopper-collection-header {
+	align-items: baseline;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--wp--style--block-gap, 0.5em);
+
+	&__heading-slot,
+	.wp-block-heading {
+		margin: 0;
+	}
+
+	&__count {
+		color: rgba(0, 0, 0, 0.7);
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+	}
+}
+
 .wc-block-shopper-collection {
 	display: grid;
 	gap: var(--wp--style--block-gap, 1.5em);
@@ -112,11 +136,20 @@
 	}
 }
 
+// Empty state mirrors the frontend: visually hidden, announced via
+// `aria-live`. Kept here so the editor preview matches what ships.
 .wc-block-shopper-collection__empty {
-	color: rgba(0, 0, 0, 0.7);
-	grid-column: 1 / -1;
-	padding: 1em 0;
-	text-align: center;
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+	word-wrap: normal !important;
 }
 
 // Error state spans every grid column so it reads as a single alert

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -23,6 +23,8 @@ const universalLock =
 type ShopperCollectionConfig = {
 	quantityLabelTemplate: string;
 	removeLabelTemplate: string;
+	headerCountSuffixSingular: string;
+	headerCountSuffixPlural: string;
 };
 
 type BlockContext = {
@@ -37,6 +39,9 @@ type BlockStore = {
 		hasError: boolean;
 		errorMessage: string;
 		isEmpty: boolean;
+		hasItems: boolean;
+		itemCount: number;
+		itemCountSuffix: string;
 		isMoveToCartHidden: boolean;
 		isPriceHidden: boolean;
 		currentItemDisplayName: string;
@@ -152,6 +157,46 @@ store< BlockStore >(
 					return true;
 				}
 				return ! list.isLoading && list.items.length === 0;
+			},
+
+			get itemCount(): number {
+				const { listSlug } = getContext< BlockContext >();
+				return getList( listSlug )?.items.length ?? 0;
+			},
+
+			// Used by `shopper-collection-header` to toggle visibility of
+			// the section heading. Mirrors `isEmpty` but lives on its own
+			// getter so the header doesn't have to also consider loading
+			// state — the heading just disappears when there's nothing to
+			// label.
+			get hasItems(): boolean {
+				const { listSlug } = getContext< BlockContext >();
+				return ( getList( listSlug )?.items.length ?? 0 ) > 0;
+			},
+
+			// Picks singular/plural at runtime so the header count suffix
+			// reacts to add/remove without the SSR rendering needing to
+			// re-run. Templates flow in through `wp_interactivity_config`
+			// alongside the existing per-row label templates. The heading
+			// text itself is editor-owned (core/heading inner block) and
+			// is not touched by iAPI.
+			get itemCountSuffix(): string {
+				const { listSlug } = getContext< BlockContext >();
+				const count = getList( listSlug )?.items.length ?? 0;
+				if ( count <= 0 ) {
+					return '';
+				}
+				const {
+					headerCountSuffixSingular,
+					headerCountSuffixPlural,
+				} = getConfig(
+					'woocommerce/shopper-collection'
+				) as ShopperCollectionConfig;
+				const template =
+					count === 1
+						? headerCountSuffixSingular
+						: headerCountSuffixPlural;
+				return template.replace( '%d', String( count ) );
 			},
 
 			get isPriceHidden(): boolean {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/inner-blocks/shopper-collection-header/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/inner-blocks/shopper-collection-header/block.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/shopper-collection-header",
+	"version": "1.0.0",
+	"title": "Shopper Collection Header",
+	"description": "Section heading with a live item count for the parent Shopper Collection.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce", "Saved for Later", "Shopper Collection" ],
+	"textdomain": "woocommerce",
+	"parent": [ "woocommerce/shopper-collection" ],
+	"usesContext": [
+		"woocommerce/shopperListSlug",
+		"woocommerce/shopperItemCount",
+		"woocommerce/shopperHeaderCountSingular",
+		"woocommerce/shopperHeaderCountPlural"
+	],
+	"attributes": {
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": true,
+				"move": true
+			}
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"interactivity": {
+			"clientNavigation": true,
+			"interactive": false
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/inner-blocks/shopper-collection-header/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/inner-blocks/shopper-collection-header/edit.tsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { PREVIEW_ITEMS } from '../../preview-items';
+
+// Keep the editor's count badge in sync with what the parent shows in
+// its preview grid — both derive from the same array so they can't drift.
+const PREVIEW_COUNT = PREVIEW_ITEMS.length;
+
+// Default child for the header: one core/heading the merchant can edit
+// like any other heading. Locked from move/remove so the heading can't
+// be deleted or rearranged out of the header — only its text and
+// per-heading supports are editable. Item-count suffix is rendered
+// alongside as a non-editable span (PHP + iAPI).
+const HEADER_TEMPLATE: [
+	string,
+	Record< string, unknown >
+][] = [
+	[
+		'core/heading',
+		{
+			level: 2,
+			content: __( 'Saved for later', 'woocommerce' ),
+			lock: { remove: true, move: true },
+		},
+	],
+];
+
+const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps( {
+		className: 'wc-block-shopper-collection-header',
+	} );
+	const innerBlocksProps = useInnerBlocksProps(
+		{ className: 'wc-block-shopper-collection-header__heading-slot' },
+		{
+			template: HEADER_TEMPLATE,
+			templateLock: 'all',
+		}
+	);
+
+	return (
+		<div { ...blockProps }>
+			<div { ...innerBlocksProps } />
+			<span className="wc-block-shopper-collection-header__count">
+				{ sprintf(
+					/* translators: %d: number of saved items. */
+					__( '(%d items)', 'woocommerce' ),
+					PREVIEW_COUNT
+				) }
+			</span>
+		</div>
+	);
+};
+
+export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/inner-blocks/shopper-collection-header/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/inner-blocks/shopper-collection-header/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { Icon, starEmpty } from '@wordpress/icons';
+import { Icon, heading } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -10,15 +10,12 @@ import { Icon, starEmpty } from '@wordpress/icons';
 import metadata from './block.json';
 import Edit from './edit';
 import Save from './save';
-import './variations';
-import './style.scss';
-import './inner-blocks/shopper-collection-header';
 
 registerBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
-				icon={ starEmpty }
+				icon={ heading }
 				className="wc-block-editor-components-block-icon"
 			/>
 		),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/inner-blocks/shopper-collection-header/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/inner-blocks/shopper-collection-header/save.tsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Heading text is stored as inner block content (core/heading), so save
+ * serializes that. The count suffix is rendered server-side and live-
+ * updated via iAPI; it has no editor representation.
+ */
+const Save = (): JSX.Element => <InnerBlocks.Content />;
+
+export default Save;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/preview-items.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/preview-items.ts
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Shared mock data for the editor preview of the Shopper Collection block
+ * and its inner blocks. The header inner block derives its preview count
+ * from `PREVIEW_ITEMS.length` so the two views stay aligned automatically.
+ */
+export const PREVIEW_ITEMS = [
+	{
+		key: 'preview-1',
+		name: __( 'Sample product one', 'woocommerce' ),
+		variation: __( 'Size: M', 'woocommerce' ),
+		price: '$19.99',
+		quantity: __( 'Qty: 2', 'woocommerce' ),
+	},
+	{
+		key: 'preview-2',
+		name: __( 'Sample product two', 'woocommerce' ),
+		variation: __( 'Color: Blue', 'woocommerce' ),
+		price: '$29.99',
+		quantity: __( 'Qty: 1', 'woocommerce' ),
+	},
+	{
+		key: 'preview-3',
+		name: __( 'Sample product three', 'woocommerce' ),
+		variation: '',
+		price: '$9.99',
+		quantity: __( 'Qty: 3', 'woocommerce' ),
+	},
+	{
+		key: 'preview-4',
+		name: __( 'Sample product four', 'woocommerce' ),
+		variation: __( 'Size: L', 'woocommerce' ),
+		price: '$24.99',
+		quantity: __( 'Qty: 1', 'woocommerce' ),
+	},
+	{
+		key: 'preview-5',
+		name: __( 'Sample product five', 'woocommerce' ),
+		variation: '',
+		price: '$14.99',
+		quantity: __( 'Qty: 2', 'woocommerce' ),
+	},
+	{
+		key: 'preview-6',
+		name: __( 'Sample product six', 'woocommerce' ),
+		variation: __( 'Color: Red', 'woocommerce' ),
+		price: '$39.99',
+		quantity: __( 'Qty: 1', 'woocommerce' ),
+	},
+];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/save.tsx
@@ -1,7 +1,13 @@
 /**
- * The block is rendered server-side. The save callback returns null so the
- * Block Editor stores no static markup.
+ * External dependencies
  */
-const Save = (): null => null;
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * The block is rendered server-side. We serialize inner block content so
+ * the server can pick up the header (and any future children) via
+ * `$content` in the PHP render callback.
+ */
+const Save = (): JSX.Element => <InnerBlocks.Content />;
 
 export default Save;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -12,6 +12,19 @@
 // the atomic blocks as inner blocks, so WordPress auto-enqueues their
 // stylesheets — we don't, so we have to handle it ourselves.
 
+// Outer section wraps the header + items list. Block-level supports
+// (color, typography, spacing) land here via `get_block_wrapper_attributes`.
+.wc-block-shopper-collection-wrapper {
+	// The CSS variable from PHP rides on this element, but it's consumed
+	// by the nested `<ul.wc-block-shopper-collection>` below. Keep it
+	// here so the variable scope covers the whole block.
+	display: flex;
+	flex-direction: column;
+	gap: var(--wp--style--block-gap, 1em);
+}
+
+// Inner list — the grid container. Items inside are atomic and not
+// editor-managed, so this element keeps the grid logic self-contained.
 .wc-block-shopper-collection {
 	display: grid;
 	gap: var(--wp--style--block-gap, 1.5em);
@@ -22,6 +35,27 @@
 	list-style: none;
 	margin: 0;
 	padding: 0;
+}
+
+// Header wraps an editable `core/heading` and the live item-count
+// badge. Flex container with baseline alignment so the heading and the
+// count sit side-by-side without the badge starting on a new line.
+// Per-heading typography/color come from `core/heading`'s own supports.
+.wc-block-shopper-collection-header {
+	align-items: baseline;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--wp--style--block-gap, 0.5em);
+
+	&__heading-slot,
+	.wp-block-heading {
+		margin: 0;
+	}
+
+	&__count {
+		color: rgba(0, 0, 0, 0.7);
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+	}
 }
 
 .wc-block-shopper-collection-item {
@@ -136,11 +170,22 @@
 	}
 }
 
+// Empty state lives in the DOM as an `aria-live` region but is visually
+// hidden — the header (and its absence) does the visual job. The
+// `screen-reader-text` utility ships with WP core; mirror it here so the
+// frontend stylesheet doesn't depend on a parent theme loading it.
 .wc-block-shopper-collection__empty {
-	color: rgba(0, 0, 0, 0.7);
-	grid-column: 1 / -1;
-	padding: 1em 0;
-	text-align: center;
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+	word-wrap: normal !important;
 }
 
 // Error state spans every grid column so it reads as a single alert

--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -38,6 +38,7 @@
 		"./assets/js/blocks/product-query/inspector-controls.tsx",
 		"./assets/js/blocks/product-gallery/**.tsx",
 		"./assets/js/blocks/product-gallery/inner-blocks/**/index.tsx",
+		"./assets/js/blocks/shopper-collection/inner-blocks/**/index.tsx",
 		"./assets/js/settings/blocks/index.ts",
 		"./packages/**/*.{tsx,ts,js}"
 	],

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -80,6 +80,42 @@ final class ShopperCollection extends AbstractBlock {
 			return $parsed_hooked_block;
 		}
 		$parsed_hooked_block['attrs']['listName'] = 'saved-for-later';
+
+		// Auto-inject the header inner block (with its default core/heading
+		// child) so the heading + count appear on pages where this block
+		// is reached via `hooked_block_types` rather than the editor's
+		// template flow. `innerContent => [ null ]` is WP's marker for
+		// "render `innerBlocks[0]` at this position".
+		$variation                           = $this->get_variation_config();
+		$heading_text                        = $variation['defaultHeading'];
+		$heading_html                        = sprintf(
+			'<h2 class="wp-block-heading">%s</h2>',
+			esc_html( $heading_text )
+		);
+		$heading_block                       = array(
+			'blockName'    => 'core/heading',
+			'attrs'        => array(
+				'level'   => 2,
+				'content' => $heading_text,
+				'lock'    => array(
+					'remove' => true,
+					'move'   => true,
+				),
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => $heading_html,
+			'innerContent' => array( $heading_html ),
+		);
+		$header_block                        = array(
+			'blockName'    => 'woocommerce/shopper-collection-header',
+			'attrs'        => array(),
+			'innerBlocks'  => array( $heading_block ),
+			'innerHTML'    => '',
+			'innerContent' => array( null ),
+		);
+		$parsed_hooked_block['innerBlocks']  = array( $header_block );
+		$parsed_hooked_block['innerContent'] = array( null );
+
 		return $parsed_hooked_block;
 	}
 
@@ -107,8 +143,10 @@ final class ShopperCollection extends AbstractBlock {
 			$list_slug = 'saved-for-later';
 		}
 
-		// `layout` comes from `supports.layout`, not a declared attribute, so WP doesn't guarantee every nested key is set — `??` covers a partial layout object.
-		$column_count = max( 1, (int) ( $attributes['layout']['columnCount'] ?? 3 ) );
+		// `columnCount` is declared with a default in block.json, but `??`
+		// covers legacy instances that pre-date the attribute (the block
+		// previously read the count out of `supports.layout`).
+		$column_count = max( 1, (int) ( $attributes['columnCount'] ?? 3 ) );
 
 		$variation = $this->get_variation_config();
 
@@ -169,16 +207,23 @@ final class ShopperCollection extends AbstractBlock {
 		wp_interactivity_config(
 			'woocommerce/shopper-collection',
 			array(
-				'quantityLabelTemplate' => $variation['quantityLabelTemplate'],
-				'removeLabelTemplate'   => $variation['removeLabelTemplate'],
+				'quantityLabelTemplate'     => $variation['quantityLabelTemplate'],
+				'removeLabelTemplate'       => $variation['removeLabelTemplate'],
+				'headerCountSuffixSingular' => $variation['headerCountSuffixSingular'],
+				'headerCountSuffixPlural'   => $variation['headerCountSuffixPlural'],
 			)
 		);
 
 		$wrapper_class = sprintf(
-			'wc-block-shopper-collection wc-block-shopper-collection--%s',
+			'wc-block-shopper-collection-wrapper wc-block-shopper-collection-wrapper--%s',
 			$variation['modifierSlug']
 		);
 
+		// Block-level supports (color, typography, spacing) ride on the
+		// outer `<section>` so admins styling the block as a whole pick up
+		// the wrapper. The grid container lives on the inner `<ul>` so
+		// item layout stays self-contained — the CSS variable here drives
+		// `style.scss`'s `grid-template-columns`.
 		$wrapper_attributes = array(
 			'class'               => $wrapper_class,
 			'data-wp-interactive' => 'woocommerce/shopper-collection',
@@ -187,13 +232,44 @@ final class ShopperCollection extends AbstractBlock {
 			// navigations land on the same block identity across renders.
 			'data-wp-key'         => $this->get_full_block_name() . '-' . $list_slug,
 			'style'               => sprintf( '--wc-shopper-collection-columns:%d;', $column_count ),
+			// Mark the wrapper as labelled by the header block. The header
+			// renders an `<h2 id>` whose id we point at here; when the list
+			// is empty the header is hidden and the section is unlabelled,
+			// but that's acceptable because the empty-state row carries the
+			// announcement instead.
+			'aria-labelledby'     => 'wc-block-shopper-collection-heading-' . $list_slug,
 		);
 
-		$is_empty = empty( $items );
+		$is_empty   = empty( $items );
+		$item_count = count( $items );
+
+		$list_class = sprintf(
+			'wc-block-shopper-collection wc-block-shopper-collection--%s',
+			$variation['modifierSlug']
+		);
+
+		// Render inner blocks ourselves (rather than using the auto-rendered
+		// `$content`) so we can hand each one explicit block context — the
+		// header reads `woocommerce/shopperItemCount` and the singular/
+		// plural count-suffix templates off this context to render the
+		// correct initial "(N items)" badge without reading iAPI state
+		// in PHP.
+		$inner_context = array(
+			'woocommerce/shopperListSlug'            => $list_slug,
+			'woocommerce/shopperItemCount'           => $item_count,
+			'woocommerce/shopperHeaderCountSingular' => $variation['headerCountSuffixSingular'],
+			'woocommerce/shopperHeaderCountPlural'   => $variation['headerCountSuffixPlural'],
+		);
+		$inner_html    = '';
+		foreach ( $block->parsed_block['innerBlocks'] as $parsed_inner_block ) {
+			$inner_html .= ( new \WP_Block( $parsed_inner_block, $inner_context ) )->render();
+		}
 
 		return sprintf(
-			'<ul %1$s>%2$s%3$s%4$s%5$s</ul>',
+			'<section %1$s>%2$s<ul class="%3$s">%4$s%5$s%6$s%7$s</ul></section>',
 			get_block_wrapper_attributes( $wrapper_attributes ),
+			$inner_html,
+			esc_attr( $list_class ),
 			$this->render_template_markup( $variation ),
 			$this->render_items_markup( $items, $variation ),
 			$this->render_empty_markup( $is_empty, $variation ),
@@ -217,15 +293,20 @@ final class ShopperCollection extends AbstractBlock {
 	 */
 	private function get_variation_config(): array {
 		return array(
-			'modifierSlug'          => 'saved-for-later',
-			'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
+			'modifierSlug'              => 'saved-for-later',
+			'emptyMessage'              => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
 			/* translators: %s: product name. */
-			'removeLabelTemplate'   => __( 'Remove %s from Saved for later list', 'woocommerce' ),
+			'removeLabelTemplate'       => __( 'Remove %s from Saved for later list', 'woocommerce' ),
 			/* translators: %d: quantity of saved items. */
-			'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
-			'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
-			'actionDirective'       => 'actions.onClickMoveToCart',
-			'showAction'            => true,
+			'quantityLabelTemplate'     => __( 'Quantity: %d', 'woocommerce' ),
+			'defaultHeading'            => __( 'Saved for later', 'woocommerce' ),
+			/* translators: %d: number of saved items. */
+			'headerCountSuffixSingular' => __( '(%d item)', 'woocommerce' ),
+			/* translators: %d: number of saved items. */
+			'headerCountSuffixPlural'   => __( '(%d items)', 'woocommerce' ),
+			'actionLabel'               => __( 'Move to cart', 'woocommerce' ),
+			'actionDirective'           => 'actions.onClickMoveToCart',
+			'showAction'                => true,
 		);
 	}
 
@@ -499,9 +580,16 @@ final class ShopperCollection extends AbstractBlock {
 	 * @return string
 	 */
 	private function render_empty_markup( bool $is_empty, array $variation ): string {
+		// Visually hidden in all states but announced when the list goes
+		// from populated to empty. `aria-live="polite"` lets the live
+		// region pick up the transition without re-announcing on every
+		// page load (a hardcoded "Nothing saved yet" greeting would be
+		// noisy when items are present). The `data-wp-bind--hidden`
+		// toggles content presence — the live region itself stays in the
+		// DOM so screen readers attach to it once and observe mutations.
 		$hidden_attr = $is_empty ? '' : ' hidden';
 		return sprintf(
-			'<li class="wc-block-shopper-collection__empty" data-wp-bind--hidden="!state.isEmpty"%1$s>%2$s</li>',
+			'<li class="wc-block-shopper-collection__empty screen-reader-text" role="status" aria-live="polite" data-wp-bind--hidden="!state.isEmpty"%1$s>%2$s</li>',
 			$hidden_attr,
 			esc_html( $variation['emptyMessage'] )
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollectionHeader.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollectionHeader.php
@@ -1,0 +1,100 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * Shopper Collection Header block.
+ *
+ * Inner block of `woocommerce/shopper-collection`. Renders a container
+ * around an editable `core/heading` (the merchant's heading text) and
+ * appends a live item-count badge. Reads from the parent's iAPI store
+ * via DOM-inherited `data-wp-interactive` — no namespace of its own —
+ * so the badge updates without a re-render when items are added or
+ * removed.
+ *
+ * SSR initial badge text comes from block context populated by the
+ * parent's manual inner-block rendering.
+ */
+final class ShopperCollectionHeader extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'shopper-collection-header';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Block content (rendered inner blocks — the heading).
+	 * @param \WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		// Sanitize the same way the parent does — the slug flows into a
+		// DOM `id` and an `aria-labelledby` reference, so anything looser
+		// than `[a-z0-9_-]+` is unacceptable.
+		$list_slug = sanitize_title( (string) ( $block->context['woocommerce/shopperListSlug'] ?? '' ) );
+		if ( '' === $list_slug ) {
+			$list_slug = 'saved-for-later';
+		}
+
+		$heading_id = 'wc-block-shopper-collection-heading-' . $list_slug;
+
+		// Block-level supports (margin/padding/blockGap only — see
+		// block.json) flow through `get_block_wrapper_attributes`. The
+		// heading's own typography/color supports apply to `core/heading`
+		// itself; the count span inherits its styling from the wrapper.
+		// `data-wp-bind--hidden` reads from the parent's iAPI namespace
+		// (inherited via the parent's `data-wp-interactive` on the
+		// section wrapper) so the entire header disappears when the list
+		// is empty.
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class'                => 'wc-block-shopper-collection-header',
+				'id'                   => $heading_id,
+				'data-wp-bind--hidden' => '!state.hasItems',
+			)
+		);
+
+		$initial_suffix = $this->build_initial_suffix( $block );
+		$hidden_attr    = '' === $initial_suffix ? ' hidden' : '';
+
+		return sprintf(
+			'<div %1$s%2$s>%3$s<span class="wc-block-shopper-collection-header__count" data-wp-text="state.itemCountSuffix">%4$s</span></div>',
+			$wrapper_attributes,
+			$hidden_attr,
+			$content,
+			esc_html( $initial_suffix )
+		);
+	}
+
+	/**
+	 * Pull the count and templates off block context and format the
+	 * initial "(N items)" suffix. Returns an empty string when the list
+	 * is empty so the header can render hidden on first paint (matches
+	 * the JS-side `hasItems` toggle).
+	 *
+	 * @param \WP_Block $block Block instance.
+	 * @return string
+	 */
+	private function build_initial_suffix( \WP_Block $block ): string {
+		$count = (int) ( $block->context['woocommerce/shopperItemCount'] ?? 0 );
+		if ( $count <= 0 ) {
+			return '';
+		}
+
+		$singular = (string) ( $block->context['woocommerce/shopperHeaderCountSingular'] ?? '' );
+		$plural   = (string) ( $block->context['woocommerce/shopperHeaderCountPlural'] ?? '' );
+
+		$template = 1 === $count ? $singular : $plural;
+		if ( '' === $template ) {
+			return '';
+		}
+
+		return sprintf( $template, $count );
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -556,6 +556,7 @@ final class BlockTypesController {
 
 		if ( FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
 			$block_types[] = 'ShopperCollection';
+			$block_types[] = 'ShopperCollectionHeader';
 		}
 
 		if ( wp_is_block_theme() ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Shoppers need to see at a glance how many items they have in their Saved-for-later list, and merchants need to be able to style the heading like any other heading on their cart page. This PR adds a new `woocommerce/shopper-collection-header` inner block to the Shopper Collection block.

The header is a flex container wrapping (a) an editable `core/heading` defaulting to "Saved for later" — merchants edit its text, level, color, typography, alignment etc. via the normal heading controls — and (b) a live "(N items)" count badge driven by the existing iAPI store. The block ships locked from move/remove so it can't be accidentally deleted; its content (the heading) is editable.

Two related a11y / layout cleanups go with this:

- The empty-state row ("Nothing saved yet…") is no longer rendered as a visible grid cell. It now lives in a `role="status" aria-live="polite"` visually-hidden node so it's announced when the list empties out, not on every page load.
- The parent block dropped its `supports.layout` declaration — WP was applying `is-layout-grid` to the section wrapper, turning the header into a grid cell. The column-count sidebar control is now a custom `RangeControl` on a top-level `columnCount` attribute, which feeds the CSS variable the inner `<ul>` already used as its grid template source.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Enable the `cart_save_for_later` feature flag at **WooCommerce → Settings → Advanced → Features**.
2. Log in, add a couple of products to the cart.
3. From the cart page, click the "Save for later" link on a couple of items.
4. Confirm the Shopper Collection appears below the cart with a heading reading **Saved for later (N items)** matching the count.
5. Save another item — confirm the count updates without a page reload.
6. Remove items down to one — confirm "(1 item)" (singular) is used.
7. Remove the last item — the entire header should disappear. With a screen reader on, confirm "Nothing saved yet…" is announced once at the transition to empty (and is not visible on screen).
8. In the editor, edit the Cart page (or insert a Shopper Collection block manually). Click the header, change the heading text, level (e.g. H3), color, and typography. Save and confirm the change persists on the frontend.
9. With the parent block selected, use the **Columns** range control in the sidebar to change the grid columns. Confirm the items grid (not the header) reflows.

### Testing that has already taken place:

- PHPStan and PHPCS pass on changed PHP files.
- Webpack build succeeds with the new inner block.
- Manual testing of the rendered HTML on the cart page (heading + count visible, hidden when empty).
- Not yet manually tested: editor flow for picking the heading level/styles, column-count range control.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was added manually as part of this PR (\`plugins/woocommerce/changelog/add-shopper-collection-header-block\`).

</details>