### PR TITLE
Align embedded admin notice padding

### DIFF
--- a/plugins/woocommerce/changelog/tweak-admin-notice-padding-wp70-align
+++ b/plugins/woocommerce/changelog/tweak-admin-notice-padding-wp70-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Align embedded admin notice padding with WordPress 7.0.

--- a/plugins/woocommerce/client/admin/client/stylesheets/_embed.scss
+++ b/plugins/woocommerce/client/admin/client/stylesheets/_embed.scss
@@ -43,7 +43,7 @@
 	}
 
 	.notice {
-		padding: 1px 12px;
+		padding: 8px 12px;
 	}
 
 	.woocommerce-layout__header {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WordPress 7.0 updates the visual rhythm for admin notices, and the embedded WooCommerce admin page still overrides notice padding to `1px 12px`. This PR updates the embedded admin notice padding to `8px 12px` so WooCommerce notices better align with the upcoming WordPress spacing.

This keeps the scope to padding only. WooCommerce does not set the notice status colors in this embedded admin override, so `.notice-info`, `.notice-success`, `.notice-error`, and other notice colors continue to come from WordPress core. That means the WP 7.0 notice palette is inherited automatically when the site runs on WordPress 7.0.

### Screenshots or screen recordings:

Before/after screenshots should be attached before moving this out of draft:

- Before: embedded admin notice with `padding: 1px 12px`.
- After: embedded admin notice with `padding: 8px 12px`, inheriting the WordPress notice color.
<img width="1280" height="240" alt="Before and after comparison" src="https://github.com/user-attachments/assets/96fd1946-cd47-4a91-a0e6-1aedd82096ff" />



### How to test the changes in this Pull Request:

1. Check out this branch and build the WooCommerce admin assets.
2. Open a WooCommerce embedded admin page that displays a WordPress admin notice.
3. Inspect the notice and confirm `.woocommerce-embed-page .notice` uses `padding: 8px 12px`.
4. Confirm the notice text and dismiss/action controls are not visually clipped and still align correctly.
5. Confirm notice status colors are inherited from WordPress core and are not overridden by this WooCommerce stylesheet.

### Testing that has already taken place:

-   Confirmed the source stylesheet now uses `padding: 8px 12px` for embedded WooCommerce admin notices.
-   Confirmed the embedded admin override does not set notice status colors.
-   Ran `pnpm --filter=@woocommerce/admin-library exec stylelint client/stylesheets/_embed.scss`.
-   Ran `git diff --check`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A manual changelog entry is included in `plugins/woocommerce/changelog/tweak-admin-notice-padding-wp70-align`.

</details>
