### PR TITLE
Fix color contrast for paragraph text on admin order screen

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-440
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-440
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve color contrast on the admin order screen by replacing #777 with #3c434a for paragraph text under #order_data, meeting WCAG AA contrast requirements.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1889,7 +1889,7 @@ ul.wc_coupon_list_block {
 	}
 
 	p {
-		color: #777;
+		color: #3c434a;
 	}
 
 	p.order_number {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] My code follows the [coding standards](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines-and-Development-Workflow).

### Changes proposed in this Pull Request

Replaces the paragraph text color under `#order_data` on the admin order edit screen from `#777` to `#3c434a`.

- `#777` on white has a 4.45:1 contrast ratio, falling just below the WCAG AA 4.5:1 minimum for normal text.
- `#3c434a` is the same neutral text color WordPress uses elsewhere in the admin and provides ~10.5:1 contrast, comfortably clearing both AA (4.5:1) and AAA (7:1).

Only the targeted selector is changed; surrounding styles (headings, `.order_data_column` paragraphs, etc.) are untouched.

Closes #60961
Linear: https://linear.app/a8c/issue/RSMAPGJ-440

### Screenshots or screen recordings

N/A — the difference is the dark gray used for descriptive paragraph text in `#order_data`. Visually it becomes a slightly darker, more readable gray.

### How to test the changes in this Pull Request

1. Check out this branch and rebuild WooCommerce admin assets (`pnpm --filter=@woocommerce/plugin-woocommerce build`).
2. In `wp-admin`, open an existing order via WooCommerce → Orders → click any order to enter the edit screen.
3. Inspect any paragraph rendered inside the `#order_data` container (for example the descriptive text above the billing/shipping columns).
4. Confirm:
   - Computed `color` is now `rgb(60, 67, 74)` (`#3c434a`), not `rgb(119, 119, 119)`.
   - Running an accessibility checker such as the WAVE browser extension or Lighthouse no longer reports a contrast failure on that text.
5. Sanity check that nothing else regressed: the order number, headings, totals, and meta boxes all look correct.

### Testing that has already taken place

- Manual code inspection of the diff: only `#order_data > p` color changes.
- Verified the new color matches WordPress core admin usage (`#3c434a`) and computes to ~10.5:1 contrast on `#fff`.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

> Added in `plugins/woocommerce/changelog/fix-rsmapgj-440` as `patch` / `fix`.

---

_Submitted via the RSMAPGJ AI Coder pipeline (batch 2, impl rev 1)._
