### PR TITLE
Gate Shopper Collection empty message on in-session item flow

### DIFF
--- a/plugins/woocommerce/changelog/feature-shopper-collection-empty-message-gating
+++ b/plugins/woocommerce/changelog/feature-shopper-collection-empty-message-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Shopper Collection: hide the empty-state message until items have appeared in the list during the current page session.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -27,6 +27,11 @@ type ShopperCollectionConfig = {
 
 type BlockContext = {
 	listSlug: string;
+	// Wrapper-scoped flag: starts as `items.length > 0` from SSR and the
+	// `trackShownItems` callback flips it to `true` the first time the
+	// list has any items at runtime. Lives in iAPI context so it resets
+	// on every full page load.
+	hasShownItems: boolean;
 	listItem?: RawShopperListItem;
 	htmlField?: 'price_html' | 'image_html';
 };
@@ -50,6 +55,7 @@ type BlockStore = {
 	};
 	callbacks: {
 		updateInnerHtml: () => void;
+		trackShownItems: () => void;
 	};
 };
 
@@ -146,12 +152,16 @@ store< BlockStore >(
 			},
 
 			get isEmpty(): boolean {
-				const { listSlug } = getContext< BlockContext >();
-				const list = getList( listSlug );
+				const ctx = getContext< BlockContext >();
+				const list = getList( ctx.listSlug );
 				if ( ! list ) {
-					return true;
+					return false;
 				}
-				return ! list.isLoading && list.items.length === 0;
+				return (
+					ctx.hasShownItems &&
+					! list.isLoading &&
+					list.items.length === 0
+				);
 			},
 
 			get isPriceHidden(): boolean {
@@ -275,6 +285,23 @@ store< BlockStore >(
 		},
 
 		callbacks: {
+			// Wrapper-level watcher: flips `hasShownItems` to `true` the
+			// first time the list has any items. Pairs with `state.isEmpty`
+			// to gate the empty message — a new shopper landing on a page
+			// with nothing saved keeps the flag at its SSR-seeded `false`
+			// and never sees the message; once they save an item (or
+			// landed with items) the flag is `true`, so emptying the list
+			// from that point surfaces the message. The flag never flips
+			// back to `false`, which is what gives the "had-items → now-empty"
+			// transition we want during the session.
+			trackShownItems: () => {
+				const ctx = getContext< BlockContext >();
+				const list = getList( ctx.listSlug );
+				if ( list && list.items.length > 0 && ! ctx.hasShownItems ) {
+					ctx.hasShownItems = true;
+				}
+			},
+
 			// Single shared innerHTML-swap callback for any slot whose
 			// content is one of the schema's preformatted HTML fields.
 			// Mirrors the atomic product-elements `updateValue` callback:

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -147,7 +147,7 @@ $grid-gap: var(--wp--style--block-gap, 1.5em);
 	color: rgba(0, 0, 0, 0.7);
 	grid-column: 1 / -1;
 	padding: 1em 0;
-	text-align: center;
+	text-align: left;
 }
 
 // Error state spans every grid column so it reads as a single alert

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -179,24 +179,36 @@ final class ShopperCollection extends AbstractBlock {
 			$variation['modifierSlug']
 		);
 
+		// `hasShownItems` seeds the per-block context so the empty message
+		// stays hidden for new shoppers who land on a page with nothing
+		// saved. The JS-side watcher flips it to `true` the first time the
+		// list has any items (whether that's the SSR seed or a runtime add
+		// via "Save for later"), and `state.isEmpty` only flips on when the
+		// flag is set *and* the list is currently empty. The flag lives in
+		// the per-block context, so it naturally resets on every full page
+		// load — no extra Store API field or persisted flag needed.
 		$wrapper_attributes = array(
 			'class'               => $wrapper_class,
 			'data-wp-interactive' => 'woocommerce/shopper-collection',
-			'data-wp-context'     => (string) wp_json_encode( array( 'listSlug' => $list_slug ) ),
+			'data-wp-context'     => (string) wp_json_encode(
+				array(
+					'listSlug'      => $list_slug,
+					'hasShownItems' => ! empty( $items ),
+				)
+			),
+			'data-wp-watch'       => 'callbacks.trackShownItems',
 			// Deterministic key derived from the list slug so iAPI router
 			// navigations land on the same block identity across renders.
 			'data-wp-key'         => $this->get_full_block_name() . '-' . $list_slug,
 			'style'               => sprintf( '--wc-shopper-collection-columns:%d;', $column_count ),
 		);
 
-		$is_empty = empty( $items );
-
 		return sprintf(
 			'<ul %1$s>%2$s%3$s%4$s%5$s</ul>',
 			get_block_wrapper_attributes( $wrapper_attributes ),
 			$this->render_template_markup( $variation ),
 			$this->render_items_markup( $items, $variation ),
-			$this->render_empty_markup( $is_empty, $variation ),
+			$this->render_empty_markup( $variation ),
 			$this->render_error_markup()
 		);
 	}
@@ -499,17 +511,16 @@ final class ShopperCollection extends AbstractBlock {
 
 	/**
 	 * Render the empty-state markup. Always present in the DOM so JS can
-	 * toggle it on once the last item is removed.
+	 * toggle it on once the last item is removed. Initially hidden: SSR
+	 * never shows the message, since `state.isEmpty` requires the JS-side
+	 * `hasShownItems` context flag to flip first.
 	 *
-	 * @param bool                 $is_empty  Whether the list is empty on initial paint.
 	 * @param array<string, mixed> $variation Per-list-type rendering config.
 	 * @return string
 	 */
-	private function render_empty_markup( bool $is_empty, array $variation ): string {
-		$hidden_attr = $is_empty ? '' : ' hidden';
+	private function render_empty_markup( array $variation ): string {
 		return sprintf(
-			'<li class="wc-block-shopper-collection__empty" data-wp-bind--hidden="!state.isEmpty"%1$s>%2$s</li>',
-			$hidden_attr,
+			'<li class="wc-block-shopper-collection__empty" data-wp-bind--hidden="!state.isEmpty" hidden>%s</li>',
 			esc_html( $variation['emptyMessage'] )
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -128,4 +128,65 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 
 		$this->assertSame( 'saved-for-later', $result['attrs']['listName'] );
 	}
+
+	/**
+	 * For a new shopper landing on the page with nothing saved, SSR must:
+	 *   - emit the empty-state `<li>` already `hidden`, so the message
+	 *     never flashes between paint and iAPI hydration, and
+	 *   - seed the wrapper's iAPI context with `hasShownItems: false` and
+	 *     the matching `data-wp-watch` callback, so the JS-side
+	 *     `state.isEmpty` getter has the inputs it needs to keep the
+	 *     message hidden until the shopper has actually saved an item.
+	 *
+	 * Driven through reflection on `render()` as a logged-out user,
+	 * since `prefetch_list_items` short-circuits to `[]` in that case —
+	 * no Store API call, no feature-flag wiring, no user fixture needed.
+	 * Sets `WP_Block_Supports::$block_to_render` up front so
+	 * `get_block_wrapper_attributes()` (which reads it for layout/style
+	 * supports) has the context it expects when called outside the
+	 * usual block-render pipeline.
+	 */
+	public function test_render_seeds_hidden_empty_state_for_new_shopper(): void {
+		wp_set_current_user( 0 );
+
+		$attributes = array( 'listName' => 'saved-for-later' );
+
+		$previous_block_to_render            = \WP_Block_Supports::$block_to_render;
+		\WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'woocommerce/shopper-collection',
+			'attrs'     => $attributes,
+		);
+
+		try {
+			$reflection = new ReflectionClass( ShopperCollection::class );
+			$method     = $reflection->getMethod( 'render' );
+			$method->setAccessible( true );
+
+			$markup = (string) $method->invoke( $this->sut, $attributes, '', null );
+		} finally {
+			\WP_Block_Supports::$block_to_render = $previous_block_to_render;
+		}
+
+		// The empty-state `<li>` is always rendered, always initially hidden.
+		$this->assertMatchesRegularExpression(
+			'/<li[^>]*class="wc-block-shopper-collection__empty"[^>]*\bhidden\b/',
+			$markup,
+			'Empty-state <li> must be initially hidden so the message does not flash before iAPI hydration.'
+		);
+
+		// The wrapper's `data-wp-context` JSON is HTML-escaped into an
+		// attribute, so the embedded quotes appear as `&quot;` in the
+		// rendered markup.
+		$this->assertStringContainsString(
+			'&quot;hasShownItems&quot;:false',
+			$markup,
+			'Wrapper context must seed hasShownItems=false for an empty list so the empty message stays hidden until the shopper actually saves an item.'
+		);
+
+		$this->assertStringContainsString(
+			'data-wp-watch="callbacks.trackShownItems"',
+			$markup,
+			'Wrapper must wire the trackShownItems watcher so hasShownItems can flip to true the first time items appear in-session.'
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Shopper Collection block previously displayed the empty-state message "Nothing saved yet — items you save from the cart will appear here." on every page load for a list with no items, including for a brand-new shopper who has never saved anything.

This PR gates that message on an in-session signal: it only appears after the list has held at least one item during the current page session, and resets on every full page reload.

Implementation uses an iAPI `hasShownItems` flag in the per-block `data-wp-context`:

- **PHP** seeds the flag as `! empty( $items )` on render, and the empty-state `<li>` is now always emitted `hidden` initially (no SSR-side flash).
- **JS** adds a wrapper-level `data-wp-watch` callback (`trackShownItems`) that flips the flag to `true` the first time the list has any items — covering both SSR-seeded lists and runtime additions from the cart's "Save for later" action. `state.isEmpty` is now gated on `hasShownItems && !isLoading && items.length === 0`, so the message only surfaces once the shopper has actually had items and then cleared them.
- The flag lives in iAPI context only, so it naturally resets on every full page load — no Store API change, no persisted flag.

### Screenshots or screen recordings:

Behavior change only; no visual styling changes in this PR. (Visuals will be updated alongside the upcoming title work — see note above.)

### How to test the changes in this Pull Request:

Prereq: `cart_save_for_later` feature flag enabled, logged in as a customer, on a cart page that contains the Shopper Collection block (auto-injected after `woocommerce/cart`).

**New shopper, never saved an item**
1. Make sure your saved-for-later list is empty.
2. Load the cart page.
3. Expected: Shopper Collection renders with no items and **no** "Nothing saved yet…" message.

**Save and clear in the same session**
1. From step 3 above (empty list visible, no empty message), use the cart line item's "Save for later" action to move at least one item into the Shopper Collection.
2. Expected: item appears; still no empty message.
3. Click the Remove icon on the saved item(s) until the list is empty again.
4. Expected: "Nothing saved yet — items you save from the cart will appear here." now appears.

**Refresh resets the gating**
1. From step 4 above (empty message visible), refresh the page.
2. Expected: empty message disappears (the per-block context flag is re-seeded from the prefetched empty list).

**Returning shopper with items, removes them all**
1. Set up the saved-for-later list to contain at least one item, then load the cart page.
2. Expected: items render, no empty message.
3. Remove items until the list is empty.
4. Expected: empty message appears.
5. Refresh.
6. Expected: empty message disappears.

### Testing that has already taken place:

- New PHP render test `ShopperCollectionTests::test_render_seeds_hidden_empty_state_for_new_shopper` exercises the logged-out / empty-list path and locks in three SSR contracts: empty `<li>` always `hidden`, `data-wp-context` seeds `hasShownItems: false`, and the wrapper wires `data-wp-watch="callbacks.trackShownItems"`.
- Full `ShopperCollectionTests` suite passes (7 tests, 9 assertions).
- `pnpm lint:php:changes` and `pnpm lint:changes:branch` are clean.
- Manual walkthrough of the four flows above on a local Studio site.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually in this branch: `plugins/woocommerce/changelog/feature-shopper-collection-empty-message-gating` (significance: patch, type: tweak).