### PR TITLE
Unstick auto-defaulted Local Pickup once a real shipping rate becomes available

### DIFF
--- a/docs/apis/store-api/resources-endpoints/cart.md
+++ b/docs/apis/store-api/resources-endpoints/cart.md
@@ -259,6 +259,7 @@ All endpoints under `/cart` (listed in this doc) return responses in the same fo
 					"quantity": 1
 				}
 			],
+			"selected_rate_origin": "auto",
 			"shipping_rates": [
 				{
 					"rate_id": "flat_rate:10",

--- a/plugins/woocommerce/changelog/expose-selected-rate-origin-store-api
+++ b/plugins/woocommerce/changelog/expose-selected-rate-origin-store-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Expose selected_rate_origin ('auto'|'manual'|null) on Store API cart shipping packages, so payment gateways can distinguish an auto-defaulted Local Pickup from one the customer explicitly chose.

--- a/plugins/woocommerce/changelog/expose-selected-rate-origin-store-api
+++ b/plugins/woocommerce/changelog/expose-selected-rate-origin-store-api
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Expose selected_rate_origin ('auto'|'manual'|null) on Store API cart shipping packages, so payment gateways can distinguish an auto-defaulted Local Pickup from one the customer explicitly chose.
+Expose selected_rate_origin ('auto'|'manual'|null) on Store API cart shipping packages, so payment gateways can identify a shipping rate known to have been auto-defaulted (such as a sticky Local Pickup) and leave every other selection alone.

--- a/plugins/woocommerce/changelog/unstick-auto-default-local-pickup
+++ b/plugins/woocommerce/changelog/unstick-auto-default-local-pickup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace auto-defaulted Local Pickup with a real shipping rate once one becomes available (e.g. after an Apple Pay / Google Pay wallet supplies a delivery address), instead of keeping pickup sticky when the customer never explicitly chose it.

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.ts
@@ -75,6 +75,7 @@ export interface CartShippingRate {
 	name: string;
 	destination: BaseAddress;
 	items: Array< ShippingRateItem >;
+	selected_rate_origin?: 'auto' | 'manual' | null;
 	shipping_rates: Array< CartShippingPackageShippingRate >;
 }
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -348,12 +348,8 @@ class WC_AJAX {
 
 	/**
 	 * Merges posted shipping methods into the chosen-methods array, recording a 'manual'
-	 * shipping-method origin only when the posted method differs from the current choice.
-	 *
-	 * The checkout page re-posts the currently selected method on every order-review refresh
-	 * (page load, address field edits), so a repeat of the existing choice is not a customer
-	 * decision. Only a change of method counts as a 'manual' origin; repeats keep the current
-	 * origin so an auto-defaulted Local Pickup stays eligible for unsticking.
+	 * shipping-method origin for each posted method. Repeats of the current choice are
+	 * ignored by the tracker (see ShippingMethodOriginTracker::record_manual_selection()).
 	 *
 	 * @param mixed $posted_shipping_methods Cleaned `shipping_method` request value.
 	 * @param mixed $chosen_shipping_methods Current chosen methods from the session.
@@ -370,13 +366,8 @@ class WC_AJAX {
 			if ( ! is_string( $value ) ) {
 				continue;
 			}
-			$previous_method = isset( $chosen_shipping_methods[ $i ] ) && is_string( $chosen_shipping_methods[ $i ] ) ? $chosen_shipping_methods[ $i ] : '';
-
+			$origin_tracker->record_manual_selection( $i, $value );
 			$chosen_shipping_methods[ $i ] = $value;
-
-			if ( $value !== $previous_method ) {
-				$origin_tracker->set_origin( $i, 'manual', $value );
-			}
 		}
 
 		return $chosen_shipping_methods;

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -345,7 +345,7 @@ class WC_AJAX {
 					continue;
 				}
 				$chosen_shipping_methods[ $i ] = $value;
-				wc_set_chosen_shipping_method_origin( $i, 'manual' );
+				wc_set_chosen_shipping_method_origin( $i, 'manual', $value );
 			}
 		}
 
@@ -414,7 +414,7 @@ class WC_AJAX {
 					continue;
 				}
 				$chosen_shipping_methods[ $i ] = $value;
-				wc_set_chosen_shipping_method_origin( $i, 'manual' );
+				wc_set_chosen_shipping_method_origin( $i, 'manual', $value );
 			}
 		}
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController;
 use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
 use Automattic\WooCommerce\Internal\Orders\CouponsController;
 use Automattic\WooCommerce\Internal\Orders\TaxesController;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
@@ -353,7 +354,7 @@ class WC_AJAX {
 				$chosen_shipping_methods[ $i ] = $value;
 
 				if ( $value !== $previous_method ) {
-					wc_set_chosen_shipping_method_origin( $i, 'manual', $value );
+					wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $i, 'manual', $value );
 				}
 			}
 		}
@@ -431,7 +432,7 @@ class WC_AJAX {
 				$chosen_shipping_methods[ $i ] = $value;
 
 				if ( $value !== $previous_method ) {
-					wc_set_chosen_shipping_method_origin( $i, 'manual', $value );
+					wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $i, 'manual', $value );
 				}
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -345,6 +345,7 @@ class WC_AJAX {
 					continue;
 				}
 				$chosen_shipping_methods[ $i ] = $value;
+				wc_set_chosen_shipping_method_origin( $i, 'manual' );
 			}
 		}
 
@@ -413,6 +414,7 @@ class WC_AJAX {
 					continue;
 				}
 				$chosen_shipping_methods[ $i ] = $value;
+				wc_set_chosen_shipping_method_origin( $i, 'manual' );
 			}
 		}
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -344,8 +344,17 @@ class WC_AJAX {
 				if ( ! is_string( $value ) ) {
 					continue;
 				}
+				// The checkout page re-posts the currently selected method on every order-review refresh
+				// (page load, address field edits), so a repeat of the existing choice is not a customer
+				// decision. Only a change of method counts as a 'manual' origin; repeats keep the current
+				// origin so an auto-defaulted Local Pickup stays eligible for unsticking.
+				$previous_method = isset( $chosen_shipping_methods[ $i ] ) && is_string( $chosen_shipping_methods[ $i ] ) ? $chosen_shipping_methods[ $i ] : '';
+
 				$chosen_shipping_methods[ $i ] = $value;
-				wc_set_chosen_shipping_method_origin( $i, 'manual', $value );
+
+				if ( $value !== $previous_method ) {
+					wc_set_chosen_shipping_method_origin( $i, 'manual', $value );
+				}
 			}
 		}
 
@@ -413,8 +422,17 @@ class WC_AJAX {
 				if ( ! is_string( $value ) ) {
 					continue;
 				}
+				// The checkout page re-posts the currently selected method on every order-review refresh
+				// (page load, address field edits), so a repeat of the existing choice is not a customer
+				// decision. Only a change of method counts as a 'manual' origin; repeats keep the current
+				// origin so an auto-defaulted Local Pickup stays eligible for unsticking.
+				$previous_method = isset( $chosen_shipping_methods[ $i ] ) && is_string( $chosen_shipping_methods[ $i ] ) ? $chosen_shipping_methods[ $i ] : '';
+
 				$chosen_shipping_methods[ $i ] = $value;
-				wc_set_chosen_shipping_method_origin( $i, 'manual', $value );
+
+				if ( $value !== $previous_method ) {
+					wc_set_chosen_shipping_method_origin( $i, 'manual', $value );
+				}
 			}
 		}
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -339,29 +339,45 @@ class WC_AJAX {
 
 		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
 		$posted_shipping_methods = isset( $_POST['shipping_method'] ) ? wc_clean( wp_unslash( $_POST['shipping_method'] ) ) : array();
-
-		if ( is_array( $posted_shipping_methods ) ) {
-			foreach ( $posted_shipping_methods as $i => $value ) {
-				if ( ! is_string( $value ) ) {
-					continue;
-				}
-				// The checkout page re-posts the currently selected method on every order-review refresh
-				// (page load, address field edits), so a repeat of the existing choice is not a customer
-				// decision. Only a change of method counts as a 'manual' origin; repeats keep the current
-				// origin so an auto-defaulted Local Pickup stays eligible for unsticking.
-				$previous_method = isset( $chosen_shipping_methods[ $i ] ) && is_string( $chosen_shipping_methods[ $i ] ) ? $chosen_shipping_methods[ $i ] : '';
-
-				$chosen_shipping_methods[ $i ] = $value;
-
-				if ( $value !== $previous_method ) {
-					wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $i, 'manual', $value );
-				}
-			}
-		}
+		$chosen_shipping_methods = self::apply_posted_shipping_methods( $posted_shipping_methods, $chosen_shipping_methods );
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
 
 		self::get_cart_totals();
+	}
+
+	/**
+	 * Merges posted shipping methods into the chosen-methods array, recording a 'manual'
+	 * shipping-method origin only when the posted method differs from the current choice.
+	 *
+	 * The checkout page re-posts the currently selected method on every order-review refresh
+	 * (page load, address field edits), so a repeat of the existing choice is not a customer
+	 * decision. Only a change of method counts as a 'manual' origin; repeats keep the current
+	 * origin so an auto-defaulted Local Pickup stays eligible for unsticking.
+	 *
+	 * @param mixed $posted_shipping_methods Cleaned `shipping_method` request value.
+	 * @param mixed $chosen_shipping_methods Current chosen methods from the session.
+	 * @return mixed Updated chosen methods array (input returned as-is when nothing was posted).
+	 */
+	private static function apply_posted_shipping_methods( $posted_shipping_methods, $chosen_shipping_methods ) {
+		if ( ! is_array( $posted_shipping_methods ) ) {
+			return $chosen_shipping_methods;
+		}
+
+		foreach ( $posted_shipping_methods as $i => $value ) {
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+			$previous_method = isset( $chosen_shipping_methods[ $i ] ) && is_string( $chosen_shipping_methods[ $i ] ) ? $chosen_shipping_methods[ $i ] : '';
+
+			$chosen_shipping_methods[ $i ] = $value;
+
+			if ( $value !== $previous_method ) {
+				wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $i, 'manual', $value );
+			}
+		}
+
+		return $chosen_shipping_methods;
 	}
 
 	/**
@@ -418,24 +434,7 @@ class WC_AJAX {
 		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
 		$posted_shipping_methods = isset( $_POST['shipping_method'] ) ? wc_clean( wp_unslash( $_POST['shipping_method'] ) ) : array();
 
-		if ( is_array( $posted_shipping_methods ) ) {
-			foreach ( $posted_shipping_methods as $i => $value ) {
-				if ( ! is_string( $value ) ) {
-					continue;
-				}
-				// The checkout page re-posts the currently selected method on every order-review refresh
-				// (page load, address field edits), so a repeat of the existing choice is not a customer
-				// decision. Only a change of method counts as a 'manual' origin; repeats keep the current
-				// origin so an auto-defaulted Local Pickup stays eligible for unsticking.
-				$previous_method = isset( $chosen_shipping_methods[ $i ] ) && is_string( $chosen_shipping_methods[ $i ] ) ? $chosen_shipping_methods[ $i ] : '';
-
-				$chosen_shipping_methods[ $i ] = $value;
-
-				if ( $value !== $previous_method ) {
-					wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $i, 'manual', $value );
-				}
-			}
-		}
+		$chosen_shipping_methods = self::apply_posted_shipping_methods( $posted_shipping_methods, $chosen_shipping_methods );
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
 		WC()->session->set( 'chosen_payment_method', empty( $_POST['payment_method'] ) ? '' : wc_clean( wp_unslash( $_POST['payment_method'] ) ) );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -364,6 +364,8 @@ class WC_AJAX {
 			return $chosen_shipping_methods;
 		}
 
+		$origin_tracker = wc_get_container()->get( ShippingMethodOriginTracker::class );
+
 		foreach ( $posted_shipping_methods as $i => $value ) {
 			if ( ! is_string( $value ) ) {
 				continue;
@@ -373,7 +375,7 @@ class WC_AJAX {
 			$chosen_shipping_methods[ $i ] = $value;
 
 			if ( $value !== $previous_method ) {
-				wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $i, 'manual', $value );
+				$origin_tracker->set_origin( $i, 'manual', $value );
 			}
 		}
 

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -322,6 +322,7 @@ final class WC_Cart_Session {
 		$wc_session->set( 'shipping_method_counts', null );
 		$wc_session->set( 'previous_shipping_methods', null );
 		$wc_session->set( 'chosen_shipping_methods', null );
+		$wc_session->set( 'chosen_shipping_method_origins', null );
 		$this->remove_shipping_for_package_from_session();
 	}
 

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -423,6 +423,7 @@ final class WC_Cart_Session {
 			$wc_session->set( 'shipping_method_counts', null );
 			$wc_session->set( 'previous_shipping_methods', null );
 			$wc_session->set( 'chosen_shipping_methods', null );
+			$wc_session->set( 'chosen_shipping_method_origins', null );
 			$this->remove_shipping_for_package_from_session();
 		}
 		if ( empty( $cart ) ) {

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -8,6 +8,7 @@
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -322,7 +323,7 @@ final class WC_Cart_Session {
 		$wc_session->set( 'shipping_method_counts', null );
 		$wc_session->set( 'previous_shipping_methods', null );
 		$wc_session->set( 'chosen_shipping_methods', null );
-		$wc_session->set( 'chosen_shipping_method_origins', null );
+		$wc_session->set( ShippingMethodOriginTracker::SESSION_KEY, null );
 		$this->remove_shipping_for_package_from_session();
 	}
 
@@ -423,7 +424,7 @@ final class WC_Cart_Session {
 			$wc_session->set( 'shipping_method_counts', null );
 			$wc_session->set( 'previous_shipping_methods', null );
 			$wc_session->set( 'chosen_shipping_methods', null );
-			$wc_session->set( 'chosen_shipping_method_origins', null );
+			$wc_session->set( ShippingMethodOriginTracker::SESSION_KEY, null );
 			$this->remove_shipping_for_package_from_session();
 		}
 		if ( empty( $cart ) ) {

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Enums\TaxDisplayMode;
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
 use Automattic\WooCommerce\Internal\Tax\TaxRateDataStore;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 use Automattic\WooCommerce\Utilities\DiscountsUtil;
@@ -2105,7 +2106,7 @@ class WC_Cart extends WC_Legacy_Cart {
 
 			foreach ( $packages as $i => $package ) {
 				$chosen_shipping_methods[ $i ] = 'free_shipping';
-				wc_set_chosen_shipping_method_origin( $i, 'manual', 'free_shipping' );
+				wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $i, 'manual', 'free_shipping' );
 			}
 
 			WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -2106,8 +2106,8 @@ class WC_Cart extends WC_Legacy_Cart {
 			$origin_tracker          = wc_get_container()->get( ShippingMethodOriginTracker::class );
 
 			foreach ( $packages as $i => $package ) {
+				$origin_tracker->record_manual_selection( $i, 'free_shipping' );
 				$chosen_shipping_methods[ $i ] = 'free_shipping';
-				$origin_tracker->set_origin( $i, 'manual', 'free_shipping' );
 			}
 
 			WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -2105,7 +2105,7 @@ class WC_Cart extends WC_Legacy_Cart {
 
 			foreach ( $packages as $i => $package ) {
 				$chosen_shipping_methods[ $i ] = 'free_shipping';
-				wc_set_chosen_shipping_method_origin( $i, 'manual' );
+				wc_set_chosen_shipping_method_origin( $i, 'manual', 'free_shipping' );
 			}
 
 			WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -2105,6 +2105,7 @@ class WC_Cart extends WC_Legacy_Cart {
 
 			foreach ( $packages as $i => $package ) {
 				$chosen_shipping_methods[ $i ] = 'free_shipping';
+				wc_set_chosen_shipping_method_origin( $i, 'manual' );
 			}
 
 			WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -2103,10 +2103,11 @@ class WC_Cart extends WC_Legacy_Cart {
 		if ( $the_coupon->get_free_shipping() ) {
 			$packages                = WC()->shipping()->get_packages();
 			$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
+			$origin_tracker          = wc_get_container()->get( ShippingMethodOriginTracker::class );
 
 			foreach ( $packages as $i => $package ) {
 				$chosen_shipping_methods[ $i ] = 'free_shipping';
-				wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $i, 'manual', 'free_shipping' );
+				$origin_tracker->set_origin( $i, 'manual', 'free_shipping' );
 			}
 
 			WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -466,7 +467,7 @@ class WC_Shipping {
 	 */
 	public function reset_shipping() {
 		unset( WC()->session->chosen_shipping_methods );
-		unset( WC()->session->chosen_shipping_method_origins );
+		unset( WC()->session->{ShippingMethodOriginTracker::SESSION_KEY} );
 		$this->packages = array();
 	}
 

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -466,6 +466,7 @@ class WC_Shipping {
 	 */
 	public function reset_shipping() {
 		unset( WC()->session->chosen_shipping_methods );
+		unset( WC()->session->chosen_shipping_method_origins );
 		$this->packages = array();
 	}
 

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -479,6 +479,7 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_methods );
 		WC()->session->set( 'shipping_method_counts', $method_counts );
+		wc_set_chosen_shipping_method_origin( $key, 'auto' );
 
 		/**
 		 * Fires when a shipping method is chosen.
@@ -489,6 +490,63 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 		do_action( 'woocommerce_shipping_method_chosen', $chosen_method );
 	}
 	return $chosen_method;
+}
+
+/**
+ * Records who picked the currently chosen shipping method for a package: the
+ * `wc_get_default_shipping_method_for_package()` auto-defaulter ('auto') or the
+ * customer via an explicit selection path like the Store API select-shipping-rate
+ * route, the shortcode cart/checkout AJAX, or a coupon-driven free-shipping
+ * override ('manual').
+ *
+ * This signal lets `wc_get_default_shipping_method_for_package()` distinguish
+ * between "the customer chose Local Pickup" (sticky on purpose) and "WC defaulted
+ * to Local Pickup because no zone matched yet" (should re-evaluate once a real
+ * shipping rate becomes available, e.g. after an Apple Pay / Google Pay wallet
+ * supplies an address).
+ *
+ * @since 10.6.0
+ *
+ * @param int|string $key    Package key.
+ * @param string     $origin Either 'auto' or 'manual'.
+ * @return void
+ */
+function wc_set_chosen_shipping_method_origin( $key, $origin ) {
+	if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
+		return;
+	}
+
+	if ( ! in_array( $origin, array( 'auto', 'manual' ), true ) ) {
+		return;
+	}
+
+	$origins         = WC()->session->get( 'chosen_shipping_method_origins', array() );
+	$origins[ $key ] = $origin;
+	WC()->session->set( 'chosen_shipping_method_origins', $origins );
+}
+
+/**
+ * Returns the recorded origin ('auto' or 'manual') of the chosen shipping method
+ * for a package, or 'manual' when no origin has been recorded yet.
+ *
+ * Defaulting to 'manual' preserves the historical sticky-Local-Pickup behavior
+ * for sessions that pre-date origin tracking. New sessions get the correct
+ * origin written from the first `wc_get_chosen_shipping_method_for_package()`
+ * call onwards.
+ *
+ * @since 10.6.0
+ *
+ * @param int|string $key Package key.
+ * @return string 'auto' or 'manual'.
+ */
+function wc_get_chosen_shipping_method_origin( $key ) {
+	if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
+		return 'manual';
+	}
+
+	$origins = WC()->session->get( 'chosen_shipping_method_origins', array() );
+
+	return isset( $origins[ $key ] ) && 'auto' === $origins[ $key ] ? 'auto' : 'manual';
 }
 
 /**
@@ -540,17 +598,27 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 	}
 
 	/**
-	 * If the customer has selected local pickup, keep it selected if it's still in the package. We don't want to auto
-	 * toggle between shipping and pickup even if available shipping methods are changed.
+	 * If the customer has explicitly selected local pickup, keep it selected if it's still in the package. We don't
+	 * want to auto toggle between shipping and pickup even if available shipping methods are changed.
 	 *
 	 * This is important for block-based checkout where there is an explicit toggle between shipping and pickup.
+	 *
+	 * However, if the previous local-pickup choice came from this auto-defaulter (because at the time only pickup
+	 * matched — e.g. no customer address yet), it is not a real customer choice and should be replaced once a
+	 * non-pickup rate becomes available (e.g. after an Apple Pay / Google Pay wallet supplies an address that
+	 * matches a shipping zone). The origin of the previous choice is tracked via `wc_set_chosen_shipping_method_origin()`.
 	 */
-	$chosen_method_id       = current( explode( ':', $chosen_method ) );
-	$chosen_method_exists   = in_array( $chosen_method, $rate_keys, true );
-	$is_local_pickup_chosen = in_array( $chosen_method_id, $local_pickup_method_ids, true );
+	$chosen_method_id            = current( explode( ':', $chosen_method ) );
+	$chosen_method_exists        = in_array( $chosen_method, $rate_keys, true );
+	$is_local_pickup_chosen      = in_array( $chosen_method_id, $local_pickup_method_ids, true );
+	$default_method_id           = '' === $default ? '' : current( explode( ':', $default ) );
+	$has_non_pickup_alternative  = '' !== $default && ! in_array( $default_method_id, $local_pickup_method_ids, true );
+	$previous_choice_was_auto    = 'auto' === wc_get_chosen_shipping_method_origin( $key );
+	$unstick_auto_default_pickup = $previous_choice_was_auto && $has_non_pickup_alternative;
 
-	// Default to local pickup if its chosen already.
-	if ( $chosen_method_exists && $is_local_pickup_chosen ) {
+	// Default to local pickup if it's chosen already — unless the previous pickup choice came from the auto-defaulter
+	// AND a real shipping rate is now available, in which case we prefer the shipping rate.
+	if ( $chosen_method_exists && $is_local_pickup_chosen && ! $unstick_auto_default_pickup ) {
 		$default = $chosen_method;
 
 	} else {

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -488,10 +488,10 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 		// Only record the choice as auto-defaulted when the auto-defaulter actually assigned a method
 		// the customer didn't pick. If it kept the customer's existing manual choice (sticky pickup),
 		// preserve that 'manual' origin — otherwise the next re-evaluation would treat it as auto and
-		// could un-stick a deliberately chosen Local Pickup. The origin lookup only runs when the
-		// method was preserved (it's irrelevant — and immediately overwritten — otherwise).
-		if ( $chosen_method !== $previous_chosen_method || 'manual' !== wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key ) ) {
-			wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $key, 'auto', $chosen_method );
+		// could un-stick a deliberately chosen Local Pickup.
+		$origin_tracker = wc_get_container()->get( ShippingMethodOriginTracker::class );
+		if ( $chosen_method !== $previous_chosen_method || ShippingMethodOriginTracker::ORIGIN_MANUAL !== $origin_tracker->get_origin( $key ) ) {
+			$origin_tracker->set_origin( $key, ShippingMethodOriginTracker::ORIGIN_AUTO, $chosen_method );
 		}
 
 		/**
@@ -579,7 +579,7 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 	// Only consult the recorded origin when it can actually influence the outcome: a pickup rate is
 	// currently chosen and a non-pickup rate exists to switch to.
 	$unstick_auto_default_pickup = $chosen_method_exists && $is_local_pickup_chosen && $has_non_pickup_alternative
-		&& 'auto' === wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key );
+		&& ShippingMethodOriginTracker::ORIGIN_AUTO === wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key );
 
 	// Default to local pickup if it's chosen already — unless the previous pickup choice came from the auto-defaulter
 	// AND a real shipping rate is now available, in which case we prefer the shipping rate.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -506,7 +506,7 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 
 /**
  * Records who picked the currently chosen shipping method for a package: the
- * `wc_get_default_shipping_method_for_package()` auto-defaulter ('auto') or the
+ * auto-defaulter in `wc_get_chosen_shipping_method_for_package()` ('auto') or the
  * customer via an explicit selection path like the Store API select-shipping-rate
  * route, the shortcode cart/checkout AJAX, or a coupon-driven free-shipping
  * override ('manual').
@@ -523,7 +523,7 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
  * recorded rate_id no longer matches the current chosen rate, and the reader
  * falls back to 'manual'.
  *
- * @since 10.6.0
+ * @since 11.1.0
  *
  * @param int|string $key     Package key.
  * @param string     $origin  Either 'auto' or 'manual'.
@@ -560,7 +560,7 @@ function wc_set_chosen_shipping_method_origin( $key, $origin, $rate_id ) {
  *   overwrote the choice, so the recorded 'auto' marker is stale and we treat
  *   the new choice as deliberate).
  *
- * @since 10.6.0
+ * @since 11.1.0
  *
  * @param int|string $key Package key.
  * @return string 'auto' or 'manual'.
@@ -651,7 +651,7 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 	$chosen_method_id            = current( explode( ':', $chosen_method ) );
 	$chosen_method_exists        = in_array( $chosen_method, $rate_keys, true );
 	$is_local_pickup_chosen      = in_array( $chosen_method_id, $local_pickup_method_ids, true );
-	$default_method_id           = '' === $default ? '' : current( explode( ':', $default ) );
+	$default_method_id           = '' === $default ? '' : current( explode( ':', (string) $default ) );
 	$has_non_pickup_alternative  = '' !== $default && ! in_array( $default_method_id, $local_pickup_method_ids, true );
 	$previous_choice_was_auto    = 'auto' === wc_get_chosen_shipping_method_origin( $key );
 	$unstick_auto_default_pickup = $previous_choice_was_auto && $has_non_pickup_alternative;

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 
 defined( 'ABSPATH' ) || exit;
@@ -476,7 +477,7 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 		// Capture the previous choice and its origin before the auto-defaulter runs, so we can tell
 		// whether it computed a new default or simply preserved an existing customer choice.
 		$previous_chosen_method = $chosen_method;
-		$previous_origin        = wc_get_chosen_shipping_method_origin( $key );
+		$previous_origin        = wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key );
 
 		$chosen_method          = wc_get_default_shipping_method_for_package( $key, $package, $chosen_method );
 		$chosen_methods[ $key ] = $chosen_method;
@@ -490,7 +491,7 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 		// preserve that 'manual' origin — otherwise the next re-evaluation would treat it as auto and
 		// could un-stick a deliberately chosen Local Pickup.
 		if ( ! ( $chosen_method === $previous_chosen_method && 'manual' === $previous_origin ) ) {
-			wc_set_chosen_shipping_method_origin( $key, 'auto', $chosen_method );
+			wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $key, 'auto', $chosen_method );
 		}
 
 		/**
@@ -502,91 +503,6 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 		do_action( 'woocommerce_shipping_method_chosen', $chosen_method );
 	}
 	return $chosen_method;
-}
-
-/**
- * Records who picked the currently chosen shipping method for a package: the
- * auto-defaulter in `wc_get_chosen_shipping_method_for_package()` ('auto') or the
- * customer via an explicit selection path like the Store API select-shipping-rate
- * route, the shortcode cart/checkout AJAX, or a coupon-driven free-shipping
- * override ('manual').
- *
- * This signal lets `wc_get_default_shipping_method_for_package()` distinguish
- * between "the customer chose Local Pickup" (sticky on purpose) and "WC defaulted
- * to Local Pickup because no zone matched yet" (should re-evaluate once a real
- * shipping rate becomes available, e.g. after an Apple Pay / Google Pay wallet
- * supplies an address).
- *
- * Origin is tied to the rate_id it was recorded against, so that a third-party
- * caller writing to `chosen_shipping_methods` directly (bypassing the Store API
- * and the AJAX endpoints) implicitly invalidates a stale 'auto' marker — the
- * recorded rate_id no longer matches the current chosen rate, and the reader
- * falls back to 'manual'.
- *
- * @since 11.1.0
- *
- * @param int|string $key     Package key.
- * @param string     $origin  Either 'auto' or 'manual'.
- * @param string     $rate_id The rate_id this origin applies to.
- * @return void
- */
-function wc_set_chosen_shipping_method_origin( $key, $origin, $rate_id ) {
-	if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
-		return;
-	}
-
-	if ( ! in_array( $origin, array( 'auto', 'manual' ), true ) ) {
-		return;
-	}
-
-	$origins         = WC()->session->get( 'chosen_shipping_method_origins', array() );
-	$origins[ $key ] = array(
-		'rate_id' => (string) $rate_id,
-		'origin'  => $origin,
-	);
-	WC()->session->set( 'chosen_shipping_method_origins', $origins );
-}
-
-/**
- * Returns the recorded origin ('auto' or 'manual') of the chosen shipping method
- * for a package.
- *
- * Falls back to 'manual' when:
- *
- * - no origin has been recorded yet (preserves the historical sticky-Local-Pickup
- *   behavior for sessions that pre-date origin tracking); or
- * - the recorded rate_id no longer matches the chosen rate currently in
- *   `chosen_shipping_methods` (something other than the tracked write paths
- *   overwrote the choice, so the recorded 'auto' marker is stale and we treat
- *   the new choice as deliberate).
- *
- * @since 11.1.0
- *
- * @param int|string $key Package key.
- * @return string 'auto' or 'manual'.
- */
-function wc_get_chosen_shipping_method_origin( $key ) {
-	if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
-		return 'manual';
-	}
-
-	$origins = WC()->session->get( 'chosen_shipping_method_origins', array() );
-	$entry   = isset( $origins[ $key ] ) ? $origins[ $key ] : null;
-
-	if ( ! is_array( $entry ) || ! isset( $entry['rate_id'], $entry['origin'] ) ) {
-		return 'manual';
-	}
-
-	$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
-	$current_rate   = isset( $chosen_methods[ $key ] ) ? (string) $chosen_methods[ $key ] : '';
-
-	// If the chosen rate has been overwritten by something that didn't go through
-	// `wc_set_chosen_shipping_method_origin()`, treat the new choice as manual.
-	if ( $current_rate !== (string) $entry['rate_id'] ) {
-		return 'manual';
-	}
-
-	return 'auto' === $entry['origin'] ? 'auto' : 'manual';
 }
 
 /**
@@ -646,14 +562,14 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 	 * However, if the previous local-pickup choice came from this auto-defaulter (because at the time only pickup
 	 * matched — e.g. no customer address yet), it is not a real customer choice and should be replaced once a
 	 * non-pickup rate becomes available (e.g. after an Apple Pay / Google Pay wallet supplies an address that
-	 * matches a shipping zone). The origin of the previous choice is tracked via `wc_set_chosen_shipping_method_origin()`.
+	 * matches a shipping zone). The origin of the previous choice is tracked via ShippingMethodOriginTracker.
 	 */
 	$chosen_method_id            = current( explode( ':', $chosen_method ) );
 	$chosen_method_exists        = in_array( $chosen_method, $rate_keys, true );
 	$is_local_pickup_chosen      = in_array( $chosen_method_id, $local_pickup_method_ids, true );
 	$default_method_id           = '' === $default ? '' : current( explode( ':', (string) $default ) );
 	$has_non_pickup_alternative  = '' !== $default && ! in_array( $default_method_id, $local_pickup_method_ids, true );
-	$previous_choice_was_auto    = 'auto' === wc_get_chosen_shipping_method_origin( $key );
+	$previous_choice_was_auto    = 'auto' === wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key );
 	$unstick_auto_default_pickup = $previous_choice_was_auto && $has_non_pickup_alternative;
 
 	// Default to local pickup if it's chosen already — unless the previous pickup choice came from the auto-defaulter

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -474,10 +474,9 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 
 	// If not set, not available, or available methods have changed, set to the DEFAULT option.
 	if ( ! $chosen_method || $changed || ! isset( $package['rates'][ $chosen_method ] ) || count( $package['rates'] ) !== $method_count ) {
-		// Capture the previous choice and its origin before the auto-defaulter runs, so we can tell
-		// whether it computed a new default or simply preserved an existing customer choice.
+		// Capture the previous choice before the auto-defaulter runs, so we can tell whether it
+		// computed a new default or simply preserved an existing customer choice.
 		$previous_chosen_method = $chosen_method;
-		$previous_origin        = wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key );
 
 		$chosen_method          = wc_get_default_shipping_method_for_package( $key, $package, $chosen_method );
 		$chosen_methods[ $key ] = $chosen_method;
@@ -489,8 +488,9 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 		// Only record the choice as auto-defaulted when the auto-defaulter actually assigned a method
 		// the customer didn't pick. If it kept the customer's existing manual choice (sticky pickup),
 		// preserve that 'manual' origin — otherwise the next re-evaluation would treat it as auto and
-		// could un-stick a deliberately chosen Local Pickup.
-		if ( ! ( $chosen_method === $previous_chosen_method && 'manual' === $previous_origin ) ) {
+		// could un-stick a deliberately chosen Local Pickup. The origin lookup only runs when the
+		// method was preserved (it's irrelevant — and immediately overwritten — otherwise).
+		if ( $chosen_method !== $previous_chosen_method || 'manual' !== wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key ) ) {
 			wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $key, 'auto', $chosen_method );
 		}
 
@@ -518,6 +518,17 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 	$rate_keys               = array_keys( $package['rates'] );
 	$local_pickup_method_ids = LocalPickupUtils::get_local_pickup_method_ids();
 
+	// The first rate in the package that isn't a local pickup method. Used as the non-shortcode
+	// default and as the replacement rate when un-sticking an auto-defaulted pickup (any context).
+	$first_non_pickup_rate = '';
+	foreach ( $rate_keys as $rate_key ) {
+		$rate_method_id = current( explode( ':', (string) $rate_key ) );
+		if ( ! in_array( $rate_method_id, $local_pickup_method_ids, true ) ) {
+			$first_non_pickup_rate = $rate_key;
+			break;
+		}
+	}
+
 	if ( 'shortcode' === WC()->cart->cart_context ) {
 		$default = current( $rate_keys );
 	} else {
@@ -525,12 +536,8 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 		$default = CartCheckoutUtils::shipping_methods_exist() ? '' : current( $rate_keys );
 
 		// Default to the first method in the package that isn't a local pickup method.
-		foreach ( $rate_keys as $rate_key ) {
-			$rate_method_id = current( explode( ':', $rate_key ) );
-			if ( ! in_array( $rate_method_id, $local_pickup_method_ids, true ) ) {
-				$default = $rate_key;
-				break;
-			}
+		if ( '' !== $first_non_pickup_rate ) {
+			$default = $first_non_pickup_rate;
 		}
 
 		// When shipping costs are hidden until an address is entered, don't auto-select pickup as the default.
@@ -564,13 +571,15 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 	 * non-pickup rate becomes available (e.g. after an Apple Pay / Google Pay wallet supplies an address that
 	 * matches a shipping zone). The origin of the previous choice is tracked via ShippingMethodOriginTracker.
 	 */
-	$chosen_method_id            = current( explode( ':', $chosen_method ) );
-	$chosen_method_exists        = in_array( $chosen_method, $rate_keys, true );
-	$is_local_pickup_chosen      = in_array( $chosen_method_id, $local_pickup_method_ids, true );
-	$default_method_id           = '' === $default ? '' : current( explode( ':', (string) $default ) );
-	$has_non_pickup_alternative  = '' !== $default && ! in_array( $default_method_id, $local_pickup_method_ids, true );
-	$previous_choice_was_auto    = 'auto' === wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key );
-	$unstick_auto_default_pickup = $previous_choice_was_auto && $has_non_pickup_alternative;
+	$chosen_method_id           = current( explode( ':', $chosen_method ) );
+	$chosen_method_exists       = in_array( $chosen_method, $rate_keys, true );
+	$is_local_pickup_chosen     = in_array( $chosen_method_id, $local_pickup_method_ids, true );
+	$has_non_pickup_alternative = '' !== $first_non_pickup_rate;
+
+	// Only consult the recorded origin when it can actually influence the outcome: a pickup rate is
+	// currently chosen and a non-pickup rate exists to switch to.
+	$unstick_auto_default_pickup = $chosen_method_exists && $is_local_pickup_chosen && $has_non_pickup_alternative
+		&& 'auto' === wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $key );
 
 	// Default to local pickup if it's chosen already — unless the previous pickup choice came from the auto-defaulter
 	// AND a real shipping rate is now available, in which case we prefer the shipping rate.
@@ -578,6 +587,12 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 		$default = $chosen_method;
 
 	} else {
+		if ( $unstick_auto_default_pickup ) {
+			// In shortcode context $default is simply the first rate in the package, which may itself
+			// be a pickup rate; when un-sticking, switch to the first non-pickup rate instead.
+			$default = $first_non_pickup_rate;
+		}
+
 		// Check coupons to see if free shipping is available. If it is, we'll use that method as the default.
 		$coupons = WC()->cart->get_coupons();
 		foreach ( $coupons as $coupon ) {

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -479,7 +479,7 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_methods );
 		WC()->session->set( 'shipping_method_counts', $method_counts );
-		wc_set_chosen_shipping_method_origin( $key, 'auto' );
+		wc_set_chosen_shipping_method_origin( $key, 'auto', $chosen_method );
 
 		/**
 		 * Fires when a shipping method is chosen.
@@ -505,13 +505,20 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
  * shipping rate becomes available, e.g. after an Apple Pay / Google Pay wallet
  * supplies an address).
  *
+ * Origin is tied to the rate_id it was recorded against, so that a third-party
+ * caller writing to `chosen_shipping_methods` directly (bypassing the Store API
+ * and the AJAX endpoints) implicitly invalidates a stale 'auto' marker — the
+ * recorded rate_id no longer matches the current chosen rate, and the reader
+ * falls back to 'manual'.
+ *
  * @since 10.6.0
  *
- * @param int|string $key    Package key.
- * @param string     $origin Either 'auto' or 'manual'.
+ * @param int|string $key     Package key.
+ * @param string     $origin  Either 'auto' or 'manual'.
+ * @param string     $rate_id The rate_id this origin applies to.
  * @return void
  */
-function wc_set_chosen_shipping_method_origin( $key, $origin ) {
+function wc_set_chosen_shipping_method_origin( $key, $origin, $rate_id ) {
 	if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
 		return;
 	}
@@ -521,18 +528,25 @@ function wc_set_chosen_shipping_method_origin( $key, $origin ) {
 	}
 
 	$origins         = WC()->session->get( 'chosen_shipping_method_origins', array() );
-	$origins[ $key ] = $origin;
+	$origins[ $key ] = array(
+		'rate_id' => (string) $rate_id,
+		'origin'  => $origin,
+	);
 	WC()->session->set( 'chosen_shipping_method_origins', $origins );
 }
 
 /**
  * Returns the recorded origin ('auto' or 'manual') of the chosen shipping method
- * for a package, or 'manual' when no origin has been recorded yet.
+ * for a package.
  *
- * Defaulting to 'manual' preserves the historical sticky-Local-Pickup behavior
- * for sessions that pre-date origin tracking. New sessions get the correct
- * origin written from the first `wc_get_chosen_shipping_method_for_package()`
- * call onwards.
+ * Falls back to 'manual' when:
+ *
+ * - no origin has been recorded yet (preserves the historical sticky-Local-Pickup
+ *   behavior for sessions that pre-date origin tracking); or
+ * - the recorded rate_id no longer matches the chosen rate currently in
+ *   `chosen_shipping_methods` (something other than the tracked write paths
+ *   overwrote the choice, so the recorded 'auto' marker is stale and we treat
+ *   the new choice as deliberate).
  *
  * @since 10.6.0
  *
@@ -545,8 +559,22 @@ function wc_get_chosen_shipping_method_origin( $key ) {
 	}
 
 	$origins = WC()->session->get( 'chosen_shipping_method_origins', array() );
+	$entry   = isset( $origins[ $key ] ) ? $origins[ $key ] : null;
 
-	return isset( $origins[ $key ] ) && 'auto' === $origins[ $key ] ? 'auto' : 'manual';
+	if ( ! is_array( $entry ) || ! isset( $entry['rate_id'], $entry['origin'] ) ) {
+		return 'manual';
+	}
+
+	$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+	$current_rate   = isset( $chosen_methods[ $key ] ) ? (string) $chosen_methods[ $key ] : '';
+
+	// If the chosen rate has been overwritten by something that didn't go through
+	// `wc_set_chosen_shipping_method_origin()`, treat the new choice as manual.
+	if ( $current_rate !== (string) $entry['rate_id'] ) {
+		return 'manual';
+	}
+
+	return 'auto' === $entry['origin'] ? 'auto' : 'manual';
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -473,13 +473,25 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 
 	// If not set, not available, or available methods have changed, set to the DEFAULT option.
 	if ( ! $chosen_method || $changed || ! isset( $package['rates'][ $chosen_method ] ) || count( $package['rates'] ) !== $method_count ) {
+		// Capture the previous choice and its origin before the auto-defaulter runs, so we can tell
+		// whether it computed a new default or simply preserved an existing customer choice.
+		$previous_chosen_method = $chosen_method;
+		$previous_origin        = wc_get_chosen_shipping_method_origin( $key );
+
 		$chosen_method          = wc_get_default_shipping_method_for_package( $key, $package, $chosen_method );
 		$chosen_methods[ $key ] = $chosen_method;
 		$method_counts[ $key ]  = count( $package['rates'] );
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_methods );
 		WC()->session->set( 'shipping_method_counts', $method_counts );
-		wc_set_chosen_shipping_method_origin( $key, 'auto', $chosen_method );
+
+		// Only record the choice as auto-defaulted when the auto-defaulter actually assigned a method
+		// the customer didn't pick. If it kept the customer's existing manual choice (sticky pickup),
+		// preserve that 'manual' origin — otherwise the next re-evaluation would treat it as auto and
+		// could un-stick a deliberately chosen Local Pickup.
+		if ( ! ( $chosen_method === $previous_chosen_method && 'manual' === $previous_origin ) ) {
+			wc_set_chosen_shipping_method_origin( $key, 'auto', $chosen_method );
+		}
 
 		/**
 		 * Fires when a shipping method is chosen.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -33208,12 +33208,6 @@ parameters:
 			path: includes/wc-cart-functions.php
 
 		-
-			message: '#^Parameter \#2 \$str of function explode expects string, int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/wc-cart-functions.php
-
-		-
 			message: '#^Parameter \#2 \$user_string of function hash_equals expects string, array\|string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/woocommerce/src/Internal/Shipping/ShippingMethodOriginTracker.php
+++ b/plugins/woocommerce/src/Internal/Shipping/ShippingMethodOriginTracker.php
@@ -79,6 +79,41 @@ class ShippingMethodOriginTracker {
 	}
 
 	/**
+	 * Records a 'manual' origin for a rate the customer explicitly selected, unless the
+	 * selection is a repeat of the package's currently chosen rate.
+	 *
+	 * Selection UIs re-assert the current choice without a customer decision — the block
+	 * checkout's pickup-options block re-posts it on mount, and the classic checkout
+	 * re-posts it on every order-review refresh (page load, address field edits). Recording
+	 * such a repeat as 'manual' would launder an auto-defaulted Local Pickup and defeat the
+	 * unstick (and the selected_rate_origin field gateways consume), so only a change of
+	 * rate counts; repeats keep the current origin.
+	 *
+	 * Call this BEFORE writing the new rate to `chosen_shipping_methods` — the repeat check
+	 * compares against the rate currently in the session.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param int|string $key     Package key.
+	 * @param string     $rate_id The rate_id the customer selected.
+	 * @return void
+	 */
+	public function record_manual_selection( $key, $rate_id ) {
+		if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
+			return;
+		}
+
+		$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+		$current_rate   = isset( $chosen_methods[ $key ] ) && is_string( $chosen_methods[ $key ] ) ? $chosen_methods[ $key ] : '';
+
+		if ( (string) $rate_id === $current_rate ) {
+			return;
+		}
+
+		$this->set_origin( $key, self::ORIGIN_MANUAL, $rate_id );
+	}
+
+	/**
 	 * Returns the recorded origin ('auto' or 'manual') of the chosen shipping method
 	 * for a package.
 	 *
@@ -118,5 +153,32 @@ class ShippingMethodOriginTracker {
 		}
 
 		return self::ORIGIN_AUTO === $entry['origin'] ? self::ORIGIN_AUTO : self::ORIGIN_MANUAL;
+	}
+
+	/**
+	 * Returns the origin of the package's currently chosen shipping rate, or null when
+	 * no rate is chosen for the package (or no session is available).
+	 *
+	 * Reads the session directly and is side-effect free, unlike
+	 * `wc_get_chosen_shipping_method_for_package()`, which can write a new default into
+	 * the session as it resolves.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param int|string $key Package key.
+	 * @return string|null 'auto', 'manual', or null when no rate is chosen.
+	 */
+	public function get_origin_for_chosen_rate( $key ) {
+		if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
+			return null;
+		}
+
+		$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+
+		if ( empty( $chosen_methods[ $key ] ) ) {
+			return null;
+		}
+
+		return $this->get_origin( $key );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Shipping/ShippingMethodOriginTracker.php
+++ b/plugins/woocommerce/src/Internal/Shipping/ShippingMethodOriginTracker.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * ShippingMethodOriginTracker class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Shipping;
+
+/**
+ * Tracks who picked the currently chosen shipping method for a package: the
+ * auto-defaulter in `wc_get_chosen_shipping_method_for_package()` ('auto') or the
+ * customer via an explicit selection path like the Store API select-shipping-rate
+ * route, the shortcode cart/checkout AJAX, or a coupon-driven free-shipping
+ * override ('manual').
+ *
+ * This signal lets `wc_get_default_shipping_method_for_package()` distinguish
+ * between "the customer chose Local Pickup" (sticky on purpose) and "WC defaulted
+ * to Local Pickup because no zone matched yet" (should re-evaluate once a real
+ * shipping rate becomes available, e.g. after an Apple Pay / Google Pay wallet
+ * supplies an address).
+ *
+ * @since 11.1.0
+ */
+class ShippingMethodOriginTracker {
+
+	/**
+	 * Session key holding the recorded origins, parallel to `chosen_shipping_methods`.
+	 *
+	 * @var string
+	 */
+	public const SESSION_KEY = 'chosen_shipping_method_origins';
+
+	/**
+	 * Origin value for a method assigned by the auto-defaulter.
+	 *
+	 * @var string
+	 */
+	public const ORIGIN_AUTO = 'auto';
+
+	/**
+	 * Origin value for a method explicitly selected by the customer.
+	 *
+	 * @var string
+	 */
+	public const ORIGIN_MANUAL = 'manual';
+
+	/**
+	 * Records the origin of the currently chosen shipping method for a package.
+	 *
+	 * Origin is tied to the rate_id it was recorded against, so that a third-party
+	 * caller writing to `chosen_shipping_methods` directly (bypassing the Store API
+	 * and the AJAX endpoints) implicitly invalidates a stale 'auto' marker — the
+	 * recorded rate_id no longer matches the current chosen rate, and the reader
+	 * falls back to 'manual'.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param int|string $key     Package key.
+	 * @param string     $origin  Either 'auto' or 'manual'.
+	 * @param string     $rate_id The rate_id this origin applies to.
+	 * @return void
+	 */
+	public function set_origin( $key, $origin, $rate_id ) {
+		if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
+			return;
+		}
+
+		if ( ! in_array( $origin, array( self::ORIGIN_AUTO, self::ORIGIN_MANUAL ), true ) ) {
+			return;
+		}
+
+		$origins         = WC()->session->get( self::SESSION_KEY, array() );
+		$origins[ $key ] = array(
+			'rate_id' => (string) $rate_id,
+			'origin'  => $origin,
+		);
+		WC()->session->set( self::SESSION_KEY, $origins );
+	}
+
+	/**
+	 * Returns the recorded origin ('auto' or 'manual') of the chosen shipping method
+	 * for a package.
+	 *
+	 * Falls back to 'manual' when:
+	 *
+	 * - no origin has been recorded yet (preserves the historical sticky-Local-Pickup
+	 *   behavior for sessions that pre-date origin tracking); or
+	 * - the recorded rate_id no longer matches the chosen rate currently in
+	 *   `chosen_shipping_methods` (something other than the tracked write paths
+	 *   overwrote the choice, so the recorded 'auto' marker is stale and we treat
+	 *   the new choice as deliberate).
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param int|string $key Package key.
+	 * @return string 'auto' or 'manual'.
+	 */
+	public function get_origin( $key ) {
+		if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
+			return self::ORIGIN_MANUAL;
+		}
+
+		$origins = WC()->session->get( self::SESSION_KEY, array() );
+		$entry   = isset( $origins[ $key ] ) ? $origins[ $key ] : null;
+
+		if ( ! is_array( $entry ) || ! isset( $entry['rate_id'], $entry['origin'] ) ) {
+			return self::ORIGIN_MANUAL;
+		}
+
+		$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+		$current_rate   = isset( $chosen_methods[ $key ] ) ? (string) $chosen_methods[ $key ] : '';
+
+		// If the chosen rate has been overwritten by something that didn't go through
+		// `set_origin()`, treat the new choice as manual.
+		if ( $current_rate !== (string) $entry['rate_id'] ) {
+			return self::ORIGIN_MANUAL;
+		}
+
+		return self::ORIGIN_AUTO === $entry['origin'] ? self::ORIGIN_AUTO : self::ORIGIN_MANUAL;
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -115,7 +115,7 @@ class CartShippingRateSchema extends AbstractSchema {
 				],
 			],
 			'selected_rate_origin' => [
-				'description' => __( 'How the currently selected shipping rate for this package was chosen: manual when the customer picked it through an explicit selection path, auto when it was assigned by the automatic defaulter. Null when no rate is selected for the package.', 'woocommerce' ),
+				'description' => __( 'How the currently selected shipping rate for this package was chosen: manual when the customer picked it through an explicit selection path, auto when it was assigned by the automatic defaulter. Null when no rate was selected for the package at the start of the request.', 'woocommerce' ),
 				'type'        => [ 'string', 'null' ],
 				'enum'        => [ 'auto', 'manual' ],
 				'context'     => [ 'view', 'edit' ],

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
 use WC_Shipping_Rate as ShippingRate;
 
 /**
@@ -28,19 +29,19 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'package_id'     => [
+			'package_id'           => [
 				'description' => __( 'The ID of the package the shipping rates belong to.', 'woocommerce' ),
 				'type'        => [ 'integer', 'string' ],
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'name'           => [
+			'name'                 => [
 				'description' => __( 'Name of the package.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'destination'    => [
+			'destination'          => [
 				'description' => __( 'Shipping destination address.', 'woocommerce' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
@@ -84,7 +85,7 @@ class CartShippingRateSchema extends AbstractSchema {
 					],
 				],
 			],
-			'items'          => [
+			'items'                => [
 				'description' => __( 'List of cart items the returned shipping rates apply to.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -113,7 +114,14 @@ class CartShippingRateSchema extends AbstractSchema {
 					],
 				],
 			],
-			'shipping_rates' => [
+			'selected_rate_origin' => [
+				'description' => __( 'How the currently selected shipping rate for this package was chosen: manual when the customer picked it through an explicit selection path, auto when it was assigned by the automatic defaulter. Null when no rate is selected for the package.', 'woocommerce' ),
+				'type'        => [ 'string', 'null' ],
+				'enum'        => [ 'auto', 'manual' ],
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'shipping_rates'       => [
 				'description' => __( 'List of shipping rates.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -223,11 +231,14 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $package ) {
 		return [
-			'package_id'     => $package['package_id'],
-			'name'           => $package['package_name'],
-			'destination'    => $this->prepare_package_destination_response( $package ),
-			'items'          => $this->prepare_package_items_response( $package ),
-			'shipping_rates' => $this->prepare_package_shipping_rates_response( $package ),
+			'package_id'           => $package['package_id'],
+			'name'                 => $package['package_name'],
+			'destination'          => $this->prepare_package_destination_response( $package ),
+			'items'                => $this->prepare_package_items_response( $package ),
+			// Must be evaluated before shipping_rates: prepare_package_shipping_rates_response() can write
+			// an auto-default (and an 'auto' origin) into the session mid-render, breaking the null semantics.
+			'selected_rate_origin' => $this->get_selected_rate_origin( $package ),
+			'shipping_rates'       => $this->prepare_package_shipping_rates_response( $package ),
 		];
 	}
 
@@ -268,6 +279,34 @@ class CartShippingRateSchema extends AbstractSchema {
 			];
 		}
 		return $items;
+	}
+
+	/**
+	 * Returns the recorded origin ('auto'|'manual') of the package's chosen shipping
+	 * rate, or null when no rate is chosen. Reads the session directly (side-effect
+	 * free) rather than wc_get_chosen_shipping_method_for_package(), which can write
+	 * a new default into the session as it resolves.
+	 *
+	 * Unrecorded origins report 'manual' (ShippingMethodOriginTracker's BC default),
+	 * so clients consuming this field treat pre-tracking sessions as deliberate
+	 * choices — the conservative direction.
+	 *
+	 * @param array $package Shipping package complete with rates from WooCommerce.
+	 * @return string|null
+	 */
+	protected function get_selected_rate_origin( $package ) {
+		if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
+			return null;
+		}
+
+		$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+		$package_id     = $package['package_id'] ?? null;
+
+		if ( null === $package_id || empty( $chosen_methods[ $package_id ] ) ) {
+			return null;
+		}
+
+		return wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $package_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -283,9 +283,7 @@ class CartShippingRateSchema extends AbstractSchema {
 
 	/**
 	 * Returns the recorded origin ('auto'|'manual') of the package's chosen shipping
-	 * rate, or null when no rate is chosen. Reads the session directly (side-effect
-	 * free) rather than wc_get_chosen_shipping_method_for_package(), which can write
-	 * a new default into the session as it resolves.
+	 * rate, or null when no rate is chosen.
 	 *
 	 * Unrecorded origins report 'manual' (ShippingMethodOriginTracker's BC default),
 	 * so clients consuming this field treat pre-tracking sessions as deliberate
@@ -295,18 +293,13 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * @return string|null
 	 */
 	protected function get_selected_rate_origin( $package ) {
-		if ( ! is_callable( array( WC()->session, 'get' ) ) ) {
+		$package_id = $package['package_id'] ?? null;
+
+		if ( null === $package_id ) {
 			return null;
 		}
 
-		$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
-		$package_id     = $package['package_id'] ?? null;
-
-		if ( null === $package_id || empty( $chosen_methods[ $package_id ] ) ) {
-			return null;
-		}
-
-		return wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin( $package_id );
+		return wc_get_container()->get( ShippingMethodOriginTracker::class )->get_origin_for_chosen_rate( $package_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -115,9 +115,9 @@ class CartShippingRateSchema extends AbstractSchema {
 				],
 			],
 			'selected_rate_origin' => [
-				'description' => __( 'How the currently selected shipping rate for this package was chosen: manual when the customer picked it through an explicit selection path, auto when it was assigned by the automatic defaulter. Null when no rate was selected for the package at the start of the request.', 'woocommerce' ),
+				'description' => __( 'How the currently selected shipping rate for this package was chosen. Auto means it is known to have been assigned by the automatic defaulter. Manual is a conservative fallback meaning anything not known to be automatic: the customer picked it through an explicit selection path, or the origin was never recorded (sessions predating origin tracking), or the choice was overwritten outside the tracked paths. Null when no rate was selected for the package at the start of the request.', 'woocommerce' ),
 				'type'        => [ 'string', 'null' ],
-				'enum'        => [ 'auto', 'manual' ],
+				'enum'        => [ 'auto', 'manual', null ],
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -916,10 +916,6 @@ class CartController {
 	/**
 	 * Selects a shipping rate.
 	 *
-	 * Records a 'manual' shipping-method origin only when the selected rate differs
-	 * from the current choice — a repeat of the existing selection is not a customer
-	 * decision.
-	 *
 	 * @param int|string $package_id ID of the package to choose a rate for.
 	 * @param string     $rate_id ID of the rate being chosen.
 	 */
@@ -927,22 +923,16 @@ class CartController {
 		if ( ! is_string( $rate_id ) ) {
 			return;
 		}
-		$cart            = $this->get_cart_instance();
-		$session_data    = wc()->session->get( 'chosen_shipping_methods' ) ? wc()->session->get( 'chosen_shipping_methods' ) : [];
-		$previous_method = isset( $session_data[ $package_id ] ) && is_string( $session_data[ $package_id ] ) ? $session_data[ $package_id ] : '';
+		$cart         = $this->get_cart_instance();
+		$session_data = wc()->session->get( 'chosen_shipping_methods' ) ? wc()->session->get( 'chosen_shipping_methods' ) : [];
+
+		// Record before writing the new choice: the tracker ignores a repeat of the
+		// currently chosen rate (e.g. the pickup-options block re-asserting on mount).
+		wc_get_container()->get( ShippingMethodOriginTracker::class )->record_manual_selection( $package_id, $rate_id );
 
 		$session_data[ $package_id ] = $rate_id;
 
 		wc()->session->set( 'chosen_shipping_methods', $session_data );
-
-		// The block checkout's pickup-options block re-asserts the current rate on mount,
-		// so a repeat of the existing selection is not a customer decision — recording it
-		// as 'manual' would launder an auto-defaulted pickup and defeat the unstick (and
-		// the selected_rate_origin field gateways consume). Mirrors the same guard on the
-		// classic path in WC_AJAX::apply_posted_shipping_methods().
-		if ( $rate_id !== $previous_method ) {
-			wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $package_id, 'manual', $rate_id );
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -927,7 +927,7 @@ class CartController {
 		$session_data[ $package_id ] = $rate_id;
 
 		wc()->session->set( 'chosen_shipping_methods', $session_data );
-		wc_set_chosen_shipping_method_origin( $package_id, 'manual' );
+		wc_set_chosen_shipping_method_origin( $package_id, 'manual', $rate_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -927,6 +927,7 @@ class CartController {
 		$session_data[ $package_id ] = $rate_id;
 
 		wc()->session->set( 'chosen_shipping_methods', $session_data );
+		wc_set_chosen_shipping_method_origin( $package_id, 'manual' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Utilities;
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
 use Automattic\WooCommerce\StoreApi\Exceptions\InvalidCartException;
 use Automattic\WooCommerce\StoreApi\Exceptions\NotPurchasableException;
 use Automattic\WooCommerce\StoreApi\Exceptions\OutOfStockException;
@@ -927,7 +928,7 @@ class CartController {
 		$session_data[ $package_id ] = $rate_id;
 
 		wc()->session->set( 'chosen_shipping_methods', $session_data );
-		wc_set_chosen_shipping_method_origin( $package_id, 'manual', $rate_id );
+		wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $package_id, 'manual', $rate_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -916,6 +916,10 @@ class CartController {
 	/**
 	 * Selects a shipping rate.
 	 *
+	 * Records a 'manual' shipping-method origin only when the selected rate differs
+	 * from the current choice — a repeat of the existing selection is not a customer
+	 * decision.
+	 *
 	 * @param int|string $package_id ID of the package to choose a rate for.
 	 * @param string     $rate_id ID of the rate being chosen.
 	 */
@@ -923,12 +927,22 @@ class CartController {
 		if ( ! is_string( $rate_id ) ) {
 			return;
 		}
-		$cart                        = $this->get_cart_instance();
-		$session_data                = wc()->session->get( 'chosen_shipping_methods' ) ? wc()->session->get( 'chosen_shipping_methods' ) : [];
+		$cart            = $this->get_cart_instance();
+		$session_data    = wc()->session->get( 'chosen_shipping_methods' ) ? wc()->session->get( 'chosen_shipping_methods' ) : [];
+		$previous_method = isset( $session_data[ $package_id ] ) && is_string( $session_data[ $package_id ] ) ? $session_data[ $package_id ] : '';
+
 		$session_data[ $package_id ] = $rate_id;
 
 		wc()->session->set( 'chosen_shipping_methods', $session_data );
-		wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $package_id, 'manual', $rate_id );
+
+		// The block checkout's pickup-options block re-asserts the current rate on mount,
+		// so a repeat of the existing selection is not a customer decision — recording it
+		// as 'manual' would launder an auto-defaulted pickup and defeat the unstick (and
+		// the selected_rate_origin field gateways consume). Mirrors the same guard on the
+		// classic path in WC_AJAX::apply_posted_shipping_methods().
+		if ( $rate_id !== $previous_method ) {
+			wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( $package_id, 'manual', $rate_id );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
@@ -8,6 +8,7 @@
 declare( strict_types = 1 );
 
 use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
+use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 
 /**
  * Tests for wc_get_default_shipping_method_for_package().
@@ -394,5 +395,48 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 			$this->origin_tracker->get_origin( 0 ),
 			'Preserving a manual choice must not overwrite the origin back to auto'
 		);
+	}
+
+	/**
+	 * The block checkout's pickup-options block re-asserts the currently selected rate
+	 * on mount via the Store API select-shipping-rate route. That repeat of the existing
+	 * selection is not a customer decision — recording it as 'manual' would launder an
+	 * auto-defaulted pickup on every block checkout page load, defeating the unstick and
+	 * corrupting the selected_rate_origin field gateways consume.
+	 *
+	 * @testdox Store API reselect of the same rate preserves the recorded auto origin.
+	 */
+	public function test_store_api_reselect_of_same_rate_preserves_auto_origin(): void {
+		$this->record_auto_choice( 0, 'pickup_location:0' );
+
+		$controller = new CartController();
+		$controller->select_shipping_rate( 0, 'pickup_location:0' );
+
+		$this->assertSame(
+			'auto',
+			$this->origin_tracker->get_origin( 0 ),
+			'Re-asserting the already-chosen rate must not flip the origin to manual'
+		);
+
+		$chosen = WC()->session->get( 'chosen_shipping_methods', array() );
+		$this->assertSame( 'pickup_location:0', $chosen[0], 'Chosen shipping method should be unchanged' );
+	}
+
+	/**
+	 * Selecting a different rate through the Store API select-shipping-rate route is a
+	 * genuine customer decision and must record a 'manual' origin so the choice sticks.
+	 *
+	 * @testdox Store API selection of a different rate records a manual origin.
+	 */
+	public function test_store_api_selecting_different_rate_records_manual_origin(): void {
+		$this->record_auto_choice( 0, 'pickup_location:0' );
+
+		$controller = new CartController();
+		$controller->select_shipping_rate( 0, 'flat_rate:14' );
+
+		$this->assertSame( 'manual', $this->origin_tracker->get_origin( 0 ) );
+
+		$chosen = WC()->session->get( 'chosen_shipping_methods', array() );
+		$this->assertSame( 'flat_rate:14', $chosen[0] );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
@@ -7,6 +7,8 @@
 
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
+
 /**
  * Tests for wc_get_default_shipping_method_for_package().
  */
@@ -20,10 +22,19 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	private $zone;
 
 	/**
+	 * Tracker for chosen shipping method origins.
+	 *
+	 * @var ShippingMethodOriginTracker
+	 */
+	private $origin_tracker;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->origin_tracker = wc_get_container()->get( ShippingMethodOriginTracker::class );
 
 		// Create a shipping zone with a flat rate so CartCheckoutUtils::shipping_methods_exist() returns true.
 		$this->zone = new WC_Shipping_Zone();
@@ -47,7 +58,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_shipping_cost_requires_address', 'no' );
 		WC()->cart->cart_context = 'shortcode';
 		WC()->session->set( 'chosen_shipping_methods', null );
-		WC()->session->set( 'chosen_shipping_method_origins', null );
+		WC()->session->set( ShippingMethodOriginTracker::SESSION_KEY, null );
 		parent::tearDown();
 	}
 
@@ -165,7 +176,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$chosen         = WC()->session->get( 'chosen_shipping_methods', array() );
 		$chosen[ $key ] = $rate_id;
 		WC()->session->set( 'chosen_shipping_methods', $chosen );
-		wc_set_chosen_shipping_method_origin( $key, 'auto', $rate_id );
+		$this->origin_tracker->set_origin( $key, 'auto', $rate_id );
 	}
 
 	/**
@@ -194,7 +205,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
 		$chosen[0] = 'local_pickup:1';
 		WC()->session->set( 'chosen_shipping_methods', $chosen );
-		wc_set_chosen_shipping_method_origin( 0, 'manual', 'local_pickup:1' );
+		$this->origin_tracker->set_origin( 0, 'manual', 'local_pickup:1' );
 
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
 		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
@@ -215,7 +226,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
 		$chosen[0] = 'local_pickup:1';
 		WC()->session->set( 'chosen_shipping_methods', $chosen );
-		WC()->session->set( 'chosen_shipping_method_origins', null );
+		WC()->session->set( ShippingMethodOriginTracker::SESSION_KEY, null );
 
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
 		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
@@ -251,11 +262,11 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 
 		wc_get_chosen_shipping_method_for_package( 0, $package );
 
-		$this->assertSame( 'auto', wc_get_chosen_shipping_method_origin( 0 ) );
+		$this->assertSame( 'auto', $this->origin_tracker->get_origin( 0 ) );
 	}
 
 	/**
-	 * `wc_set_chosen_shipping_method_origin()` is the helper manual-write paths
+	 * ShippingMethodOriginTracker::set_origin() is the helper manual-write paths
 	 * call (Store API select-shipping-rate, AJAX update_shipping_method, etc.).
 	 * Origin must round-trip correctly through the session.
 	 *
@@ -263,16 +274,16 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_manual_write_overrides_auto_origin(): void {
 		$this->record_auto_choice( 0, 'local_pickup:1' );
-		$this->assertSame( 'auto', wc_get_chosen_shipping_method_origin( 0 ) );
+		$this->assertSame( 'auto', $this->origin_tracker->get_origin( 0 ) );
 
-		wc_set_chosen_shipping_method_origin( 0, 'manual', 'local_pickup:1' );
-		$this->assertSame( 'manual', wc_get_chosen_shipping_method_origin( 0 ) );
+		$this->origin_tracker->set_origin( 0, 'manual', 'local_pickup:1' );
+		$this->assertSame( 'manual', $this->origin_tracker->get_origin( 0 ) );
 	}
 
 	/**
 	 * Third-party plugins occasionally write directly to `chosen_shipping_methods`
 	 * in the WC session without going through Store API, the AJAX endpoints, or
-	 * `wc_set_chosen_shipping_method_origin()`. The recorded origin must invalidate
+	 * ShippingMethodOriginTracker::set_origin(). The recorded origin must invalidate
 	 * itself in that case, so a stale 'auto' marker can't override a third party's
 	 * deliberate choice on a subsequent re-evaluation.
 	 *
@@ -281,7 +292,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	public function test_external_chosen_shipping_methods_write_invalidates_auto_origin(): void {
 		// Simulate the auto-defaulter having recorded pickup_location:1 as 'auto'.
 		$this->record_auto_choice( 0, 'local_pickup:1' );
-		$this->assertSame( 'auto', wc_get_chosen_shipping_method_origin( 0 ) );
+		$this->assertSame( 'auto', $this->origin_tracker->get_origin( 0 ) );
 
 		// Simulate a third-party plugin overwriting the chosen rate directly.
 		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
@@ -290,7 +301,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 
 		$this->assertSame(
 			'manual',
-			wc_get_chosen_shipping_method_origin( 0 ),
+			$this->origin_tracker->get_origin( 0 ),
 			'External write to chosen_shipping_methods should invalidate the stale auto marker'
 		);
 
@@ -319,7 +330,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
 		$chosen[0] = 'local_pickup:1';
 		WC()->session->set( 'chosen_shipping_methods', $chosen );
-		wc_set_chosen_shipping_method_origin( 0, 'manual', 'local_pickup:1' );
+		$this->origin_tracker->set_origin( 0, 'manual', 'local_pickup:1' );
 
 		// A non-pickup rate is now available, forcing the auto-defaulter to re-evaluate.
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
@@ -328,7 +339,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$this->assertSame( 'local_pickup:1', $result, 'Manually chosen pickup should be preserved' );
 		$this->assertSame(
 			'manual',
-			wc_get_chosen_shipping_method_origin( 0 ),
+			$this->origin_tracker->get_origin( 0 ),
 			'Preserving a manual choice must not overwrite the origin back to auto'
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
@@ -46,6 +46,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$this->zone->delete( true );
 		update_option( 'woocommerce_shipping_cost_requires_address', 'no' );
 		WC()->cart->cart_context = 'shortcode';
+		WC()->session->set( 'chosen_shipping_method_origins', null );
 		parent::tearDown();
 	}
 
@@ -150,5 +151,98 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$result  = wc_get_default_shipping_method_for_package( 0, $package, '' );
 
 		$this->assertSame( 'local_pickup:1', $result, 'Shortcode context should always select the first rate' );
+	}
+
+	/**
+	 * When the previous Local Pickup choice came from the auto-defaulter and a
+	 * shipping rate is now available, the auto pickup should be replaced with
+	 * the shipping rate. This is the WOOPMNT-6159 / Apple Pay scenario.
+	 *
+	 * @testdox Replaces auto-chosen local pickup with shipping rate when one is now available.
+	 */
+	public function test_replaces_auto_local_pickup_when_shipping_rate_becomes_available(): void {
+		wc_set_chosen_shipping_method_origin( 0, 'auto' );
+
+		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
+		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
+
+		$this->assertSame( 'flat_rate:1', $result, 'Should replace auto-chosen pickup with the first non-pickup rate' );
+	}
+
+	/**
+	 * When the customer explicitly selected Local Pickup (origin = manual), the
+	 * sticky behavior must be preserved even when a shipping rate is available.
+	 *
+	 * @testdox Preserves manually chosen local pickup even when a shipping rate is available.
+	 */
+	public function test_preserves_manual_local_pickup_when_shipping_rate_available(): void {
+		wc_set_chosen_shipping_method_origin( 0, 'manual' );
+
+		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
+		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
+
+		$this->assertSame( 'local_pickup:1', $result, 'Should preserve manually chosen pickup' );
+	}
+
+	/**
+	 * Sessions that pre-date origin tracking default to 'manual' to preserve
+	 * existing sticky behavior; without a recorded origin we cannot tell the
+	 * choice was an auto-default, so we must not silently switch it.
+	 *
+	 * @testdox Defaults unrecorded origin to manual (backwards-compat).
+	 */
+	public function test_unrecorded_origin_preserves_local_pickup(): void {
+		WC()->session->set( 'chosen_shipping_method_origins', null );
+
+		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
+		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
+
+		$this->assertSame( 'local_pickup:1', $result, 'Unrecorded origin should be treated as manual' );
+	}
+
+	/**
+	 * When pickup is the only rate available, even an auto origin must keep
+	 * pickup — there is nothing else to switch to.
+	 *
+	 * @testdox Keeps auto local pickup when no shipping alternative exists.
+	 */
+	public function test_keeps_auto_local_pickup_when_no_alternative(): void {
+		wc_set_chosen_shipping_method_origin( 0, 'auto' );
+
+		$package = $this->build_package( array( 'local_pickup:1' ) );
+		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
+
+		$this->assertSame( 'local_pickup:1', $result, 'Should keep pickup when no non-pickup alternative is available' );
+	}
+
+	/**
+	 * `wc_get_chosen_shipping_method_for_package()` is the path through which
+	 * the auto-defaulter writes to the session. After it runs, the origin must
+	 * be recorded as 'auto' so a subsequent re-evaluation can unstick if a
+	 * shipping rate becomes available.
+	 *
+	 * @testdox Auto-defaulter records the chosen shipping method origin as 'auto'.
+	 */
+	public function test_auto_defaulter_records_auto_origin(): void {
+		$package = $this->build_package( array( 'local_pickup:1' ) );
+
+		wc_get_chosen_shipping_method_for_package( 0, $package );
+
+		$this->assertSame( 'auto', wc_get_chosen_shipping_method_origin( 0 ) );
+	}
+
+	/**
+	 * `wc_set_chosen_shipping_method_origin()` is the helper manual-write paths
+	 * call (Store API select-shipping-rate, AJAX update_shipping_method, etc.).
+	 * Origin must round-trip correctly through the session.
+	 *
+	 * @testdox Manual write paths can flip the origin from auto to manual.
+	 */
+	public function test_manual_write_overrides_auto_origin(): void {
+		wc_set_chosen_shipping_method_origin( 0, 'auto' );
+		$this->assertSame( 'auto', wc_get_chosen_shipping_method_origin( 0 ) );
+
+		wc_set_chosen_shipping_method_origin( 0, 'manual' );
+		$this->assertSame( 'manual', wc_get_chosen_shipping_method_origin( 0 ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
@@ -181,6 +181,20 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Helper: simulate a customer having explicitly selected a rate for a package
+	 * by writing the session entries a manual selection path would write.
+	 *
+	 * @param int|string $key      Package key.
+	 * @param string     $rate_id  Rate id (e.g. 'local_pickup:1').
+	 */
+	private function record_manual_choice( $key, string $rate_id ): void {
+		$chosen         = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[ $key ] = $rate_id;
+		WC()->session->set( 'chosen_shipping_methods', $chosen );
+		$this->origin_tracker->set_origin( $key, 'manual', $rate_id );
+	}
+
+	/**
 	 * When the previous Local Pickup choice came from the auto-defaulter and a
 	 * shipping rate is now available, the auto pickup should be replaced with
 	 * the shipping rate. This is the WOOPMNT-6159 / Apple Pay scenario.
@@ -203,10 +217,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 * @testdox Preserves manually chosen local pickup even when a shipping rate is available.
 	 */
 	public function test_preserves_manual_local_pickup_when_shipping_rate_available(): void {
-		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
-		$chosen[0] = 'local_pickup:1';
-		WC()->session->set( 'chosen_shipping_methods', $chosen );
-		$this->origin_tracker->set_origin( 0, 'manual', 'local_pickup:1' );
+		$this->record_manual_choice( 0, 'local_pickup:1' );
 
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
 		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
@@ -358,10 +369,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 
 		// A subsequent explicit pickup choice (all real selection paths record 'manual') must stay
 		// sticky — the earlier stale 'auto' record must not leak into the new choice.
-		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
-		$chosen[0] = 'local_pickup:1';
-		WC()->session->set( 'chosen_shipping_methods', $chosen );
-		$this->origin_tracker->set_origin( 0, 'manual', 'local_pickup:1' );
+		$this->record_manual_choice( 0, 'local_pickup:1' );
 
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
 		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
@@ -380,10 +388,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_manual_origin_survives_auto_defaulter_recalculation(): void {
 		// Customer explicitly chose Local Pickup.
-		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
-		$chosen[0] = 'local_pickup:1';
-		WC()->session->set( 'chosen_shipping_methods', $chosen );
-		$this->origin_tracker->set_origin( 0, 'manual', 'local_pickup:1' );
+		$this->record_manual_choice( 0, 'local_pickup:1' );
 
 		// A non-pickup rate is now available, forcing the auto-defaulter to re-evaluate.
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
@@ -154,6 +154,20 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Helper: simulate the auto-defaulter having selected a rate for a package
+	 * by writing the session entries it would write.
+	 *
+	 * @param int|string $key      Package key.
+	 * @param string     $rate_id  Rate id (e.g. 'local_pickup:1').
+	 */
+	private function record_auto_choice( $key, string $rate_id ): void {
+		$chosen         = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[ $key ] = $rate_id;
+		WC()->session->set( 'chosen_shipping_methods', $chosen );
+		wc_set_chosen_shipping_method_origin( $key, 'auto', $rate_id );
+	}
+
+	/**
 	 * When the previous Local Pickup choice came from the auto-defaulter and a
 	 * shipping rate is now available, the auto pickup should be replaced with
 	 * the shipping rate. This is the WOOPMNT-6159 / Apple Pay scenario.
@@ -161,7 +175,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 * @testdox Replaces auto-chosen local pickup with shipping rate when one is now available.
 	 */
 	public function test_replaces_auto_local_pickup_when_shipping_rate_becomes_available(): void {
-		wc_set_chosen_shipping_method_origin( 0, 'auto' );
+		$this->record_auto_choice( 0, 'local_pickup:1' );
 
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
 		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
@@ -176,7 +190,10 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 * @testdox Preserves manually chosen local pickup even when a shipping rate is available.
 	 */
 	public function test_preserves_manual_local_pickup_when_shipping_rate_available(): void {
-		wc_set_chosen_shipping_method_origin( 0, 'manual' );
+		$chosen      = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[ 0 ] = 'local_pickup:1';
+		WC()->session->set( 'chosen_shipping_methods', $chosen );
+		wc_set_chosen_shipping_method_origin( 0, 'manual', 'local_pickup:1' );
 
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
 		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
@@ -207,7 +224,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 * @testdox Keeps auto local pickup when no shipping alternative exists.
 	 */
 	public function test_keeps_auto_local_pickup_when_no_alternative(): void {
-		wc_set_chosen_shipping_method_origin( 0, 'auto' );
+		$this->record_auto_choice( 0, 'local_pickup:1' );
 
 		$package = $this->build_package( array( 'local_pickup:1' ) );
 		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
@@ -239,10 +256,46 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 * @testdox Manual write paths can flip the origin from auto to manual.
 	 */
 	public function test_manual_write_overrides_auto_origin(): void {
-		wc_set_chosen_shipping_method_origin( 0, 'auto' );
+		$this->record_auto_choice( 0, 'local_pickup:1' );
 		$this->assertSame( 'auto', wc_get_chosen_shipping_method_origin( 0 ) );
 
-		wc_set_chosen_shipping_method_origin( 0, 'manual' );
+		wc_set_chosen_shipping_method_origin( 0, 'manual', 'local_pickup:1' );
 		$this->assertSame( 'manual', wc_get_chosen_shipping_method_origin( 0 ) );
+	}
+
+	/**
+	 * Third-party plugins occasionally write directly to `chosen_shipping_methods`
+	 * in the WC session without going through Store API, the AJAX endpoints, or
+	 * `wc_set_chosen_shipping_method_origin()`. The recorded origin must invalidate
+	 * itself in that case, so a stale 'auto' marker can't override a third party's
+	 * deliberate choice on a subsequent re-evaluation.
+	 *
+	 * @testdox External write to chosen_shipping_methods invalidates the recorded auto origin.
+	 */
+	public function test_external_chosen_shipping_methods_write_invalidates_auto_origin(): void {
+		// Simulate the auto-defaulter having recorded pickup_location:1 as 'auto'.
+		$this->record_auto_choice( 0, 'local_pickup:1' );
+		$this->assertSame( 'auto', wc_get_chosen_shipping_method_origin( 0 ) );
+
+		// Simulate a third-party plugin overwriting the chosen rate directly.
+		$chosen      = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[ 0 ] = 'local_pickup:2';
+		WC()->session->set( 'chosen_shipping_methods', $chosen );
+
+		$this->assertSame(
+			'manual',
+			wc_get_chosen_shipping_method_origin( 0 ),
+			'External write to chosen_shipping_methods should invalidate the stale auto marker'
+		);
+
+		// And the auto-defaulter must not unstick the externally-chosen pickup.
+		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:2' ) );
+		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:2' );
+
+		$this->assertSame(
+			'local_pickup:2',
+			$result,
+			'Externally-chosen pickup should be preserved (treated as manual)'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
@@ -298,4 +298,32 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 			'Externally-chosen pickup should be preserved (treated as manual)'
 		);
 	}
+
+	/**
+	 * Regression: when the auto-defaulter runs and the sticky-pickup path preserves a
+	 * manually-chosen Local Pickup, `wc_get_chosen_shipping_method_for_package()` must not
+	 * overwrite the recorded origin back to 'auto'. Otherwise a subsequent re-evaluation
+	 * would treat the deliberate pickup as auto-defaulted and un-stick it — the inverse of
+	 * the bug this change fixes.
+	 *
+	 * @testdox Auto-defaulter preserves a manual origin when it keeps the customer's chosen pickup.
+	 */
+	public function test_manual_origin_survives_auto_defaulter_recalculation(): void {
+		// Customer explicitly chose Local Pickup.
+		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[0] = 'local_pickup:1';
+		WC()->session->set( 'chosen_shipping_methods', $chosen );
+		wc_set_chosen_shipping_method_origin( 0, 'manual', 'local_pickup:1' );
+
+		// A non-pickup rate is now available, forcing the auto-defaulter to re-evaluate.
+		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
+		$result  = wc_get_chosen_shipping_method_for_package( 0, $package );
+
+		$this->assertSame( 'local_pickup:1', $result, 'Manually chosen pickup should be preserved' );
+		$this->assertSame(
+			'manual',
+			wc_get_chosen_shipping_method_origin( 0 ),
+			'Preserving a manual choice must not overwrite the origin back to auto'
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
@@ -317,6 +317,58 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * In shortcode (classic checkout) context the pre-sticky default is simply the first rate in
+	 * the package. When Local Pickup sorts first, that default is itself a pickup rate — the
+	 * unstick must still fire and switch to the first non-pickup rate found in the package.
+	 *
+	 * @testdox Replaces auto-chosen pickup with the delivery rate in shortcode context even when pickup sorts first.
+	 */
+	public function test_replaces_auto_local_pickup_in_shortcode_context_when_pickup_sorts_first(): void {
+		WC()->cart->cart_context = 'shortcode';
+		$this->record_auto_choice( 0, 'local_pickup:1' );
+
+		// Pickup deliberately ordered before the delivery rate.
+		$package = $this->build_package( array( 'local_pickup:1', 'flat_rate:1' ) );
+		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
+
+		$this->assertSame( 'flat_rate:1', $result, 'Shortcode-context unstick should switch to the first non-pickup rate even when pickup sorts first' );
+	}
+
+	/**
+	 * A different code path (e.g. WC_AJAX::update_order_review clearing chosen_shipping_methods
+	 * when no shipping methods are posted — see the fix for #51197) may empty the chosen-methods
+	 * session entry after an 'auto' origin was recorded. The stale origin must self-invalidate:
+	 * the reader falls back to 'manual' and the stale marker cannot un-stick a later pickup choice.
+	 *
+	 * @testdox Clearing chosen_shipping_methods after an auto origin was recorded invalidates the stale marker.
+	 */
+	public function test_cleared_chosen_methods_invalidates_stale_auto_origin(): void {
+		$this->record_auto_choice( 0, 'local_pickup:1' );
+		$this->assertSame( 'auto', $this->origin_tracker->get_origin( 0 ) );
+
+		// Simulate another code path emptying the chosen methods entirely.
+		WC()->session->set( 'chosen_shipping_methods', array() );
+
+		$this->assertSame(
+			'manual',
+			$this->origin_tracker->get_origin( 0 ),
+			'A cleared chosen_shipping_methods entry should invalidate the recorded auto origin'
+		);
+
+		// A subsequent explicit pickup choice (all real selection paths record 'manual') must stay
+		// sticky — the earlier stale 'auto' record must not leak into the new choice.
+		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[0] = 'local_pickup:1';
+		WC()->session->set( 'chosen_shipping_methods', $chosen );
+		$this->origin_tracker->set_origin( 0, 'manual', 'local_pickup:1' );
+
+		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
+		$result  = wc_get_default_shipping_method_for_package( 0, $package, 'local_pickup:1' );
+
+		$this->assertSame( 'local_pickup:1', $result, 'Pickup explicitly chosen after the clear should be preserved' );
+	}
+
+	/**
 	 * Regression: when the auto-defaulter runs and the sticky-pickup path preserves a
 	 * manually-chosen Local Pickup, `wc_get_chosen_shipping_method_for_package()` must not
 	 * overwrite the recorded origin back to 'auto'. Otherwise a subsequent re-evaluation

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-default-shipping-method-test.php
@@ -46,6 +46,7 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$this->zone->delete( true );
 		update_option( 'woocommerce_shipping_cost_requires_address', 'no' );
 		WC()->cart->cart_context = 'shortcode';
+		WC()->session->set( 'chosen_shipping_methods', null );
 		WC()->session->set( 'chosen_shipping_method_origins', null );
 		parent::tearDown();
 	}
@@ -190,8 +191,8 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 * @testdox Preserves manually chosen local pickup even when a shipping rate is available.
 	 */
 	public function test_preserves_manual_local_pickup_when_shipping_rate_available(): void {
-		$chosen      = WC()->session->get( 'chosen_shipping_methods', array() );
-		$chosen[ 0 ] = 'local_pickup:1';
+		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[0] = 'local_pickup:1';
 		WC()->session->set( 'chosen_shipping_methods', $chosen );
 		wc_set_chosen_shipping_method_origin( 0, 'manual', 'local_pickup:1' );
 
@@ -209,6 +210,11 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 	 * @testdox Defaults unrecorded origin to manual (backwards-compat).
 	 */
 	public function test_unrecorded_origin_preserves_local_pickup(): void {
+		// Mirror the actual pre-upgrade session state: the auto-defaulter had already written pickup
+		// into chosen_shipping_methods before this PR shipped, but no origin was ever recorded.
+		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[0] = 'local_pickup:1';
+		WC()->session->set( 'chosen_shipping_methods', $chosen );
 		WC()->session->set( 'chosen_shipping_method_origins', null );
 
 		$package = $this->build_package( array( 'flat_rate:1', 'local_pickup:1' ) );
@@ -278,8 +284,8 @@ class WC_Cart_Default_Shipping_Method_Test extends WC_Unit_Test_Case {
 		$this->assertSame( 'auto', wc_get_chosen_shipping_method_origin( 0 ) );
 
 		// Simulate a third-party plugin overwriting the chosen rate directly.
-		$chosen      = WC()->session->get( 'chosen_shipping_methods', array() );
-		$chosen[ 0 ] = 'local_pickup:2';
+		$chosen    = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[0] = 'local_pickup:2';
 		WC()->session->set( 'chosen_shipping_methods', $chosen );
 
 		$this->assertSame(

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartSelectShippingRate.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartSelectShippingRate.php
@@ -15,25 +15,10 @@ use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
  * Cart Select Shipping Rate Controller Tests.
  *
  * These tests pin the route's `package_id` normalization, which the shipping-method
- * origin guard in `CartController::select_shipping_rate()` silently depends on.
- *
- * The block checkout's pickup-options block does NOT send `package_id: 0` — it sends
- * `package_id: null`. A real batch request from the block looks like:
- *
- *     {"path":"/wc/store/v1/cart/select-shipping-rate","method":"POST",
- *      "data":{"package_id":null,"rate_id":"local_pickup:3"}}
- *
- * `CartSelectShippingRate::get_route_post_response()` normalizes that null by iterating
- * `CartController::get_shipping_packages()` and calling `select_shipping_rate()` with the
- * real integer package id. That normalization is what lets the origin guard compare the
- * incoming rate against the correct `chosen_shipping_methods` session key.
- *
- * If the normalization were ever dropped, `null` would reach `select_shipping_rate()`, PHP
- * would coerce it to `''` as an array key, and the route would read and write a phantom
- * package instead of package 0: the guard would never see the current choice, and the real
- * package's chosen rate would never be updated — re-breaking the Local Pickup unstick. Every
- * unit test of `select_shipping_rate()` passes an explicit integer, so none of them would
- * notice. These route-level tests do.
+ * origin guard in `CartController::select_shipping_rate()` silently depends on: the
+ * pickup-options block posts `package_id: null`, and the route must resolve it to the
+ * real package id before the guard compares the incoming rate against the session —
+ * otherwise the guard reads and writes a phantom `''` key instead of the real package.
  */
 class CartSelectShippingRate extends ControllerTestCase {
 
@@ -185,11 +170,8 @@ class CartSelectShippingRate extends ControllerTestCase {
 	}
 
 	/**
-	 * Re-asserting the already-chosen pickup rate without a `package_id` must be a no-op for the
-	 * recorded origin. That only holds if the route normalized the missing (null) `package_id` to
-	 * the real package id — otherwise `select_shipping_rate()` reads and writes the coerced ''
-	 * key, the differs-guard never matches, and the auto-defaulted pickup gets laundered into a
-	 * customer decision on every block checkout page load.
+	 * Re-asserting the already-chosen pickup rate without a `package_id` must write to the
+	 * real package and be a no-op for the recorded origin (see the class docblock).
 	 *
 	 * @testdox Selecting the same rate without a package_id writes to the real package and preserves the auto origin.
 	 */

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartSelectShippingRate.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartSelectShippingRate.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Controller Tests.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+
+/**
+ * Cart Select Shipping Rate Controller Tests.
+ *
+ * These tests pin the route's `package_id` normalization, which the shipping-method
+ * origin guard in `CartController::select_shipping_rate()` silently depends on.
+ *
+ * The block checkout's pickup-options block does NOT send `package_id: 0` — it sends
+ * `package_id: null`. A real batch request from the block looks like:
+ *
+ *     {"path":"/wc/store/v1/cart/select-shipping-rate","method":"POST",
+ *      "data":{"package_id":null,"rate_id":"local_pickup:3"}}
+ *
+ * `CartSelectShippingRate::get_route_post_response()` normalizes that null by iterating
+ * `CartController::get_shipping_packages()` and calling `select_shipping_rate()` with the
+ * real integer package id. That normalization is what lets the origin guard compare the
+ * incoming rate against the correct `chosen_shipping_methods` session key.
+ *
+ * If the normalization were ever dropped, `null` would reach `select_shipping_rate()`, PHP
+ * would coerce it to `''` as an array key, and the route would read and write a phantom
+ * package instead of package 0: the guard would never see the current choice, and the real
+ * package's chosen rate would never be updated — re-breaking the Local Pickup unstick. Every
+ * unit test of `select_shipping_rate()` passes an explicit integer, so none of them would
+ * notice. These route-level tests do.
+ */
+class CartSelectShippingRate extends ControllerTestCase {
+
+	/**
+	 * Local pickup rate injected into the test package.
+	 *
+	 * @var string
+	 */
+	private const PICKUP_RATE_ID = 'local_pickup:1';
+
+	/**
+	 * Delivery rate injected into the test package.
+	 *
+	 * @var string
+	 */
+	private const DELIVERY_RATE_ID = 'flat_rate:1';
+
+	/**
+	 * Product IDs shared by the class.
+	 *
+	 * @var int[]
+	 */
+	private static $product_ids = array();
+
+	/**
+	 * Tracker for chosen shipping method origins.
+	 *
+	 * @var ShippingMethodOriginTracker
+	 */
+	private $origin_tracker;
+
+	/**
+	 * Create immutable catalog rows shared by all test methods.
+	 */
+	public static function wpSetUpBeforeClass(): void {
+		$products = self::create_class_fixture_products(
+			array(
+				array(
+					'name'          => 'Test Product 1',
+					'stock_status'  => ProductStockStatus::IN_STOCK,
+					'regular_price' => 10,
+					'weight'        => 10,
+				),
+			)
+		);
+
+		self::$product_ids = array_map( fn( $product ) => $product->get_id(), $products );
+	}
+
+	/**
+	 * Delete class products through WooCommerce data stores.
+	 */
+	public static function wpTearDownAfterClass(): void {
+		self::delete_class_fixture_products( self::$product_ids );
+	}
+
+	/**
+	 * Setup a shippable cart with a package offering both pickup and delivery.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->origin_tracker = wc_get_container()->get( ShippingMethodOriginTracker::class );
+
+		// Register the rate filter and drop any cached package rates before anything can trigger a
+		// shipping calculation — WC_Shipping caches calculated rates in the session per package hash,
+		// so a calculation that runs before the filter is in place would be reused for the whole test.
+		add_filter( 'woocommerce_package_rates', array( $this, 'inject_pickup_and_delivery_rates' ), 100 );
+		wc()->session->set( 'shipping_for_package_0', null );
+
+		// A registered flat rate in the default zone makes shipping methods "exist" for the
+		// block-checkout default logic; the actual rates in the package come from the filter above.
+		$fixtures = new FixtureData();
+		$fixtures->shipping_add_flat_rate();
+		$fixtures->shipping_add_flat_rate_instance();
+
+		wc_empty_cart();
+
+		wc()->customer->set_shipping_country( 'US' );
+		wc()->customer->set_shipping_state( 'CA' );
+		wc()->customer->set_shipping_postcode( '90210' );
+		wc()->customer->set_shipping_city( 'Beverly Hills' );
+
+		wc()->cart->add_to_cart( self::$product_ids[0], 1 );
+	}
+
+	/**
+	 * Remove the rate filter and the session state the shipping calculation leaves behind.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'woocommerce_package_rates', array( $this, 'inject_pickup_and_delivery_rates' ), 100 );
+
+		wc()->session->set( 'chosen_shipping_methods', null );
+		wc()->session->set( ShippingMethodOriginTracker::SESSION_KEY, null );
+		wc()->session->set( 'previous_shipping_methods', null );
+		wc()->session->set( 'shipping_method_counts', null );
+		wc()->session->set( 'shipping_for_package_0', null );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Replace the calculated rates with a deterministic pickup + delivery pair.
+	 *
+	 * Mirrors the synthetic-rate approach used by WC_Cart_Default_Shipping_Method_Test, so the
+	 * rate IDs the tests select are stable and `local_pickup` is recognised as a pickup method by
+	 * LocalPickupUtils.
+	 *
+	 * @return \WC_Shipping_Rate[]
+	 */
+	public function inject_pickup_and_delivery_rates(): array {
+		return array(
+			self::PICKUP_RATE_ID   => new \WC_Shipping_Rate( self::PICKUP_RATE_ID, 'Local pickup', '0', array(), 'local_pickup' ),
+			self::DELIVERY_RATE_ID => new \WC_Shipping_Rate( self::DELIVERY_RATE_ID, 'Flat rate', '10', array(), 'flat_rate' ),
+		);
+	}
+
+	/**
+	 * Leave the session in the state a block checkout page load produces once the auto-defaulter
+	 * has settled on Local Pickup: the rate is chosen for package 0 and its origin is 'auto'.
+	 *
+	 * The priming calculation populates `previous_shipping_methods` / `shipping_method_counts` so a
+	 * later `calculate_totals()` short-circuits instead of re-running the auto-defaulter, which is
+	 * exactly the steady state the pickup-options block re-asserts its rate into.
+	 */
+	private function arrange_auto_chosen_pickup(): void {
+		wc()->cart->calculate_totals();
+
+		$chosen    = wc()->session->get( 'chosen_shipping_methods', array() );
+		$chosen[0] = self::PICKUP_RATE_ID;
+		wc()->session->set( 'chosen_shipping_methods', $chosen );
+
+		$this->origin_tracker->set_origin( 0, ShippingMethodOriginTracker::ORIGIN_AUTO, self::PICKUP_RATE_ID );
+	}
+
+	/**
+	 * Build a select-shipping-rate request that omits `package_id` entirely, the way the block
+	 * checkout's pickup-options block does.
+	 *
+	 * @param string $rate_id Rate to select.
+	 * @return \WP_REST_Request
+	 */
+	private function build_request_without_package_id( string $rate_id ): \WP_REST_Request {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/select-shipping-rate' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params( array( 'rate_id' => $rate_id ) );
+
+		return $request;
+	}
+
+	/**
+	 * Re-asserting the already-chosen pickup rate without a `package_id` must be a no-op for the
+	 * recorded origin. That only holds if the route normalized the missing (null) `package_id` to
+	 * the real package id — otherwise `select_shipping_rate()` reads and writes the coerced ''
+	 * key, the differs-guard never matches, and the auto-defaulted pickup gets laundered into a
+	 * customer decision on every block checkout page load.
+	 *
+	 * @testdox Selecting the same rate without a package_id writes to the real package and preserves the auto origin.
+	 */
+	public function test_select_shipping_rate_without_package_id_normalizes_to_real_package_id(): void {
+		$this->arrange_auto_chosen_pickup();
+
+		$this->assertAPIResponse( $this->build_request_without_package_id( self::PICKUP_RATE_ID ), 200 );
+
+		$this->assertSame(
+			array( 0 => 'local_pickup:1' ),
+			wc()->session->get( 'chosen_shipping_methods' ),
+			'A missing package_id must be normalized to the real package id, not coerced into an empty array key'
+		);
+
+		$this->assertSame(
+			'auto',
+			$this->origin_tracker->get_origin( 0 ),
+			'Re-asserting the already-chosen rate must not flip the recorded origin to manual'
+		);
+	}
+
+	/**
+	 * Control for the test above: the same request shape, but selecting a different rate. It proves
+	 * the no-package_id path really does reach the origin tracker, so the preserved 'auto' origin
+	 * above is the differs-guard working rather than a dead code path.
+	 *
+	 * @testdox Selecting a different rate without a package_id records a manual origin against the real package.
+	 */
+	public function test_select_shipping_rate_without_package_id_records_manual_on_genuine_change(): void {
+		$this->arrange_auto_chosen_pickup();
+
+		$this->assertAPIResponse( $this->build_request_without_package_id( self::DELIVERY_RATE_ID ), 200 );
+
+		$this->assertSame(
+			array( 0 => 'flat_rate:1' ),
+			wc()->session->get( 'chosen_shipping_methods' ),
+			'A genuine change must land on the real package id'
+		);
+
+		$this->assertSame(
+			'manual',
+			$this->origin_tracker->get_origin( 0 ),
+			'Selecting a different rate is a customer decision and must record a manual origin'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/V1/CartShippingRateSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/V1/CartShippingRateSchemaTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Schemas\V1;
 
+use Automattic\WooCommerce\Internal\Shipping\ShippingMethodOriginTracker;
 use Automattic\WooCommerce\StoreApi\Formatters;
 use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
 use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
@@ -43,6 +44,17 @@ class CartShippingRateSchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		WC()->session->set( 'chosen_shipping_methods', null );
+		WC()->session->set( ShippingMethodOriginTracker::SESSION_KEY, null );
+		WC()->session->set( 'shipping_method_counts', null );
+		WC()->session->set( 'previous_shipping_methods', null );
+		parent::tearDown();
+	}
+
+	/**
 	 * @testdox Should exclude hidden shipping rate meta from API response.
 	 */
 	public function test_get_rate_response_excludes_hidden_meta_data(): void {
@@ -70,6 +82,68 @@ class CartShippingRateSchemaTest extends WC_Unit_Test_Case {
 			),
 			$response['meta_data'],
 			'Only public shipping rate meta should be exposed by the Store API.'
+		);
+	}
+
+	/**
+	 * @testdox selected_rate_origin reflects the recorded origin of the chosen rate.
+	 */
+	public function test_selected_rate_origin_exposes_recorded_origin(): void {
+		WC()->session->set( 'chosen_shipping_methods', array( 0 => 'flat_rate:14' ) );
+		wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( 0, 'auto', 'flat_rate:14' );
+
+		$response = $this->sut->get_item_response( $this->build_package() );
+		$this->assertSame( 'auto', $response['selected_rate_origin'] );
+
+		wc_get_container()->get( ShippingMethodOriginTracker::class )->set_origin( 0, 'manual', 'flat_rate:14' );
+		$response = $this->sut->get_item_response( $this->build_package() );
+		$this->assertSame( 'manual', $response['selected_rate_origin'] );
+	}
+
+	/**
+	 * @testdox selected_rate_origin is null when no rate is chosen for the package.
+	 */
+	public function test_selected_rate_origin_null_without_chosen_rate(): void {
+		WC()->session->set( 'chosen_shipping_methods', null );
+		WC()->session->set( ShippingMethodOriginTracker::SESSION_KEY, null );
+
+		$response = $this->sut->get_item_response( $this->build_package() );
+		$this->assertNull( $response['selected_rate_origin'] );
+	}
+
+	/**
+	 * @testdox selected_rate_origin defaults to manual for sessions predating origin tracking.
+	 */
+	public function test_selected_rate_origin_manual_when_unrecorded(): void {
+		WC()->session->set( 'chosen_shipping_methods', array( 0 => 'flat_rate:14' ) );
+		WC()->session->set( ShippingMethodOriginTracker::SESSION_KEY, null );
+
+		$response = $this->sut->get_item_response( $this->build_package() );
+		$this->assertSame( 'manual', $response['selected_rate_origin'] );
+	}
+
+	/**
+	 * Builds a minimal calculated shipping package as get_item_response() consumes it.
+	 *
+	 * @param int $package_id Package id/key.
+	 * @return array
+	 */
+	private function build_package( int $package_id = 0 ): array {
+		return array(
+			'package_id'   => $package_id,
+			'package_name' => 'Shipping',
+			'destination'  => array(
+				'address_1' => '',
+				'address_2' => '',
+				'city'      => '',
+				'state'     => '',
+				'postcode'  => '',
+				'country'   => 'US',
+			),
+			'contents'     => array(),
+			'rates'        => array(
+				'flat_rate:14' => new WC_Shipping_Rate( 'flat_rate:14', 'Flat rate', 10, array(), 'flat_rate', 14 ),
+			),
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a customer reaches the cart or checkout with no address, only Local Pickup rates match, so the auto-defaulter writes pickup into the session, and the sticky-pickup branch keeps it selected even after a real address (typed, or supplied by an Apple Pay / Google Pay wallet) makes delivery rates available. Customers end up confirming pickup orders that were meant to be shipped.

This PR records whether the chosen method came from the auto-defaulter (`'auto'`) or an explicit customer action (`'manual'`) in a new `Internal\Shipping\ShippingMethodOriginTracker` (session key parallel to `chosen_shipping_methods`), and only keeps pickup sticky when the choice was manual or no non-pickup alternative exists. The Store API cart response gains a read-only `selected_rate_origin` field (`'auto' | 'manual' | null`) so gateway wallet flows can gate their mitigations on it (consumed by [Automattic/woocommerce-payments#11697](https://github.com/Automattic/woocommerce-payments/pull/11697)).

Previously closed as covered by #58066 / #64092; those fix the Store API cart context only, while classic (shortcode) page renders still seed the sticky pickup, which this PR unsticks.

**Backwards compatibility:** sessions predating origin tracking report `'manual'`, preserving the existing sticky behavior; third-party writes to `chosen_shipping_methods` self-invalidate a stale `'auto'` marker via a rate-id check; the Store API field is additive and read-only; no hook signatures or firing changed. The one intended behavior change: an auto-defaulted pickup now unsticks once a delivery rate becomes available.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Settings: General → Default customer location = "No location by default"; Shipping → enable Local Pickup with one location; add a United States zone with a Flat Rate. Use the checkout block on the Checkout page.
2. In a fresh incognito session, add a physical product and open the checkout without clicking anything. Pickup is auto-selected.
3. Simulate a wallet address via the Store API: `POST /wp-json/wc/store/v1/cart/update-customer` with a US shipping address.
4. The response now marks `flat_rate:N` as `selected: true` (on trunk, pickup stays selected, which is the bug). The new `selected_rate_origin` field on the package reads `auto` before the flip.
5. Regression: explicitly select pickup (`POST /cart/select-shipping-rate`), then repeat step 3. Pickup stays selected.
6. Regression: with only Local Pickup configured (no delivery zones), pickup stays selected after an address update.

<!-- End testing instructions -->

### Testing that has already taken place:

- 23 PHPUnit tests (unit + Store API route/schema) pass in wp-env (PHP 8.1), covering the unstick, the sticky-manual regression, backwards-compat fallbacks, shortcode context, and the block checkout's mount re-assert not laundering the origin.
- `phpcs` and PHPStan clean on all modified files.
- Manual end-to-end on wp-env (Storefront, real HTTP): classic cart render auto-selects pickup, `update-customer` flips it to the flat rate; after an explicit pickup choice, two forced re-defaults keep pickup selected.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `unstick-auto-default-local-pickup` (fix, patch) and `expose-selected-rate-origin-store-api`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
