### PR TITLE
fix: reject reserved internal meta keys in order item Add Meta UI (RSMAPGJ-444)

### DIFF
--- a/plugins/woocommerce/changelog/64903-ai-agent-rsmapgj-444-1778756902
+++ b/plugins/woocommerce/changelog/64903-ai-agent-rsmapgj-444-1778756902
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reject reserved internal meta keys (like `_product_id`, `_qty`, `_line_total`) submitted via the order edit screen's "Add meta" button, so they no longer trigger `doing_it_wrong` warnings or write rows that are hidden from the UI.

--- a/plugins/woocommerce/changelog/64903-ai-agent-rsmapgj-444-1778756902
+++ b/plugins/woocommerce/changelog/64903-ai-agent-rsmapgj-444-1778756902
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Reject reserved internal meta keys (like `_product_id`, `_qty`, `_line_total`) submitted via the order edit screen's "Add meta" button, so they no longer trigger `doing_it_wrong` warnings or write rows that are hidden from the UI.

--- a/plugins/woocommerce/changelog/fix-rsmapgj-444
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-444
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment:
+
+Reject reserved internal meta keys (like _product_id, _qty, _line_total) submitted via the order edit screen's "Add meta" button, so they no longer trigger doing_it_wrong warnings or write rows that are hidden from the UI.

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -295,6 +295,47 @@ function wc_maybe_adjust_line_item_product_stock( $item, $item_quantity = -1 ) {
 }
 
 /**
+ * Get the list of meta keys reserved for internal use by an order item's data store.
+ *
+ * These keys map to first-class object properties (e.g. `_product_id`, `_qty`,
+ * `_line_total`) and must not be saved as user-defined meta data via the
+ * "Add meta" UI in the order edit screen. Storing user values under these keys
+ * either triggers a `doing_it_wrong` notice (for keys with matching
+ * setters/getters) or silently writes invisible rows to the meta table that
+ * cannot be removed from the UI.
+ *
+ * @since 10.9.0
+ *
+ * @param WC_Order_Item $item Order item object.
+ * @return string[] List of meta keys that are reserved by the item's data store.
+ */
+function wc_get_protected_order_item_meta_keys( $item ) {
+	if ( ! is_object( $item ) || ! is_callable( array( $item, 'get_data_store' ) ) ) {
+		return array();
+	}
+
+	$data_store = $item->get_data_store();
+	if ( ! $data_store ) {
+		return array();
+	}
+
+	$internal_meta_keys = is_callable( array( $data_store, 'get_internal_meta_keys' ) )
+		? (array) $data_store->get_internal_meta_keys()
+		: array();
+
+	// Also include the auto-prefixed data keys ("_" + property name), mirroring
+	// the filtering done in WC_Data_Store_WP::filter_raw_meta_data() so that
+	// every key the data store hides on read is also blocked on save.
+	if ( is_callable( array( $item, 'get_data_keys' ) ) ) {
+		foreach ( (array) $item->get_data_keys() as $data_key ) {
+			$internal_meta_keys[] = '_' === substr( $data_key, 0, 1 ) ? $data_key : '_' . $data_key;
+		}
+	}
+
+	return array_values( array_unique( array_filter( $internal_meta_keys, 'is_string' ) ) );
+}
+
+/**
  * Save order items. Uses the CRUD.
  *
  * @since 2.2
@@ -362,6 +403,8 @@ function wc_save_order_items( $order_id, $items ) {
 			}
 
 			if ( isset( $items['meta_key'][ $item_id ], $items['meta_value'][ $item_id ] ) ) {
+				$protected_meta_keys = wc_get_protected_order_item_meta_keys( $item );
+
 				foreach ( $items['meta_key'][ $item_id ] as $meta_id => $meta_key ) {
 					$meta_key   = substr( wp_unslash( $meta_key ), 0, 255 );
 					$meta_value = isset( $items['meta_value'][ $item_id ][ $meta_id ] ) ? wp_unslash( $items['meta_value'][ $item_id ][ $meta_id ] ) : '';
@@ -370,6 +413,11 @@ function wc_save_order_items( $order_id, $items ) {
 						if ( ! strstr( $meta_id, 'new-' ) ) {
 							$item->delete_meta_data_by_mid( $meta_id );
 						}
+					} elseif ( in_array( $meta_key, $protected_meta_keys, true ) ) {
+						// Skip meta keys that are reserved for the item's data store. Saving them as
+						// generic meta either triggers a "doing it wrong" warning or persists rows
+						// that are hidden from the UI, which the user cannot then remove.
+						continue;
 					} elseif ( strstr( $meta_id, 'new-' ) ) {
 						$item->add_meta_data( $meta_key, $meta_value, false );
 					} else {
@@ -428,6 +476,8 @@ function wc_save_order_items( $order_id, $items ) {
 			);
 
 			if ( isset( $items['meta_key'][ $item_id ], $items['meta_value'][ $item_id ] ) ) {
+				$protected_meta_keys = wc_get_protected_order_item_meta_keys( $item );
+
 				foreach ( $items['meta_key'][ $item_id ] as $meta_id => $meta_key ) {
 					$meta_value = isset( $items['meta_value'][ $item_id ][ $meta_id ] ) ? wp_unslash( $items['meta_value'][ $item_id ][ $meta_id ] ) : '';
 
@@ -435,6 +485,11 @@ function wc_save_order_items( $order_id, $items ) {
 						if ( ! strstr( $meta_id, 'new-' ) ) {
 							$item->delete_meta_data_by_mid( $meta_id );
 						}
+					} elseif ( in_array( $meta_key, $protected_meta_keys, true ) ) {
+						// Skip meta keys that are reserved for the item's data store. Saving them as
+						// generic meta either triggers a "doing it wrong" warning or persists rows
+						// that are hidden from the UI, which the user cannot then remove.
+						continue;
 					} elseif ( strstr( $meta_id, 'new-' ) ) {
 						$item->add_meta_data( $meta_key, $meta_value, false );
 					} else {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -535,4 +535,227 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$order_item = new WC_Order_Item_Product( $order_item_id );
 		$this->assertEquals( 4, $order_item->get_meta( '_reduced_stock', true ), 'Reduced stock meta should be updated to new quantity' );
 	}
+
+	/**
+	 * Data provider listing meta keys that are reserved by the line item data store.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function protected_line_item_meta_keys_provider() {
+		return array(
+			'_product_id'        => array( '_product_id' ),
+			'_variation_id'      => array( '_variation_id' ),
+			'_tax_class'         => array( '_tax_class' ),
+			'_qty'               => array( '_qty' ),
+			'_line_subtotal'     => array( '_line_subtotal' ),
+			'_line_subtotal_tax' => array( '_line_subtotal_tax' ),
+			'_line_total'        => array( '_line_total' ),
+			'_line_tax'          => array( '_line_tax' ),
+			'_line_tax_data'     => array( '_line_tax_data' ),
+		);
+	}
+
+	/**
+	 * @testdox Should not persist line item meta when a protected internal meta key is submitted via the order editor.
+	 *
+	 * @dataProvider protected_line_item_meta_keys_provider
+	 *
+	 * @param string $protected_key Reserved meta key being submitted.
+	 */
+	public function test_wc_save_order_items_rejects_protected_line_item_meta_keys( $protected_key ) {
+		$order         = WC_Helper_Order::create_order();
+		$order_item_id = 0;
+		foreach ( $order->get_items() as $item ) {
+			$order_item_id = $item->get_id();
+			break;
+		}
+		$this->assertGreaterThan( 0, $order_item_id, 'Helper order should expose a line item.' );
+
+		$existing_item = WC_Order_Factory::get_order_item( $order_item_id );
+		$original_qty  = (int) $existing_item->get_quantity();
+
+		$items = array(
+			'order_item_id'        => array( $order_item_id ),
+			'order_item_name'      => array( $order_item_id => $existing_item->get_name() ),
+			'order_item_qty'       => array( $order_item_id => $original_qty ),
+			'order_item_tax_class' => array( $order_item_id => '' ),
+			'line_total'           => array( $order_item_id => $existing_item->get_total() ),
+			'line_subtotal'        => array( $order_item_id => $existing_item->get_subtotal() ),
+			'line_tax'             => array( $order_item_id => array() ),
+			'line_subtotal_tax'    => array( $order_item_id => array() ),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_key'             => array(
+				$order_item_id => array(
+					'new-1' => $protected_key,
+				),
+			),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			'meta_value'           => array(
+				$order_item_id => array(
+					'new-1' => 'qa-test-62328',
+				),
+			),
+		);
+
+		wc_save_order_items( $order->get_id(), $items );
+
+		// Reload the item and verify the protected key was not stored as user meta.
+		$reloaded = WC_Order_Factory::get_order_item( $order_item_id );
+		$this->assertInstanceOf( WC_Order_Item_Product::class, $reloaded, 'Order item should still exist after save.' );
+
+		// The "Add meta" flow should never add a row using the protected key. Direct DB lookup confirms nothing was persisted.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		$persisted = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id = %d AND meta_key = %s AND meta_value = %s",
+				$order_item_id,
+				$protected_key,
+				'qa-test-62328'
+			)
+		);
+
+		$this->assertSame(
+			'0',
+			(string) $persisted,
+			sprintf( 'Protected meta key "%s" should not be persisted to the order itemmeta table.', $protected_key )
+		);
+
+		// Real data-store properties should not have been clobbered by the rejected meta either.
+		$this->assertSame( $original_qty, (int) $reloaded->get_quantity(), 'Existing line item quantity should be unchanged.' );
+	}
+
+	/**
+	 * @testdox Should still persist user-defined meta when a protected meta key is rejected.
+	 */
+	public function test_wc_save_order_items_keeps_user_meta_alongside_rejected_protected_key() {
+		$order         = WC_Helper_Order::create_order();
+		$order_item_id = 0;
+		foreach ( $order->get_items() as $item ) {
+			$order_item_id = $item->get_id();
+			break;
+		}
+		$this->assertGreaterThan( 0, $order_item_id, 'Helper order should expose a line item.' );
+
+		$existing_item = WC_Order_Factory::get_order_item( $order_item_id );
+
+		$items = array(
+			'order_item_id'        => array( $order_item_id ),
+			'order_item_name'      => array( $order_item_id => $existing_item->get_name() ),
+			'order_item_qty'       => array( $order_item_id => $existing_item->get_quantity() ),
+			'order_item_tax_class' => array( $order_item_id => '' ),
+			'line_total'           => array( $order_item_id => $existing_item->get_total() ),
+			'line_subtotal'        => array( $order_item_id => $existing_item->get_subtotal() ),
+			'line_tax'             => array( $order_item_id => array() ),
+			'line_subtotal_tax'    => array( $order_item_id => array() ),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_key'             => array(
+				$order_item_id => array(
+					'new-1' => '_variation_id',
+					'new-2' => 'gift_note',
+				),
+			),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			'meta_value'           => array(
+				$order_item_id => array(
+					'new-1' => 'qa-test-62328',
+					'new-2' => 'Happy birthday!',
+				),
+			),
+		);
+
+		wc_save_order_items( $order->get_id(), $items );
+
+		$reloaded = WC_Order_Factory::get_order_item( $order_item_id );
+
+		$this->assertSame(
+			'Happy birthday!',
+			(string) $reloaded->get_meta( 'gift_note', true ),
+			'User-defined meta should be saved even when a protected key is also submitted.'
+		);
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		$persisted = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id = %d AND meta_key = %s AND meta_value = %s",
+				$order_item_id,
+				'_variation_id',
+				'qa-test-62328'
+			)
+		);
+		$this->assertSame( '0', (string) $persisted, 'Protected _variation_id meta should not have been persisted.' );
+	}
+
+	/**
+	 * @testdox Should return reserved data store meta keys for a line item.
+	 */
+	public function test_wc_get_protected_order_item_meta_keys_returns_internal_meta_keys() {
+		$order         = WC_Helper_Order::create_order();
+		$order_item_id = 0;
+		foreach ( $order->get_items() as $item ) {
+			$order_item_id = $item->get_id();
+			break;
+		}
+
+		$item     = WC_Order_Factory::get_order_item( $order_item_id );
+		$reserved = wc_get_protected_order_item_meta_keys( $item );
+
+		$this->assertContains( '_product_id', $reserved, 'Product line items should reserve the _product_id meta key.' );
+		$this->assertContains( '_variation_id', $reserved, 'Product line items should reserve the _variation_id meta key.' );
+		$this->assertContains( '_qty', $reserved, 'Product line items should reserve the _qty meta key.' );
+		$this->assertContains( '_line_total', $reserved, 'Product line items should reserve the _line_total meta key.' );
+		$this->assertNotContains( 'gift_note', $reserved, 'User-defined keys should not be reported as reserved.' );
+	}
+
+	/**
+	 * @testdox Should not persist shipping item meta when a protected internal meta key is submitted.
+	 */
+	public function test_wc_save_order_items_rejects_protected_shipping_meta_keys() {
+		$order = WC_Helper_Order::create_order();
+
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_method_title( 'Flat rate' );
+		$shipping_item->set_method_id( 'flat_rate' );
+		$shipping_item->set_total( 5 );
+		$order->add_item( $shipping_item );
+		$order->save();
+
+		$shipping_item_id = $shipping_item->get_id();
+
+		$items = array(
+			'shipping_method_id'    => array( $shipping_item_id ),
+			'shipping_method'       => array( $shipping_item_id => 'flat_rate' ),
+			'shipping_method_title' => array( $shipping_item_id => 'Flat rate' ),
+			'shipping_cost'         => array( $shipping_item_id => '5' ),
+			'shipping_taxes'        => array( $shipping_item_id => array() ),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_key'              => array(
+				$shipping_item_id => array(
+					'new-1' => 'method_id',
+				),
+			),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			'meta_value'            => array(
+				$shipping_item_id => array(
+					'new-1' => 'qa-test-62328',
+				),
+			),
+		);
+
+		wc_save_order_items( $order->get_id(), $items );
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		$persisted = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id = %d AND meta_key = %s AND meta_value = %s",
+				$shipping_item_id,
+				'method_id',
+				'qa-test-62328'
+			)
+		);
+
+		$this->assertSame( '0', (string) $persisted, 'Protected method_id meta should not have been persisted on a shipping item.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When an admin uses the **Add meta** button on an order item in the order edit screen, the submitted meta key/value pair is forwarded to `wc_save_order_items()` and then handed to `WC_Data::add_meta_data()` / `update_meta_data()`. If the key matches one of the line item data store's reserved keys (`_product_id`, `_variation_id`, `_qty`, `_tax_class`, `_line_subtotal`, `_line_subtotal_tax`, `_line_total`, `_line_tax`, `_line_tax_data`) two broken behaviors result:

1. Keys whose data store also exposes a matching setter (e.g. `_product_id`, `_variation_id`, `_tax_class`) hit `is_internal_meta_key()` which calls `wc_doing_it_wrong()` and re-routes the value to the setter. The setter typically rejects the user-supplied string with a `WC_Data_Exception`, the AJAX handler never sends a response, and the order page is stuck in a perpetual loading state.
2. Keys without a matching setter (e.g. `_qty`, `_line_subtotal`, `_line_total`) get stored as regular meta rows. They are then filtered out by `WC_Data_Store_WP::filter_raw_meta_data()` on read, so the user sees no meta in the UI even though rows now exist in `woocommerce_order_itemmeta`, leaving them unable to clean up except by editing the DB directly.

This PR adds a new helper `wc_get_protected_order_item_meta_keys( $item )` that asks the item's own data store for its internal meta keys plus the auto-prefixed data property keys, then uses that allow-list inside `wc_save_order_items()` to skip protected keys for both line items and shipping items. Submitted protected keys are silently dropped: the existing item state is preserved, no `doing_it_wrong` notice is emitted, no hidden DB rows are created, and the AJAX request completes normally so the UI refreshes. User-defined meta keys submitted in the same request continue to be saved.

Closes #62328

### Screenshots or screen recordings:

<!-- Screenshots not captured by the AI Coder pipeline. -->

### How to test the changes in this Pull Request:

1. Create an order with at least one product line item.
2. On the order edit screen, click the edit (pencil) icon next to the line item, then **Add meta**.
3. Add a meta row with key `_variation_id` and any value, then click **Save**. Confirm the order saves without hanging, no `wc_doing_it_wrong` entry appears in `wc-logs`, and the row is not persisted.
4. Repeat with `_qty`, `_line_subtotal`, `_line_total`, `_tax_class`. Inspect the `woocommerce_order_itemmeta` table after each save and confirm no new row was inserted for the protected key.
5. As a regression check, add a custom meta key (e.g. `gift_note` with value `Happy birthday!`) at the same time as a protected key and confirm the custom one is still saved and visible after refresh.

### Testing that has already taken place:

- Automated: RSMAPGJ AI Coder pilot 2026-05-14 ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `composer exec -- phpstan analyse includes/admin/wc-admin-functions.php --memory-limit=2G` locally. PHPUnit tests were added under `tests/php/includes/admin/class-wc-admin-functions-test.php` but executed by PR CI (no local docker available in this pipeline).
- Manual: none yet. Human verification recommended before merge.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message

Reject reserved internal meta keys (like `_product_id`, `_qty`, `_line_total`) submitted via the order edit screen's "Add meta" button, so they no longer trigger `doing_it_wrong` warnings or write rows that are hidden from the UI.

</details>

---

Generated by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14). Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-444
