### PR TITLE
Fix invalid WooCommerce cache prefixes

### DIFF
--- a/plugins/woocommerce/changelog/fix-cache-prefix-invalid-values
+++ b/plugins/woocommerce/changelog/fix-cache-prefix-invalid-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent invalid cache prefixes from causing fatal errors in cached order data.

--- a/plugins/woocommerce/src/Caching/CacheNameSpaceTrait.php
+++ b/plugins/woocommerce/src/Caching/CacheNameSpaceTrait.php
@@ -22,11 +22,12 @@ trait CacheNameSpaceTrait {
 	 */
 	public static function get_cache_prefix( $group ) {
 		// Get cache key - uses cache key wc_orders_cache_prefix to invalidate when needed.
-		$prefix = wp_cache_get( 'wc_' . $group . '_cache_prefix', $group );
+		$cache_key = 'wc_' . $group . '_cache_prefix';
+		$prefix    = wp_cache_get( $cache_key, $group );
 
-		if ( false === $prefix ) {
-			$prefix = microtime();
-			wp_cache_set( 'wc_' . $group . '_cache_prefix', $prefix, $group );
+		if ( ! self::is_valid_cache_prefix( $prefix ) ) {
+			$prefix = self::generate_cache_prefix();
+			wp_cache_set( $cache_key, $prefix, $group );
 		}
 
 		return 'wc_cache_' . $prefix . '_';
@@ -49,7 +50,7 @@ trait CacheNameSpaceTrait {
 	 * @since 3.9.0
 	 */
 	public static function invalidate_cache_group( $group ) {
-		return wp_cache_set( 'wc_' . $group . '_cache_prefix', microtime(), $group );
+		return wp_cache_set( 'wc_' . $group . '_cache_prefix', self::generate_cache_prefix(), $group );
 	}
 
 	/**
@@ -62,5 +63,28 @@ trait CacheNameSpaceTrait {
 	 */
 	public static function get_prefixed_key( $key, $group ) {
 		return self::get_cache_prefix( $group ) . $key;
+	}
+
+	/**
+	 * Generate a cache-safe prefix value.
+	 *
+	 * @return float Cache prefix.
+	 */
+	private static function generate_cache_prefix() {
+		return microtime( true );
+	}
+
+	/**
+	 * Check whether a cached prefix can safely be used in cache keys.
+	 *
+	 * @param mixed $prefix Cached prefix value.
+	 * @return bool True if the prefix is valid.
+	 */
+	private static function is_valid_cache_prefix( $prefix ) {
+		if ( is_int( $prefix ) || is_float( $prefix ) ) {
+			return true;
+		}
+
+		return is_string( $prefix ) && '' !== $prefix && 1 !== preg_match( '/\s/', $prefix );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cache-helper-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cache-helper-test.php
@@ -8,6 +8,15 @@ declare( strict_types = 1 );
 class WC_Cache_Helper_Tests extends WC_Unit_Test_Case {
 
 	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wp_cache_delete( 'wc_orders_cache_prefix', 'orders' );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Data provider for test_geolocation_ajax_get_location_hash.
 	 *
 	 * @return array[]
@@ -73,5 +82,63 @@ class WC_Cache_Helper_Tests extends WC_Unit_Test_Case {
 			$expected,
 			WC_Cache_Helper::geolocation_ajax_get_location_hash()
 		);
+	}
+
+	/**
+	 * @testdox Get cache prefix should generate cache-safe prefixes for empty cache groups.
+	 */
+	public function test_get_cache_prefix_generates_cache_safe_prefix(): void {
+		wp_cache_delete( 'wc_orders_cache_prefix', 'orders' );
+
+		$prefix = WC_Cache_Helper::get_cache_prefix( 'orders' );
+
+		$this->assert_cache_safe_prefix( $prefix );
+	}
+
+	/**
+	 * @testdox Get cache prefix should replace stale whitespace-prefixed values.
+	 */
+	public function test_get_cache_prefix_replaces_stale_whitespace_prefix(): void {
+		wp_cache_set( 'wc_orders_cache_prefix', '0.84069400 1778478731', 'orders' );
+
+		$prefix = WC_Cache_Helper::get_cache_prefix( 'orders' );
+
+		$this->assert_cache_safe_prefix( $prefix );
+		$this->assertNotSame( 'wc_cache_0.84069400 1778478731_', $prefix );
+	}
+
+	/**
+	 * @testdox Invalidate cache group should generate cache-safe prefixes.
+	 */
+	public function test_invalidate_cache_group_generates_cache_safe_prefix(): void {
+		WC_Cache_Helper::invalidate_cache_group( 'orders' );
+
+		$prefix = WC_Cache_Helper::get_cache_prefix( 'orders' );
+
+		$this->assert_cache_safe_prefix( $prefix );
+	}
+
+	/**
+	 * @testdox Get cache prefix should recover when a cached prefix is not stringable.
+	 */
+	public function test_get_cache_prefix_recovers_non_stringable_cached_prefix(): void {
+		wp_cache_set( 'wc_orders_cache_prefix', (object) array( 'invalid' => true ), 'orders' );
+
+		$cache_key = WC_Order::generate_meta_cache_key( 123, 'orders' );
+
+		$this->assertStringStartsWith( 'wc_cache_', $cache_key );
+		$this->assertStringContainsString( 'object_meta_123', $cache_key );
+	}
+
+	/**
+	 * Assert that a generated cache prefix is safe to use in cache keys.
+	 *
+	 * @param string $prefix Cache prefix.
+	 */
+	private function assert_cache_safe_prefix( string $prefix ): void {
+		$this->assertStringStartsWith( 'wc_cache_', $prefix );
+		$this->assertStringEndsWith( '_', $prefix );
+		$this->assertNotSame( 'wc_cache__', $prefix );
+		$this->assertSame( 0, preg_match( '/\s/', $prefix ), 'Cache prefix should not contain whitespace.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Cache prefixes are read from the object cache and concatenated into order and object-meta cache keys. If a persisted prefix is not stringable, `WC_Order::generate_meta_cache_key()` can fatal; if the prefix is an old whitespace-containing `microtime()` value, WooCommerce can keep generating unsafe cache keys.

This PR validates cached prefix values before use, regenerates non-stringable or whitespace-containing prefixes with `microtime( true )`, and uses the same cache-safe generation path when invalidating a cache group.

Closes #64763.

### How to test the changes in this Pull Request:

1. Run `wp eval 'wp_cache_set( "wc_orders_cache_prefix", (object) array( "invalid" => true ), "orders" ); echo WC_Order::generate_meta_cache_key( 123, "orders" );'`.
2. Confirm the command prints a cache key containing `object_meta_123` and does not fatal with `Object of class stdClass could not be converted to string`.
3. Run `wp eval 'wp_cache_set( "wc_orders_cache_prefix", "0.84069400 1778478731", "orders" ); echo WC_Cache_Helper::get_cache_prefix( "orders" );'`.
4. Confirm the generated prefix starts with `wc_cache_`, ends with `_`, and contains no whitespace.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Cache_Helper_Tests`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `composer exec -- phpstan analyse src/Caching/CacheNameSpaceTrait.php --memory-limit=2G --debug`
- Standalone PHP reproduction confirmed the reported object concatenation fatal, and confirmed the patched trait regenerates the cached prefix before building the order meta cache key.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually: `plugins/woocommerce/changelog/fix-cache-prefix-invalid-values`.

</details>
