### PR TITLE
Fix typos in docblock and test comment (formating, overriden)

### DIFF
--- a/plugins/woocommerce/changelog/fix-typos-round-4
+++ b/plugins/woocommerce/changelog/fix-typos-round-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix typos in comments and docblocks: formating, overriden.

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductItemTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductItemTrait.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Utilities;
 /**
  * ProductItemTrait
  *
- * Shared functionality for formating product item data.
+ * Shared functionality for formatting product item data.
  */
 trait ProductItemTrait {
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
@@ -69,7 +69,7 @@ class EvaluateOverridesTest extends WC_Unit_Test_Case {
 		$extensions = $this->get_extensions();
 		$result     = $evaluator->evaluate( array( $extensions[3] ) );
 
-		// Evaluation should pass and return the overriden value.
+		// Evaluation should pass and return the overridden value.
 		$this->assertEquals( 2, $result[0]->order );
 
 		// Reset the default country.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fix two spelling typos in comments:

| File | Typo | Correct |
|------|------|---------|
| `src/StoreApi/Utilities/ProductItemTrait.php` | `formating` (class docblock) | `formatting` |
| `tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php` | `overriden` (inline comment) | `overridden` |

Both changes are comment-only — no logic affected.

### Screenshots or screen recordings:

Not applicable.

### How to test the changes in this Pull Request:

1. Review the diff — confirm each change is a comment-only spelling correction.
2. No functional testing required.

### Testing that has already taken place:

Diff review confirming all changes are isolated spelling corrections with no logic impact.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

Changelog entry added: `plugins/woocommerce/changelog/fix-typos-round-4`