### PR TITLE
Document actual default of woocommerce_gallery_thumbnail_size filter

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-377
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-377
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Document the woocommerce_gallery_thumbnail_size filter's actual default value (an array of width/height integers, not the image size name) and add inline docblocks to its sibling gallery image filters.
+
+

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1280,7 +1280,13 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		/**
 		 * Filters the size for the gallery thumbnail.
 		 *
-		 * @param array $size Array containing width and height dimensions.
+		 * The default value passed to this filter is an array of explicit width/height integers
+		 * sourced from the `gallery_thumbnail` image size, not the size name string. A registered
+		 * image size name (string) is also accepted as a return value.
+		 *
+		 * @param array|string $size Default: array( int $width, int $height ) from the
+		 *                           `gallery_thumbnail` image size. May be filtered to return a
+		 *                           registered image size name string.
 		 *
 		 * @since 2.6.0
 		 */

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1809,7 +1809,10 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
 /**
  * Get HTML for a gallery image.
  *
- * Hooks: woocommerce_gallery_thumbnail_size, woocommerce_gallery_image_size and woocommerce_gallery_full_size accept name based image sizes, or an array of width/height values.
+ * Hooks: woocommerce_gallery_thumbnail_size, woocommerce_gallery_image_size and woocommerce_gallery_full_size accept
+ * either a registered image size name (string) or an array of width/height values. By default,
+ * woocommerce_gallery_thumbnail_size is passed an array of dimensions derived from the `gallery_thumbnail` image size,
+ * not the size name itself.
  *
  * @since 3.3.2
  * @param int  $attachment_id Attachment ID.
@@ -1822,15 +1825,53 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_
 
 	$flexslider        = (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) );
 	$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
-	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
-	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $main_image ? 'woocommerce_single' : $thumbnail_size );
-	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
-	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
-	$thumbnail_srcset  = wp_get_attachment_image_srcset( $attachment_id, $thumbnail_size );
-	$thumbnail_sizes   = wp_get_attachment_image_sizes( $attachment_id, $thumbnail_size );
-	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
-	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-	$alt_text          = ( empty( $alt_text ) && ( $product instanceof WC_Product ) ) ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index ) : $alt_text;
+	/**
+	 * Filters the size used for product gallery thumbnails.
+	 *
+	 * The default value is an array containing the width and height of the registered `gallery_thumbnail` image size,
+	 * not the size name string. A registered image size name (string) is also accepted as a return value and will be
+	 * passed through to `wp_get_attachment_image_src()`.
+	 *
+	 * @since 3.3.2
+	 *
+	 * @param array|string $size Default: array( int $width, int $height ) from the `gallery_thumbnail` image size.
+	 *                           May be filtered to return a registered image size name string.
+	 */
+	$thumbnail_size = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
+
+	/**
+	 * Filters the size used for the main product gallery image.
+	 *
+	 * @since 3.3.2
+	 *
+	 * @param array|string $size Image size name or array of width/height dimensions.
+	 */
+	$image_size = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $main_image ? 'woocommerce_single' : $thumbnail_size );
+
+	/**
+	 * Filters the large/full size used for product thumbnails.
+	 *
+	 * @since 3.3.2
+	 *
+	 * @param string $size Image size name. Defaults to 'full'.
+	 */
+	$large_thumbnails_size = apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' );
+
+	/**
+	 * Filters the size used for the full gallery image.
+	 *
+	 * @since 3.3.2
+	 *
+	 * @param array|string $size Image size name or array of width/height dimensions.
+	 */
+	$full_size = apply_filters( 'woocommerce_gallery_full_size', $large_thumbnails_size );
+
+	$thumbnail_src    = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
+	$thumbnail_srcset = wp_get_attachment_image_srcset( $attachment_id, $thumbnail_size );
+	$thumbnail_sizes  = wp_get_attachment_image_sizes( $attachment_id, $thumbnail_size );
+	$full_src         = wp_get_attachment_image_src( $attachment_id, $full_size );
+	$alt_text         = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
+	$alt_text         = ( empty( $alt_text ) && ( $product instanceof WC_Product ) ) ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index ) : $alt_text;
 
 	/**
 	 * Filters the attributes for the image markup.


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Workflow](https://github.com/woocommerce/woocommerce/wiki/Recommended-Workflow).

### Changes proposed in this Pull Request

The `woocommerce_gallery_thumbnail_size` filter is documented externally and in our public docs as receiving the registered image size name string (`woocommerce_gallery_thumbnail`), but the code actually passes an array of explicit width/height integers derived from the `gallery_thumbnail` image size. Reported back in 2019 (#24707) — the discrepancy makes the filter hard to use correctly, especially when overriding the gallery thumbnail size to soft crop.

Per the original author's note on the issue, the array form is intentional: it guarantees correct dimensions and aspect ratio when thumbnail regeneration hasn't been run, even if settings or filters changed. So this PR keeps that behavior (no theme/plugin breakage) and fixes the documentation instead:

- Update the `wc_get_gallery_image_html()` function-level note to spell out the default precisely.
- Add an inline `@param array|string` docblock at the `apply_filters( 'woocommerce_gallery_thumbnail_size', ... )` call site in `wc-template-functions.php` describing the actual default and the alternate accepted return type.
- Do the same for the same filter's second call site in `wc-product-functions.php` (the `WC_Product_Variation_Data_Store_CPT::set_image_url` flow).
- Add inline docblocks for the adjacent filters (`woocommerce_gallery_image_size`, `woocommerce_gallery_full_size`, `woocommerce_product_thumbnails_large_size`) that were previously only covered by the function-level "Hooks:" comment, so the WooCommerce PHPCS rule for hook documentation is satisfied across the now-modified block.

Behavior is unchanged. No callers updated. Public docs at https://docs.woocommerce.com/document/image-sizes-theme-developers/ were already corrected in 2019.

### Screenshots or screen recordings

N/A — docblock-only change.

### How to test the changes in this Pull Request

This is a docblock-only change, so the on-site behavior is unchanged. Reviewer steps:

1. Read the diff in `plugins/woocommerce/includes/wc-template-functions.php` and `plugins/woocommerce/includes/wc-product-functions.php` and confirm the docblocks accurately describe what's passed to the filters.
2. (Optional) Confirm no behavior change by adding a temporary `var_dump` for the value `$thumbnail_size` in `wc_get_gallery_image_html()` and reloading a product page — value should still be `array( 100, 100 )` for the default `gallery_thumbnail` size.

### Testing that has already taken place

- `composer run-script lint` on the changed files (clean, 0 errors / 0 warnings).
- `composer exec -- phpstan analyse includes/wc-template-functions.php includes/wc-product-functions.php --memory-limit=2G` — `[OK] No errors`.
- Manual diff review to confirm only docblocks and a trivial inlining of the nested `apply_filters()` (extracted into `$large_thumbnails_size` so the docblock can sit above its own filter call) — no functional change.

---

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to an existing feature
- [x] Other - Documentation / inline docblock fix

#### Message

Document the `woocommerce_gallery_thumbnail_size` filter's actual default value (an array of width/height integers, not the image size name) and add inline docblocks to its sibling gallery image filters.

#### Comment

Changelog file `plugins/woocommerce/changelog/fix-rsmapgj-377` was created manually.

</details>

Closes #24707.

Linear: https://linear.app/a8c/issue/RSMAPGJ-377

---

*RSMAPGJ AI Coder pipeline (pilot 2026-05-14)*
