### PR TITLE
fix: cast WC_Product::get_image_id() return value to int

### DIFF
--- a/plugins/woocommerce/changelog/64900-ai-agent-rsmapgj-419-1778756902
+++ b/plugins/woocommerce/changelog/64900-ai-agent-rsmapgj-419-1778756902
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Cast `WC_Product::get_image_id()` and `WC_Product_Variation::get_image_id()` return values to `int` so they are compatible with strict-typed callbacks on `wp_get_attachment_image_url()` and related WordPress filters.

--- a/plugins/woocommerce/changelog/64900-ai-agent-rsmapgj-419-1778756902
+++ b/plugins/woocommerce/changelog/64900-ai-agent-rsmapgj-419-1778756902
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Cast `WC_Product::get_image_id()` and `WC_Product_Variation::get_image_id()` return values to `int` so they are compatible with strict-typed callbacks on `wp_get_attachment_image_url()` and related WordPress filters.

--- a/plugins/woocommerce/changelog/fix-rsmapgj-419
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-419
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment:
+
+Cast WC_Product::get_image_id() and WC_Product_Variation::get_image_id() return values to int so they are compatible with strict-typed callbacks on wp_get_attachment_image_url() and related WordPress filters.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -707,10 +707,10 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 *
 	 * @since  3.0.0
 	 * @param  string $context What the value is for. Valid values are view and edit.
-	 * @return string
+	 * @return int Attachment ID, or 0 if no image is set.
 	 */
 	public function get_image_id( $context = 'view' ) {
-		return $this->get_prop( 'image_id', $context );
+		return (int) $this->get_prop( 'image_id', $context );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -368,7 +368,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 *
 	 * @since 3.0.0
 	 * @param  string $context What the value is for. Valid values are view and edit.
-	 * @return string
+	 * @return int Attachment ID, or 0 if no image is set.
 	 */
 	public function get_image_id( $context = 'view' ) {
 		$image_id = $this->get_prop( 'image_id', $context );
@@ -377,7 +377,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 			$image_id = apply_filters( $this->get_hook_prefix() . 'image_id', $this->parent_data['image_id'], $this );
 		}
 
-		return $image_id;
+		return (int) $image_id;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-simple.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-simple.php
@@ -72,6 +72,29 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_image_id() returns 0 (int) when no image is set.
+	 */
+	public function test_get_image_id_returns_int_zero_when_unset() {
+		$image_id = $this->product->get_image_id();
+
+		$this->assertIsInt( $image_id, 'get_image_id() must return an int even when no image is set.' );
+		$this->assertSame( 0, $image_id, 'get_image_id() should return 0 (int) when no image is set, not an empty string.' );
+	}
+
+	/**
+	 * @testdox get_image_id() returns an int when an image id is set as a numeric string.
+	 */
+	public function test_get_image_id_returns_int_when_set_as_string() {
+		$this->product->set_image_id( '123' );
+		$this->product->save();
+
+		$image_id = $this->product->get_image_id();
+
+		$this->assertIsInt( $image_id, 'get_image_id() must return an int even if stored as a numeric string.' );
+		$this->assertSame( 123, $image_id, 'get_image_id() should return the numeric value cast to int.' );
+	}
+
+	/**
 	 * Test get_stock_quantity().
 	 *
 	 * @since 2.3

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-variation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-variation.php
@@ -114,4 +114,43 @@ class WC_Tests_Product_Variation extends WC_Unit_Test_Case {
 		$actual = $sut->get_variation_attributes( $with_prefix );
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * @testdox get_image_id() on a variation returns int 0 when neither the variation nor its parent has an image.
+	 */
+	public function test_get_image_id_returns_int_zero_when_unset() {
+		$product = new WC_Product_Variable();
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->save();
+
+		$variation = wc_get_product( $variation->get_id() );
+
+		$image_id = $variation->get_image_id();
+
+		$this->assertIsInt( $image_id, 'WC_Product_Variation::get_image_id() must return an int even when no image is set.' );
+		$this->assertSame( 0, $image_id, 'WC_Product_Variation::get_image_id() should return 0 (int) when no image is set on the variation or its parent.' );
+	}
+
+	/**
+	 * @testdox get_image_id() on a variation returns an int when stored as a numeric string.
+	 */
+	public function test_get_image_id_returns_int_when_set_as_string() {
+		$product = new WC_Product_Variable();
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_image_id( '456' );
+		$variation->save();
+
+		$variation = wc_get_product( $variation->get_id() );
+
+		$image_id = $variation->get_image_id();
+
+		$this->assertIsInt( $image_id, 'WC_Product_Variation::get_image_id() must return an int even if stored as a numeric string.' );
+		$this->assertSame( 456, $image_id, 'WC_Product_Variation::get_image_id() should return the numeric value cast to int.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Product::get_image_id()` and `WC_Product_Variation::get_image_id()` returned the raw value coming back from `get_prop( 'image_id', ... )`. Because the image ID is persisted as postmeta, the raw value is a numeric string when an image is set and an empty string when nothing is set. WordPress core's `wp_get_attachment_image_url()` declares its first parameter as `int`, and any callback hooked into `wp_get_attachment_image_src` that types the attachment ID as `int` will trigger a `TypeError` when WooCommerce hands it the string from `get_image_id()`.

This PR casts the return of both getters to `int` at the boundary, so callers always get a real integer (and `0` instead of `''` when no image is set). The setter still accepts `int|string`, so existing CRUD paths and CSV imports are unaffected. PHPDoc `@return` annotations are updated from `string` to `int`.

The fix is intentionally small and surgical: a single cast inside each getter. No behaviour changes for callers that already coerced or used loose comparisons.

Closes #45168

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Create a simple product with a featured image (any path: editor, REST, CSV import).
2. In a mu-plugin, register a callback on the `wp_get_attachment_image_src` filter with the signature `function ( $image, int $attachment_id, $size, $icon )` — note the `int` typehint.
3. On a front-end page that renders the product image (shop loop, single product), confirm no `TypeError` is thrown.
4. From PHP, assert `is_int( wc_get_product( $product_id )->get_image_id() ) === true` and that a product with no image returns `0` (not `''`).
5. Repeat step 4 against a `WC_Product_Variation` — both the variation's own image and the inherited parent image should come back as `int`.

### Testing that has already taken place:

- Automated: RSMAPGJ AI Coder pilot 2026-05-14 ran lint:php:changes + phpstan locally; tests added but executed by PR CI (no local docker).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message

Cast `WC_Product::get_image_id()` and `WC_Product_Variation::get_image_id()` return values to `int` so they are compatible with strict-typed callbacks on `wp_get_attachment_image_url()` and related WordPress filters.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14). Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-419
