### PR TITLE
Make WC_Email_Customer_Review_Request_Test self-contained for the feature gate

### DIFF
--- a/plugins/woocommerce/changelog/64906-wooplug-fix-email-test-flag-isolation
+++ b/plugins/woocommerce/changelog/64906-wooplug-fix-email-test-flag-isolation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Make `WC_Email_Customer_Review_Request_Test` self-contained for the `customer_review_request` feature gate so `test_is_registered_with_wc_emails` doesn't depend on incidental test ordering.

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
@@ -17,9 +17,18 @@ class WC_Email_Customer_Review_Request_Test extends \WC_Unit_Test_Case {
 
 	/**
 	 * Load up the email classes since they aren't loaded by default.
+	 *
+	 * `WC_Emails::init()` only registers the review-request email class
+	 * when the `customer_review_request` feature flag is on, so the suite
+	 * has to enable the option (and re-init the mailer to pick up the
+	 * flag change) before exercising the mailer-level registration. Doing
+	 * it here makes every test self-contained rather than relying on the
+	 * incidental order of other OrderReviews suites that also flip the flag.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		update_option( 'woocommerce_feature_customer_review_request_enabled', 'yes' );
 
 		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
 		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email.php';
@@ -27,7 +36,19 @@ class WC_Email_Customer_Review_Request_Test extends \WC_Unit_Test_Case {
 
 		$this->ensure_review_order_page();
 
+		WC()->mailer()->init();
+
 		$this->sut = new WC_Email_Customer_Review_Request();
+	}
+
+	/**
+	 * Reset the feature flag between tests so the suite doesn't leak the
+	 * enabled state into unrelated test classes that assume the default.
+	 */
+	public function tearDown(): void {
+		delete_option( 'woocommerce_feature_customer_review_request_enabled' );
+
+		parent::tearDown();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`WC_Emails::init()` registers `WC_Email_Customer_Review_Request` only when the `customer_review_request` feature flag is on (introduced in #\64845). The existing `WC_Email_Customer_Review_Request_Test::test_is_registered_with_wc_emails` asserts the class is present in `WC()->mailer()->get_emails()`, but the test's `setUp()` didn't enable the flag.

The test was therefore order-dependent: it only passed when another OrderReviews suite (SchedulerTest etc.) happened to run first and enable the flag + re-init the mailer. The release/10.8 backport PR #\64895 hit this — PHPUnit picked up the email test before any flag-enabling suite — and the same flake reproduces on trunk when the test is run in isolation:

```
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "WC_Email_Customer_Review_Request_Test::test_is_registered_with_wc_emails"

→ Failed asserting that an array has the key 'WC_Email_Customer_Review_Request'.
```

This PR makes the test self-contained:

- `setUp()` enables the `customer_review_request` feature flag option and re-inits the mailer so the gated registration in `WC_Emails::init()` actually picks the flag change up.
- `tearDown()` deletes the option so the suite doesn't leak the enabled state into unrelated test classes that assume the default.

After the change, the full file passes in isolation (14/14) and the previously-flaky case passes regardless of test ordering.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Run the file in isolation on a fresh checkout:

\`\`\`
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "WC_Email_Customer_Review_Request_Test"
\`\`\`

- Before this patch: 1 failure on `test_is_registered_with_wc_emails`.
- After this patch: 14/14 pass.

Then run the broader test:env suite locally or via CI and confirm no regressions in:
- `WC_Email_Customer_Review_Request_Test`
- `Internal\OrderReviews\SchedulerTest`
- `Internal\OrderReviews\EndpointTest`
- `Internal\OrderReviews\ItemEligibilityTest`
- `Internal\OrderReviews\SubmissionHandlerTest`

<!-- End testing instructions -->

### Testing that has already taken place:

- 14/14 in the email test file pass in isolation after the change.
- Branch-level PHPCS clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Make `WC_Email_Customer_Review_Request_Test` self-contained for the `customer_review_request` feature gate so `test_is_registered_with_wc_emails` doesn't depend on incidental test ordering.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>