### PR TITLE
Close quick edit drawer after a fully successful save

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-app-drawer-closes-on-save
+++ b/packages/js/experimental-products-app/changelog/fix-products-app-drawer-closes-on-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Close the quick/bulk edit drawer after a fully successful save in the experimental products app. The drawer still stays open if any product fails to save so the user can correct and retry.

--- a/packages/js/experimental-products-app/src/product-edit/index.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/index.tsx
@@ -371,10 +371,13 @@ export default function ProductEdit( { products }: ProductEditProps ) {
 					type: 'snackbar',
 				} );
 			}
+
+			closeDrawer();
 		} finally {
 			setIsSaving( false );
 		}
 	}, [
+		closeDrawer,
 		createErrorNotice,
 		createSuccessNotice,
 		editEntityRecord,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes the experimental products app quick/bulk edit drawer after a successful save. Previously the drawer stayed open in every case, leaving the user to click the close button manually after persisting their changes. With this change:

- **Full success** (all selected products saved) → drawer closes, success snackbar appears.
- **Any failure** → drawer stays open, error snackbar appears; the user can correct the failing record(s) and retry without losing context.

The fix is a single \`closeDrawer()\` call inside the existing \`onSave\` callback, after the success-notice block. The failure branch already returns early before reaching that point, so success-only closing falls out naturally. \`closeDrawer\` is added to the \`useCallback\` deps array.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <!-- drop before recording here --> | <!-- drop after recording here --> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open WooCommerce → Products.
2. Click **Quick edit** on a product, change a field (e.g. price), click **Save**.
    - Drawer closes.
    - Success snackbar appears.
3. Select multiple products and **Bulk edit** them. Change a field. Click **Save**.
    - Drawer closes.
    - Success snackbar appears.
4. Simulate a save failure (e.g., open DevTools → Network, block the \`POST /wp-json/wc/v3/products/<id>\` request, edit a product, click Save).
    - Drawer **stays open**.
    - Error snackbar appears.
    - The user can edit again and retry.
5. Quick edit a product but don't change anything, click Save.
    - Drawer closes (no actual changes to fail).

### Testing that has already taken place:

Local visual + DOM check; manual reproduction of success and failure paths.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under \`packages/js/experimental-products-app/changelog/fix-products-app-drawer-closes-on-save\`.

</details>