### PR TITLE
fix: use IPv6-capable HTTPS ipify endpoint in WC_Geolocation

### DIFF
--- a/plugins/woocommerce/changelog/64898-ai-agent-rsmapgj-423-1778756902
+++ b/plugins/woocommerce/changelog/64898-ai-agent-rsmapgj-423-1778756902
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use the IPv6-capable HTTPS ipify endpoint in WC_Geolocation so external IP lookups behave consistently with the other lookup providers.

--- a/plugins/woocommerce/changelog/64898-ai-agent-rsmapgj-423-1778756902
+++ b/plugins/woocommerce/changelog/64898-ai-agent-rsmapgj-423-1778756902
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Use the IPv6-capable HTTPS ipify endpoint in WC_Geolocation so external IP lookups behave consistently with the other lookup providers.

--- a/plugins/woocommerce/changelog/fix-rsmapgj-423
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-423
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment:
+
+Use the IPv6-capable HTTPS ipify endpoint in WC_Geolocation so external IP lookups behave consistently with the other lookup providers.

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -47,7 +47,7 @@ class WC_Geolocation {
 	 * @var array
 	 */
 	private static $ip_lookup_apis = array(
-		'ipify'  => 'http://api.ipify.org/',
+		'ipify'  => 'https://api64.ipify.org/',
 		'ipecho' => 'http://ipecho.net/plain',
 		'ident'  => 'http://ident.me',
 		'tnedi'  => 'http://tnedi.me',

--- a/plugins/woocommerce/tests/php/includes/class-wc-geolocation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-geolocation-test.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WC_Geolocation tests.
+ *
+ * @package WooCommerce\Tests\Geolocation.
+ */
+
+/**
+ * Class WC_Geolocation_Test.
+ */
+class WC_Geolocation_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Returns the value of the private static `$ip_lookup_apis` property.
+	 *
+	 * @return array
+	 */
+	private function get_ip_lookup_apis(): array {
+		$reflection = new ReflectionClass( WC_Geolocation::class );
+		$property   = $reflection->getProperty( 'ip_lookup_apis' );
+		$property->setAccessible( true );
+
+		return (array) $property->getValue();
+	}
+
+	/**
+	 * @testdox Should expose the ipify IP lookup API entry.
+	 */
+	public function test_ipify_entry_is_present(): void {
+		$apis = $this->get_ip_lookup_apis();
+
+		$this->assertArrayHasKey( 'ipify', $apis, 'ipify entry should remain available in the IP lookup APIs list.' );
+	}
+
+	/**
+	 * @testdox Should not use plain HTTP for the ipify IP lookup endpoint.
+	 */
+	public function test_ipify_endpoint_does_not_use_plain_http(): void {
+		$apis = $this->get_ip_lookup_apis();
+
+		$this->assertArrayHasKey( 'ipify', $apis );
+		$this->assertStringStartsNotWith(
+			'http://',
+			$apis['ipify'],
+			'The ipify endpoint should not use plain HTTP because that variant does not support IPv6.'
+		);
+	}
+
+	/**
+	 * @testdox Should use an IPv6-capable ipify endpoint over HTTPS.
+	 */
+	public function test_ipify_endpoint_supports_ipv6(): void {
+		$apis = $this->get_ip_lookup_apis();
+
+		$this->assertArrayHasKey( 'ipify', $apis );
+		$this->assertStringStartsWith(
+			'https://',
+			$apis['ipify'],
+			'The ipify endpoint should be reached over HTTPS.'
+		);
+		$this->assertStringContainsString(
+			'api64.ipify.org',
+			$apis['ipify'],
+			'The ipify endpoint should use the api64 subdomain so it returns both IPv4 and IPv6 addresses, matching the other lookup providers.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Geolocation::$ip_lookup_apis` lists four external services that are used as a fallback to determine the visitor's IP address. The original ipify entry was `http://api.ipify.org/`, which is the IPv4-only flavour of the service. The other three providers in the list (`ipecho.net`, `ident.me`, `tnedi.me`) all support IPv6 and return whichever address family the request was made from. That inconsistency means that on a dual-stack host the ipify entry can return a different IP family than the other providers, defeating the cache key used in `get_external_ip_address()` and triggering extra lookups, as noted by the reporter.

This PR switches the ipify entry to `https://api64.ipify.org/`. The `api64` subdomain is ipify's documented IPv4/IPv6 dual-stack endpoint and is reachable over HTTPS, bringing the entry in line with the rest of the list and resolving the reproducer's `"ipify_uses_http":true` signal.

Closes #47566

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Check out this branch on a dual-stack host (or any environment that resolves both A and AAAA records).
2. Open a PHP shell with WooCommerce loaded and inspect `WC_Geolocation::$ip_lookup_apis` via reflection — the `ipify` entry should now be `https://api64.ipify.org/`.
3. Call `WC_Geolocation::get_external_ip_address()` repeatedly; confirm successive calls return the same IP and that no warning about an unreachable lookup endpoint appears in `wp-content/debug.log`.
4. Optionally run `wp_safe_remote_get( 'https://api64.ipify.org/', [ 'timeout' => 2 ] )` and verify it returns a non-empty body in both IPv4-only and IPv6-only network conditions.
5. Run the new unit tests in `plugins/woocommerce/tests/php/includes/class-wc-geolocation-test.php`.

### Testing that has already taken place:

- Automated: RSMAPGJ AI Coder pilot 2026-05-14 ran lint:php:changes + phpstan locally; tests added but executed by PR CI (no local docker).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message

Use the IPv6-capable HTTPS ipify endpoint in WC_Geolocation so external IP lookups behave consistently with the other lookup providers.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14). Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-423
