### PR TITLE
[Experimental Products App] Use theme provider defaults

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-products-app-admin-theme-color
+++ b/packages/js/experimental-products-app/changelog/update-products-app-admin-theme-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update the experimental products app admin theme color.

--- a/packages/js/experimental-products-app/src/app.tsx
+++ b/packages/js/experimental-products-app/src/app.tsx
@@ -36,7 +36,7 @@ export function ProductsApp() {
 		<NewNavigationProvider>
 			<UnsavedChangesWarning />
 			<RouterProvider>
-				<ThemeProvider>
+				<ThemeProvider isRoot>
 					<ProductsLayout />
 				</ThemeProvider>
 			</RouterProvider>

--- a/packages/js/experimental-products-app/src/variation-view-app.tsx
+++ b/packages/js/experimental-products-app/src/variation-view-app.tsx
@@ -3,6 +3,7 @@
  */
 import { StrictMode, Suspense, createRoot, lazy } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { privateApis as themeProviderPrivateApis } from '@wordpress/theme';
 
 /**
  * Internal dependencies
@@ -10,6 +11,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { unlock } from './lock-unlock';
 
 const { RouterProvider } = unlock( routerPrivateApis );
+const { ThemeProvider } = unlock( themeProviderPrivateApis );
 
 const VariationView = lazy( () =>
 	import(
@@ -41,7 +43,9 @@ export function initializeVariationView(
 		<StrictMode>
 			<Suspense fallback={ null }>
 				<RouterProvider>
-					<VariationView productId={ productId } />
+					<ThemeProvider>
+						<VariationView productId={ productId } />
+					</ThemeProvider>
 				</RouterProvider>
 			</Suspense>
 		</StrictMode>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental products app should rely on the WordPress Design System theme provider defaults so admin theme variables and WPDS tokens stay aligned. This PR marks the products dashboard `ThemeProvider` as the root provider and wraps the standalone classic variation view in `ThemeProvider`, allowing `--wp-admin-theme-color` and related variables to come from `@wordpress/theme`.

### Screenshots or screen recordings:

Screenshots are not included because this change affects theme token provisioning rather than a specific layout state.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Build the experimental products app with `pnpm --filter=@woocommerce/experimental-products-app build`.
2. Open the experimental products app in WooCommerce admin.
3. Inspect the products app root and confirm `--wp-admin-theme-color` resolves to the WordPress theme provider default color.
4. Open the product quick edit drawer and confirm controls still use the same themed focus/accent color.
5. Open the classic product editor variation view and confirm controls render with the themed focus/accent color.

<!-- End testing instructions -->

### Testing that has already taken place:

Built the package with `pnpm --filter=@woocommerce/experimental-products-app build`. The build passed with the existing webpack asset-size warnings.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was added manually in `packages/js/experimental-products-app/changelog/update-products-app-admin-theme-color`.

</details>
