### PR TITLE
Fix Indian state code for Chhattisgarh (CT -> CG)

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-412
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-412
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correct the Indian state code for Chhattisgarh from `CT` to `CG` to match the GST state code, and migrate existing stored values.

--- a/plugins/woocommerce/i18n/states.php
+++ b/plugins/woocommerce/i18n/states.php
@@ -810,7 +810,7 @@ return array(
 		'AS' => __( 'Assam', 'woocommerce' ),
 		'BR' => __( 'Bihar', 'woocommerce' ),
 		'CH' => __( 'Chandigarh', 'woocommerce' ),
-		'CT' => __( 'Chhattisgarh', 'woocommerce' ),
+		'CG' => __( 'Chhattisgarh', 'woocommerce' ),
 		'DD' => __( 'Daman and Diu', 'woocommerce' ),
 		'DH' => __( 'Dādra and Nagar Haveli and Damān and Diu', 'woocommerce' ),
 		'DL' => __( 'Delhi', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -329,6 +329,9 @@ class WC_Install {
 			'wc_update_1080_slim_orders_meta_key_index',
 			'wc_update_1080_backfill_email_template_sync_meta',
 		),
+		'10.9.0' => array(
+			'wc_update_1090_adjust_indian_states',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3511,3 +3511,20 @@ function wc_update_1080_slim_orders_meta_key_index(): void {
 function wc_update_1080_backfill_email_template_sync_meta(): bool {
 	return WCEmailTemplateSyncBackfill::run();
 }
+
+/**
+ * Update the Indian state code for Chhattisgarh from `CT` to `CG` in the database
+ * after it was corrected in code to match the GST state code.
+ *
+ * @since 10.9.0
+ *
+ * @return bool True if there are more records that need to be migrated, false otherwise.
+ */
+function wc_update_1090_adjust_indian_states() {
+	return MigrationHelper::migrate_country_states(
+		'IN',
+		array(
+			'CT' => 'CG',
+		)
+	);
+}

--- a/plugins/woocommerce/tests/e2e-pw/data/countries/in.json
+++ b/plugins/woocommerce/tests/e2e-pw/data/countries/in.json
@@ -19,7 +19,7 @@
             "name": "Bihar"
         },
         {
-            "code": "CT",
+            "code": "CG",
             "name": "Chhattisgarh"
         },
         {

--- a/plugins/woocommerce/tests/e2e-pw/data/settings.ts
+++ b/plugins/woocommerce/tests/e2e-pw/data/settings.ts
@@ -1005,7 +1005,7 @@ export const stateOptions = {
 	'IN:AR': 'India - Arunachal Pradesh',
 	'IN:AS': 'India - Assam',
 	'IN:BR': 'India - Bihar',
-	'IN:CT': 'India - Chhattisgarh',
+	'IN:CG': 'India - Chhattisgarh',
 	'IN:GA': 'India - Goa',
 	'IN:GJ': 'India - Gujarat',
 	'IN:HR': 'India - Haryana',

--- a/plugins/woocommerce/tests/php/includes/class-wc-countries-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-countries-test.php
@@ -43,4 +43,16 @@ class WC_Countries_Test extends \WC_Unit_Test_Case {
 			),
 		);
 	}
+
+	/**
+	 * @testdox Should expose Chhattisgarh under the GST state code `CG` and not the legacy `CT`.
+	 */
+	public function test_indian_state_chhattisgarh_uses_cg_code() {
+		$in_states = wc()->countries->get_states( 'IN' );
+
+		$this->assertIsArray( $in_states, 'Indian states list should be available.' );
+		$this->assertArrayHasKey( 'CG', $in_states, 'Chhattisgarh should be keyed by the GST state code `CG`.' );
+		$this->assertSame( 'Chhattisgarh', $in_states['CG'], '`CG` should map to Chhattisgarh.' );
+		$this->assertArrayNotHasKey( 'CT', $in_states, 'The legacy `CT` code for Chhattisgarh should no longer be present in the Indian states list.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Quality Code Coding Standards](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines-and-Development).

### Changes proposed in this Pull Request

Closes #39651.

The state code for the Indian state of **Chhattisgarh** in `plugins/woocommerce/i18n/states.php` was `CT`, but the [official GST state code](https://www.zoho.com/in/books/kb/gst/valid-state-codes-list.html) is `CG`. This caused incorrect state codes to be returned when merchants configured tax rates or shipping zones for Chhattisgarh.

This PR:

- Renames the `IN` key from `CT` to `CG` in `i18n/states.php`.
- Adds `wc_update_1090_adjust_indian_states()` (registered for `10.9.0`) which uses `MigrationHelper::migrate_country_states()` to rewrite any stored `CT` value to `CG` for `IN` across orders, customer meta, tax rates, and locations — mirroring the established pattern used previously for New Zealand (`wc_update_721_adjust_new_zealand_states`) and Ukraine (`wc_update_721_adjust_ukraine_states`).
- Refreshes the e2e test fixtures that hard-code the legacy code (`tests/e2e-pw/data/countries/in.json`, `tests/e2e-pw/data/settings.ts`).
- Adds a PHPUnit test in `WC_Countries_Test` asserting Chhattisgarh is keyed by `CG` and not `CT`.

### Screenshots or screen recordings

N/A — data-only change.

### How to test the changes in this Pull Request

1. Set up a fresh local environment on this branch.
2. Visit **WooCommerce > Settings > Tax > Standard rates** and add a tax row for India (`IN`), state **Chhattisgarh**. Save.
3. Confirm the saved row stores `CG` (not `CT`) — visible in the table and in `wp_woocommerce_tax_rates.tax_rate_state`.
4. Migration test:
   - Before applying the update, manually insert a row with state `CT` for `IN` in `wp_woocommerce_tax_rates`.
   - Bump `woocommerce_db_version` below `10.9.0` and trigger the WC updater (or run `wp wc update`).
   - Confirm the row now has `CG`.
5. Run the new PHPUnit test:

   ```sh
   pnpm test:php:env -- --filter WC_Countries_Test
   ```

### Testing that has already taken place

- Manually verified the change in `i18n/states.php`.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- Ran `composer exec -- phpstan analyse <changed files> --memory-limit=2G` — clean for changed files (the remaining `mafes` duplicate-key warning on `states.php` line 1189 is pre-existing on trunk and unrelated).

### Changelog entry

- [x] This Pull Request includes a changelog entry (`plugins/woocommerce/changelog/fix-rsmapgj-412`).

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-412

_Generated by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14)._
