### PR TITLE
Fix wc_get_var() callsites mutating $_REQUEST and $_POST

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-385
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-385
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Stop wc_get_var() callsites from auto-creating nonce keys in $_REQUEST and $_POST when reading nonce values, so isset() checks on those superglobals no longer return false positives.
+
+

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1285,7 +1285,7 @@ class WC_Checkout {
 	 */
 	public function process_checkout() {
 		try {
-			$nonce_value    = wc_get_var( $_REQUEST['woocommerce-process-checkout-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // phpcs:ignore
+			$nonce_value    = isset( $_REQUEST['woocommerce-process-checkout-nonce'] ) ? $_REQUEST['woocommerce-process-checkout-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // phpcs:ignore
 			$expiry_message = sprintf(
 				/* translators: %s: shop cart url */
 				__( 'Sorry, your session has expired. <a href="%s" class="wc-backward">Return to shop</a>', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -83,7 +83,7 @@ class WC_Form_Handler {
 	public static function save_address() {
 		global $wp;
 
-		$nonce_value = wc_get_var( $_REQUEST['woocommerce-edit-address-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+		$nonce_value = isset( $_REQUEST['woocommerce-edit-address-nonce'] ) ? $_REQUEST['woocommerce-edit-address-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 		if ( ! wp_verify_nonce( $nonce_value, 'woocommerce-edit_address' ) ) {
 			return;
@@ -235,7 +235,7 @@ class WC_Form_Handler {
 	 * Save the password/account details and redirect back to the my account page.
 	 */
 	public static function save_account_details() {
-		$nonce_value = wc_get_var( $_REQUEST['save-account-details-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+		$nonce_value = isset( $_REQUEST['save-account-details-nonce'] ) ? $_REQUEST['save-account-details-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 		if ( ! wp_verify_nonce( $nonce_value, 'save_account_details' ) ) {
 			return;
@@ -420,7 +420,7 @@ class WC_Form_Handler {
 		if ( isset( $_POST['woocommerce_pay'], $_GET['key'] ) ) {
 			wc_nocache_headers();
 
-			$nonce_value = wc_get_var( $_REQUEST['woocommerce-pay-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+			$nonce_value = isset( $_REQUEST['woocommerce-pay-nonce'] ) ? $_REQUEST['woocommerce-pay-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 			if ( ! wp_verify_nonce( $nonce_value, 'woocommerce-pay' ) ) {
 				return;
@@ -510,7 +510,7 @@ class WC_Form_Handler {
 		if ( isset( $_POST['woocommerce_add_payment_method'], $_POST['payment_method'] ) ) {
 			wc_nocache_headers();
 
-			$nonce_value = wc_get_var( $_REQUEST['woocommerce-add-payment-method-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+			$nonce_value = isset( $_REQUEST['woocommerce-add-payment-method-nonce'] ) ? $_REQUEST['woocommerce-add-payment-method-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 			if ( ! wp_verify_nonce( $nonce_value, 'woocommerce-add-payment-method' ) ) {
 				return;
@@ -641,7 +641,7 @@ class WC_Form_Handler {
 
 		wc_nocache_headers();
 
-		$nonce_value = wc_get_var( $_REQUEST['woocommerce-cart-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+		$nonce_value = isset( $_REQUEST['woocommerce-cart-nonce'] ) ? $_REQUEST['woocommerce-cart-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 		if ( ! empty( $_POST['apply_coupon'] ) && ! empty( $_POST['coupon_code'] ) ) {
 			WC()->cart->add_discount( wc_format_coupon_code( wp_unslash( $_POST['coupon_code'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -1038,7 +1038,7 @@ class WC_Form_Handler {
 
 		if ( null === $valid_nonce ) {
 			// The global form-login.php template used `_wpnonce` in template versions < 3.3.0.
-			$nonce_value = wc_get_var( $_REQUEST['woocommerce-login-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+			$nonce_value = isset( $_REQUEST['woocommerce-login-nonce'] ) ? $_REQUEST['woocommerce-login-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 			$valid_nonce = wp_verify_nonce( $nonce_value, 'woocommerce-login' );
 		}
@@ -1104,7 +1104,7 @@ class WC_Form_Handler {
 	 */
 	public static function process_lost_password() {
 		if ( isset( $_POST['wc_reset_password'], $_POST['user_login'] ) ) {
-			$nonce_value = wc_get_var( $_REQUEST['woocommerce-lost-password-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+			$nonce_value = isset( $_REQUEST['woocommerce-lost-password-nonce'] ) ? $_REQUEST['woocommerce-lost-password-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 			if ( ! wp_verify_nonce( $nonce_value, 'lost_password' ) ) {
 				return;
@@ -1124,7 +1124,7 @@ class WC_Form_Handler {
 	 * Handle reset password form.
 	 */
 	public static function process_reset_password() {
-		$nonce_value = wc_get_var( $_REQUEST['woocommerce-reset-password-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+		$nonce_value = isset( $_REQUEST['woocommerce-reset-password-nonce'] ) ? $_REQUEST['woocommerce-reset-password-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 		if ( ! wp_verify_nonce( $nonce_value, 'reset_password' ) ) {
 			return;

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-cart.php
@@ -79,7 +79,7 @@ class WC_Shortcode_Cart {
 		wc_maybe_define_constant( 'WOOCOMMERCE_CART', true );
 
 		$atts        = shortcode_atts( array(), $atts, 'woocommerce_cart' );
-		$nonce_value = wc_get_var( $_REQUEST['woocommerce-shipping-calculator-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+		$nonce_value = isset( $_REQUEST['woocommerce-shipping-calculator-nonce'] ) ? $_REQUEST['woocommerce-shipping-calculator-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 		// Update Shipping. Nonce check uses new value and old value (woocommerce-cart). @todo remove in 4.0.
 		if ( ! empty( $_POST['calc_shipping'] ) && ( wp_verify_nonce( $nonce_value, 'woocommerce-shipping-calculator' ) || wp_verify_nonce( $nonce_value, 'woocommerce-cart' ) ) ) { // WPCS: input var ok.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-order-tracking.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-order-tracking.php
@@ -37,7 +37,7 @@ class WC_Shortcode_Order_Tracking {
 		}
 
 		$atts        = shortcode_atts( array(), $atts, 'woocommerce_order_tracking' );
-		$nonce_value = wc_get_var( $_REQUEST['woocommerce-order-tracking-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+		$nonce_value = isset( $_REQUEST['woocommerce-order-tracking-nonce'] ) ? $_REQUEST['woocommerce-order-tracking-nonce'] : ( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ); // @codingStandardsIgnoreLine.
 
 		if ( isset( $_REQUEST['orderid'] ) && wp_verify_nonce( $nonce_value, 'woocommerce-order_tracking' ) ) { // WPCS: input var ok.
 

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2231,11 +2231,20 @@ function wc_make_phone_clickable( $phone ) {
  */
 function wc_get_post_data_by_key( $key, $default = '' ) {
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput, WordPress.Security.NonceVerification.Missing
-	return wc_clean( wp_unslash( wc_get_var( $_POST[ $key ], $default ) ) );
+	return wc_clean( wp_unslash( isset( $_POST[ $key ] ) ? $_POST[ $key ] : $default ) );
 }
 
 /**
  * Get data if set, otherwise return a default value or null. Prevents notices when data is not set.
+ *
+ * Note: because this function accepts its first argument by reference, passing an
+ * array element that does not yet exist (for example `wc_get_var( $_POST['foo'] )`)
+ * will auto-create that element with a null value in the source array. This is a
+ * side effect of PHP's pass-by-reference semantics and cannot be avoided from within
+ * the function. Prefer `isset( $array['key'] ) ? $array['key'] : $default` (or the
+ * null coalescing operator `$array['key'] ?? $default`) when reading values from
+ * superglobals such as `$_GET`, `$_POST` and `$_REQUEST`, so the superglobal is not
+ * mutated on every request.
  *
  * @since  3.2.0
  * @param  mixed  $var     Variable.

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -275,4 +275,60 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertFalse( _wc_delete_transients( true ) );
 		$this->assertFalse( _wc_delete_transients( new stdClass() ) );
 	}
+
+	/**
+	 * @testdox wc_get_post_data_by_key() should not auto-create the requested key in $_POST when the key is missing.
+	 */
+	public function test_wc_get_post_data_by_key_does_not_mutate_post_superglobal() {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		$original_post = $_POST;
+		$_POST         = array();
+
+		$result = wc_get_post_data_by_key( 'rsmapgj_385_missing_key', 'default-value' );
+
+		$this->assertSame( 'default-value', $result, 'Default value should be returned when key is missing.' );
+		$this->assertArrayNotHasKey(
+			'rsmapgj_385_missing_key',
+			$_POST,
+			'$_POST must not be mutated when reading a missing key.'
+		);
+
+		$_POST = $original_post;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * @testdox wc_get_post_data_by_key() should return the sanitized value when the key exists in $_POST.
+	 */
+	public function test_wc_get_post_data_by_key_returns_sanitized_existing_value() {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		$original_post = $_POST;
+		$_POST         = array( 'rsmapgj_385_present_key' => '  hello world  ' );
+
+		$result = wc_get_post_data_by_key( 'rsmapgj_385_present_key', 'default-value' );
+
+		$this->assertSame( 'hello world', $result, 'Existing values should be returned trimmed and sanitized.' );
+
+		$_POST = $original_post;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * @testdox wc_get_var() should return the default value when the variable is not set.
+	 */
+	public function test_wc_get_var_returns_default_for_undefined_variable() {
+		$undefined = null;
+		unset( $undefined );
+
+		$this->assertSame( 'fallback', wc_get_var( $undefined, 'fallback' ) );
+	}
+
+	/**
+	 * @testdox wc_get_var() should return the value when the variable is set.
+	 */
+	public function test_wc_get_var_returns_value_when_set() {
+		$defined = 'hello';
+
+		$this->assertSame( 'hello', wc_get_var( $defined, 'fallback' ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Rules](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?

### Changes proposed in this Pull Request:

`wc_get_var()` accepts its first argument by reference. When called with an array element that does not yet exist — for example `wc_get_var( $_REQUEST['woocommerce-login-nonce'] )` — PHP must materialize the lvalue before entering the function, which auto-creates that element with a `null` value in the source array. The function body cannot prevent that side effect (it happens at the call site, before the function executes).

The visible symptom: on every front-end request, WooCommerce pre-populates `$_REQUEST` with `null` entries for `woocommerce-login-nonce`, `woocommerce-reset-password-nonce`, `woocommerce-edit-address-nonce`, `save-account-details-nonce`, `_wpnonce`, etc. Third-party code that runs `isset( $_REQUEST['_wpnonce'] )` on a plain GET request gets a false positive.

This PR:

- Replaces the eleven `wc_get_var( $_REQUEST[…], wc_get_var( $_REQUEST['_wpnonce'], '' ) )` nonce reads in `class-wc-form-handler.php`, `class-wc-checkout.php`, `class-wc-shortcode-cart.php`, and `class-wc-shortcode-order-tracking.php` with inline `isset()` ternaries so the superglobal is no longer mutated.
- Rewrites `wc_get_post_data_by_key()` to call `isset( $_POST[ $key ] )` directly instead of routing through `wc_get_var()`, so `$_POST` is no longer mutated either.
- Leaves `wc_get_var()` itself alone for BC (removing the `&` would emit notices for the function's legitimate use case of testing an undefined local), and documents the pitfall in its docblock so extension authors know to use `isset()` / `??` for superglobals.

Closes #29503.

Linear: https://linear.app/a8c/issue/RSMAPGJ-385

### Screenshots or screen recordings:

Not applicable — back-end-only change with no UI surface.

### How to test the changes in this Pull Request:

Reproducer from the original report (place the snippet anywhere that runs on the front end, e.g. a temporary `init` callback):

```php
add_action( 'init', function () {
    var_dump( array_keys( $_REQUEST ) );
    var_dump( array_keys( $_POST ) );
} );
```

1. Visit any front-end page on a plain `GET` request.
2. Before this fix, the output contains `woocommerce-login-nonce`, `woocommerce-reset-password-nonce`, `woocommerce-edit-address-nonce`, `save-account-details-nonce`, `_wpnonce` in `$_REQUEST` (all `null`).
3. With this fix applied, those entries are absent — `isset( $_REQUEST['_wpnonce'] )` returns `false` on a plain GET, as expected.
4. Submit each affected form (login, register, lost password, reset password, edit address, save account details, cart shipping calculator, order tracking, checkout, pay-for-order, add payment method) and confirm the nonce check still succeeds and the form processes normally.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

#### Changelog entry

> Added in `plugins/woocommerce/changelog/fix-rsmapgj-385`.

---
*RSMAPGJ AI Coder pipeline (pilot 2026-05-14)*
