### PR TITLE
Remove helper text from Featured product toggle in quick edit panel

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-remove-featured-helper-text
+++ b/packages/js/experimental-products-app/changelog/update-remove-featured-helper-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove the helper text from the Featured product toggle in the experimental quick edit panel.

--- a/packages/js/experimental-products-app/src/fields/featured/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/featured/field.tsx
@@ -13,10 +13,6 @@ import type { ProductEntityRecord } from '../types';
 const fieldDefinition = {
 	type: 'boolean',
 	label: __( 'Featured product', 'woocommerce' ),
-	description: __(
-		'Highlight this product in dedicated sections such as "Featured" or "Recommended".',
-		'woocommerce'
-	),
 	enableSorting: false,
 	enableHiding: false,
 	filterBy: false,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The "Highlight this product in dedicated sections such as 'Featured' or 'Recommended'." helper text under the Featured product toggle adds visual noise in the quick edit drawer without adding meaningful clarity — the toggle label alone is self-explanatory. This PR drops the `description` from the `featured` field definition. The field is only referenced from the quick edit form, so the change is scoped to that surface.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open WooCommerce → Products in wp-admin.
2. Click the quick edit row action on any product.
3. Locate the "Featured product" toggle in the drawer.
4. Confirm only the label appears — the prior helper text ("Highlight this product in dedicated sections…") is gone.

### Testing that has already taken place:

Local visual check in the experimental products app quick edit drawer.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under `packages/js/experimental-products-app/changelog/update-remove-featured-helper-text`.

</details>