### PR TITLE
Fix shipping class cleared on quick/bulk edit with non-ASCII slugs

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-381
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-381
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix shipping class being cleared on quick/bulk edit when the slug contains non-ASCII (e.g. Asian) characters.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -435,8 +435,11 @@ class WC_Admin_Post_Types {
 			if ( '_no_shipping_class' === $request_data['_shipping_class'] ) {
 				$product->set_shipping_class_id( 0 );
 			} else {
-				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-				$shipping_class_id = $data_store->get_shipping_class_id_by_slug( wc_clean( $request_data['_shipping_class'] ) );
+				// Use sanitize_title() to preserve percent-encoded characters in non-ASCII slugs.
+				// wc_clean() / sanitize_text_field() strips percent-encoded octets, which breaks
+				// shipping class slugs that contain Asian or other non-ASCII characters.
+				$shipping_class_slug = sanitize_title( wp_unslash( $request_data['_shipping_class'] ) );
+				$shipping_class_id   = $data_store->get_shipping_class_id_by_slug( $shipping_class_slug );
 				$product->set_shipping_class_id( $shipping_class_id );
 			}
 		}
@@ -564,7 +567,11 @@ class WC_Admin_Post_Types {
 			if ( '_no_shipping_class' === $request_data['_shipping_class'] ) {
 				$product->set_shipping_class_id( 0 );
 			} else {
-				$shipping_class_id = $data_store->get_shipping_class_id_by_slug( wc_clean( $request_data['_shipping_class'] ) );
+				// Use sanitize_title() to preserve percent-encoded characters in non-ASCII slugs.
+				// wc_clean() / sanitize_text_field() strips percent-encoded octets, which breaks
+				// shipping class slugs that contain Asian or other non-ASCII characters.
+				$shipping_class_slug = sanitize_title( wp_unslash( $request_data['_shipping_class'] ) );
+				$shipping_class_id   = $data_store->get_shipping_class_id_by_slug( $shipping_class_slug );
 				$product->set_shipping_class_id( $shipping_class_id );
 			}
 		}

--- a/plugins/woocommerce/tests/unit-tests/admin/class-wc-tests-admin-post-types.php
+++ b/plugins/woocommerce/tests/unit-tests/admin/class-wc-tests-admin-post-types.php
@@ -151,4 +151,95 @@ class WC_Tests_Admin_Post_Types extends WC_Unit_Test_Case {
 		$actual  = $product->{"get_{$type_of_price}_price"}();
 		$this->assertEquals( $expected_new_price, $actual );
 	}
+
+	/**
+	 * Data for shipping class quick/bulk edit with non-ASCII (Asian / Cyrillic) slugs test.
+	 *
+	 * Term slugs in WordPress are stored URL-encoded when they contain non-ASCII characters
+	 * (e.g. `冷凍` is stored as `%e5%86%b7%e5%87%8d`). The quick/bulk edit form posts the slug
+	 * back unchanged, so the save handler must look the term up by that percent-encoded slug.
+	 *
+	 * @return array
+	 */
+	public function data_provider_shipping_class_non_ascii_slugs() {
+		return array(
+			'quick_edit_chinese'  => array( 'quick_edit', '冷凍' ),
+			'bulk_edit_chinese'   => array( 'bulk_edit', '常溫' ),
+			'quick_edit_cyrillic' => array( 'quick_edit', 'охлаждённый' ),
+		);
+	}
+
+	/**
+	 * @test
+	 * @testdox Quick/bulk edit should save the shipping class even when its slug contains non-ASCII (Asian) characters.
+	 * @dataProvider data_provider_shipping_class_non_ascii_slugs
+	 *
+	 * @param string $edit_type 'quick_edit' or 'bulk_edit'.
+	 * @param string $term_name Name of the shipping class term (used to derive the non-ASCII slug).
+	 */
+	public function shipping_class_non_ascii_slug_is_saved( $edit_type, $term_name ) {
+		// Create a shipping class with a non-ASCII name. WordPress will URL-encode the slug.
+		$term = wp_insert_term( $term_name, 'product_shipping_class' );
+		$this->assertIsArray( $term, 'Failed to create shipping class term.' );
+
+		$term_data = get_term( $term['term_id'], 'product_shipping_class' );
+		$slug      = $term_data->slug;
+
+		// Sanity check: the slug should contain a percent-encoded octet for non-ASCII characters.
+		$this->assertMatchesRegularExpression( '/%[a-f0-9]{2}/i', $slug, 'Expected slug to be percent-encoded.' );
+
+		$product = WC_Helper_Product::create_simple_product( true );
+
+		$this->login_as_administrator();
+
+		$request_data = array(
+			"woocommerce_{$edit_type}"     => '1',
+			'_shipping_class'              => $slug,
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+		);
+
+		$sut = $this->get_sut_with_request_data( $request_data );
+
+		$sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		$updated = wc_get_product( $product->get_id() );
+		$this->assertEquals(
+			$term['term_id'],
+			$updated->get_shipping_class_id(),
+			'Shipping class with non-ASCII slug should be saved on the product.'
+		);
+
+		// Cleanup.
+		wp_delete_term( $term['term_id'], 'product_shipping_class' );
+	}
+
+	/**
+	 * @test
+	 * @testdox Quick edit should clear the shipping class when '_no_shipping_class' is selected.
+	 */
+	public function quick_edit_clears_shipping_class_when_no_shipping_class_selected() {
+		$term = wp_insert_term( 'Standard', 'product_shipping_class' );
+		$this->assertIsArray( $term );
+
+		$product = WC_Helper_Product::create_simple_product( true );
+		$product->set_shipping_class_id( $term['term_id'] );
+		$product->save();
+
+		$this->login_as_administrator();
+
+		$request_data = array(
+			'woocommerce_quick_edit'       => '1',
+			'_shipping_class'              => '_no_shipping_class',
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+		);
+
+		$sut = $this->get_sut_with_request_data( $request_data );
+
+		$sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		$updated = wc_get_product( $product->get_id() );
+		$this->assertEquals( 0, $updated->get_shipping_class_id() );
+
+		wp_delete_term( $term['term_id'], 'product_shipping_class' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Coding Guidelines](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

Closes #26488.
Linear: https://linear.app/a8c/issue/RSMAPGJ-381

When a product is saved via Quick Edit or Bulk Edit, the shipping class slug submitted by the form was being passed through `wc_clean()` (i.e. `sanitize_text_field()`) before being looked up in the database. `sanitize_text_field()` strips percent-encoded octets (`%[a-f0-9]{2}`). Shipping class slugs with non-ASCII names (e.g. `冷凍`, `常溫`) are stored URL-encoded in the database (`%e5%86%b7%e5%87%8d`), so `wc_clean()` reduced the slug to an empty string. The subsequent `get_shipping_class_id_by_slug('')` returned `false`, so the product's shipping class was cleared on save.

This PR switches the sanitization to `sanitize_title( wp_unslash( ... ) )` in both the quick edit and bulk edit save paths. `sanitize_title()` is the canonical sanitizer for term slugs and preserves percent-encoded characters. The existing `_no_shipping_class` sentinel comparison is unaffected because it is checked before sanitization.

### Screenshots or screen recordings

N/A — non-visual fix. Repro steps in the original issue.

### How to test the changes in this Pull Request

1. In `WooCommerce → Settings → Shipping → Shipping classes`, add a shipping class with a non-ASCII name (e.g. `冷凍`). Confirm WordPress stores its slug as a percent-encoded string (visible in the term row, or via `wp term list product_shipping_class`).
2. Go to `Products → All Products`.
3. Click **Quick Edit** on any simple product.
4. Select the non-ASCII shipping class and click **Update**.
5. Re-open **Quick Edit** on the same product — the shipping class should remain selected. On `trunk` it would have reverted to "No shipping class".
6. Repeat with **Bulk Edit** (Bulk actions → Edit, select shipping class, Update).
7. Existing ASCII shipping class slugs and the "No shipping class" option should continue to behave as before.

### Testing that has already taken place

- Added `WC_Tests_Admin_Post_Types::shipping_class_non_ascii_slug_is_saved` covering Chinese (quick + bulk) and Cyrillic shipping class slugs.
- Added `WC_Tests_Admin_Post_Types::quick_edit_clears_shipping_class_when_no_shipping_class_selected` covering the `_no_shipping_class` sentinel path.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passes.
- `composer exec -- phpstan analyse includes/admin/class-wc-admin-post-types.php --memory-limit=2G` reports no errors. No additions to `phpstan-baseline.neon`.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance**: Patch
**Type**: Fix
**Message**: Fix shipping class being cleared on quick/bulk edit when the slug contains non-ASCII (e.g. Asian) characters.

</details>

---

🤖 RSMAPGJ AI Coder pipeline (pilot 2026-05-14).
