### PR TITLE
Add Product type column to the experimental products app

### DIFF
--- a/packages/js/experimental-products-app/changelog/add-products-app-product-type-column
+++ b/packages/js/experimental-products-app/changelog/add-products-app-product-type-column
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add an opt-in "Product type" column to the experimental products app product list, showing whether each row is a Simple, Variable, Grouped, Affiliate, or Variation product.

--- a/packages/js/experimental-products-app/src/fields/type/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/type/field.tsx
@@ -13,7 +13,6 @@ const fieldDefinition = {
 	type: 'text',
 	label: __( 'Product type', 'woocommerce' ),
 	enableSorting: false,
-	enableHiding: false,
 	filterBy: {
 		operators: [ 'isAny', 'isNone' ],
 	},
@@ -21,11 +20,18 @@ const fieldDefinition = {
 		{ label: __( 'Simple', 'woocommerce' ), value: 'simple' },
 		{ label: __( 'Variable', 'woocommerce' ), value: 'variable' },
 		{ label: __( 'Grouped', 'woocommerce' ), value: 'grouped' },
-		{ label: __( 'External', 'woocommerce' ), value: 'external' },
+		{ label: __( 'Affiliate', 'woocommerce' ), value: 'external' },
+		{ label: __( 'Variation', 'woocommerce' ), value: 'variation' },
 	],
 } satisfies Partial< Field< ProductEntityRecord > >;
 
 export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 	...fieldDefinition,
 	getValue: ( { item } ) => item.type,
+	render: ( { item }: { item: ProductEntityRecord } ) => {
+		const match = fieldDefinition.elements.find(
+			( element ) => element.value === item.type
+		);
+		return match ? match.label : item.type;
+	},
 };

--- a/packages/js/experimental-products-app/src/product-list/layouts.ts
+++ b/packages/js/experimental-products-app/src/product-list/layouts.ts
@@ -8,6 +8,7 @@ export const DEFAULT_PRODUCT_TABLE_MEDIA_FIELD = 'images';
 
 export const DEFAULT_PRODUCT_TABLE_FIELDS = [
 	'product_status',
+	'type',
 	'sku',
 	'stock',
 	'categories',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The experimental products app already registered a `Product type` field for the toolbar's "Filter by product type" dropdown, but the field was hidden from the View options popover (`enableHiding: false`) so users could not surface it as a column.

- Removes `enableHiding: false` from the `type` field so it appears in the View options → Properties list.
- Adds a `render` function that maps the raw type slug to a human-readable label.
- Renames the `external` label from "External" → "Affiliate" to match the term used in the rest of the product UI.
- Adds a new `Variation` element so variation rows render correctly in the hierarchical (tree) view.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <!-- view options popover without "Product type" --> | <!-- view options popover with "Product type" toggleable and the column showing Simple / Variable / Grouped / Affiliate / Variation --> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open **Products → All Products ( new )**.
2. Click the **View options** (gear) button in the toolbar to open the Appearance popover.
3. Scroll the Properties list to **Product type**. Confirm it is unchecked by default.
4. Click to enable it. The product list shows a new **Product type** column with the human-readable label for each product (Simple, Variable, Grouped, Affiliate; Variation for variation rows under a variable parent in tree view).
5. Toggle the column off again — it should disappear from the table, and the existing **Filter by product type** dropdown in the toolbar should still work unchanged.

### Testing that has already taken place:

Local visual check across all five product types in the product list.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under `packages/js/experimental-products-app/changelog/add-products-app-product-type-column`.

</details>