### PR TITLE
Improve Shop page editor experience

### DIFF
--- a/plugins/woocommerce/changelog/tangerine-f1918dc0
+++ b/plugins/woocommerce/changelog/tangerine-f1918dc0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add a non-dismissible warning notice when editing the Shop page in the block editor, explaining that layout and content are managed by the Product Catalog template.

--- a/plugins/woocommerce/changelog/tangerine-f1918dc0
+++ b/plugins/woocommerce/changelog/tangerine-f1918dc0
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Add a non-dismissible warning notice when editing the Shop page in the block editor, explaining that layout and content are managed by the Product Catalog template.
+Improve the Shop page editing experience in the block editor.

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews;
 use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides;
+use Automattic\WooCommerce\Internal\Admin\ShopPageEditor;
 
 /**
  * Loader Class.
@@ -72,6 +73,7 @@ class Loader {
 
 		wc_get_container()->get( Reviews::class );
 		wc_get_container()->get( ReviewsCommentsOverrides::class );
+		wc_get_container()->get( ShopPageEditor::class );
 
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_filter( 'admin_title', array( __CLASS__, 'update_admin_title' ) );

--- a/plugins/woocommerce/src/Internal/Admin/ShopPageEditor.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShopPageEditor.php
@@ -1,0 +1,64 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Admin;
+
+/**
+ * Displays a non-dismissible warning notice in the block editor when
+ * editing the Shop page, mirroring the WordPress core pattern for the
+ * Posts page (blog home).
+ *
+ * @since 10.9.0
+ */
+class ShopPageEditor {
+
+	/**
+	 * Hook into the block editor load.
+	 */
+	public function __construct() {
+		add_action( 'enqueue_block_editor_assets', array( $this, 'maybe_add_shop_page_notice' ) );
+	}
+
+	/**
+	 * Enqueue a warning notice when editing the Shop page.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 * @since 10.9.0
+	 */
+	public function maybe_add_shop_page_notice(): void {
+		$screen = get_current_screen();
+
+		if ( ! $screen || 'page' !== $screen->post_type ) {
+			return;
+		}
+
+		$shop_page_id = wc_get_page_id( 'shop' );
+
+		if ( $shop_page_id <= 0 ) {
+			return;
+		}
+
+		global $post;
+
+		if ( ! $post || (int) $post->ID !== $shop_page_id ) {
+			return;
+		}
+
+		$template_edit_url = admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Farchive-product' );
+
+		$notice_text = sprintf(
+			/* translators: %s: URL to edit the Product Catalog template in the Site Editor */
+			__( 'You are currently editing the Shop page. The layout and content of this page are managed by the <a href="%s">Product Catalog template</a>.', 'woocommerce' ),
+			esc_url( $template_edit_url )
+		);
+
+		wp_add_inline_script(
+			'wp-notices',
+			sprintf(
+				'wp.data.dispatch( "core/notices" ).createWarningNotice( "%s", { isDismissible: false, __unstableHTML: true } )',
+				wp_slash( $notice_text )
+			),
+			'after'
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/ShopPageEditor.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShopPageEditor.php
@@ -17,6 +17,10 @@ class ShopPageEditor {
 	 */
 	public function __construct() {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'maybe_add_shop_page_notice' ) );
+		add_filter( 'display_post_states', array( $this, 'add_shop_page_state' ), 10, 2 );
+		add_filter( 'theme_page_templates', array( $this, 'hide_shop_page_templates' ), 10, 4 );
+		add_filter( 'block_editor_settings_all', array( $this, 'lock_shop_page_template_selector' ), 10, 2 );
+		add_action( 'admin_bar_menu', array( $this, 'add_shop_page_edit_link' ), 80 );
 	}
 
 	/**
@@ -26,23 +30,11 @@ class ShopPageEditor {
 	 * @since 10.9.0
 	 */
 	public function maybe_add_shop_page_notice(): void {
-		$screen = get_current_screen();
-
-		if ( ! $screen || 'page' !== $screen->post_type ) {
+		if ( ! $this->is_shop_page_block_editor() ) {
 			return;
 		}
 
 		$shop_page_id = wc_get_page_id( 'shop' );
-
-		if ( $shop_page_id <= 0 ) {
-			return;
-		}
-
-		global $post;
-
-		if ( ! $post || (int) $post->ID !== $shop_page_id ) {
-			return;
-		}
 
 		$template_edit_url = admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Farchive-product' );
 
@@ -60,5 +52,124 @@ class ShopPageEditor {
 			),
 			'after'
 		);
+	}
+
+	/**
+	 * Add a Shop Page state label in the page list table and editor header.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 * @since 10.9.0
+	 *
+	 * @param array<string, string> $post_states  Post states.
+	 * @param \WP_Post              $post         Post object.
+	 * @return array<string, string>
+	 */
+	public function add_shop_page_state( array $post_states, \WP_Post $post ): array {
+		if ( $this->is_shop_page_id( (int) $post->ID ) ) {
+			$post_states['woocommerce_shop_page'] = _x( 'Shop page', 'page label', 'woocommerce' );
+		}
+
+		return $post_states;
+	}
+
+	/**
+	 * Remove page template choices for the Shop page, matching the Posts page behavior.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 * @since 10.9.0
+	 *
+	 * @param array<string, string> $page_templates  Page templates.
+	 * @param \WP_Theme             $theme           Theme object.
+	 * @param \WP_Post|null         $post            Post object.
+	 * @param string                $post_type       Post type.
+	 * @return array<string, string>
+	 */
+	public function hide_shop_page_templates( array $page_templates, \WP_Theme $theme, ?\WP_Post $post, string $post_type ): array {
+		if ( 'page' === $post_type && $post && $this->is_shop_page_id( (int) $post->ID ) ) {
+			return array();
+		}
+
+		return $page_templates;
+	}
+
+	/**
+	 * Disable the block editor template selector for the Shop page.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 * @since 10.9.0
+	 *
+	 * @param array<string, mixed>     $editor_settings Block editor settings.
+	 * @param \WP_Block_Editor_Context $editor_context  Block editor context.
+	 * @return array<string, mixed>
+	 */
+	public function lock_shop_page_template_selector( array $editor_settings, \WP_Block_Editor_Context $editor_context ): array {
+		if ( ! empty( $editor_context->post ) && $this->is_shop_page_id( (int) $editor_context->post->ID ) ) {
+			$editor_settings['availableTemplates'] = array();
+		}
+
+		return $editor_settings;
+	}
+
+	/**
+	 * Add an admin bar link to edit the Shop page from the frontend.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 * @since 10.9.0
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar Admin bar instance.
+	 */
+	public function add_shop_page_edit_link( \WP_Admin_Bar $wp_admin_bar ): void {
+		if ( is_admin() || ! is_shop() ) {
+			return;
+		}
+
+		$shop_page_id = wc_get_page_id( 'shop' );
+
+		if ( $shop_page_id <= 0 || ! current_user_can( 'edit_post', $shop_page_id ) ) {
+			return;
+		}
+
+		$edit_link = get_edit_post_link( $shop_page_id );
+
+		if ( ! $edit_link ) {
+			return;
+		}
+
+		$wp_admin_bar->add_node(
+			array(
+				'id'    => 'edit',
+				'title' => __( 'Edit page', 'woocommerce' ),
+				'href'  => $edit_link,
+			)
+		);
+	}
+
+	/**
+	 * Check if the current block editor screen edits the Shop page.
+	 *
+	 * @return bool
+	 */
+	private function is_shop_page_block_editor(): bool {
+		$screen = get_current_screen();
+
+		if ( ! $screen || 'page' !== $screen->post_type ) {
+			return false;
+		}
+
+		global $post;
+
+		return $post instanceof \WP_Post && $this->is_shop_page_id( (int) $post->ID );
+	}
+
+	/**
+	 * Check whether a post ID is the configured Shop page.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	private function is_shop_page_id( int $post_id ): bool {
+		$shop_page_id = wc_get_page_id( 'shop' );
+
+		return $shop_page_id > 0 && $post_id === $shop_page_id;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ShopPageEditorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ShopPageEditorTest.php
@@ -145,6 +145,63 @@ class ShopPageEditorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should add a Shop page post state label.
+	 */
+	public function test_adds_shop_page_post_state(): void {
+		$shop_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+
+		$post_states = $this->sut->add_shop_page_state( array(), get_post( $shop_page_id ) );
+
+		$this->assertSame( 'Shop page', $post_states['woocommerce_shop_page'] );
+	}
+
+	/**
+	 * @testdox Should hide template choices for the Shop page.
+	 */
+	public function test_hides_template_choices_for_shop_page(): void {
+		$shop_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+
+		$page_templates = $this->sut->hide_shop_page_templates(
+			array( 'template.php' => 'Template' ),
+			wp_get_theme(),
+			get_post( $shop_page_id ),
+			'page'
+		);
+
+		$this->assertSame( array(), $page_templates );
+	}
+
+	/**
+	 * @testdox Should keep template choices for non-Shop pages.
+	 */
+	public function test_keeps_template_choices_for_non_shop_page(): void {
+		$page_id        = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$page_templates = array( 'template.php' => 'Template' );
+
+		$this->assertSame(
+			$page_templates,
+			$this->sut->hide_shop_page_templates( $page_templates, wp_get_theme(), get_post( $page_id ), 'page' )
+		);
+	}
+
+	/**
+	 * @testdox Should disable available templates in block editor settings for the Shop page.
+	 */
+	public function test_disables_available_templates_for_shop_page(): void {
+		$shop_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+
+		$settings = $this->sut->lock_shop_page_template_selector(
+			array( 'availableTemplates' => array( 'template.php' => 'Template' ) ),
+			new \WP_Block_Editor_Context( array( 'post' => get_post( $shop_page_id ) ) )
+		);
+
+		$this->assertSame( array(), $settings['availableTemplates'] );
+	}
+
+	/**
 	 * Set the current screen to a given post type.
 	 *
 	 * @param string $post_type Post type slug.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ShopPageEditorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ShopPageEditorTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Tests for the ShopPageEditor class.
+ *
+ * @package WooCommerce\Tests\Internal\Admin
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use Automattic\WooCommerce\Internal\Admin\ShopPageEditor;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the ShopPageEditor class.
+ */
+class ShopPageEditorTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ShopPageEditor
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new ShopPageEditor();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Cleaning up test state.
+		unset( $GLOBALS['current_screen'], $GLOBALS['post'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should not enqueue notice when screen is not a page.
+	 */
+	public function test_does_not_enqueue_notice_for_non_page_screen(): void {
+		$this->set_current_screen( 'post' );
+
+		$this->sut->maybe_add_shop_page_notice();
+
+		$this->assertFalse(
+			$this->has_inline_script_containing( 'createWarningNotice' ),
+			'Notice should not be enqueued for non-page post types'
+		);
+	}
+
+	/**
+	 * @testdox Should not enqueue notice when editing a page that is not the shop page.
+	 */
+	public function test_does_not_enqueue_notice_for_non_shop_page(): void {
+		$page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$this->set_current_screen( 'page' );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Setting up test state.
+		$GLOBALS['post'] = get_post( $page_id );
+
+		$this->sut->maybe_add_shop_page_notice();
+
+		$this->assertFalse(
+			$this->has_inline_script_containing( 'createWarningNotice' ),
+			'Notice should not be enqueued for non-shop pages'
+		);
+	}
+
+	/**
+	 * @testdox Should enqueue notice when editing the shop page.
+	 */
+	public function test_enqueues_notice_for_shop_page(): void {
+		$shop_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+		$this->set_current_screen( 'page' );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Setting up test state.
+		$GLOBALS['post'] = get_post( $shop_page_id );
+
+		$this->sut->maybe_add_shop_page_notice();
+
+		$this->assertTrue(
+			$this->has_inline_script_containing( 'createWarningNotice' ),
+			'Notice should be enqueued for the shop page'
+		);
+	}
+
+	/**
+	 * @testdox Should include a link to the Product Catalog template in the notice.
+	 */
+	public function test_notice_includes_template_link(): void {
+		$shop_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+		$this->set_current_screen( 'page' );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Setting up test state.
+		$GLOBALS['post'] = get_post( $shop_page_id );
+
+		$this->sut->maybe_add_shop_page_notice();
+
+		$this->assertTrue(
+			$this->has_inline_script_containing( 'archive-product' ),
+			'Notice should include link to Product Catalog template'
+		);
+	}
+
+	/**
+	 * @testdox Should make the notice non-dismissible.
+	 */
+	public function test_notice_is_non_dismissible(): void {
+		$shop_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+		$this->set_current_screen( 'page' );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Setting up test state.
+		$GLOBALS['post'] = get_post( $shop_page_id );
+
+		$this->sut->maybe_add_shop_page_notice();
+
+		$this->assertTrue(
+			$this->has_inline_script_containing( 'isDismissible: false' ),
+			'Notice should be non-dismissible'
+		);
+	}
+
+	/**
+	 * @testdox Should not enqueue notice when no shop page is configured.
+	 */
+	public function test_does_not_enqueue_notice_when_no_shop_page_set(): void {
+		delete_option( 'woocommerce_shop_page_id' );
+		$this->set_current_screen( 'page' );
+		$page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Setting up test state.
+		$GLOBALS['post'] = get_post( $page_id );
+
+		$this->sut->maybe_add_shop_page_notice();
+
+		$this->assertFalse(
+			$this->has_inline_script_containing( 'createWarningNotice' ),
+			'Notice should not be enqueued when no shop page is configured'
+		);
+	}
+
+	/**
+	 * Set the current screen to a given post type.
+	 *
+	 * @param string $post_type Post type slug.
+	 */
+	private function set_current_screen( string $post_type ): void {
+		set_current_screen( 'post' );
+		$screen            = get_current_screen();
+		$screen->post_type = $post_type;
+	}
+
+	/**
+	 * Check if wp-notices has an inline script containing the given string.
+	 *
+	 * @param string $needle String to search for.
+	 * @return bool
+	 */
+	private function has_inline_script_containing( string $needle ): bool {
+		$scripts = wp_scripts();
+
+		if ( ! isset( $scripts->registered['wp-notices'] ) ) {
+			return false;
+		}
+
+		$script = $scripts->registered['wp-notices'];
+
+		if ( empty( $script->extra['after'] ) ) {
+			return false;
+		}
+
+		foreach ( $script->extra['after'] as $inline ) {
+			if ( strpos( $inline, $needle ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Improve the block editor experience for the configured WooCommerce Shop page so it behaves closer to WordPress core's Posts page editing flow:

- Adds a non-dismissible warning notice explaining Shop page layout/content is controlled by the Product Catalog template.
- Adds a Shop page post state label.
- Hides/disables page template selection for the Shop page.
- Adds a frontend admin bar Edit page link for the Shop page.

Closes #42152.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Configure a Shop page in WooCommerce settings.
2. Open the Shop page in the block editor and verify the warning notice appears and cannot be dismissed.
3. Verify the page has a Shop page badge/state and the template selector cannot be changed.
4. View the Shop page on the frontend while logged in and verify the admin bar Edit page link opens the Shop page editor.

<!-- End testing instructions -->

### Testing that has already taken place:

- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`.
- Ran `composer exec -- phpstan analyse src/Internal/Admin/ShopPageEditor.php --memory-limit=2G`.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`.
- Tried PHP unit tests via wp-env; blocked because environment is not initialized.
- Tried local PHPUnit; blocked because `/tmp/wordpress-tests-lib` is missing.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Improve the Shop page editing experience in the block editor.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
