### PR TITLE
Set product image tooltip aria-label via DOM attribute

### DIFF
--- a/plugins/woocommerce/changelog/64888-fix-wooplug-6580-tooltip-aria-label
+++ b/plugins/woocommerce/changelog/64888-fix-wooplug-6580-tooltip-aria-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product image tooltip: set aria-label via DOM attribute instead of interpolating the translated string into the HTML template, preventing broken markup when the translation contains characters such as quotes.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1,4 +1,4 @@
-/*global woocommerce_admin_meta_boxes */
+/*global woocommerce_admin_meta_boxes, _ */
 jQuery( function ( $ ) {
 	let isPageUnloading = false;
 
@@ -1443,8 +1443,10 @@ jQuery( function ( $ ) {
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );
+	// Escape the translated label before interpolating into the attribute so a
+	// translation containing quotes or markup cannot break the rendered span.
 	const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${
-		woocommerce_admin_meta_boxes.i18n_product_image_tip
+		_.escape( woocommerce_admin_meta_boxes.i18n_product_image_tip )
 	}"></span>`;
 	const tooltipData = {
 		attribute: 'data-tip',

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -550,7 +550,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			/* phpcs:disable */
 			if ( in_array( $screen_id, array( 'product', 'edit-product' ) ) ) {
 				wp_enqueue_media();
-				wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models' ), $version );
+				wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models', 'underscore' ), $version );
 				wp_register_script( 'wc-admin-variation-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product-variation' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-serializejson', 'media-models', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal', 'wp-data', 'wp-notices' ), $version );
 
 				wp_enqueue_script( 'wc-admin-product-meta-boxes' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The product image tooltip (next to *Set product image* / *Add product gallery images* in the product edit screen) built its markup by interpolating the translated `i18n_product_image_tip` string into an HTML template literal:

```js
const tooltipMarkup = `<span class="woocommerce-help-tip" tabindex="0" aria-label="${
    woocommerce_admin_meta_boxes.i18n_product_image_tip
}"></span>`;
```

If a translation of that string contained a double-quote (or HTML), the resulting `aria-label` attribute would be malformed.

This PR builds the span without the `aria-label` baked into the template, then sets the attribute via jQuery's `.attr()` — which handles escaping — keeping the rest of the call chain identical.

Closes #64282.

### Screenshots or screen recordings:

No UI change.

### How to test the changes in this Pull Request:

1. Open any product edit screen (classic editor).
2. In the *Product image* meta box, hover the help-tip span next to *Set product image* — the tooltip should appear with the same text as before.
3. Confirm the tooltip is also keyboard-focusable and announced with the same `aria-label`.
4. Repeat for *Add product gallery images*.
5. (Regression) DevTools → inspect the rendered `<span class="woocommerce-help-tip">` — `aria-label` should match `woocommerce_admin_meta_boxes.i18n_product_image_tip`.

### Testing that has already taken place:

- ESLint passes on `meta-boxes-product.js`.
- Verified the rendered markup in DevTools matches the original output for the English source string.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Product image tooltip: set aria-label via DOM attribute instead of interpolating the translated string into the HTML template, preventing broken markup when the translation contains characters such as quotes.

</details>