### PR TITLE
Bump mockery/mockery to ^1.6.10 to silence PHP 8.4 deprecations

### DIFF
--- a/plugins/woocommerce/changelog/fix-php-warnings-debug-log-mockery
+++ b/plugins/woocommerce/changelog/fix-php-warnings-debug-log-mockery
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump mockery/mockery dev dependency to ^1.6.10 to silence PHP 8.4 implicit-nullable deprecation warnings emitted on every request when opcache is disabled.

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -64,7 +64,7 @@
 		"bamarni/composer-bin-plugin": "^1.4",
 		"dms/phpunit-arraysubset-asserts": "^0.4.0",
 		"johnkary/phpunit-speedtrap": "*",
-		"mockery/mockery": "1.6.6",
+		"mockery/mockery": "^1.6.10",
 		"php-stubs/wordpress-stubs": "^6.8",
 		"phpstan/phpstan": "^2.1",
 		"phpunit/phpunit": "^9.6",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c50934dcb05857900ec57b146a3aefef",
+    "content-hash": "37bed2e19d8b44bc71451de7683919df",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -2106,16 +2106,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.6.6",
+            "version": "1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "b8e0bb7d8c604046539c1115994632c74dcb361e"
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/b8e0bb7d8c604046539c1115994632c74dcb361e",
-                "reference": "b8e0bb7d8c604046539c1115994632c74dcb361e",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
                 "shasum": ""
             },
             "require": {
@@ -2127,10 +2127,8 @@
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.6.10",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "symplify/easy-coding-standard": "^11.5.0",
-                "vimeo/psalm": "^4.30"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
             "autoload": {
@@ -2187,7 +2185,7 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2023-08-09T00:03:52+00:00"
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -5596,5 +5594,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Mockery 1.6.6 emits "implicitly nullable parameter" deprecation notices from `Mockery::formatArgs()` and `Mockery::formatObjects()` under PHP 8.4. Because Mockery registers `Mockery.php` and `helpers.php` under Composer's `files` autoload, those files are parsed on every request that loads `vendor/autoload.php`, not only during test runs, so the deprecations end up in the logs on any **dev install** running PHP 8.4+.

This PR bumps the `mockery/mockery` dev dependency from a hard pin on `1.6.6` to `^1.6.10` (currently resolves to 1.6.12). 1.6.10 [addressed the deprecation warnings](https://github.com/mockery/mockery/releases/tag/1.6.10).

> [!NOTE]
> This package is only installed on dev environments so it doesn't have any public facing consequences. For verification, tests passing and no error logs being generated should be enough.

Closes #54366.

### How to test the changes in this Pull Request:

1. Check out this branch and run `composer install` in `plugins/woocommerce/`.
2. On a PHP 8.4+ install with `WP_DEBUG_LOG` enabled and `opcache.enable=0`, load any frontend or admin page.
3. Confirm debug log doesn't contain `Mockery::formatArgs()` / `Mockery::formatObjects()` "implicitly marking parameter as nullable" deprecations.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->