### PR TITLE
Surface server error details on Review Order AJAX response

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6697-surface-ajax-error-details
+++ b/plugins/woocommerce/changelog/wooplug-6697-surface-ajax-error-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Surface server-side error details on the Review Order page: non-JSON responses, top-level messages, and per-row error codes from the AJAX submission handler.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes WOOPLUG-6697.

Follow-up to #\64833 (review feedback from Ferdev). `initAjaxSubmit()` in `plugins/woocommerce/client/legacy/js/frontend/order-review.js` currently:

- Swallows non-JSON server responses (HTML 500 pages, security plugin walls) via `response.json().catch(() => ({ success: false }))` — user sees the generic fallback.
- Ignores `payload.data.message` at the top level.
- Ignores `entry.error` codes/messages per row in favour of the localized default.

This PR surfaces the detail the server already returns:

1. Detect non-JSON bodies and render a distinguishable user-facing message (e.g. "We couldn't reach the server — please try again.").
2. If `payload.data.message` is present, render a top-of-form notice instead of dropping it.
3. Per-row `entry.error.message` (when present) wins over the localized default.

Keeps the existing `anySaved && !anyFailed` thank-you gate untouched.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

To be expanded as the implementation lands. Outline:

1. Force a non-JSON 5xx (e.g. throw inside the AJAX handler) → confirm the user-facing copy reflects the network/server failure, not the generic fallback.
2. Have the server return `payload.data.message` → confirm the message renders above the form.
3. Have a row return `entry.error = { message: "..." }` → confirm that message wins over the localized default in the row's status note.

<!-- End testing instructions -->

### Testing that has already taken place:

- Branch scaffolded only; implementation pending.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix
-   [ ] Add
-   [ ] Update
-   [ ] Dev
-   [ ] Tweak
-   [ ] Performance
-   [x] Enhancement

#### Message

Surface server-side error details on the Review Order page: non-JSON responses, top-level messages, and per-row error codes from the AJAX submission handler.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>