### PR TITLE
Announce order note save to screen readers

### DIFF
--- a/plugins/woocommerce/changelog/64891-fix-wooplug-6629-order-notes-a11y
+++ b/plugins/woocommerce/changelog/64891-fix-wooplug-6629-order-notes-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Announce order note save success to screen readers when adding a note from the order admin meta box, distinguishing between private notes and customer-emailed notes (WCAG 4.1.3).

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1405,6 +1405,17 @@ jQuery( function ( $ ) {
 				$( 'ul.order_notes' ).prepend( response );
 				$( '#woocommerce-order-notes' ).unblock();
 				$( '#add_order_note' ).val( '' );
+
+				// Announce the result to screen readers (WCAG 4.1.3).
+				if ( window.wp && window.wp.a11y && 'function' === typeof window.wp.a11y.speak ) {
+					var message = 'customer' === data.note_type
+						? woocommerce_admin_meta_boxes.i18n_customer_order_note_added
+						: woocommerce_admin_meta_boxes.i18n_order_note_added;
+					if ( message ) {
+						window.wp.a11y.speak( message, 'polite' );
+					}
+				}
+
 				window.wcTracks.recordEvent( 'order_edit_add_order_note', {
 					order_id: woocommerce_admin_meta_boxes.post_id,
 					note_type: data.note_type || 'private',

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -595,7 +595,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			if ( $this->is_order_meta_box_screen( $screen_id ) ) {
 				$default_location = wc_get_customer_default_location();
 
-				wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-backbone-modal', 'selectWoo', 'wc-clipboard' ), $version );
+				wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-backbone-modal', 'selectWoo', 'wc-clipboard', 'wp-a11y' ), $version );
 				wp_localize_script(
 					'wc-admin-order-meta-boxes',
 					'woocommerce_admin_meta_boxes_order',
@@ -704,6 +704,8 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_delete_note'                                => __( 'Are you sure you wish to delete this note? This action cannot be undone.', 'woocommerce' ),
 					'i18n_delete_customer_note'                       => __( 'Are you sure you wish to delete this note? This action cannot be undone. Caution: This only removes the note from your records — it does not recall the email already sent to the customer.', 'woocommerce' ),
 					'i18n_no_notes_yet'                               => __( 'There are no notes yet.', 'woocommerce' ),
+					'i18n_order_note_added'                           => __( 'Order note added.', 'woocommerce' ),
+					'i18n_customer_order_note_added'                  => __( 'Order note added and emailed to the customer.', 'woocommerce' ),
 					'i18n_apply_coupon'                               => __( 'Enter a coupon code to apply. Discounts are applied to line totals, before taxes.', 'woocommerce' ),
 					'i18n_add_fee'                                    => __( 'Enter a fixed amount or percentage to apply as a fee.', 'woocommerce' ),
 					'i18n_attribute_name_placeholder'                 => __( 'New attribute', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a store admin adds an order note from the *Order notes* meta box on the order edit screen, the new note is prepended to the list via AJAX but nothing is announced to assistive technology. Screen reader users have no way to know whether the note was saved or — for customer notes — that it was emailed. This fails WCAG 4.1.3 Status Messages (Level AA).

This PR fixes it by calling `wp.a11y.speak()` after the AJAX success handler:

- For private notes: "Order note added."
- For customer notes: "Order note added and emailed to the customer."

Localized strings live alongside the other order meta-box i18n entries in `class-wc-admin-assets.php`. `wp-a11y` is declared as a dependency of the order meta-boxes script so the function is available when called.

Closes #64512.

### Screenshots or screen recordings:

No visible UI change. Screen reader behaviour:

| Before | After |
| ------ | ----- |
| Silent on save | "Order note added." (private) / "Order note added and emailed to the customer." (customer note) |

### How to test the changes in this Pull Request:

1. Open WP admin → WooCommerce → Orders → any order.
2. Turn on a screen reader (NVDA, VoiceOver, or JAWS).
3. Scroll to the Order notes meta box.
4. Select note type "Private note", type any text, click Add.
5. Confirm the screen reader announces "Order note added.".
6. Repeat with "Note to customer" — confirm the announcement is "Order note added and emailed to the customer.".
7. Confirm the visual UI is unchanged (no extra elements rendered).

### Testing that has already taken place:

- Confirmed `wp.a11y.speak()` is namespaced behind a `typeof` check so missing `wp-a11y` won't throw.
- ESLint passes on `meta-boxes-order.js`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Announce order note save success to screen readers when adding a note from the order admin meta box, distinguishing between private notes and customer-emailed notes (WCAG 4.1.3).

</details>