### PR TITLE
List problematic db update callbacks when release check fails

### DIFF
--- a/.github/workflows/scripts/release-check-db-updates.js
+++ b/.github/workflows/scripts/release-check-db-updates.js
@@ -198,13 +198,12 @@ const run = async ( currentRef, { github, context } ) => {
     const updates2 = currentDbUpdates.get( key2 )
     const [ base1, suffix1 ] = key1.split( '-' );
 
-    updates2.forEach(
-      ( e ) => {
-        if ( ! updates1.includes( e ) ) {
-          throw new Error( `A new db update callback was added under key '${ key1 }' in version '${ version }'. Add them under a new key instead (e.g. '${ base1 }-${ Number( suffix1 || 0 ) + 1 }').` );
-        }
-      }
-    );
+    const newCallbacks = updates2.filter( ( e ) => ! updates1.includes( e ) );
+
+    if ( newCallbacks.length > 0 ) {
+      const callbackList = newCallbacks.map( ( c ) => `  - ${ c }` ).join( '\n' );
+      throw new Error( `${ newCallbacks.length } new db update callback(s) were added under key '${ key1 }' in version '${ version }':\n${ callbackList }\nAdd them under a new key instead (e.g. '${ base1 }-${ Number( suffix1 || 0 ) + 1 }').` );
+    }
 
     return;
   }

--- a/.github/workflows/scripts/release-check-db-updates.js
+++ b/.github/workflows/scripts/release-check-db-updates.js
@@ -196,13 +196,16 @@ const run = async ( currentRef, { github, context } ) => {
   if ( key1 === key2 ) {
     const updates1 = previousDbUpdates.get( key1 );
     const updates2 = currentDbUpdates.get( key2 )
-    const [ base1, suffix1 ] = key1.split( '-' );
 
     const newCallbacks = updates2.filter( ( e ) => ! updates1.includes( e ) );
 
     if ( newCallbacks.length > 0 ) {
       const callbackList = newCallbacks.map( ( c ) => `  - ${ c }` ).join( '\n' );
-      throw new Error( `${ newCallbacks.length } new db update callback(s) were added under key '${ key1 }' in version '${ version }':\n${ callbackList }\nAdd them under a new key instead (e.g. '${ base1 }-${ Number( suffix1 || 0 ) + 1 }').` );
+      // Suggest the version itself when it's above the last key's base; a suffix bump would sort below patch releases shipped in between.
+      const [ base1, suffix1 ] = key1.split( '-' );
+      const versionBase = version.replace( /-.*$/, '' );
+      const suggestedKey = dbUpdateKeyGreaterThan( versionBase, base1 ) ? versionBase : `${ base1 }-${ Number( suffix1 || 0 ) + 1 }`;
+      throw new Error( `${ newCallbacks.length } new db update callback(s) were added under key '${ key1 }' in version '${ version }':\n${ callbackList }\nAdd them under a new key instead (e.g. '${ suggestedKey }').` );
     }
 
     return;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the release build zip workflow's db updates check detects callbacks added under an existing key, it currently throws on the first offender, forcing the author to re-run CI to find each one. This PR changes the check to collect all newly-added callbacks and list them in a single error message so the fix can be made in one pass.

### How to test the changes in this Pull Request:

The idea is to simulate building the next 10.8 patch release (10.8.2) from a `release/10.8` branch that adds db update callbacks under an already-released key, which is what the check catches.

1. Fork this repository and enable workflows in the fork's Actions tab.
2. In the fork, go to Branches → New branch and create `release/10.8`, selecting `woocommerce/woocommerce` as the source repository and its `release/10.8` branch.
3. Merge this PR's branch into the fork's `trunk`.
4. Go to Releases → Draft a new release, type `10.8.1` as a new tag, target `release/10.8`, and publish.
5. On `release/10.8`, edit `plugins/woocommerce/woocommerce.php` with the web editor and bump the `Version:` header to `10.8.2`.
6. On `release/10.8`, edit `plugins/woocommerce/includes/class-wc-install.php` and add two fake callbacks under the `'10.8.0-2'` key of `$db_updates`, e.g. `wc_update_1082_test_one` and `wc_update_1082_test_two`.
7. Go to Actions → "Release: Build ZIP file" → Run workflow, enter `10.8` as the branch, and leave both checkboxes unchecked.
8. Confirm the verify job fails at the "Pre-build verification: db updates" step and the log shows `Comparing versions '10.8.1' and '10.8.2'`.
9. Confirm the error lists the offending callbacks:
    ```
    Error: 2 new db update callbacks were added under key '10.8.0-2' in version '10.8.2':
      - wc_update_1082_test_one
      - wc_update_1082_test_two
    Add them under a new key instead (e.g. '10.8.2').
    ```

   ([Example in my fork](https://github.com/jorgeatorres/woocommerce/actions/runs/30493704070/job/90717488789#step:9:14))
10. Remove one of the callbacks and move the remaining one under a new `'10.8.0-3'` key and re-run. Confirm the db updates step passes and the build job starts (you can cancel the run at that point).
