### PR TITLE
PoC: Add Wishlist endpoint and single-product star toggle

### DIFF
--- a/plugins/woocommerce/changelog/add-cart-save-for-later-link
+++ b/plugins/woocommerce/changelog/add-cart-save-for-later-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a "Save for later" link beneath each cart line item that saves the item to the saved-for-later shopper list and removes it from the cart on success. The link is only shown to logged-in users and is hidden in the mini-cart.

--- a/plugins/woocommerce/changelog/add-shopper-collections-cart-hook
+++ b/plugins/woocommerce/changelog/add-shopper-collections-cart-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Auto-inject the Shopper Collection block on the cart page when the shopper lists feature is enabled.

--- a/plugins/woocommerce/changelog/add-shopper-collections-feature-flag
+++ b/plugins/woocommerce/changelog/add-shopper-collections-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Gate shopper lists behind a new experimental flag.

--- a/plugins/woocommerce/changelog/add-shopper-collections-iapi-store
+++ b/plugins/woocommerce/changelog/add-shopper-collections-iapi-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Wire the Shopper Collection (Saved-for-later) block to the shopper-lists Store API via a private iAPI store, with server-side rendering of saved items, optimistic remove, and Move-to-cart for simple products.

--- a/plugins/woocommerce/changelog/add-wishlist-my-account-scope
+++ b/plugins/woocommerce/changelog/add-wishlist-my-account-scope
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a Wishlist endpoint under My Account that renders the saved-for-later shopper list, plus a single-product star toggle that adds/removes the configured product (with variation) from the list.

--- a/plugins/woocommerce/changelog/rsm-shopper-collections-add-storeapi-endpoints
+++ b/plugins/woocommerce/changelog/rsm-shopper-collections-add-storeapi-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the foundation for shopper lists via new Store API endpoints under /wc/store/v1/shopper-lists. Lists are persisted per-user in usermeta.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -11,6 +11,7 @@ import {
 	useStoreCartItemQuantity,
 	useStoreEvents,
 	useStoreCart,
+	useSaveForLater,
 } from '@woocommerce/base-context/hooks';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import {
@@ -117,7 +118,9 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 
 		const { quantity, setItemQuantity, removeItem, isPendingDelete } =
 			useStoreCartItemQuantity( lineItem );
+		const { saveForLater, isSaving: isSavingForLater } = useSaveForLater();
 		const { dispatchStoreEvent } = useStoreEvents();
+		const isUserLoggedIn = !! getSetting< number >( 'currentUserId', 0 );
 
 		// Prepare props to pass to the applyCheckoutFilter filter.
 		// We need to pluck out receiveCart.
@@ -339,6 +342,59 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 								</button>
 							) }
 						</div>
+						{ isUserLoggedIn && (
+							<div className="wc-block-cart-item__save-for-later">
+								<button
+									type="button"
+									className="wc-block-cart-item__save-for-later-link"
+									onClick={ async () => {
+										const saved = await saveForLater(
+											lineItem.key
+										);
+										if ( ! saved ) {
+											return;
+										}
+										// removeItem surfaces its own errors
+										// via processErrorResponse; we still
+										// fire the analytics event and a11y
+										// announcement to mirror the regular
+										// remove flow.
+										await removeItem();
+										// TODO: consider a dedicated
+										// 'cart-save-for-later' store event so
+										// analytics can distinguish a save
+										// from a plain remove.
+										dispatchStoreEvent(
+											'cart-remove-item',
+											{
+												product: lineItem,
+												quantity,
+											}
+										);
+										speak(
+											sprintf(
+												/* translators: %s refers to the item name. */
+												__(
+													'%s has been saved for later and removed from your cart.',
+													'woocommerce'
+												),
+												name
+											)
+										);
+									} }
+									disabled={
+										isPendingDelete || isSavingForLater
+									}
+								>
+									{ isSavingForLater
+										? __( 'Saving…', 'woocommerce' )
+										: __(
+												'Save for later',
+												'woocommerce'
+										  ) }
+								</button>
+							</div>
+						) }
 					</div>
 				</td>
 				<td className="wc-block-cart-item__total">

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -96,6 +96,21 @@ table.wc-block-cart-items {
 				}
 			}
 		}
+		.wc-block-cart-item__save-for-later {
+			.wc-block-cart-item__save-for-later-link {
+				@include link-button();
+				@include hover-effect();
+				@include font-small-locked;
+
+				text-transform: none;
+				white-space: nowrap;
+
+				&:disabled {
+					cursor: default;
+					opacity: 0.5;
+				}
+			}
+		}
 		.wc-block-components-product-name {
 			@include font-small-locked;
 			display: block;
@@ -118,6 +133,10 @@ table.wc-block-cart-items {
 			pointer-events: none;
 			transition: opacity 200ms ease;
 		}
+	}
+
+	&.wc-block-mini-cart-items .wc-block-cart-item__save-for-later {
+		display: none;
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/index.ts
@@ -1,3 +1,4 @@
 export * from './use-store-cart';
 export * from './use-store-cart-coupons';
 export * from './use-store-cart-item-quantity';
+export * from './use-save-for-later';

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-save-for-later.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-save-for-later.ts
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { dispatch, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { cartStore } from '@woocommerce/block-data';
+
+/**
+ * Save a cart line item to the saved-for-later shopper list.
+ *
+ * Dispatches the wp.data cart store's `saveForLater` thunk, which POSTs the
+ * item and emits a `wc-blocks_store_sync_required` event. A Shopper
+ * Collection block on the same page picks up that event in its iAPI store
+ * and applies the new row reactively.
+ *
+ * Resolves to `true` on success so the caller can chain the cart removal;
+ * on failure surfaces an error notice in the cart context and resolves to
+ * `false`. The cart removal is the caller's responsibility — keep the two
+ * awaits separate so save and remove errors stay distinct.
+ */
+export const useSaveForLater = (): {
+	isSaving: boolean;
+	saveForLater: ( cartItemKey: string ) => Promise< boolean >;
+} => {
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { saveForLater: dispatchSaveForLater } = useDispatch( cartStore );
+
+	const saveForLater = useCallback(
+		async ( cartItemKey: string ): Promise< boolean > => {
+			if ( ! cartItemKey || isSaving ) {
+				return false;
+			}
+			setIsSaving( true );
+			try {
+				await dispatchSaveForLater( cartItemKey );
+				return true;
+			} catch ( error ) {
+				const message =
+					error &&
+					typeof error === 'object' &&
+					'message' in error &&
+					typeof ( error as { message: unknown } ).message ===
+						'string'
+						? ( error as { message: string } ).message
+						: __(
+								'There was a problem saving this item for later.',
+								'woocommerce'
+						  );
+				dispatch( noticesStore ).createNotice( 'error', message, {
+					context: 'wc/cart',
+					isDismissible: true,
+				} );
+				return false;
+			} finally {
+				setIsSaving( false );
+			}
+		},
+		[ isSaving, dispatchSaveForLater ]
+	);
+
+	return { isSaving, saveForLater };
+};

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -288,3 +288,38 @@ const { state } = store< Store >(
 	},
 	{ lock: universalLock }
 );
+
+// Listen for shopper-list item additions emitted from the wp.data side (e.g.
+// the cart store's saveForLater thunk). Mirrors the cart's iAPI → wp.data
+// sync direction, which also ships a payload (`from_iAPI` carries
+// `quantityChanges`). The event carries the saved item directly so we can
+// splice it in without an extra GET — keeps the merge ordering deterministic
+// and avoids the loadList-vs-mutation race the iAPI store's loadList still
+// has a TODO about.
+//
+// Keeps the discriminator + payload contract in sync with
+// `assets/js/data/cart/thunks.ts::saveForLater`.
+window.addEventListener( 'wc-blocks_store_sync_required', ( event: Event ) => {
+	const detail = ( event as CustomEvent ).detail as
+		| { type?: string; slug?: string; item?: RawShopperListItem }
+		| undefined;
+	if ( detail?.type !== 'shopper-list-item-added' ) {
+		return;
+	}
+	if (
+		typeof detail.slug !== 'string' ||
+		detail.slug.trim().length === 0 ||
+		! isShopperListItem( detail.item )
+	) {
+		return;
+	}
+	const list = ensureListState( state, detail.slug );
+	const item = detail.item;
+	const existingIndex = list.items.findIndex( ( i ) => i.key === item.key );
+	if ( existingIndex >= 0 ) {
+		list.items[ existingIndex ] = item;
+	} else {
+		list.items.push( item );
+	}
+	list.error = null;
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -1,0 +1,290 @@
+/**
+ * External dependencies
+ */
+import { store } from '@wordpress/interactivity';
+import type { AsyncAction, TypeYield } from '@wordpress/interactivity';
+import type { CurrencyResponse } from '@woocommerce/types';
+
+/**
+ * Mirror of `Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListItemSchema::get_properties()`.
+ *
+ * Keep this in sync with the schema. State here must not include any UI-derived
+ * fields — display values belong in block-private stores or PHP SSR.
+ * TO DO: decide where UI-derived state lives
+ */
+export type ShopperListItemImage = {
+	id: number;
+	src: string;
+	thumbnail: string;
+	srcset: string;
+	sizes: string;
+	name: string;
+	alt: string;
+	thumbnail_srcset: string;
+	thumbnail_sizes: string;
+};
+
+export type ShopperListItemVariation = {
+	raw_attribute: string;
+	attribute: string;
+	value: string;
+};
+
+export type ShopperListItemPrices = CurrencyResponse & {
+	price: string;
+	regular_price: string;
+	sale_price: string;
+};
+
+export type RawShopperListItem = {
+	key: string;
+	id: number;
+	product_id: number;
+	variation_id: number;
+	quantity: number;
+	product_exists: boolean;
+	name: string;
+	permalink: string;
+	images: ShopperListItemImage[];
+	variation: ShopperListItemVariation[];
+	prices: ShopperListItemPrices | null;
+	price_html: string;
+	image_html: string;
+	date_added_gmt: string;
+};
+
+export type ShopperListState = {
+	items: RawShopperListItem[];
+	isLoading: boolean;
+	error: string | null;
+};
+
+export type AddItemPayload = {
+	product_id?: number;
+	cart_item_key?: string;
+	variation?: Array< { attribute: string; value: string } >;
+	quantity?: number;
+};
+
+export type Store = {
+	state: {
+		restUrl: string;
+		// TODO: revisit nonce handling when we look at authentication for
+		// the shopper-lists routes. Today PHP seeds this via
+		// `wp_create_nonce( 'wc_store_api' )` and we refresh it from
+		// response headers (see restRequest below). Likely changes once
+		// the routes start enforcing nonces server-side: align with the
+		// cart store's bootstrap-from-response-header pattern, share the
+		// cart's `state.nonce` instead of duplicating, or move to a
+		// caching-friendlier transport.
+		nonce: string;
+		lists: Record< string, ShopperListState >;
+	};
+	actions: {
+		loadList: ( slug: string ) => Promise< void >;
+		addItem: ( slug: string, payload: AddItemPayload ) => Promise< void >;
+		removeItem: ( slug: string, key: string ) => Promise< void >;
+	};
+};
+
+// Stores are locked to prevent 3PD usage until the API is stable.
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+const isShopperListItem = ( value: unknown ): value is RawShopperListItem =>
+	!! value &&
+	typeof value === 'object' &&
+	typeof ( value as { key?: unknown } ).key === 'string';
+
+const ensureListState = (
+	state: Store[ 'state' ],
+	slug: string
+): ShopperListState => {
+	let list = state.lists[ slug ];
+	if ( ! list ) {
+		list = { items: [], isLoading: false, error: null };
+		state.lists[ slug ] = list;
+	}
+	return list;
+};
+
+/**
+ * Send a Store API request following the cart store's auth shape:
+ * Nonce header, `wc_store_api` action on the server side, cookie auth via
+ * `credentials: 'include'`, and `cache: 'no-store'` so user-specific data is
+ * never cached.
+ *
+ * The starter nonce is seeded by PHP via `wp_interactivity_state` and
+ * refreshed from the `Nonce` response header on every subsequent request,
+ * so the server-side enforcement (landing in a follow-up PR) can be
+ * flipped on without rewriting the client.
+ */
+async function restRequest< T >(
+	state: Store[ 'state' ],
+	path: string,
+	init: RequestInit = {}
+): Promise< T | null > {
+	const headers = new Headers( init.headers );
+	headers.set( 'Content-Type', 'application/json' );
+	if ( state.nonce ) {
+		headers.set( 'Nonce', state.nonce );
+	}
+
+	const response = await fetch( `${ state.restUrl }${ path }`, {
+		...init,
+		headers,
+		cache: 'no-store',
+		credentials: 'include',
+	} );
+
+	const nextNonce = response.headers.get( 'Nonce' );
+	if ( nextNonce ) {
+		state.nonce = nextNonce;
+	}
+
+	if ( response.status === 204 ) {
+		return null;
+	}
+
+	const text = await response.text();
+	const contentType = response.headers.get( 'Content-Type' ) || '';
+	const json =
+		text && contentType.includes( 'json' ) ? JSON.parse( text ) : null;
+
+	if ( ! response.ok ) {
+		const message =
+			( json && typeof json === 'object' && 'message' in json
+				? String( ( json as { message: unknown } ).message )
+				: '' ) ||
+			response.statusText ||
+			'Request failed.';
+		throw new Error( message );
+	}
+
+	return json as T | null;
+}
+
+// Do NOT supply `nonce` / `restUrl` defaults here. iAPI's deep-merge has the
+// JS-supplied state win over the existing (PHP-seeded) state for primitives,
+// so an empty-string default would clobber the values seeded server-side via
+// `wp_interactivity_state`. State for those fields comes purely from PHP. Same
+// reason the cart store doesn't ship state defaults — see cart.ts.
+const { state } = store< Store >(
+	'woocommerce/shopper-lists',
+	{
+		actions: {
+			*loadList( slug: string ): AsyncAction< void > {
+				const list = ensureListState( state, slug );
+				list.isLoading = true;
+				list.error = null;
+
+				try {
+					const response = ( yield restRequest<
+						RawShopperListItem[]
+					>(
+						state,
+						`wc/store/v1/shopper-lists/${ encodeURIComponent(
+							slug
+						) }/items`,
+						{ method: 'GET' }
+					) ) as TypeYield<
+						typeof restRequest< RawShopperListItem[] >
+					>;
+
+					if ( ! Array.isArray( response ) ) {
+						throw new Error( 'Invalid shopper list response.' );
+					}
+
+					const items = response.filter( isShopperListItem );
+
+					// TODO: track in-flight mutation count and skip applying
+					// load results when mutations are pending, so a slow
+					// loadList cannot clobber a fresh add/remove.
+					list.items = items;
+				} catch ( error ) {
+					list.error = ( error as Error ).message;
+				} finally {
+					list.isLoading = false;
+				}
+			},
+
+			*addItem(
+				slug: string,
+				payload: AddItemPayload
+			): AsyncAction< void > {
+				const list = ensureListState( state, slug );
+				list.error = null;
+
+				try {
+					const item = ( yield restRequest< RawShopperListItem >(
+						state,
+						`wc/store/v1/shopper-lists/${ encodeURIComponent(
+							slug
+						) }/items`,
+						{
+							method: 'POST',
+							body: JSON.stringify( payload ),
+						}
+					) ) as TypeYield<
+						typeof restRequest< RawShopperListItem >
+					>;
+
+					if ( ! isShopperListItem( item ) ) {
+						throw new Error(
+							'Invalid shopper list item response.'
+						);
+					}
+
+					// Merge the returned item by key — replace if present,
+					// append otherwise. Re-saving the same product POSTs
+					// twice and the server merges quantity, so we mirror
+					// that behaviour locally.
+					const existingIndex = list.items.findIndex(
+						( i ) => i.key === item.key
+					);
+					if ( existingIndex >= 0 ) {
+						list.items[ existingIndex ] = item;
+					} else {
+						list.items.push( item );
+					}
+				} catch ( error ) {
+					list.error = ( error as Error ).message;
+				}
+			},
+
+			*removeItem( slug: string, key: string ): AsyncAction< void > {
+				const list = state.lists[ slug ];
+				if ( ! list ) {
+					return;
+				}
+
+				const removedIndex = list.items.findIndex(
+					( i ) => i.key === key
+				);
+				if ( removedIndex < 0 ) {
+					return;
+				}
+				const removed = list.items[ removedIndex ];
+
+				// Optimistic remove.
+				list.items.splice( removedIndex, 1 );
+				list.error = null;
+
+				try {
+					yield restRequest(
+						state,
+						`wc/store/v1/shopper-lists/${ encodeURIComponent(
+							slug
+						) }/items/${ encodeURIComponent( key ) }`,
+						{ method: 'DELETE' }
+					);
+				} catch ( error ) {
+					// Restore the row at its original position.
+					list.items.splice( removedIndex, 0, removed );
+					list.error = ( error as Error ).message;
+				}
+			},
+		},
+	},
+	{ lock: universalLock }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -15,8 +15,6 @@ import type {
 import type { Store as StoreNotices } from '@woocommerce/stores/store-notices';
 import '@woocommerce/stores/woocommerce/products';
 import type { ProductsStore } from '@woocommerce/stores/woocommerce/products';
-// PoC: side-effect import so the shopper-lists iAPI store is registered on
-// single-product pages where the Wishlist button is injected after the form.
 import '@woocommerce/stores/woocommerce/shopper-lists';
 import type {
 	RawShopperListItem,
@@ -186,9 +184,7 @@ const { actions } = store< MergedAddToCartWithOptionsStores >(
 									( v ) => v.attribute && v.value
 							  )
 							: [];
-						if (
-							itemPairs.length !== selectedByAttribute.size
-						) {
+						if ( itemPairs.length !== selectedByAttribute.size ) {
 							return false;
 						}
 						return itemPairs.every(
@@ -396,13 +392,12 @@ const { actions } = store< MergedAddToCartWithOptionsStores >(
 					return;
 				}
 
-				const { actions: shopperListsActions } = store<
-					ShopperListsStore
-				>(
-					'woocommerce/shopper-lists',
-					{},
-					{ lock: universalLock }
-				);
+				const { actions: shopperListsActions } =
+					store< ShopperListsStore >(
+						'woocommerce/shopper-lists',
+						{},
+						{ lock: universalLock }
+					);
 
 				const existing = state.matchingWishlistItem;
 				if ( existing ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -7,6 +7,7 @@ import {
 	getConfig,
 	withSyncEvent,
 } from '@wordpress/interactivity';
+import type { AsyncAction } from '@wordpress/interactivity';
 import type {
 	Store as WooCommerce,
 	SelectedAttributes,
@@ -14,6 +15,13 @@ import type {
 import type { Store as StoreNotices } from '@woocommerce/stores/store-notices';
 import '@woocommerce/stores/woocommerce/products';
 import type { ProductsStore } from '@woocommerce/stores/woocommerce/products';
+// PoC: side-effect import so the shopper-lists iAPI store is registered on
+// single-product pages where the Wishlist button is injected after the form.
+import '@woocommerce/stores/woocommerce/shopper-lists';
+import type {
+	RawShopperListItem,
+	Store as ShopperListsStore,
+} from '@woocommerce/stores/woocommerce/shopper-lists';
 
 /**
  * Internal dependencies
@@ -63,6 +71,12 @@ const { state: productsState } = store< ProductsStore >(
 	{ lock: universalLock }
 );
 
+const { state: shopperListsState } = store< ShopperListsStore >(
+	'woocommerce/shopper-lists',
+	{},
+	{ lock: universalLock }
+);
+
 export type AddToCartWithOptionsStore = {
 	state: {
 		noticeIds: string[];
@@ -71,6 +85,8 @@ export type AddToCartWithOptionsStore = {
 		allowsAddingToCart: boolean;
 		quantity: Record< number, number >;
 		selectedAttributes: SelectedAttributes[];
+		matchingWishlistItem: RawShopperListItem | null;
+		isInWishlist: boolean;
 	};
 	actions: {
 		validateQuantity: ( productId: number, value?: number ) => void;
@@ -78,6 +94,7 @@ export type AddToCartWithOptionsStore = {
 		addError: ( error: AddToCartError ) => string;
 		clearErrors: ( group?: string ) => void;
 		addToCart: ( event: SubmitEvent ) => void;
+		toggleWishlistFromForm: () => void;
 	};
 };
 
@@ -130,6 +147,60 @@ const { actions } = store< MergedAddToCartWithOptionsStores >(
 			get selectedAttributes(): SelectedAttributes[] {
 				const context = getContext< Context >();
 				return context.selectedAttributes || [];
+			},
+			// PoC: returns the saved-for-later item that matches the currently
+			// configured product (and variation, if applicable), or null. Used
+			// by both the toggle action (needs the item's `key` to remove) and
+			// the visibility/aria-pressed bindings. Matches by product_id +
+			// attribute/value pairs (order-insensitive) rather than replicating
+			// the server's MD5 key — cheaper and good enough until we tackle
+			// the dedicated wishlist slug.
+			get matchingWishlistItem(): RawShopperListItem | null {
+				const product = productsState.productInContext;
+				if ( ! product ) {
+					return null;
+				}
+				const list = shopperListsState.lists?.[ 'saved-for-later' ];
+				if ( ! list || ! Array.isArray( list.items ) ) {
+					return null;
+				}
+				const context = getContext< Context >();
+				const selected = context.selectedAttributes || [];
+				const selectedByAttribute = new Map(
+					selected
+						.filter( ( s ) => s.attribute && s.value )
+						.map( ( s ) => [ s.attribute, s.value ] )
+				);
+				return (
+					list.items.find( ( item ) => {
+						// Use Number() so a stringified product_id from the
+						// serialized state still matches the typed
+						// product.id (number from the products store).
+						if (
+							Number( item.product_id ) !== Number( product.id )
+						) {
+							return false;
+						}
+						const itemPairs = Array.isArray( item.variation )
+							? item.variation.filter(
+									( v ) => v.attribute && v.value
+							  )
+							: [];
+						if (
+							itemPairs.length !== selectedByAttribute.size
+						) {
+							return false;
+						}
+						return itemPairs.every(
+							( v ) =>
+								selectedByAttribute.get( v.attribute ) ===
+								v.value
+						);
+					} ) || null
+				);
+			},
+			get isInWishlist(): boolean {
+				return state.matchingWishlistItem !== null;
 			},
 		},
 		actions: {
@@ -311,6 +382,45 @@ const { actions } = store< MergedAddToCartWithOptionsStores >(
 					}
 				);
 			} ),
+			// PoC: Toggle the currently configured product in the Saved-for-later
+			// list — add when absent, remove when present. Lives on this store
+			// so the star button injected after the form inherits the form's
+			// iAPI context (`quantity`, `selectedAttributes`) for free.
+			*toggleWishlistFromForm(): AsyncAction< void > {
+				const product = productsState.productInContext;
+				if ( ! product ) {
+					return;
+				}
+
+				if ( ! state.isFormValid ) {
+					return;
+				}
+
+				const { actions: shopperListsActions } = store<
+					ShopperListsStore
+				>(
+					'woocommerce/shopper-lists',
+					{},
+					{ lock: universalLock }
+				);
+
+				const existing = state.matchingWishlistItem;
+				if ( existing ) {
+					yield shopperListsActions.removeItem(
+						'saved-for-later',
+						existing.key
+					);
+					return;
+				}
+
+				const { quantity, selectedAttributes } =
+					getContext< Context >();
+				yield shopperListsActions.addItem( 'saved-for-later', {
+					product_id: product.id,
+					quantity: quantity[ product.id ] || 1,
+					variation: selectedAttributes,
+				} );
+			},
 		},
 	},
 	{ lock: universalLock }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/shopper-collection",
+	"version": "1.0.0",
+	"title": "Shopper Collection",
+	"description": "Display a collection curated by the shopper, such as items they've saved for later.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce", "Saved for Later", "Wishlist", "Shopper Collection" ],
+	"textdomain": "woocommerce",
+	"attributes": {
+		"listName": {
+			"type": "string",
+			"default": "saved-for-later"
+		}
+	},
+	"supports": {
+		 "align": [ "wide", "full" ],
+		"interactivity": true,
+		"html": false,
+		"reusable": false,
+		"layout": {
+			"default": {
+				"type": "grid",
+				"columnCount": 3
+			},
+			"allowEditing": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		},
+		"color": {
+			"text": true,
+			"background": true
+		}
+	},
+	"viewScriptModule": "woocommerce/shopper-collection",
+	"style": "file:../woocommerce/shopper-collection-style.css"
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
@@ -41,5 +41,6 @@
 		}
 	},
 	"viewScriptModule": "woocommerce/shopper-collection",
-	"style": "file:../woocommerce/shopper-collection-style.css"
+	"style": "file:../woocommerce/shopper-collection-style.css",
+	"editorStyle": "file:../woocommerce/shopper-collection-editor.css"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
@@ -1,0 +1,165 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
+
+interface ShopperCollectionAttributes {
+	listName: string;
+	layout?: {
+		type?: string;
+		columnCount?: number;
+	};
+}
+
+interface EditProps {
+	attributes: ShopperCollectionAttributes;
+	setAttributes: ( attrs: Partial< ShopperCollectionAttributes > ) => void;
+}
+
+const DEFAULT_COLUMN_COUNT = 3;
+
+const PREVIEW_ITEMS = [
+	{
+		key: 'preview-1',
+		name: __( 'Sample product one', 'woocommerce' ),
+		variation: __( 'Size: M', 'woocommerce' ),
+		price: '$19.99',
+		quantity: __( 'Qty: 2', 'woocommerce' ),
+	},
+	{
+		key: 'preview-2',
+		name: __( 'Sample product two', 'woocommerce' ),
+		variation: __( 'Color: Blue', 'woocommerce' ),
+		price: '$29.99',
+		quantity: __( 'Qty: 1', 'woocommerce' ),
+	},
+	{
+		key: 'preview-3',
+		name: __( 'Sample product three', 'woocommerce' ),
+		variation: '',
+		price: '$9.99',
+		quantity: __( 'Qty: 3', 'woocommerce' ),
+	},
+	{
+		key: 'preview-4',
+		name: __( 'Sample product four', 'woocommerce' ),
+		variation: __( 'Size: L', 'woocommerce' ),
+		price: '$24.99',
+		quantity: __( 'Qty: 1', 'woocommerce' ),
+	},
+	{
+		key: 'preview-5',
+		name: __( 'Sample product five', 'woocommerce' ),
+		variation: '',
+		price: '$14.99',
+		quantity: __( 'Qty: 2', 'woocommerce' ),
+	},
+	{
+		key: 'preview-6',
+		name: __( 'Sample product six', 'woocommerce' ),
+		variation: __( 'Color: Red', 'woocommerce' ),
+		price: '$39.99',
+		quantity: __( 'Qty: 1', 'woocommerce' ),
+	},
+];
+
+const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
+	const { listName, layout } = attributes;
+	const columnCount =
+		typeof layout?.columnCount === 'number'
+			? layout.columnCount
+			: DEFAULT_COLUMN_COUNT;
+	const blockProps = useBlockProps( {
+		className: 'wc-block-shopper-collection',
+		style: {
+			'--wc-shopper-collection-columns': columnCount,
+		} as React.CSSProperties,
+	} );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Collection settings', 'woocommerce' ) }>
+					<SelectControl
+						label={ __( 'List', 'woocommerce' ) }
+						help={ __(
+							'Choose which shopper list this block displays.',
+							'woocommerce'
+						) }
+						value={ listName }
+						options={ [
+							{
+								label: __( 'Saved for Later', 'woocommerce' ),
+								value: 'saved-for-later',
+							},
+						] }
+						onChange={ ( value: string ) =>
+							setAttributes( { listName: value } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<ul { ...blockProps }>
+				{ PREVIEW_ITEMS.map( ( item ) => (
+					<li
+						key={ item.key }
+						className="wc-block-shopper-collection-item"
+					>
+						<div className="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+							<a
+								href="#preview"
+								onClick={ ( e ) => e.preventDefault() }
+							>
+								<img src={ PLACEHOLDER_IMG_SRC } alt="" />
+							</a>
+							<div className="wc-block-components-product-image__inner-container">
+								<button
+									type="button"
+									className="wc-block-shopper-collection-item__remove"
+									disabled
+								>
+									{ __( 'Remove', 'woocommerce' ) }
+								</button>
+							</div>
+						</div>
+						<h2 className="wp-block-post-title has-text-align-center has-medium-font-size">
+							<a
+								href="#preview"
+								onClick={ ( e ) => e.preventDefault() }
+							>
+								{ item.name }
+							</a>
+						</h2>
+						{ item.variation && (
+							<span className="wc-block-shopper-collection-item__variation">
+								{ item.variation }
+							</span>
+						) }
+						<div className="price wc-block-components-product-price has-text-align-center has-small-font-size">
+							<span className="wc-block-components-product-price__value">
+								{ item.price }
+							</span>
+						</div>
+						<span className="wc-block-shopper-collection-item__quantity">
+							{ item.quantity }
+						</span>
+						<div className="wp-block-button wc-block-components-product-button">
+							<button
+								type="button"
+								className="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+								disabled
+							>
+								{ __( 'Move to cart', 'woocommerce' ) }
+							</button>
+						</div>
+					</li>
+				) ) }
+			</ul>
+		</>
+	);
+};
+
+export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, SelectControl } from '@wordpress/components';
+import { Icon, trash } from '@wordpress/icons';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
 
 interface ShopperCollectionAttributes {
@@ -115,15 +116,26 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 							>
 								<img src={ PLACEHOLDER_IMG_SRC } alt="" />
 							</a>
-							<div className="wc-block-components-product-image__inner-container">
-								<button
-									type="button"
-									className="wc-block-shopper-collection-item__remove"
-									disabled
-								>
-									{ __( 'Remove', 'woocommerce' ) }
-								</button>
-							</div>
+							<button
+								type="button"
+								className="wc-block-shopper-collection-item__remove"
+								aria-label={ sprintf(
+									/* translators: %s: product name. */
+									__(
+										'Remove %s from Saved for later list',
+										'woocommerce'
+									),
+									item.name
+								) }
+								disabled
+							>
+								<Icon icon={ trash } size={ 24 } />
+							</button>
+							{ item.variation && (
+								<span className="wc-block-shopper-collection-item__variation">
+									{ item.variation }
+								</span>
+							) }
 						</div>
 						<h2 className="wp-block-post-title has-text-align-center has-medium-font-size">
 							<a
@@ -133,11 +145,6 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 								{ item.name }
 							</a>
 						</h2>
-						{ item.variation && (
-							<span className="wc-block-shopper-collection-item__variation">
-								{ item.variation }
-							</span>
-						) }
 						<div className="price wc-block-components-product-price has-text-align-center has-small-font-size">
 							<span className="wc-block-components-product-price__value">
 								{ item.price }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
@@ -31,10 +31,9 @@
 		margin: 0 0 0.75rem;
 	}
 
-	// Variation and quantity have no atomic equivalent in Product Collection,
-	// so we own their styling. Center-aligned and small to mirror the rest
-	// of the row (price + button use the WP `has-small-font-size` preset).
-	&__variation,
+	// Quantity has no atomic equivalent in Product Collection, so we own
+	// its styling. Center-aligned and small to mirror the rest of the row
+	// (price + button use the WP `has-small-font-size` preset).
 	&__quantity {
 		color: rgba(0, 0, 0, 0.7);
 		display: block;
@@ -42,30 +41,73 @@
 		text-align: center;
 	}
 
-	// Remove button overlays the image (mirrors Product Collection's
-	// sale-badge slot — top-right corner inside the product-image wrapper).
-	// Positioned absolute with align-self: flex-end so the parent's
-	// __inner-container flex layout pushes it to the right edge.
-	&__remove {
-		align-self: flex-end;
-		appearance: none;
-		background: rgba(0, 0, 0, 0.65);
-		border: 0;
-		border-radius: 999px;
-		color: #fff;
-		cursor: pointer;
-		font-size: var(--wp--preset--font-size--small, 0.75em);
-		line-height: 1;
-		padding: 0.4em 0.75em;
+	// Variation overlay sits at the bottom of the image and shares the
+	// remove badge's border/background/radius so the two corner overlays
+	// read as a pair. Spans the full image width (with the same 4px inset
+	// the remove badge uses on top/right) and is only rendered for
+	// variation products, so when absent the image isn't pushed around.
+	&__variation {
+		background: #fff;
+		border: 1px solid #43454b;
+		border-radius: 4px;
+		bottom: 4px;
+		box-sizing: border-box;
+		color: #43454b;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		left: 4px;
+		padding: 0.25em 0.75em;
+		position: absolute;
+		right: 4px;
+		text-align: center;
 		z-index: 10;
+	}
+
+	// Icon-only Remove button overlaying the image. Visually mirrors the
+	// `wc-block-components-product-sale-badge--align-right` overlay (same
+	// border, radius, colors, white fill, top-right inset over the image)
+	// so it reads as a corner badge. Symmetric padding keeps the hit
+	// area square. Hover inverts the colors for a clear affordance.
+	&__remove {
+		appearance: none;
+		background: #fff;
+		border: 1px solid #fff;
+		border-radius: 4px;
+		box-sizing: border-box;
+		color: #43454b;
+		cursor: pointer;
+		display: block;
+		line-height: 0;
+		padding: 0.25em;
+		position: absolute;
+		right: 4px;
+		top: 4px;
+		transition: background-color 120ms ease, color 120ms ease;
+		z-index: 10;
+
+		svg {
+			display: block;
+			fill: currentColor;
+		}
+
+		&:hover:not([disabled]) {
+			background: #43454b;
+			color: #fff;
+		}
+
+		// Keyboard focus indicator. The default :focus-visible ring would
+		// land on a transparent border against the white badge body and
+		// be invisible, so paint our own — outline (so it sits outside the
+		// border without nudging layout) plus a soft offset to keep it
+		// readable over both the badge body and the product image behind
+		// it. Not applied to :hover-only — pointer users keep the invert.
+		&:focus-visible:not([disabled]) {
+			outline: 2px solid #43454b;
+			outline-offset: 1px;
+		}
 
 		&[disabled] {
 			cursor: not-allowed;
 			opacity: 0.7;
-		}
-
-		&:hover:not([disabled]) {
-			background: rgba(0, 0, 0, 0.85);
 		}
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/editor.scss
@@ -1,0 +1,88 @@
+// The block IS the grid. supports.layout's `columnCount` attribute drives
+// our --wc-shopper-collection-columns CSS variable (set inline on the wrapper
+// in both editor preview and PHP render). No nested grids, no inner blocks.
+.wc-block-shopper-collection {
+	display: grid;
+	gap: var(--wp--style--block-gap, 1.5em);
+	grid-template-columns: repeat(
+		var(--wc-shopper-collection-columns, 3),
+		minmax(0, 1fr)
+	);
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wc-block-shopper-collection-item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em;
+
+	// Image and price visual styling come from the shared atomic classes
+	// (wc-block-components-product-image / -price) loaded by the global
+	// wc-blocks stylesheet — no per-element rules needed here.
+
+	// Title spacing/line-height matches Product Collection's default
+	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
+	// We target wp-block-post-title (core's post-title class) because the
+	// editor preview mirrors PC's editor render, which uses core/post-title.
+	.wp-block-post-title {
+		line-height: 1.4;
+		margin: 0 0 0.75rem;
+	}
+
+	// Variation and quantity have no atomic equivalent in Product Collection,
+	// so we own their styling. Center-aligned and small to mirror the rest
+	// of the row (price + button use the WP `has-small-font-size` preset).
+	&__variation,
+	&__quantity {
+		color: rgba(0, 0, 0, 0.7);
+		display: block;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		text-align: center;
+	}
+
+	// Remove button overlays the image (mirrors Product Collection's
+	// sale-badge slot — top-right corner inside the product-image wrapper).
+	// Positioned absolute with align-self: flex-end so the parent's
+	// __inner-container flex layout pushes it to the right edge.
+	&__remove {
+		align-self: flex-end;
+		appearance: none;
+		background: rgba(0, 0, 0, 0.65);
+		border: 0;
+		border-radius: 999px;
+		color: #fff;
+		cursor: pointer;
+		font-size: var(--wp--preset--font-size--small, 0.75em);
+		line-height: 1;
+		padding: 0.4em 0.75em;
+		z-index: 10;
+
+		&[disabled] {
+			cursor: not-allowed;
+			opacity: 0.7;
+		}
+
+		&:hover:not([disabled]) {
+			background: rgba(0, 0, 0, 0.85);
+		}
+	}
+}
+
+.wc-block-shopper-collection__empty {
+	color: rgba(0, 0, 0, 0.7);
+	grid-column: 1 / -1;
+	padding: 1em 0;
+	text-align: center;
+}
+
+// Error state spans every grid column so it reads as a single alert
+// rather than a badly-sized cell when the collection has a multi-column
+// layout. Same treatment as the empty state above for symmetry.
+.wc-block-shopper-collection__error {
+	color: #b91c1c;
+	grid-column: 1 / -1;
+	padding: 1em 0;
+	text-align: center;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -1,0 +1,6 @@
+/**
+ * Side-effect import that boots the Shopper Collection iAPI store on the
+ * frontend. The store itself will be wired in a follow-up that adds the
+ * `@woocommerce/stores/woocommerce/shopper-lists` module.
+ */
+export {};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -1,6 +1,305 @@
 /**
- * Side-effect import that boots the Shopper Collection iAPI store on the
- * frontend. The store itself will be wired in a follow-up that adds the
- * `@woocommerce/stores/woocommerce/shopper-lists` module.
+ * External dependencies
  */
-export {};
+import {
+	getConfig,
+	getContext,
+	getElement,
+	store,
+	type AsyncAction,
+} from '@wordpress/interactivity';
+import '@woocommerce/stores/woocommerce/shopper-lists';
+import '@woocommerce/stores/woocommerce/cart';
+import type {
+	RawShopperListItem,
+	Store as ShopperListsStore,
+} from '@woocommerce/stores/woocommerce/shopper-lists';
+import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
+import { sanitizeHTML } from '@woocommerce/sanitize';
+
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+type ShopperCollectionConfig = {
+	quantityLabelTemplate: string;
+	removeLabelTemplate: string;
+};
+
+type BlockContext = {
+	listSlug: string;
+	listItem?: RawShopperListItem;
+	htmlField?: 'price_html' | 'image_html';
+};
+
+type BlockStore = {
+	state: {
+		currentItems: RawShopperListItem[];
+		hasError: boolean;
+		errorMessage: string;
+		isEmpty: boolean;
+		isMoveToCartHidden: boolean;
+		isPriceHidden: boolean;
+		currentItemDisplayName: string;
+		currentItemQuantityLabel: string;
+		currentItemRemoveLabel: string;
+		currentItemVariationLabel: string;
+	};
+	actions: {
+		onClickRemove: () => Generator< unknown, void >;
+		onClickMoveToCart: () => Generator< unknown, void >;
+	};
+	callbacks: {
+		updateInnerHtml: () => void;
+	};
+};
+
+// Allow-list for sanitizing the schema's preformatted strings on innerHTML
+// swap. Covers what `wc_price` (sale/discount markup, currency symbol) and
+// `wp_get_attachment_image` / `wc_placeholder_img` emit (responsive image
+// + dimensions + lazy loading).
+const ALLOWED_TAGS = [
+	'a',
+	'b',
+	'em',
+	'i',
+	'strong',
+	'p',
+	'br',
+	'span',
+	'bdi',
+	'del',
+	'ins',
+	'img',
+	'picture',
+	'source',
+];
+const ALLOWED_ATTR = [
+	'class',
+	'target',
+	'href',
+	'rel',
+	'name',
+	'download',
+	'aria-hidden',
+	'src',
+	'srcset',
+	'sizes',
+	'alt',
+	'width',
+	'height',
+	'loading',
+	'decoding',
+];
+
+const { state: shopperListsState, actions: shopperListsActions } =
+	store< ShopperListsStore >(
+		'woocommerce/shopper-lists',
+		{},
+		{ lock: universalLock }
+	);
+
+const { state: cartState, actions: cartActions } = store< WooCommerce >(
+	'woocommerce',
+	{},
+	{ lock: universalLock }
+);
+
+const decodeEntities = ( encoded: string ): string => {
+	const txt = document.createElement( 'textarea' );
+	txt.innerHTML = encoded;
+	return txt.value;
+};
+
+const formatVariationLabel = ( item: RawShopperListItem ): string => {
+	if ( ! item.variation || item.variation.length === 0 ) {
+		return '';
+	}
+	return item.variation
+		.map(
+			( v ) =>
+				`${ decodeEntities( v.attribute ) }: ${ decodeEntities(
+					v.value
+				) }`
+		)
+		.join( ', ' );
+};
+
+const getList = ( slug: string ) => shopperListsState.lists[ slug ] ?? null;
+
+store< BlockStore >(
+	'woocommerce/shopper-collection',
+	{
+		state: {
+			get currentItems(): RawShopperListItem[] {
+				const { listSlug } = getContext< BlockContext >();
+				return getList( listSlug )?.items ?? [];
+			},
+
+			get hasError(): boolean {
+				const { listSlug } = getContext< BlockContext >();
+				return !! getList( listSlug )?.error;
+			},
+
+			get errorMessage(): string {
+				const { listSlug } = getContext< BlockContext >();
+				return getList( listSlug )?.error ?? '';
+			},
+
+			get isEmpty(): boolean {
+				const { listSlug } = getContext< BlockContext >();
+				const list = getList( listSlug );
+				if ( ! list ) {
+					return true;
+				}
+				return ! list.isLoading && list.items.length === 0;
+			},
+
+			get isPriceHidden(): boolean {
+				const { listItem } = getContext< BlockContext >();
+				return ! listItem?.price_html;
+			},
+
+			get isMoveToCartHidden(): boolean {
+				const { listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return true;
+				}
+				// Tombstones never have a buyable product.
+				return ! listItem.product_exists;
+			},
+
+			// `data-wp-text` writes its argument as text-content without
+			// running entity decoding, so a name returned by the schema as
+			// `Tom &amp; Jerry` would render literally that way. Bind
+			// templates and SSR text spans to this getter instead of the
+			// raw context field so what the browser shows matches what
+			// PHP wrote on first paint.
+			get currentItemDisplayName(): string {
+				const { listItem } = getContext< BlockContext >();
+				return listItem ? decodeEntities( listItem.name ) : '';
+			},
+
+			get currentItemQuantityLabel(): string {
+				const { listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return '';
+				}
+				const { quantityLabelTemplate } = getConfig(
+					'woocommerce/shopper-collection'
+				) as ShopperCollectionConfig;
+				return quantityLabelTemplate.replace(
+					'%d',
+					String( listItem.quantity )
+				);
+			},
+
+			get currentItemRemoveLabel(): string {
+				const { listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return '';
+				}
+				const { removeLabelTemplate } = getConfig(
+					'woocommerce/shopper-collection'
+				) as ShopperCollectionConfig;
+				return removeLabelTemplate.replace(
+					'%s',
+					decodeEntities( listItem.name )
+				);
+			},
+
+			get currentItemVariationLabel(): string {
+				const { listItem } = getContext< BlockContext >();
+				return listItem ? formatVariationLabel( listItem ) : '';
+			},
+		},
+
+		actions: {
+			*onClickRemove(): AsyncAction< void > {
+				const { listSlug, listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return;
+				}
+				yield shopperListsActions.removeItem( listSlug, listItem.key );
+			},
+
+			*onClickMoveToCart(): AsyncAction< void > {
+				const { listSlug, listItem } = getContext< BlockContext >();
+				if ( ! listItem || ! listItem.product_exists ) {
+					return;
+				}
+
+				// Map the schema's `variation` shape to the cart's
+				// SelectedAttributes shape. The schema returns the
+				// slug-form attribute under `raw_attribute` (e.g.
+				// `attribute_pa_color`) plus a display label under
+				// `attribute` (e.g. "Color"); the cart matches by the
+				// slug-form, so override `attribute` with `raw_attribute`.
+				// Same swap mini-cart's `changeQuantity` does. Empty for
+				// simple products.
+				const variation = listItem.variation.map(
+					( { raw_attribute: rawAttribute, value, attribute } ) => ( {
+						attribute: rawAttribute || attribute,
+						value,
+					} )
+				);
+				const isVariation = listItem.variation_id > 0;
+
+				// `cartActions.addCartItem` catches its own errors and
+				// surfaces them as store notices, so the yield resolves
+				// the same way on success and failure. Snapshot the
+				// matching line's quantity, run the add, then only remove
+				// from the saved list if it actually grew.
+				const lookup = {
+					id: listItem.id,
+					...( isVariation && { variation } ),
+				};
+				const beforeItem = cartState.findItemInCart( lookup );
+				const beforeQuantity = beforeItem?.quantity ?? 0;
+
+				yield cartActions.addCartItem( {
+					id: listItem.id,
+					quantityToAdd: listItem.quantity,
+					type: isVariation ? 'variation' : 'simple',
+					...( isVariation && { variation } ),
+				} );
+
+				const afterItem = cartState.findItemInCart( lookup );
+				const afterQuantity = afterItem?.quantity ?? 0;
+
+				if ( afterQuantity <= beforeQuantity ) {
+					return;
+				}
+
+				yield shopperListsActions.removeItem( listSlug, listItem.key );
+			},
+		},
+
+		callbacks: {
+			// Single shared innerHTML-swap callback for any slot whose
+			// content is one of the schema's preformatted HTML fields.
+			// Mirrors the atomic product-elements `updateValue` callback:
+			// the watched element carries `data-wp-context='{"htmlField":"price_html"}'`
+			// (or `"image_html"`), and this callback reads that field
+			// off the row's `listItem` and pastes its sanitized HTML into
+			// `element.ref`. PHP renders the same HTML server-side, so
+			// hydration is a no-op when the row's listItem hasn't changed,
+			// and a clean swap when it has (e.g. after Remove shifts the
+			// next item into this slot).
+			updateInnerHtml: () => {
+				const { ref } = getElement();
+				const { listItem, htmlField } = getContext< BlockContext >();
+				if ( ! ref || ! listItem || ! htmlField ) {
+					return;
+				}
+				const html = listItem[ htmlField ];
+				if ( typeof html === 'string' ) {
+					ref.innerHTML = sanitizeHTML( html, {
+						tags: ALLOWED_TAGS,
+						attr: ALLOWED_ATTR,
+					} );
+				}
+			},
+		},
+	},
+	{ lock: universalLock }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/index.tsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { Icon, starEmpty } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import Save from './save';
+import './variations';
+import './style.scss';
+
+registerBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				icon={ starEmpty }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+	save: Save,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/save.tsx
@@ -1,0 +1,7 @@
+/**
+ * The block is rendered server-side. The save callback returns null so the
+ * Block Editor stores no static markup.
+ */
+const Save = (): null => null;
+
+export default Save;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -1,6 +1,31 @@
-// The block IS the grid. supports.layout's `columnCount` attribute drives
-// our --wc-shopper-collection-columns CSS variable (set inline on the wrapper
-// in both editor preview and PHP render). No nested grids, no inner blocks.
+// Frontend stylesheet for the Shopper Collection block.
+// Diverges from `editor.scss` because the editor canvas loads the
+// WooCommerce atomic block stylesheet for free (which provides image
+// sizing, the relative/absolute positioning for the remove-button
+// overlay, etc.); the frontend only ships this block's CSS, so anything
+// the layout depends on has to live here. If we add pieces to
+// editor.scss that the frontend also needs, mirror them here too —
+// keep the visual result aligned.
+// TODO: revisit how this block depends on atomic-block CSS. We currently
+// borrow `.wc-block-components-product-image` / `__inner-container` from
+// the product-image atomic block. Product Collection avoids this problem
+// by *rendering* the atomic blocks as inner blocks, so WordPress
+// auto-enqueues their stylesheets — we don't, so we have to handle it
+// ourselves. Three options:
+//   1. (current) Duplicate the rules we need into this file.
+//      Self-contained but drifts if atomic styles change upstream.
+//   2. Enqueue the atomic image stylesheet from ShopperCollection.php
+//      (e.g. `wp_enqueue_style( 'wc-block-product-elements-image' )` —
+//      verify the actual handle in the build). Zero duplication, but
+//      pulls in the whole atomic stylesheet for a few rules.
+//   3. Stop borrowing atomic classes — give our markup its own
+//      block-local classes (e.g. `wc-block-shopper-collection-item__image`,
+//      `__image-link`) and own all the styling. Cleanest ownership, but
+//      requires a small template rewrite.
+// Option 1 is the lightest while we only borrow two classes; switch to
+// option 2 if we end up borrowing more, or option 3 if a future
+// variation needs different image/overlay behaviour.
+
 .wc-block-shopper-collection {
 	display: grid;
 	gap: var(--wp--style--block-gap, 1.5em);
@@ -18,9 +43,34 @@
 	flex-direction: column;
 	gap: 0.25em;
 
-	// Image and price visual styling come from the shared atomic classes
-	// (wc-block-components-product-image / -price) loaded by the global
-	// wc-blocks stylesheet — no per-element rules needed here.
+	// `.wc-block-components-product-image` is normally styled by the
+	// atomic-block stylesheet. Reproduce just enough here so the
+	// image fills its column track and acts as a positioning anchor
+	// for the remove-button overlay.
+	.wc-block-components-product-image {
+		display: block;
+		margin: 0;
+		position: relative;
+
+		img {
+			display: block;
+			height: auto;
+			max-width: 100%;
+			width: 100%;
+		}
+	}
+
+	// The remove button lives inside `__inner-container` which the
+	// atomic stylesheet positions absolutely in the top-right of the
+	// image. Replicate that here so the button overlays rather than
+	// stacking below the thumbnail.
+	.wc-block-components-product-image__inner-container {
+		padding: 0.5em;
+		position: absolute;
+		right: 0;
+		top: 0;
+		z-index: 10;
+	}
 
 	// Title spacing/line-height matches Product Collection's default
 	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
@@ -42,12 +92,10 @@
 		text-align: center;
 	}
 
-	// Remove button overlays the image (mirrors Product Collection's
-	// sale-badge slot — top-right corner inside the product-image wrapper).
-	// Positioned absolute with align-self: flex-end so the parent's
-	// __inner-container flex layout pushes it to the right edge.
+	// The remove button is centered inside `__inner-container`, which is
+	// itself absolutely positioned over the image. No alignment hacks
+	// needed here; just style the pill.
 	&__remove {
-		align-self: flex-end;
 		appearance: none;
 		background: rgba(0, 0, 0, 0.65);
 		border: 0;
@@ -57,7 +105,6 @@
 		font-size: var(--wp--preset--font-size--small, 0.75em);
 		line-height: 1;
 		padding: 0.4em 0.75em;
-		z-index: 10;
 
 		&[disabled] {
 			cursor: not-allowed;
@@ -72,6 +119,17 @@
 
 .wc-block-shopper-collection__empty {
 	color: rgba(0, 0, 0, 0.7);
+	grid-column: 1 / -1;
+	padding: 1em 0;
+	text-align: center;
+}
+
+// Error state spans every grid column so it reads as a single alert
+// rather than a badly-sized cell when the collection has a multi-column
+// layout. Same treatment as the empty state above for symmetry.
+.wc-block-shopper-collection__error {
+	color: #b91c1c;
+	grid-column: 1 / -1;
 	padding: 1em 0;
 	text-align: center;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -1,0 +1,77 @@
+// The block IS the grid. supports.layout's `columnCount` attribute drives
+// our --wc-shopper-collection-columns CSS variable (set inline on the wrapper
+// in both editor preview and PHP render). No nested grids, no inner blocks.
+.wc-block-shopper-collection {
+	display: grid;
+	gap: var(--wp--style--block-gap, 1.5em);
+	grid-template-columns: repeat(
+		var(--wc-shopper-collection-columns, 3),
+		minmax(0, 1fr)
+	);
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wc-block-shopper-collection-item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em;
+
+	// Image and price visual styling come from the shared atomic classes
+	// (wc-block-components-product-image / -price) loaded by the global
+	// wc-blocks stylesheet — no per-element rules needed here.
+
+	// Title spacing/line-height matches Product Collection's default
+	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
+	// We target wp-block-post-title (core's post-title class) because the
+	// editor preview mirrors PC's editor render, which uses core/post-title.
+	.wp-block-post-title {
+		line-height: 1.4;
+		margin: 0 0 0.75rem;
+	}
+
+	// Variation and quantity have no atomic equivalent in Product Collection,
+	// so we own their styling. Center-aligned and small to mirror the rest
+	// of the row (price + button use the WP `has-small-font-size` preset).
+	&__variation,
+	&__quantity {
+		color: rgba(0, 0, 0, 0.7);
+		display: block;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		text-align: center;
+	}
+
+	// Remove button overlays the image (mirrors Product Collection's
+	// sale-badge slot — top-right corner inside the product-image wrapper).
+	// Positioned absolute with align-self: flex-end so the parent's
+	// __inner-container flex layout pushes it to the right edge.
+	&__remove {
+		align-self: flex-end;
+		appearance: none;
+		background: rgba(0, 0, 0, 0.65);
+		border: 0;
+		border-radius: 999px;
+		color: #fff;
+		cursor: pointer;
+		font-size: var(--wp--preset--font-size--small, 0.75em);
+		line-height: 1;
+		padding: 0.4em 0.75em;
+		z-index: 10;
+
+		&[disabled] {
+			cursor: not-allowed;
+			opacity: 0.7;
+		}
+
+		&:hover:not([disabled]) {
+			background: rgba(0, 0, 0, 0.85);
+		}
+	}
+}
+
+.wc-block-shopper-collection__empty {
+	color: rgba(0, 0, 0, 0.7);
+	padding: 1em 0;
+	text-align: center;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -1,30 +1,16 @@
 // Frontend stylesheet for the Shopper Collection block.
 // Diverges from `editor.scss` because the editor canvas loads the
 // WooCommerce atomic block stylesheet for free (which provides image
-// sizing, the relative/absolute positioning for the remove-button
-// overlay, etc.); the frontend only ships this block's CSS, so anything
-// the layout depends on has to live here. If we add pieces to
-// editor.scss that the frontend also needs, mirror them here too —
-// keep the visual result aligned.
+// sizing for the borrowed `.wc-block-components-product-image` class);
+// the frontend only ships this block's CSS, so anything the layout
+// depends on has to live here. If we add pieces to editor.scss that
+// the frontend also needs, mirror them here too — keep the visual
+// result aligned.
 // TODO: revisit how this block depends on atomic-block CSS. We currently
-// borrow `.wc-block-components-product-image` / `__inner-container` from
-// the product-image atomic block. Product Collection avoids this problem
-// by *rendering* the atomic blocks as inner blocks, so WordPress
-// auto-enqueues their stylesheets — we don't, so we have to handle it
-// ourselves. Three options:
-//   1. (current) Duplicate the rules we need into this file.
-//      Self-contained but drifts if atomic styles change upstream.
-//   2. Enqueue the atomic image stylesheet from ShopperCollection.php
-//      (e.g. `wp_enqueue_style( 'wc-block-product-elements-image' )` —
-//      verify the actual handle in the build). Zero duplication, but
-//      pulls in the whole atomic stylesheet for a few rules.
-//   3. Stop borrowing atomic classes — give our markup its own
-//      block-local classes (e.g. `wc-block-shopper-collection-item__image`,
-//      `__image-link`) and own all the styling. Cleanest ownership, but
-//      requires a small template rewrite.
-// Option 1 is the lightest while we only borrow two classes; switch to
-// option 2 if we end up borrowing more, or option 3 if a future
-// variation needs different image/overlay behaviour.
+// borrow `.wc-block-components-product-image` from the product-image
+// atomic block. Product Collection avoids this problem by *rendering*
+// the atomic blocks as inner blocks, so WordPress auto-enqueues their
+// stylesheets — we don't, so we have to handle it ourselves.
 
 .wc-block-shopper-collection {
 	display: grid;
@@ -46,7 +32,7 @@
 	// `.wc-block-components-product-image` is normally styled by the
 	// atomic-block stylesheet. Reproduce just enough here so the
 	// image fills its column track and acts as a positioning anchor
-	// for the remove-button overlay.
+	// for the remove-button badge overlay.
 	.wc-block-components-product-image {
 		display: block;
 		margin: 0;
@@ -60,18 +46,6 @@
 		}
 	}
 
-	// The remove button lives inside `__inner-container` which the
-	// atomic stylesheet positions absolutely in the top-right of the
-	// image. Replicate that here so the button overlays rather than
-	// stacking below the thumbnail.
-	.wc-block-components-product-image__inner-container {
-		padding: 0.5em;
-		position: absolute;
-		right: 0;
-		top: 0;
-		z-index: 10;
-	}
-
 	// Title spacing/line-height matches Product Collection's default
 	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
 	// We target wp-block-post-title (core's post-title class) because the
@@ -81,10 +55,9 @@
 		margin: 0 0 0.75rem;
 	}
 
-	// Variation and quantity have no atomic equivalent in Product Collection,
-	// so we own their styling. Center-aligned and small to mirror the rest
-	// of the row (price + button use the WP `has-small-font-size` preset).
-	&__variation,
+	// Quantity has no atomic equivalent in Product Collection, so we own
+	// its styling. Center-aligned and small to mirror the rest of the row
+	// (price + button use the WP `has-small-font-size` preset).
 	&__quantity {
 		color: rgba(0, 0, 0, 0.7);
 		display: block;
@@ -92,27 +65,73 @@
 		text-align: center;
 	}
 
-	// The remove button is centered inside `__inner-container`, which is
-	// itself absolutely positioned over the image. No alignment hacks
-	// needed here; just style the pill.
+	// Variation overlay sits at the bottom of the image and shares the
+	// remove badge's border/background/radius so the two corner overlays
+	// read as a pair. Spans the full image width (with the same 4px inset
+	// the remove badge uses on top/right) and is only rendered for
+	// variation products, so when absent the image isn't pushed around.
+	&__variation {
+		background: #fff;
+		border: 1px solid #43454b;
+		border-radius: 4px;
+		bottom: 4px;
+		box-sizing: border-box;
+		color: #43454b;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		left: 4px;
+		padding: 0.25em 0.75em;
+		position: absolute;
+		right: 4px;
+		text-align: center;
+		z-index: 10;
+	}
+
+	// Icon-only Remove button overlaying the image. Visually mirrors the
+	// `wc-block-components-product-sale-badge--align-right` overlay (same
+	// border, radius, colors, white fill, top-right inset over the image)
+	// so it reads as a corner badge. Symmetric padding keeps the hit
+	// area square. Hover inverts the colors for a clear affordance.
 	&__remove {
 		appearance: none;
-		background: rgba(0, 0, 0, 0.65);
-		border: 0;
-		border-radius: 999px;
-		color: #fff;
+		background: #fff;
+		border: 1px solid #fff;
+		border-radius: 4px;
+		box-sizing: border-box;
+		color: #43454b;
 		cursor: pointer;
-		font-size: var(--wp--preset--font-size--small, 0.75em);
-		line-height: 1;
-		padding: 0.4em 0.75em;
+		display: block;
+		line-height: 0;
+		padding: 0.25em;
+		position: absolute;
+		right: 4px;
+		top: 4px;
+		transition: background-color 120ms ease, color 120ms ease;
+		z-index: 10;
+
+		svg {
+			display: block;
+			fill: currentColor;
+		}
+
+		&:hover:not([disabled]) {
+			background: #43454b;
+			color: #fff;
+		}
+
+		// Keyboard focus indicator. The default :focus-visible ring would
+		// land on a transparent border against the white badge body and
+		// be invisible, so paint our own — outline (so it sits outside the
+		// border without nudging layout) plus a soft offset to keep it
+		// readable over both the badge body and the product image behind
+		// it. Not applied to :hover-only — pointer users keep the invert.
+		&:focus-visible:not([disabled]) {
+			outline: 2px solid #43454b;
+			outline-offset: 1px;
+		}
 
 		&[disabled] {
 			cursor: not-allowed;
 			opacity: 0.7;
-		}
-
-		&:hover:not([disabled]) {
-			background: rgba(0, 0, 0, 0.85);
 		}
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/variations/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/variations/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './saved-for-later';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/variations/saved-for-later.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/variations/saved-for-later.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { registerBlockVariation } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { starEmpty } from '@wordpress/icons';
+
+export const VARIATION_NAME = 'saved-for-later';
+
+registerBlockVariation( 'woocommerce/shopper-collection', {
+	name: VARIATION_NAME,
+	title: __( 'Saved for Later', 'woocommerce' ),
+	description: __(
+		'Display items the shopper has saved from their cart for later.',
+		'woocommerce'
+	),
+	icon: starEmpty,
+	scope: [ 'inserter', 'block' ],
+	attributes: {
+		listName: 'saved-for-later',
+	},
+	isActive: [ 'listName' ],
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -21,6 +21,7 @@ import {
 	type ConfigOf,
 	type ActionCreatorsOf,
 } from '@wordpress/data/build-types/types';
+import { __ } from '@wordpress/i18n';
 import { cartStore } from '@woocommerce/block-data';
 
 /**
@@ -160,8 +161,8 @@ export const applyExtensionCartUpdate =
 
 			if ( ! includeShipping || ! includeBilling ) {
 				const {
-					shipping_address: _,
-					billing_address: __,
+					shipping_address: _shipping,
+					billing_address: _billing,
 					...responseWithoutAddresses
 				} = response;
 
@@ -485,6 +486,58 @@ export const removeItemFromCart =
 	};
 
 /**
+ * Saves a cart line item to the saved-for-later shopper list.
+ *
+ * On success, emits a `wc-blocks_store_sync_required` event with the saved
+ * item in `detail.item` so a `woocommerce/shopper-lists` iAPI store on the
+ * same page (rendered by a Shopper Collection block) can splice the row
+ * into its local state — no extra GET, no race window between a slow
+ * refetch and concurrent mutations. Same envelope the cart's iAPI → wp.data
+ * sync uses to ship payloads (`detail.type === 'from_iAPI'` carries
+ * `quantityChanges`); this is the wp.data → iAPI direction of the same
+ * pattern.
+ *
+ * Removing the item from the cart is the caller's responsibility — keep the
+ * two awaits separate so save and remove errors can be reported distinctly.
+ *
+ * @param {string} cartItemKey Cart item to save.
+ */
+export const saveForLater =
+	( cartItemKey: string ) => async (): Promise< { key: string } > => {
+		if (
+			typeof cartItemKey !== 'string' ||
+			cartItemKey.trim().length === 0
+		) {
+			throw new Error(
+				__(
+					'A cart item is required to save it for later.',
+					'woocommerce'
+				)
+			);
+		}
+		const { response } = await apiFetchWithHeaders< {
+			response: { key: string };
+		} >( {
+			path: '/wc/store/v1/shopper-lists/saved-for-later/items',
+			method: 'POST',
+			data: { cart_item_key: cartItemKey },
+			cache: 'no-store',
+		} );
+
+		window.dispatchEvent(
+			new CustomEvent( 'wc-blocks_store_sync_required', {
+				detail: {
+					type: 'shopper-list-item-added',
+					slug: 'saved-for-later',
+					item: response,
+				},
+			} )
+		);
+
+		return response;
+	};
+
+/**
  * Tracks AbortControllers per cart item for cancelling in-flight quantity requests.
  */
 const quantityAbortControllers = new Map< string, AbortController >();
@@ -698,6 +751,7 @@ export type Thunks =
 	| typeof removeCoupon
 	| typeof addItemToCart
 	| typeof removeItemFromCart
+	| typeof saveForLater
 	| typeof changeCartItemQuantity
 	| typeof selectShippingRate
 	| typeof updateCustomerData;

--- a/plugins/woocommerce/client/blocks/assets/js/data/shared-controls.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/shared-controls.ts
@@ -130,6 +130,9 @@ const preventBatching = [
 	'/wc/store/v1/checkout',
 	'/wc/store/v1/checkout?__experimental_calc_totals=true',
 	'/wc/store/v1/cart/update-item',
+	// Shopper-lists routes don't declare allow_batch yet. Drop these once
+	// the routes opt into batching server-side.
+	'/wc/store/v1/shopper-lists/saved-for-later/items',
 ];
 
 /**

--- a/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
@@ -46,6 +46,8 @@ const entries = {
 		'./assets/js/base/stores/store-notices.ts',
 	'@woocommerce/stores/woocommerce/products':
 		'./assets/js/base/stores/woocommerce/products.ts',
+	'@woocommerce/stores/woocommerce/shopper-lists':
+		'./assets/js/base/stores/woocommerce/shopper-lists.ts',
 };
 
 module.exports = {

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -115,6 +115,7 @@ const blocks = {
 	'reviews-by-product': {
 		customDir: 'reviews/reviews-by-product',
 	},
+	'shopper-collection': {},
 	'single-product': {},
 	'stock-filter': {},
 	'store-notices': {},

--- a/plugins/woocommerce/client/blocks/tsconfig.base.json
+++ b/plugins/woocommerce/client/blocks/tsconfig.base.json
@@ -124,6 +124,9 @@
 			"@woocommerce/stores/woocommerce/products": [
 				"assets/js/base/stores/woocommerce/products"
 			],
+			"@woocommerce/stores/woocommerce/shopper-lists": [
+				"assets/js/base/stores/woocommerce/shopper-lists"
+			],
 			"@woocommerce/type-defs/*": [
 				"assets/js/types/type-defs/*"
 			],

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -399,6 +399,8 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\ProductFeed\ProductFeed::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\ShopperLists\WishlistEndpoint::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\ShopperLists\WishlistFromSingleProduct::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/phpstan.neon
+++ b/plugins/woocommerce/phpstan.neon
@@ -39,6 +39,17 @@ parameters:
 		WC_TEMPLATE_DEBUG_MODE: bool
 	ignoreErrors:
 		- identifier: missingType.iterableValue
+		# ShopperListItemSchema uses ProductItemTrait only for format_variation_data();
+		# the trait's unused prepare_product_price_response() assumes a ProductSchema parent.
+		-
+			message: '#Call to an undefined method Automattic\\WooCommerce\\StoreApi\\Schemas\\V1\\ShopperListItemSchema::get_tax_display_mode\(\)#'
+			path: src/StoreApi/Utilities/ProductItemTrait.php
+		-
+			message: '#Call to an undefined method Automattic\\WooCommerce\\StoreApi\\Schemas\\V1\\ShopperListItemSchema::get_price_function_from_tax_display_mode\(\)#'
+			path: src/StoreApi/Utilities/ProductItemTrait.php
+		-
+			message: '#Call to an undefined static method Automattic\\WooCommerce\\StoreApi\\Schemas\\V1\\AbstractSchema::prepare_product_price_response\(\)#'
+			path: src/StoreApi/Utilities/ProductItemTrait.php
 	parallel:
 		maximumNumberOfProcesses: 4
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -264,6 +264,10 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'isBlockTheme', wp_is_block_theme() );
 		$this->asset_data_registry->add( 'shippingMethodsExist', CartCheckoutUtils::shipping_methods_exist() > 0 );
 
+		if ( has_block( 'woocommerce/shopper-collection' ) ) {
+			$this->asset_data_registry->add( 'cartPageHasSavedForLater', true );
+		}
+
 		$is_block_editor = $this->is_block_editor();
 
 		// Check `current_user_can` so we can show notices about incompatible extensions in the front-end to admins too.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -4,13 +4,15 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+
 /**
  * Shopper Collection block.
  *
- * Renders a collection curated by the shopper (e.g. Saved for Later). The data
- * source and frontend interactivity are wired in follow-up tasks; this class
- * is the structural backbone that registers the block and outputs the
- * server-side container the iAPI store will hydrate.
+ * Renders a collection curated by the shopper (e.g. Saved for Later) wired to
+ * the `shopper-lists` Store API endpoints via the shared `woocommerce/shopper-lists`
+ * iAPI store. PHP prefetches the active list so the first paint is already
+ * populated; JS then takes over for adds, removes, and Move-to-cart.
  */
 final class ShopperCollection extends AbstractBlock {
 	/**
@@ -29,36 +31,474 @@ final class ShopperCollection extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$column_count = isset( $attributes['layout']['columnCount'] ) && is_numeric( $attributes['layout']['columnCount'] )
-			? max( 1, (int) $attributes['layout']['columnCount'] )
-			: 3;
+		// `listName` is declared with a default in block.json, so WP core's
+		// `prepare_attributes_for_render` guarantees it's set as a string by
+		// the time we get here. `sanitize_title` is *not* redundant though:
+		// the schema only enforces `type: string`, and the block editor's
+		// "Edit as HTML" path lets anyone override the attribute with an
+		// arbitrary string. The slug then flows into a REST URL, into the
+		// `data-wp-context` JSON, into `data-wp-key`, and into the
+		// `wc-block-shopper-collection--{slug}` CSS modifier class — so we
+		// normalize it to `[a-z0-9_-]+` here. Empty result falls back to the
+		// declared default.
+		$list_slug = sanitize_title( $attributes['listName'] );
+		if ( '' === $list_slug ) {
+			$list_slug = 'saved-for-later';
+		}
+
+		// `layout` comes from `supports.layout`, not a declared attribute, so WP doesn't guarantee every nested key is set — `??` covers a partial layout object.
+		$column_count = max( 1, (int) ( $attributes['layout']['columnCount'] ?? 3 ) );
+
+		$variation = $this->get_variation_config();
+
+		wp_enqueue_script_module( $this->get_full_block_name() );
+
+		$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
+		BlocksSharedState::load_store_config( $consent );
+		BlocksSharedState::load_placeholder_image( $consent );
+		// `Move to cart` calls into the shared cart store, which expects
+		// `state.cart.items` and friends. Without this load the cart store
+		// would have no hydrated cart and the action would throw on the
+		// first click.
+		BlocksSharedState::load_cart_state( $consent );
+
+		$items = $this->prefetch_list_items( $list_slug );
+
+		// Seed the shared shopper-lists store with the rest URL, the
+		// pre-fetched items, and a starter nonce. The starter nonce is
+		// what the cart store also seeds via `state.nonce` — the JS layer
+		// keeps it fresh by reading the `Nonce` response header on every
+		// subsequent request, so this is just the bootstrap value (and
+		// avoids deadlocking mutations that await `isNonceReady` before
+		// any GET has fired).
+		wp_interactivity_state(
+			'woocommerce/shopper-lists',
+			array(
+				'restUrl' => get_rest_url(),
+				'nonce'   => wp_create_nonce( 'wc_store_api' ),
+				'lists'   => array(
+					$list_slug => array(
+						'items'     => $items,
+						'isLoading' => false,
+						'error'     => null,
+					),
+				),
+			)
+		);
+
+		// Only the templates the JS getters consume need to flow through
+		// `wp_interactivity_config`. Visible strings (empty / error /
+		// action label) are rendered server-side and toggled with
+		// directives, so no need to duplicate them here.
+		// NOTE: this config is global per namespace, so multiple
+		// shopper-collection blocks on the same page would clobber each
+		// other's labels. v1 ships with one collection per page; if we
+		// later need multi-instance, move these into per-block context.
+		// phpcs:disable Generic.Commenting.Todo.TaskFound
+		// TODO: scope these labels per list type once a second variation
+		// (Wishlist, etc.) lands. Two shopper-collection blocks on the
+		// same page would otherwise share one set of templates — the
+		// last one rendered wins, so a Wishlist row would say
+		// "Quantity: 3" using Saved-for-later's wording (or the other
+		// way around). Move into `data-wp-context` keyed by listSlug,
+		// or namespace the config keys (e.g.
+		// `quantityLabelTemplate.{slug}`) and update the JS getters to
+		// pick the right one off the per-row context.
+		// phpcs:enable Generic.Commenting.Todo.TaskFound
+		wp_interactivity_config(
+			'woocommerce/shopper-collection',
+			array(
+				'quantityLabelTemplate' => $variation['quantityLabelTemplate'],
+				'removeLabelTemplate'   => $variation['removeLabelTemplate'],
+			)
+		);
+
+		$wrapper_class = sprintf(
+			'wc-block-shopper-collection wc-block-shopper-collection--%s',
+			$variation['modifierSlug']
+		);
 
 		$wrapper_attributes = array(
-			'class'               => 'wc-block-shopper-collection',
-			'data-wp-interactive' => 'woocommerce/shopper-collections',
-			'data-wp-context'     => '{}',
-			'data-wp-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),
+			'class'               => $wrapper_class,
+			'data-wp-interactive' => 'woocommerce/shopper-collection',
+			'data-wp-context'     => (string) wp_json_encode( array( 'listSlug' => $list_slug ) ),
+			// Deterministic key derived from the list slug so iAPI router
+			// navigations land on the same block identity across renders.
+			'data-wp-key'         => $this->get_full_block_name() . '-' . $list_slug,
 			'style'               => sprintf( '--wc-shopper-collection-columns:%d;', $column_count ),
 		);
 
+		$is_empty = empty( $items );
+
 		return sprintf(
-			'<ul %1$s>%2$s</ul>',
+			'<ul %1$s>%2$s%3$s%4$s%5$s</ul>',
 			get_block_wrapper_attributes( $wrapper_attributes ),
-			$this->get_placeholder_markup()
+			$this->render_template_markup( $variation ),
+			$this->render_items_markup( $items, $variation ),
+			$this->render_empty_markup( $is_empty, $variation ),
+			$this->render_error_markup()
 		);
 	}
 
 	/**
-	 * Placeholder markup for the rendered block. The real `data-wp-each` template
-	 * over `state.currentListItems` will be added once the iAPI store lands.
+	 * Per-list-type rendering config. Centralises every string and
+	 * behaviour switch that differs across list types so the renderer
+	 * stays generic.
+	 *
+	 * Today only `saved-for-later` exists, so the config is returned
+	 * verbatim. When a second list type lands (Wishlist, Recently
+	 * Viewed, etc.), turn this into a lookup keyed by the list slug
+	 * and add the slug as a parameter. Unknown slugs in that future
+	 * lookup should render the empty state or surface an error rather
+	 * than silently borrow another list type's copy.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_variation_config(): array {
+		return array(
+			'modifierSlug'          => 'saved-for-later',
+			'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
+			'removeButtonLabel'     => __( 'Remove', 'woocommerce' ),
+			/* translators: %s: product name. */
+			'removeLabelTemplate'   => __( 'Remove %s from saved items', 'woocommerce' ),
+			/* translators: %d: quantity of saved items. */
+			'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
+			'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
+			'actionDirective'       => 'actions.onClickMoveToCart',
+			'showAction'            => true,
+		);
+	}
+
+	/**
+	 * Prefetch the items in a list via `rest_do_request()`. Logged-out users
+	 * short-circuit to an empty list — the route requires authentication and
+	 * we don't want to fire an API call that's only going to 401.
+	 *
+	 * @param string $list_slug The list slug.
+	 * @return array<int, array<string, mixed>> Items in the schema response shape.
+	 */
+	private function prefetch_list_items( string $list_slug ): array {
+		if ( ! is_user_logged_in() ) {
+			return array();
+		}
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/shopper-lists/' . $list_slug . '/items' );
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			$error   = $response->as_error();
+			$message = $error instanceof \WP_Error ? $error->get_error_message() : 'Unknown error';
+			// Logged at debug level on purpose: prefetch failures are
+			// often transient (network blips, auth refresh races) and
+			// the user-visible behaviour is the empty state — nothing
+			// for ops to act on. Anyone investigating a regression can
+			// flip the WC logger to debug to surface them.
+			wc_get_logger()->debug(
+				sprintf( 'Shopper Collection prefetch failed: %s', $message ),
+				array(
+					'source' => 'shopper-collection',
+					'data'   => array( 'slug' => $list_slug ),
+				)
+			);
+			return array();
+		}
+
+		$data = $response->get_data();
+		if ( ! is_array( $data ) && ! is_object( $data ) ) {
+			return array();
+		}
+
+		// The schema casts `prices` and image entries to stdClass so the
+		// JSON response renders objects, not arrays. Round-trip through
+		// JSON encode/decode to normalise everything to nested arrays so
+		// the SSR markup helpers below can treat fields uniformly.
+		$decoded = json_decode( (string) wp_json_encode( $data ), true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * The `<template data-wp-each>` describing how each item is rendered on
+	 * the client. Pre-rendered children sit alongside as `data-wp-each-child`
+	 * elements so first paint is populated.
+	 *
+	 * @param array<string, mixed> $variation Per-list-type rendering config.
+	 * @return string
+	 */
+	private function render_template_markup( array $variation ): string {
+		$item_class = sprintf(
+			'wc-block-shopper-collection-item wc-block-shopper-collection-item--%s',
+			$variation['modifierSlug']
+		);
+
+		ob_start();
+		?>
+		<template
+			data-wp-each--list-item="state.currentItems"
+			data-wp-each-key="context.listItem.key"
+		>
+			<li class="<?php echo esc_attr( $item_class ); ?>">
+				<?php
+				// Single anchor for both live products and tombstones. For
+				// tombstones `permalink` is empty, so iAPI removes the `href`
+				// attribute and the anchor degrades to non-clickable.
+				// Image and price markup come pre-formatted from the schema
+				// (`image_html`, `price_html`) — `data-wp-watch` callbacks
+				// swap each slot's innerHTML on hydrate / state change so we
+				// don't reimplement WC's `wc_price` / `wp_get_attachment_image`
+				// in JS.
+				?>
+				<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+					<a data-wp-bind--href="context.listItem.permalink">
+						<span class="wc-block-shopper-collection-item__image-slot" data-wp-context='{"htmlField":"image_html"}' data-wp-watch="callbacks.updateInnerHtml"></span>
+					</a>
+					<div class="wc-block-components-product-image__inner-container">
+						<button
+							type="button"
+							class="wc-block-shopper-collection-item__remove"
+							data-wp-on--click="actions.onClickRemove"
+							data-wp-bind--aria-label="state.currentItemRemoveLabel"
+						>
+							<?php echo esc_html( $variation['removeButtonLabel'] ); ?>
+						</button>
+					</div>
+				</div>
+				<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
+					<a data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"></a>
+				</h2>
+				<span class="wc-block-shopper-collection-item__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
+				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="state.isPriceHidden" data-wp-context='{"htmlField":"price_html"}' data-wp-watch="callbacks.updateInnerHtml"></div>
+				<span class="wc-block-shopper-collection-item__quantity" data-wp-text="state.currentItemQuantityLabel"></span>
+				<?php if ( ! empty( $variation['showAction'] ) ) : ?>
+					<div class="wp-block-button wc-block-components-product-button" data-wp-bind--hidden="state.isMoveToCartHidden">
+						<button
+							type="button"
+							class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+							data-wp-on--click="<?php echo esc_attr( $variation['actionDirective'] ); ?>"
+						>
+							<?php echo esc_html( $variation['actionLabel'] ); ?>
+						</button>
+					</div>
+				<?php endif; ?>
+			</li>
+		</template>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Render the SSR markup for each item. JS will reconcile these via
+	 * `data-wp-each-child` after hydration.
+	 *
+	 * @param array<int, array<string, mixed>> $items     Schema-shape items.
+	 * @param array<string, mixed>             $variation Per-list-type rendering config.
+	 * @return string
+	 */
+	private function render_items_markup( array $items, array $variation ): string {
+		$markup = '';
+		foreach ( $items as $item ) {
+			$markup .= $this->render_item_markup( $item, $variation );
+		}
+		return $markup;
+	}
+
+	/**
+	 * Render a single SSR item.
+	 *
+	 * @param array<string, mixed> $item      Schema-shape item.
+	 * @param array<string, mixed> $variation Per-list-type rendering config.
+	 * @return string
+	 */
+	private function render_item_markup( array $item, array $variation ): string {
+		$product_exists  = ! empty( $item['product_exists'] );
+		$name            = (string) ( $item['name'] ?? '' );
+		$permalink       = (string) ( $item['permalink'] ?? '' );
+		$quantity        = (int) ( $item['quantity'] ?? 1 );
+		$alt             = html_entity_decode( $name, ENT_QUOTES, 'UTF-8' );
+		$image_html      = (string) ( $item['image_html'] ?? '' );
+		$price_html      = (string) ( $item['price_html'] ?? '' );
+		$variation_label = $this->get_variation_label( $item );
+
+		$quantity_label = sprintf( $variation['quantityLabelTemplate'], $quantity );
+		$remove_aria    = sprintf( $variation['removeLabelTemplate'], $alt );
+
+		$is_price_hidden = '' === $price_html;
+
+		$item_class = sprintf(
+			'wc-block-shopper-collection-item wc-block-shopper-collection-item--%s',
+			$variation['modifierSlug']
+		);
+
+		$context = array(
+			'listItem' => $item,
+		);
+
+		ob_start();
+		?>
+		<li
+			class="<?php echo esc_attr( $item_class ); ?>"
+			data-wp-each-child
+			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<?php echo wp_interactivity_data_wp_context( $context ); ?>
+		>
+			<?php
+			// Emit the same structure as the `<template>` so iAPI
+			// hydration is a no-op diff. For tombstones the anchor's
+			// href is omitted (the anchor degrades to non-clickable
+			// rather than self-linking back to the current page).
+			// Image and price markup come pre-formatted from the
+			// schema (`image_html`, `price_html`) and are echoed into
+			// the watcher slots — the JS-side `updateInnerHtml`
+			// callback takes over after hydration to swap the slot's
+			// innerHTML when the row's context.listItem changes.
+			?>
+			<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink">
+					<span
+						class="wc-block-shopper-collection-item__image-slot"
+						data-wp-context='{"htmlField":"image_html"}'
+						data-wp-watch="callbacks.updateInnerHtml"
+					>
+						<?php echo wp_kses_post( $image_html ); ?>
+					</span>
+				</a>
+				<div class="wc-block-components-product-image__inner-container">
+					<button
+						type="button"
+						class="wc-block-shopper-collection-item__remove"
+						aria-label="<?php echo esc_attr( $remove_aria ); ?>"
+						data-wp-on--click="actions.onClickRemove"
+						data-wp-bind--aria-label="state.currentItemRemoveLabel"
+					>
+						<?php echo esc_html( $variation['removeButtonLabel'] ); ?>
+					</button>
+				</div>
+			</div>
+			<?php
+			// Render the decoded display name as plain text so the SSR
+			// output matches what `data-wp-text="state.currentItemDisplayName"`
+			// will write after hydration. Names like "Tom &amp; Jerry"
+			// must show as "Tom & Jerry" both before and after JS.
+			// Same single-anchor pattern as the image — href omitted
+			// for tombstones.
+			?>
+			<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
+				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
+			</h2>
+			<?php if ( '' !== $variation_label ) : ?>
+				<span class="wc-block-shopper-collection-item__variation"><?php echo esc_html( $variation_label ); ?></span>
+			<?php endif; ?>
+			<div
+				class="price wc-block-components-product-price has-text-align-center has-small-font-size"
+				data-wp-bind--hidden="state.isPriceHidden"
+				data-wp-context='{"htmlField":"price_html"}'
+				data-wp-watch="callbacks.updateInnerHtml"
+				<?php
+				if ( $is_price_hidden ) {
+					echo 'hidden';
+				}
+				?>
+			>
+				<?php echo wp_kses_post( $price_html ); ?>
+			</div>
+			<span class="wc-block-shopper-collection-item__quantity"><?php echo esc_html( $quantity_label ); ?></span>
+			<?php if ( ! empty( $variation['showAction'] ) ) : ?>
+				<?php
+				// Always emit the wrapper with the same `data-wp-bind--hidden`
+				// the template uses, and start it hidden when the SSR-side
+				// rule (the row is a tombstone) says so. That way a state
+				// change after hydration (e.g. the product is later flagged
+				// as deleted) hides the button without iAPI having to swap
+				// the entire row out.
+				$is_move_to_cart_hidden = ! $product_exists;
+				?>
+			<div
+				class="wp-block-button wc-block-components-product-button"
+				data-wp-bind--hidden="state.isMoveToCartHidden"
+				<?php
+				if ( $is_move_to_cart_hidden ) {
+					echo 'hidden';
+				}
+				?>
+			>
+				<button
+					type="button"
+					class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+					data-wp-on--click="<?php echo esc_attr( $variation['actionDirective'] ); ?>"
+				>
+					<?php echo esc_html( $variation['actionLabel'] ); ?>
+				</button>
+			</div>
+			<?php endif; ?>
+		</li>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Render the empty-state markup. Always present in the DOM so JS can
+	 * toggle it on once the last item is removed.
+	 *
+	 * @param bool                 $is_empty  Whether the list is empty on initial paint.
+	 * @param array<string, mixed> $variation Per-list-type rendering config.
+	 * @return string
+	 */
+	private function render_empty_markup( bool $is_empty, array $variation ): string {
+		$hidden_attr = $is_empty ? '' : ' hidden';
+		return sprintf(
+			'<li class="wc-block-shopper-collection__empty" data-wp-bind--hidden="!state.isEmpty"%1$s>%2$s</li>',
+			$hidden_attr,
+			esc_html( $variation['emptyMessage'] )
+		);
+	}
+
+	/**
+	 * Render the error-state markup. Hidden on initial paint and toggled on
+	 * by the JS-side `state.hasError` getter when a request fails. The text
+	 * content is left empty here on purpose: errors only happen post-hydration,
+	 * and `data-wp-text="state.errorMessage"` writes the actual server-supplied
+	 * message — surfacing that is more useful than a generic fallback.
+	 *
+	 * phpcs:disable Generic.Commenting.Todo.TaskFound
+	 *
+	 * TODO: replace this in-list error row with a `store-notices` notice
+	 * rendered above the list. Mini-cart's pattern (cart.ts → showNoticeError →
+	 * `@woocommerce/stores/store-notices`) is the right reference: dispatch
+	 * the server message there from the JS catch blocks in shopper-lists.ts
+	 * instead of holding it on `list.error`. That gives users a dismissible,
+	 * stylistically-aligned notice rather than a row tucked into the grid.
+	 *
+	 * phpcs:enable Generic.Commenting.Todo.TaskFound
 	 *
 	 * @return string
 	 */
-	private function get_placeholder_markup(): string {
-		return sprintf(
-			'<li class="wc-block-shopper-collection__empty">%s</li>',
-			esc_html__( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' )
-		);
+	private function render_error_markup(): string {
+		return '<li class="wc-block-shopper-collection__error" role="alert" data-wp-bind--hidden="!state.hasError" data-wp-text="state.errorMessage" hidden></li>';
+	}
+
+	/**
+	 * Build a comma-separated variation label like "Color: Blue, Size: M".
+	 *
+	 * @param array<string, mixed> $item Schema-shape item.
+	 * @return string
+	 */
+	private function get_variation_label( array $item ): string {
+		$variation = $item['variation'] ?? array();
+		if ( ! is_array( $variation ) || empty( $variation ) ) {
+			return '';
+		}
+		$parts = array();
+		foreach ( $variation as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$attribute = isset( $entry['attribute'] ) ? html_entity_decode( (string) $entry['attribute'], ENT_QUOTES, 'UTF-8' ) : '';
+			$value     = isset( $entry['value'] ) ? html_entity_decode( (string) $entry['value'], ENT_QUOTES, 'UTF-8' ) : '';
+			if ( '' === $attribute && '' === $value ) {
+				continue;
+			}
+			$parts[] = $attribute . ': ' . $value;
+		}
+		return implode( ', ', $parts );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -219,9 +219,8 @@ final class ShopperCollection extends AbstractBlock {
 		return array(
 			'modifierSlug'          => 'saved-for-later',
 			'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
-			'removeButtonLabel'     => __( 'Remove', 'woocommerce' ),
 			/* translators: %s: product name. */
-			'removeLabelTemplate'   => __( 'Remove %s from saved items', 'woocommerce' ),
+			'removeLabelTemplate'   => __( 'Remove %s from Saved for later list', 'woocommerce' ),
 			/* translators: %d: quantity of saved items. */
 			'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
 			'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
@@ -312,21 +311,19 @@ final class ShopperCollection extends AbstractBlock {
 					<a data-wp-bind--href="context.listItem.permalink">
 						<span class="wc-block-shopper-collection-item__image-slot" data-wp-context='{"htmlField":"image_html"}' data-wp-watch="callbacks.updateInnerHtml"></span>
 					</a>
-					<div class="wc-block-components-product-image__inner-container">
-						<button
-							type="button"
-							class="wc-block-shopper-collection-item__remove"
-							data-wp-on--click="actions.onClickRemove"
-							data-wp-bind--aria-label="state.currentItemRemoveLabel"
-						>
-							<?php echo esc_html( $variation['removeButtonLabel'] ); ?>
-						</button>
-					</div>
+					<button
+						type="button"
+						class="wc-block-shopper-collection-item__remove"
+						data-wp-on--click="actions.onClickRemove"
+						data-wp-bind--aria-label="state.currentItemRemoveLabel"
+					>
+						<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
+					</button>
+					<span class="wc-block-shopper-collection-item__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
 				</div>
 				<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
 					<a data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"></a>
 				</h2>
-				<span class="wc-block-shopper-collection-item__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
 				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="state.isPriceHidden" data-wp-context='{"htmlField":"price_html"}' data-wp-watch="callbacks.updateInnerHtml"></div>
 				<span class="wc-block-shopper-collection-item__quantity" data-wp-text="state.currentItemQuantityLabel"></span>
 				<?php if ( ! empty( $variation['showAction'] ) ) : ?>
@@ -422,17 +419,18 @@ final class ShopperCollection extends AbstractBlock {
 						<?php echo wp_kses_post( $image_html ); ?>
 					</span>
 				</a>
-				<div class="wc-block-components-product-image__inner-container">
-					<button
-						type="button"
-						class="wc-block-shopper-collection-item__remove"
-						aria-label="<?php echo esc_attr( $remove_aria ); ?>"
-						data-wp-on--click="actions.onClickRemove"
-						data-wp-bind--aria-label="state.currentItemRemoveLabel"
-					>
-						<?php echo esc_html( $variation['removeButtonLabel'] ); ?>
-					</button>
-				</div>
+				<button
+					type="button"
+					class="wc-block-shopper-collection-item__remove"
+					aria-label="<?php echo esc_attr( $remove_aria ); ?>"
+					data-wp-on--click="actions.onClickRemove"
+					data-wp-bind--aria-label="state.currentItemRemoveLabel"
+				>
+					<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
+				</button>
+				<?php if ( '' !== $variation_label ) : ?>
+					<span class="wc-block-shopper-collection-item__variation"><?php echo esc_html( $variation_label ); ?></span>
+				<?php endif; ?>
 			</div>
 			<?php
 			// Render the decoded display name as plain text so the SSR
@@ -445,9 +443,6 @@ final class ShopperCollection extends AbstractBlock {
 			<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
 				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
 			</h2>
-			<?php if ( '' !== $variation_label ) : ?>
-				<span class="wc-block-shopper-collection-item__variation"><?php echo esc_html( $variation_label ); ?></span>
-			<?php endif; ?>
 			<div
 				class="price wc-block-components-product-price has-text-align-center has-small-font-size"
 				data-wp-bind--hidden="state.isPriceHidden"
@@ -534,6 +529,19 @@ final class ShopperCollection extends AbstractBlock {
 	 */
 	private function render_error_markup(): string {
 		return '<li class="wc-block-shopper-collection__error" role="alert" data-wp-bind--hidden="!state.hasError" data-wp-text="state.errorMessage" hidden></li>';
+	}
+
+	/**
+	 * Markup for the trash icon used in the remove-item button. Mirrors the
+	 * `trash` icon from `@wordpress/icons` that the cart line item uses for
+	 * `wc-block-cart-item__remove-link`, inlined here so SSR first paint
+	 * matches what JS would render after hydration. `currentColor` lets the
+	 * surrounding badge wrapper drive the fill.
+	 *
+	 * @return string
+	 */
+	private function get_remove_icon_svg(): string {
+		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"/></svg>';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * Shopper Collection block.
+ *
+ * Renders a collection curated by the shopper (e.g. Saved for Later). The data
+ * source and frontend interactivity are wired in follow-up tasks; this class
+ * is the structural backbone that registers the block and outputs the
+ * server-side container the iAPI store will hydrate.
+ */
+final class ShopperCollection extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'shopper-collection';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Block content.
+	 * @param \WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$column_count = isset( $attributes['layout']['columnCount'] ) && is_numeric( $attributes['layout']['columnCount'] )
+			? max( 1, (int) $attributes['layout']['columnCount'] )
+			: 3;
+
+		$wrapper_attributes = array(
+			'class'               => 'wc-block-shopper-collection',
+			'data-wp-interactive' => 'woocommerce/shopper-collections',
+			'data-wp-context'     => '{}',
+			'data-wp-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),
+			'style'               => sprintf( '--wc-shopper-collection-columns:%d;', $column_count ),
+		);
+
+		return sprintf(
+			'<ul %1$s>%2$s</ul>',
+			get_block_wrapper_attributes( $wrapper_attributes ),
+			$this->get_placeholder_markup()
+		);
+	}
+
+	/**
+	 * Placeholder markup for the rendered block. The real `data-wp-each` template
+	 * over `state.currentListItems` will be added once the iAPI store lands.
+	 *
+	 * @return string
+	 */
+	private function get_placeholder_markup(): string {
+		return sprintf(
+			'<li class="wc-block-shopper-collection__empty">%s</li>',
+			esc_html__( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' )
+		);
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * Scripts are loaded via `viewScriptModule` in block.json.
+	 *
+	 * @param string|null $key The key of the script to get.
+	 * @return null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+
+	/**
+	 * Disable the editor style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_editor_style() {
+		return null;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -23,6 +23,67 @@ final class ShopperCollection extends AbstractBlock {
 	protected $block_name = 'shopper-collection';
 
 	/**
+	 * Initialize this block type.
+	 */
+	protected function initialize(): void {
+		parent::initialize();
+
+		// We do not use `BlockHooksTrait` currently as it has issues with PHPStan.
+		add_filter( 'hooked_block_types', array( $this, 'register_hooked_block' ), 9, 4 );
+		add_filter( 'hooked_block_woocommerce/shopper-collection', array( $this, 'set_hooked_block_attributes' ), 10, 4 );
+	}
+
+	/**
+	 * Auto-inject this block after `woocommerce/cart`, scoped to the cart page.
+	 *
+	 * @param array                                  $hooked_block_types Block names hooked at this position.
+	 * @param string                                 $relative_position  Position of the insertion point.
+	 * @param string                                 $anchor_block_type  Anchor block name.
+	 * @param array|\WP_Post|\WP_Block_Template|null $context            Where the block is being embedded.
+	 * @return array
+	 */
+	public function register_hooked_block( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+		if ( 'after' !== $relative_position || 'woocommerce/cart' !== $anchor_block_type ) {
+			return $hooked_block_types;
+		}
+
+		// `wc_get_page_id()` returns -1 when the page option isn't set.
+		$cart_page_id = (int) wc_get_page_id( 'cart' );
+		if ( $cart_page_id <= 0 || ! ( $context instanceof \WP_Post ) || (int) $context->ID !== $cart_page_id ) {
+			return $hooked_block_types;
+		}
+
+		// Don't double-inject if the block is already in the cart page
+		// content.
+		if ( has_block( $this->get_full_block_name(), $context ) ) {
+			return $hooked_block_types;
+		}
+
+		$hooked_block_types[] = $this->get_full_block_name();
+		return $hooked_block_types;
+	}
+
+	/**
+	 * Set the `listName` attribute on the auto-injected block.
+	 *
+	 * @param array|null $parsed_hooked_block The parsed hooked block array, or null to suppress insertion.
+	 * @param string     $hooked_block_type   The hooked block type name.
+	 * @param string     $relative_position   Position of the insertion point.
+	 * @param array      $parsed_anchor_block The anchor block, in parsed block array format.
+	 * @return array|null
+	 */
+	public function set_hooked_block_attributes( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block ) {
+		if ( null === $parsed_hooked_block || 'after' !== $relative_position ) {
+			return $parsed_hooked_block;
+		}
+		if ( ! isset( $parsed_anchor_block['blockName'] ) || 'woocommerce/cart' !== $parsed_anchor_block['blockName'] ) {
+			return $parsed_hooked_block;
+		}
+		$parsed_hooked_block['attrs']['listName'] = 'saved-for-later';
+		return $parsed_hooked_block;
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array     $attributes Block attributes.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
 use Automattic\WooCommerce\Blocks\BlockTypes\Checkout;
 use Automattic\WooCommerce\Blocks\BlockTypes\MiniCartContents;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * BlockTypesController class.
@@ -506,7 +507,6 @@ final class BlockTypesController {
 			'ReviewsByCategory',
 			'ReviewsByProduct',
 			'RelatedProducts',
-			'ShopperCollection',
 			'SingleProduct',
 			'StockFilter',
 			'PageContentWrapper',
@@ -553,6 +553,10 @@ final class BlockTypesController {
 			Checkout::get_checkout_block_types(),
 			MiniCartContents::get_mini_cart_block_types()
 		);
+
+		if ( FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
+			$block_types[] = 'ShopperCollection';
+		}
 
 		if ( wp_is_block_theme() ) {
 			$block_types[] = 'AddToCartWithOptions\AddToCartWithOptions';

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -506,6 +506,7 @@ final class BlockTypesController {
 			'ReviewsByCategory',
 			'ReviewsByProduct',
 			'RelatedProducts',
+			'ShopperCollection',
 			'SingleProduct',
 			'StockFilter',
 			'PageContentWrapper',

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -602,6 +602,19 @@ class FeaturesController {
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
+			'cart_save_for_later'                => array(
+				'name'                         => __( 'Save for Later in Cart', 'woocommerce' ),
+				'description'                  => __(
+					'Let shoppers save cart items to a list to purchase later.',
+					'woocommerce'
+				),
+				'is_experimental'              => true,
+				'enabled_by_default'           => false,
+				// Custom option_key as we expect this setting to move out of features to
+				// a cart/checkout settings section.
+				'option_key'                   => 'woocommerce_cart_save_for_later_enabled',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+			),
 			ProductCacheController::FEATURE_NAME => array(
 				'name'                         => __( 'Cache Product Objects', 'woocommerce' ),
 				'description'                  => __(

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -1,0 +1,227 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\Utilities\Users;
+
+/**
+ * A user's saved list of products.
+ */
+class ShopperList {
+	/**
+	 * Prefix for per-list usermeta key for list details.
+	 */
+	const META_KEY_PREFIX = '_wc_shopper_list_';
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * List slug.
+	 *
+	 * @var string
+	 */
+	private $slug;
+
+	/**
+	 * Datetime the list was created.
+	 *
+	 * @var string
+	 */
+	private $date_created_gmt;
+
+	/**
+	 * Items in the list.
+	 *
+	 * @var array<string, ShopperListItem>
+	 */
+	private $items;
+
+	/**
+	 * Private constructor. Use the static factories to obtain concrete instances.
+	 *
+	 * @param int                            $user_id          Owning user ID.
+	 * @param string                         $slug             List slug.
+	 * @param string                         $date_created_gmt MySQL DATETIME, GMT.
+	 * @param array<string, ShopperListItem> $items            Items keyed by storage key.
+	 */
+	private function __construct(
+		int $user_id,
+		string $slug,
+		string $date_created_gmt,
+		array $items
+	) {
+		$this->user_id          = $user_id;
+		$this->slug             = $slug;
+		$this->date_created_gmt = $date_created_gmt;
+		$this->items            = $items;
+	}
+
+	/**
+	 * Load a list by slug. Returns false for any other list that doesn't exist.
+	 *
+	 * @param string   $slug List identifier.
+	 * @param int|null $user_id Defaults to the current user.
+	 * @return self|false
+	 */
+	public static function get_by_slug( string $slug, ?int $user_id = null ) {
+		$user_id = absint( $user_id ? $user_id : get_current_user_id() );
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$stored = Users::get_site_user_meta( $user_id, self::META_KEY_PREFIX . $slug );
+
+		if ( is_array( $stored ) ) {
+			return self::from_array( $stored, $user_id );
+		}
+
+		// In-memory saved-for-later; persisted lazily on the first save().
+		if ( 'saved-for-later' === $slug ) {
+			return new self(
+				$user_id,
+				'saved-for-later',
+				current_time( 'mysql', true ),
+				array()
+			);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get all of the user's lists.
+	 *
+	 * @param int|null $user_id Defaults to the current user.
+	 * @return array<string, self>
+	 */
+	public static function get_all_for_user( ?int $user_id = null ): array {
+		// For now, only saved-for-later exists.
+		return array_filter(
+			array(
+				'saved-for-later' => self::get_by_slug( 'saved-for-later', $user_id ),
+			)
+		);
+	}
+
+	/**
+	 * The list slug (e.g. 'saved-for-later').
+	 */
+	public function get_slug(): string {
+		return $this->slug;
+	}
+
+	/**
+	 * Add an item, or merge quantities if it already exists.
+	 *
+	 * @param ShopperListItem $item Item to add.
+	 */
+	public function add_item( ShopperListItem $item ): void {
+		$key = $item->get_key();
+
+		if ( isset( $this->items[ $key ] ) ) {
+			$this->items[ $key ] = ShopperListItem::from_array(
+				array_merge(
+					$this->items[ $key ]->to_array(),
+					array( 'quantity' => $this->items[ $key ]->get_quantity() + $item->get_quantity() )
+				)
+			);
+			return;
+		}
+
+		$this->items[ $key ] = $item;
+	}
+
+	/**
+	 * Remove an item by key. Returns false if the key wasn't present.
+	 *
+	 * @param string $key Storage key of the item to remove.
+	 */
+	public function remove_item( string $key ): bool {
+		if ( ! isset( $this->items[ $key ] ) ) {
+			return false;
+		}
+		unset( $this->items[ $key ] );
+		return true;
+	}
+
+	/**
+	 * Get all items currently in the list.
+	 *
+	 * @return array<string, ShopperListItem>
+	 */
+	public function get_items(): array {
+		return $this->items;
+	}
+
+	/**
+	 * Find an item by key.
+	 *
+	 * @param string $key Storage key.
+	 */
+	public function find_item( string $key ): ?ShopperListItem {
+		return $this->items[ $key ] ?? null;
+	}
+
+	/**
+	 * Persist the current state to user meta.
+	 */
+	public function save(): void {
+		Users::update_site_user_meta(
+			$this->user_id,
+			self::META_KEY_PREFIX . $this->slug,
+			$this->to_array()
+		);
+	}
+
+	/**
+	 * Storage / response shape.
+	 */
+	public function to_array(): array {
+		$items_array = array();
+		foreach ( $this->items as $key => $item ) {
+			$items_array[ $key ] = $item->to_array();
+		}
+
+		return array(
+			'slug'             => $this->slug,
+			'date_created_gmt' => $this->date_created_gmt,
+			'items'            => $items_array,
+		);
+	}
+
+	/**
+	 * Build a ShopperList from a stored array.
+	 *
+	 * @param array $data    Stored list record.
+	 * @param int   $user_id Owning user ID.
+	 */
+	private static function from_array( array $data, int $user_id ): self {
+		$items = array();
+		if ( ! empty( $data['items'] ) && is_array( $data['items'] ) ) {
+			foreach ( $data['items'] as $key => $item_data ) {
+				if ( ! is_array( $item_data ) ) {
+					continue;
+				}
+
+				try {
+					$items[ (string) $key ] = ShopperListItem::from_array( $item_data );
+				} catch ( \Throwable $e ) {
+					continue;
+				}
+			}
+		}
+
+		return new self(
+			$user_id,
+			$data['slug'] ?? '',
+			$data['date_created_gmt'] ?? current_time( 'mysql', true ),
+			$items
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -1,0 +1,309 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Enums\ProductType;
+
+/**
+ * A single saved item within a shopper list.
+ */
+class ShopperListItem {
+	/**
+	 * Storage key (md5 of identity tuple).
+	 *
+	 * @var string
+	 */
+	private $key;
+
+	/**
+	 * Product ID at the time the item was saved.
+	 *
+	 * @var int
+	 */
+	private $product_id;
+
+	/**
+	 * Variation ID at the time the item was saved (0 for non-variable products).
+	 *
+	 * @var int
+	 */
+	private $variation_id;
+
+	/**
+	 * Variation attributes captured at save time.
+	 *
+	 * @var array
+	 */
+	private $variation;
+
+	/**
+	 * Saved quantity (always 1 in the current contract).
+	 *
+	 * @var int
+	 */
+	private $quantity;
+
+	/**
+	 * MySQL DATETIME the item was saved, in GMT.
+	 *
+	 * @var string
+	 */
+	private $date_added_gmt;
+
+	/**
+	 * Snapshot of the product title at save time.
+	 *
+	 * @var string
+	 */
+	private $product_title_at_save;
+
+	/**
+	 * Private constructor. Use the static factories to obtain concrete instances.
+	 *
+	 * @param string $key                   Storage key (md5 of identity tuple).
+	 * @param int    $product_id            Product ID.
+	 * @param int    $variation_id          Variation ID, or 0.
+	 * @param array  $variation             Variation attributes.
+	 * @param int    $quantity              Saved quantity.
+	 * @param string $date_added_gmt        MySQL DATETIME, GMT.
+	 * @param string $product_title_at_save Title snapshot.
+	 */
+	private function __construct(
+		string $key,
+		int $product_id,
+		int $variation_id,
+		array $variation,
+		int $quantity,
+		string $date_added_gmt,
+		string $product_title_at_save
+	) {
+		$this->key                   = $key;
+		$this->product_id            = $product_id;
+		$this->variation_id          = $variation_id;
+		$this->variation             = $variation;
+		$this->quantity              = $quantity;
+		$this->date_added_gmt        = $date_added_gmt;
+		$this->product_title_at_save = $product_title_at_save;
+	}
+
+	/**
+	 * Construct from a stored item array (from user_meta).
+	 *
+	 * @throws \Exception When the stored payload is missing required fields.
+	 *
+	 * @param array $data Stored item record.
+	 */
+	public static function from_array( array $data ): self {
+		if (
+			empty( $data['key'] ) || ! is_string( $data['key'] )
+			|| empty( $data['product_id'] ) || ! is_int( $data['product_id'] )
+			|| empty( $data['quantity'] ) || ! is_int( $data['quantity'] )
+		) {
+			throw new \Exception( 'Shopper list item requires "key" (string), "product_id" (int), and "quantity" (int).' );
+		}
+
+		return new self(
+			$data['key'],
+			absint( $data['product_id'] ),
+			absint( $data['variation_id'] ?? 0 ),
+			$data['variation'] ?? array(),
+			absint( $data['quantity'] ),
+			$data['date_added_gmt'] ?? '',
+			$data['product_title_at_save'] ?? ''
+		);
+	}
+
+	/**
+	 * Construct from a product (or variation) ID and optional payload fields.
+	 *
+	 * @throws \InvalidArgumentException When the provided variation attributes do not match the variation product.
+	 *
+	 * @param int   $product_or_variation_id Product or variation ID.
+	 * @param array $variation               Variation attributes keyed by attribute name.
+	 * @param int   $quantity                Saved quantity. Coerced to a minimum of 1.
+	 * @return self|null Null if the underlying product can't be resolved.
+	 */
+	public static function from_product( int $product_or_variation_id, array $variation = array(), int $quantity = 1 ): ?self {
+		$product = wc_get_product( absint( $product_or_variation_id ) );
+		if ( ! $product ) {
+			return null;
+		}
+
+		if ( $product->is_type( ProductType::VARIATION ) ) {
+			$variation_id = $product->get_id();
+			$product_id   = $product->get_parent_id();
+			$variation    = self::resolve_variation_attributes( $product, $variation );
+		} elseif ( $product->is_type( ProductType::VARIABLE ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'When saving a variation, product_id must be the variation ID, not the parent product ID.', 'woocommerce' )
+			);
+		} else {
+			$product_id   = $product->get_id();
+			$variation_id = 0;
+			$variation    = array();
+		}
+
+		return new self(
+			self::generate_key( $product_id, $variation_id, $variation ),
+			$product_id,
+			$variation_id,
+			$variation,
+			max( 1, $quantity ),
+			current_time( 'mysql', true ),
+			$product->get_title()
+		);
+	}
+
+	/**
+	 * Resolve and validate the variation attribute array against the variation product.
+	 *
+	 * Mirrors {@see CartController::parse_variation_data()}: specific values come from
+	 * the variation (server-authoritative); "any" slots must be supplied by the caller
+	 * with a value that exists on the parent product.
+	 *
+	 * @throws \InvalidArgumentException When the supplied variation attributes are
+	 *                                   missing required values or don't match the
+	 *                                   variation product.
+	 *
+	 * @param \WC_Product $variation_product     Variation product.
+	 * @param array       $requested_attributes  Variation attributes supplied by the caller, keyed by `attribute_<slug>`.
+	 * @return array
+	 */
+	private static function resolve_variation_attributes( \WC_Product $variation_product, array $requested_attributes ): array {
+		$parent = wc_get_product( $variation_product->get_parent_id() );
+		if ( ! $parent || ! $parent->is_type( ProductType::VARIABLE ) || ! $variation_product->is_type( ProductType::VARIATION ) ) {
+			return array();
+		}
+
+		$result = array();
+
+		$all_attributes       = array_filter( $parent->get_attributes(), fn( $attribute ) => $attribute->get_variation() );
+		$variation_attributes = wc_get_product_variation_attributes( $variation_product->get_id() );
+
+		foreach ( $all_attributes as $name => $attribute ) {
+			$key      = 'attribute_' . $name;
+			$expected = $variation_attributes[ $key ] ?? '';
+
+			// Variation doesn't provide attribute ('any' attribute).
+			if ( '' === $expected ) {
+				if ( ! isset( $requested_attributes[ $key ] ) ) {
+					throw new \InvalidArgumentException(
+						esc_html(
+							sprintf(
+								/* translators: %s: attribute name. */
+								__( 'Attribute "%s" is required.', 'woocommerce' ),
+								$name
+							)
+						)
+					);
+				}
+
+				if ( ! in_array( $requested_attributes[ $key ], $attribute->get_slugs(), true ) ) {
+					throw new \InvalidArgumentException(
+						esc_html(
+							sprintf(
+								/* translators: 1: attribute name, 2: comma-separated allowed values. */
+								__( 'Invalid value posted for "%1$s". Allowed values: %2$s', 'woocommerce' ),
+								$name,
+								implode( ', ', $attribute->get_slugs() )
+							)
+						)
+					);
+				}
+
+				$result[ $key ] = $requested_attributes[ $key ];
+				continue;
+			}//end if
+
+			// Variation provides attribute.
+			if ( isset( $requested_attributes[ $key ] ) && $requested_attributes[ $key ] !== $expected ) {
+				throw new \InvalidArgumentException(
+					esc_html(
+						sprintf(
+							/* translators: 1: attribute name, 2: expected value. */
+							__( 'Invalid value posted for "%1$s". Expected "%2$s".', 'woocommerce' ),
+							$name,
+							$expected
+						)
+					)
+				);
+			}
+
+			$result[ $key ] = $expected;
+		}//end foreach
+
+		return $result;
+	}
+
+	/**
+	 * Storage key — also used as the response identifier.
+	 */
+	public function get_key(): string {
+		return $this->key;
+	}
+
+	/**
+	 * Product ID at save time.
+	 */
+	public function get_product_id(): int {
+		return $this->product_id;
+	}
+
+	/**
+	 * Variation ID at save time, or 0 for non-variable products.
+	 */
+	public function get_variation_id(): int {
+		return $this->variation_id;
+	}
+
+	/**
+	 * Saved quantity.
+	 */
+	public function get_quantity(): int {
+		return $this->quantity;
+	}
+
+	/**
+	 * Storage / response shape.
+	 */
+	public function to_array(): array {
+		return array(
+			'key'                   => $this->key,
+			'product_id'            => $this->product_id,
+			'variation_id'          => $this->variation_id,
+			'variation'             => $this->variation,
+			'quantity'              => $this->quantity,
+			'date_added_gmt'        => $this->date_added_gmt,
+			'product_title_at_save' => $this->product_title_at_save,
+		);
+	}
+
+	/**
+	 * Compute a deterministic item key. Mirrors WC_Cart::generate_cart_id() so the same
+	 * product+variation always hashes to the same key, regardless of the input key order
+	 * for variation attributes.
+	 *
+	 * @param int   $product_id   Product ID.
+	 * @param int   $variation_id Variation ID, or 0.
+	 * @param array $variation    Variation attributes.
+	 */
+	private static function generate_key( int $product_id, int $variation_id, array $variation ): string {
+		$id_parts = array( $product_id );
+
+		if ( $variation_id ) {
+			$id_parts[] = $variation_id;
+		}
+
+		if ( ! empty( $variation ) ) {
+			ksort( $variation );
+			$variation_key = '';
+			foreach ( $variation as $k => $v ) {
+				$variation_key .= trim( (string) $k ) . trim( (string) $v );
+			}
+			$id_parts[] = $variation_key;
+		}
+
+		return md5( implode( '_', $id_parts ) );
+	}
+}

--- a/plugins/woocommerce/src/Internal/ShopperLists/WishlistEndpoint.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/WishlistEndpoint.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+
+/**
+ * PoC: a `/my-account/wishlist/` endpoint that renders the existing
+ * `woocommerce/shopper-collection` block (Saved for Later) inside My Account.
+ *
+ * Purpose: validate that the Shopper Collection block can render outside its
+ * current cart-page injection point and still interact correctly with the cart
+ * store. For the PoC the data is the user's existing saved-for-later list —
+ * a dedicated wishlist slug and per-list config arrive in a follow-up.
+ *
+ * Adding the endpoint slug to `woocommerce_get_query_vars` is enough to wire
+ * both the query var (`WC_Query::add_query_vars()`) and the rewrite endpoint
+ * (`WC_Query::add_endpoints()`) — both consult that filter.
+ *
+ * @internal Just for internal use.
+ */
+class WishlistEndpoint implements RegisterHooksInterface {
+
+	/**
+	 * Endpoint slug.
+	 */
+	private const ENDPOINT = 'wishlist';
+
+	/**
+	 * Register hooks and filters.
+	 */
+	public function register() {
+		add_filter( 'woocommerce_get_query_vars', array( $this, 'add_query_var' ) );
+		add_filter( 'woocommerce_account_menu_items', array( $this, 'add_menu_item' ) );
+		add_filter( 'woocommerce_endpoint_' . self::ENDPOINT . '_title', array( $this, 'endpoint_title' ) );
+		add_action( 'woocommerce_account_' . self::ENDPOINT . '_endpoint', array( $this, 'render' ) );
+	}
+
+	/**
+	 * Register the `wishlist` query var. `WC_Query` consults this filter from
+	 * both `add_endpoints()` and `add_query_vars()`, so adding the slug here
+	 * gives us both the rewrite endpoint and the recognized query var in one
+	 * shot.
+	 *
+	 * @param array $vars Existing query vars keyed by slug.
+	 * @return array
+	 */
+	public function add_query_var( $vars ) {
+		$vars[ self::ENDPOINT ] = self::ENDPOINT;
+		return $vars;
+	}
+
+	/**
+	 * Insert the Wishlist link into the My Account navigation, just before the
+	 * logout link.
+	 *
+	 * @param array $items Existing menu items keyed by slug.
+	 * @return array
+	 */
+	public function add_menu_item( $items ) {
+		$new_items = array();
+		foreach ( $items as $key => $label ) {
+			if ( 'customer-logout' === $key ) {
+				$new_items[ self::ENDPOINT ] = __( 'Wishlist', 'woocommerce' );
+			}
+			$new_items[ $key ] = $label;
+		}
+		if ( ! isset( $new_items[ self::ENDPOINT ] ) ) {
+			$new_items[ self::ENDPOINT ] = __( 'Wishlist', 'woocommerce' );
+		}
+		return $new_items;
+	}
+
+	/**
+	 * Endpoint page title.
+	 *
+	 * @param string $title Default title (empty for unknown endpoints).
+	 * @return string
+	 */
+	public function endpoint_title( $title ) {
+		return __( 'Wishlist', 'woocommerce' );
+	}
+
+	/**
+	 * Render the Shopper Collection block inside the endpoint. The block is
+	 * already gated by the `cart_save_for_later` feature flag at registration
+	 * time, so if the flag is off `do_blocks()` parses the comment but renders
+	 * nothing — no separate guard needed here.
+	 */
+	public function render() {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- block markup is a static literal; do_blocks() output is rendered HTML.
+		echo do_blocks( '<!-- wp:woocommerce/shopper-collection {"listName":"saved-for-later"} /-->' );
+	}
+}

--- a/plugins/woocommerce/src/Internal/ShopperLists/WishlistEndpoint.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/WishlistEndpoint.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\ShopperLists;
 
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * PoC: a `/my-account/wishlist/` endpoint that renders the existing
@@ -28,9 +29,15 @@ class WishlistEndpoint implements RegisterHooksInterface {
 	private const ENDPOINT = 'wishlist';
 
 	/**
-	 * Register hooks and filters.
+	 * Register hooks and filters. The endpoint piggy-backs on the SFL feature
+	 * flag because the block it renders is itself gated on `cart_save_for_later`;
+	 * registering the menu item, query var, and rewrite endpoint when the
+	 * underlying block can't render would just surface an empty page.
 	 */
-	public function register() {
+	public function register(): void {
+		if ( ! FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
+			return;
+		}
 		add_filter( 'woocommerce_get_query_vars', array( $this, 'add_query_var' ) );
 		add_filter( 'woocommerce_account_menu_items', array( $this, 'add_menu_item' ) );
 		add_filter( 'woocommerce_endpoint_' . self::ENDPOINT . '_title', array( $this, 'endpoint_title' ) );
@@ -78,17 +85,14 @@ class WishlistEndpoint implements RegisterHooksInterface {
 	 * @param string $title Default title (empty for unknown endpoints).
 	 * @return string
 	 */
-	public function endpoint_title( $title ) {
+	public function endpoint_title( $title ): string {
 		return __( 'Wishlist', 'woocommerce' );
 	}
 
 	/**
-	 * Render the Shopper Collection block inside the endpoint. The block is
-	 * already gated by the `cart_save_for_later` feature flag at registration
-	 * time, so if the flag is off `do_blocks()` parses the comment but renders
-	 * nothing — no separate guard needed here.
+	 * Render the Shopper Collection block inside the endpoint.
 	 */
-	public function render() {
+	public function render(): void {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- block markup is a static literal; do_blocks() output is rendered HTML.
 		echo do_blocks( '<!-- wp:woocommerce/shopper-collection {"listName":"saved-for-later"} /-->' );
 	}

--- a/plugins/woocommerce/src/Internal/ShopperLists/WishlistFromSingleProduct.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/WishlistFromSingleProduct.php
@@ -1,0 +1,206 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+
+/**
+ * PoC: inject a "Save to wishlist" button after the Add-to-Cart-with-Options
+ * form on the single product page and wire it to the existing Saved-for-later
+ * shopper list.
+ *
+ * The button is rendered INSIDE the form so it inherits the parent form's iAPI
+ * context (`quantity`, `selectedAttributes`). The matching action lives on the
+ * `woocommerce/add-to-cart-with-options` store; we just seed the
+ * `woocommerce/shopper-lists` iAPI state here with the REST URL and a starter
+ * nonce so the addItem action can hit the Store API.
+ *
+ * "Wishlist" is a label; data goes into the existing `saved-for-later` slug
+ * until a dedicated wishlist slug + variation lands.
+ *
+ * @internal Just for internal use.
+ */
+class WishlistFromSingleProduct implements RegisterHooksInterface {
+
+	/**
+	 * Register hooks and filters.
+	 */
+	public function register() {
+		add_filter( 'render_block_woocommerce/add-to-cart-with-options', array( $this, 'inject_button' ), 10, 1 );
+	}
+
+	/**
+	 * Append a button inside the rendered Add-to-Cart-with-Options form.
+	 *
+	 * @param string $block_content Rendered block HTML.
+	 * @return string
+	 */
+	public function inject_button( $block_content ) {
+		if ( ! is_user_logged_in() ) {
+			return $block_content;
+		}
+
+		// Only inject if the form rendered as an iAPI interactive form. Legacy
+		// mode (cart redirect on, or extensions hooking into the form) skips
+		// the `data-wp-on--submit` directive and would not have the form's
+		// iAPI context available either.
+		if ( false === strpos( $block_content, 'data-wp-interactive="woocommerce/add-to-cart-with-options"' ) ) {
+			return $block_content;
+		}
+
+		$insertion_point = strrpos( $block_content, '</form>' );
+		if ( false === $insertion_point ) {
+			return $block_content;
+		}
+
+		$prefetched_items = $this->prefetch_saved_for_later_items();
+		$this->seed_shopper_lists_state( $prefetched_items );
+
+		// iAPI binds directives only AFTER first paint, so SSR has to already
+		// match the intended initial state — otherwise an already-saved product
+		// would flash an empty star until hydration runs and flips it. We
+		// resolve the initial state here for simple products by parsing the
+		// product_id out of the rendered form. For variable products the user
+		// hasn't selected attributes on initial paint, so the default "not in
+		// wishlist" SSR state is correct without further work.
+		$initial_product_id = $this->extract_product_id( $block_content );
+		$is_in_wishlist     = $initial_product_id > 0
+			&& $this->is_simple_product_in_list( $initial_product_id, $prefetched_items );
+
+		$empty_hidden_attr  = $is_in_wishlist ? ' hidden' : '';
+		$filled_hidden_attr = $is_in_wishlist ? '' : ' hidden';
+		$aria_pressed       = $is_in_wishlist ? 'true' : 'false';
+
+		// `aria-pressed` carries the toggle state for assistive tech. Both
+		// SSR `hidden` attributes and `aria-pressed` start at the resolved
+		// value and the matching `data-wp-bind--*` directives keep them in
+		// sync after hydration as the user toggles variations.
+		$button_html = sprintf(
+			'<button type="button" class="wc-block-add-to-wishlist-button" aria-label="%1$s" aria-pressed="%2$s" data-wp-bind--aria-pressed="state.isInWishlist" data-wp-on--click="actions.toggleWishlistFromForm" style="%3$s">'
+				. '<span class="wc-block-add-to-wishlist-button__icon wc-block-add-to-wishlist-button__icon--empty" data-wp-bind--hidden="state.isInWishlist"%4$s>%6$s</span>'
+				. '<span class="wc-block-add-to-wishlist-button__icon wc-block-add-to-wishlist-button__icon--filled" data-wp-bind--hidden="!state.isInWishlist"%5$s>%7$s</span>'
+				. '</button>',
+			esc_attr__( 'Add to wishlist', 'woocommerce' ),
+			$aria_pressed,
+			'background:transparent;border:none;cursor:pointer;padding:8px;color:inherit;vertical-align:middle;display:inline-flex;align-items:center;',
+			$empty_hidden_attr,
+			$filled_hidden_attr,
+			$this->get_star_svg( false ),
+			$this->get_star_svg( true )
+		);
+
+		return substr( $block_content, 0, $insertion_point ) . $button_html . substr( $block_content, $insertion_point );
+	}
+
+	/**
+	 * Pull the form's `add-to-cart` hidden input value out of the rendered
+	 * HTML. AddToCartWithOptions emits this for every product type, so it's
+	 * the most reliable handle on which product the block is rendering for
+	 * (more reliable than `get_queried_object_id()` since the block can be
+	 * embedded outside the single-product template).
+	 *
+	 * @param string $block_content Rendered block HTML.
+	 * @return int Product ID, or 0 when not found.
+	 */
+	private function extract_product_id( string $block_content ): int {
+		if ( ! preg_match( '/name="add-to-cart"\s+value="(\d+)"/', $block_content, $matches ) ) {
+			return 0;
+		}
+		return (int) $matches[1];
+	}
+
+	/**
+	 * Whether the given product is in the prefetched list with no variation
+	 * captured (i.e. it was saved as a simple/external product). Variable
+	 * products require a selected variation, which only the JS-side getter
+	 * has access to on initial render.
+	 *
+	 * @param int                              $product_id Product ID to look for.
+	 * @param array<int, array<string, mixed>> $items      Prefetched items.
+	 * @return bool
+	 */
+	private function is_simple_product_in_list( int $product_id, array $items ): bool {
+		foreach ( $items as $item ) {
+			if ( (int) ( $item['product_id'] ?? 0 ) !== $product_id ) {
+				continue;
+			}
+			$variation = $item['variation'] ?? array();
+			if ( ! is_array( $variation ) || 0 === count( $variation ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Inline star SVG, outlined when not filled, solid when filled. Both use
+	 * `currentColor` so the surrounding button's text color drives the icon
+	 * color — the same convention `ShopperCollection::get_remove_icon_svg()`
+	 * follows.
+	 *
+	 * @param bool $filled Whether to render the filled variant.
+	 * @return string
+	 */
+	private function get_star_svg( bool $filled ): string {
+		$path     = 'M12 2.6l2.85 5.77 6.37.93-4.61 4.49 1.09 6.35L12 17.13l-5.7 3.01 1.09-6.35-4.61-4.49 6.37-.93L12 2.6z';
+		$fill     = $filled ? 'currentColor' : 'none';
+		$stroke   = 'currentColor';
+		$markup   = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">'
+			. '<path d="' . $path . '" fill="' . $fill . '" stroke="' . $stroke . '" stroke-width="1.5" stroke-linejoin="round"/>'
+			. '</svg>';
+		return $markup;
+	}
+
+	/**
+	 * Seed the `woocommerce/shopper-lists` iAPI state with the REST URL, a
+	 * starter nonce, and the user's current saved-for-later items so the
+	 * "already in wishlist" check has correct data on first paint.
+	 *
+	 * Mirrors `ShopperCollection::prefetch_list_items()` rather than calling
+	 * it directly to avoid coupling this PoC to a block class.
+	 *
+	 * @param array<int, array<string, mixed>> $items Prefetched items to seed.
+	 */
+	private function seed_shopper_lists_state( array $items ): void {
+		wp_interactivity_state(
+			'woocommerce/shopper-lists',
+			array(
+				'restUrl' => get_rest_url(),
+				'nonce'   => wp_create_nonce( 'wc_store_api' ),
+				'lists'   => array(
+					'saved-for-later' => array(
+						'items'     => $items,
+						'isLoading' => false,
+						'error'     => null,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Fetch the current user's saved-for-later items via the Store API so the
+	 * client-side getter can compare against them on first paint.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function prefetch_saved_for_later_items(): array {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			return array();
+		}
+
+		$data = $response->get_data();
+		if ( ! is_array( $data ) && ! is_object( $data ) ) {
+			return array();
+		}
+
+		// Normalize stdClass entries (prices, images) into plain nested arrays
+		// so they round-trip through `wp_interactivity_state` cleanly.
+		$decoded = json_decode( (string) wp_json_encode( $data ), true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+}

--- a/plugins/woocommerce/src/Internal/ShopperLists/WishlistFromSingleProduct.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/WishlistFromSingleProduct.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\ShopperLists;
 
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * PoC: inject a "Save to wishlist" button after the Add-to-Cart-with-Options
@@ -24,9 +25,13 @@ use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 class WishlistFromSingleProduct implements RegisterHooksInterface {
 
 	/**
-	 * Register hooks and filters.
+	 * Register hooks and filters. Piggy-backs on the SFL feature flag because
+	 * the iAPI store and action this button targets are themselves gated there.
 	 */
-	public function register() {
+	public function register(): void {
+		if ( ! FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
+			return;
+		}
 		add_filter( 'render_block_woocommerce/add-to-cart-with-options', array( $this, 'inject_button' ), 10, 1 );
 	}
 
@@ -143,10 +148,10 @@ class WishlistFromSingleProduct implements RegisterHooksInterface {
 	 * @return string
 	 */
 	private function get_star_svg( bool $filled ): string {
-		$path     = 'M12 2.6l2.85 5.77 6.37.93-4.61 4.49 1.09 6.35L12 17.13l-5.7 3.01 1.09-6.35-4.61-4.49 6.37-.93L12 2.6z';
-		$fill     = $filled ? 'currentColor' : 'none';
-		$stroke   = 'currentColor';
-		$markup   = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">'
+		$path   = 'M12 2.6l2.85 5.77 6.37.93-4.61 4.49 1.09 6.35L12 17.13l-5.7 3.01 1.09-6.35-4.61-4.49 6.37-.93L12 2.6z';
+		$fill   = $filled ? 'currentColor' : 'none';
+		$stroke = 'currentColor';
+		$markup = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">'
 			. '<path d="' . $path . '" fill="' . $fill . '" stroke="' . $stroke . '" stroke-width="1.5" stroke-linejoin="round"/>'
 			. '</svg>';
 		return $markup;

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -1,0 +1,250 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * GET / POST on /shopper-lists/{slug}/items.
+ *
+ * GET returns the items in a list.
+ * POST saves an item to the list either from an existing cart line or from direct item payload fields.
+ */
+class ShopperListItems extends AbstractRoute {
+	/**
+	 * Route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-list-items';
+
+	/**
+	 * Schema identifier this route uses.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'shopper-list-item';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/shopper-lists/(?P<slug>[a-z0-9-]+)/items';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array(
+			'args'   => array(
+				'slug' => array(
+					'description' => __( 'Stable slug for the list.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+			),
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
+				'args'                => array(
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
+				'args'                => array(
+					'cart_item_key' => array(
+						'description' => __( 'Existing cart item key to copy into the list.', 'woocommerce' ),
+						'type'        => 'string',
+					),
+					'product_id'    => array(
+						'description' => __( 'Product or variation ID to save. Required when cart_item_key is not supplied.', 'woocommerce' ),
+						'type'        => 'integer',
+					),
+					'variation'     => array(
+						'description' => __( 'Chosen attributes (for variations).', 'woocommerce' ),
+						'type'        => 'array',
+						'context'     => array( 'view', 'edit' ),
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'attribute' => array(
+									'description' => __( 'Variation attribute name.', 'woocommerce' ),
+									'type'        => 'string',
+									'context'     => array( 'view', 'edit' ),
+								),
+								'value'     => array(
+									'description' => __( 'Variation attribute value.', 'woocommerce' ),
+									'type'        => 'string',
+									'context'     => array( 'view', 'edit' ),
+								),
+							),
+						),
+					),
+					'quantity'      => array(
+						'description' => __( 'Quantity for the saved item.', 'woocommerce' ),
+						'type'        => 'integer',
+						'default'     => 1,
+					),
+				),
+			),
+			'schema' => array( $this->schema, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Return the items in the requested list.
+	 *
+	 * @throws RouteException When the list doesn't exist.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		$list = ShopperList::get_by_slug( (string) $request['slug'] );
+		if ( ! $list ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+		}
+
+		$items = array_values( $list->get_items() );
+		$this->prime_product_caches_for_items( $items );
+
+		$response = array();
+		foreach ( $items as $item ) {
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $item->to_array(), $request ) );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Add an item to the requested list from cart_item_key or direct product payload fields.
+	 *
+	 * @throws RouteException On validation failure.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_post_response( \WP_REST_Request $request ) {
+		$list = ShopperList::get_by_slug( (string) $request['slug'] );
+
+		if ( ! $list ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+		}
+
+		[ $lookup_id, $variation, $quantity ] = $this->resolve_item_payload( $request );
+
+		try {
+			$item = ShopperListItem::from_product( $lookup_id, $variation, $quantity );
+		} catch ( \InvalidArgumentException $e ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_invalid_variation', esc_html( $e->getMessage() ), 400 );
+		}
+		if ( ! $item ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_unknown_product', esc_html__( 'No product exists for the supplied item.', 'woocommerce' ), 404 );
+		}
+
+		$list->add_item( $item );
+		$list->save();
+
+		$saved = $list->find_item( $item->get_key() ) ?? $item;
+		return new \WP_REST_Response( $this->schema->get_item_response( $saved->to_array() ), 201 );
+	}
+
+	/**
+	 * Resolve the POST input into a uniform payload (product lookup id, variation, quantity).
+	 *
+	 * Accepts either an existing cart_item_key, or direct product_id/variation_id/variation.
+	 *
+	 * @throws RouteException When neither a cart_item_key nor a product_id is supplied, or the cart_item_key is unknown.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return array{0:int,1:array,2:int} `[ lookup_id, variation, quantity ]`.
+	 */
+	private function resolve_item_payload( \WP_REST_Request $request ): array {
+		$cart_item_key = (string) $request->get_param( 'cart_item_key' );
+
+		if ( $cart_item_key ) {
+			if ( ! did_action( 'woocommerce_load_cart_from_session' ) || ! wc()->cart ) {
+				wc_load_cart();
+			}
+
+			$cart_contents = wc()->cart->get_cart();
+			if ( empty( $cart_contents[ $cart_item_key ] ) ) {
+				throw new RouteException( 'woocommerce_rest_shopper_list_invalid_cart_item_key', esc_html__( 'No cart item exists for the supplied key.', 'woocommerce' ), 404 );
+			}
+
+			$line            = $cart_contents[ $cart_item_key ];
+			$product_id      = absint( $line['product_id'] ?? 0 );
+			$variation_id    = absint( $line['variation_id'] ?? 0 );
+			$variation_attrs = isset( $line['variation'] ) && is_array( $line['variation'] ) ? $line['variation'] : array();
+
+			return array(
+				$variation_id ? $variation_id : $product_id,
+				$variation_attrs,
+				absint( $line['quantity'] ?? 1 ),
+			);
+		}//end if
+
+		$product_id = absint( $request->get_param( 'product_id' ) );
+		if ( ! $product_id ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_missing_item_input', esc_html__( 'Provide cart_item_key or product_id.', 'woocommerce' ), 400 );
+		}
+
+		$variation = wp_list_pluck( (array) $request->get_param( 'variation' ), 'value', 'attribute' );
+
+		return array(
+			$product_id,
+			(array) array_combine(
+				array_map( 'wc_variation_attribute_name', array_keys( $variation ) ),
+				array_values( $variation )
+			),
+			absint( $request->get_param( 'quantity' ) ),
+		);
+	}
+
+	/**
+	 * Prime post caches before the per-item product lookup loop in the schema.
+	 *
+	 * @param ShopperListItem[] $items Items.
+	 */
+	private function prime_product_caches_for_items( array $items ): void {
+		$ids = array_map(
+			fn( $item ) => $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id(),
+			$items
+		);
+
+		_prime_post_caches( array_unique( $ids ) );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -1,0 +1,99 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * DELETE /shopper-lists/{slug}/items/{key}.
+ */
+class ShopperListItemsByKey extends AbstractRoute {
+	/**
+	 * Route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-list-items-by-key';
+
+	/**
+	 * Schema identifier this route uses.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'shopper-list-item';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/shopper-lists/(?P<slug>[a-z0-9-]+)/items/(?P<key>[\w-]{32})';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array(
+			'args'   => array(
+				'slug' => array(
+					'description' => __( 'Stable slug for the list.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+				'key'  => array(
+					'description' => __( 'Item key.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+			),
+			array(
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
+			),
+			'schema' => array( $this->schema, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Delete a single item from a list.
+	 *
+	 * @throws RouteException When the list or item doesn't exist.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_delete_response( \WP_REST_Request $request ) {
+		$list = ShopperList::get_by_slug( (string) $request['slug'] );
+
+		if ( ! $list ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+		}
+
+		if ( ! $list->remove_item( (string) $request['key'] ) ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_item_not_found', esc_html__( 'No saved item exists for the supplied key.', 'woocommerce' ), 404 );
+		}
+
+		$list->save();
+
+		return new \WP_REST_Response( null, 204 );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
@@ -1,0 +1,83 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+
+/**
+ * GET /shopper-lists — collection of the current user's shopper lists.
+ */
+class ShopperLists extends AbstractRoute {
+	/**
+	 * Route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-lists';
+
+	/**
+	 * Schema identifier this route uses.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'shopper-list';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/shopper-lists';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array(
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
+				'args'                => array(
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			'schema' => array( $this->schema, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Return the lists for the current user.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		$response = array();
+
+		foreach ( ShopperList::get_all_for_user() as $list ) {
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $list->to_array(), $request ) );
+		}
+
+		return rest_ensure_response( $response );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
@@ -1,0 +1,92 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * GET /shopper-lists/{slug} — metadata for a single list.
+ */
+class ShopperListsBySlug extends AbstractRoute {
+	/**
+	 * Route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-lists-by-slug';
+
+	/**
+	 * Schema identifier this route uses.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'shopper-list';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/shopper-lists/(?P<slug>[a-z0-9-]+)';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array(
+			'args'   => array(
+				'slug' => array(
+					'description' => __( 'Stable slug for the list.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+			),
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
+				'args'                => array(
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			'schema' => array( $this->schema, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Return the list metadata for the requested slug.
+	 *
+	 * @throws RouteException When the list doesn't exist.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		$list = ShopperList::get_by_slug( (string) $request['slug'] );
+
+		if ( ! $list ) {
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+		}
+
+		return rest_ensure_response( $this->prepare_item_for_response( $list->to_array(), $request ) );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -70,6 +70,10 @@ class RoutesController {
 				Routes\V1\Products::IDENTIFIER           => Routes\V1\Products::class,
 				Routes\V1\ProductsById::IDENTIFIER       => Routes\V1\ProductsById::class,
 				Routes\V1\ProductsBySlug::IDENTIFIER     => Routes\V1\ProductsBySlug::class,
+				Routes\V1\ShopperLists::IDENTIFIER       => Routes\V1\ShopperLists::class,
+				Routes\V1\ShopperListsBySlug::IDENTIFIER => Routes\V1\ShopperListsBySlug::class,
+				Routes\V1\ShopperListItems::IDENTIFIER   => Routes\V1\ShopperListItems::class,
+				Routes\V1\ShopperListItemsByKey::IDENTIFIER => Routes\V1\ShopperListItemsByKey::class,
 			],
 			'private' => [
 				// This route should be moved outside of the Store API namespace.

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -39,7 +39,7 @@ class RoutesController {
 	public function __construct( SchemaController $schema_controller ) {
 		$this->schema_controller = $schema_controller;
 		$this->routes            = [
-			'v1'      => [
+			'v1'            => [
 				Routes\V1\Batch::IDENTIFIER              => Routes\V1\Batch::class,
 				Routes\V1\Cart::IDENTIFIER               => Routes\V1\Cart::class,
 				Routes\V1\CartAddItem::IDENTIFIER        => Routes\V1\CartAddItem::class,
@@ -70,16 +70,19 @@ class RoutesController {
 				Routes\V1\Products::IDENTIFIER           => Routes\V1\Products::class,
 				Routes\V1\ProductsById::IDENTIFIER       => Routes\V1\ProductsById::class,
 				Routes\V1\ProductsBySlug::IDENTIFIER     => Routes\V1\ProductsBySlug::class,
+			],
+			'private'       => [
+				// This route should be moved outside of the Store API namespace.
+				Routes\V1\Patterns::IDENTIFIER => Routes\V1\Patterns::class,
+			],
+			'shopper_lists' => [
+				// Gated behind the `cart_save_for_later` feature flag.
 				Routes\V1\ShopperLists::IDENTIFIER       => Routes\V1\ShopperLists::class,
 				Routes\V1\ShopperListsBySlug::IDENTIFIER => Routes\V1\ShopperListsBySlug::class,
 				Routes\V1\ShopperListItems::IDENTIFIER   => Routes\V1\ShopperListItems::class,
 				Routes\V1\ShopperListItemsByKey::IDENTIFIER => Routes\V1\ShopperListItemsByKey::class,
 			],
-			'private' => [
-				// This route should be moved outside of the Store API namespace.
-				Routes\V1\Patterns::IDENTIFIER => Routes\V1\Patterns::class,
-			],
-			'agentic' => [
+			'agentic'       => [
 				// Agentic Commerce Protocol endpoints.
 				Routes\V1\Agentic\CheckoutSessions::IDENTIFIER         => Routes\V1\Agentic\CheckoutSessions::class,
 				Routes\V1\Agentic\CheckoutSessionsUpdate::IDENTIFIER   => Routes\V1\Agentic\CheckoutSessionsUpdate::class,
@@ -95,6 +98,10 @@ class RoutesController {
 		$this->register_routes( 'v1', self::$api_namespace );
 		$this->register_routes( 'v1', self::$api_namespace . '/v1' );
 		$this->register_routes( 'private', 'wc/private' );
+
+		if ( FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
+			$this->register_routes( 'shopper_lists', self::$api_namespace . '/v1' );
+		}
 
 		if ( FeaturesUtil::feature_is_enabled( 'agentic_checkout' ) ) {
 			$this->register_routes( 'agentic', 'wc/agentic/v1' );

--- a/plugins/woocommerce/src/StoreApi/SchemaController.php
+++ b/plugins/woocommerce/src/StoreApi/SchemaController.php
@@ -56,6 +56,8 @@ class SchemaController {
 				Schemas\V1\ProductCollectionDataSchema::IDENTIFIER => Schemas\V1\ProductCollectionDataSchema::class,
 				Schemas\V1\ProductReviewSchema::IDENTIFIER => Schemas\V1\ProductReviewSchema::class,
 				Schemas\V1\PatternsSchema::IDENTIFIER      => Schemas\V1\PatternsSchema::class,
+				Schemas\V1\ShopperListSchema::IDENTIFIER   => Schemas\V1\ShopperListSchema::class,
+				Schemas\V1\ShopperListItemSchema::IDENTIFIER => Schemas\V1\ShopperListItemSchema::class,
 				Schemas\V1\Agentic\CheckoutSessionSchema::IDENTIFIER => Schemas\V1\Agentic\CheckoutSessionSchema::class,
 			],
 		];

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -180,6 +180,18 @@ class ShopperListItemSchema extends AbstractSchema {
 					)
 				),
 			),
+			'price_html'     => array(
+				'description' => __( 'Live product price as HTML, formatted via wc_price including sale/discount markup. Empty when the product no longer exists.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'image_html'     => array(
+				'description' => __( 'Product thumbnail as a fully-formed <img> element with srcset, sizes, alt, and lazy-loading attributes. Falls back to the configured placeholder image when the product has no image or no longer exists.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
 			'date_added_gmt' => array(
 				'description' => __( 'The date the item was saved, as GMT.', 'woocommerce' ),
 				'type'        => 'string',
@@ -215,17 +227,21 @@ class ShopperListItemSchema extends AbstractSchema {
 		$variation_data = isset( $item['variation'] ) && is_array( $item['variation'] ) ? $item['variation'] : array();
 
 		if ( $has_product ) {
-			$response['name']      = $this->get_name( $product );
-			$response['permalink'] = $product->get_permalink();
-			$response['images']    = $this->get_images( $product );
-			$response['variation'] = $this->format_variation_data( $variation_data, $product );
-			$response['prices']    = (object) $this->get_prices( $product );
+			$response['name']       = $this->get_name( $product );
+			$response['permalink']  = $product->get_permalink();
+			$response['images']     = $this->get_images( $product );
+			$response['variation']  = $this->format_variation_data( $variation_data, $product );
+			$response['prices']     = (object) $this->get_prices( $product );
+			$response['price_html'] = (string) $product->get_price_html();
+			$response['image_html'] = $this->get_image_html( $product );
 		} else {
-			$response['name']      = $this->prepare_html_response( (string) ( $item['product_title_at_save'] ?? '' ) );
-			$response['permalink'] = '';
-			$response['images']    = array();
-			$response['variation'] = array();
-			$response['prices']    = null;
+			$response['name']       = $this->prepare_html_response( (string) ( $item['product_title_at_save'] ?? '' ) );
+			$response['permalink']  = '';
+			$response['images']     = array();
+			$response['variation']  = array();
+			$response['prices']     = null;
+			$response['price_html'] = '';
+			$response['image_html'] = $this->get_image_html( null );
 		}//end if
 
 		return $response;
@@ -259,6 +275,26 @@ class ShopperListItemSchema extends AbstractSchema {
 
 		$image = $this->image_attachment_schema->get_item_response( $image_id );
 		return $image ? array( $image ) : array();
+	}
+
+	/**
+	 * Get the thumbnail image HTML for a shopper list item, falling back to the
+	 * WooCommerce placeholder when the product has no image or has been deleted.
+	 *
+	 * Pre-formatting on the server lets renderers (PHP SSR + JS hydration)
+	 * consume one canonical string instead of each side composing the markup
+	 * from the structured `images` array. Mirrors the pattern WC uses in
+	 * `ProductSchema::price_html` / `ProductImage::render`.
+	 *
+	 * @param \WC_Product|null $product Live product instance, or null for tombstones.
+	 * @return string
+	 */
+	private function get_image_html( ?\WC_Product $product ): string {
+		$image_id = $product instanceof \WC_Product ? (int) $product->get_image_id() : 0;
+		if ( $image_id > 0 ) {
+			return (string) wp_get_attachment_image( $image_id, 'woocommerce_thumbnail' );
+		}
+		return (string) wc_placeholder_img( 'woocommerce_thumbnail' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -1,0 +1,287 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
+
+/**
+ * ShopperListItemSchema class.
+ *
+ * One row in a shopper list. Serves live product data when the product still
+ * exists in the catalog, and at-save tombstone data when it doesn't, distinguishing
+ * the two states via the `product_exists` boolean.
+ */
+class ShopperListItemSchema extends AbstractSchema {
+	// We only call format_variation_data(); see phpstan.neon for the related suppressions.
+	use ProductItemTrait;
+
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'shopper_list_item';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-list-item';
+
+	/**
+	 * Image attachment schema instance.
+	 *
+	 * @var ImageAttachmentSchema
+	 */
+	protected $image_attachment_schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @throws \RuntimeException When the ImageAttachmentSchema is not registered.
+	 *
+	 * @param ExtendSchema     $extend Rest Extending instance.
+	 * @param SchemaController $controller Schema Controller instance.
+	 */
+	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
+		parent::__construct( $extend, $controller );
+		$schema = $this->controller->get( ImageAttachmentSchema::IDENTIFIER );
+		if ( ! $schema instanceof ImageAttachmentSchema ) {
+			throw new \RuntimeException( 'ImageAttachmentSchema is not registered in SchemaController.' );
+		}
+		$this->image_attachment_schema = $schema;
+	}
+
+	/**
+	 * Item schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return array(
+			'key'            => array(
+				'description' => __( 'Stable identifier for the saved item within its list.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'id'             => array(
+				'description' => __( 'Variation ID if applicable, otherwise product ID.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'product_id'     => array(
+				'description' => __( 'Product ID at the time the item was saved.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'variation_id'   => array(
+				'description' => __( 'Variation ID at the time the item was saved, or 0 for non-variable products.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'quantity'       => array(
+				'description' => __( 'Quantity of this saved item.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'product_exists' => array(
+				'description' => __( 'True when the underlying product still exists in the catalog. When false, the row is a tombstone served from at-save snapshot data.', 'woocommerce' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'name'           => array(
+				'description' => __( 'Product name. Live when product_exists is true; falls back to the at-save title snapshot otherwise.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'permalink'      => array(
+				'description' => __( 'Product URL. Empty when the product no longer exists.', 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'uri',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'images'         => array(
+				'description' => __( 'List of images for the live product. Empty when the product no longer exists.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => $this->image_attachment_schema->get_properties(),
+				),
+			),
+			'variation'      => array(
+				'description' => __( 'Chosen variation attributes, if applicable.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'raw_attribute' => array(
+							'description' => __( 'Variation system generated attribute name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'attribute'     => array(
+							'description' => __( 'Variation attribute name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'value'         => array(
+							'description' => __( 'Variation attribute value.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+			'prices'         => array(
+				'description' => __( 'Live product prices. Omitted when the product no longer exists.', 'woocommerce' ),
+				'type'        => array( 'object', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'properties'  => array_merge(
+					$this->get_store_currency_properties(),
+					array(
+						'price'         => array(
+							'description' => __( 'Current product price.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'regular_price' => array(
+							'description' => __( 'Regular product price.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'sale_price'    => array(
+							'description' => __( 'Sale product price, if applicable.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					)
+				),
+			),
+			'date_added_gmt' => array(
+				'description' => __( 'The date the item was saved, as GMT.', 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		);
+	}
+
+	/**
+	 * Convert a stored item record into the response shape.
+	 *
+	 * @param array $item Stored item record.
+	 * @return array
+	 */
+	public function get_item_response( $item ) {
+		$variation_id = $item['variation_id'] ?? 0;
+		$product_id   = $variation_id > 0 ? $variation_id : ( $item['product_id'] ?? 0 );
+		$product      = $product_id ? wc_get_product( $product_id ) : false;
+		$has_product  = $product instanceof \WC_Product;
+
+		$response = array(
+			'key'            => $item['key'] ?? '',
+			'id'             => $product_id,
+			'product_id'     => $item['product_id'] ?? 0,
+			'variation_id'   => $item['variation_id'] ?? 0,
+			'quantity'       => $item['quantity'] ?? 1,
+			'product_exists' => $has_product,
+			'date_added_gmt' => wc_rest_prepare_date_response( $item['date_added_gmt'] ?? current_time( 'mysql', true ) ),
+		);
+
+		$variation_data = isset( $item['variation'] ) && is_array( $item['variation'] ) ? $item['variation'] : array();
+
+		if ( $has_product ) {
+			$response['name']      = $this->get_name( $product );
+			$response['permalink'] = $product->get_permalink();
+			$response['images']    = $this->get_images( $product );
+			$response['variation'] = $this->format_variation_data( $variation_data, $product );
+			$response['prices']    = (object) $this->get_prices( $product );
+		} else {
+			$response['name']      = $this->prepare_html_response( (string) ( $item['product_title_at_save'] ?? '' ) );
+			$response['permalink'] = '';
+			$response['images']    = array();
+			$response['variation'] = array();
+			$response['prices']    = null;
+		}//end if
+
+		return $response;
+	}
+
+	/**
+	 * Get the displayable name for the live product.
+	 *
+	 * @param \WC_Product $product Live product instance.
+	 * @return string
+	 */
+	private function get_name( \WC_Product $product ): string {
+		$prepared = $this->prepare_html_response( $product->get_title() );
+		return is_string( $prepared ) ? $prepared : (string) $product->get_title();
+	}
+
+	/**
+	 * Get the main image for a shopper list item.
+	 *
+	 * Returns the product's main image only — shopper list rows are compact and
+	 * the gallery isn't needed at the row level.
+	 *
+	 * @param \WC_Product $product Live product instance.
+	 * @return array
+	 */
+	private function get_images( \WC_Product $product ): array {
+		$image_id = (int) $product->get_image_id();
+		if ( $image_id <= 0 ) {
+			return array();
+		}
+
+		$image = $this->image_attachment_schema->get_item_response( $image_id );
+		return $image ? array( $image ) : array();
+	}
+
+	/**
+	 * Compute live prices for the saved item.
+	 *
+	 * We don't extend ProductSchema because saved items aren't products. The shape
+	 * here is a thin subset of cart-item prices.
+	 *
+	 * @param \WC_Product $product Live product instance.
+	 * @return array
+	 */
+	private function get_prices( \WC_Product $product ): array {
+		$decimals      = wc_get_price_decimals();
+		$regular_price = $product->get_regular_price();
+		$sale_price    = $product->get_sale_price();
+		$current_price = $product->get_price();
+
+		return $this->prepare_currency_response(
+			array(
+				'price'         => $this->prepare_money_response( $current_price, $decimals ),
+				'regular_price' => $this->prepare_money_response( '' === $regular_price ? $current_price : $regular_price, $decimals ),
+				'sale_price'    => '' === $sale_price ? '' : $this->prepare_money_response( $sale_price, $decimals ),
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
@@ -1,0 +1,126 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+
+/**
+ * ShopperListSchema class.
+ *
+ * Represents a single shopper list, including its saved items.
+ */
+class ShopperListSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'shopper_list';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shopper-list';
+
+	/**
+	 * Item schema instance.
+	 *
+	 * @var ShopperListItemSchema
+	 */
+	protected $item_schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @throws \RuntimeException When the ShopperListItemSchema is not registered.
+	 *
+	 * @param ExtendSchema     $extend Rest Extending instance.
+	 * @param SchemaController $controller Schema Controller instance.
+	 */
+	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
+		parent::__construct( $extend, $controller );
+		$schema = $this->controller->get( ShopperListItemSchema::IDENTIFIER );
+		if ( ! $schema instanceof ShopperListItemSchema ) {
+			throw new \RuntimeException( 'ShopperListItemSchema is not registered in SchemaController.' );
+		}
+		$this->item_schema = $schema;
+	}
+
+	/**
+	 * Schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return array(
+			'slug'             => array(
+				'description' => __( 'Stable slug for the list.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'date_created_gmt' => array(
+				'description' => __( 'The date the list was created, as GMT.', 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'item_count'       => array(
+				'description' => __( 'Number of items currently in the list.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'items'            => array(
+				'description' => __( 'List of saved items.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->item_schema->get_properties() ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Convert a stored list record into the response shape.
+	 *
+	 * @param array $shopper_list List array (as returned by ShopperList::to_array()).
+	 * @return array
+	 */
+	public function get_item_response( $shopper_list ) {
+		$items = isset( $shopper_list['items'] ) && is_array( $shopper_list['items'] ) ? $shopper_list['items'] : array();
+
+		$product_ids = array_filter(
+			array_map(
+				static function ( $item ) {
+					$variation_id = absint( $item['variation_id'] ?? 0 );
+					return $variation_id ? $variation_id : absint( $item['product_id'] ?? 0 );
+				},
+				$items
+			)
+		);
+		if ( ! empty( $product_ids ) ) {
+			_prime_post_caches( array_unique( $product_ids ) );
+		}
+
+		return array(
+			'slug'             => $shopper_list['slug'] ?? '',
+			'date_created_gmt' => wc_rest_prepare_date_response( $shopper_list['date_created_gmt'] ?? current_time( 'mysql', true ) ),
+			'item_count'       => count( $items ),
+			'items'            => array_values(
+				array_map(
+					fn( $item ) => $this->item_schema->get_item_response( $item ),
+					$items
+				)
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -1,0 +1,131 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
+use ReflectionClass;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the ShopperCollection block type.
+ */
+class ShopperCollectionTests extends WP_UnitTestCase {
+
+	/**
+	 * System under test.
+	 *
+	 * Constructed via reflection so `AbstractBlock::__construct` doesn't run
+	 * `parent::initialize()` and re-register the block (the test bootstrap
+	 * has already registered it). The filter callbacks under test only read
+	 * `$this->namespace` and `$this->block_name`, both class defaults.
+	 *
+	 * @var ShopperCollection
+	 */
+	private ShopperCollection $sut;
+
+	/**
+	 * Instantiate the block without invoking its constructor.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$reflection = new ReflectionClass( ShopperCollection::class );
+		$this->sut  = $reflection->newInstanceWithoutConstructor();
+	}
+
+	/**
+	 * @return array<string, array{string, string, bool, bool}>
+	 */
+	public function provider_register_hooked_block(): array {
+		$cart_only         = '<!-- wp:woocommerce/cart /-->';
+		$cart_with_shopper = '<!-- wp:woocommerce/cart /--><!-- wp:woocommerce/shopper-collection {"listName":"saved-for-later"} /-->';
+
+		return array(
+			// label                                => array( cart_page_content, anchor, context_is_cart_page, expected_hooked ).
+			'hooked after cart on cart page'        => array( $cart_only, 'woocommerce/cart', true, true ),
+			'not hooked after non-cart anchor'      => array( $cart_only, 'core/paragraph', true, false ),
+			'not hooked when context is other page' => array( $cart_only, 'woocommerce/cart', false, false ),
+			'not hooked when already present'       => array( $cart_with_shopper, 'woocommerce/cart', true, false ),
+		);
+	}
+
+	/**
+	 * `register_hooked_block` only adds the block when the anchor is `woocommerce/cart`,
+	 * the context is the cart page, and the cart page doesn't already contain the block.
+	 *
+	 * @dataProvider provider_register_hooked_block
+	 *
+	 * @param string $cart_page_content    Initial content of the cart page.
+	 * @param string $anchor               Anchor block name passed to the filter.
+	 * @param bool   $context_is_cart_page Whether the filter context is the cart page or some other page.
+	 * @param bool   $expected_hooked      Whether the block should end up in the hooked list.
+	 */
+	public function test_register_hooked_block( string $cart_page_content, string $anchor, bool $context_is_cart_page, bool $expected_hooked ): void {
+		$cart_page_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => $cart_page_content,
+			)
+		);
+		update_option( 'woocommerce_cart_page_id', $cart_page_id );
+
+		$context_id = $context_is_cart_page
+			? $cart_page_id
+			: self::factory()->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+				)
+			);
+
+		$hooked = $this->sut->register_hooked_block( array(), 'after', $anchor, get_post( $context_id ) );
+
+		if ( $expected_hooked ) {
+			$this->assertContains( 'woocommerce/shopper-collection', $hooked );
+		} else {
+			$this->assertNotContains( 'woocommerce/shopper-collection', $hooked );
+		}
+	}
+
+	/**
+	 * When the cart page option is unset, `wc_get_page_id()` returns -1 — the filter
+	 * must treat that as "no cart page" rather than letting it match a real post ID.
+	 */
+	public function test_register_hooked_block_skips_when_cart_page_unset(): void {
+		delete_option( 'woocommerce_cart_page_id' );
+
+		$context_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:woocommerce/cart /-->',
+			)
+		);
+
+		$hooked = $this->sut->register_hooked_block( array(), 'after', 'woocommerce/cart', get_post( $context_id ) );
+
+		$this->assertNotContains( 'woocommerce/shopper-collection', $hooked );
+	}
+
+	/**
+	 * The auto-injected block has its `listName` attribute set to `saved-for-later`.
+	 */
+	public function test_hooked_block_attributes_set_list_name(): void {
+		$parsed_hooked_block = array(
+			'blockName' => 'woocommerce/shopper-collection',
+			'attrs'     => array(),
+		);
+		$parsed_anchor_block = array( 'blockName' => 'woocommerce/cart' );
+
+		$result = $this->sut->set_hooked_block_attributes(
+			$parsed_hooked_block,
+			'woocommerce/shopper-collection',
+			'after',
+			$parsed_anchor_block
+		);
+
+		$this->assertSame( 'saved-for-later', $result['attrs']['listName'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * Shopper Lists Route Tests.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+
+/**
+ * Tests for the /wc/store/v1/shopper-lists/* endpoints.
+ */
+class ShopperLists extends ControllerTestCase {
+
+	/**
+	 * Test product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * Test customer user ID.
+	 *
+	 * @var int
+	 */
+	private $customer_id;
+
+	/**
+	 * Second test customer user ID, used to verify cross-user isolation.
+	 *
+	 * @var int
+	 */
+	private $other_customer_id;
+
+	/**
+	 * Setup test data.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$fixtures      = new FixtureData();
+		$this->product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		$this->customer_id       = $this->factory->user->create(
+			array(
+				'role'       => 'customer',
+				'user_email' => 'shopper-lists-1@test.com',
+			)
+		);
+		$this->other_customer_id = $this->factory->user->create(
+			array(
+				'role'       => 'customer',
+				'user_email' => 'shopper-lists-2@test.com',
+			)
+		);
+	}
+
+	/**
+	 * Tear down test data.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		if ( $this->customer_id ) {
+			wp_delete_user( $this->customer_id );
+		}
+		if ( $this->other_customer_id ) {
+			wp_delete_user( $this->other_customer_id );
+		}
+	}
+
+	/**
+	 * Helper: dispatch a request and return the response.
+	 *
+	 * @param string $method HTTP method.
+	 * @param string $route Route path.
+	 * @param array  $params Body params.
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch( string $method, string $route, array $params = array() ): \WP_REST_Response {
+		$request = new \WP_REST_Request( $method, $route );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Helper: add the test product to the cart and return its cart_item_key.
+	 *
+	 * @return string
+	 */
+	private function add_product_to_cart(): string {
+		$key = wc()->cart->add_to_cart( $this->product->get_id(), 1 );
+		$this->assertNotEmpty( $key, 'add_to_cart should return a non-empty cart item key.' );
+		return (string) $key;
+	}
+
+	/**
+	 * Test that an unauthenticated request to GET /shopper-lists is rejected.
+	 */
+	public function test_get_lists_requires_login() {
+		wp_set_current_user( 0 );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists' );
+
+		$this->assertContains( $response->get_status(), array( 401, 403 ), 'Unauthenticated requests must be rejected by the permission callback.' );
+	}
+
+	/**
+	 * Test that a logged-in user starts with saved-for-later auto-created and empty.
+	 */
+	public function test_get_lists_returns_save_for_later_for_logged_in_user() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists' );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+		$this->assertCount( 1, $data, 'Only saved-for-later is returned in v1.' );
+		$this->assertSame( 'saved-for-later', $data[0]['slug'] );
+		$this->assertSame( 0, $data[0]['item_count'] );
+	}
+
+	/**
+	 * Test that GET /shopper-lists/saved-for-later returns the list metadata.
+	 */
+	public function test_get_list_by_id_returns_save_for_later_metadata() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later' );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 'saved-for-later', $data['slug'] );
+	}
+
+	/**
+	 * Test that GET /shopper-lists/{slug} returns 404 for any list other than saved-for-later.
+	 */
+	public function test_get_list_by_id_returns_404_for_unsupported_list() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/wishlist' );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test POST /shopper-lists/saved-for-later/items with a real cart_item_key returns the saved item.
+	 */
+	public function test_post_item_via_cart_item_key() {
+		wp_set_current_user( $this->customer_id );
+
+		$cart_item_key = $this->add_product_to_cart();
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/saved-for-later/items',
+			array( 'cart_item_key' => $cart_item_key )
+		);
+		$data     = $response->get_data();
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertSame( $this->product->get_id(), $data['product_id'] );
+		$this->assertSame( 1, $data['quantity'], 'Saved quantity should mirror the cart line quantity.' );
+		$this->assertTrue( $data['product_exists'] );
+		$this->assertSame( $this->product->get_title(), $data['name'] );
+		$this->assertNotEmpty( wc()->cart->cart_contents, 'Cart should still contain the line — POST is additive only.' );
+	}
+
+	/**
+	 * Test POST rejects requests without cart_item_key or product_id.
+	 */
+	public function test_post_item_requires_cart_item_key_or_product_id() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test POST /shopper-lists/saved-for-later/items via direct product payload returns the saved item.
+	 */
+	public function test_post_item_via_manual_product_payload() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/saved-for-later/items',
+			array(
+				'product_id' => $this->product->get_id(),
+				'quantity'   => 2,
+			)
+		);
+		$data     = $response->get_data();
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertSame( $this->product->get_id(), $data['product_id'] );
+		$this->assertSame( 2, $data['quantity'], 'Posted quantity should be honored.' );
+	}
+
+	/**
+	 * Test POST rejects an unknown cart_item_key.
+	 */
+	public function test_post_item_unknown_cart_item_key_returns_404() {
+		wp_set_current_user( $this->customer_id );
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/saved-for-later/items',
+			array( 'cart_item_key' => 'thiskeydoesnotexist' )
+		);
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test POST returns 404 for any slug other than saved-for-later.
+	 */
+	public function test_post_item_unsupported_slug_returns_404() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+
+		$response = $this->dispatch(
+			'POST',
+			'/wc/store/v1/shopper-lists/wishlist/items',
+			array( 'cart_item_key' => $cart_item_key )
+		);
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test that adding the same cart line twice merges quantities into a single row.
+	 */
+	public function test_post_item_is_idempotent_for_same_cart_line() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+
+		$first  = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+		$second = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+
+		$this->assertEquals( 201, $first->get_status() );
+		$this->assertEquals( 201, $second->get_status() );
+		$this->assertSame( $first->get_data()['key'], $second->get_data()['key'], 'Same cart line should resolve to the same item key.' );
+		$this->assertSame( 2, $second->get_data()['quantity'], 'Repeating the same cart line must merge quantities.' );
+
+		$items_response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+		$this->assertCount( 1, $items_response->get_data(), 'Same cart line should not produce a duplicate row.' );
+	}
+
+	/**
+	 * Test that GET /items returns the saved items.
+	 */
+	public function test_get_items_returns_saved_items() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+
+		$this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+	}
+
+	/**
+	 * Test that DELETE removes the item and returns 204 No Content.
+	 */
+	public function test_delete_item_removes_item() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+
+		$created = $this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+		$key     = $created->get_data()['key'];
+
+		$response = $this->dispatch( 'DELETE', '/wc/store/v1/shopper-lists/saved-for-later/items/' . $key );
+
+		$this->assertEquals( 204, $response->get_status() );
+		$this->assertNull( $response->get_data() );
+
+		$items_response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+		$this->assertCount( 0, $items_response->get_data(), 'List should be empty after the only item is deleted.' );
+	}
+
+	/**
+	 * Test that DELETE returns 404 when the item does not exist.
+	 */
+	public function test_delete_item_unknown_returns_404() {
+		wp_set_current_user( $this->customer_id );
+
+		// Auto-create the list so the route reaches the item-lookup branch.
+		$this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later' );
+
+		$nonexistent_key = str_repeat( 'a', 32 );
+		$response        = $this->dispatch( 'DELETE', '/wc/store/v1/shopper-lists/saved-for-later/items/' . $nonexistent_key );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test that a logged-out user cannot delete via the route.
+	 */
+	public function test_delete_item_requires_login() {
+		wp_set_current_user( 0 );
+
+		$nonexistent_key = str_repeat( 'a', 32 );
+		$response        = $this->dispatch( 'DELETE', '/wc/store/v1/shopper-lists/saved-for-later/items/' . $nonexistent_key );
+
+		$this->assertContains( $response->get_status(), array( 401, 403 ) );
+	}
+
+	/**
+	 * Test that one user cannot see another user's items.
+	 */
+	public function test_users_lists_are_isolated() {
+		wp_set_current_user( $this->customer_id );
+		$cart_item_key = $this->add_product_to_cart();
+		$this->dispatch( 'POST', '/wc/store/v1/shopper-lists/saved-for-later/items', array( 'cart_item_key' => $cart_item_key ) );
+
+		wp_set_current_user( $this->other_customer_id );
+		$response = $this->dispatch( 'GET', '/wc/store/v1/shopper-lists/saved-for-later/items' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 0, $response->get_data(), 'Other user should not see the first user\'s items.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -39,6 +39,11 @@ class ShopperLists extends ControllerTestCase {
 	 * Setup test data.
 	 */
 	protected function setUp(): void {
+		// The shopper-lists routes are gated behind the `cart_save_for_later`
+		// feature flag, which is read inside `do_action( 'rest_api_init' )`
+		// fired by parent::setUp(). The option must be in place before then.
+		update_option( 'woocommerce_cart_save_for_later_enabled', 'yes' );
+
 		parent::setUp();
 
 		$fixtures      = new FixtureData();
@@ -75,6 +80,8 @@ class ShopperLists extends ControllerTestCase {
 		if ( $this->other_customer_id ) {
 			wp_delete_user( $this->other_customer_id );
 		}
+
+		delete_option( 'woocommerce_cart_save_for_later_enabled' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -1,0 +1,127 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Schemas;
+
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListItemSchema;
+use WC_Unit_Test_Case;
+
+/**
+ * ShopperListItemSchemaTest class.
+ */
+class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ShopperListItemSchema
+	 */
+	private $sut;
+
+	/**
+	 * ExtendSchema instance.
+	 *
+	 * @var ExtendSchema
+	 */
+	private $extend;
+
+	/**
+	 * SchemaController instance.
+	 *
+	 * @var SchemaController
+	 */
+	private $schema_controller;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+
+		$this->extend            = new ExtendSchema( $formatters );
+		$this->schema_controller = new SchemaController( $this->extend );
+		$this->sut               = new ShopperListItemSchema( $this->extend, $this->schema_controller );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->sut               = null;
+		$this->extend            = null;
+		$this->schema_controller = null;
+	}
+
+	/**
+	 * Build a minimal stored item record around a product.
+	 *
+	 * @param int    $product_id   Product ID.
+	 * @param int    $variation_id Variation ID, or 0.
+	 * @param array  $variation    Variation attributes.
+	 * @param string $title        Title snapshot.
+	 * @return array
+	 */
+	private function build_item( int $product_id, int $variation_id = 0, array $variation = array(), string $title = 'Snapshot Title' ): array {
+		return array(
+			'key'                   => md5( (string) $product_id ),
+			'product_id'            => $product_id,
+			'variation_id'          => $variation_id,
+			'variation'             => $variation,
+			'quantity'              => 1,
+			'date_added_gmt'        => '2024-04-25 03:20:00',
+			'product_title_at_save' => $title,
+		);
+	}
+
+	/**
+	 * @testdox Should serve live product data and product_exists=true when the product exists.
+	 */
+	public function test_returns_live_data_when_product_exists(): void {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Live T-Shirt',
+				'regular_price' => 19.99,
+			)
+		);
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id(), 0, array(), 'Snapshot T-Shirt' ) );
+
+		$this->assertTrue( $response['product_exists'], 'product_exists must be true when the product still exists' );
+		$this->assertSame( 'Live T-Shirt', $response['name'], 'Live name should be served, not the snapshot' );
+		$this->assertSame( $product->get_permalink(), $response['permalink'] );
+		$this->assertNotNull( $response['prices'], 'Live prices should be populated' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should fall back to at-save snapshot data when the product no longer exists.
+	 */
+	public function test_falls_back_to_snapshot_when_product_missing(): void {
+		$product    = \WC_Helper_Product::create_simple_product( true, array( 'name' => 'About to be Deleted' ) );
+		$product_id = $product->get_id();
+		$item       = $this->build_item( $product_id, 0, array(), 'Snapshot Title' );
+		wp_delete_post( $product_id, true );
+
+		$response = $this->sut->get_item_response( $item );
+
+		$this->assertFalse( $response['product_exists'], 'product_exists must be false when the product is gone' );
+		$this->assertSame( 'Snapshot Title', $response['name'], 'Tombstone name should fall back to the at-save title snapshot' );
+		$this->assertSame( '', $response['permalink'], 'permalink should be empty in tombstone path' );
+		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );
+		$this->assertNull( $response['prices'], 'Live prices should be null for missing products' );
+		$this->assertArrayNotHasKey( 'product_title_at_save', $response, 'Internal at-save title snapshot should not leak into the public response' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -107,6 +107,68 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should expose price_html for live products and an empty string for tombstones.
+	 */
+	public function test_price_html_is_populated_for_live_products(): void {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Priced T-Shirt',
+				'regular_price' => 19.99,
+			)
+		);
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertArrayHasKey( 'price_html', $response, 'price_html must be present on the response' );
+		$this->assertIsString( $response['price_html'] );
+		$this->assertNotSame( '', $response['price_html'], 'price_html must be non-empty for a live priced product' );
+		$this->assertStringContainsString( 'woocommerce-Price-amount', $response['price_html'], 'price_html should be the formatted markup from wc_price' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should expose image_html with the configured product thumbnail when one is set.
+	 */
+	public function test_image_html_uses_product_thumbnail_when_available(): void {
+		$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$product       = \WC_Helper_Product::create_simple_product( true, array( 'name' => 'Imaged T-Shirt' ) );
+		$product->set_image_id( $attachment_id );
+		$product->save();
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertArrayHasKey( 'image_html', $response, 'image_html must be present on the response' );
+		$this->assertIsString( $response['image_html'] );
+		$this->assertStringContainsString( '<img', $response['image_html'], 'image_html must be a fully-formed <img> element' );
+		$this->assertStringContainsString( 'srcset=', $response['image_html'], 'image_html must carry the responsive srcset attribute' );
+
+		$product->delete( true );
+		wp_delete_attachment( $attachment_id, true );
+	}
+
+	/**
+	 * @testdox Should expose image_html using the WooCommerce placeholder when the product has no image.
+	 */
+	public function test_image_html_falls_back_to_placeholder_when_product_has_no_image(): void {
+		$product = \WC_Helper_Product::create_simple_product( true, array( 'name' => 'No-Image T-Shirt' ) );
+		$product->set_image_id( 0 );
+		$product->save();
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertArrayHasKey( 'image_html', $response );
+		$this->assertSame(
+			(string) wc_placeholder_img( 'woocommerce_thumbnail' ),
+			$response['image_html'],
+			'image_html for an image-less product must equal the configured placeholder markup'
+		);
+
+		$product->delete( true );
+	}
+
+	/**
 	 * @testdox Should fall back to at-save snapshot data when the product no longer exists.
 	 */
 	public function test_falls_back_to_snapshot_when_product_missing(): void {
@@ -123,5 +185,32 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );
 		$this->assertNull( $response['prices'], 'Live prices should be null for missing products' );
 		$this->assertArrayNotHasKey( 'product_title_at_save', $response, 'Internal at-save title snapshot should not leak into the public response' );
+	}
+
+	/**
+	 * @testdox Should expose an empty price_html and the placeholder image_html for tombstones.
+	 */
+	public function test_tombstone_returns_empty_price_html_and_placeholder_image_html(): void {
+		$product    = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Going Away',
+				'regular_price' => 24.99,
+			)
+		);
+		$product_id = $product->get_id();
+		$item       = $this->build_item( $product_id, 0, array(), 'Going Away' );
+		wp_delete_post( $product_id, true );
+
+		$response = $this->sut->get_item_response( $item );
+
+		$this->assertArrayHasKey( 'price_html', $response );
+		$this->assertSame( '', $response['price_html'], 'Tombstones must not advertise a price' );
+		$this->assertArrayHasKey( 'image_html', $response );
+		$this->assertSame(
+			(string) wc_placeholder_img( 'woocommerce_thumbnail' ),
+			$response['image_html'],
+			'Tombstones must use the placeholder image markup'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -1,0 +1,153 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
+use WC_Unit_Test_Case;
+
+/**
+ * Unit tests for ShopperListItem.
+ */
+class ShopperListItemTests extends WC_Unit_Test_Case {
+	/**
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Item SUT Product',
+				'regular_price' => 19.99,
+			)
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		if ( $this->product ) {
+			$this->product->delete( true );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox from_product should build an item from a live product, snapshotting the title.
+	 */
+	public function test_from_product_builds_item_from_live_product(): void {
+		$item = ShopperListItem::from_product( $this->product->get_id(), array(), 3 );
+
+		$this->assertInstanceOf( ShopperListItem::class, $item );
+		$arr = $item->to_array();
+		$this->assertSame( $this->product->get_title(), $arr['product_title_at_save'] );
+		$this->assertSame( 3, $arr['quantity'], 'Quantity should reflect the value passed to from_product.' );
+	}
+
+	/**
+	 * @testdox from_product should default quantity to 1 and coerce zero/negative values up to 1.
+	 */
+	public function test_from_product_normalizes_quantity_floor(): void {
+		$default = ShopperListItem::from_product( $this->product->get_id() );
+		$this->assertInstanceOf( ShopperListItem::class, $default );
+		$this->assertSame( 1, $default->to_array()['quantity'] );
+
+		$zero = ShopperListItem::from_product( $this->product->get_id(), array(), 0 );
+		$this->assertInstanceOf( ShopperListItem::class, $zero );
+		$this->assertSame( 1, $zero->to_array()['quantity'] );
+
+		$negative = ShopperListItem::from_product( $this->product->get_id(), array(), -5 );
+		$this->assertInstanceOf( ShopperListItem::class, $negative );
+		$this->assertSame( 1, $negative->to_array()['quantity'] );
+	}
+
+	/**
+	 * @testdox from_product should return null when the product can't be resolved.
+	 */
+	public function test_from_product_returns_null_for_missing_product(): void {
+		$this->assertNull( ShopperListItem::from_product( 99999999 ) );
+	}
+
+	/**
+	 * @testdox to_array round-trips through from_array.
+	 */
+	public function test_round_trips_through_from_array(): void {
+		$original = ShopperListItem::from_product( $this->product->get_id() );
+		$rebuilt  = ShopperListItem::from_array( $original->to_array() );
+
+		$this->assertSame( $original->to_array(), $rebuilt->to_array() );
+	}
+
+	/**
+	 * @testdox from_product validates the variation array against the variation product, like cart does.
+	 */
+	public function test_from_variation_validates_against_variation_product(): void {
+		$variable = \WC_Helper_Product::create_variation_product();
+
+		$find = function ( array $attrs ) use ( $variable ): int {
+			foreach ( $variable->get_children() as $variation_id ) {
+				$expected = wc_get_product_variation_attributes( (int) $variation_id );
+				if ( empty( array_diff_assoc( $attrs, $expected ) ) ) {
+					return (int) $variation_id;
+				}
+			}
+			$this->fail( 'No variation matched the requested attribute set.' );
+		};
+
+		$all_specific = $find(
+			array(
+				'attribute_pa_size'   => 'huge',
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_number' => '0',
+			)
+		);
+		$any_number   = $find(
+			array(
+				'attribute_pa_size'   => 'huge',
+				'attribute_pa_colour' => 'blue',
+				'attribute_pa_number' => '',
+			)
+		);
+
+		// Specific attrs: server fills them in even when the caller passes nothing.
+		$variation = ShopperListItem::from_product( $all_specific, array() )->to_array()['variation'];
+		$this->assertSame( 'huge', $variation['attribute_pa_size'] );
+		$this->assertSame( 'red', $variation['attribute_pa_colour'] );
+		$this->assertSame( '0', $variation['attribute_pa_number'] );
+
+		// Specific attrs: client value mismatching the variation is rejected.
+		try {
+			ShopperListItem::from_product( $all_specific, array( 'attribute_pa_colour' => 'blue' ) );
+			$this->fail( 'Expected mismatched specific value to throw.' );
+		} catch ( \InvalidArgumentException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
+
+		// "Any" slot: missing client value is rejected.
+		try {
+			ShopperListItem::from_product( $any_number, array() );
+			$this->fail( 'Expected missing any-slot value to throw.' );
+		} catch ( \InvalidArgumentException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
+
+		// "Any" slot: a value present on the parent is accepted and stored.
+		$variation = ShopperListItem::from_product( $any_number, array( 'attribute_pa_number' => '2' ) )->to_array()['variation'];
+		$this->assertSame( '2', $variation['attribute_pa_number'] );
+
+		// "Any" slot: a value not in the parent's slugs is rejected.
+		try {
+			ShopperListItem::from_product( $any_number, array( 'attribute_pa_number' => '99' ) );
+			$this->fail( 'Expected invalid any-slot value to throw.' );
+		} catch ( \InvalidArgumentException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -1,0 +1,151 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
+use Automattic\WooCommerce\Internal\Utilities\Users;
+use WC_Unit_Test_Case;
+
+/**
+ * Unit tests for ShopperList.
+ */
+class ShopperListTests extends WC_Unit_Test_Case {
+	private const SAVED_FOR_LATER_SLUG = 'saved-for-later';
+
+	/**
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * @var ShopperListItem
+	 */
+	private $item;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		$this->product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'List SUT Product',
+				'regular_price' => 19.99,
+			)
+		);
+		$this->item    = ShopperListItem::from_product( $this->product->get_id() );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		if ( $this->product ) {
+			$this->product->delete( true );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox saved-for-later is in-memory only on first read and is persisted lazily on the first add_item()+save().
+	 */
+	public function test_save_for_later_persistence_is_lazy(): void {
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+
+		$this->assertInstanceOf( ShopperList::class, $list );
+		$this->assertSame( self::SAVED_FOR_LATER_SLUG, $list->get_slug() );
+		$this->assertSame( array(), $list->get_items() );
+
+		$meta_key = ShopperList::META_KEY_PREFIX . self::SAVED_FOR_LATER_SLUG;
+		$this->assertSame( '', Users::get_site_user_meta( $this->user_id, $meta_key ), 'Empty saved-for-later should not be persisted before the first add.' );
+
+		$list->add_item( $this->item );
+		$list->save();
+
+		$this->assertIsArray( Users::get_site_user_meta( $this->user_id, $meta_key ), 'saved-for-later should be persisted after the first add+save.' );
+	}
+
+	/**
+	 * @testdox get_by_slug should return false for any list slug other than saved-for-later.
+	 */
+	public function test_load_returns_false_for_unsupported_list_slug(): void {
+		$this->assertFalse( ShopperList::get_by_slug( 'wishlist', $this->user_id ) );
+		$this->assertFalse( ShopperList::get_by_slug( 'INVALID', $this->user_id ) );
+		$this->assertFalse( ShopperList::get_by_slug( '', $this->user_id ) );
+	}
+
+	/**
+	 * @testdox get_by_slug should self-heal saved-for-later when the stored meta is corrupt.
+	 */
+	public function test_load_self_heals_corrupt_saved_for_later(): void {
+		Users::update_site_user_meta(
+			$this->user_id,
+			ShopperList::META_KEY_PREFIX . self::SAVED_FOR_LATER_SLUG,
+			'this-is-not-an-array'
+		);
+
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+
+		$this->assertInstanceOf( ShopperList::class, $list );
+		$this->assertSame( array(), $list->get_items(), 'Corrupt meta must yield an empty in-memory list.' );
+	}
+
+	/**
+	 * @testdox get_by_slug should skip individual corrupt items but still return the rest of the list.
+	 */
+	public function test_load_skips_corrupt_items(): void {
+		$good_item = $this->item->to_array();
+		Users::update_site_user_meta(
+			$this->user_id,
+			ShopperList::META_KEY_PREFIX . self::SAVED_FOR_LATER_SLUG,
+			array(
+				'slug'             => self::SAVED_FOR_LATER_SLUG,
+				'date_created_gmt' => '2026-04-01 00:00:00',
+				'items'            => array(
+					$good_item['key'] => $good_item,
+					// Missing key + product_id.
+					'broken-row-key'  => array( 'variation_id' => 0 ),
+				),
+			)
+		);
+
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+
+		$this->assertInstanceOf( ShopperList::class, $list );
+		$this->assertCount( 1, $list->get_items(), 'Bad rows should be skipped, the rest kept.' );
+		$this->assertNotNull( $list->find_item( $good_item['key'] ) );
+	}
+
+	/**
+	 * @testdox add_item/remove_item round-trip through save() and reload, merge quantities for the same key, and report unknown keys.
+	 */
+	public function test_list_item_crud(): void {
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+
+		$list->add_item( $this->item );
+		$list->add_item( $this->item );
+		$list->save();
+
+		$reloaded = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+		$this->assertCount( 1, $reloaded->get_items(), 'Adding the same item twice must keep a single row.' );
+
+		$merged = $reloaded->find_item( $this->item->get_key() );
+		$this->assertNotNull( $merged );
+		$this->assertSame( 2, $merged->get_quantity(), 'Quantities must be summed when the same product+variation is added again.' );
+
+		$this->assertFalse( $reloaded->remove_item( 'nonexistent-key' ), 'remove_item should return false for unknown keys.' );
+		$this->assertTrue( $reloaded->remove_item( $this->item->get_key() ) );
+		$reloaded->save();
+
+		$this->assertSame( array(), ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id )->get_items() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PoC stacked on `feature/shopper-collections` to validate that the existing `woocommerce/shopper-collection` block and the shopper-lists Store API can be reused for a wishlist UX without writing new infrastructure.

- Adds a `/my-account/wishlist/` endpoint via filter-based hooks that renders the existing Shopper Collection block (\`listName: "saved-for-later"\`) inside My Account.
- Injects a star toggle button into the rendered Add-to-Cart-with-Options form via `render_block_woocommerce/add-to-cart-with-options`. The button lives inside the form's iAPI scope so it inherits the parent's `quantity` and `selectedAttributes` context, and dispatches `addItem` / `removeItem` on the existing `woocommerce/shopper-lists` iAPI store with slug `saved-for-later`.
- Extends the locked `woocommerce/add-to-cart-with-options` store with `state.matchingWishlistItem`, `state.isInWishlist`, and `actions.toggleWishlistFromForm`. PHP prefetches the user's saved-for-later items and seeds them into iAPI state for correct first-paint of the star (filled vs empty).

Both surfaces are logged-in only and gated indirectly by the `cart_save_for_later` feature flag (the block they depend on is gated there).

### Screenshots or screen recordings:

<img width="823" height="548" alt="Screenshot 2026-05-12 at 00 21 31" src="https://github.com/user-attachments/assets/7b054e05-9e8d-458e-ba19-060ed97e6b94" />

<img width="333" height="354" alt="Screenshot 2026-05-12 at 00 15 15" src="https://github.com/user-attachments/assets/ca612462-9003-4d80-8819-b7d6dc760be8" />



### How to test the changes in this Pull Request:

1. Enable the `cart_save_for_later` feature flag (Settings → Advanced → Features).
2. Visit `/wp-admin/options-permalink.php` and click **Save** (flushes rewrite rules so `/my-account/wishlist/` resolves).
3. Log in as a customer.
4. Visit a **simple product** using the block-themed Single Product template (Add-to-Cart-with-Options form must render). The star button appears at the bottom of the form, empty.
5. Click the star — it fills, `aria-pressed="true"`. Network tab shows `POST /wc/store/v1/shopper-lists/saved-for-later/items`.
6. Reload the page — star renders filled on first paint (SSR resolves the initial state).
7. Visit `/my-account/wishlist/` — the Shopper Collection block renders with the saved item. The "Wishlist" menu item is highlighted.
8. Click **Move to cart** on the row — item moves into the cart, row disappears from the wishlist.
9. Return to the product page — star is empty again.
10. Repeat steps 4–9 with a **variable product**: pick a variation, click the star, confirm only that specific variation appears in the wishlist. Switching to a different (un-saved) variation empties the star; switching back fills it.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog file added manually in this PR (\`plugins/woocommerce/changelog/add-wishlist-my-account-scope\`).

</details>