### PR TITLE
Introduce Product Filters Dropdown inner block

### DIFF
--- a/plugins/woocommerce/changelog/add-product-filters-dropdown
+++ b/plugins/woocommerce/changelog/add-product-filters-dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Introduce Product Filters Dropdown inner block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/block.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"name": "woocommerce/product-filter-dropdown",
+	"title": "Dropdown",
+	"description": "Display options in a dropdown.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce" ],
+	"textdomain": "woocommerce",
+	"apiVersion": 3,
+	"ancestor": [
+		"woocommerce/product-filter-attribute",
+		"woocommerce/product-filter-status",
+		"woocommerce/product-filter-taxonomy",
+		"woocommerce/product-filter-rating"
+	],
+	"supports": {
+		"interactivity": true
+	},
+	"usesContext": [ "woocommerceSelectableItems" ],
+	"attributes": {},
+	"viewScriptModule": "woocommerce/product-filter-dropdown",
+	"style": "file:../woocommerce/product-filter-dropdown-style.css",
+	"editorStyle": "file:../woocommerce/product-filter-dropdown-editor.css"
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/edit.tsx
@@ -85,18 +85,24 @@ const Edit = ( props: EditProps ): JSX.Element => {
 									  )
 									: __( 'Select an option', 'woocommerce' ) }
 							</option>
-							{ items.map( ( item, index ) => (
-								<option
-									key={ index }
-									value={ item.value }
-									disabled={ !! item.disabled }
-								>
-									{ getOptionLabel( item ) }
-									{ item.count !== undefined
-										? ` (${ item.count })`
-										: '' }
-								</option>
-							) ) }
+							{ items.map( ( item, index ) => {
+								const optionLabel = getOptionLabel( item );
+								if ( ! optionLabel ) {
+									return null;
+								}
+								return (
+									<option
+										key={ index }
+										value={ item.value }
+										disabled={ !! item.disabled }
+									>
+										{ optionLabel }
+										{ item.count !== undefined
+											? ` (${ item.count })`
+											: '' }
+									</option>
+								);
+							} ) }
 						</select>
 					) }
 				</fieldset>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/edit.tsx
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { decodeHtmlEntities } from '@woocommerce/utils';
+import { Disabled } from '@wordpress/components';
+import { useBlockProps } from '@wordpress/block-editor';
+import type { BlockEditProps } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import type { SelectableItemsBlockContext } from '../../../../types/type-defs/selectable-items';
+import type { FilterItemFields } from '../../types';
+import './editor.scss';
+import './style.scss';
+
+export type BlockAttributes = Record< string, never >;
+
+export type EditProps = BlockEditProps< BlockAttributes > & {
+	context: SelectableItemsBlockContext< FilterItemFields >;
+};
+
+function getOptionLabel( item: {
+	label: string | unknown;
+	ariaLabel?: string;
+} ): string {
+	if (
+		typeof item.ariaLabel === 'string' &&
+		item.ariaLabel.trim().length > 0
+	) {
+		return item.ariaLabel;
+	}
+	if ( typeof item.label === 'string' ) {
+		return decodeHtmlEntities( item.label );
+	}
+	return '';
+}
+
+const Edit = ( props: EditProps ): JSX.Element => {
+	const { context } = props;
+	const selectableItems = context?.woocommerceSelectableItems ?? {};
+	const isLoading = selectableItems.isLoading ?? false;
+	const items = Array.isArray( selectableItems.items )
+		? selectableItems.items
+		: [];
+	const groupLabel = selectableItems.groupLabel ?? '';
+
+	const blockProps = useBlockProps( {
+		className: clsx( 'wc-block-product-filter-dropdown', {
+			'is-loading': isLoading,
+		} ),
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<Disabled>
+				<fieldset className="wc-block-product-filter-dropdown__fieldset">
+					{ groupLabel ? (
+						<legend className="screen-reader-text">
+							{ groupLabel }
+						</legend>
+					) : null }
+					{ isLoading ? (
+						<div className="wc-block-product-filter-dropdown__skeleton">
+							<div className="wc-block-product-filter-dropdown__skeleton-option" />
+						</div>
+					) : (
+						<select
+							className="wc-block-product-filter-dropdown__select"
+							aria-label={
+								groupLabel ||
+								__( 'Filter options', 'woocommerce' )
+							}
+							disabled
+							value=""
+						>
+							<option value="">
+								{ groupLabel
+									? sprintf(
+											/* translators: %s: Attribute or filter type label. */
+											__( 'Select a %s', 'woocommerce' ),
+											groupLabel
+									  )
+									: __( 'Select an option', 'woocommerce' ) }
+							</option>
+							{ items.map( ( item, index ) => (
+								<option
+									key={ index }
+									value={ item.value }
+									disabled={ !! item.disabled }
+								>
+									{ getOptionLabel( item ) }
+									{ item.count !== undefined
+										? ` (${ item.count })`
+										: '' }
+								</option>
+							) ) }
+						</select>
+					) }
+				</fieldset>
+			</Disabled>
+		</div>
+	);
+};
+
+export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/editor.scss
@@ -1,0 +1,16 @@
+.wc-block-product-filter-dropdown__skeleton-option {
+	height: 1.75em;
+	border-radius: 2px;
+	background: color-mix(in srgb, currentColor 8%, transparent);
+	animation: wc-block-product-filter-dropdown-pulse 1.2s ease-in-out infinite
+		alternate;
+}
+
+@keyframes wc-block-product-filter-dropdown-pulse {
+	from {
+		opacity: 0.55;
+	}
+	to {
+		opacity: 1;
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
@@ -42,7 +42,9 @@ store(
 			get selectValue(): string {
 				const { storeNamespace } = getContext< DropdownContext >();
 				const parent = store< ProductFiltersStore >( storeNamespace );
-				const items = parent.state.selectableItems as SelectableRow[];
+				const items = Array.isArray( parent.state.selectableItems )
+					? parent.state.selectableItems
+					: [];
 				const selected = items.find( ( row ) => row.selected );
 				return selected?.value ?? '';
 			},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+/**
+ * Internal dependencies
+ */
+import type { ProductFiltersStore } from '../../frontend';
+import type { FilterOptionItem } from '../../types';
+
+type DropdownContext = {
+	storeNamespace: string;
+	filterItemType: string;
+};
+
+type SelectableRow = FilterOptionItem & {
+	selected?: boolean;
+	value?: string;
+	type?: string;
+};
+
+function isToggleableItem(
+	item: SelectableRow | undefined
+): item is FilterOptionItem & {
+	type: string;
+	value: string;
+} {
+	return (
+		!! item &&
+		typeof item.type === 'string' &&
+		item.type.length > 0 &&
+		typeof item.value === 'string' &&
+		item.value.length > 0
+	);
+}
+
+store(
+	'woocommerce/product-filter-dropdown',
+	{
+		state: {
+			get selectValue(): string {
+				const { storeNamespace } = getContext< DropdownContext >();
+				const parent = store< ProductFiltersStore >( storeNamespace );
+				const items = parent.state.selectableItems as SelectableRow[];
+				const selected = items.find( ( row ) => row.selected );
+				return selected?.value ?? '';
+			},
+		},
+		actions: {
+			onDropdownChange( event: Event ) {
+				const target = event.currentTarget;
+				if ( ! ( target instanceof HTMLSelectElement ) ) {
+					return;
+				}
+				const { storeNamespace, filterItemType } =
+					getContext< DropdownContext >();
+				const parent = store< ProductFiltersStore >( storeNamespace );
+				const value = target.value;
+
+				// Clear previously selected option.
+				if ( filterItemType ) {
+					parent.actions.removeActiveFiltersBy(
+						( filter ) => filter.type === filterItemType
+					);
+					parent.actions.navigate();
+				}
+
+				const row = parent.state.selectableItems.find(
+					( item ) => item.value === value
+				);
+
+				// Don't try to toggle empty option ("") or invalid options.
+				if ( ! isToggleableItem( row ) ) {
+					return;
+				}
+
+				parent.actions.toggle( row );
+			},
+		},
+	},
+	{ lock: true }
+);
+
+export type { DropdownContext };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
@@ -63,7 +63,6 @@ store(
 					parent.actions.removeActiveFiltersBy(
 						( filter ) => filter.type === filterItemType
 					);
-					parent.actions.navigate();
 				}
 
 				const row = parent.state.selectableItems.find(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
@@ -73,6 +73,7 @@ store(
 
 				// Don't try to toggle empty option ("") or invalid options.
 				if ( ! isToggleableItem( row ) ) {
+					parent.actions.navigate();
 					return;
 				}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/frontend.ts
@@ -67,9 +67,10 @@ store(
 					);
 				}
 
-				const row = parent.state.selectableItems.find(
-					( item ) => item.value === value
-				);
+				const items = Array.isArray( parent.state.selectableItems )
+					? parent.state.selectableItems
+					: [];
+				const row = items.find( ( item ) => item.value === value );
 
 				// Don't try to toggle empty option ("") or invalid options.
 				if ( ! isToggleableItem( row ) ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { productFilterOptions } from '@woocommerce/icons';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import Save from './save';
+
+registerBlockType( metadata, {
+	edit: Edit,
+	icon: productFilterOptions,
+	save: Save,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/save.tsx
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+const Save = () => {
+	const blockProps = useBlockProps.save( {
+		className: 'wc-block-product-filter-dropdown',
+	} );
+
+	return <div { ...blockProps } />;
+};
+
+export default Save;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/dropdown/style.scss
@@ -1,0 +1,18 @@
+:where(.wc-block-product-filter-dropdown__fieldset) {
+	border: 0;
+	margin: 0;
+	padding: 0;
+	min-width: 0;
+}
+
+:where(.wc-block-product-filter-dropdown__select) {
+	background: transparent;
+	border: 1px solid color-mix(in srgb,currentColor 40%,transparent);
+	border-radius: 2px;
+	box-sizing: border-box;
+	color: inherit;
+	font-family: inherit;
+	font-size: .8em;
+	max-width: 100%;
+	padding: .25em .75em;
+}

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -149,6 +149,9 @@ const blocks = {
 	'product-filter-chips': {
 		customDir: 'product-filters/inner-blocks/chips',
 	},
+	'product-filter-dropdown': {
+		customDir: 'product-filters/inner-blocks/dropdown',
+	},
 	'product-filter-price-slider': {
 		customDir: 'product-filters/inner-blocks/price-slider',
 	},

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
@@ -8,7 +8,7 @@ This document defines the **context protocol pattern** used by WooCommerce block
 
 | Context Key | Purpose | Inner Blocks |
 | --- | --- | --- |
-| `woocommerceSelectableItems` | Select/deselect items (filters, variations) | checkbox-list, chips |
+| `woocommerceSelectableItems` | Select/deselect items (filters, variations) | checkbox-list, chips, dropdown |
 | `woocommerceRemovableItems` | Remove individual items (active filters) | removable-chips |
 | `woocommerceRangeInput` | Numeric range input (price, slider) | price-slider |
 
@@ -592,7 +592,7 @@ Key points:
 - **Nested `data-wp-interactive`** — outer wrapper under the inner namespace, items region switches to the parent namespace so wp-each + parent selection bindings resolve there; presentational bindings (`itemHidden`, `ratingStyle`) use cross-namespace `::` back to the inner store
 - **`filterType` discriminator** — inner block can branch rendering (e.g. stars for `'rating'`) without leaking presentation into the parent store
 
-Reference implementation: `ProductFilterCheckboxList.php`, `ProductFilterChips.php`, `checkbox-list/frontend.ts`, `chips/frontend.ts`
+Reference implementation: `ProductFilterCheckboxList.php`, `ProductFilterChips.php`, `ProductFilterDropdown.php`, `checkbox-list/frontend.ts`, `chips/frontend.ts`, `dropdown/frontend.ts`
 
 ### Implementing as Parent Block (Provider)
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/content-templates/template_archive-product_attribute-filter-dropdown.handlebars
+++ b/plugins/woocommerce/client/blocks/tests/e2e/content-templates/template_archive-product_attribute-filter-dropdown.handlebars
@@ -1,0 +1,42 @@
+<!-- wp:woocommerce/product-filters -->
+<div class="wp-block-woocommerce-product-filters wc-block-product-filters" style="--wc-product-filters-text-color:#111;--wc-product-filters-background-color:#fff">
+<!-- wp:woocommerce/product-filter-active -->
+<div class="wp-block-woocommerce-product-filter-active">
+
+<!-- wp:woocommerce/product-filter-clear-button -->
+<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}}},"layout":{"type":"flex","verticalAlignment":"stretched"}} -->
+<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--10)"><!-- wp:button {"textAlign":"center","width":100,"className":"wc-block-product-filter-clear-button is-style-outline","style":{"border":{"width":"1px"},"typography":{"textDecoration":"none"},"outline":"none","fontSize":"medium","spacing":{"padding":{"left":"8px","right":"8px","top":"5px","bottom":"5px"}}}} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 wc-block-product-filter-clear-button is-style-outline"><a class="wp-block-button__link has-text-align-center wp-element-button" style="border-width:1px;padding-top:5px;padding-right:8px;padding-bottom:5px;padding-left:8px;text-decoration:none">Clear filters</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+<!-- /wp:woocommerce/product-filter-clear-button --></div>
+<!-- /wp:woocommerce/product-filter-active -->
+{{#> wp-block blockName='woocommerce/product-filter-attribute' attributes=attributes }}
+<div class="wp-block-woocommerce-product-filter-attribute"><!-- wp:group {"metadata":{"name":"Header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Attribute</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:woocommerce/product-filter-dropdown {"lock":{"remove":true}} -->
+<div class="wp-block-woocommerce-product-filter-dropdown wc-block-product-filter-dropdown"></div>
+<!-- /wp:woocommerce/product-filter-dropdown --></div>
+{{/ wp-block }}
+
+</div>
+<!-- /wp:woocommerce/product-filters -->
+
+<!-- wp:woocommerce/product-collection {"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":true,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"queryContextIncludes":["collection"]} -->
+<div class="wp-block-woocommerce-product-collection">
+	<!-- wp:woocommerce/product-template -->
+	<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+		<!-- wp:woocommerce/product-sale-badge {"isDescendentOfQueryLoop":true,"align":"right"} /-->
+	<!-- /wp:woocommerce/product-image -->
+	<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+	<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+
+	<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
+	<!-- /wp:woocommerce/product-template -->
+</div>
+<!-- /wp:woocommerce/product-collection -->

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-dropdown-frontend.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-dropdown-frontend.block_theme.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import type { Page } from '@playwright/test';
+import { TemplateCompiler, test as base, expect } from '@woocommerce/e2e-utils';
+
+const COLOR_ATTRIBUTE_VALUES = [ 'Blue', 'Red', 'Green', 'Gray', 'Yellow' ];
+const COLOR_ATTRIBUTES_WITH_COUNTS = [
+	'Blue (4)',
+	'Red (4)',
+	'Green (3)',
+	'Gray (2)',
+	'Yellow (1)',
+];
+
+function attributeFilterSelect( page: Page ) {
+	return page
+		.locator( '.wc-block-product-filters' )
+		.locator( '.wc-block-product-filter-dropdown__select' );
+}
+
+const test = base.extend< { templateCompiler: TemplateCompiler } >( {
+	templateCompiler: async ( { requestUtils }, use ) => {
+		const compiler = await requestUtils.createTemplateFromFile(
+			'archive-product_attribute-filter-dropdown'
+		);
+		await use( compiler );
+	},
+} );
+
+test.describe( 'woocommerce/product-filter-attribute - Frontend (dropdown display)', () => {
+	test.describe( 'With dropdown display style', () => {
+		test.beforeEach( async ( { templateCompiler, page } ) => {
+			await templateCompiler.compile( {
+				attributes: {
+					attributeId: 1,
+				},
+			} );
+
+			await page.addInitScript( () => {
+				// Mock the wc global variable.
+				if ( typeof window.wc === 'undefined' ) {
+					window.wc = {
+						wcSettings: {
+							getSetting() {
+								return true;
+							},
+						},
+					};
+				}
+			} );
+		} );
+
+		test( 'renders a dropdown with the available attribute filters', async ( {
+			page,
+		} ) => {
+			await page.goto( '/shop' );
+
+			const select = attributeFilterSelect( page );
+			await expect( select ).toBeVisible();
+
+			const options = select.locator( 'option' );
+			await expect( options ).toHaveCount( 6 );
+
+			for ( let i = 0; i < COLOR_ATTRIBUTE_VALUES.length; i++ ) {
+				await expect( options.nth( i + 1 ) ).toHaveText(
+					COLOR_ATTRIBUTE_VALUES[ i ]
+				);
+			}
+		} );
+
+		test( 'filters the list of products by selecting an attribute', async ( {
+			page,
+		} ) => {
+			await page.goto( '/shop' );
+
+			await attributeFilterSelect( page ).selectOption( 'gray' );
+
+			// wait for navigation
+			await page.waitForURL( /.*filter_color=gray.*/ );
+
+			const products = page.locator( '.wc-block-product' );
+
+			await expect( products ).toHaveCount( 2 );
+		} );
+
+		test( 'filters are cleared after clear button is clicked', async ( {
+			page,
+		} ) => {
+			await page.goto( '/shop' );
+
+			await attributeFilterSelect( page ).selectOption( 'gray' );
+
+			// wait for navigation
+			await page.waitForURL( /.*filter_color=gray.*/ );
+
+			const button = page.getByRole( 'button', {
+				name: 'Clear filters',
+			} );
+
+			await button.click();
+
+			await expect( attributeFilterSelect( page ) ).toHaveValue( '' );
+		} );
+	} );
+
+	test.describe( 'With show counts enabled', () => {
+		test.beforeEach( async ( { templateCompiler } ) => {
+			await templateCompiler.compile( {
+				attributes: {
+					attributeId: 1,
+					showCounts: true,
+				},
+			} );
+		} );
+
+		test( 'Renders dropdown options with associated product counts', async ( {
+			page,
+		} ) => {
+			await page.goto( '/shop' );
+
+			const select = attributeFilterSelect( page );
+			await expect( select ).toBeVisible();
+
+			const options = select.locator( 'option' );
+			await expect( options ).toHaveCount( 6 );
+
+			for ( let i = 0; i < COLOR_ATTRIBUTES_WITH_COUNTS.length; i++ ) {
+				await expect( options.nth( i + 1 ) ).toHaveText(
+					COLOR_ATTRIBUTES_WITH_COUNTS[ i ]
+				);
+			}
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -223,7 +223,7 @@ a.added_to_cart {
 */
 .woocommerce-page {
 	// Ensure text input fields aren't too small.
-	select,
+	select:where(:not(.wc-block-product-filter-dropdown__select)),
 	.input-text,
 	.select2-container {
 		font-size: var(--wp--preset--font-size--small);

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -481,9 +481,8 @@ function wc_get_attribute( $id ) {
  *     @type string $name         Attribute name. Always required.
  *     @type string $slug         Attribute alphanumeric identifier.
  *     @type string $type         Type of attribute.
- *                                Core by default accepts: 'select', 'wc-visual'
- *                                (which is experimental) and 'text'
- *                                (which is deprecated).
+ *                                Core by default accepts: 'select' and
+ *                                'wc-visual' (which is experimental).
  *                                Default to 'select'.
  *     @type string $order_by     Sort order.
  *                                Accepts: 'menu_order', 'name', 'name_num' and 'id'.

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -481,7 +481,9 @@ function wc_get_attribute( $id ) {
  *     @type string $name         Attribute name. Always required.
  *     @type string $slug         Attribute alphanumeric identifier.
  *     @type string $type         Type of attribute.
- *                                Core by default accepts: 'select' and 'text'.
+ *                                Core by default accepts: 'select', 'wc-visual'
+ *                                (which is experimental) and 'text'
+ *                                (which is deprecated).
  *                                Default to 'select'.
  *     @type string $order_by     Sort order.
  *                                Accepts: 'menu_order', 'name', 'name_num' and 'id'.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
@@ -46,9 +46,9 @@ final class ProductFilterDropdown extends AbstractBlock {
 			return '';
 		}
 
-		$block_context   = $block->context['woocommerceSelectableItems'];
-		$items           = is_array( $block_context['items'] ?? null ) ? $block_context['items'] : array();
-		$store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
+		$selectable_items = $block->context['woocommerceSelectableItems'];
+		$items            = is_array( $selectable_items['items'] ?? null ) ? $selectable_items['items'] : array();
+		$store_namespace  = $selectable_items['storeNamespace'] ?? 'woocommerce/product-filters';
 
 		if ( array() === $items ) {
 			return '';
@@ -70,16 +70,16 @@ final class ProductFilterDropdown extends AbstractBlock {
 
 		$select_id   = wp_unique_id( 'wc-block-product-filter-dropdown-' );
 		$show_counts = is_array( $first ) && array_key_exists( 'count', $first );
-		$aria_label  = ! empty( $block_context['groupLabel'] )
-			? (string) $block_context['groupLabel']
+		$aria_label  = ! empty( $selectable_items['groupLabel'] )
+			? (string) $selectable_items['groupLabel']
 			: __( 'Product filter', 'woocommerce' );
 
 		ob_start();
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<fieldset class="wc-block-product-filter-dropdown__fieldset">
-				<?php if ( ! empty( $block_context['groupLabel'] ) ) : ?>
-					<legend class="screen-reader-text"><?php echo esc_html( $block_context['groupLabel'] ); ?></legend>
+				<?php if ( ! empty( $selectable_items['groupLabel'] ) ) : ?>
+					<legend class="screen-reader-text"><?php echo esc_html( $selectable_items['groupLabel'] ); ?></legend>
 				<?php endif; ?>
 				<select
 					class="wc-block-product-filter-dropdown__select"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
@@ -70,6 +70,9 @@ final class ProductFilterDropdown extends AbstractBlock {
 
 		$select_id   = wp_unique_id( 'wc-block-product-filter-dropdown-' );
 		$show_counts = is_array( $first ) && array_key_exists( 'count', $first );
+		$aria_label  = ! empty( $block_context['groupLabel'] )
+			? (string) $block_context['groupLabel']
+			: __( 'Product filter', 'woocommerce' );
 
 		ob_start();
 		?>
@@ -81,9 +84,7 @@ final class ProductFilterDropdown extends AbstractBlock {
 				<select
 					class="wc-block-product-filter-dropdown__select"
 					id="<?php echo esc_attr( $select_id ); ?>"
-					<?php if ( ! empty( $block_context['groupLabel'] ) ) : ?>
-						aria-label="<?php echo esc_attr( (string) $block_context['groupLabel'] ); ?>"
-					<?php endif; ?>
+					aria-label="<?php echo esc_attr( $aria_label ); ?>"
 					data-wp-bind--value="woocommerce/product-filter-dropdown::state.selectValue"
 					data-wp-on--change="actions.onDropdownChange"
 				>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
@@ -1,0 +1,134 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * Product Filter: Dropdown block (native select).
+ */
+final class ProductFilterDropdown extends AbstractBlock {
+
+	use EnableBlockJsonAssetsTrait;
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-filter-dropdown';
+
+	/**
+	 * Plain-text label for a select option (no HTML in `<option>`).
+	 *
+	 * @param array $item Selectable item from context.
+	 * @return string
+	 */
+	private function get_option_text( array $item ): string {
+		if ( ! empty( $item['ariaLabel'] ) && is_string( $item['ariaLabel'] ) ) {
+			return $item['ariaLabel'];
+		}
+		if ( isset( $item['label'] ) && is_string( $item['label'] ) ) {
+			return wp_strip_all_tags( $item['label'] );
+		}
+		return '';
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+			return '';
+		}
+
+		$block_context   = $block->context['woocommerceSelectableItems'];
+		$items           = is_array( $block_context['items'] ?? null ) ? $block_context['items'] : array();
+		$store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
+
+		if ( array() === $items ) {
+			return '';
+		}
+
+		$first       = reset( $items );
+		$filter_type = ( is_array( $first ) && ! empty( $first['type'] ) ) ? (string) $first['type'] : '';
+
+		$classes = '';
+		$style   = '';
+
+		$tags = new \WP_HTML_Tag_Processor( $content );
+		if ( $tags->next_tag( array( 'class_name' => 'wc-block-product-filter-dropdown' ) ) ) {
+			$classes = $tags->get_attribute( 'class' );
+			$style   = $tags->get_attribute( 'style' );
+		}
+
+		$wrapper_attributes = array(
+			'data-wp-interactive' => 'woocommerce/product-filter-dropdown',
+			'data-wp-context'     => (string) wp_json_encode(
+				array(
+					'storeNamespace' => $store_namespace,
+					'filterItemType' => $filter_type,
+				),
+				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+			),
+			'class'               => esc_attr( $classes ),
+		);
+
+		if ( ! empty( $style ) ) {
+			$wrapper_attributes['style'] = esc_attr( $style ) . ';';
+		}
+
+		$select_id   = wp_unique_id( 'wc-block-product-filter-dropdown-' );
+		$show_counts = is_array( $first ) && array_key_exists( 'count', $first );
+
+		ob_start();
+		?>
+		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+			<fieldset class="wc-block-product-filter-dropdown__fieldset">
+				<?php if ( ! empty( $block_context['groupLabel'] ) ) : ?>
+					<legend class="screen-reader-text"><?php echo esc_html( $block_context['groupLabel'] ); ?></legend>
+				<?php endif; ?>
+				<select
+					class="wc-block-product-filter-dropdown__select"
+					id="<?php echo esc_attr( $select_id ); ?>"
+					<?php if ( ! empty( $block_context['groupLabel'] ) ) : ?>
+						aria-label="<?php echo esc_attr( (string) $block_context['groupLabel'] ); ?>"
+					<?php endif; ?>
+					data-wp-bind--value="woocommerce/product-filter-dropdown::state.selectValue"
+					data-wp-on--change="actions.onDropdownChange"
+				>
+					<option value="">
+						<?php esc_html_e( 'Select an option', 'woocommerce' ); ?>
+					</option>
+					<?php foreach ( $items as $item ) : ?>
+						<?php
+						if ( ! is_array( $item ) ) {
+							continue;
+						}
+						$option_label = $this->get_option_text( $item );
+						?>
+						<option
+							value="<?php echo esc_attr( isset( $item['value'] ) ? (string) $item['value'] : '' ); ?>"
+							<?php selected( ! empty( $item['selected'] ), true ); ?>
+							<?php disabled( ! empty( $item['disabled'] ) ); ?>
+						>
+							<?php
+							$option_output = $option_label;
+							if ( $show_counts && isset( $item['count'] ) ) {
+								$option_output .= ' (' . (string) $item['count'] . ')';
+							}
+							echo esc_html( $option_output );
+							?>
+						</option>
+					<?php endforeach; ?>
+				</select>
+			</fieldset>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
@@ -97,6 +97,9 @@ final class ProductFilterDropdown extends AbstractBlock {
 							continue;
 						}
 						$option_label = $this->get_option_text( $item );
+						if ( empty( $option_label ) ) {
+							continue;
+						}
 						?>
 						<option
 							value="<?php echo esc_attr( isset( $item['value'] ) ? (string) $item['value'] : '' ); ?>"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
@@ -72,7 +72,7 @@ final class ProductFilterDropdown extends AbstractBlock {
 		$show_counts = is_array( $first ) && array_key_exists( 'count', $first );
 		$aria_label  = ! empty( $selectable_items['groupLabel'] )
 			? (string) $selectable_items['groupLabel']
-			: __( 'Product filter', 'woocommerce' );
+			: __( 'Filter options', 'woocommerce' );
 
 		ob_start();
 		?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterDropdown.php
@@ -36,9 +36,9 @@ final class ProductFilterDropdown extends AbstractBlock {
 	/**
 	 * Render the block.
 	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content    Block content.
-	 * @param WP_Block $block      Block instance.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Block content.
+	 * @param \WP_Block $block      Block instance.
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
@@ -57,15 +57,6 @@ final class ProductFilterDropdown extends AbstractBlock {
 		$first       = reset( $items );
 		$filter_type = ( is_array( $first ) && ! empty( $first['type'] ) ) ? (string) $first['type'] : '';
 
-		$classes = '';
-		$style   = '';
-
-		$tags = new \WP_HTML_Tag_Processor( $content );
-		if ( $tags->next_tag( array( 'class_name' => 'wc-block-product-filter-dropdown' ) ) ) {
-			$classes = $tags->get_attribute( 'class' );
-			$style   = $tags->get_attribute( 'style' );
-		}
-
 		$wrapper_attributes = array(
 			'data-wp-interactive' => 'woocommerce/product-filter-dropdown',
 			'data-wp-context'     => (string) wp_json_encode(
@@ -75,12 +66,7 @@ final class ProductFilterDropdown extends AbstractBlock {
 				),
 				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 			),
-			'class'               => esc_attr( $classes ),
 		);
-
-		if ( ! empty( $style ) ) {
-			$wrapper_attributes['style'] = esc_attr( $style ) . ';';
-		}
 
 		$select_id   = wp_unique_id( 'wc-block-product-filter-dropdown-' );
 		$show_counts = is_array( $first ) && array_key_exists( 'count', $first );
@@ -129,6 +115,7 @@ final class ProductFilterDropdown extends AbstractBlock {
 			</fieldset>
 		</div>
 		<?php
-		return ob_get_clean();
+		$output = ob_get_clean();
+		return is_string( $output ) ? $output : '';
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -400,6 +400,7 @@ final class BlockTypesController {
 			'ProductFilterClearButton',
 			'ProductFilterCheckboxList',
 			'ProductFilterChips',
+			'ProductFilterDropdown',
 			'ProductFilterTaxonomy',
 
 			// Keep hidden legacy filter blocks for backward compatibility.
@@ -476,6 +477,7 @@ final class BlockTypesController {
 			'ProductFilterClearButton',
 			'ProductFilterCheckboxList',
 			'ProductFilterChips',
+			'ProductFilterDropdown',
 			'ProductFilterTaxonomy',
 			'ProductGallery',
 			'ProductGalleryLargeImage',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a new Dropdown inner block for product filters. This will ultimately be required by the _Add to Cart + Options_ block, but it's also a nice addition to Product Filters.

Note: for now, the Dropdown doesn't allow any user styles.

### How to test the changes in this Pull Request:

1. Create a post or page (or edit the Product Catalog template).
2. Add the Product Collection block and the Product Filters block inside it.
3. Select one of the filters, verify you see a 'Dropdown' option in the 'Display Settings'.

<img width="1136" height="636" alt="imatge" src="https://github.com/user-attachments/assets/9d526f99-6f7a-400f-aeb1-e283c55a4ce5" />

4. Select it and save.
5. Go to the frontend and interact with it.
6. Verify selecting an option actually activates the filter.

https://github.com/user-attachments/assets/8b3f883c-91bd-4f26-bc57-ba000449e731

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
