### PR TITLE
Add postcode validation for Australia and New Zealand

### DIFF
--- a/plugins/woocommerce/changelog/64901-ai-agent-rsmapgj-420-1778757497
+++ b/plugins/woocommerce/changelog/64901-ai-agent-rsmapgj-420-1778757497
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add 4-digit numeric postcode validation for Australia (AU) and New Zealand (NZ) so invalid entries are rejected at checkout.

--- a/plugins/woocommerce/changelog/64901-ai-agent-rsmapgj-420-1778757497
+++ b/plugins/woocommerce/changelog/64901-ai-agent-rsmapgj-420-1778757497
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add 4-digit numeric postcode validation for Australia (AU) and New Zealand (NZ) so invalid entries are rejected at checkout.

--- a/plugins/woocommerce/changelog/fix-rsmapgj-420
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-420
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment:
+
+Add 4-digit numeric postcode validation for Australia (AU) and New Zealand (NZ) so invalid entries are rejected at checkout.

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -51,10 +51,12 @@ class WC_Validation {
 
 		switch ( $country ) {
 			case 'AT':
+			case 'AU':
 			case 'BE':
 			case 'CH':
 			case 'HU':
 			case 'NO':
+			case 'NZ':
 				$valid = (bool) preg_match( '/^([0-9]{4})$/', $postcode );
 				break;
 			case 'BA':

--- a/plugins/woocommerce/tests/php/includes/class-wc-validation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-validation-test.php
@@ -33,7 +33,27 @@ class WC_Validation_Test extends \WC_Unit_Test_Case {
 			array( false, '948A', 'LI' ),
 		);
 
-		return array_merge( $cz, $se, $li );
+		$au = array(
+			array( true, '2000', 'AU' ),
+			array( true, '0800', 'AU' ),
+			array( false, 'ABCD', 'AU' ),
+			array( false, '200', 'AU' ),
+			array( false, '20000', 'AU' ),
+			array( false, '20A0', 'AU' ),
+			array( false, '', 'AU' ),
+		);
+
+		$nz = array(
+			array( true, '6011', 'NZ' ),
+			array( true, '0110', 'NZ' ),
+			array( false, 'ABCD', 'NZ' ),
+			array( false, '601', 'NZ' ),
+			array( false, '60111', 'NZ' ),
+			array( false, '60A1', 'NZ' ),
+			array( false, '', 'NZ' ),
+		);
+
+		return array_merge( $cz, $se, $li, $au, $nz );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Validation::is_postcode()` validates postcodes per country using a switch statement. Australia (AU) and New Zealand (NZ) were not represented, so the switch fell through to the default branch that returns `true` for any input. As a result, the shortcode checkout accepted arbitrary strings (e.g. `ABCD`) as a valid postcode for either country.

Both AU and NZ use four-digit numeric postcodes. This PR adds `AU` and `NZ` to the same case as `AT/BE/CH/HU/NO`, which already uses the `/^([0-9]{4})$/` regex. The validation runs through the existing `woocommerce_validate_postcode` filter, so any merchant overrides continue to work.

Tests in `class-wc-validation-test.php` are extended to cover the new countries with valid, too-short, too-long, and non-numeric inputs.

Closes #46516

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Add any product to the cart and proceed to the shortcode checkout (`[woocommerce_checkout]`).
2. Select **Australia** (or **New Zealand**) as the billing country.
3. Enter a non-numeric value such as `ABCD` (or a number with the wrong length, e.g. `12345`) in the **Postcode** field.
4. Fill the remaining required fields and click **Place order**.
5. Confirm checkout is blocked with `Billing Postcode is not a valid postcode / ZIP.`
6. Repeat with a valid 4-digit numeric postcode (e.g. `2000` for AU, `6011` for NZ) and confirm checkout proceeds.

### Testing that has already taken place:

- Automated: RSMAPGJ AI Coder pilot 2026-05-14 ran lint:php:changes + phpstan locally; tests added but executed by PR CI (no local docker).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message

Add 4-digit numeric postcode validation for Australia (AU) and New Zealand (NZ) so invalid entries are rejected at checkout.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14). Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-420
