### PR TITLE
RSM: refactor shopper-lists schema to use API objects directly

### DIFF
--- a/plugins/woocommerce/changelog/refactor-shopper-list-schemas-take-objects
+++ b/plugins/woocommerce/changelog/refactor-shopper-list-schemas-take-objects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Pass ShopperList and ShopperListItem objects directly to their Store API schemas instead of round-tripping through to_array(); no JSON response shape change.

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -117,6 +117,13 @@ class ShopperList {
 	}
 
 	/**
+	 * Creation time as a MySQL DATETIME in GMT.
+	 */
+	public function get_date_created_gmt(): string {
+		return $this->date_created_gmt;
+	}
+
+	/**
 	 * Add an item, or merge quantities if it already exists.
 	 *
 	 * @param ShopperListItem $item Item to add.

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -109,7 +109,7 @@ class ShopperListItem {
 			absint( $data['variation_id'] ?? 0 ),
 			$data['variation'] ?? array(),
 			absint( $data['quantity'] ),
-			$data['date_added_gmt'] ?? '',
+			$data['date_added_gmt'] ?? current_time( 'mysql', true ),
 			$data['product_title_at_save'] ?? ''
 		);
 	}
@@ -265,7 +265,28 @@ class ShopperListItem {
 	}
 
 	/**
-	 * Storage / response shape.
+	 * Variation attributes captured at save time.
+	 */
+	public function get_variation_attributes(): array {
+		return $this->variation;
+	}
+
+	/**
+	 * Save time as a MySQL DATETIME in GMT.
+	 */
+	public function get_date_added_gmt(): string {
+		return $this->date_added_gmt;
+	}
+
+	/**
+	 * Snapshot of the product title at save time. Used as the tombstone label.
+	 */
+	public function get_product_title_at_save(): string {
+		return $this->product_title_at_save;
+	}
+
+	/**
+	 * Storage shape used to persist into user_meta.
 	 */
 	public function to_array(): array {
 		return array(

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -137,7 +137,7 @@ class ShopperListItems extends AbstractRoute {
 
 		$response = array();
 		foreach ( $items as $item ) {
-			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $item->to_array(), $request ) );
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $item, $request ) );
 		}
 
 		return rest_ensure_response( $response );
@@ -176,7 +176,7 @@ class ShopperListItems extends AbstractRoute {
 		$list->save();
 
 		$saved = $list->find_item( $item->get_key() ) ?? $item;
-		return new \WP_REST_Response( $this->schema->get_item_response( $saved->to_array() ), 201 );
+		return new \WP_REST_Response( $this->schema->get_item_response( $saved ), 201 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
@@ -75,7 +75,7 @@ class ShopperLists extends AbstractRoute {
 		$response = array();
 
 		foreach ( ShopperList::get_all_for_user() as $list ) {
-			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $list->to_array(), $request ) );
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $list, $request ) );
 		}
 
 		return rest_ensure_response( $response );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
@@ -87,6 +87,6 @@ class ShopperListsBySlug extends AbstractRoute {
 			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
 		}
 
-		return rest_ensure_response( $this->prepare_item_for_response( $list->to_array(), $request ) );
+		return rest_ensure_response( $this->prepare_item_for_response( $list, $request ) );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
@@ -10,9 +11,8 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
 /**
  * ShopperListItemSchema class.
  *
- * One row in a shopper list. Serves live product data when the product still
- * exists in the catalog, and at-save tombstone data when it doesn't, distinguishing
- * the two states via the `product_exists` boolean.
+ * Serializes a {@see ShopperListItem}. Serves live product data when the
+ * underlying product still exists, and at-save tombstone data otherwise.
  */
 class ShopperListItemSchema extends AbstractSchema {
 	// We only call format_variation_data(); see phpstan.neon for the related suppressions.
@@ -203,46 +203,44 @@ class ShopperListItemSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Convert a stored item record into the response shape.
+	 * Serialize the saved item.
 	 *
-	 * @param array $item Stored item record.
+	 * @param ShopperListItem $item Saved item.
 	 * @return array
 	 */
 	public function get_item_response( $item ) {
-		$variation_id = $item['variation_id'] ?? 0;
-		$product_id   = $variation_id > 0 ? $variation_id : ( $item['product_id'] ?? 0 );
-		$product      = $product_id ? wc_get_product( $product_id ) : false;
+		$variation_id = $item->get_variation_id();
+		$product_id   = $variation_id > 0 ? $variation_id : $item->get_product_id();
+		$product      = $product_id > 0 ? wc_get_product( $product_id ) : false;
 		$has_product  = $product instanceof \WC_Product;
 
 		$response = array(
-			'key'            => $item['key'] ?? '',
+			'key'            => $item->get_key(),
 			'id'             => $product_id,
-			'product_id'     => $item['product_id'] ?? 0,
-			'variation_id'   => $item['variation_id'] ?? 0,
-			'quantity'       => $item['quantity'] ?? 1,
+			'product_id'     => $item->get_product_id(),
+			'variation_id'   => $variation_id,
+			'quantity'       => $item->get_quantity(),
 			'product_exists' => $has_product,
-			'date_added_gmt' => wc_rest_prepare_date_response( $item['date_added_gmt'] ?? current_time( 'mysql', true ) ),
+			'date_added_gmt' => wc_rest_prepare_date_response( $item->get_date_added_gmt() ),
 		);
-
-		$variation_data = isset( $item['variation'] ) && is_array( $item['variation'] ) ? $item['variation'] : array();
 
 		if ( $has_product ) {
 			$response['name']       = $this->get_name( $product );
 			$response['permalink']  = $product->get_permalink();
 			$response['images']     = $this->get_images( $product );
-			$response['variation']  = $this->format_variation_data( $variation_data, $product );
+			$response['variation']  = $this->format_variation_data( $item->get_variation_attributes(), $product );
 			$response['prices']     = (object) $this->get_prices( $product );
 			$response['price_html'] = (string) $product->get_price_html();
 			$response['image_html'] = $this->get_image_html( $product );
 		} else {
-			$response['name']       = $this->prepare_html_response( (string) ( $item['product_title_at_save'] ?? '' ) );
+			$response['name']       = $this->prepare_html_response( $item->get_product_title_at_save() );
 			$response['permalink']  = '';
 			$response['images']     = array();
 			$response['variation']  = array();
 			$response['prices']     = null;
 			$response['price_html'] = '';
 			$response['image_html'] = $this->get_image_html( null );
-		}//end if
+		}
 
 		return $response;
 	}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListSchema.php
@@ -3,6 +3,8 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 
@@ -90,19 +92,19 @@ class ShopperListSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Convert a stored list record into the response shape.
+	 * Serialize the shopper list.
 	 *
-	 * @param array $shopper_list List array (as returned by ShopperList::to_array()).
+	 * @param ShopperList $shopper_list The list.
 	 * @return array
 	 */
 	public function get_item_response( $shopper_list ) {
-		$items = isset( $shopper_list['items'] ) && is_array( $shopper_list['items'] ) ? $shopper_list['items'] : array();
+		$items = array_values( $shopper_list->get_items() );
 
 		$product_ids = array_filter(
 			array_map(
-				static function ( $item ) {
-					$variation_id = absint( $item['variation_id'] ?? 0 );
-					return $variation_id ? $variation_id : absint( $item['product_id'] ?? 0 );
+				static function ( ShopperListItem $item ): int {
+					$variation_id = $item->get_variation_id();
+					return $variation_id > 0 ? $variation_id : $item->get_product_id();
 				},
 				$items
 			)
@@ -112,12 +114,12 @@ class ShopperListSchema extends AbstractSchema {
 		}
 
 		return array(
-			'slug'             => $shopper_list['slug'] ?? '',
-			'date_created_gmt' => wc_rest_prepare_date_response( $shopper_list['date_created_gmt'] ?? current_time( 'mysql', true ) ),
+			'slug'             => $shopper_list->get_slug(),
+			'date_created_gmt' => wc_rest_prepare_date_response( $shopper_list->get_date_created_gmt() ),
 			'item_count'       => count( $items ),
 			'items'            => array_values(
 				array_map(
-					fn( $item ) => $this->item_schema->get_item_response( $item ),
+					fn( ShopperListItem $item ) => $this->item_schema->get_item_response( $item ),
 					$items
 				)
 			),

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Schemas;
 
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
 use Automattic\WooCommerce\StoreApi\Formatters;
 use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
 use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
@@ -64,23 +65,24 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Build a minimal stored item record around a product.
+	 * Build a ShopperListItem around a product.
 	 *
 	 * @param int    $product_id   Product ID.
 	 * @param int    $variation_id Variation ID, or 0.
 	 * @param array  $variation    Variation attributes.
 	 * @param string $title        Title snapshot.
-	 * @return array
 	 */
-	private function build_item( int $product_id, int $variation_id = 0, array $variation = array(), string $title = 'Snapshot Title' ): array {
-		return array(
-			'key'                   => md5( (string) $product_id ),
-			'product_id'            => $product_id,
-			'variation_id'          => $variation_id,
-			'variation'             => $variation,
-			'quantity'              => 1,
-			'date_added_gmt'        => '2024-04-25 03:20:00',
-			'product_title_at_save' => $title,
+	private function build_item( int $product_id, int $variation_id = 0, array $variation = array(), string $title = 'Snapshot Title' ): ShopperListItem {
+		return ShopperListItem::from_array(
+			array(
+				'key'                   => md5( (string) $product_id ),
+				'product_id'            => $product_id,
+				'variation_id'          => $variation_id,
+				'variation'             => $variation,
+				'quantity'              => 1,
+				'date_added_gmt'        => '2024-04-25 03:20:00',
+				'product_title_at_save' => $title,
+			)
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListItemSchemaTest.php
@@ -215,4 +215,81 @@ class ShopperListItemSchemaTest extends WC_Unit_Test_Case {
 			'Tombstones must use the placeholder image markup'
 		);
 	}
+
+	/**
+	 * @testdox Should expose key on a live-product response.
+	 */
+	public function test_response_carries_the_item_key(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$item    = $this->build_item( $product->get_id() );
+
+		$response = $this->sut->get_item_response( $item );
+
+		$this->assertArrayHasKey( 'key', $response );
+		$this->assertSame( $item->get_key(), $response['key'], 'Response key must match the saved item key.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should format date_added_gmt via wc_rest_prepare_date_response (ISO8601, no timezone suffix).
+	 */
+	public function test_date_added_gmt_is_iso8601(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+
+		$response = $this->sut->get_item_response( $this->build_item( $product->get_id() ) );
+
+		$this->assertArrayHasKey( 'date_added_gmt', $response );
+		$this->assertSame( '2024-04-25T03:20:00', $response['date_added_gmt'], 'date_added_gmt must be the ISO8601 formatting of the GMT save time.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should expose the variation ID as id when the saved item is a variation.
+	 */
+	public function test_id_resolves_to_variation_id_for_variations(): void {
+		$variable_product = \WC_Helper_Product::create_variation_product();
+		$variation_ids    = $variable_product->get_children();
+		$variation_id     = (int) $variation_ids[0];
+		$item             = $this->build_item( $variable_product->get_id(), $variation_id );
+
+		$response = $this->sut->get_item_response( $item );
+
+		$this->assertArrayHasKey( 'id', $response );
+		$this->assertSame( $variation_id, $response['id'], 'id should resolve to variation_id when set.' );
+		$this->assertArrayHasKey( 'product_id', $response );
+		$this->assertSame( $variable_product->get_id(), $response['product_id'], 'product_id should still hold the parent product id.' );
+		$this->assertArrayHasKey( 'variation_id', $response );
+		$this->assertSame( $variation_id, $response['variation_id'] );
+
+		$variable_product->delete( true );
+	}
+
+	/**
+	 * @testdox Should format saved variation attributes via format_variation_data on live variations.
+	 */
+	public function test_variation_attributes_are_formatted_on_live_variations(): void {
+		$variable_product = \WC_Helper_Product::create_variation_product();
+		$variation_id     = (int) $variable_product->get_children()[0];
+		$item             = $this->build_item(
+			$variable_product->get_id(),
+			$variation_id,
+			array( 'attribute_pa_size' => 'small' )
+		);
+
+		$response = $this->sut->get_item_response( $item );
+
+		$this->assertArrayHasKey( 'variation', $response );
+		$this->assertIsArray( $response['variation'] );
+		$this->assertCount( 1, $response['variation'], 'A single saved attribute should produce one entry in the variation list.' );
+
+		$entry = $response['variation'][0];
+		$this->assertArrayHasKey( 'raw_attribute', $entry );
+		$this->assertArrayHasKey( 'attribute', $entry );
+		$this->assertArrayHasKey( 'value', $entry );
+		$this->assertSame( 'attribute_pa_size', $entry['raw_attribute'] );
+
+		$variable_product->delete( true );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListSchemaTest.php
@@ -1,0 +1,162 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Schemas;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem;
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListSchema;
+use WC_Unit_Test_Case;
+
+/**
+ * ShopperListSchemaTest class.
+ */
+class ShopperListSchemaTest extends WC_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ShopperListSchema
+	 */
+	private $sut;
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+
+		$extend            = new ExtendSchema( $formatters );
+		$schema_controller = new SchemaController( $extend );
+		$this->sut         = new ShopperListSchema( $extend, $schema_controller );
+		$this->user_id     = $this->factory->user->create( array( 'role' => 'customer' ) );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		wp_delete_user( $this->user_id );
+		$this->sut = null;
+		parent::tearDown();
+	}
+
+	/**
+	 * Build an empty saved-for-later list for the test user.
+	 */
+	private function build_list(): ShopperList {
+		return ShopperList::get_by_slug( 'saved-for-later', $this->user_id );
+	}
+
+	/**
+	 * Build a minimal ShopperListItem around a product ID.
+	 *
+	 * @param int $product_id Product ID.
+	 */
+	private function build_item( int $product_id ): ShopperListItem {
+		return ShopperListItem::from_array(
+			array(
+				'key'                   => md5( (string) $product_id ),
+				'product_id'            => $product_id,
+				'variation_id'          => 0,
+				'variation'             => array(),
+				'quantity'              => 1,
+				'date_added_gmt'        => '2024-04-25 03:20:00',
+				'product_title_at_save' => 'Snapshot',
+			)
+		);
+	}
+
+	/**
+	 * @testdox Should expose slug, item_count, date_created_gmt and a 0-indexed items array.
+	 */
+	public function test_serializes_top_level_fields(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$list    = $this->build_list();
+		$list->add_item( $this->build_item( $product->get_id() ) );
+
+		$response = $this->sut->get_item_response( $list );
+
+		$this->assertArrayHasKey( 'slug', $response );
+		$this->assertSame( 'saved-for-later', $response['slug'] );
+
+		$this->assertArrayHasKey( 'item_count', $response );
+		$this->assertSame( 1, $response['item_count'] );
+
+		$this->assertArrayHasKey( 'items', $response );
+		$this->assertIsArray( $response['items'] );
+		$this->assertSame( array( 0 ), array_keys( $response['items'] ), 'items must be a 0-indexed list, not keyed by storage key.' );
+
+		$this->assertArrayHasKey( 'date_created_gmt', $response );
+		$this->assertIsString( $response['date_created_gmt'] );
+		$this->assertNotSame( '', $response['date_created_gmt'] );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox item_count should include items whose products no longer exist.
+	 */
+	public function test_item_count_includes_tombstones(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$list    = $this->build_list();
+		$list->add_item( $this->build_item( $product->get_id() ) );
+		$list->add_item( $this->build_item( 999999 ) );
+
+		$response = $this->sut->get_item_response( $list );
+
+		$this->assertSame( 2, $response['item_count'], 'item_count must count tombstoned items, not just live products.' );
+		$this->assertCount( 2, $response['items'] );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Empty list should serialize with item_count=0 and items=[].
+	 */
+	public function test_empty_list(): void {
+		$list = $this->build_list();
+
+		$response = $this->sut->get_item_response( $list );
+
+		$this->assertSame( 0, $response['item_count'] );
+		$this->assertSame( array(), $response['items'] );
+	}
+
+	/**
+	 * @testdox Each item should carry the keys produced by the item schema.
+	 */
+	public function test_items_use_item_schema_shape(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$list    = $this->build_list();
+		$list->add_item( $this->build_item( $product->get_id() ) );
+
+		$response = $this->sut->get_item_response( $list );
+
+		$item = $response['items'][0];
+		$this->assertArrayHasKey( 'key', $item );
+		$this->assertArrayHasKey( 'product_id', $item );
+		$this->assertArrayHasKey( 'quantity', $item );
+		$this->assertArrayHasKey( 'product_exists', $item );
+		$this->assertTrue( $item['product_exists'], 'Live product items should have product_exists=true.' );
+
+		$product->delete( true );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Pure refactor with no behavior change. The shopper-list StoreApi routes already had `ShopperList` and `ShopperListItem` objects in hand, then called `to_array()` on them solely to satisfy the schemas' previous array contract. The schemas now accept the domain objects directly (mirroring `ProductSchema`/`OrderSchema`'s pattern), and drop the redundant `to_array()` round-trips. JSON response shape is identical to before.

> [!NOTE]
> This PR is just an intermediate step for further changes in upcoming PRs. The idea being to centralize concerns in `ShopperList` and `ShopperListItem` instead of at the route level.

### How to test the changes in this Pull Request:

Confirm the saved-for-later UI on the cart page renders rows correctly, removing items works and adding from the cart or moving to the cart works as well.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**