### PR TITLE
Improve payment setup fallback coverage

### DIFF
--- a/plugins/woocommerce/changelog/dev-payment-setup-fallback-tests
+++ b/plugins/woocommerce/changelog/dev-payment-setup-fallback-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Improve payment setup fallback test coverage and translator context.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
@@ -172,7 +172,7 @@ export const EnableGatewayButton = ( {
 					} else {
 						createErrorNotice(
 							sprintf(
-								/* translators: %s: payment gateway title. */
+								/* translators: %s: payment gateway title, or 'this payment method'. */
 								__(
 									'Finish setting up %s before enabling it.',
 									'woocommerce'

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/enable-gateway-button.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/enable-gateway-button.test.tsx
@@ -106,39 +106,45 @@ describe( 'EnableGatewayButton', () => {
 		} );
 	} );
 
-	it( 'falls back to a generic setup message when the gateway title is empty', async () => {
-		const gatewayProviderWithoutTitle = {
-			...gatewayProvider,
-			title: '',
-		} as PaymentGatewayProvider;
+	it.each( [
+		[ 'empty', '' ],
+		[ 'null', null ],
+	] )(
+		'falls back to a generic setup message when the gateway title is %s',
+		async ( _case, title ) => {
+			const gatewayProviderWithoutTitle = {
+				...gatewayProvider,
+				title,
+			} as unknown as PaymentGatewayProvider;
 
-		const { getByRole } = render(
-			<EnableGatewayButton
-				gatewayProvider={ gatewayProviderWithoutTitle }
-				settingsHref="/settings/test-gateway"
-				onboardingHref="/onboard/test-gateway"
-				isOffline={ false }
-				gatewayHasRecommendedPaymentMethods={ false }
-				installingPlugin={ null }
-			/>
-		);
-
-		fireEvent.click( getByRole( 'link', { name: 'Enable' } ) );
-
-		await waitFor( () => {
-			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
-				'Finish setting up this payment method before enabling it.',
-				expect.objectContaining( {
-					type: 'snackbar',
-					explicitDismiss: true,
-					actions: expect.arrayContaining( [
-						expect.objectContaining( {
-							label: 'Manage',
-							url: '/settings/test-gateway',
-						} ),
-					] ),
-				} )
+			const { getByRole } = render(
+				<EnableGatewayButton
+					gatewayProvider={ gatewayProviderWithoutTitle }
+					settingsHref="/settings/test-gateway"
+					onboardingHref="/onboard/test-gateway"
+					isOffline={ false }
+					gatewayHasRecommendedPaymentMethods={ false }
+					installingPlugin={ null }
+				/>
 			);
-		} );
-	} );
+
+			fireEvent.click( getByRole( 'link', { name: 'Enable' } ) );
+
+			await waitFor( () => {
+				expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+					expect.stringContaining( 'this payment method' ),
+					expect.objectContaining( {
+						type: 'snackbar',
+						explicitDismiss: true,
+						actions: expect.arrayContaining( [
+							expect.objectContaining( {
+								label: 'Manage',
+								url: '/settings/test-gateway',
+							} ),
+						] ),
+					} )
+				);
+			} );
+		}
+	);
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up to #64799. The payment setup fallback behavior remains unchanged, but the translator comment now calls out the generic fallback phrase so translation context matches the value that can be passed into `%s`.

The fallback unit coverage now checks both empty-string and `null` titles, and uses a less brittle partial message assertion.

### How to test the changes in this Pull Request:

1. Review `plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx` and confirm the translator comment mentions the `this payment method` fallback.
2. Run `pnpm --filter=@woocommerce/admin-library test:js client/settings-payments/components/buttons/test/enable-gateway-button.test.tsx --runInBand`.
3. Confirm the `EnableGatewayButton` tests pass, including the empty and null fallback title cases.

### Testing that has already taken place:

- Ran `pnpm --filter=@woocommerce/admin-library test:js client/settings-payments/components/buttons/test/enable-gateway-button.test.tsx --runInBand` and confirmed 3 tests passed. The existing `ts-jest` deprecation warning still appears.
- Ran `pnpm --filter=@woocommerce/admin-library exec eslint client/settings-payments/components/buttons/enable-gateway-button.tsx client/settings-payments/components/buttons/test/enable-gateway-button.test.tsx --ext=js,ts,tsx`.
- Ran `composer exec -- changelogger validate`; it exited successfully with existing vendor PHP 8.4 deprecation notices.
- Ran `git diff --check`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Manual changelog entry included in `plugins/woocommerce/changelog/dev-payment-setup-fallback-tests`.

</details>
