### PR TITLE
Bootstrap Action Scheduler during uninstall so scheduled jobs are cleared

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-438
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-438
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure scheduled actions are removed during uninstall by bootstrapping Action Scheduler if no other plugin has loaded it.

--- a/plugins/woocommerce/tests/php/includes/class-wc-uninstall-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-uninstall-test.php
@@ -1,0 +1,137 @@
+<?php
+declare( strict_types=1 );
+/**
+ * Unit tests for WooCommerce uninstall routines.
+ *
+ * @package WooCommerce\Tests
+ */
+
+/**
+ * Class WC_Uninstall_Test
+ *
+ * Static-analysis style tests for `plugins/woocommerce/uninstall.php`. The uninstall
+ * script is a procedural file that aborts unless `WP_UNINSTALL_PLUGIN` is defined,
+ * which makes it impractical to execute directly from PHPUnit. These tests instead
+ * verify that the file contains the expected guards and bootstrap logic so that
+ * Action Scheduler jobs are reliably cleared when WooCommerce is uninstalled —
+ * including the scenario where WooCommerce is the only plugin using Action
+ * Scheduler (so the library is not loaded by the time `uninstall.php` runs).
+ */
+class WC_Uninstall_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Absolute path to the uninstall.php file under test.
+	 *
+	 * @var string
+	 */
+	private $uninstall_file;
+
+	/**
+	 * Cached contents of uninstall.php.
+	 *
+	 * @var string
+	 */
+	private $uninstall_source;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->uninstall_file = dirname( __DIR__, 3 ) . '/uninstall.php';
+		$this->assertFileExists( $this->uninstall_file, 'uninstall.php must exist in the plugin root' );
+
+		// Local file read for static analysis of the uninstall script.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$source = file_get_contents( $this->uninstall_file );
+		$this->assertNotFalse( $source, 'uninstall.php must be readable' );
+		$this->uninstall_source = (string) $source;
+	}
+
+	/**
+	 * @testdox Should bootstrap Action Scheduler before invoking as_unschedule_all_actions.
+	 */
+	public function test_bootstraps_action_scheduler_before_cleanup(): void {
+		$cleanup_position = strpos( $this->uninstall_source, 'as_unschedule_all_actions' );
+		$this->assertNotFalse( $cleanup_position, 'uninstall.php must reference as_unschedule_all_actions' );
+
+		$bootstrap_position = strpos( $this->uninstall_source, 'packages/action-scheduler/action-scheduler.php' );
+		$this->assertNotFalse(
+			$bootstrap_position,
+			'uninstall.php must require the Action Scheduler bootstrap so jobs are cleared even when WC is the only plugin using AS'
+		);
+
+		$this->assertLessThan(
+			$cleanup_position,
+			$bootstrap_position,
+			'Action Scheduler must be loaded before the scheduled-action cleanup runs'
+		);
+	}
+
+	/**
+	 * @testdox Should guard Action Scheduler bootstrap with a class_exists check to avoid double loading.
+	 */
+	public function test_action_scheduler_bootstrap_is_guarded(): void {
+		$bootstrap_position = strpos( $this->uninstall_source, 'packages/action-scheduler/action-scheduler.php' );
+		$this->assertNotFalse( $bootstrap_position, 'uninstall.php must reference the AS bootstrap path' );
+
+		$preceding_window = substr( $this->uninstall_source, max( 0, $bootstrap_position - 200 ), 200 );
+
+		$this->assertStringContainsString(
+			"class_exists( 'ActionScheduler', false )",
+			$preceding_window,
+			'Action Scheduler bootstrap must be guarded by a class_exists check to avoid loading it twice'
+		);
+	}
+
+	/**
+	 * @testdox Should still guard the unschedule calls behind class_exists and is_initialized checks.
+	 */
+	public function test_unschedule_calls_remain_guarded(): void {
+		$this->assertStringContainsString(
+			'class_exists( ActionScheduler::class )',
+			$this->uninstall_source,
+			'Cleanup block must keep its class_exists guard to stay safe if the bootstrap could not be loaded'
+		);
+
+		$this->assertStringContainsString(
+			'ActionScheduler::is_initialized()',
+			$this->uninstall_source,
+			'Cleanup block must keep its is_initialized guard'
+		);
+
+		$this->assertStringContainsString(
+			"function_exists( 'as_unschedule_all_actions' )",
+			$this->uninstall_source,
+			'Cleanup block must keep its function_exists guard for as_unschedule_all_actions'
+		);
+	}
+
+	/**
+	 * @testdox Should unschedule every WooCommerce recurring action that uses Action Scheduler.
+	 */
+	public function test_unschedules_all_known_woocommerce_actions(): void {
+		$expected_hooks = array(
+			'woocommerce_scheduled_sales',
+			'woocommerce_cancel_unpaid_orders',
+			'woocommerce_cleanup_sessions',
+			'woocommerce_cleanup_personal_data',
+			'woocommerce_cleanup_logs',
+			'woocommerce_geoip_updater',
+			'woocommerce_tracker_send_event',
+			'woocommerce_cleanup_rate_limits',
+			'wc_admin_daily',
+			'generate_category_lookup_table',
+			'wc_admin_unsnooze_admin_notes',
+		);
+
+		foreach ( $expected_hooks as $hook ) {
+			$this->assertStringContainsString(
+				"as_unschedule_all_actions( '{$hook}' )",
+				$this->uninstall_source,
+				"uninstall.php must unschedule the {$hook} action"
+			);
+		}
+	}
+}

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -27,6 +27,21 @@ wp_clear_scheduled_hook( 'wc_admin_daily' );
 wp_clear_scheduled_hook( 'generate_category_lookup_table' );
 wp_clear_scheduled_hook( 'wc_admin_unsnooze_admin_notes' );
 
+/*
+ * Ensure Action Scheduler is loaded before unscheduling actions.
+ *
+ * When WooCommerce is the only plugin using Action Scheduler, the library
+ * will not be loaded during uninstall. We need to manually bootstrap it
+ * here so that the cleanup calls below can actually remove pending jobs.
+ */
+if ( ! class_exists( 'ActionScheduler', false ) ) {
+	$wc_action_scheduler_bootstrap = __DIR__ . '/packages/action-scheduler/action-scheduler.php';
+	if ( is_readable( $wc_action_scheduler_bootstrap ) ) {
+		require_once $wc_action_scheduler_bootstrap;
+	}
+	unset( $wc_action_scheduler_bootstrap );
+}
+
 if ( class_exists( ActionScheduler::class ) && ActionScheduler::is_initialized() && function_exists( 'as_unschedule_all_actions' ) ) {
 	as_unschedule_all_actions( 'woocommerce_scheduled_sales' );
 	as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Contributor Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Closes #60415
Linear: https://linear.app/a8c/issue/RSMAPGJ-438

In `plugins/woocommerce/uninstall.php` the scheduled-action cleanup block is gated by `class_exists( ActionScheduler::class )`. When WooCommerce is the only plugin using Action Scheduler, the library is not loaded by the time `uninstall.php` runs, so the guard fails and `as_unschedule_all_actions(...)` is silently skipped — leaving orphan recurring jobs in the database after the plugin is removed.

This PR bootstraps the bundled Action Scheduler before the cleanup block when the class is not already present. The AS bootstrap (`packages/action-scheduler/action-scheduler.php`) self-initializes if `plugins_loaded` has already fired — which is the case during uninstall — so no manual `ActionScheduler::init()` call is required. The existing `class_exists` / `is_initialized` / `function_exists` guards are kept around the cleanup block as a defence-in-depth measure for the rare case where the bootstrap file is unreadable.

### Screenshots or screen recordings:

N/A — backend cleanup behaviour only.

### How to test the changes in this Pull Request:

1. On a fresh WordPress site, install WooCommerce and **only** WooCommerce (no other plugin that loads Action Scheduler — e.g. Jetpack, WooCommerce Subscriptions, etc.).
2. Activate WooCommerce, run through onboarding far enough to register recurring actions (or visit `WooCommerce → Status → Scheduled Actions` and confirm pending entries exist).
3. Confirm pending entries by querying the DB: `SELECT hook FROM wp_actionscheduler_actions WHERE status = 'pending';` — expect rows like `wc_admin_daily_wrapper`, `woocommerce_cleanup_sessions`, etc.
4. Deactivate, then **Delete** the WooCommerce plugin from `Plugins → Installed Plugins` (this triggers `uninstall.php`).
5. Verify the `wp_actionscheduler_actions` table either no longer exists (if `WC_REMOVE_ALL_DATA` is set) or no longer has pending WooCommerce-owned rows. Prior to this fix the rows would have remained.
6. Repeat steps 1-5 with another Action-Scheduler-using plugin (e.g. WooCommerce Subscriptions) active to confirm the existing happy-path is unchanged.

### Testing that has already taken place:

- **Automated (RSMAPGJ AI Coder pilot 2026-05-14):** `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passes, and `composer exec -- phpstan analyse uninstall.php tests/php/includes/class-wc-uninstall-test.php --memory-limit=2G` introduces no new errors against the baseline. PHPUnit execution is deferred to PR CI.
- **Manual:** None yet.

<!-- Please review the milestone for this PR. By default, PRs without a milestone are tagged with the next-next release. Please make sure this is correct. -->
- [x] Automatically assign a milestone based on the release schedule.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

> Changelog entry created manually at `plugins/woocommerce/changelog/fix-rsmapgj-438`.

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Ensure scheduled actions are removed during uninstall by bootstrapping Action Scheduler if no other plugin has loaded it.

</details>

---

_Drafted by the RSMAPGJ AI Coder pipeline (batch 2, 2026-05-14)._
