### PR TITLE
Cap the View options popover height with inner scroll

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-app-view-options-popover-scroll
+++ b/packages/js/experimental-products-app/changelog/fix-products-app-view-options-popover-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Cap the DataViews "View options" popover height in the experimental products app so its inner content scrolls instead of letting the popover extend past the viewport.

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -94,14 +94,12 @@
 	gap: 8px;
 }
 
-// Cap the DataViews "View options" (Appearance) popover height so its
-// inner content scrolls instead of letting the popover grow past the
-// viewport. The upstream `is-expanded` mode is what enables scroll, but
-// it's not triggered in our wp-admin context — apply the equivalent
-// constraint directly here. Viewport-relative so the popover always
-// leaves room for the wp-admin top bar and a bit of breathing room.
+// Give the DataViews "View options" (Appearance) popover a fixed
+// maximum height so its inner content scrolls inside the popover
+// instead of growing with the property list. Mirrors the upstream
+// `is-expanded` behavior, which our wp-admin context doesn't trigger.
 .dataviews-config__popover .dataviews-config__popover-content-wrapper {
-	max-height: calc(100vh - 120px);
+	max-height: min(500px, calc(100vh - 120px));
 	overflow-y: auto;
 }
 

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -94,4 +94,15 @@
 	gap: 8px;
 }
 
+// Cap the DataViews "View options" (Appearance) popover height so its
+// inner content scrolls instead of letting the popover grow past the
+// viewport. The upstream `is-expanded` mode is what enables scroll, but
+// it's not triggered in our wp-admin context — apply the equivalent
+// constraint directly here. Viewport-relative so the popover always
+// leaves room for the wp-admin top bar and a bit of breathing room.
+.dataviews-config__popover .dataviews-config__popover-content-wrapper {
+	max-height: calc(100vh - 120px);
+	overflow-y: auto;
+}
+
 @import "./variation-view/style.scss";


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The DataViews "View options" (Appearance) popover in the experimental products app expanded to fit all of its content, pushing the bottom of the popover past the viewport on shorter screens — the user couldn't reach the bottom-most options. Upstream DataViews has an `is-expanded` mode that caps the wrapper height and makes the inner list scroll, but that modifier isn't applied in our wp-admin context.

This PR adds the equivalent constraint directly in the experimental products app stylesheet:

- `.dataviews-config__popover .dataviews-config__popover-content-wrapper` gets `max-height: calc(100vh - 120px)` and `overflow-y: auto`.
- Viewport-relative so the popover always leaves room for the wp-admin top bar and a bit of breathing room.
- Inner content scrolls within the popover instead of the popover extending past the viewport.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <!-- popover extends past viewport --> | <!-- popover fits, inner list scrolls --> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open WooCommerce → Products.
2. Resize the browser window so the viewport height is small (under ~900px is enough to reproduce on a default install).
3. Click the **View options** (gear / sliders) button in the list toolbar to open the Appearance popover.
4. Confirm the popover fits inside the viewport with a small gap at the bottom, and the inner Properties / Sort / etc. list scrolls within the popover when its content overflows.
5. Restore a tall viewport and confirm the popover still renders normally without unwanted clipping.

### Testing that has already taken place:

Local visual check at viewport height 963px (popover capped at 843px, inner content scrolls; verified `max-height` and `overflow-y` applied via DevTools).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under `packages/js/experimental-products-app/changelog/fix-products-app-view-options-popover-scroll`.

</details>