### PR TITLE
Animate the quick edit drawer close transition

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-app-drawer-close-animation
+++ b/packages/js/experimental-products-app/changelog/fix-products-app-drawer-close-animation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Animate the quick/bulk edit drawer's close transition in the experimental products app so it mirrors the open animation instead of disappearing abruptly. The drawer also closes after a fully successful save (it stays open on any failure so the user can correct and retry).

--- a/packages/js/experimental-products-app/src/product-edit/index.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/index.tsx
@@ -371,6 +371,8 @@ export default function ProductEdit( { products }: ProductEditProps ) {
 					type: 'snackbar',
 				} );
 			}
+
+			setIsDrawerOpen( false );
 		} finally {
 			setIsSaving( false );
 		}
@@ -384,14 +386,15 @@ export default function ProductEdit( { products }: ProductEditProps ) {
 	] );
 
 	useEffect( () => {
-		if ( requestedProductIds.length > 0 && ! isDrawerOpen ) {
+		if ( requestedProductIds.length > 0 ) {
 			setIsDrawerOpen( true );
 		}
-	}, [ requestedProductIds, isDrawerOpen ] );
+	}, [ requestedProductIds ] );
 
 	return (
 		<Drawer.Root
 			open={ isDrawerOpen }
+			onOpenChange={ setIsDrawerOpen }
 			onOpenChangeComplete={ ( isOpen ) => {
 				if ( ! isOpen ) {
 					closeDrawer();
@@ -411,7 +414,7 @@ export default function ProductEdit( { products }: ProductEditProps ) {
 						{ title }
 					</Drawer.Title>
 					<Drawer.CloseIcon
-						onClick={ closeDrawer }
+						onClick={ () => setIsDrawerOpen( false ) }
 						label={ __( 'Close quick edit', 'woocommerce' ) }
 					/>
 				</Drawer.Header>
@@ -460,7 +463,7 @@ export default function ProductEdit( { products }: ProductEditProps ) {
 					<Drawer.Footer className="woocommerce-product-edit__footer">
 						<Button
 							variant="tertiary"
-							onClick={ closeDrawer }
+							onClick={ () => setIsDrawerOpen( false ) }
 							disabled={ isSaving }
 						>
 							{ __( 'Cancel', 'woocommerce' ) }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The experimental products app quick/bulk edit drawer slid in smoothly when opened but disappeared abruptly on close — the slide-out animation never played. Root cause: \`Drawer.Root\` was wired with \`open={...}\` but no \`onOpenChange\`, and click handlers (X icon, Cancel, after Save) called \`closeDrawer()\` directly, which performs the cleanup (clear entity edits + navigate) synchronously. The route change cascaded into a re-render that hid the drawer before the animation could play.

This PR wires the drawer as a fully controlled component and routes the cleanup through the post-animation callback:

- Adds \`onOpenChange={ setIsDrawerOpen }\` on \`Drawer.Root\` so base-ui's own close affordances (escape, swipe) can update React state.
- Replaces direct \`closeDrawer()\` calls on the X icon, Cancel button, and post-Save with \`setIsDrawerOpen( false )\`. This flips the open state, base-ui plays the slide-out animation, and \`onOpenChangeComplete\` fires \`closeDrawer()\` after the animation finishes.
- Removes \`isDrawerOpen\` from the auto-open \`useEffect\`'s dep array so it doesn't re-open the drawer the instant the user closes it (while \`requestedProductIds\` is still set in the URL).

This PR also subsumes #64854 (close drawer after successful save) — the \`setIsDrawerOpen( false )\` added after the success branch in \`onSave\` is the same behavior, now arriving via the animated path. If #64854 lands first this PR rebases trivially; if this lands first, #64854 should be closed.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <!-- drop before recording here --> | <!-- drop after recording here --> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open WooCommerce → Products.
2. Click **Quick edit** on a product. Drawer slides in.
3. Click the **X** icon. Drawer slides out (mirror of the open animation).
4. Open the drawer again. Click **Cancel** in the footer. Same slide-out animation.
5. Open the drawer again. Change a field. Click **Save**. Success snackbar appears; drawer slides out smoothly.
6. Press **Escape** while the drawer is open. Drawer slides out.
7. Swipe right on the drawer (touchpad horizontal swipe). It dismisses with the same animation.

### Testing that has already taken place:

Local visual check across each close trigger.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under \`packages/js/experimental-products-app/changelog/fix-products-app-drawer-close-animation\`.

</details>