### PR TITLE
Fix Store API legacy payment processor fatal on non-array result

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-422
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-422
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Prevent a fatal error in the Store API legacy payment processor when a gateway's process_payment() returns a non-array value (e.g. null) after adding an error notice.

--- a/plugins/woocommerce/src/StoreApi/Legacy.php
+++ b/plugins/woocommerce/src/StoreApi/Legacy.php
@@ -58,6 +58,18 @@ class Legacy {
 		// Restore $_POST data.
 		$_POST = $post_data;
 
+		// `process_payment` is documented to return an array, but some gateways abort early and
+		// return null (or another non-array value) after adding a notice. Normalize to an array so
+		// the rest of this method can rely on array access without triggering a fatal error.
+		if ( ! is_array( $gateway_result ) ) {
+			// Convert any notices added by the gateway to exceptions so the customer sees the
+			// gateway's message instead of a generic one when possible.
+			NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
+
+			// If no notices were thrown above, treat the missing array as a generic failure.
+			$gateway_result = array( 'result' => 'failure' );
+		}
+
 		// If the payment failed with a message, throw an exception.
 		if ( isset( $gateway_result['result'] ) && 'failure' === $gateway_result['result'] ) {
 			if ( isset( $gateway_result['message'] ) ) {

--- a/plugins/woocommerce/tests/php/src/StoreApi/LegacyTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/LegacyTest.php
@@ -1,0 +1,265 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi;
+
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\Legacy;
+use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
+use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
+use WC_Order;
+use WC_Payment_Gateway;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the StoreApi Legacy class, especially the resilience of
+ * process_legacy_payment() to non-array return values from a gateway's
+ * process_payment() method.
+ */
+class LegacyTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var Legacy
+	 */
+	private $sut;
+
+	/**
+	 * Order used across tests.
+	 *
+	 * @var WC_Order
+	 */
+	private $order;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut   = new Legacy();
+		$this->order = wc_create_order();
+
+		// Make sure no stale notices leak between tests.
+		wc_clear_notices();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wc_clear_notices();
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a PaymentContext anonymous subclass returning the supplied gateway
+	 * instance from get_payment_method_instance(), bypassing the global
+	 * registered gateways list.
+	 *
+	 * @param WC_Payment_Gateway|null $gateway Gateway instance to inject.
+	 * @return PaymentContext
+	 */
+	private function make_context( $gateway ): PaymentContext {
+		$context = new class() extends PaymentContext {
+			/**
+			 * The injected gateway instance.
+			 *
+			 * @var WC_Payment_Gateway|null
+			 */
+			public $injected_gateway;
+
+			/**
+			 * Override to return the injected gateway.
+			 *
+			 * @return WC_Payment_Gateway|null
+			 */
+			public function get_payment_method_instance() {
+				return $this->injected_gateway;
+			}
+		};
+
+		$context->injected_gateway = $gateway;
+		$context->set_order( $this->order );
+
+		return $context;
+	}
+
+	/**
+	 * @testdox Should not fatal and should default status to failure when gateway returns null with no notices.
+	 */
+	public function test_handles_null_gateway_result_without_notices(): void {
+		$gateway = new class() extends WC_Payment_Gateway {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id = 'qa_null_gateway';
+			}
+
+			/**
+			 * Returns null instead of the documented array.
+			 *
+			 * @param int $order_id Order ID.
+			 * @return null
+			 */
+			public function process_payment( $order_id ) {
+				return null;
+			}
+		};
+
+		$context = $this->make_context( $gateway );
+		$result  = new PaymentResult();
+
+		$this->sut->process_legacy_payment( $context, $result );
+
+		$this->assertSame(
+			'failure',
+			$result->get_status(),
+			'A null gateway result with no notices should be treated as a generic failure.'
+		);
+	}
+
+	/**
+	 * @testdox Should throw a RouteException carrying the gateway notice when gateway returns null after adding an error notice.
+	 */
+	public function test_converts_notice_to_exception_when_gateway_returns_null_with_notice(): void {
+		$gateway = new class() extends WC_Payment_Gateway {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id = 'qa_null_gateway_with_notice';
+			}
+
+			/**
+			 * Adds an error notice and returns null.
+			 *
+			 * @param int $order_id Order ID.
+			 * @return null
+			 */
+			public function process_payment( $order_id ) {
+				wc_add_notice( 'my gateway error', 'error' );
+				return null;
+			}
+		};
+
+		$context = $this->make_context( $gateway );
+		$result  = new PaymentResult();
+
+		$this->expectException( RouteException::class );
+		$this->expectExceptionMessage( 'my gateway error' );
+
+		$this->sut->process_legacy_payment( $context, $result );
+	}
+
+	/**
+	 * @testdox Should default status to failure without fatal when gateway returns a non-array scalar.
+	 */
+	public function test_handles_non_array_scalar_gateway_result(): void {
+		$gateway = new class() extends WC_Payment_Gateway {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id = 'qa_scalar_gateway';
+			}
+
+			/**
+			 * Returns an unexpected string.
+			 *
+			 * @param int $order_id Order ID.
+			 * @return string
+			 */
+			public function process_payment( $order_id ) {
+				return 'not-an-array';
+			}
+		};
+
+		$context = $this->make_context( $gateway );
+		$result  = new PaymentResult();
+
+		$this->sut->process_legacy_payment( $context, $result );
+
+		$this->assertSame(
+			'failure',
+			$result->get_status(),
+			'A non-array scalar gateway result should be treated as a failure.'
+		);
+	}
+
+	/**
+	 * @testdox Should pass status and redirect through when gateway returns a valid success array.
+	 */
+	public function test_passes_through_valid_success_array(): void {
+		$gateway = new class() extends WC_Payment_Gateway {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id = 'qa_success_gateway';
+			}
+
+			/**
+			 * Returns the canonical success array shape.
+			 *
+			 * @param int $order_id Order ID.
+			 * @return array
+			 */
+			public function process_payment( $order_id ) {
+				return array(
+					'result'   => 'success',
+					'redirect' => 'https://example.test/thanks',
+				);
+			}
+		};
+
+		$context = $this->make_context( $gateway );
+		$result  = new PaymentResult();
+
+		$this->sut->process_legacy_payment( $context, $result );
+
+		$this->assertSame( 'success', $result->get_status(), 'A success array should set status to success.' );
+		$this->assertSame(
+			'https://example.test/thanks',
+			$result->redirect_url,
+			'A success array with a redirect should propagate the redirect URL.'
+		);
+	}
+
+	/**
+	 * @testdox Should throw a RouteException carrying the gateway message when result array reports failure with a message.
+	 */
+	public function test_failure_array_with_message_throws_route_exception(): void {
+		$gateway = new class() extends WC_Payment_Gateway {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id = 'qa_failure_message_gateway';
+			}
+
+			/**
+			 * Returns a failure array with a message.
+			 *
+			 * @param int $order_id Order ID.
+			 * @return array
+			 */
+			public function process_payment( $order_id ) {
+				return array(
+					'result'  => 'failure',
+					'message' => 'card declined',
+				);
+			}
+		};
+
+		$context = $this->make_context( $gateway );
+		$result  = new PaymentResult();
+
+		$this->expectException( RouteException::class );
+		$this->expectExceptionMessage( 'card declined' );
+
+		$this->sut->process_legacy_payment( $context, $result );
+	}
+}


### PR DESCRIPTION
## Submission Review Guidelines

- [x] I have reviewed the [Contributing to WooCommerce](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) document.
- [x] I have reviewed the [WooCommerce Coding Guidelines](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines).
- [x] I have reviewed the [Naming conventions, Architecture and Best Practices](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines#naming-conventions-architecture-and-best-practices).
- [x] I have added unit tests where appropriate.

## Changes proposed in this Pull Request

The Store API's legacy payment processor (`Automattic\WooCommerce\StoreApi\Legacy::process_legacy_payment()`) assumes that a gateway's `process_payment()` method always returns an array of the shape `[ 'result' => 'success|failure', ... ]`. In practice some gateways abort early after adding an error notice and return `null` (or another non-array value). When the legacy processor then reached `array_merge( $result->payment_details, $gateway_result )`, PHP raised a `TypeError` and customers saw a generic fatal-style message instead of the gateway's notice.

This change normalizes the gateway result before it is used downstream:

- If `process_payment()` returns a non-array value, any pending error notices are converted to a `RouteException` via `NoticeHandler::convert_notices_to_exceptions()`, so the customer sees the gateway's own message when one was queued.
- If no notices were queued, the result is coerced to `[ 'result' => 'failure' ]` so the existing failure-handling path continues to work safely without ever reaching `array_merge()` with a non-array value.

The behaviour for gateways that already return a well-formed array is unchanged.

Closes #46927

### Screenshots or screen recordings

N/A — backend-only fix; no UI changes.

## How to test the changes in this Pull Request

1. Temporarily patch `class-wc-gateway-cod.php` so `process_payment()` adds an error notice and returns early:
   ```php
   public function process_payment( $order_id ) {
       wc_add_notice( 'my error', 'error' );
       return;
   }
   ```
2. Place a simple product into the cart and proceed to a block-based Checkout page with Cash on Delivery enabled.
3. Submit the order. Before this fix, a fatal error was raised and the customer saw an incorrect/generic message. After the fix, the gateway's notice (`my error`) is surfaced as the checkout error.
4. Run the new unit tests in `plugins/woocommerce/tests/php/src/StoreApi/LegacyTest.php`.

## Testing that has already taken place

- Automated: pilot 2026-05-14 lint+phpstan (`pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`, `composer exec -- phpstan analyse src/StoreApi/Legacy.php --memory-limit=2G`, and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`) all clean.
- Manual: none yet.

---

- [x] Automatically create a changelog entry from the details below.

<details>

### Changelog Entry Details

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Enhancement
- [x] Fix
- [ ] Performance
- [ ] Tweak
- [ ] Update
- [ ] Dev
- [ ] Other

#### Message

Prevent a fatal error in the Store API legacy payment processor when a gateway's `process_payment()` returns a non-array value (e.g. `null`) after adding an error notice.

</details>

---

- [x] Automatically assign this Pull Request to the first available milestone.

---

Generated by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14). Opened as **draft** so a human reviewer can verify the fix in context before promotion to ready-for-review and merge.

Linear: https://linear.app/a8c/issue/RSMAPGJ-422
