### PR TITLE
Fix negative Net sales in Analytics after deleting refunded orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-426
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-426
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevent Analytics Orders report from showing negative Net sales after every order is deleted by cascading deletion of refund stats rows when their parent order is removed.
+
+

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -634,22 +634,69 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Deletes the order stats when an order is deleted.
 	 *
+	 * When the deleted order is a parent order (i.e. not a refund), any child
+	 * refund stats rows that reference it via `parent_id` are also removed.
+	 * This prevents orphaned refund rows (which carry negative totals) from
+	 * lingering in `wc_order_stats` and skewing reports such as Net sales,
+	 * which is the scenario that produces negative totals after every order
+	 * has been deleted.
+	 *
 	 * @param int $post_id Post ID.
 	 */
 	public static function delete_order( $post_id ) {
 		global $wpdb;
 		$order_id = (int) $post_id;
 
-		if ( ! OrderUtil::is_order( $post_id, array( 'shop_order', 'shop_order_refund' ) ) ) {
+		if ( $order_id <= 0 ) {
 			return;
 		}
 
-		// Retrieve customer details before the order is deleted.
-		$order       = wc_get_order( $order_id );
-		$customer_id = absint( CustomersDataStore::get_existing_customer_id_from_order( $order ) );
+		$table_name = self::get_db_table_name();
 
-		// Delete the order.
-		$wpdb->delete( self::get_db_table_name(), array( 'order_id' => $order_id ) );
+		// Look up the existing stats row directly. We cannot rely on
+		// OrderUtil::is_order() here because this method is also fired from
+		// WordPress' `delete_post` action, by which time the underlying order
+		// (and its HPOS record) may already be gone — leaving the analytics
+		// row behind. Reading the row first keeps the cleanup idempotent and
+		// lets us cascade-delete child refund rows even in that case.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$existing = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT order_id, parent_id FROM {$table_name} WHERE order_id = %d",
+				$order_id
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$is_known_order = (bool) $existing;
+		$is_refund_row  = $is_known_order && (int) $existing->parent_id > 0;
+
+		// Fall back to the order type lookup for rows that have not been synced
+		// yet (e.g. the row was never created) so we still bail out for
+		// non-order post IDs and keep prior behaviour for callers that pass in
+		// unrelated post IDs via `delete_post`.
+		if ( ! $is_known_order && ! OrderUtil::is_order( $post_id, array( 'shop_order', 'shop_order_refund' ) ) ) {
+			return;
+		}
+
+		// Retrieve customer details before the order is deleted. wc_get_order()
+		// may legitimately return false here (the order has already been
+		// removed from its data store), so handle that gracefully.
+		$order       = wc_get_order( $order_id );
+		$customer_id = $order ? absint( CustomersDataStore::get_existing_customer_id_from_order( $order ) ) : 0;
+
+		// Delete the order's own row.
+		$wpdb->delete( $table_name, array( 'order_id' => $order_id ) );
+
+		// If the deleted row represents a parent order (not a refund), cascade
+		// the deletion to any child refund rows so they cannot remain as
+		// orphaned negative entries in the stats table.
+		if ( ! $is_refund_row ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->delete( $table_name, array( 'parent_id' => $order_id ) );
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		}
+
 		/**
 		 * Fires when orders stats are deleted.
 		 *

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -4132,6 +4132,153 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Regression test for negative Net sales after deleting refunded orders.
+	 *
+	 * When an order with one or more refunds is force-deleted, the analytics
+	 * `wc_order_stats` table should not retain the refund rows (which carry
+	 * negative totals). Otherwise Net sales remains negative even after every
+	 * order has been deleted.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/48955
+	 */
+	public function test_delete_order_cascades_to_refund_stats_rows() {
+		global $wpdb;
+
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create a product and an order with a partial refund.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->set_total( 100 );
+		$order->set_shipping_total( 0 );
+		$order->set_cart_tax( 0 );
+		$order->save();
+
+		$refund = null;
+		foreach ( $order->get_items() as $item_values ) {
+			$item_data = $item_values->get_data();
+			$refund    = wc_create_refund(
+				array(
+					'amount'     => 10,
+					'order_id'   => $order->get_id(),
+					'line_items' => array(
+						$item_data['id'] => array(
+							'qty'          => 0,
+							'refund_total' => 10,
+						),
+					),
+				)
+			);
+			break;
+		}
+		$this->assertNotNull( $refund );
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$order_id  = $order->get_id();
+		$refund_id = $refund->get_id();
+
+		// Sanity: both rows exist in wc_order_stats before deletion.
+		$pre_order_row  = $wpdb->get_row(
+			$wpdb->prepare( "SELECT order_id, parent_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $order_id )
+		);
+		$pre_refund_row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT order_id, parent_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $refund_id )
+		);
+		$this->assertNotNull( $pre_order_row, 'Order stats row should exist before deletion.' );
+		$this->assertNotNull( $pre_refund_row, 'Refund stats row should exist before deletion.' );
+		$this->assertSame( (int) $order_id, (int) $pre_refund_row->parent_id );
+
+		// Delete the parent order. The refund row should be cleaned up too.
+		$order->delete( true );
+
+		$post_order_row  = $wpdb->get_row(
+			$wpdb->prepare( "SELECT order_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $order_id )
+		);
+		$post_refund_row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT order_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $refund_id )
+		);
+		$orphan_rows     = $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_order_stats WHERE parent_id = %d", $order_id )
+		);
+
+		$this->assertNull( $post_order_row, 'Order stats row should be removed after deletion.' );
+		$this->assertNull( $post_refund_row, 'Refund stats row should be removed when its parent order is deleted.' );
+		$this->assertSame( 0, (int) $orphan_rows, 'No refund rows should reference the deleted parent order.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * Deleting only a refund should not delete its parent order's stats row.
+	 *
+	 * Guards against an over-eager cascade in `delete_order` that could remove
+	 * the parent order's analytics row when only a child refund is deleted.
+	 */
+	public function test_delete_refund_only_does_not_remove_parent_order_stats() {
+		global $wpdb;
+
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->set_total( 100 );
+		$order->set_shipping_total( 0 );
+		$order->set_cart_tax( 0 );
+		$order->save();
+
+		$refund = null;
+		foreach ( $order->get_items() as $item_values ) {
+			$item_data = $item_values->get_data();
+			$refund    = wc_create_refund(
+				array(
+					'amount'     => 10,
+					'order_id'   => $order->get_id(),
+					'line_items' => array(
+						$item_data['id'] => array(
+							'qty'          => 0,
+							'refund_total' => 10,
+						),
+					),
+				)
+			);
+			break;
+		}
+		$this->assertNotNull( $refund );
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$order_id  = $order->get_id();
+		$refund_id = $refund->get_id();
+
+		// Delete only the refund.
+		$refund->delete( true );
+
+		$order_row  = $wpdb->get_row(
+			$wpdb->prepare( "SELECT order_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $order_id )
+		);
+		$refund_row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT order_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $refund_id )
+		);
+
+		$this->assertNotNull( $order_row, 'Parent order stats row should remain after only the refund is deleted.' );
+		$this->assertNull( $refund_row, 'Refund stats row should be removed after the refund is deleted.' );
+
+		$order->delete( true );
+		$product->delete( true );
+	}
+
+	/**
 	 * Test segmenting by product id and by variation id.
 	 */
 	public function test_segmenting_by_product_and_variation() {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

Closes #48955.

The Analytics → Orders report was showing a negative `Net sales` value after a store owner deleted every order — provided some of those orders had partial refunds.

**Root cause.** Each order and each refund gets its own row in `wc_order_stats` (refund rows carry negative totals and reference the parent order via `parent_id`). The analytics cleanup callback `Reports\Orders\Stats\DataStore::delete_order()` was hooked to both `woocommerce_before_delete_order` and `delete_post`, but:

- `Internal\DataStores\Orders\OrdersTableRefundDataStore::delete()` (HPOS) does not fire `woocommerce_before_delete_order`, and the `delete_post` callback runs after the HPOS row is already gone, so `OrderUtil::is_order()` short-circuits and the refund's stats row is never removed.
- In the CPT path the same callback bails for the same reason when invoked for orphaned IDs.

Result: refund rows lingered in `wc_order_stats` after their parent orders were deleted, leaving negative `Net sales` on a "clean" store.

**Fix.** When `delete_order()` runs for a stats row that represents a parent order, cascade-delete any child refund rows that reference it via `parent_id`. The check is also relaxed so the callback uses the existing `wc_order_stats` row as the source of truth rather than `OrderUtil::is_order()`, which can't see deleted orders.

### Screenshots or screen recordings

N/A (analytics totals only).

### How to test the changes in this Pull Request

Testing Instructions:

1. On a clean store, create 2–3 orders with a simple product, set them to "Completed".
2. Issue a partial refund (e.g. $10) on at least one of them.
3. Visit Analytics → Orders and confirm the report renders with the expected totals.
4. Go to WooCommerce → Orders, move every order to trash, then empty the trash.
5. Visit Analytics → Orders again. `Net sales` should be `$0.00`, not a negative value.
6. (Optional) Query `SELECT * FROM wp_wc_order_stats;` — the table should be empty.
7. (Optional regression check) Repeat steps 1–3, then delete only the refund row from the order edit screen. Reload Analytics → Orders: the parent order's totals should remain intact.

### Testing that has already taken place

- Added two PHPUnit regression tests in `tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php`:
  - `test_delete_order_cascades_to_refund_stats_rows` — covers the bug: deleting a parent order also clears its refund rows from `wc_order_stats`.
  - `test_delete_refund_only_does_not_remove_parent_order_stats` — guards against an over-eager cascade when only a refund is deleted.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse src/Admin/API/Reports/Orders/Stats/DataStore.php --memory-limit=2G` — no errors.
- PHPUnit was not executed locally per the AI Coder pipeline rules; tests are intended to run in CI.

<!-- If you're a WooCommerce Core developer, please make sure to fill out the following sections. Otherwise, you're welcome to remove them. -->

### Milestone

<!-- Tick the box below to auto-assign this PR to the first available milestone, or replace with the desired milestone. -->

- [x] Auto-assign to milestone.

### Changelog entry

- [x] Changelog entry has been created manually (see `plugins/woocommerce/changelog/fix-rsmapgj-426`).

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-426

🤖 RSMAPGJ AI Coder pipeline (pilot 2026-05-14)
