### PR TITLE
Fix typos in code comments (compatability, reinstallaing, Existance, absense, accomodate)

### DIFF
--- a/plugins/woocommerce/changelog/fix-typos-in-comments
+++ b/plugins/woocommerce/changelog/fix-typos-in-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix typos in code comments: compatability, reinstallaing, Existance, absense.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/edit.tsx
@@ -25,8 +25,8 @@ export default function Edit( { attributes, setAttributes }: EditProps ) {
 	const { color, storeOnly } = attributes;
 	const blockProps = { ...useBlockProps() };
 
-	// Existance of storeOnly attribute means it doesn't have a background color,
-	// absense of custom color attribute means it's post-v1 template,
+	// Existence of storeOnly attribute means it doesn't have a background color,
+	// absence of custom color attribute means it's post-v1 template,
 	// in both cases, no need to show the color picker.
 	if ( storeOnly || ! color ) {
 		return (

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1830,7 +1830,7 @@ function wc_asort_by_locale( &$data, $locale = '' ) {
 			if ( Constants::is_true( 'WP_DEBUG' ) ) {
 				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					sprintf(
-						'An unexpected error occurred while trying to use PHP Intl Collator class, it may be caused by an incorrect installation of PHP Intl and ICU, and could be fixed by reinstallaing PHP Intl, see more details about PHP Intl installation: %1$s. Error message: %2$s',
+						'An unexpected error occurred while trying to use PHP Intl Collator class, it may be caused by an incorrect installation of PHP Intl and ICU, and could be fixed by reinstalling PHP Intl, see more details about PHP Intl installation: %1$s. Error message: %2$s',
 						'https://www.php.net/manual/en/intl.installation.php',
 						$e->getMessage()
 					)

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -238,7 +238,7 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * @return object
 	 */
 	protected function prepare_package_destination_response( $package ) {
-		// If address_1 fails check address for back compatability.
+		// If address_1 fails check address for back compatibility.
 		$address = isset( $package['destination']['address_1'] ) ? $package['destination']['address_1'] : $package['destination']['address'];
 		return (object) $this->prepare_html_response(
 			[

--- a/tools/monorepo-utils/src/ci-jobs/lib/package-file.ts
+++ b/tools/monorepo-utils/src/ci-jobs/lib/package-file.ts
@@ -23,7 +23,7 @@ const packageCache: { [ key: string ]: PackageJSON } = {};
  * @return {Object} The package file's contents.
  */
 export function loadPackage( packagePath: string ): PackageJSON {
-	// Use normalized paths to accomodate any path tokens.
+	// Use normalized paths to accommodate any path tokens.
 	packagePath = path.normalize( packagePath );
 	if ( packageCache[ packagePath ] ) {
 		return packageCache[ packagePath ];


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fix five spelling typos found in code comments across the monorepo:

| File | Typo | Correct |
|------|------|---------|
| `plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php` | `compatability` | `compatibility` |
| `plugins/woocommerce/includes/wc-core-functions.php` | `reinstallaing` | `reinstalling` |
| `plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/edit.tsx` | `Existance` | `Existence` |
| `plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/edit.tsx` | `absense` | `absence` |
| `tools/monorepo-utils/src/ci-jobs/lib/package-file.ts` | `accomodate` | `accommodate` |

All changes are in comments only — no logic is affected.

### Screenshots or screen recordings:

Not applicable — comment-only changes.

### How to test the changes in this Pull Request:

1. Review the diff — confirm each change is a comment-only spelling correction.
2. No functional testing required.

### Testing that has already taken place:

Visual diff review confirming all changes are in comments with no logic impact.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

Changelog entry added: `plugins/woocommerce/changelog/fix-typos-in-comments`