### PR TITLE
Fix Product Gallery variation switch behaviors

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -91,8 +91,11 @@ const computeArrowsState = ( imageData: number[], selectedImageId: number ) => {
 };
 
 /** Scroll both the large viewer and the thumbnail strip to the given image. */
-const scrollImageEverywhereIntoView = ( imageId: number ) => {
-	scrollImageIntoView( imageId );
+const scrollImageEverywhereIntoView = (
+	imageId: number,
+	behavior: ScrollBehavior = 'smooth'
+) => {
+	scrollImageIntoView( imageId, behavior );
 	scrollThumbnailIntoView( imageId );
 };
 
@@ -127,15 +130,12 @@ const updateVisibleImageSet = (
 		return;
 	}
 
-	// Defer the scroll until after Preact has applied the DOM updates
-	// (notably the `hidden` attribute on the thumbnails strip and the
-	// Next/Previous arrows) and the browser has reflowed. Otherwise, the
-	// scroll target is computed against the pre-reflow container width,
-	// and the layout shift that follows leaves the selected image
-	// off-center on a neighbouring one.
-	requestAnimationFrame(
-		withScope( () => scrollImageEverywhereIntoView( nextSelectedImageId ) )
-	);
+	// Variation switches replace the gallery's image set entirely; an
+	// animation between them would just smear across unrelated images, so
+	// snap instantly. Instant is also race-proof: index-based scroll targets
+	// computed below are correct regardless of whether iAPI's per-wrapper
+	// `data-wp-watch` callbacks have flushed yet.
+	scrollImageEverywhereIntoView( nextSelectedImageId, 'instant' );
 };
 
 /**
@@ -187,63 +187,59 @@ const toggleActiveThumbnailAttributes = ( element: HTMLElement ) => {
 };
 
 /**
- * Scrolls the image into view for the main image.
+ * Scrolls the large viewer to the given image. The horizontal scroll target
+ * is `imageIndex × clientWidth`: every visible large-image wrapper is exactly
+ * one container-width (`min/max-width: 100%`) and non-subset wrappers are
+ * `display: none`, so the visible image at index N lives at content position
+ * `N × clientWidth`. Computing the target from the index — rather than from
+ * `getBoundingClientRect` on the `<img>` — keeps it correct even when iAPI's
+ * per-wrapper `data-wp-watch` callbacks haven't yet revealed the target
+ * wrapper (a hidden element's rect is `0`, which used to produce wrong scroll
+ * targets on variation switch).
  *
- * We use getElement to get the current element that triggered the action
- * to find the closest gallery container and scroll the image into view.
- * This is necessary because if you have two galleries on the same page with the same image IDs,
- * then we need to query the image in the correct gallery to avoid scrolling the wrong image into view.
+ * We resolve the gallery via `getElement().ref` so multiple galleries on the
+ * same page with overlapping image IDs each scroll independently.
  *
- * @param {string} imageId - The ID of the image to scroll into view.
+ * @param imageId  ID of the image to center in the viewer.
+ * @param behavior `scrollTo` behavior — `'smooth'` for arrow nav, `'instant'`
+ *                 for variation swaps where any animation would just smear
+ *                 across unrelated images.
  */
-const scrollImageIntoView = ( imageId: number ) => {
+const scrollImageIntoView = (
+	imageId: number,
+	behavior: ScrollBehavior = 'smooth'
+) => {
 	if ( ! imageId ) {
 		return;
 	}
 
-	// Get the current element that triggered the action
 	const element = getElement()?.ref as HTMLElement;
-
 	if ( ! element ) {
 		return;
 	}
 
 	const galleryContainer = element.closest( SELECTORS.galleryContainer );
-
 	if ( ! galleryContainer ) {
 		return;
 	}
 
-	// Find the scrollable container for the viewer gallery
 	const scrollableContainer = galleryContainer.querySelector(
 		SELECTORS.largeImageContainer
-	);
-
+	) as HTMLElement | null;
 	if ( ! scrollableContainer ) {
 		return;
 	}
 
-	const imageElement = scrollableContainer.querySelector(
-		SELECTORS.imgByImageId( imageId )
-	);
-
-	if ( imageElement ) {
-		// Calculate the scroll position to center the image horizontally
-		const containerRect = scrollableContainer.getBoundingClientRect();
-		const imageRect = imageElement.getBoundingClientRect();
-
-		const scrollLeft =
-			scrollableContainer.scrollLeft +
-			( imageRect.left - containerRect.left ) -
-			( containerRect.width - imageRect.width ) / 2;
-
-		// Use scrollTo as scrollIntoView with inline: 'center'
-		// is not supported in iOS (Safari and Chrome).
-		scrollableContainer.scrollTo( {
-			left: scrollLeft,
-			behavior: 'smooth',
-		} );
+	const { imageData } = getContext();
+	const imageIndex = imageData.indexOf( imageId );
+	if ( imageIndex < 0 ) {
+		return;
 	}
+
+	scrollableContainer.scrollTo( {
+		left: imageIndex * scrollableContainer.clientWidth,
+		behavior,
+	} );
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -601,13 +601,31 @@ const productGallery = {
 		 * `productsState.variationId` changes.
 		 */
 		listenToProductDataChanges: () => {
+			// Bridge the blockified Add to Cart with Options block to the
+			// gallery: when that block updates `productsState.variationId`,
+			// we mirror the change into the gallery's imageData.
+			//
+			// Bail when no variation is selected in the products store. Two
+			// reasons:
+			//   1. Initial mount — the server-rendered `defaultImageData`
+			//      is already correct, no need to reset.
+			//   2. Legacy classic-form pages — the legacy form never writes
+			//      to `productsState.variationId`, so it stays null
+			//      forever; `watchForChangesOnAddToCartForm` is the source
+			//      of truth there. Without this guard, this watch re-fires
+			//      after every imageData mutation (iAPI's Proxy reactivity
+			//      triggers it on unrelated signal writes) and would
+			//      clobber what the legacy watcher just set.
+			const variationId = productsState.variationId;
+			if ( ! variationId ) {
+				return;
+			}
+
 			// Use `mainProductInContext` (always the parent variable
 			// product) rather than `productInContext`, which resolves to the
 			// active variation when one is selected — `getProductImageSet`
-			// is keyed on the parent's ID. Read `variationId` directly from
-			// the store so this watcher re-fires on variation change.
+			// is keyed on the parent's ID.
 			const product = productsState.mainProductInContext;
-
 			if ( ! product ) {
 				return;
 			}
@@ -618,7 +636,7 @@ const productGallery = {
 			}
 
 			const variationImageSet =
-				productImageSet.variations?.[ productsState.variationId || 0 ];
+				productImageSet.variations?.[ variationId ];
 
 			if ( variationImageSet?.image_ids?.length ) {
 				actions.setImageData(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -185,8 +185,8 @@ const toggleActiveThumbnailAttributes = ( element: HTMLElement ) => {
 
 /**
  * Scroll the large viewer to the given image, using `imageIndex × clientWidth`.
- * Index-based math stays correct even before iAPI watches have revealed the
- * target wrapper (a hidden element's rect is zero).
+ * Index-based math stays correct even before the Interactivity API watches
+ * have revealed the target wrapper (a hidden element's rect is zero).
  */
 const scrollImageIntoView = (
 	imageId: number,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -123,9 +123,19 @@ const updateVisibleImageSet = (
 	context.isDisabledPrevious = arrowsState.isDisabledPrevious;
 	context.isDisabledNext = arrowsState.isDisabledNext;
 
-	if ( nextSelectedImageId !== -1 ) {
-		scrollImageEverywhereIntoView( nextSelectedImageId );
+	if ( nextSelectedImageId === -1 ) {
+		return;
 	}
+
+	// Defer the scroll until after Preact has applied the DOM updates
+	// (notably the `hidden` attribute on the thumbnails strip and the
+	// Next/Previous arrows) and the browser has reflowed. Otherwise, the
+	// scroll target is computed against the pre-reflow container width,
+	// and the layout shift that follows leaves the selected image
+	// off-center on a neighbouring one.
+	requestAnimationFrame(
+		withScope( () => scrollImageEverywhereIntoView( nextSelectedImageId ) )
+	);
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -300,6 +300,12 @@ const { state: productsState } = store< ProductsStore >(
 	{ lock: universalLock }
 );
 
+// Tracks the last `productsState.variationId` we acted on, keyed by gallery
+// product ID. Lets `listenToProductDataChanges` distinguish "variation just
+// cleared" (reset to default) from "variation never set" (legacy form path)
+// and from a spurious re-fire of the watch.
+const lastSeenVariationId = new Map< string, number | null | undefined >();
+
 const productGallery = {
 	state: {
 		/**
@@ -584,13 +590,29 @@ const productGallery = {
 		 * `productsState.variationId` changes.
 		 */
 		listenToProductDataChanges: () => {
-			// No variation selected — initial mount uses the server-rendered
-			// `defaultImageData`, and legacy-form pages rely on
-			// `watchForChangesOnAddToCartForm` instead.
+			const context = getContext();
 			const variationId = productsState.variationId;
-			if ( ! variationId ) {
+			const prevVariationId = lastSeenVariationId.get(
+				context.productId
+			);
+
+			// Spurious re-fire (iAPI re-runs the watch even when our deps
+			// didn't actually change) — skip to avoid clobbering imageData
+			// the legacy-form watcher may have just set.
+			if ( prevVariationId === variationId ) {
 				return;
 			}
+
+			// First fire, no variation in the store: leave the
+			// server-rendered `defaultImageData` alone. Legacy-form pages
+			// stay on this branch forever and let
+			// `watchForChangesOnAddToCartForm` drive the gallery.
+			if ( prevVariationId === undefined && ! variationId ) {
+				lastSeenVariationId.set( context.productId, variationId );
+				return;
+			}
+
+			lastSeenVariationId.set( context.productId, variationId );
 
 			// `mainProductInContext` is always the parent (variable) product;
 			// `getProductImageSet` is keyed by that ID.
@@ -601,6 +623,11 @@ const productGallery = {
 
 			const productImageSet = getProductImageSet( product.id );
 			if ( ! productImageSet ) {
+				return;
+			}
+
+			if ( ! variationId ) {
+				actions.resetImageData();
 				return;
 			}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -130,11 +130,8 @@ const updateVisibleImageSet = (
 		return;
 	}
 
-	// Variation switches replace the gallery's image set entirely; an
-	// animation between them would just smear across unrelated images, so
-	// snap instantly. Instant is also race-proof: index-based scroll targets
-	// computed below are correct regardless of whether iAPI's per-wrapper
-	// `data-wp-watch` callbacks have flushed yet.
+	// Scroll instantly on variation switch — animation would smear across
+	// unrelated images.
 	scrollImageEverywhereIntoView( nextSelectedImageId, 'instant' );
 };
 
@@ -187,23 +184,9 @@ const toggleActiveThumbnailAttributes = ( element: HTMLElement ) => {
 };
 
 /**
- * Scrolls the large viewer to the given image. The horizontal scroll target
- * is `imageIndex × clientWidth`: every visible large-image wrapper is exactly
- * one container-width (`min/max-width: 100%`) and non-subset wrappers are
- * `display: none`, so the visible image at index N lives at content position
- * `N × clientWidth`. Computing the target from the index — rather than from
- * `getBoundingClientRect` on the `<img>` — keeps it correct even when iAPI's
- * per-wrapper `data-wp-watch` callbacks haven't yet revealed the target
- * wrapper (a hidden element's rect is `0`, which used to produce wrong scroll
- * targets on variation switch).
- *
- * We resolve the gallery via `getElement().ref` so multiple galleries on the
- * same page with overlapping image IDs each scroll independently.
- *
- * @param imageId  ID of the image to center in the viewer.
- * @param behavior `scrollTo` behavior — `'smooth'` for arrow nav, `'instant'`
- *                 for variation swaps where any animation would just smear
- *                 across unrelated images.
+ * Scroll the large viewer to the given image, using `imageIndex × clientWidth`.
+ * Index-based math stays correct even before iAPI watches have revealed the
+ * target wrapper (a hidden element's rect is zero).
  */
 const scrollImageIntoView = (
 	imageId: number,
@@ -601,30 +584,16 @@ const productGallery = {
 		 * `productsState.variationId` changes.
 		 */
 		listenToProductDataChanges: () => {
-			// Bridge the blockified Add to Cart with Options block to the
-			// gallery: when that block updates `productsState.variationId`,
-			// we mirror the change into the gallery's imageData.
-			//
-			// Bail when no variation is selected in the products store. Two
-			// reasons:
-			//   1. Initial mount — the server-rendered `defaultImageData`
-			//      is already correct, no need to reset.
-			//   2. Legacy classic-form pages — the legacy form never writes
-			//      to `productsState.variationId`, so it stays null
-			//      forever; `watchForChangesOnAddToCartForm` is the source
-			//      of truth there. Without this guard, this watch re-fires
-			//      after every imageData mutation (iAPI's Proxy reactivity
-			//      triggers it on unrelated signal writes) and would
-			//      clobber what the legacy watcher just set.
+			// No variation selected — initial mount uses the server-rendered
+			// `defaultImageData`, and legacy-form pages rely on
+			// `watchForChangesOnAddToCartForm` instead.
 			const variationId = productsState.variationId;
 			if ( ! variationId ) {
 				return;
 			}
 
-			// Use `mainProductInContext` (always the parent variable
-			// product) rather than `productInContext`, which resolves to the
-			// active variation when one is selected — `getProductImageSet`
-			// is keyed on the parent's ID.
+			// `mainProductInContext` is always the parent (variable) product;
+			// `getProductImageSet` is keyed by that ID.
 			const product = productsState.mainProductInContext;
 			if ( ! product ) {
 				return;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -246,6 +246,13 @@ $dialog-padding: 20px;
 	display: flex;
 }
 
+// `display: flex` above overrides the UA `[hidden] { display: none }`, so the
+// `hidden` attribute (set reactively by `syncThumbnailState` for images not in
+// the active variation's subset) needs an author rule with higher specificity.
+.wc-block-product-gallery-thumbnails__thumbnail[hidden] {
+	display: none;
+}
+
 :where(.wc-block-product-gallery-thumbnails__thumbnail__image) {
 	cursor: pointer;
 	max-width: 100%;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -39,8 +39,8 @@ $dialog-padding: 20px;
 		}
 	}
 
-	// `display: flex` above overrides the UA `[hidden]` rule; make `hidden`
-	// hide non-subset wrappers on variation switch.
+	// `display: flex` above overrides the browser's default `[hidden]` rule;
+	// make `hidden` hide non-subset wrappers on variation switch.
 	.wc-block-product-gallery-large-image__wrapper[hidden] {
 		display: none;
 	}
@@ -255,8 +255,8 @@ $dialog-padding: 20px;
 	display: flex;
 }
 
-// `display: flex` above overrides the UA `[hidden]` rule; make `hidden` hide
-// non-subset thumbnails on variation switch.
+// `display: flex` above overrides the browser's default `[hidden]` rule;
+// make `hidden` hide non-subset thumbnails on variation switch.
 .wc-block-product-gallery-thumbnails__thumbnail[hidden] {
 	display: none;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -21,6 +21,11 @@ $dialog-padding: 20px;
 		align-items: center;
 		margin: 0;
 		padding: 0;
+		// Chrome silently drops `scrollTo({behavior:'smooth'})` on
+		// `overflow:hidden` elements unless `scroll-behavior` is set on the
+		// element itself. Without this, arrow-nav scrolls inside the viewer
+		// would no-op and the carousel would never visually advance.
+		scroll-behavior: smooth;
 	}
 
 	:where(.wc-block-product-gallery-large-image__wrapper) {
@@ -34,6 +39,15 @@ $dialog-padding: 20px;
 		&:has(.wc-block-components-product-image--aspect-ratio-auto) {
 			aspect-ratio: 1/1;
 		}
+	}
+
+	// `display: flex` above overrides the UA `[hidden] { display: none }`, so
+	// the `hidden` attribute (set reactively by `toggleImageVisibility` for
+	// images not in the active variation's subset) needs an author rule with
+	// higher specificity. For non-variable products `imageData` always equals
+	// the full gallery, so no wrapper is ever hidden — this is a no-op there.
+	.wc-block-product-gallery-large-image__wrapper[hidden] {
+		display: none;
 	}
 
 	// These rules are overriding styles from WooCommerce core, that's why we

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -21,10 +21,8 @@ $dialog-padding: 20px;
 		align-items: center;
 		margin: 0;
 		padding: 0;
-		// Chrome silently drops `scrollTo({behavior:'smooth'})` on
-		// `overflow:hidden` elements unless `scroll-behavior` is set on the
-		// element itself. Without this, arrow-nav scrolls inside the viewer
-		// would no-op and the carousel would never visually advance.
+		// Chrome drops `scrollTo({behavior:'smooth'})` on `overflow:hidden`
+		// unless `scroll-behavior` is set on the element.
 		scroll-behavior: smooth;
 	}
 
@@ -41,11 +39,8 @@ $dialog-padding: 20px;
 		}
 	}
 
-	// `display: flex` above overrides the UA `[hidden] { display: none }`, so
-	// the `hidden` attribute (set reactively by `toggleImageVisibility` for
-	// images not in the active variation's subset) needs an author rule with
-	// higher specificity. For non-variable products `imageData` always equals
-	// the full gallery, so no wrapper is ever hidden — this is a no-op there.
+	// `display: flex` above overrides the UA `[hidden]` rule; make `hidden`
+	// hide non-subset wrappers on variation switch.
 	.wc-block-product-gallery-large-image__wrapper[hidden] {
 		display: none;
 	}
@@ -260,9 +255,8 @@ $dialog-padding: 20px;
 	display: flex;
 }
 
-// `display: flex` above overrides the UA `[hidden] { display: none }`, so the
-// `hidden` attribute (set reactively by `syncThumbnailState` for images not in
-// the active variation's subset) needs an author rule with higher specificity.
+// `display: flex` above overrides the UA `[hidden]` rule; make `hidden` hide
+// non-subset thumbnails on variation switch.
 .wc-block-product-gallery-thumbnails__thumbnail[hidden] {
 	display: none;
 }

--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
@@ -34,6 +34,11 @@ wp post term set $hoodie_product_id product_brand $brand_id --by=id
 wp post term set $beanie_product_id product_brand $brand_id --by=id
 wp post term set $album_product_id product_brand $brand_id --by=id
 
+# Give Beanie (simple product) a multi-image gallery so the Product Gallery
+# e2e tests can exercise multi-thumbnail behavior without depending on a
+# variable product. Reuses Hoodie's existing attachments.
+wp post meta update $beanie_product_id _product_image_gallery "$image1,$image2,$image3"
+
 # This is a non-hacky work around to set up the cross sells product.
 cap_product_id=$(wp post list --post_type=product --field=ID --name="Cap" --format=ids)
 wp post meta update $beanie_product_id _crosssell_ids "$cap_product_id"

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -222,7 +222,10 @@ test.describe( `${ blockData.name }`, () => {
 				isOnlyCurrentEntityDirty: true,
 			} );
 
-			await page.goto( blockData.productPage );
+			// Swipe needs a multi-image gallery; Hoodie (variable) shows
+			// only the featured image until a variation is picked, so use
+			// Beanie which has a multi-image gallery from products.sh.
+			await page.goto( '/product/beanie/' );
 
 			await page.setViewportSize( {
 				height: 667,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -162,7 +162,7 @@ test.describe( `${ blockData.name }`, () => {
 		} );
 	} );
 
-	test( 'Renders correct image when selecting a product variation in the Add to Cart with Options block', async ( {
+	test( 'Variable product gallery: featured → variation → cleared', async ( {
 		page,
 		editor,
 		pageObject,
@@ -173,7 +173,6 @@ test.describe( `${ blockData.name }`, () => {
 		const viewerBlock = await pageObject.getViewerBlock( {
 			page: 'editor',
 		} );
-
 		await expect( viewerBlock ).toBeVisible();
 
 		await editor.saveSiteEditorEntities( {
@@ -182,24 +181,31 @@ test.describe( `${ blockData.name }`, () => {
 
 		await page.goto( blockData.productPage );
 
-		const initialImageId = await pageObject.getViewerImageId();
+		// Initial state: only the parent's featured image is visible.
+		const featuredImageId = await pageObject.getViewerImageId();
+		expect( featuredImageId ).not.toBeNull();
 
-		const addToCartWithOptionsBlock =
-			await pageObject.getAddToCartWithOptionsBlock( {
-				page: 'frontend',
-			} );
-		const addToCartWithOptionsColorSelector =
-			addToCartWithOptionsBlock.getByLabel( 'Color' );
-		const addToCartWithOptionsSizeSelector =
-			addToCartWithOptionsBlock.getByLabel( 'Logo' );
+		const cartForm = await pageObject.getAddToCartWithOptionsBlock( {
+			page: 'frontend',
+		} );
+		const colorSelect = cartForm.getByLabel( 'Color' );
+		const logoSelect = cartForm.getByLabel( 'Logo' );
 
-		await addToCartWithOptionsColorSelector.selectOption( 'Green' );
-		await addToCartWithOptionsSizeSelector.selectOption( 'No' );
+		// Variation selected: visible image switches to the variation's image.
+		await colorSelect.selectOption( 'Green' );
+		await logoSelect.selectOption( 'No' );
 
 		await expect( async () => {
 			const variationImageId = await pageObject.getViewerImageId();
+			expect( variationImageId ).not.toEqual( featuredImageId );
+		} ).toPass( { timeout: 5_000 } );
 
-			expect( initialImageId ).not.toEqual( variationImageId );
+		// Clear: gallery returns to the parent's featured image.
+		await colorSelect.selectOption( '' );
+
+		await expect( async () => {
+			const afterClearImageId = await pageObject.getViewerImageId();
+			expect( afterClearImageId ).toEqual( featuredImageId );
 		} ).toPass( { timeout: 5_000 } );
 	} );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -222,9 +222,6 @@ test.describe( `${ blockData.name }`, () => {
 				isOnlyCurrentEntityDirty: true,
 			} );
 
-			// Swipe needs a multi-image gallery; Hoodie (variable) shows
-			// only the featured image until a variation is picked, so use
-			// Beanie which has a multi-image gallery from products.sh.
 			await page.goto( '/product/beanie/' );
 
 			await page.setViewportSize( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
@@ -61,7 +61,6 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 		} );
 
 		await test.step( 'in frontend', async () => {
-			// Beanie is configured with a multi-image gallery in products.sh.
 			await page.goto( '/product/beanie/' );
 
 			const productGalleryBlock = page.locator(
@@ -135,7 +134,6 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 		} );
 
 		await test.step( 'in frontend', async () => {
-			// Beanie is configured with a multi-image gallery in products.sh.
 			await page.goto( '/product/beanie/' );
 
 			const thumbnailsBlock = page.locator(
@@ -194,7 +192,6 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 		} );
 
 		await test.step( 'in frontend', async () => {
-			// Beanie is configured with a multi-image gallery in products.sh.
 			await page.goto( '/product/beanie/' );
 
 			const thumbnailsContainer = page.locator(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
@@ -61,7 +61,8 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 		} );
 
 		await test.step( 'in frontend', async () => {
-			await page.goto( '/product/hoodie/' );
+			// Beanie is configured with a multi-image gallery in products.sh.
+			await page.goto( '/product/beanie/' );
 
 			const productGalleryBlock = page.locator(
 				'[data-block-name="woocommerce/product-gallery"]'
@@ -134,7 +135,8 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 		} );
 
 		await test.step( 'in frontend', async () => {
-			await page.goto( '/product/hoodie/' );
+			// Beanie is configured with a multi-image gallery in products.sh.
+			await page.goto( '/product/beanie/' );
 
 			const thumbnailsBlock = page.locator(
 				'[data-block-name="woocommerce/product-gallery-thumbnails"]'
@@ -191,9 +193,43 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 			} );
 		} );
 
-		// TODO: Frontend overflow assertion requires a variation with a
-		// multi-image gallery now that variable products show only the
-		// parent's featured image until a variation is selected. Re-enable
-		// when a fixture sets `gallery_image_ids` on a Hoodie variation.
+		await test.step( 'in frontend', async () => {
+			// Beanie is configured with a multi-image gallery in products.sh.
+			await page.goto( '/product/beanie/' );
+
+			const thumbnailsContainer = page.locator(
+				'[data-block-name="woocommerce/product-gallery-thumbnails"]'
+			);
+
+			const scrollableContainer = page.locator(
+				'.wc-block-product-gallery-thumbnails__scrollable'
+			);
+
+			const thumbnails = scrollableContainer.locator(
+				'.wc-block-product-gallery-thumbnails__thumbnail'
+			);
+
+			// Get the last thumbnail
+			const lastThumbnail = thumbnails.last();
+
+			await expect( async () => {
+				await page.reload();
+				// Check if overflow classes are present initially
+				await expect( thumbnailsContainer ).toHaveClass(
+					/wc-block-product-gallery-thumbnails--overflow-bottom/
+				);
+
+				// Scroll to the last thumbnail
+				await lastThumbnail.scrollIntoViewIfNeeded();
+
+				// Verify the last thumbnail is visible
+				await expect( lastThumbnail ).toBeVisible();
+
+				// After scrolling to the end, the bottom overflow should be gone
+				await expect( thumbnailsContainer ).not.toHaveClass(
+					/wc-block-product-gallery-thumbnails--overflow-bottom/
+				);
+			} ).toPass( { timeout: 3_000 } );
+		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
@@ -191,42 +191,9 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 			} );
 		} );
 
-		await test.step( 'in frontend', async () => {
-			await page.goto( '/product/hoodie/' );
-
-			const thumbnailsContainer = page.locator(
-				'[data-block-name="woocommerce/product-gallery-thumbnails"]'
-			);
-
-			const scrollableContainer = page.locator(
-				'.wc-block-product-gallery-thumbnails__scrollable'
-			);
-
-			const thumbnails = scrollableContainer.locator(
-				'.wc-block-product-gallery-thumbnails__thumbnail'
-			);
-
-			// Get the last thumbnail
-			const lastThumbnail = thumbnails.last();
-
-			await expect( async () => {
-				await page.reload();
-				// Check if overflow classes are present initially
-				await expect( thumbnailsContainer ).toHaveClass(
-					/wc-block-product-gallery-thumbnails--overflow-bottom/
-				);
-
-				// Scroll to the last thumbnail
-				await lastThumbnail.scrollIntoViewIfNeeded();
-
-				// Verify the last thumbnail is visible
-				await expect( lastThumbnail ).toBeVisible();
-
-				// After scrolling to the end, the bottom overflow should be gone
-				await expect( thumbnailsContainer ).not.toHaveClass(
-					/wc-block-product-gallery-thumbnails--overflow-bottom/
-				);
-			} ).toPass( { timeout: 3_000 } );
-		} );
+		// TODO: Frontend overflow assertion requires a variation with a
+		// multi-image gallery now that variable products show only the
+		// parent's featured image until a variation is selected. Re-enable
+		// when a fixture sets `gallery_image_ids` on a Hoodie variation.
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -13,10 +13,6 @@ const blockData = {
 	name: 'woocommerce/product-gallery',
 	title: 'Product Gallery',
 	slug: 'single-product',
-	// Beanie is a simple product with a multi-image gallery (set up in
-	// products.sh). Hoodie is variable and now shows only the featured image
-	// until a variation is selected — see `product-gallery-large-image`'s
-	// variation test for that flow.
 	productPage: '/product/beanie/',
 };
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -13,7 +13,11 @@ const blockData = {
 	name: 'woocommerce/product-gallery',
 	title: 'Product Gallery',
 	slug: 'single-product',
-	productPage: '/product/hoodie/',
+	// Beanie is a simple product with a multi-image gallery (set up in
+	// products.sh). Hoodie is variable and now shows only the featured image
+	// until a variation is selected — see `product-gallery-large-image`'s
+	// variation test for that flow.
+	productPage: '/product/beanie/',
 };
 
 const test = base.extend< { pageObject: ProductGalleryPage } >( {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -113,11 +113,8 @@ class ProductGallery extends AbstractBlock {
 			return '';
 		}
 
-		$image_ids = ProductGalleryUtils::get_all_image_ids( $product );
-		// `defaultImageData` shows all images (parent + variations) when no
-		// variation is selected, so thumbnails stay visible until the merchant
-		// picks a variation.
-		$default_image_ids = $image_ids;
+		$image_ids         = ProductGalleryUtils::get_all_image_ids( $product );
+		$default_image_ids = array_map( 'intval', ProductGalleryUtils::get_product_gallery_image_ids( $product ) );
 
 		$number_of_images       = count( $default_image_ids );
 		$classname              = StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -113,8 +113,15 @@ class ProductGallery extends AbstractBlock {
 			return '';
 		}
 
-		$image_ids         = ProductGalleryUtils::get_all_image_ids( $product );
-		$default_image_ids = array_map( 'intval', ProductGalleryUtils::get_product_gallery_image_ids( $product ) );
+		$image_ids = ProductGalleryUtils::get_all_image_ids( $product );
+
+		// Variable products show only the parent's featured image until a
+		// variation is picked; non-variable products show the full gallery.
+		if ( $product->is_type( ProductType::VARIABLE ) ) {
+			$default_image_ids = array( (int) $product->get_image_id() );
+		} else {
+			$default_image_ids = array_map( 'intval', ProductGalleryUtils::get_product_gallery_image_ids( $product ) );
+		}
 
 		$number_of_images       = count( $default_image_ids );
 		$classname              = StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -113,8 +113,11 @@ class ProductGallery extends AbstractBlock {
 			return '';
 		}
 
-		$image_ids         = ProductGalleryUtils::get_all_image_ids( $product );
-		$default_image_ids = array_map( 'intval', ProductGalleryUtils::get_product_gallery_image_ids( $product ) );
+		$image_ids = ProductGalleryUtils::get_all_image_ids( $product );
+		// `defaultImageData` shows all images (parent + variations) when no
+		// variation is selected, so thumbnails stay visible until the merchant
+		// picks a variation.
+		$default_image_ids = $image_ids;
 
 		$number_of_images       = count( $default_image_ids );
 		$classname              = StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -172,7 +172,18 @@ class ProductImage extends AbstractBlock {
 		$target_image_id = $provided_image_id_is_valid ? $image_id : $featured_image_id;
 
 		if ( ! $target_image_id ) {
-			return wc_placeholder_img( $image_size, array( 'style' => $image_style ) );
+			// Tag the placeholder with `data-image-id="0"` so the Product
+			// Gallery's `toggleImageVisibility` watch can hide it when a
+			// variation that DOES have images is selected. Without this
+			// attribute, the watch returns early and the placeholder
+			// remains visible alongside the real variation image.
+			return wc_placeholder_img(
+				$image_size,
+				array(
+					'style'         => $image_style,
+					'data-image-id' => 0,
+				)
+			);
 		}
 
 		$alt_text = get_post_meta( $target_image_id, '_wp_attachment_image_alt', true );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -172,11 +172,9 @@ class ProductImage extends AbstractBlock {
 		$target_image_id = $provided_image_id_is_valid ? $image_id : $featured_image_id;
 
 		if ( ! $target_image_id ) {
-			// Tag the placeholder with `data-image-id="0"` so the Product
-			// Gallery's `toggleImageVisibility` watch can hide it when a
-			// variation that DOES have images is selected. Without this
-			// attribute, the watch returns early and the placeholder
-			// remains visible alongside the real variation image.
+			// `data-image-id="0"` lets the Product Gallery's
+			// `toggleImageVisibility` watch hide the placeholder when a
+			// variation with images is selected.
 			return wc_placeholder_img(
 				$image_size,
 				array(

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -191,13 +191,8 @@ class ProductGalleryUtils {
 		$image_ids = self::get_variation_gallery_image_ids( $variation );
 
 		if ( empty( $image_ids ) ) {
-			// The variation has no usable images of its own. Prefer the
-			// parent product's featured image (so the merchant still sees
-			// the most representative image when picking a variation
-			// without a dedicated gallery), and fall back to the
-			// placeholder sentinel (id = 0) only when the parent has no
-			// featured image either. The product-image block renders
-			// `wc_placeholder_img()` for id = 0.
+			// No usable images: fall back to parent's featured, or the
+			// placeholder sentinel (id = 0) if parent has none either.
 			$fallback_id = $parent_image_id && wp_attachment_is_image( $parent_image_id ) ? $parent_image_id : 0;
 			return array(
 				'image_id'  => $fallback_id,
@@ -230,11 +225,8 @@ class ProductGalleryUtils {
 			$image_ids = array_merge( $image_ids, $gallery_image_ids );
 		}
 
-		// Drop IDs whose attachment is missing or no longer an image. The
-		// gallery would otherwise render them as empty `<li>` wrappers (no
-		// `<img>`, no `data-image-id`, default `hidden=false`) — phantom
-		// slots that `toggleImageVisibility` can't manage and that stay
-		// visible across every variation switch.
+		// Filter out missing/invalid attachments to avoid rendering phantom
+		// empty `<li>` wrappers that the visibility watch can't manage.
 		$image_ids = array_filter(
 			$image_ids,
 			function ( $id ) {

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -178,7 +178,9 @@ class ProductGalleryUtils {
 	 * Extracted so {@see self::get_product_variation_gallery_data()} reads as
 	 * "fetch + prime + project" without inlining the projection details.
 	 *
-	 * @param int $variation_id Variation post ID.
+	 * @param int $variation_id    Variation post ID.
+	 * @param int $parent_image_id Parent product's featured image ID, used as
+	 *                             fallback when the variation has no images.
 	 * @return array<string, mixed>|null
 	 */
 	private static function build_variation_gallery_entry( int $variation_id, int $parent_image_id ): ?array {

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -157,9 +157,11 @@ class ProductGalleryUtils {
 			_prime_post_caches( $variations );
 		}
 
+		$parent_image_id = (int) $product->get_image_id();
+
 		foreach ( $variations as $variation_id ) {
 			$variation_id = (int) $variation_id;
-			$entry        = self::build_variation_gallery_entry( $variation_id );
+			$entry        = self::build_variation_gallery_entry( $variation_id, $parent_image_id );
 
 			if ( null !== $entry ) {
 				$variation_gallery_data[ $variation_id ] = $entry;
@@ -179,7 +181,7 @@ class ProductGalleryUtils {
 	 * @param int $variation_id Variation post ID.
 	 * @return array<string, mixed>|null
 	 */
-	private static function build_variation_gallery_entry( int $variation_id ): ?array {
+	private static function build_variation_gallery_entry( int $variation_id, int $parent_image_id ): ?array {
 		$variation = wc_get_product( $variation_id );
 
 		if ( ! $variation instanceof \WC_Product_Variation ) {
@@ -189,7 +191,18 @@ class ProductGalleryUtils {
 		$image_ids = self::get_variation_gallery_image_ids( $variation );
 
 		if ( empty( $image_ids ) ) {
-			return null;
+			// The variation has no usable images of its own. Prefer the
+			// parent product's featured image (so the merchant still sees
+			// the most representative image when picking a variation
+			// without a dedicated gallery), and fall back to the
+			// placeholder sentinel (id = 0) only when the parent has no
+			// featured image either. The product-image block renders
+			// `wc_placeholder_img()` for id = 0.
+			$fallback_id = $parent_image_id && wp_attachment_is_image( $parent_image_id ) ? $parent_image_id : 0;
+			return array(
+				'image_id'  => $fallback_id,
+				'image_ids' => array( $fallback_id ),
+			);
 		}
 
 		return array(
@@ -216,6 +229,18 @@ class ProductGalleryUtils {
 		if ( ! empty( $gallery_image_ids ) ) {
 			$image_ids = array_merge( $image_ids, $gallery_image_ids );
 		}
+
+		// Drop IDs whose attachment is missing or no longer an image. The
+		// gallery would otherwise render them as empty `<li>` wrappers (no
+		// `<img>`, no `data-image-id`, default `hidden=false`) — phantom
+		// slots that `toggleImageVisibility` can't manage and that stay
+		// visible across every variation switch.
+		$image_ids = array_filter(
+			$image_ids,
+			function ( $id ) {
+				return $id > 0 && wp_attachment_is_image( $id );
+			}
+		);
 
 		return array_values( array_unique( $image_ids ) );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Follow-up to #64524 addressing three Product Gallery block issues uncovered while testing the variation switching flow:

1. **Thumbnails strip** showed every parent image instead of just the active variation's subset. The reactive `syncThumbnailState` watch was setting `wrapper.hidden = true` correctly, but a `display: flex` author rule on the thumbnail wrapper overrode the UA `[hidden] { display: none }` rule. Added a specificity-matching `[hidden]` author rule. Same fix applied to the large-image wrapper.

2. **Large image landing between two images** when switching variations from a non-first image. Two underlying causes: rect-based scroll math returned `0` for `display: none` wrappers (iAPI's `data-wp-watch` flushes asynchronously via `rAF -> setTimeout(0)`, so the target wrapper was still hidden when the math ran); and `scrollTo({behavior: 'smooth'})` is a silent no-op on `overflow: hidden` containers in Chrome. Replaced rect math with `imageIndex * clientWidth` (layout-state-independent), added `scroll-behavior: smooth` CSS so arrow nav animates, and switched variation changes to `behavior: 'instant'` — animating between unrelated image sets just smears across images.

3. **Variations without images** rendered as blank/empty gallery slots. Broken or deleted attachment IDs produced phantom `<li>` wrappers with no `<img>` and no `data-image-id`, which `toggleImageVisibility` couldn't manage, so they stayed visible across every variation switch. Filter invalid IDs at the data source (`get_variation_gallery_image_ids`) and fall back to the parent product's featured image (or placeholder if the parent has none).

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|   https://github.com/user-attachments/assets/5ef8c887-eb4d-4016-a031-4ef3ec4c581a     | https://github.com/user-attachments/assets/0fd22c05-9073-4883-88f5-39f0a97634bc     |

### How to test the changes in this Pull Request:

1. Enable the variation gallery feature flag (Settings → Advanced → Features → "Variation gallery").
2. On a variable product with at least two variations that have multi-image galleries and one variation with no images, view the storefront with the **Product Gallery block** and **Add to Cart with Options block**.
3. **Subset filtering**: pick a variation with several images. Confirm the thumbnails strip shows only that variation's images, not the parent gallery.
4. **Scroll across variations**: pick variation A, click Next to advance to its 2nd or 3rd image, then switch to variation B. Confirm the large image lands cleanly on B's first image — no in-between split.
5. **Single-image variation**: pick a variation that has just one image. Confirm the thumbnails strip and Next/Previous arrows are hidden.
6. **No-image variation**: pick a variation with no images (or whose image attachment was deleted). Confirm the large image shows the parent product's featured image (or placeholder if parent has none) — not an empty/blank slot.
7. **Arrow nav within a variation**: click Next/Previous inside a multi-image variation. Confirm the large image smoothly scrolls between that variation's images.

### Testing that has already taken place:

Manually verified in Chrome (incognito) against a local environment with two variable products — one with multi-image variations, one with broken-attachment variations. PHP lint passes (`pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`).

### Milestone

-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changes are part of the variation gallery feature in #64524, which already ships a changelog entry. This PR addresses reviewer feedback on that work.

</details>