### PR TITLE
Fix typos in code identifiers and CSS class names (SUBSCRIPTON, WpAjaxReponse, email-adddress)

### DIFF
--- a/plugins/woocommerce/changelog/fix-more-typos-in-code
+++ b/plugins/woocommerce/changelog/fix-more-typos-in-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix typos in code identifiers and CSS class names: SUBSCRIPTON, WpAjaxReponse, email-adddress.

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -342,7 +342,7 @@ export const BusinessInfo = ( {
 							<TextControl
 								__nextHasNoMarginBottom
 								className={ clsx(
-									'woocommerce-profiler-business-info-email-adddress',
+									'woocommerce-profiler-business-info-email-address',
 									{ 'is-error': isEmailInvalid }
 								) }
 								onChange={ ( value ) => {

--- a/plugins/woocommerce/client/admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/style.scss
@@ -528,7 +528,7 @@
 		}
 
 		.woocommerce-profiler-question-label,
-		.woocommerce-profiler-business-info-email-adddress
+		.woocommerce-profiler-business-info-email-address
 		.components-base-control__label,
 		.woocommerce-profiler-business-info-store-name
 		.components-base-control__label {
@@ -542,14 +542,14 @@
 
 		.woocommerce-profiler-question-label
 		.woocommerce-profiler-question-required,
-		.woocommerce-profiler-business-info-email-adddress
+		.woocommerce-profiler-business-info-email-address
 		.woocommerce-profiler-question-required {
 			color: #cc1818;
 			padding-left: 3px;
 		}
 
 		.woocommerce-profiler-business-info-store-name,
-		.woocommerce-profiler-business-info-email-adddress {
+		.woocommerce-profiler-business-info-email-address {
 			.components-base-control__field {
 				margin-bottom: 8px;
 			}
@@ -565,7 +565,7 @@
 			}
 		}
 
-		.woocommerce-profiler-business-info-email-adddress.is-error {
+		.woocommerce-profiler-business-info-email-address.is-error {
 			& .components-text-control__input {
 				box-shadow: 0 0 0 1px var(--color-error);
 			}
@@ -576,11 +576,11 @@
 			width: 20px;
 		}
 
-		.woocommerce-profiler-select-control__country-spacer + .woocommerce-profiler-business-info-email-adddress {
+		.woocommerce-profiler-select-control__country-spacer + .woocommerce-profiler-business-info-email-address {
 			margin-top: 8px;
 		}
 
-		.woocommerce-profiler-business-info-email-adddress {
+		.woocommerce-profiler-business-info-email-address {
 			margin-top: 20px;
 		}
 

--- a/plugins/woocommerce/client/admin/client/marketplace/components/constants.ts
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/constants.ts
@@ -15,7 +15,7 @@ export const MARKETPLACE_IAM_SETTINGS_API_PATH =
 export const MARKETPLACE_ITEMS_PER_PAGE = 60; // This should match the number of results returned by the API
 export const MARKETPLACE_SEARCH_RESULTS_PER_PAGE = 8;
 export const MARKETPLACE_CART_PATH = MARKETPLACE_HOST + '/cart/';
-export const MARKETPLACE_RENEW_SUBSCRIPTON_PATH =
+export const MARKETPLACE_RENEW_SUBSCRIPTION_PATH =
 	MARKETPLACE_HOST + '/my-account/my-subscriptions/';
 export const MARKETPLACE_SUPPORT_PATH =
 	MARKETPLACE_HOST + '/my-account/contact-support/';

--- a/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/error-utils.ts
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/error-utils.ts
@@ -9,7 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import type { NoticeAction } from '~/lib/notices/types';
 import {
-	MARKETPLACE_RENEW_SUBSCRIPTON_PATH,
+	MARKETPLACE_RENEW_SUBSCRIPTION_PATH,
 	MARKETPLACE_SUPPORT_PATH,
 } from '../constants';
 import { ERROR_CODES_WITH_MESSAGES } from './constants';
@@ -129,7 +129,7 @@ function getConnectionErrorAction( error: ConnectError ): StoreAction | null {
 			label: __( 'Manage subscriptions', 'woocommerce' ),
 			onClick: () => {
 				trackConnectErrorActionClicked( 'manage_subscriptions', code );
-				window.location.assign( MARKETPLACE_RENEW_SUBSCRIPTON_PATH );
+				window.location.assign( MARKETPLACE_RENEW_SUBSCRIPTION_PATH );
 			},
 		};
 	}

--- a/plugins/woocommerce/client/admin/client/marketplace/utils/functions.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/utils/functions.tsx
@@ -17,7 +17,7 @@ import {
 	MARKETPLACE_CATEGORY_API_PATH,
 	MARKETPLACE_HOST,
 	MARKETPLACE_SEARCH_API_PATH,
-	MARKETPLACE_RENEW_SUBSCRIPTON_PATH,
+	MARKETPLACE_RENEW_SUBSCRIPTION_PATH,
 } from '../components/constants';
 import { Subscription } from '../components/my-subscriptions/types';
 import {
@@ -325,7 +325,7 @@ function disconnectProduct( subscription: Subscription ): Promise< void > {
 	} );
 }
 
-type WpAjaxReponse = {
+type WpAjaxResponse = {
 	success: boolean;
 	data: WpAjaxResponseData;
 };
@@ -343,7 +343,7 @@ function wpAjax(
 		theme?: string;
 		success?: boolean;
 	}
-): Promise< WpAjaxReponse > {
+): Promise< WpAjaxResponse > {
 	return new Promise( ( resolve, reject ) => {
 		if ( ! window.wp.updates ) {
 			reject( __( 'Please reload and try again', 'woocommerce' ) );
@@ -438,7 +438,7 @@ function installProduct( subscription: Subscription ): Promise< void > {
 	} );
 }
 
-function updateProduct( subscription: Subscription ): Promise< WpAjaxReponse > {
+function updateProduct( subscription: Subscription ): Promise< WpAjaxResponse > {
 	return wpAjax( 'update-' + subscription.product_type, {
 		slug: subscription.local.slug,
 		[ subscription.product_type ]: subscription.local.path,
@@ -517,9 +517,9 @@ const appendURLParams = (
 const enableAutorenewalUrl = ( subscription: Subscription ): string => {
 	if ( ! subscription.product_key ) {
 		// review subscriptions on the Marketplace
-		return MARKETPLACE_RENEW_SUBSCRIPTON_PATH;
+		return MARKETPLACE_RENEW_SUBSCRIPTION_PATH;
 	}
-	return appendURLParams( MARKETPLACE_RENEW_SUBSCRIPTON_PATH, [
+	return appendURLParams( MARKETPLACE_RENEW_SUBSCRIPTION_PATH, [
 		[ 'key', subscription.product_key.toString() ],
 	] );
 };


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fix spelling typos in code identifiers and CSS class names across the admin client:

| File | Typo | Correct |
|------|------|---------|
| `client/admin/client/marketplace/components/constants.ts` | `MARKETPLACE_RENEW_SUBSCRIPTON_PATH` | `MARKETPLACE_RENEW_SUBSCRIPTION_PATH` |
| `client/admin/client/marketplace/utils/functions.tsx` | `MARKETPLACE_RENEW_SUBSCRIPTON_PATH` (import + uses) | `MARKETPLACE_RENEW_SUBSCRIPTION_PATH` |
| `client/admin/client/marketplace/utils/functions.tsx` | `WpAjaxReponse` (type definition + uses) | `WpAjaxResponse` |
| `client/admin/client/marketplace/components/my-subscriptions/error-utils.ts` | `MARKETPLACE_RENEW_SUBSCRIPTON_PATH` (import + use) | `MARKETPLACE_RENEW_SUBSCRIPTION_PATH` |
| `client/admin/client/core-profiler/pages/BusinessInfo.tsx` | `email-adddress` (CSS class) | `email-address` |
| `client/admin/client/core-profiler/style.scss` | `email-adddress` (6 selectors) | `email-address` |

All renames are consistent across their respective definition and usage sites. No logic is affected.

### Screenshots or screen recordings:

Not applicable — identifier/class renames with no visual change.

### How to test the changes in this Pull Request:

1. Review the diff to confirm all rename sites are consistent.
2. Run `pnpm run ts:check` in `plugins/woocommerce/client/admin` — should pass with no new errors.
3. No functional testing required.

### Testing that has already taken place:

Diff review confirming all definition and usage sites were updated consistently.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

Changelog entry added: `plugins/woocommerce/changelog/fix-more-typos-in-code`