### PR TITLE
Shopper Collection: own the grid layout (custom columnCount + responsive)

### DIFF
--- a/plugins/woocommerce/changelog/tweak-shopper-collection-custom-grid
+++ b/plugins/woocommerce/changelog/tweak-shopper-collection-custom-grid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Shopper Collection: own the grid layout (custom `columnCount` attribute + `.columns-N` class) and ship Product-Collection-equivalent responsive behavior. Items now reflow to fewer columns on narrow viewports instead of shrinking uniformly.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
@@ -15,7 +15,7 @@
 		},
 		"columnCount": {
 			"type": "number",
-			"default": 3
+			"default": 5
 		}
 	},
 	"supports": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
@@ -12,6 +12,10 @@
 		"listName": {
 			"type": "string",
 			"default": "saved-for-later"
+		},
+		"columnCount": {
+			"type": "number",
+			"default": 3
 		}
 	},
 	"supports": {
@@ -19,13 +23,6 @@
 		"interactivity": true,
 		"html": false,
 		"reusable": false,
-		"layout": {
-			"default": {
-				"type": "grid",
-				"columnCount": 3
-			},
-			"allowEditing": true
-		},
 		"spacing": {
 			"margin": true,
 			"padding": true,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
@@ -3,16 +3,13 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { PanelBody, RangeControl, SelectControl } from '@wordpress/components';
 import { Icon, trash } from '@wordpress/icons';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
 
 interface ShopperCollectionAttributes {
 	listName: string;
-	layout?: {
-		type?: string;
-		columnCount?: number;
-	};
+	columnCount: number;
 }
 
 interface EditProps {
@@ -20,7 +17,8 @@ interface EditProps {
 	setAttributes: ( attrs: Partial< ShopperCollectionAttributes > ) => void;
 }
 
-const DEFAULT_COLUMN_COUNT = 3;
+const MIN_COLUMNS = 2;
+const MAX_COLUMNS = 6;
 
 const PREVIEW_ITEMS = [
 	{
@@ -68,16 +66,10 @@ const PREVIEW_ITEMS = [
 ];
 
 const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
-	const { listName, layout } = attributes;
-	const columnCount =
-		typeof layout?.columnCount === 'number'
-			? layout.columnCount
-			: DEFAULT_COLUMN_COUNT;
+	const { listName, columnCount } = attributes;
+
 	const blockProps = useBlockProps( {
-		className: 'wc-block-shopper-collection',
-		style: {
-			'--wc-shopper-collection-columns': columnCount,
-		} as React.CSSProperties,
+		className: `wc-block-shopper-collection columns-${ columnCount }`,
 	} );
 
 	return (
@@ -100,6 +92,20 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 						onChange={ ( value: string ) =>
 							setAttributes( { listName: value } )
 						}
+					/>
+					<RangeControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Columns', 'woocommerce' ) }
+						value={ columnCount }
+						onChange={ ( value?: number ) => {
+							if ( typeof value !== 'number' ) {
+								return;
+							}
+							setAttributes( { columnCount: value } );
+						} }
+						min={ MIN_COLUMNS }
+						max={ MAX_COLUMNS }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -5,16 +5,31 @@
 // which we declare as style dependencies in `block.json` so WordPress
 // enqueues them whenever this block renders. Don't duplicate those rules here.
 
+// One concrete `.columns-N` class per supported column count so narrow
+// viewports reflow to fewer columns instead of shrinking items uniformly.
+// Mirrors Product Collection's `__responsive` formula.
+$min-item-width: 150px;
+$grid-gap: var(--wp--style--block-gap, 1.5em);
+
 .wc-block-shopper-collection {
 	display: grid;
-	gap: var(--wp--style--block-gap, 1.5em);
-	grid-template-columns: repeat(
-		var(--wc-shopper-collection-columns, 3),
-		minmax(0, 1fr)
-	);
+	gap: $grid-gap;
 	list-style: none;
 	margin: 0;
 	padding: 0;
+
+	@for $i from 2 through 6 {
+		$gap-count: calc(#{$i} - 1);
+		$total-gap-width: calc(#{$gap-count} * #{$grid-gap});
+		$max-item-width: calc((100% - #{$total-gap-width}) / #{$i});
+
+		&.columns-#{ $i } {
+			grid-template-columns: repeat(
+				auto-fill,
+				minmax(max(#{$min-item-width}, #{$max-item-width}), 1fr)
+			);
+		}
+	}
 }
 
 .wc-block-shopper-collection-item {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -77,18 +77,17 @@ $grid-gap: var(--wp--style--block-gap, 1.5em);
 		z-index: 10;
 	}
 
-	// Icon-only Remove button overlaying the image. Visually mirrors the
-	// `wc-block-components-product-sale-badge--align-right` overlay (same
-	// border, radius, colors, white fill, top-right inset over the image)
-	// so it reads as a corner badge. Symmetric padding keeps the hit
-	// area square. Hover inverts the colors for a clear affordance.
+	// Icon-only Remove button overlaying the image. Mirrors the
+	// `woocommerce-product-gallery__trigger` corner-overlay styles
+	// (white fill, circular, black icon, no border) so the affordance
+	// reads consistently with the gallery zoom trigger.
 	&__remove {
 		appearance: none;
 		background: #fff;
-		border: 1px solid #fff;
-		border-radius: 4px;
+		border: none;
+		border-radius: 100%;
 		box-sizing: border-box;
-		color: #43454b;
+		color: #000;
 		cursor: pointer;
 		display: block;
 		line-height: 0;
@@ -105,7 +104,7 @@ $grid-gap: var(--wp--style--block-gap, 1.5em);
 		}
 
 		&:hover:not([disabled]) {
-			background: #43454b;
+			background: #000;
 			color: #fff;
 		}
 
@@ -116,7 +115,7 @@ $grid-gap: var(--wp--style--block-gap, 1.5em);
 		// readable over both the badge body and the product image behind
 		// it. Not applied to :hover-only — pointer users keep the invert.
 		&:focus-visible:not([disabled]) {
-			outline: 2px solid #43454b;
+			outline: 2px solid #000;
 			outline-offset: 1px;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -107,8 +107,7 @@ final class ShopperCollection extends AbstractBlock {
 			$list_slug = 'saved-for-later';
 		}
 
-		// `layout` comes from `supports.layout`, not a declared attribute, so WP doesn't guarantee every nested key is set — `??` covers a partial layout object.
-		$column_count = max( 1, (int) ( $attributes['layout']['columnCount'] ?? 3 ) );
+		$column_count = max( 1, (int) ( $attributes['columnCount'] ?? 3 ) );
 
 		$variation = $this->get_variation_config();
 
@@ -175,8 +174,9 @@ final class ShopperCollection extends AbstractBlock {
 		);
 
 		$wrapper_class = sprintf(
-			'wc-block-shopper-collection wc-block-shopper-collection--%s',
-			$variation['modifierSlug']
+			'wc-block-shopper-collection wc-block-shopper-collection--%s columns-%d',
+			$variation['modifierSlug'],
+			$column_count
 		);
 
 		$wrapper_attributes = array(
@@ -186,7 +186,6 @@ final class ShopperCollection extends AbstractBlock {
 			// Deterministic key derived from the list slug so iAPI router
 			// navigations land on the same block identity across renders.
 			'data-wp-key'         => $this->get_full_block_name() . '-' . $list_slug,
-			'style'               => sprintf( '--wc-shopper-collection-columns:%d;', $column_count ),
 		);
 
 		$is_empty = empty( $items );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -107,7 +107,7 @@ final class ShopperCollection extends AbstractBlock {
 			$list_slug = 'saved-for-later';
 		}
 
-		$column_count = max( 1, (int) ( $attributes['columnCount'] ?? 3 ) );
+		$column_count = max( 1, (int) ( $attributes['columnCount'] ?? 5 ) );
 
 		$variation = $this->get_variation_config();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -107,11 +107,12 @@ final class ShopperCollection extends AbstractBlock {
 			$list_slug = 'saved-for-later';
 		}
 
-		// `absint()` defends against a code-editor override (the attribute can
-		// be set to any JSON value there) before the value flows into the
-		// wrapper class. `max( 1, ... )` keeps the SCSS `&.columns-#{$i}` rules
-		// from missing for a 0-or-below value.
-		$column_count = max( 1, absint( $attributes['columnCount'] ?? 5 ) );
+		// Clamp to the 2-6 range the SCSS `@for $i from 2 through 6` loop and
+		// the editor `RangeControl` both support. `absint()` first defends
+		// against a code-editor override (the attribute can be set to any
+		// JSON value there); the `min`/`max` then keep the value within the
+		// range where a `&.columns-#{$i}` rule actually exists.
+		$column_count = min( 6, max( 2, absint( $attributes['columnCount'] ?? 5 ) ) );
 
 		$variation = $this->get_variation_config();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -107,7 +107,11 @@ final class ShopperCollection extends AbstractBlock {
 			$list_slug = 'saved-for-later';
 		}
 
-		$column_count = max( 1, (int) ( $attributes['columnCount'] ?? 5 ) );
+		// `absint()` defends against a code-editor override (the attribute can
+		// be set to any JSON value there) before the value flows into the
+		// wrapper class. `max( 1, ... )` keeps the SCSS `&.columns-#{$i}` rules
+		// from missing for a 0-or-below value.
+		$column_count = max( 1, absint( $attributes['columnCount'] ?? 5 ) );
 
 		$variation = $this->get_variation_config();
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -130,20 +130,44 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Invoke the protected `render` method directly.
+	 *
+	 * `do_blocks()` would 404 here: the block is only registered when the
+	 * `cart_save_for_later` feature flag is on, which the test bootstrap
+	 * doesn't enable. Calling `render()` via reflection sidesteps the WP
+	 * block registry entirely — same pattern the rest of this file uses
+	 * for filter callbacks.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @return string
+	 */
+	private function invoke_render( array $attributes ): string {
+		$reflection = new ReflectionClass( ShopperCollection::class );
+		$method     = $reflection->getMethod( 'render' );
+		$method->setAccessible( true );
+		return (string) $method->invoke( $this->sut, $attributes, '', null );
+	}
+
+	/**
 	 * The wrapper carries a `columns-N` class matching the `columnCount` attribute.
 	 */
 	public function test_render_emits_columns_class(): void {
-		$markup = do_blocks( '<!-- wp:woocommerce/shopper-collection {"columnCount":4} /-->' );
+		$markup = $this->invoke_render(
+			array(
+				'listName'    => 'saved-for-later',
+				'columnCount' => 4,
+			)
+		);
 
 		$this->assertStringContainsString( 'columns-4', $markup );
 	}
 
 	/**
-	 * With no column attribute set, the renderer falls back to the declared
-	 * `columnCount` default (5).
+	 * With no column attribute set, the renderer falls back to its hard-coded
+	 * default (5), matching the `block.json` `columnCount` default.
 	 */
 	public function test_render_defaults_to_five_columns(): void {
-		$markup = do_blocks( '<!-- wp:woocommerce/shopper-collection /-->' );
+		$markup = $this->invoke_render( array( 'listName' => 'saved-for-later' ) );
 
 		$this->assertStringContainsString( 'columns-5', $markup );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -140,11 +140,11 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 
 	/**
 	 * With no column attribute set, the renderer falls back to the declared
-	 * `columnCount` default (3).
+	 * `columnCount` default (5).
 	 */
-	public function test_render_defaults_to_three_columns(): void {
+	public function test_render_defaults_to_five_columns(): void {
 		$markup = do_blocks( '<!-- wp:woocommerce/shopper-collection /-->' );
 
-		$this->assertStringContainsString( 'columns-3', $markup );
+		$this->assertStringContainsString( 'columns-5', $markup );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -128,47 +128,4 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 
 		$this->assertSame( 'saved-for-later', $result['attrs']['listName'] );
 	}
-
-	/**
-	 * Invoke the protected `render` method directly.
-	 *
-	 * `do_blocks()` would 404 here: the block is only registered when the
-	 * `cart_save_for_later` feature flag is on, which the test bootstrap
-	 * doesn't enable. Calling `render()` via reflection sidesteps the WP
-	 * block registry entirely — same pattern the rest of this file uses
-	 * for filter callbacks.
-	 *
-	 * @param array<string, mixed> $attributes Block attributes.
-	 * @return string
-	 */
-	private function invoke_render( array $attributes ): string {
-		$reflection = new ReflectionClass( ShopperCollection::class );
-		$method     = $reflection->getMethod( 'render' );
-		$method->setAccessible( true );
-		return (string) $method->invoke( $this->sut, $attributes, '', null );
-	}
-
-	/**
-	 * The wrapper carries a `columns-N` class matching the `columnCount` attribute.
-	 */
-	public function test_render_emits_columns_class(): void {
-		$markup = $this->invoke_render(
-			array(
-				'listName'    => 'saved-for-later',
-				'columnCount' => 4,
-			)
-		);
-
-		$this->assertStringContainsString( 'columns-4', $markup );
-	}
-
-	/**
-	 * With no column attribute set, the renderer falls back to its hard-coded
-	 * default (5), matching the `block.json` `columnCount` default.
-	 */
-	public function test_render_defaults_to_five_columns(): void {
-		$markup = $this->invoke_render( array( 'listName' => 'saved-for-later' ) );
-
-		$this->assertStringContainsString( 'columns-5', $markup );
-	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -128,4 +128,23 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 
 		$this->assertSame( 'saved-for-later', $result['attrs']['listName'] );
 	}
+
+	/**
+	 * The wrapper carries a `columns-N` class matching the `columnCount` attribute.
+	 */
+	public function test_render_emits_columns_class(): void {
+		$markup = do_blocks( '<!-- wp:woocommerce/shopper-collection {"columnCount":4} /-->' );
+
+		$this->assertStringContainsString( 'columns-4', $markup );
+	}
+
+	/**
+	 * With no column attribute set, the renderer falls back to the declared
+	 * `columnCount` default (3).
+	 */
+	public function test_render_defaults_to_three_columns(): void {
+		$markup = do_blocks( '<!-- wp:woocommerce/shopper-collection /-->' );
+
+		$this->assertStringContainsString( 'columns-3', $markup );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WP's `supports.layout` typed grid emits a non-responsive `grid-template-columns: repeat(N, minmax(0, 1fr))` rule that ties our block class on specificity but lands later in the cascade. Items shrink uniformly at narrow widths instead of reflowing to fewer columns. Known WP limitation — Gutenberg [#67607](https://github.com/WordPress/gutenberg/issues/67607).

This PR opts out of `supports.layout`, adds an explicit `columnCount` attribute (default 5, matching Product Collection's curated variations), renders a `.columns-N` class server-side, and ships the Product-Template-equivalent responsive formula in `style.scss`. The Layout panel disappears from the inspector; a "Columns" `RangeControl` (min 2, max 6) takes its place inside the existing "Collection settings" panel.

Also restyles the per-item Remove button to match `woocommerce-product-gallery__trigger` (white fill, circular, black icon, no border) so the corner-overlay affordance reads consistently with the gallery's zoom trigger.

**Existing instances of the Shopper Collection block on the cart page will not migrate** — the attribute shape changed (`layout.columnCount` → `columnCount`). Remove the Cart block from the page and add it back so the Shopper Collection re-injects with the new defaults.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Enable the `cart_save_for_later` feature flag.
2. Open the cart page in the editor. Remove the Cart block and add it back so the Shopper Collection re-injects with the new attribute shape.
3. If the Shopper Collection still doesn't appear after step 2: switch to the **code editor** view and look for `{"metadata":{"ignoredHookedBlocks":["woocommerce/shopper-collection"]}}` on the Cart block's opening comment. WP writes that metadata when a hooked block was previously suppressed, which blocks re-injection. Clear it via SQL (replace `ID = 7` with your cart page ID — `wp option get woocommerce_cart_page_id`):
    ```sql
    UPDATE wp_posts
    SET post_content = REGEXP_REPLACE(
      post_content,
      ',?"metadata":\\{"ignoredHookedBlocks":\\[[^]]*\\]\\}',
      ''
    )
    WHERE ID = 7;
    ```
    Reload the editor.
4. Insert a Product Collection block on the same page (or on any page where you can resize freely) so you can compare responsive behavior side-by-side.
5. **In the editor**: resize the editor canvas / browser window through narrow widths. Both blocks should reflow the column count rather than shrinking items uniformly.
6. **On the storefront**: visit the cart page and resize the browser through the same widths. Shopper Collection's reflow should match what you saw in the editor and match Product Collection's behavior.
7. Open the "Collection settings" panel in the inspector. Drag the new "Columns" RangeControl between 2 and 6 — the wrapper's `.columns-N` class should update without a reload, and the editor grid should re-flow accordingly.
8. Confirm the Remove icon on each item renders as a white circular button with a black trash icon, matches `woocommerce-product-gallery__trigger`'s visual treatment, and inverts to black/white on hover.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

#### Comment

Changelog entry was created manually as part of this PR: `plugins/woocommerce/changelog/tweak-shopper-collection-custom-grid`.