### PR TITLE
Remove helper text from Tags field in quick edit panel

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-remove-tags-helper-text
+++ b/packages/js/experimental-products-app/changelog/update-remove-tags-helper-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove the helper text from the Tags field in the experimental quick edit panel.

--- a/packages/js/experimental-products-app/src/fields/tags/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/tags/field.tsx
@@ -16,10 +16,6 @@ import { TaxonomyEdit } from '../components/taxonomy-edit';
 const fieldDefinition = {
 	type: 'array',
 	label: __( 'Tags', 'woocommerce' ),
-	description: __(
-		'Add descriptive tags to help customers find related items while shopping.',
-		'woocommerce'
-	),
 	enableSorting: false,
 	filterBy: false,
 } satisfies Partial< Field< ProductEntityRecord > >;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The "Add descriptive tags to help customers find related items while shopping." helper text under the Tags field adds vertical noise in the quick edit drawer without giving the user information they need at edit time — the label and placeholder ("Search or create tags") already make the field's purpose clear. This PR drops the `description` from the `tags` field definition, scoped to the quick edit form surface where this field is rendered.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open WooCommerce → Products in wp-admin.
2. Click the quick edit row action on any product.
3. Locate the **Tags** field in the drawer.
4. Confirm only the label and search input appear — the prior helper text ("Add descriptive tags…") is gone.

### Testing that has already taken place:

Local visual check in the experimental products app quick edit drawer.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under `packages/js/experimental-products-app/changelog/update-remove-tags-helper-text`.

</details>