### PR TITLE
fix: fire product.deleted webhook when a variation is deleted

### DIFF
--- a/plugins/woocommerce/changelog/64899-ai-agent-rsmapgj-389-1778756902
+++ b/plugins/woocommerce/changelog/64899-ai-agent-rsmapgj-389-1778756902
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fire the product.deleted webhook when a product variation is deleted, restoring parity with product.created and product.updated.

--- a/plugins/woocommerce/changelog/64899-ai-agent-rsmapgj-389-1778756902
+++ b/plugins/woocommerce/changelog/64899-ai-agent-rsmapgj-389-1778756902
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fire the product.deleted webhook when a product variation is deleted, restoring parity with product.created and product.updated.

--- a/plugins/woocommerce/changelog/fix-rsmapgj-389
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-389
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment:
+
+Fire the product.deleted webhook when a product variation is deleted, restoring parity with product.created and product.updated.

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -1027,6 +1027,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			),
 			'product.deleted'   => array(
 				'wp_trash_post',
+				'woocommerce_delete_product_variation',
 			),
 			'product.restored'  => array(
 				'untrashed_post',

--- a/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
@@ -112,4 +112,99 @@ class WC_Webhook_Test extends WC_Unit_Test_Case {
 		$this->assertSame( 999, $webhook2->get_user_id() );
 	}
 
+	/**
+	 * @testDox The product.deleted topic listens to woocommerce_delete_product_variation so it fires when a variation is deleted.
+	 */
+	public function test_product_deleted_topic_includes_variation_delete_hook() {
+		$webhook = new WC_Webhook();
+		$webhook->set_topic( 'product.deleted' );
+
+		$hooks = $webhook->get_hooks();
+
+		$this->assertContains(
+			'woocommerce_delete_product_variation',
+			$hooks,
+			'product.deleted webhook should listen to woocommerce_delete_product_variation so variation deletions fire the webhook.'
+		);
+		$this->assertContains(
+			'wp_trash_post',
+			$hooks,
+			'product.deleted webhook should continue to listen to wp_trash_post for regular product deletions.'
+		);
+	}
+
+	/**
+	 * @testDox The product.deleted webhook is queued for delivery when a product variation is deleted.
+	 */
+	public function test_product_deleted_webhook_fires_for_variation_deletion() {
+		// Create a variable product with one variation.
+		$variable = new WC_Product_Variable();
+		$variable->set_name( 'Webhook Variable Product' );
+		$variable->set_status( 'publish' );
+		$variable->save();
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'Color' );
+		$attribute->set_options( array( 'Red', 'Blue' ) );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+		$variable->set_attributes( array( $attribute ) );
+		$variable->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $variable->get_id() );
+		$variation->set_attributes( array( 'color' => 'Red' ) );
+		$variation->set_regular_price( '10.00' );
+		$variation->set_status( 'publish' );
+		$variation->save();
+		$variation_id = $variation->get_id();
+
+		// Create a product.deleted webhook and enqueue its hooks.
+		$webhook = new WC_Webhook();
+		$webhook->set_name( 'Test product.deleted variation webhook' );
+		$webhook->set_topic( 'product.deleted' );
+		$webhook->set_delivery_url( 'https://example.com/webhook-sink/' );
+		$webhook->set_status( 'active' );
+		$webhook->set_user_id( 1 );
+		$webhook->save();
+		$webhook->enqueue();
+
+		// Capture topics queued for delivery via the should_deliver filter.
+		$queued  = array();
+		$capture = function ( $should_deliver, $hooked_webhook, $arg ) use ( &$queued ) {
+			$queued[] = array(
+				'topic' => $hooked_webhook->get_topic(),
+				'arg'   => $arg,
+			);
+			// Prevent the actual HTTP delivery from being scheduled.
+			return false;
+		};
+		add_filter( 'woocommerce_webhook_should_deliver', $capture, 10, 3 );
+
+		try {
+			// Delete the variation: this should trigger woocommerce_delete_product_variation.
+			$variation->delete( true );
+		} finally {
+			remove_filter( 'woocommerce_webhook_should_deliver', $capture, 10 );
+		}
+
+		$queued_topics = wp_list_pluck( $queued, 'topic' );
+		$this->assertContains(
+			'product.deleted',
+			$queued_topics,
+			'product.deleted webhook should be queued when a product variation is deleted.'
+		);
+
+		$variation_queue_entries = array_filter(
+			$queued,
+			static function ( $entry ) use ( $variation_id ) {
+				return 'product.deleted' === $entry['topic'] && (int) $entry['arg'] === (int) $variation_id;
+			}
+		);
+		$this->assertNotEmpty(
+			$variation_queue_entries,
+			'product.deleted webhook should be queued with the deleted variation ID.'
+		);
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `product.deleted` webhook topic only listened to `wp_trash_post`. Product variations are deleted directly (they are not trashed), so `wp_trash_post` never fires for them and subscribers never received a `product.deleted` payload when a variation was removed. This was asymmetric with `product.created` and `product.updated`, which already fire for variations via `woocommerce_new_product_variation` and `woocommerce_update_product_variation`.

This PR adds `woocommerce_delete_product_variation` to the `product.deleted` topic's default hook list. That action is fired by `WC_Product_Data_Store_CPT::delete()` after `wp_delete_post()` runs on a variation, so the webhook is queued with the deleted variation ID exactly once and only on actual variation deletions (regular products continue to flow through `wp_trash_post`). The `woocommerce_webhook_topic_hooks` filter remains the integration point for plugins that want to customise this mapping.

Closes #31620

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Create a variable product with at least one variation.
2. Register an active `product.deleted` webhook pointing at a request bin (e.g. `https://webhook.site`).
3. Delete the variation (from the Variations panel in the product editor, or via `DELETE /wc/v3/products/<parent>/variations/<id>?force=true`).
4. Confirm the webhook endpoint receives a `product.deleted` payload containing the variation ID.
5. As a regression check, trash a regular (non-variable) product and confirm `product.deleted` still fires exactly once.

### Testing that has already taken place:

- Automated: RSMAPGJ AI Coder pilot 2026-05-14 ran lint:php:changes + phpstan locally; tests added but executed by PR CI (no local docker).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message

Fire the product.deleted webhook when a product variation is deleted, restoring parity with product.created and product.updated.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14). Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-389
