### PR TITLE
Normalize shopper list item keys for a more stable de-duping

### DIFF
--- a/plugins/woocommerce/changelog/fix-shopper-list-item-key-normalization
+++ b/plugins/woocommerce/changelog/fix-shopper-list-item-key-normalization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Normalize ShopperListItem variation attributes so equivalent inputs (case, whitespace, empty-vs-absent slots, numeric type drift) deduplicate to the same item key.

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -199,7 +199,17 @@ class ShopperListItem {
 					);
 				}
 
-				if ( ! in_array( $requested_attributes[ $key ], $attribute->get_slugs(), true ) ) {
+				// Canonicalize the caller-supplied value the same way the cart does, so
+				// equivalent inputs (e.g. "Red" / " red ") match the parent slug list.
+				$requested = $attribute->is_taxonomy()
+					? sanitize_title( wp_unslash( (string) $requested_attributes[ $key ] ) )
+					: html_entity_decode(
+						wc_clean( wp_unslash( (string) $requested_attributes[ $key ] ) ),
+						ENT_QUOTES,
+						get_bloginfo( 'charset' )
+					);
+
+				if ( '' === $requested || ! in_array( $requested, $attribute->get_slugs(), true ) ) {
 					throw new \InvalidArgumentException(
 						esc_html(
 							sprintf(
@@ -212,7 +222,7 @@ class ShopperListItem {
 					);
 				}
 
-				$result[ $key ] = $requested_attributes[ $key ];
+				$result[ $key ] = $requested;
 				continue;
 			}//end if
 
@@ -280,9 +290,20 @@ class ShopperListItem {
 	}
 
 	/**
-	 * Compute a deterministic item key. Mirrors WC_Cart::generate_cart_id() so the same
-	 * product+variation always hashes to the same key, regardless of the input key order
-	 * for variation attributes.
+	 * Compute a deterministic item key for dedupe.
+	 *
+	 * Like {@see WC_Cart::generate_cart_id()} we hash the identity tuple, but we
+	 * canonicalize the variation array first so that semantically-equivalent inputs
+	 * always collapse to the same key:
+	 *
+	 * - Cast keys and values to string (defends against int/string drift through JSON).
+	 * - Trim keys and values.
+	 * - Drop entries with an empty value (so `attr => ''` and a missing `attr` match).
+	 * - `ksort()` so attribute order on the wire doesn't affect the hash.
+	 *
+	 * Per-attribute sanitization (taxonomy → `sanitize_title`, custom → `wc_clean`)
+	 * happens upstream in {@see self::resolve_variation_attributes()}, mirroring how
+	 * the cart pipelines normalize before hashing.
 	 *
 	 * @param int   $product_id   Product ID.
 	 * @param int   $variation_id Variation ID, or 0.
@@ -295,11 +316,21 @@ class ShopperListItem {
 			$id_parts[] = $variation_id;
 		}
 
-		if ( ! empty( $variation ) ) {
-			ksort( $variation );
+		$normalized = array();
+		foreach ( $variation as $k => $v ) {
+			$k = trim( (string) $k );
+			$v = trim( (string) $v );
+			if ( '' === $k || '' === $v ) {
+				continue;
+			}
+			$normalized[ $k ] = $v;
+		}
+
+		if ( ! empty( $normalized ) ) {
+			ksort( $normalized );
 			$variation_key = '';
-			foreach ( $variation as $k => $v ) {
-				$variation_key .= trim( (string) $k ) . trim( (string) $v );
+			foreach ( $normalized as $k => $v ) {
+				$variation_key .= $k . $v;
 			}
 			$id_parts[] = $variation_key;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -150,4 +150,103 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 			$this->addToAssertionCount( 1 );
 		}
 	}
+
+	/**
+	 * @testdox from_product canonicalizes "any" slot values like cart does, so equivalent inputs produce the same item.
+	 */
+	public function test_from_variation_canonicalizes_any_slot_values(): void {
+		$variable = \WC_Helper_Product::create_variation_product();
+
+		$any_number = 0;
+		foreach ( $variable->get_children() as $variation_id ) {
+			$attrs = wc_get_product_variation_attributes( (int) $variation_id );
+			if ( ( $attrs['attribute_pa_number'] ?? null ) === '' ) {
+				$any_number = (int) $variation_id;
+				break;
+			}
+		}
+		$this->assertNotSame( 0, $any_number, 'Expected the variation fixture to expose an "any pa_number" slot.' );
+
+		$canonical = ShopperListItem::from_product( $any_number, array( 'attribute_pa_number' => '2' ) );
+
+		// Leading/trailing whitespace is trimmed by sanitize_title.
+		$padded = ShopperListItem::from_product( $any_number, array( 'attribute_pa_number' => '  2  ' ) );
+		$this->assertSame( $canonical->get_key(), $padded->get_key() );
+		$this->assertSame( '2', $padded->to_array()['variation']['attribute_pa_number'] );
+
+		// Empty after sanitization is rejected (covers the explicit "" guard in the "any" branch).
+		try {
+			ShopperListItem::from_product( $any_number, array( 'attribute_pa_number' => '   ' ) );
+			$this->fail( 'Expected whitespace-only any-slot value to throw.' );
+		} catch ( \InvalidArgumentException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
+	}
+
+	/**
+	 * @testdox generate_key collapses semantically-equivalent variation arrays to the same hash.
+	 */
+	public function test_generate_key_canonicalizes_variation_inputs(): void {
+		$method = new \ReflectionMethod( ShopperListItem::class, 'generate_key' );
+		$method->setAccessible( true );
+
+		$base = $method->invoke(
+			null,
+			10,
+			20,
+			array(
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_number' => '2',
+			)
+		);
+
+		// Different key order hashes the same (ksort).
+		$reordered = $method->invoke(
+			null,
+			10,
+			20,
+			array(
+				'attribute_pa_number' => '2',
+				'attribute_pa_colour' => 'red',
+			)
+		);
+		$this->assertSame( $base, $reordered, 'Key order must not affect the hash.' );
+
+		// Leading/trailing whitespace on keys and values is trimmed.
+		$padded = $method->invoke(
+			null,
+			10,
+			20,
+			array(
+				' attribute_pa_colour ' => ' red ',
+				'attribute_pa_number'   => "\t2\n",
+			)
+		);
+		$this->assertSame( $base, $padded, 'Whitespace around keys/values must not affect the hash.' );
+
+		// Numeric values cast through (string) match their string equivalents.
+		$numeric = $method->invoke(
+			null,
+			10,
+			20,
+			array(
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_number' => 2,
+			)
+		);
+		$this->assertSame( $base, $numeric, 'Numeric/string drift must not affect the hash.' );
+
+		// An attribute with an empty value is treated as if the key were absent.
+		$with_empty = $method->invoke(
+			null,
+			10,
+			20,
+			array(
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_number' => '2',
+				'attribute_pa_size'   => '',
+			)
+		);
+		$this->assertSame( $base, $with_empty, 'An empty attribute value must hash the same as the key being absent.' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`ShopperListItem::generate_key()` hashes the identity tuple to find and dedupe items, but a few canonicalization gaps let semantically-equivalent inputs hash differently, so two adds of "the same" product could end up as separate rows.

This change aligns our code with how the cart normalizes variation attributes and `generate_key()` defensively casts to string to prevent empty values or type drift (int vs string) from altering hashes.

Closes WOOPRD-3528.

### How to test the changes in this Pull Request:

1. Check out the branch and run the unit tests: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter ShopperListItemTests`. All cases pass, including the two new ones (`test_from_variation_canonicalizes_any_slot_values` and `test_generate_key_canonicalizes_variation_inputs`).
2. From a shell against a WooCommerce install with the shopper-collections feature flag on, call `\Automattic\WooCommerce\Internal\ShopperLists\ShopperListItem::from_product()` twice with the same simple product and confirm `get_key()` matches.
3. For a variable product with an "any" slot, call `from_product()` with the same attribute value spelled `'Red'`, `' red '`, and `'red'`. Confirm `get_key()` is identical for all three.
4. Call `from_product()` for the same variation with attributes passed in different key orders, and once with `attribute_pa_color => ''` vs. the key absent. Confirm all calls produce the same `get_key()`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->