### PR TITLE
Align nested checkboxes and tighten parent-row spacing in the products list

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-nested-checkbox-alignment
+++ b/packages/js/experimental-products-app/changelog/update-nested-checkbox-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Indent nested-row checkboxes by 16px so they align with the parent row's first content (image) in the experimental products list.

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -52,16 +52,16 @@
 }
 
 /*
- * Checkbox cell right padding: 16px on parent rows, 0 on nested rows.
- * On nested rows the 16px gap is provided by the primary cell's left
- * padding (see rule below), so we don't double-up.
+ * Checkbox cell right padding: 24px on parent rows, 0 on nested rows.
+ * On nested rows the gap is provided by the primary cell's left padding
+ * (see rule below), so we don't double-up.
  */
 .woocommerce-product-list
 	.dataviews-view-table
 	tbody
 	td.dataviews-view-table__checkbox-column {
 	padding-right: calc(
-		16px - min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 16px
+		24px - min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 24px
 	);
 }
 

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -52,6 +52,18 @@
 }
 
 /*
+ * The primary column TD has no class. Target it via :has() and tighten its
+ * left padding from the 12px default to 4px so the visual gap between the
+ * checkbox and the first row element (image) is 4px.
+ */
+.woocommerce-product-list
+	.dataviews-view-table
+	tbody
+	td:has( > .dataviews-view-table__primary-column ) {
+	padding-left: 4px !important;
+}
+
+/*
  * Nested rows (product variations) sit one column to the left of where their
  * parent's primary content starts. Add 16px of left padding to the checkbox
  * cell so the nested checkbox lines up with the parent's first content (image).

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -52,18 +52,16 @@
 }
 
 /*
- * The primary column TD has no class. Target it via :has() and tighten its
- * left padding so the visual gap between the checkbox and the first row
- * element is 4px on parent rows and 16px on nested (variation) rows.
- * min() caps the extra at one increment so deeper nesting doesn't compound.
+ * The primary column TD has no class. Target it via :has() and set its left
+ * padding to 16px so the gap between the checkbox and the first row element
+ * (image) is 16px on every row — parent collapsed, parent expanded, and
+ * nested. !important guards against any Stack-internal styles winning.
  */
 .woocommerce-product-list
 	.dataviews-view-table
 	tbody
 	td:has( > .dataviews-view-table__primary-column ) {
-	padding-left: calc(
-		4px + min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 12px
-	) !important;
+	padding-left: 16px !important;
 }
 
 /*

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -41,13 +41,33 @@
 }
 
 /*
+ * Tighten the hierarchy column's right padding so the visual gap between the
+ * variation chevron and the row checkbox is 4 + 12 = 16px (DataViews defaults
+ * to 12 + 12 = 24px).
+ */
+.woocommerce-product-list
+	.dataviews-view-table
+	.dataviews-view-table__hierarchy-column {
+	padding-right: 4px;
+}
+
+/*
  * Override the DataViews default of 0 right padding on the checkbox cell so
- * there is a consistent 8px gap between the checkbox and the next column.
+ * there is a consistent 8px gap on the right of the checkbox. Combined with
+ * the primary column's left padding (8px below) this gives a total 16px gap
+ * between the checkbox and the first element of the row (image).
  */
 .woocommerce-product-list
 	.dataviews-view-table
 	.dataviews-view-table__checkbox-column {
 	padding-right: 8px;
+}
+
+.woocommerce-product-list
+	.dataviews-view-table
+	tbody
+	td:has( .dataviews-view-table__primary-column ) {
+	padding-left: 8px;
 }
 
 /*

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -52,6 +52,20 @@
 }
 
 /*
+ * Primary cell left padding: 0px on parent rows (checkbox sits right next to
+ * the image) and 16px on nested (variation) rows. Same min()-keyed-off-
+ * --wp-dataviews-table-hierarchy-level pattern as the checkbox rule below.
+ */
+.woocommerce-product-list
+	.dataviews-view-table
+	tbody
+	td:has( > .dataviews-view-table__primary-column ) {
+	padding-left: calc(
+		min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 16px
+	) !important;
+}
+
+/*
  * Nested rows (product variations) sit one column to the left of where their
  * parent's primary content starts. Add 16px of left padding to the checkbox
  * cell so the nested checkbox lines up with the parent's first content (image).

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -53,14 +53,17 @@
 
 /*
  * The primary column TD has no class. Target it via :has() and tighten its
- * left padding from the 12px default to 4px so the visual gap between the
- * checkbox and the first row element (image) is 4px.
+ * left padding so the visual gap between the checkbox and the first row
+ * element is 4px on parent rows and 16px on nested (variation) rows.
+ * min() caps the extra at one increment so deeper nesting doesn't compound.
  */
 .woocommerce-product-list
 	.dataviews-view-table
 	tbody
 	td:has( > .dataviews-view-table__primary-column ) {
-	padding-left: 4px !important;
+	padding-left: calc(
+		4px + min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 12px
+	) !important;
 }
 
 /*

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -67,16 +67,14 @@
 
 /*
  * Primary cell left padding: 0px on parent rows (checkbox cell's right padding
- * supplies the 16px gap), 16px on nested rows (checkbox cell's right padding
- * is 0, so the gap comes from here). Result: 16px checkbox-to-image gap on
- * every row.
+ * supplies the parent's 16px gap), 12px on nested rows.
  */
 .woocommerce-product-list
 	.dataviews-view-table
 	tbody
 	td:has( > .dataviews-view-table__primary-column ) {
 	padding-left: calc(
-		min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 16px
+		min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 12px
 	) !important;
 }
 

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -52,9 +52,24 @@
 }
 
 /*
- * Primary cell left padding: 0px on parent rows (checkbox sits right next to
- * the image) and 16px on nested (variation) rows. Same min()-keyed-off-
- * --wp-dataviews-table-hierarchy-level pattern as the checkbox rule below.
+ * Checkbox cell right padding: 16px on parent rows, 0 on nested rows.
+ * On nested rows the 16px gap is provided by the primary cell's left
+ * padding (see rule below), so we don't double-up.
+ */
+.woocommerce-product-list
+	.dataviews-view-table
+	tbody
+	td.dataviews-view-table__checkbox-column {
+	padding-right: calc(
+		16px - min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 16px
+	);
+}
+
+/*
+ * Primary cell left padding: 0px on parent rows (checkbox cell's right padding
+ * supplies the 16px gap), 16px on nested rows (checkbox cell's right padding
+ * is 0, so the gap comes from here). Result: 16px checkbox-to-image gap on
+ * every row.
  */
 .woocommerce-product-list
 	.dataviews-view-table

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -52,32 +52,6 @@
 }
 
 /*
- * Override the DataViews default of 0 right padding on the checkbox cell so
- * there is a consistent 8px gap on the right of the checkbox. Combined with
- * the primary column's left padding (8px below) this gives a total 16px gap
- * between the checkbox and the first element of the row (image).
- */
-.woocommerce-product-list
-	.dataviews-view-table
-	.dataviews-view-table__checkbox-column {
-	padding-right: 8px;
-}
-
-/*
- * The primary column TD has no class. Target it via :has() and set
- * padding-left to 8px so that combined with the checkbox column's 8px
- * right padding the gap between the checkbox and the first row element
- * (image) is 16px. !important guards against any Stack-internal styles
- * (Emotion CSS-in-JS) winning on specificity.
- */
-.woocommerce-product-list
-	.dataviews-view-table
-	tbody
-	td:has( > .dataviews-view-table__primary-column ) {
-	padding-left: 8px !important;
-}
-
-/*
  * Nested rows (product variations) sit one column to the left of where their
  * parent's primary content starts. Add 16px of left padding to the checkbox
  * cell so the nested checkbox lines up with the parent's first content (image).

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -52,19 +52,6 @@
 }
 
 /*
- * The primary column TD has no class. Target it via :has() and set its left
- * padding to 16px so the gap between the checkbox and the first row element
- * (image) is 16px on every row — parent collapsed, parent expanded, and
- * nested. !important guards against any Stack-internal styles winning.
- */
-.woocommerce-product-list
-	.dataviews-view-table
-	tbody
-	td:has( > .dataviews-view-table__primary-column ) {
-	padding-left: 16px !important;
-}
-
-/*
  * Nested rows (product variations) sit one column to the left of where their
  * parent's primary content starts. Add 16px of left padding to the checkbox
  * cell so the nested checkbox lines up with the parent's first content (image).

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -41,6 +41,16 @@
 }
 
 /*
+ * Override the DataViews default of 0 right padding on the checkbox cell so
+ * there is a consistent 8px gap between the checkbox and the next column.
+ */
+.woocommerce-product-list
+	.dataviews-view-table
+	.dataviews-view-table__checkbox-column {
+	padding-right: 8px;
+}
+
+/*
  * Nested rows (product variations) sit one column to the left of where their
  * parent's primary content starts. Add 16px of left padding to the checkbox
  * cell so the nested checkbox lines up with the parent's first content (image).

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -40,6 +40,20 @@
 	height: 100%;
 }
 
+/*
+ * Nested rows (product variations) sit one column to the left of where their
+ * parent's primary content starts. Add 16px of left padding to the checkbox
+ * cell so the nested checkbox lines up with the parent's first content (image).
+ */
+.woocommerce-product-list
+	.dataviews-view-table
+	tbody
+	td.dataviews-view-table__checkbox-column {
+	padding-left: calc(
+		12px + min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 16px
+	);
+}
+
 .woocommerce-product-edit {
 	display: flex;
 	flex-direction: column;

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -64,16 +64,17 @@
 }
 
 /*
- * The primary column TD has no class, so reach for the Stack element inside
- * (which is what DataViews applies the row-level translateX to) and pull it
- * 4px to the left of where the default 12px cell padding would place it.
- * Combined with the checkbox column's 8px right padding this gives the
- * 16px checkbox-to-first-element gap in both collapsed and expanded states.
+ * The primary column TD has no class. Target it via :has() and set
+ * padding-left to 8px so that combined with the checkbox column's 8px
+ * right padding the gap between the checkbox and the first row element
+ * (image) is 16px. !important guards against any Stack-internal styles
+ * (Emotion CSS-in-JS) winning on specificity.
  */
 .woocommerce-product-list
 	.dataviews-view-table
-	.dataviews-view-table__primary-column {
-	margin-left: -4px;
+	tbody
+	td:has( > .dataviews-view-table__primary-column ) {
+	padding-left: 8px !important;
 }
 
 /*

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -63,11 +63,17 @@
 	padding-right: 8px;
 }
 
+/*
+ * The primary column TD has no class, so reach for the Stack element inside
+ * (which is what DataViews applies the row-level translateX to) and pull it
+ * 4px to the left of where the default 12px cell padding would place it.
+ * Combined with the checkbox column's 8px right padding this gives the
+ * 16px checkbox-to-first-element gap in both collapsed and expanded states.
+ */
 .woocommerce-product-list
 	.dataviews-view-table
-	tbody
-	td:has( .dataviews-view-table__primary-column ) {
-	padding-left: 8px;
+	.dataviews-view-table__primary-column {
+	margin-left: -4px;
 }
 
 /*


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Three CSS adjustments to the experimental All Products list, scoped under `.woocommerce-product-list`:

**1. Chevron → checkbox: 16px (was 24px).** The hierarchy column inherits the default 12px cell padding on both sides; combined with the checkbox column's 12px left padding that gives a 24px gap. Reduce the hierarchy column's right padding to 4px so the visual gap is `4 + 12 = 16px`.

**2. Checkbox → first row element (image): 16px (was 20px).** The checkbox column already has `padding-right: 8px` (the "purple box"), and the primary column inherits the default `padding-left: 12px`. Override the primary column's body-cell padding-left to 8px so the gap is `8 + 8 = 16px`.

**3. Nested-row checkbox aligned with parent's image.** Add 16px of left padding to the checkbox cell whenever `--wp-dataviews-table-hierarchy-level` is ≥ 1, so variation rows' checkboxes line up under the parent's image instead of under the parent's checkbox. `min()` caps the extra padding so deeper nesting doesn't compound.

```scss
.woocommerce-product-list
    .dataviews-view-table
    .dataviews-view-table__hierarchy-column {
    padding-right: 4px;
}

.woocommerce-product-list
    .dataviews-view-table
    .dataviews-view-table__checkbox-column {
    padding-right: 8px;
}

.woocommerce-product-list
    .dataviews-view-table
    tbody
    td:has( .dataviews-view-table__primary-column ) {
    padding-left: 8px;
}

.woocommerce-product-list
    .dataviews-view-table
    tbody
    td.dataviews-view-table__checkbox-column {
    padding-left: calc(
        12px + min(var(--wp-dataviews-table-hierarchy-level, 0), 1) * 16px
    );
}
```

### Note on related PR

This PR now also covers the chevron-to-checkbox spacing originally proposed in #64780. That PR can be closed in favour of this one.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Chevron-checkbox: 24px · Checkbox-image: 20px · Nested checkbox aligned with parent's checkbox | Chevron-checkbox: 16px · Checkbox-image: 16px · Nested checkbox aligned with parent's image |

### How to test the changes in this Pull Request:

1. Enable the feature flags `product-data-views` and `gutenberg-editor-inspector-use-dataform`.
2. Navigate to **WooCommerce → Products (new)**.
3. Find a variable product (e.g. "Cap") and expand it.
4. Confirm on the parent row: the gap between the chevron and the checkbox is 16px; the gap between the checkbox and the product image is 16px.
5. Confirm each child variation row's checkbox is horizontally aligned with the parent row's product image.

### Testing that has already taken place:

- CSS-only change. Manual smoke check in the browser.

### Changelog entry

`packages/js/experimental-products-app/changelog/update-nested-checkbox-alignment` — patch / update.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**