### PR TITLE
Fix early textdomain loading regression in GraphQL API

### DIFF
--- a/plugins/woocommerce/changelog/64881-fix-graphql-early-textdomain-regression
+++ b/plugins/woocommerce/changelog/64881-fix-graphql-early-textdomain-regression
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a \`_load_textdomain_just_in_time\` notice from firing on every request when the GraphQL API feature is registered.

--- a/plugins/woocommerce/changelog/64881-fix-graphql-early-textdomain-regression
+++ b/plugins/woocommerce/changelog/64881-fix-graphql-early-textdomain-regression
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent a \`_load_textdomain_just_in_time\` notice from firing on every request when the GraphQL API feature is registered.
+Prevent a `_load_textdomain_just_in_time` notice from firing on every request when the GraphQL API feature is registered.

--- a/plugins/woocommerce/src/Internal/Api/Main.php
+++ b/plugins/woocommerce/src/Internal/Api/Main.php
@@ -174,9 +174,7 @@ class Main {
 		$settings = wc_get_container()->get( Settings::class );
 		$settings->register();
 
-		if ( self::is_enabled() ) {
-			add_action( OpcacheFileExpiry::ACTION_HOOK, array( OpcacheFileExpiry::class, 'handle_cleanup_action' ) );
-		}
+		add_action( OpcacheFileExpiry::ACTION_HOOK, array( OpcacheFileExpiry::class, 'handle_cleanup_action' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
+++ b/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
@@ -81,8 +81,10 @@ class OpcacheFileExpiry {
 	/**
 	 * Schedule the cleanup if it isn't already scheduled.
 	 *
-	 * Called from {@see QueryCache::write_to_opcache()} so the first run is
-	 * triggered by the first write — no separate bootstrap step.
+	 * Called from {@see QueryCache::write_to_opcache()} and
+	 * {@see QueryCache::read_from_opcache()} so the cleanup is rescheduled
+	 * after a feature-disable/re-enable cycle even when every request hits a
+	 * cached file (no writes).
 	 */
 	public static function ensure_scheduled(): void {
 		if ( wp_cache_get( self::SCHEDULED_CACHE_KEY, QueryCache::CACHE_GROUP ) ) {

--- a/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
+++ b/plugins/woocommerce/src/Internal/Api/OpcacheFileExpiry.php
@@ -62,12 +62,16 @@ class OpcacheFileExpiry {
 	 * Action Scheduler callback: delete expired files and reschedule.
 	 *
 	 * Immediate reschedule when files were deleted (drain the backlog), 24h
-	 * otherwise.
+	 * otherwise. Skipped when the feature is disabled.
 	 *
 	 * @internal
 	 */
 	public static function handle_cleanup_action(): void {
 		$interval = self::delete_expired_files() > 0 ? 1 : DAY_IN_SECONDS;
+
+		if ( ! Main::is_enabled() ) {
+			return;
+		}
 
 		if ( function_exists( 'as_schedule_single_action' ) ) {
 			as_schedule_single_action( time() + $interval, self::ACTION_HOOK, array(), self::ACTION_GROUP );

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -367,10 +367,13 @@ class QueryCache {
 		}
 
 		try {
-			return AST::fromArray( $data );
+			$document = AST::fromArray( $data );
 		} catch ( \Throwable $e ) {
 			return false;
 		}
+
+		OpcacheFileExpiry::ensure_scheduled();
+		return $document;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Api/QueryCache.php
+++ b/plugins/woocommerce/src/Internal/Api/QueryCache.php
@@ -367,13 +367,12 @@ class QueryCache {
 		}
 
 		try {
-			$document = AST::fromArray( $data );
+			return AST::fromArray( $data );
 		} catch ( \Throwable $e ) {
 			return false;
+		} finally {
+			OpcacheFileExpiry::ensure_scheduled();
 		}
-
-		OpcacheFileExpiry::ensure_scheduled();
-		return $document;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Reverts the early `Main::is_enabled()` call PR #64596 added to `Main::register()`, which triggered `_load_textdomain_just_in_time` on every request. Adds an `is_enabled()` check inside `OpcacheFileExpiry::handle_cleanup_action()` so a queued cleanup runs once more and then stops if the feature has been disabled.

Additionally, makes sure that the action that deletes expired OPcache-backed query cache entries is scheduled even when reusing cached queries. This covers the case of users disabling and re-enabling the dual API feature: without this change, after re-enabling the feature the action would never be scheduled as long as already cached queries were executed.

### How to test the changes in this Pull Request:

To test the textdomain warning:

1. Enable `WP_DEBUG` in `wp-config.php`.
2. On `trunk`, load any wp-admin or front-end page and confirm a `_load_textdomain_just_in_time` notice appears for the `woocommerce` domain.
3. Check out this branch, load the same page again. Confirm the notice no longer appears.

To test the action re-scheduling:

4. Perform any GraphQL query to force a cache entry, for example:

```sh
curl -X POST -H 'Content-Type: application/json' \
  -d '{"query":"{ __typename }"}' \
  http://your-site.test/wp-json/wc/graphql
```

(if it fails saying that you don't have permissions, add this to your server: `add_filter( 'woocommerce_graphql_can_introspect', '__return_true' );` )

5. Go to WooCommerce - Status - Scheduled actions and verify that there's a pending `woocommerce_graphql_opcache_cleanup` action.

6. Disable the feature: `wp option update woocommerce_feature_dual_code_graphql_api_enabled no`

7. Run the scheduled action. You'll see that it doesn't get re-scheduled, as expected.

8. If you are using a persistent object cache, clear it.

9. Re-enable the feature: `wp option update woocommerce_feature_dual_code_graphql_api_enabled yes`

10. Re-run the same query from step 4 and verify that the action is scheduled again. Without this change, that wouldn't be the case.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Prevent a `_load_textdomain_just_in_time` notice from firing on every request when the GraphQL API feature is registered.

</details>
