### PR TITLE
Skip malformed entries in order-details actions loop

### DIFF
--- a/plugins/woocommerce/changelog/64892-fix-wooplug-6623-order-details-hardening
+++ b/plugins/woocommerce/changelog/64892-fix-wooplug-6623-order-details-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Internal: skip malformed entries returned by the wc_get_account_orders_actions filter when rendering the order details actions list to avoid notices on stricter PHP versions.

--- a/plugins/woocommerce/templates/myaccount/orders.php
+++ b/plugins/woocommerce/templates/myaccount/orders.php
@@ -14,7 +14,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.5.0
+ * @version 10.9.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -75,6 +75,10 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 								if ( ! empty( $actions ) ) {
 									foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+										// wc_get_account_orders_actions() is filterable; skip entries that don't expose the keys we render.
+										if ( ! is_array( $action ) || empty( $action['name'] ) || empty( $action['url'] ) ) {
+											continue;
+										}
 										if ( empty( $action['aria-label'] ) ) {
 											// Generate the aria-label based on the action name.
 											/* translators: %1$s Action name, %2$s Order number. */

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -120,6 +120,10 @@ if ( $show_downloads ) {
 						<?php
 						$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 						foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+							// wc_get_account_orders_actions() is filterable; skip entries that don't expose the keys we render.
+							if ( ! is_array( $action ) || empty( $action['name'] ) || empty( $action['url'] ) ) {
+								continue;
+							}
 							if ( empty( $action['aria-label'] ) ) {
 								// Generate the aria-label based on the action name.
 								/* translators: %1$s Action name, %2$s Order number. */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `$actions` loop in `templates/order/order-details.php` renders action links from `wc_get_account_orders_actions()`, whose return value is filterable via `woocommerce_my_account_my_orders_actions`. If a third-party extension returns an entry that is not an array (e.g. `false`) or is missing the `name`/`url` keys, the existing code emits PHP warnings on stricter PHP versions (8.x+ tightening around scalar-as-array access) and renders broken anchor markup with empty `href`/text.

This PR adds a single guard at the top of the loop body that skips such entries cleanly. Kept intentionally minimal — the existing `empty()` check on `aria-label` already handles its absence; no additional cast cascade or scalar-vs-string dance is needed.

Identified during review of #64358 — the structural fix in that PR was kept narrow, and this hardening was deferred to a follow-up per @Aljullu's request.

Closes #64465.

### Screenshots or screen recordings:

No UI change in the normal case. Malformed extension entries no longer render or emit notices.

### How to test the changes in this Pull Request:

1. As a customer with at least one completed order, visit *My account → Orders* — confirm the Actions column renders the standard buttons (View, Pay, Cancel where applicable) exactly as before.
2. Add a temporary filter in a mu-plugin or `functions.php` to inject a malformed entry:
   ```php
   add_filter( 'woocommerce_my_account_my_orders_actions', function ( \$actions ) {
       \$actions['broken-array'] = false;
       \$actions['missing-keys'] = array( 'aria-label' => 'no name or url' );
       return \$actions;
   } );
   ```
3. Reload the My Orders / Order details page. Confirm no broken anchors render, no PHP warnings appear in the log, and legitimate actions still render normally.
4. Remove the filter — output is identical to step 1.

### Testing that has already taken place:

- PHPCS passes on `order-details.php`.
- PHPStan output is unchanged before/after (pre-existing template typing errors are present on trunk and are out of scope here).
- Manual reproduction with the malformed-entry filter above confirms the guard skips entries cleanly.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Internal: skip malformed entries returned by the wc_get_account_orders_actions filter when rendering the order details actions list to avoid notices on stricter PHP versions.

</details>