### PR TITLE
Tighten chevron-to-checkbox spacing to 16px in the products list

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-chevron-checkbox-spacing
+++ b/packages/js/experimental-products-app/changelog/update-chevron-checkbox-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Tighten the spacing between the variation chevron and the row checkbox in the experimental products list to 16px.

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -40,6 +40,12 @@
 	height: 100%;
 }
 
+.woocommerce-product-list
+	.dataviews-view-table
+	.dataviews-view-table__hierarchy-column {
+	padding-right: 4px;
+}
+
 .woocommerce-product-edit {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

In the experimental All Products list, rows for variable products show an expand chevron in the hierarchy column followed by the row checkbox. The visual gap between the chevron and the checkbox is currently **24px** — that comes from DataViews' default cell padding (12px on the hierarchy column's right + 12px on the checkbox column's left).

This PR reduces the hierarchy column's right padding from `12px` → `4px` so the visual gap is `4 + 12 = 16px`, matching the spec.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| 24px gap between chevron and checkbox | 16px gap between chevron and checkbox |

### How to test the changes in this Pull Request:

1. Enable the feature flags `product-data-views` and `gutenberg-editor-inspector-use-dataform`.
2. Navigate to **WooCommerce → Products (new)**.
3. Find a variable product (one that has an expand chevron) in the list.
4. Confirm the gap between the chevron and the row checkbox is visually 16px (~half the prior gap).
5. Confirm child variation rows (which don't have a chevron) are unaffected — their checkbox column is unchanged.

### Testing that has already taken place:

- CSS-only change; no logic affected. Manual smoke check.

### Changelog entry

`packages/js/experimental-products-app/changelog/update-chevron-checkbox-spacing` — patch / update.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**