### PR TITLE
Bump WordPress MCP adapter to v0.5.0

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -35,10 +35,6 @@
 		},
 		{
 			"type": "vcs",
-			"url": "https://github.com/WordPress/mcp-adapter.git"
-		},
-		{
-			"type": "vcs",
 			"url": "https://github.com/WordPress/abilities-api"
 		}
 	],
@@ -57,7 +53,7 @@
 		"woocommerce/blueprint": "*",
 		"woocommerce/email-editor": "*",
 		"wordpress/abilities-api": "^0.4.0",
-		"wordpress/mcp-adapter": "^0.3.0"
+		"wordpress/mcp-adapter": "^0.5.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",
@@ -168,6 +164,9 @@
 	},
 	"extra": {
 		"installer-paths": {
+			"vendor/{$vendor}/{$name}/": [
+				"wordpress/mcp-adapter"
+			],
 			"packages/{$name}": [
 				"woocommerce/action-scheduler",
 				"woocommerce/email-editor",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c50934dcb05857900ec57b146a3aefef",
+    "content-hash": "bea5d8025042f5a0ffd4454aff892074",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1351,23 +1351,26 @@
         },
         {
             "name": "wordpress/mcp-adapter",
-            "version": "v0.3.0",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/mcp-adapter.git",
-                "reference": "653ca8d95180b25809b1a1dc489d8305ec5beb63"
+                "reference": "7bfc49f46b3ea7544dded49d5a606089f825a80b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/653ca8d95180b25809b1a1dc489d8305ec5beb63",
-                "reference": "653ca8d95180b25809b1a1dc489d8305ec5beb63",
+                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/7bfc49f46b3ea7544dded49d5a606089f825a80b",
+                "reference": "7bfc49f46b3ea7544dded49d5a606089f825a80b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0",
+                "wordpress/php-mcp-schema": "^0.1.0"
             },
             "require-dev": {
                 "automattic/vipwpcs": "^3.0",
+                "php-stubs/wordpress-stubs": "^6.9",
                 "php-stubs/wp-cli-stubs": "^2.12",
                 "phpcompatibility/php-compatibility": "10.x-dev as 9.99.99",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
@@ -1382,7 +1385,7 @@
                 "wpackagist-plugin/plugin-check": "^1.6",
                 "yoast/phpunit-polyfills": "^4.0"
             },
-            "type": "library",
+            "type": "wordpress-plugin",
             "extra": {
                 "installer-paths": {
                     "vendor/{$vendor}/{$name}/": [
@@ -1395,27 +1398,7 @@
                     "WP\\MCP\\": "includes/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "WP\\MCP\\Tests\\": [
-                        "tests/"
-                    ]
-                }
-            },
-            "scripts": {
-                "lint:php": [
-                    "phpcs"
-                ],
-                "lint:php:fix": [
-                    "phpcbf"
-                ],
-                "lint:php:stan": [
-                    "vendor/bin/phpstan analyse --memory-limit=1G"
-                ],
-                "test": [
-                    "phpunit --strict-coverage"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
@@ -1441,7 +1424,58 @@
                 "issues": "https://github.com/wordpress/mcp-adapter/issues",
                 "source": "https://github.com/wordpress/mcp-adapter"
             },
-            "time": "2025-11-06T14:56:51+00:00"
+            "time": "2026-04-14T12:12:58+00:00"
+        },
+        {
+            "name": "wordpress/php-mcp-schema",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/php-mcp-schema.git",
+                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/e2118ec421ead51a3e17a3d8160f4537727e91b9",
+                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WP\\McpSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress",
+                    "homepage": "https://wordpress.org"
+                }
+            ],
+            "description": "PHP DTOs for the Model Context Protocol (MCP) specification",
+            "homepage": "https://github.com/WordPress/php-mcp-schema",
+            "keywords": [
+                "dto",
+                "mcp",
+                "model-context-protocol",
+                "php",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/php-mcp-schema/issues",
+                "source": "https://github.com/WordPress/php-mcp-schema/tree/v0.1.1"
+            },
+            "time": "2026-04-10T19:35:16+00:00"
         }
     ],
     "packages-dev": [

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -115,15 +115,6 @@ class MCPAdapterProvider {
 			return;
 		}
 
-		/*
-		 * Temporarily disable MCP validation during server creation.
-		 * Workaround for validator bug with union types (e.g., ["integer", "null"]).
-		 * This will be removed once the mcp-adapter validator bug is fixed.
-		 *
-		 * @see https://github.com/WordPress/mcp-adapter/issues/47
-		 */
-		add_filter( 'mcp_validation_enabled', array( __CLASS__, 'disable_mcp_validation' ), 999 );
-
 		try {
 			// Create MCP server.
 			$adapter->create_server(
@@ -145,9 +136,6 @@ class MCPAdapterProvider {
 					array( 'source' => 'woocommerce-mcp' )
 				);
 			}
-		} finally {
-			// Re-enable MCP validation immediately after server creation.
-			remove_filter( 'mcp_validation_enabled', array( __CLASS__, 'disable_mcp_validation' ), 999 );
 		}
 	}
 
@@ -217,18 +205,6 @@ class MCPAdapterProvider {
 			}
 		}
 
-		return false;
-	}
-
-	/**
-	 * Temporarily disable MCP validation.
-	 *
-	 * Used as a callback for the mcp_validation_enabled filter to work around
-	 * validator bugs with union types.
-	 *
-	 * @return bool Always returns false to disable validation.
-	 */
-	public static function disable_mcp_validation(): bool {
 		return false;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -126,7 +126,6 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		// Reset any filters that might have been added.
 		remove_all_filters( 'woocommerce_mcp_include_ability' );
 		remove_all_filters( 'woocommerce_mcp_allow_insecure_transport' );
-		remove_all_filters( 'mcp_validation_enabled' );
 
 		foreach ( $this->registered_ability_ids as $ability_id ) {
 			if ( function_exists( 'wp_unregister_ability' ) ) {
@@ -351,15 +350,6 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should disable MCP validation.
-	 */
-	public function test_disable_mcp_validation_returns_false(): void {
-		$result = MCPAdapterProvider::disable_mcp_validation();
-
-		$this->assertFalse( $result, 'disable_mcp_validation should always return false' );
-	}
-
-	/**
 	 * @testdox Should track initialization state.
 	 */
 	public function test_is_initialized_tracks_state(): void {
@@ -426,6 +416,11 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	 */
 	private function register_test_ability( string $ability_id, array $meta ): void {
 		$this->ensure_test_ability_category( 'woocommerce-rest' );
+
+		if ( function_exists( 'wp_has_ability' ) ) {
+			// Initialize the registry before firing the test callback to avoid recursive action dispatch.
+			$this->assertFalse( wp_has_ability( $ability_id ), 'Test ability should not already be registered.' );
+		}
 
 		$ability  = null;
 		$callback = null;


### PR DESCRIPTION
## Summary

- Bumps `wordpress/mcp-adapter` from v0.3.0 to v0.5.0.
- Locks the adapter's new `wordpress/php-mcp-schema` dependency.
- Removes the VCS repository override now that the adapter is available through Packagist.
- Keeps the adapter installed under `vendor/wordpress/mcp-adapter` even though v0.5.0 is packaged as a `wordpress-plugin`.
- Removes the stale `mcp_validation_enabled` workaround; v0.5.0 uses `mcp_adapter_validation_enabled`, and validation remains disabled by default upstream.
- Updates the MCP provider test helper to work with WordPress core's active-action Abilities API registration behavior.

## Why

The bundled MCP integration should track the upstream WordPress MCP adapter rather than carrying a stale pinned version and a workaround that no longer affects the adapter's validation behavior. I checked for an official WordPress.org feature plugin release before making this change; the official distribution path is still the Composer package.

## Testing

- `php -l plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php`
- `php -l plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'MCPAdapterProviderTest|WooCommerceRestTransportTest'`
- `composer validate`