### PR TITLE
Fix Marketplace product card title focus ring

### DIFF
--- a/plugins/woocommerce/changelog/fix-marketplace-product-card-title-focus-ring
+++ b/plugins/woocommerce/changelog/fix-marketplace-product-card-title-focus-ring
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent the Marketplace product card title focus ring from being clipped.

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.scss
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.scss
@@ -144,8 +144,14 @@
 				calc(-1 * var(--woocommerce-marketplace-product-card-title-focus-width))
 				calc(-1 * var(--woocommerce-marketplace-product-card-title-focus-width));
 			padding: var(--woocommerce-marketplace-product-card-title-focus-width);
+			max-width: 100%;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			width: fit-content;
+
+			&:has(.woocommerce-marketplace__product-card__link:focus-visible) {
+				box-shadow: 0 0 0 var(--woocommerce-marketplace-product-card-title-focus-width) var(--wp-admin-theme-color, #2271b1);
+			}
 		}
 
 		&__link {
@@ -161,7 +167,7 @@
 			}
 
 			&:focus-visible {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus, 2px) var(--wp-admin-theme-color, #2271b1);
+				box-shadow: none;
 			}
 
 			/* Use the ::after trick to make the whole card clickable: */

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.scss
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.scss
@@ -129,6 +129,8 @@
 		}
 
 		&__title {
+			--woocommerce-marketplace-product-card-title-focus-width: var(--wp-admin-border-width-focus, 2px);
+
 			display: -webkit-box;
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: 2;
@@ -137,8 +139,11 @@
 			font-style: normal;
 			font-weight: 600;
 			line-height: $large-gap;
-			margin: -4px 0 0;
-			padding: 0;
+			margin:
+				calc(-4px - var(--woocommerce-marketplace-product-card-title-focus-width))
+				calc(-1 * var(--woocommerce-marketplace-product-card-title-focus-width))
+				calc(-1 * var(--woocommerce-marketplace-product-card-title-focus-width));
+			padding: var(--woocommerce-marketplace-product-card-title-focus-width);
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}
@@ -444,4 +449,3 @@
 		}
 	}
 }
-


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Marketplace product card title uses a two-line clamp, which clips descendants and can cut off the keyboard focus ring on the title link. This PR gives the clamped title enough internal space for the focus ring and offsets that space with margins so the product card layout stays visually unchanged.

Refs #64254.

### Screenshots or screen recordings:

| Before | After |
Before
<img width="932" height="554" alt="image" src="https://github.com/user-attachments/assets/b3cd776d-a2bc-499f-b429-3d9fdaeda1ca" />

See the screenshot in #64254. 

After 
<img width="480" height="170" alt="issue-64254-end-result" src="https://github.com/user-attachments/assets/28875594-07de-488a-b843-4514e70c0e85" />

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Extensions**.
2. Use the keyboard to tab to a Marketplace product card title.
3. Confirm the focus ring around the title link is fully visible and is not clipped at the bottom edge.
4. Check product cards with one-line and two-line titles to confirm the title spacing and card layout are unchanged.

### Testing that has already taken place:

-   Ran `pnpm exec stylelint client/admin/client/marketplace/components/product-card/product-card.scss --config client/admin/stylelint.config.js`.
-   Ran `git diff --check`.
-   Rendered a local visual repro for a focused two-line product title and confirmed the focus ring is no longer clipped.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A manual changelog entry was added in `plugins/woocommerce/changelog/fix-marketplace-product-card-title-focus-ring`.

</details>

