### PR TITLE
Fix typos in code: linkToDescrption, unkown-status, identifer

### DIFF
--- a/plugins/woocommerce/changelog/fix-typos-round-3
+++ b/plugins/woocommerce/changelog/fix-typos-round-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix typos in code: linkToDescrption, unkown-status, identifer.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/edit.tsx
@@ -132,7 +132,7 @@ const LinkToDescription = ( {
 	return (
 		<p>
 			<RichText
-				identifier="linkToDescrption"
+				identifier="linkToDescription"
 				className="wc-block-components-product-summary__more-link"
 				tagName="a"
 				aria-label={ __( '“Read more” link text', 'woocommerce' ) }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractSchema.php
@@ -251,7 +251,7 @@ abstract class AbstractSchema {
 	/**
 	 * Returns extended schema for a specific endpoint.
 	 *
-	 * @param string $endpoint The endpoint identifer.
+	 * @param string $endpoint The endpoint identifier.
 	 * @param array  ...$passed_args An array of arguments to be passed to callbacks.
 	 * @return array the data that will get added.
 	 */

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -95,7 +95,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		}
 
 		// Invalid status returns 0.
-		$this->assertEquals( 0, wc_orders_count( 'unkown-status' ) );
+		$this->assertEquals( 0, wc_orders_count( 'unknown-status' ) );
 
 		// Invalid order type should return 0.
 		$this->assertEquals( 0, wc_orders_count( OrderInternalStatus::PENDING, 'invalid-order-type' ) );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fix three spelling typos found across blocks, tests, and Store API:

| File | Typo | Correct |
|------|------|---------|
| `client/blocks/.../product-elements/summary/edit.tsx` | `linkToDescrption` (RichText identifier) | `linkToDescription` |
| `tests/legacy/unit-tests/order/class-wc-tests-order-functions.php` | `unkown-status` (test string value) | `unknown-status` |
| `src/StoreApi/Schemas/V1/AbstractSchema.php` | `identifer` (PHPDoc `@param`) | `identifier` |

The RichText `identifier` is attribute-based (paired with `value`/`onChange`), so renaming it does not affect serialized block HTML. All changes are low-risk.

### Screenshots or screen recordings:

Not applicable.

### How to test the changes in this Pull Request:

1. Review the diff — confirm each change is a spelling correction only.
2. No functional testing required.

### Testing that has already taken place:

Diff review confirming all changes are isolated spelling corrections with no logic impact.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added: `plugins/woocommerce/changelog/fix-typos-round-3`