### PR TITLE
Do not render saved for later block for logged-out users

### DIFF
--- a/plugins/woocommerce/changelog/hide-shopper-collection-logged-out
+++ b/plugins/woocommerce/changelog/hide-shopper-collection-logged-out
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Shopper Collection: skip rendering and asset enqueue for logged-out shoppers.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -92,6 +92,11 @@ final class ShopperCollection extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		// Guests have no personal list — bail before enqueuing assets or seeding state.
+		if ( ! is_user_logged_in() ) {
+			return '';
+		}
+
 		// `listName` is declared with a default in block.json, so WP core's
 		// `prepare_attributes_for_render` guarantees it's set as a string by
 		// the time we get here. `sanitize_title` is *not* redundant though:

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
 use ReflectionClass;
+use ReflectionMethod;
 use WP_UnitTestCase;
 
 /**
@@ -130,15 +131,14 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `render()` emits markup only for logged-in shoppers.
+	 * `render()` returns an empty string for logged-out shoppers.
 	 */
-	public function test_render_is_gated_on_login(): void {
-		$block_markup = '<!-- wp:woocommerce/shopper-collection {"listName":"saved-for-later"} /-->';
-
+	public function test_render_returns_empty_for_logged_out_user(): void {
 		wp_set_current_user( 0 );
-		$this->assertSame( '', trim( (string) do_blocks( $block_markup ) ) );
 
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'customer' ) ) );
-		$this->assertStringContainsString( 'wc-block-shopper-collection', (string) do_blocks( $block_markup ) );
+		$render = new ReflectionMethod( ShopperCollection::class, 'render' );
+		$render->setAccessible( true );
+
+		$this->assertSame( '', (string) $render->invoke( $this->sut, array( 'listName' => 'saved-for-later' ), '', null ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
 use ReflectionClass;
-use ReflectionMethod;
 use WP_UnitTestCase;
 
 /**
@@ -134,14 +133,12 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	 * `render()` emits markup only for logged-in shoppers.
 	 */
 	public function test_render_is_gated_on_login(): void {
-		$render = new ReflectionMethod( ShopperCollection::class, 'render' );
-		$render->setAccessible( true );
-		$attributes = array( 'listName' => 'saved-for-later' );
+		$block_markup = '<!-- wp:woocommerce/shopper-collection {"listName":"saved-for-later"} /-->';
 
 		wp_set_current_user( 0 );
-		$this->assertSame( '', (string) $render->invoke( $this->sut, $attributes, '', null ) );
+		$this->assertSame( '', trim( (string) do_blocks( $block_markup ) ) );
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'customer' ) ) );
-		$this->assertStringContainsString( 'wc-block-shopper-collection', (string) $render->invoke( $this->sut, $attributes, '', null ) );
+		$this->assertStringContainsString( 'wc-block-shopper-collection', (string) do_blocks( $block_markup ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
 use ReflectionClass;
+use ReflectionMethod;
 use WP_UnitTestCase;
 
 /**
@@ -127,5 +128,20 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 'saved-for-later', $result['attrs']['listName'] );
+	}
+
+	/**
+	 * `render()` emits markup only for logged-in shoppers.
+	 */
+	public function test_render_is_gated_on_login(): void {
+		$render = new ReflectionMethod( ShopperCollection::class, 'render' );
+		$render->setAccessible( true );
+		$attributes = array( 'listName' => 'saved-for-later' );
+
+		wp_set_current_user( 0 );
+		$this->assertSame( '', (string) $render->invoke( $this->sut, $attributes, '', null ) );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'customer' ) ) );
+		$this->assertStringContainsString( 'wc-block-shopper-collection', (string) $render->invoke( $this->sut, $attributes, '', null ) );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The saved for later block is auto-injected after `woocommerce/cart` on the cart page, so logged-out shoppers were seeing the empty state copy.

This PR makes `ShopperCollection::render()` bail early when the user is not logged in.

Closes [WOOPRD-3533](https://linear.app/a8c/issue/WOOPRD-3533/do-not-render-block-for-logged-out-sers).


### How to test the changes in this Pull Request:

1. Enable saved for later in **WC > Settings > Advanced > Features**.
1. Visit the cart page while logged in: the block should appear as normal (including its empty state).
   <img width="669" height="103" alt="Screenshot 2026-05-13 at 14 17 46" src="https://github.com/user-attachments/assets/73c8f09b-2e3e-48eb-93e0-e7519d34c136" />
1. Visit the cart page while logged out: the saved for later block should not be rendered. For example, look for `wc-block-shopper-collection` in the DOM using the dev tools.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->