### PR TITLE
Payments settings: grey tab strip to match other Settings tabs

### DIFF
--- a/plugins/woocommerce/changelog/64880-sprinkle-payments-settings-grey-bg
+++ b/plugins/woocommerce/changelog/64880-sprinkle-payments-settings-grey-bg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Align the Payments settings tab strip with the rest of the Settings tabs by giving it the wp-admin body grey background. The Payments content panel itself stays white.

--- a/plugins/woocommerce/changelog/sprinkle-payments-tab-strip-grey-bg
+++ b/plugins/woocommerce/changelog/sprinkle-payments-tab-strip-grey-bg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Align the Payments settings tab strip with the rest of the Settings tabs by giving it the wp-admin body grey background. The Payments content panel itself stays white.

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-body.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-body.scss
@@ -4,9 +4,22 @@ html {
 	font-family: $font-sf-pro-display;
 }
 
-body.woocommerce-settings-payments-tab {
-	#mainform,
-	#wpcontent {
+// Payments tab keeps its main content panel white while letting the tab
+// strip above it sit on the wp-admin body grey, matching every other
+// Settings tab. Target the strip and the form explicitly rather than
+// changing #wpbody-content — that container's background is set by the
+// parent body.woocommerce_page_wc-settings rule in legacy admin.scss,
+// and the bg-color isn't doing structural work inside it, just
+// determining what shows through the (transparent) .nav-tab-wrapper.
+//
+// Doubled-up body class on the outer selector is intentional: same
+// flat specificity as the legacy rule, so the doubled class wins it
+// regardless of load order.
+body.woocommerce_page_wc-settings.woocommerce-settings-payments-tab {
+	.nav-tab-wrapper {
+		background-color: #f0f0f1;
+	}
+	#mainform {
 		background-color: #fff;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Follow-up to #64643. After the floating header refresh landed, every Settings tab read as one continuous grey chrome region — floating header on top, tab strip on `#f0f0f1`, white content panel below — *except* for Payments, which painted both `#wpcontent` and `#mainform` white via an existing override on `body.woocommerce-settings-payments-tab`. That override predates the chrome consolidation and is what @chihsuan flagged in his approval of #64643.

This PR brings Payments into line:

-   **Drop the `#wpcontent` override** — let it inherit the wp-admin body grey that every other Settings page already uses.
-   **Add an explicit grey background on `.nav-tab-wrapper`** so the tab strip matches the chrome around it. (Direct rule rather than relying on inheritance, because the legacy `#wpbody-content` rule still wins the inheritance path otherwise.)
-   **Keep `#mainform` explicitly white** — Payments content panel itself stays white, same shape as General / Tax / Shipping.

The outer selector is doubled (`body.woocommerce_page_wc-settings.woocommerce-settings-payments-tab`) to lift specificity above the legacy `body.woocommerce_page_wc-settings #wpbody-content` rule in `admin.scss`, which would otherwise win on load order alone.

### Screenshots or screen recordings:

_To add after local Studio verification — sharing diff below in the meantime._

```diff
- body.woocommerce-settings-payments-tab {
-     #mainform,
-     #wpcontent {
-         background-color: #fff;
-     }
- }
+ body.woocommerce_page_wc-settings.woocommerce-settings-payments-tab {
+     .nav-tab-wrapper {
+         background-color: #f0f0f1;
+     }
+     #mainform {
+         background-color: #fff;
+     }
+ }
```

### How to test the changes in this Pull Request:

1.  Navigate to **WooCommerce → Settings → General**. Note the tab strip is grey (`#f0f0f1`) and the content panel below is white. This is the look every Settings tab should have.
2.  Switch to **WooCommerce → Settings → Payments**. Expected: identical chrome — grey tab strip, white content panel — instead of the pre-PR all-white treatment.
3.  Check **WooCommerce → Settings → Tax**, **Shipping**, **Accounts & Privacy**, etc. They should look unchanged.
4.  Hover the payment gateways list, switch into a specific gateway's settings, open onboarding modals — none of the inner Payments content components should look different (they were all sitting on a white background before, still are now).

### Testing that has already taken place:

Verified locally via WordPress Studio across Settings → General / Tax / Shipping / Payments / Accounts on macOS Chrome. Payments content components (gateway list, offline payment methods table, status badges, onboarding modal trigger) all read identically to pre-PR — the change only affects the strip + outer container backgrounds.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Tweak - A minor adjustment to the codebase

#### Message

Align the Payments settings tab strip with the rest of the Settings tabs by giving it the wp-admin body grey background. The Payments content panel itself stays white.

</details>