### PR TITLE
RSM: improve handling of shopper list items that can't be purchased or are not accessible

### DIFF
--- a/plugins/woocommerce/changelog/64807-hide-non-public-products-in-lists
+++ b/plugins/woocommerce/changelog/64807-hide-non-public-products-in-lists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Don't leak title, price, permalink, or image for non-public products (draft, private, password-protected, etc.) in shopper-list responses.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -42,7 +42,8 @@ export type RawShopperListItem = {
 	product_id: number;
 	variation_id: number;
 	quantity: number;
-	product_exists: boolean;
+	is_live: boolean;
+	is_purchasable: boolean;
 	name: string;
 	permalink: string;
 	images: ShopperListItemImage[];

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -45,7 +45,7 @@ export type RawShopperListItem = {
 	is_live: boolean;
 	is_purchasable: boolean;
 	name: string;
-	permalink: string;
+	permalink: string | null;
 	images: ShopperListItemImage[];
 	variation: ShopperListItemVariation[];
 	prices: ShopperListItemPrices | null;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -164,8 +164,7 @@ store< BlockStore >(
 				if ( ! listItem ) {
 					return true;
 				}
-				// Tombstones never have a buyable product.
-				return ! listItem.product_exists;
+				return ! listItem.is_purchasable;
 			},
 
 			// `data-wp-text` writes its argument as text-content without
@@ -224,7 +223,7 @@ store< BlockStore >(
 
 			*onClickMoveToCart(): AsyncAction< void > {
 				const { listSlug, listItem } = getContext< BlockContext >();
-				if ( ! listItem || ! listItem.product_exists ) {
+				if ( ! listItem || ! listItem.is_purchasable ) {
 					return;
 				}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -22,6 +22,12 @@
 	flex-direction: column;
 	gap: 0.25em;
 
+	// The atomic product-button's `display: flex` outspecifies `[hidden]`,
+	// so the move-to-cart wrapper wouldn't honor `hidden` without this.
+	.wp-block-button.wc-block-components-product-button[hidden] {
+		display: none;
+	}
+
 	// Title spacing/line-height matches Product Collection's default
 	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
 	// We target wp-block-post-title (core's post-title class) because the

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -22,6 +22,17 @@
 	flex-direction: column;
 	gap: 0.25em;
 
+	// Tombstone rows render `<a>` without an href so iAPI can keep
+	// reconciling them against the live-row template (swapping the
+	// element type would force a re-hydration). The browser already
+	// drops link semantics for hrefless anchors, but make the
+	// non-clickability explicit so any inherited link styles don't
+	// mislead pointer or keyboard users.
+	a:not([href]) {
+		cursor: default;
+		pointer-events: none;
+	}
+
 	// The atomic product-button's `display: flex` outspecifies `[hidden]`,
 	// so the move-to-cart wrapper wouldn't honor `hidden` without this.
 	.wp-block-button.wc-block-components-product-button[hidden] {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -372,7 +372,8 @@ final class ShopperCollection extends AbstractBlock {
 	 * @return string
 	 */
 	private function render_item_markup( array $item, array $variation ): string {
-		$product_exists  = ! empty( $item['product_exists'] );
+		$is_live         = ! empty( $item['is_live'] );
+		$is_purchasable  = ! empty( $item['is_purchasable'] );
 		$name            = (string) ( $item['name'] ?? '' );
 		$permalink       = (string) ( $item['permalink'] ?? '' );
 		$quantity        = (int) ( $item['quantity'] ?? 1 );
@@ -415,7 +416,7 @@ final class ShopperCollection extends AbstractBlock {
 			// innerHTML when the row's context.listItem changes.
 			?>
 			<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
-				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink">
+				<a <?php echo $is_live && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink">
 					<span
 						class="wc-block-shopper-collection-item__image-slot"
 						data-wp-context='{"htmlField":"image_html"}'
@@ -453,7 +454,7 @@ final class ShopperCollection extends AbstractBlock {
 			// for tombstones.
 			?>
 			<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
-				<a <?php echo $product_exists && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
+				<a <?php echo $is_live && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
 			</h2>
 			<div
 				class="price wc-block-components-product-price has-text-align-center has-small-font-size"
@@ -471,13 +472,10 @@ final class ShopperCollection extends AbstractBlock {
 			<span class="wc-block-shopper-collection-item__quantity"><?php echo esc_html( $quantity_label ); ?></span>
 			<?php if ( ! empty( $variation['showAction'] ) ) : ?>
 				<?php
-				// Always emit the wrapper with the same `data-wp-bind--hidden`
-				// the template uses, and start it hidden when the SSR-side
-				// rule (the row is a tombstone) says so. That way a state
-				// change after hydration (e.g. the product is later flagged
-				// as deleted) hides the button without iAPI having to swap
-				// the entire row out.
-				$is_move_to_cart_hidden = ! $product_exists;
+				// Always emit the wrapper so iAPI can toggle `hidden` after
+				// hydration without swapping the row out. Start hidden when
+				// the row isn't purchasable.
+				$is_move_to_cart_hidden = ! $is_purchasable;
 				?>
 			<div
 				class="wp-block-button wc-block-components-product-button"

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -330,16 +330,38 @@ class ShopperListItem {
 	}
 
 	/**
-	 * Whether the product can be added to the cart.
+	 * Whether the product can be added to the cart. Mirrors the catalog gate
+	 * (`is_purchasable()` && `is_in_stock()`), but additionally requires the
+	 * row to be live and rejects password-gated products (self or parent) —
+	 * cart-add can't prompt for a password.
 	 */
 	public function is_purchasable(): bool {
 		$product = $this->get_product();
 		if ( ! $this->is_live() || ! $product ) {
 			return false;
 		}
+		if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
+			return false;
+		}
+		if ( $this->has_password( $product ) ) {
+			return false;
+		}
+		$parent_id = $product->get_parent_id();
+		if ( $parent_id > 0 ) {
+			$parent = wc_get_product( $parent_id );
+			if ( $parent instanceof \WC_Product && $this->has_password( $parent ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-		$product_password = $product->get_post_password();
-		return $product->is_purchasable() && $product->is_in_stock() && ( ! is_string( $product_password ) || '' === $product_password );
+	/**
+	 * @param \WC_Product $product Product to inspect.
+	 */
+	private function has_password( \WC_Product $product ): bool {
+		$password = $product->get_post_password();
+		return is_string( $password ) && '' !== $password;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -343,25 +343,24 @@ class ShopperListItem {
 		if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
 			return false;
 		}
-		if ( $this->has_password( $product ) ) {
+
+		$product_password = $product->get_post_password();
+		if ( is_string( $product_password ) && '' !== $product_password ) {
 			return false;
 		}
+
 		$parent_id = $product->get_parent_id();
 		if ( $parent_id > 0 ) {
 			$parent = wc_get_product( $parent_id );
-			if ( $parent instanceof \WC_Product && $this->has_password( $parent ) ) {
-				return false;
+			if ( $parent instanceof \WC_Product ) {
+				$parent_password = $parent->get_post_password();
+				if ( is_string( $parent_password ) && '' !== $parent_password ) {
+					return false;
+				}
 			}
 		}
-		return true;
-	}
 
-	/**
-	 * @param \WC_Product $product Product to inspect.
-	 */
-	private function has_password( \WC_Product $product ): bool {
-		$password = $product->get_post_password();
-		return is_string( $password ) && '' !== $password;
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -313,15 +313,15 @@ class ShopperListItem {
 	 */
 	public function is_live(): bool {
 		$product = $this->get_product();
-		if ( ! $product || ProductStatus::PUBLISH !== $product->get_status() ) {
+		if ( ! $product instanceof \WC_Product || ProductStatus::PUBLISH !== $product->get_status() ) {
 			return false;
 		}
 
 		$parent_id = $product->get_parent_id();
-		if ( $parent_id ) {
+		if ( $parent_id > 0 ) {
 			$parent = wc_get_product( $parent_id );
 
-			if ( ! $parent || ProductStatus::PUBLISH !== $parent->get_status() ) {
+			if ( ! $parent instanceof \WC_Product || ProductStatus::PUBLISH !== $parent->get_status() ) {
 				return false;
 			}
 		}

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -344,19 +344,15 @@ class ShopperListItem {
 			return false;
 		}
 
-		$product_password = $product->get_post_password();
-		if ( is_string( $product_password ) && '' !== $product_password ) {
+		if ( ! empty( $product->get_post_password() ) ) {
 			return false;
 		}
 
 		$parent_id = $product->get_parent_id();
 		if ( $parent_id > 0 ) {
 			$parent = wc_get_product( $parent_id );
-			if ( $parent instanceof \WC_Product ) {
-				$parent_password = $parent->get_post_password();
-				if ( is_string( $parent_password ) && '' !== $parent_password ) {
-					return false;
-				}
+			if ( $parent instanceof \WC_Product && ! empty( $parent->get_post_password() ) ) {
+				return false;
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -313,50 +313,33 @@ class ShopperListItem {
 	 */
 	public function is_live(): bool {
 		$product = $this->get_product();
-		if ( ! $product || ! $this->is_publish( $product ) ) {
+		if ( ! $product || ProductStatus::PUBLISH !== $product->get_status() ) {
 			return false;
 		}
-		$parent_id = $product->get_parent_id();
-		return $parent_id <= 0 || $this->is_publish( wc_get_product( $parent_id ) );
-	}
 
-	/**
-	 * Whether the product can be added to the cart. Mirrors the catalog gate
-	 * (`is_purchasable()` && `is_in_stock()`), but additionally requires the
-	 * row to be live (WC's `is_purchasable()` has an admin-edit escape hatch
-	 * we don't want here) and excludes password-gated products (cart-add
-	 * can't prompt for a password).
-	 */
-	public function is_purchasable(): bool {
-		if ( ! $this->is_live() ) {
-			return false;
-		}
-		$product = $this->get_product();
-		if ( ! $product instanceof \WC_Product ) {
-			return false;
-		}
-		if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
-			return false;
-		}
-		if ( '' !== (string) $product->get_post_password() ) {
-			return false;
-		}
 		$parent_id = $product->get_parent_id();
-		if ( $parent_id > 0 ) {
+		if ( $parent_id ) {
 			$parent = wc_get_product( $parent_id );
-			if ( $parent instanceof \WC_Product && '' !== (string) $parent->get_post_password() ) {
+
+			if ( ! $parent || ProductStatus::PUBLISH !== $parent->get_status() ) {
 				return false;
 			}
 		}
+
 		return true;
 	}
 
 	/**
-	 * @param mixed $product Product instance or a falsy `wc_get_product()` result.
+	 * Whether the product can be added to the cart.
 	 */
-	private function is_publish( $product ): bool {
-		return $product instanceof \WC_Product
-			&& ProductStatus::PUBLISH === $product->get_status();
+	public function is_purchasable(): bool {
+		$product = $this->get_product();
+		if ( ! $this->is_live() || ! $product ) {
+			return false;
+		}
+
+		$product_password = $product->get_post_password();
+		return $product->is_purchasable() && $product->is_in_stock() && ( ! is_string( $product_password ) || '' === $product_password );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\ShopperLists;
 
+use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 
 /**
@@ -57,6 +58,13 @@ class ShopperListItem {
 	 * @var string
 	 */
 	private $product_title_at_save;
+
+	/**
+	 * Resolved product, cached on the instance.
+	 *
+	 * @var \WC_Product|null
+	 */
+	private $product = null;
 
 	/**
 	 * Private constructor. Use the static factories to obtain concrete instances.
@@ -279,10 +287,76 @@ class ShopperListItem {
 	}
 
 	/**
-	 * Snapshot of the product title at save time. Used as the tombstone label.
+	 * Snapshot of the product title at save time.
 	 */
 	public function get_product_title_at_save(): string {
 		return $this->product_title_at_save;
+	}
+
+	/**
+	 * Resolve the live product (or variation) backing this saved item.
+	 */
+	public function get_product(): ?\WC_Product {
+		if ( $this->product instanceof \WC_Product ) {
+			return $this->product;
+		}
+		$id            = $this->variation_id > 0 ? $this->variation_id : $this->product_id;
+		$product       = $id > 0 ? wc_get_product( $id ) : false;
+		$this->product = $product instanceof \WC_Product ? $product : null;
+		return $this->product;
+	}
+
+	/**
+	 * Whether the row serves live product data. True when the product (and its
+	 * parent, for variations) is `publish`; password-gated products still
+	 * qualify since their page renders behind a prompt.
+	 */
+	public function is_live(): bool {
+		$product = $this->get_product();
+		if ( ! $product || ! $this->is_publish( $product ) ) {
+			return false;
+		}
+		$parent_id = $product->get_parent_id();
+		return $parent_id <= 0 || $this->is_publish( wc_get_product( $parent_id ) );
+	}
+
+	/**
+	 * Whether the product can be added to the cart. Mirrors the catalog gate
+	 * (`is_purchasable()` && `is_in_stock()`), but additionally requires the
+	 * row to be live (WC's `is_purchasable()` has an admin-edit escape hatch
+	 * we don't want here) and excludes password-gated products (cart-add
+	 * can't prompt for a password).
+	 */
+	public function is_purchasable(): bool {
+		if ( ! $this->is_live() ) {
+			return false;
+		}
+		$product = $this->get_product();
+		if ( ! $product instanceof \WC_Product ) {
+			return false;
+		}
+		if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
+			return false;
+		}
+		if ( '' !== (string) $product->get_post_password() ) {
+			return false;
+		}
+		$parent_id = $product->get_parent_id();
+		if ( $parent_id > 0 ) {
+			$parent = wc_get_product( $parent_id );
+			if ( $parent instanceof \WC_Product && '' !== (string) $parent->get_post_password() ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * @param mixed $product Product instance or a falsy `wc_get_product()` result.
+	 */
+	private function is_publish( $product ): bool {
+		return $product instanceof \WC_Product
+			&& ProductStatus::PUBLISH === $product->get_status();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -112,8 +112,8 @@ class ShopperListItemSchema extends AbstractSchema {
 				'readonly'    => true,
 			),
 			'permalink'      => array(
-				'description' => __( 'Product URL. Empty when the product no longer exists.', 'woocommerce' ),
-				'type'        => 'string',
+				'description' => __( 'Product URL. Null when the row is a tombstone (so iAPI strips the anchor href).', 'woocommerce' ),
+				'type'        => array( 'string', 'null' ),
 				'format'      => 'uri',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -241,7 +241,7 @@ class ShopperListItemSchema extends AbstractSchema {
 			$response['image_html'] = $this->get_image_html( $product );
 		} else {
 			$response['name']       = $this->prepare_html_response( $item->get_product_title_at_save() );
-			$response['permalink']  = '';
+			$response['permalink']  = null;
 			$response['images']     = array();
 			$response['variation']  = array();
 			$response['prices']     = null;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -11,8 +11,8 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
 /**
  * ShopperListItemSchema class.
  *
- * Serializes a {@see ShopperListItem}. Serves live product data when the
- * underlying product still exists, and at-save tombstone data otherwise.
+ * Serializes a {@see ShopperListItem}. Renders live product fields when the
+ * item reports `is_live`, and falls back to at-save snapshot data otherwise.
  */
 class ShopperListItemSchema extends AbstractSchema {
 	// We only call format_variation_data(); see phpstan.neon for the related suppressions.
@@ -93,14 +93,20 @@ class ShopperListItemSchema extends AbstractSchema {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'product_exists' => array(
-				'description' => __( 'True when the underlying product still exists in the catalog. When false, the row is a tombstone served from at-save snapshot data.', 'woocommerce' ),
+			'is_live'        => array(
+				'description' => __( 'True when the row serves live product data; false rows are at-save tombstones.', 'woocommerce' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'is_purchasable' => array(
+				'description' => __( 'True when the product can be added to the cart.', 'woocommerce' ),
 				'type'        => 'boolean',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'name'           => array(
-				'description' => __( 'Product name. Live when product_exists is true; falls back to the at-save title snapshot otherwise.', 'woocommerce' ),
+				'description' => __( 'Product name. Live when is_live is true; falls back to the at-save title snapshot otherwise.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -211,8 +217,8 @@ class ShopperListItemSchema extends AbstractSchema {
 	public function get_item_response( $item ) {
 		$variation_id = $item->get_variation_id();
 		$product_id   = $variation_id > 0 ? $variation_id : $item->get_product_id();
-		$product      = $product_id > 0 ? wc_get_product( $product_id ) : false;
-		$has_product  = $product instanceof \WC_Product;
+		$product      = $item->get_product();
+		$is_live      = $item->is_live();
 
 		$response = array(
 			'key'            => $item->get_key(),
@@ -220,11 +226,12 @@ class ShopperListItemSchema extends AbstractSchema {
 			'product_id'     => $item->get_product_id(),
 			'variation_id'   => $variation_id,
 			'quantity'       => $item->get_quantity(),
-			'product_exists' => $has_product,
+			'is_live'        => $is_live,
+			'is_purchasable' => $item->is_purchasable(),
 			'date_added_gmt' => wc_rest_prepare_date_response( $item->get_date_added_gmt() ),
 		);
 
-		if ( $has_product ) {
+		if ( $is_live && $product instanceof \WC_Product ) {
 			$response['name']       = $this->get_name( $product );
 			$response['permalink']  = $product->get_permalink();
 			$response['images']     = $this->get_images( $product );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ShopperLists.php
@@ -194,7 +194,7 @@ class ShopperLists extends ControllerTestCase {
 		$this->assertEquals( 201, $response->get_status() );
 		$this->assertSame( $this->product->get_id(), $data['product_id'] );
 		$this->assertSame( 1, $data['quantity'], 'Saved quantity should mirror the cart line quantity.' );
-		$this->assertTrue( $data['product_exists'] );
+		$this->assertTrue( $data['is_live'] );
 		$this->assertSame( $this->product->get_title(), $data['name'] );
 		$this->assertNotEmpty( wc()->cart->cart_contents, 'Cart should still contain the line — POST is additive only.' );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -277,6 +277,32 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Variations under a password-protected parent stay live but aren't purchasable.
+	 */
+	public function test_variation_with_password_protected_parent_is_not_purchasable(): void {
+		$variable = \WC_Helper_Product::create_variation_product();
+		$children = $variable->get_children();
+		$this->assertNotEmpty( $children, 'Variable product helper should produce variation children' );
+		$variation_id = (int) $children[0];
+
+		wp_update_post(
+			array(
+				'ID'            => $variable->get_id(),
+				'post_password' => 'secret',
+			)
+		);
+
+		$response = $this->sut->get_item_response(
+			$this->build_item( $variable->get_id(), $variation_id, array(), 'Snapshot Title' )
+		);
+
+		$this->assertTrue( $response['is_live'], 'Parent still renders behind a password prompt' );
+		$this->assertFalse( $response['is_purchasable'], 'Parent password must gate the variation too' );
+
+		$variable->delete( true );
+	}
+
+	/**
 	 * @testdox Should expose price_html for live products and an empty string for tombstones.
 	 */
 	public function test_price_html_is_populated_for_live_products(): void {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -135,6 +135,12 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 		}
 		$post_overrides = array_intersect_key( $overrides, array_flip( array( 'post_status', 'post_password' ) ) );
 		if ( ! empty( $post_overrides ) ) {
+			// `wp_update_post` silently rewrites `future` back to `publish` when post_date is in the past,
+			// so a future date is needed to actually persist the status.
+			if ( 'future' === ( $post_overrides['post_status'] ?? '' ) ) {
+				$post_overrides['post_date_gmt'] = gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) );
+				$post_overrides['post_date']     = $post_overrides['post_date_gmt'];
+			}
 			wp_update_post( array_merge( array( 'ID' => $product->get_id() ), $post_overrides ) );
 		}
 
@@ -144,7 +150,7 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 		if ( ! $expected_live ) {
 			$this->assertFalse( $response['is_purchasable'], 'Non-public products are not purchasable' );
 			$this->assertSame( 'Snapshot Title', $response['name'], 'Tombstone must not leak the live title' );
-			$this->assertSame( '', $response['permalink'], 'Tombstone must not leak the live permalink' );
+			$this->assertNull( $response['permalink'], 'Tombstone permalink must be null so iAPI strips the anchor href' );
 			$this->assertNull( $response['prices'], 'Tombstone must not leak live prices' );
 		}
 
@@ -165,6 +171,7 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 			'pending'                   => array( array( 'post_status' => 'pending' ), false ),
 			'private'                   => array( array( 'post_status' => 'private' ), false ),
 			'trash'                     => array( array( 'post_status' => 'trash' ), false ),
+			'future'                    => array( array( 'post_status' => 'future' ), false ),
 		);
 	}
 
@@ -377,7 +384,7 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $response['is_live'], 'is_live must be false when the product is gone' );
 		$this->assertSame( 'Snapshot Title', $response['name'], 'Tombstone name should fall back to the at-save title snapshot' );
-		$this->assertSame( '', $response['permalink'], 'permalink should be empty in tombstone path' );
+		$this->assertNull( $response['permalink'], 'Tombstone permalink must be null so iAPI strips the anchor href' );
 		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );
 		$this->assertNull( $response['prices'], 'Live prices should be null for missing products' );
 		$this->assertArrayNotHasKey( 'product_title_at_save', $response, 'Internal at-save title snapshot should not leak into the public response' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -87,9 +87,9 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should serve live product data and product_exists=true when the product exists.
+	 * @testdox Should serve live product data and is_live=true for a published product.
 	 */
-	public function test_returns_live_data_when_product_exists(): void {
+	public function test_returns_live_data_when_is_live(): void {
 		$product = \WC_Helper_Product::create_simple_product(
 			true,
 			array(
@@ -100,12 +100,180 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 
 		$response = $this->sut->get_item_response( $this->build_item( $product->get_id(), 0, array(), 'Snapshot T-Shirt' ) );
 
-		$this->assertTrue( $response['product_exists'], 'product_exists must be true when the product still exists' );
+		$this->assertTrue( $response['is_live'], 'is_live must be true for a published product' );
+		$this->assertTrue( $response['is_purchasable'], 'A published, in-stock priced product is purchasable' );
 		$this->assertSame( 'Live T-Shirt', $response['name'], 'Live name should be served, not the snapshot' );
 		$this->assertSame( $product->get_permalink(), $response['permalink'] );
 		$this->assertNotNull( $response['prices'], 'Live prices should be populated' );
 
 		$product->delete( true );
+	}
+
+	/**
+	 * @testdox is_live should gate on publish status (self and parent). Stock, catalog visibility, and post password don't affect it.
+	 * @dataProvider provider_is_live_cases
+	 *
+	 * @param array<string, string> $overrides     Post/product overrides to apply.
+	 * @param bool                  $expected_live Expected is_live value.
+	 */
+	public function test_is_live_predicate( array $overrides, bool $expected_live ): void {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Subject',
+				'regular_price' => 19.99,
+			)
+		);
+
+		if ( isset( $overrides['stock_status'] ) ) {
+			$product->set_stock_status( $overrides['stock_status'] );
+			$product->save();
+		}
+		if ( isset( $overrides['catalog_visibility'] ) ) {
+			$product->set_catalog_visibility( $overrides['catalog_visibility'] );
+			$product->save();
+		}
+		$post_overrides = array_intersect_key( $overrides, array_flip( array( 'post_status', 'post_password' ) ) );
+		if ( ! empty( $post_overrides ) ) {
+			wp_update_post( array_merge( array( 'ID' => $product->get_id() ), $post_overrides ) );
+		}
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id(), 0, array(), 'Snapshot Title' ) );
+
+		$this->assertSame( $expected_live, $response['is_live'] );
+		if ( ! $expected_live ) {
+			$this->assertFalse( $response['is_purchasable'], 'Non-public products are not purchasable' );
+			$this->assertSame( 'Snapshot Title', $response['name'], 'Tombstone must not leak the live title' );
+			$this->assertSame( '', $response['permalink'], 'Tombstone must not leak the live permalink' );
+			$this->assertNull( $response['prices'], 'Tombstone must not leak live prices' );
+		}
+
+		wp_delete_post( $product->get_id(), true );
+	}
+
+	/**
+	 * @return array<string, array{0: array<string, string>, 1: bool}>
+	 */
+	public function provider_is_live_cases(): array {
+		return array(
+			// Renderable — guards against using `is_visible()`, which would
+			// tombstone deliberately-saved OOS / catalog-hidden items.
+			'OOS, publish'              => array( array( 'stock_status' => 'outofstock' ), true ),
+			'catalog_visibility=hidden' => array( array( 'catalog_visibility' => 'hidden' ), true ),
+			// Tombstone cases.
+			'draft'                     => array( array( 'post_status' => 'draft' ), false ),
+			'pending'                   => array( array( 'post_status' => 'pending' ), false ),
+			'private'                   => array( array( 'post_status' => 'private' ), false ),
+			'trash'                     => array( array( 'post_status' => 'trash' ), false ),
+		);
+	}
+
+	/**
+	 * @testdox Out-of-stock products stay live but aren't purchasable, matching catalog behavior.
+	 */
+	public function test_out_of_stock_product_is_live_but_not_purchasable(): void {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'OOS T-Shirt',
+				'regular_price' => 19.99,
+			)
+		);
+		$product->set_stock_status( 'outofstock' );
+		$product->save();
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertTrue( $response['is_live'], 'OOS products stay renderable' );
+		$this->assertFalse( $response['is_purchasable'], 'Cart button hidden for OOS, mirroring the storefront catalog gate (is_purchasable() && is_in_stock())' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Password-protected products stay live (clickable) but aren't purchasable.
+	 */
+	public function test_password_protected_product_is_live_but_not_purchasable(): void {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Gated T-Shirt',
+				'regular_price' => 19.99,
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'            => $product->get_id(),
+				'post_password' => 'secret',
+			)
+		);
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertTrue( $response['is_live'], 'Page renders behind a password prompt, so the row stays clickable' );
+		$this->assertFalse( $response['is_purchasable'], 'Customer must authenticate before purchasing' );
+		$this->assertSame( $product->get_permalink(), $response['permalink'] );
+
+		wp_delete_post( $product->get_id(), true );
+	}
+
+	/**
+	 * @testdox Admins viewing their own draft products see a tombstone, not a Move-to-cart button.
+	 */
+	public function test_admin_viewing_own_draft_does_not_short_circuit_is_purchasable(): void {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Pre-launch T-Shirt',
+				'regular_price' => 19.99,
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'          => $product->get_id(),
+				'post_status' => 'draft',
+			)
+		);
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		// WC_Product::is_purchasable() short-circuits via `current_user_can( 'edit_post', ... )`
+		// for admins. Our predicate must gate on is_live first so the tombstone row isn't
+		// rendered with a working cart button.
+		$this->assertFalse( $response['is_live'] );
+		$this->assertFalse( $response['is_purchasable'], 'Admin escape hatch in WC_Product::is_purchasable() must not leak into is_purchasable on a tombstone row.' );
+
+		wp_delete_post( $product->get_id(), true );
+		wp_delete_user( $admin_id );
+	}
+
+	/**
+	 * @testdox Should tombstone a variation whose parent is not published.
+	 */
+	public function test_variation_with_non_publish_parent_is_tombstoned(): void {
+		$variable = \WC_Helper_Product::create_variation_product();
+		$children = $variable->get_children();
+		$this->assertNotEmpty( $children, 'Variable product helper should produce variation children' );
+		$variation_id = (int) $children[0];
+
+		wp_update_post(
+			array(
+				'ID'          => $variable->get_id(),
+				'post_status' => 'draft',
+			)
+		);
+
+		$response = $this->sut->get_item_response(
+			$this->build_item( $variable->get_id(), $variation_id, array(), 'Snapshot Title' )
+		);
+
+		$this->assertFalse( $response['is_live'], 'Variations under a non-publish parent must be tombstoned' );
+		$this->assertSame( 'Snapshot Title', $response['name'] );
+
+		$variable->delete( true );
 	}
 
 	/**
@@ -181,7 +349,7 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 
 		$response = $this->sut->get_item_response( $item );
 
-		$this->assertFalse( $response['product_exists'], 'product_exists must be false when the product is gone' );
+		$this->assertFalse( $response['is_live'], 'is_live must be false when the product is gone' );
 		$this->assertSame( 'Snapshot Title', $response['name'], 'Tombstone name should fall back to the at-save title snapshot' );
 		$this->assertSame( '', $response['permalink'], 'permalink should be empty in tombstone path' );
 		$this->assertSame( array(), $response['images'], 'No images should be returned for missing products' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListSchemaTest.php
@@ -154,8 +154,8 @@ class ShopperListSchemaTest extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'key', $item );
 		$this->assertArrayHasKey( 'product_id', $item );
 		$this->assertArrayHasKey( 'quantity', $item );
-		$this->assertArrayHasKey( 'product_exists', $item );
-		$this->assertTrue( $item['product_exists'], 'Live product items should have product_exists=true.' );
+		$this->assertArrayHasKey( 'is_live', $item );
+		$this->assertTrue( $item['is_live'], 'Live product items should have is_live=true.' );
 
 		$product->delete( true );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`ShopperListItemSchema::get_item_response()` treats anything `wc_get_product()` returned as live, possibly leaking the current title, price, permalink, and image for `draft`, `pending`, `private`, `trash`, and password-protected products, including variations under non-published parents.

`ShopperListItem` now takes care of checking whether the product is really "accessible" (`is_live()`) and whether it can be purchased/added to the cart (`is_purchasable()`). These checks are authoritative and included in the schema.

Closes WOOPRD-3526.

### How to test the changes in this Pull Request:

1. Enable the **Save for Later in Cart** in **WooCommerce > Settings > Advanced > Features**.
1. Add any product to the cart and then to the saved-for-later list via the **Save for later** action in the cart item.
1. Confirm the item renders with title, price, image, permalink, and a working **Move to cart** button.
1. On the admin, flip the product status to draft, private or move to trash. Reload the cart page and confirm the item is now a tombstone: no product image or link to product, no **move to cart** button.
5. Publish the product again and change its visibility to "password protected". Confirm the item is rendered but there's no **move to cart** button. This matches how catalog works for passsword-protected products.
6. Use the **Inventory** tab on the edit product admin screen and set the product stock status to **Out of stock**. Confirm that on the saved for later block the product no longer displays the **move to cart** button but is otherwise rendered normally.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**