### PR TITLE
Bind products app accent color to the WP admin color scheme

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-products-app-accent-follows-scheme
+++ b/packages/js/experimental-products-app/changelog/update-products-app-accent-follows-scheme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Bind the experimental products app accent color to the WP admin color scheme so primary buttons, filter chips, badges, and links follow the user's selected scheme.

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -94,4 +94,56 @@
 	gap: 8px;
 }
 
+// Bind design-system accent tokens to the WP admin scheme color so the
+// products app accent follows the user's selected admin color scheme.
+// Without this, the @wordpress/components accent tokens are unset (and
+// fall back to a hardcoded blueberry) and the @wordpress/theme "brand"
+// tokens are hardcoded in design-tokens.css. None of them are wired to
+// `--wp-admin-theme-color`, which is what wp-admin actually exposes.
+.product_page_woocommerce-products-dashboard {
+	// @wordpress/components accent family (used by older Button / link
+	// styles that read `--wp-components-color-accent`).
+	--wp-components-color-accent: var(--wp-admin-theme-color);
+	--wp-components-color-accent-darker-10: var(
+		--wp-admin-theme-color-darker-10
+	);
+	--wp-components-color-accent-darker-20: var(
+		--wp-admin-theme-color-darker-20
+	);
+	--wp-components-color-accent-inverted: #fff;
+
+	// @wordpress/theme brand/interactive family (used by `@wordpress/ui`
+	// Button primary, badges, chips, etc.). The base tokens are hardcoded
+	// blueberry in design-tokens.css; rebinding here makes them follow
+	// the scheme without forking the package.
+	--wpds-color-bg-interactive-brand-strong: var(--wp-admin-theme-color);
+	--wpds-color-bg-interactive-brand-strong-active: var(
+		--wp-admin-theme-color-darker-10
+	);
+	// Soft tint (e.g. filter chip background). Mix the scheme color with
+	// white at 10% so the relationship to the scheme color is preserved
+	// across all schemes rather than a static lavender.
+	--wpds-color-bg-interactive-brand-weak-active: color-mix(
+		in srgb,
+		var(--wp-admin-theme-color) 10%,
+		#fff
+	);
+	--wpds-color-bg-thumb-brand: var(--wp-admin-theme-color);
+	--wpds-color-bg-thumb-brand-active: var(--wp-admin-theme-color);
+	--wpds-color-fg-interactive-brand: var(--wp-admin-theme-color);
+	--wpds-color-stroke-interactive-brand: var(--wp-admin-theme-color);
+
+	// Table title links and other generic links inside the dashboard.
+	// WP admin's default link color is independent of the scheme; bind
+	// links inside this app to the scheme accent + darker hover variant.
+	a {
+		color: var(--wp-admin-theme-color);
+
+		&:hover,
+		&:focus {
+			color: var(--wp-admin-theme-color-darker-10);
+		}
+	}
+}
+
 @import "./variation-view/style.scss";


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The experimental products app showed a hardcoded "blueberry" (`#3858E9`) on its primary surfaces (Add new button, filter badge, filter chip tint, "Add filter" / "Reset" links) and WP admin's default `#2271b1` on title links — regardless of the user's WP admin color scheme. This PR wires the design-system accent tokens used by the app to `--wp-admin-theme-color` so every accent surface follows the selected scheme automatically.

Tokens bound (scoped to `.product_page_woocommerce-products-dashboard`):

- `@wordpress/components` accent family (`--wp-components-color-accent`, `-darker-10`, `-darker-20`, `-inverted`).
- `@wordpress/theme` (wpds) brand family (`--wpds-color-bg-interactive-brand-strong`, `-active`, `-weak-active`, `--wpds-color-bg-thumb-brand*`, `--wpds-color-fg-interactive-brand`, `--wpds-color-stroke-interactive-brand`).
- Generic `a` color (and `:hover` / `:focus`) inside the dashboard scope — covers the title link in the table and any other in-scope link.

The soft tint variant (`--wpds-color-bg-interactive-brand-weak-active`) uses `color-mix(in srgb, var(--wp-admin-theme-color) 10%, #fff)` so the chip tint remains a faint version of whichever scheme the user picked.

No JS / TSX / PHP changes. No new dependencies.

### Screenshots or screen recordings:

#### Before / After

| Before | After |
| ------ | ----- |
| <!-- drop before screenshot here --> | <!-- drop after screenshot here --> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open WooCommerce → Products.
2. Go to Users → Profile → Color Scheme. Switch through schemes one at a time (Default, Light, Modern, Blue, Coffee, Ectoplasm, Midnight, Ocean, Sunrise), saving each.
3. After each save, return to WooCommerce → Products and confirm the following all match the strip color of the selected scheme:
    - **Add new** button background (and chevron color stays readable on it).
    - Filter funnel icon **count badge** background.
    - Filter chip pill background (faint tint of the scheme color) and text color.
    - "Add filter" / "Reset" link colors.
    - Product **title links** in the table (e.g. "Hoodie with Pocket").
    - Hover state on the Add new button and on a product title link — slightly darker than the base.
4. Confirm no element still shows the previous hardcoded blueberry (`#3858E9`) or WP admin default blue (`#2271b1`) — unless the selected scheme legitimately uses those colors.

### Testing that has already taken place:

Local visual check across at least one scheme.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under `packages/js/experimental-products-app/changelog/update-products-app-accent-follows-scheme`.

</details>