### PR TITLE
Fix: remove deleted Media Library attachments from product gallery meta

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-413
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-413
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Remove deleted Media Library attachments from product gallery meta so they no longer render as blank slots on the product page.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -65,6 +65,7 @@ class WC_Post_Data {
 		add_action( 'untrashed_post', array( __CLASS__, 'untrash_post' ) );
 		add_action( 'before_delete_post', array( __CLASS__, 'before_delete_order' ) );
 		add_action( 'woocommerce_before_delete_order', array( __CLASS__, 'before_delete_order' ) );
+		add_action( 'delete_attachment', array( __CLASS__, 'remove_deleted_attachment_from_product_galleries' ) );
 
 		// Meta cache flushing.
 		add_action( 'updated_post_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
@@ -450,6 +451,71 @@ class WC_Post_Data {
 					}
 				}
 				break;
+		}
+	}
+
+	/**
+	 * Remove a deleted attachment ID from any product gallery (`_product_image_gallery`) meta that references it.
+	 *
+	 * When an attachment used in a product gallery is permanently deleted from the Media Library,
+	 * WordPress detaches the post-thumbnail relationship for featured images but leaves the gallery
+	 * meta untouched, causing the deleted ID to render as a blank slot on the product page until
+	 * the product is re-saved. This hook keeps the gallery meta in sync with the Media Library.
+	 *
+	 * @internal Hooked to the `delete_attachment` action.
+	 * @since 10.9.0
+	 *
+	 * @param int $attachment_id The ID of the attachment being deleted.
+	 *
+	 * @return void
+	 */
+	public static function remove_deleted_attachment_from_product_galleries( $attachment_id ) {
+		global $wpdb;
+
+		$attachment_id = (int) $attachment_id;
+		if ( $attachment_id <= 0 ) {
+			return;
+		}
+
+		$product_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_product_image_gallery' AND ( meta_value = %s OR meta_value LIKE %s OR meta_value LIKE %s OR meta_value LIKE %s )",
+				(string) $attachment_id,
+				$wpdb->esc_like( $attachment_id . ',' ) . '%',
+				'%' . $wpdb->esc_like( ',' . $attachment_id . ',' ) . '%',
+				'%' . $wpdb->esc_like( ',' . $attachment_id )
+			)
+		);
+
+		if ( empty( $product_ids ) ) {
+			return;
+		}
+
+		foreach ( $product_ids as $product_id ) {
+			$gallery = get_post_meta( (int) $product_id, '_product_image_gallery', true );
+			if ( ! is_string( $gallery ) || '' === $gallery ) {
+				continue;
+			}
+
+			$gallery_ids = array_filter(
+				array_map( 'absint', explode( ',', $gallery ) ),
+				static function ( $id ) use ( $attachment_id ) {
+					return $id > 0 && $id !== $attachment_id;
+				}
+			);
+
+			$new_value = implode( ',', $gallery_ids );
+			if ( $new_value === $gallery ) {
+				continue;
+			}
+
+			update_post_meta( (int) $product_id, '_product_image_gallery', $new_value );
+
+			// Bust caches so the next read of the product reflects the cleaned-up gallery.
+			$product = wc_get_product( (int) $product_id );
+			if ( $product instanceof WC_Product ) {
+				wc_delete_product_transients( $product->get_id() );
+			}
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
@@ -162,4 +162,177 @@ class WC_Post_Data_Test extends \WC_Unit_Test_Case {
 		remove_action( 'woocommerce_product_published', $callback );
 		$product->delete( true );
 	}
+
+	/**
+	 * Helper to insert a stub attachment post for gallery tests.
+	 *
+	 * @param int $parent_id Optional parent post ID.
+	 *
+	 * @return int Attachment post ID.
+	 */
+	private function insert_gallery_attachment( int $parent_id = 0 ): int {
+		return (int) wp_insert_attachment(
+			array(
+				'post_title'     => 'Gallery image ' . wp_generate_password( 6, false ),
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/png',
+				'post_status'    => 'inherit',
+			),
+			'',
+			$parent_id
+		);
+	}
+
+	/**
+	 * @testdox Should remove the deleted attachment ID from a product gallery meta when the attachment is deleted.
+	 */
+	public function test_remove_deleted_attachment_from_product_galleries_strips_middle_id(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+
+		$gallery_ids = array(
+			$this->insert_gallery_attachment( $product->get_id() ),
+			$this->insert_gallery_attachment( $product->get_id() ),
+			$this->insert_gallery_attachment( $product->get_id() ),
+		);
+
+		update_post_meta( $product->get_id(), '_product_image_gallery', implode( ',', $gallery_ids ) );
+
+		WC_Post_Data::remove_deleted_attachment_from_product_galleries( $gallery_ids[1] );
+
+		$gallery_after = get_post_meta( $product->get_id(), '_product_image_gallery', true );
+
+		$this->assertSame(
+			$gallery_ids[0] . ',' . $gallery_ids[2],
+			$gallery_after,
+			'Deleted attachment ID should be removed from the gallery meta.'
+		);
+	}
+
+	/**
+	 * @testdox Should remove the attachment ID when it is the only item in the gallery.
+	 */
+	public function test_remove_deleted_attachment_from_product_galleries_handles_single_id(): void {
+		$product       = \WC_Helper_Product::create_simple_product();
+		$attachment_id = $this->insert_gallery_attachment( $product->get_id() );
+
+		update_post_meta( $product->get_id(), '_product_image_gallery', (string) $attachment_id );
+
+		WC_Post_Data::remove_deleted_attachment_from_product_galleries( $attachment_id );
+
+		$gallery_after = get_post_meta( $product->get_id(), '_product_image_gallery', true );
+
+		$this->assertSame( '', $gallery_after, 'Gallery meta should become empty when the sole image is deleted.' );
+	}
+
+	/**
+	 * @testdox Should remove the attachment ID when it is the last item in the gallery.
+	 */
+	public function test_remove_deleted_attachment_from_product_galleries_handles_trailing_id(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+
+		$gallery_ids = array(
+			$this->insert_gallery_attachment( $product->get_id() ),
+			$this->insert_gallery_attachment( $product->get_id() ),
+		);
+
+		update_post_meta( $product->get_id(), '_product_image_gallery', implode( ',', $gallery_ids ) );
+
+		WC_Post_Data::remove_deleted_attachment_from_product_galleries( $gallery_ids[1] );
+
+		$this->assertSame(
+			(string) $gallery_ids[0],
+			get_post_meta( $product->get_id(), '_product_image_gallery', true ),
+			'Trailing attachment ID should be removed from the gallery meta.'
+		);
+	}
+
+	/**
+	 * @testdox Should clean gallery meta across every product that references the deleted attachment.
+	 */
+	public function test_remove_deleted_attachment_from_product_galleries_cleans_multiple_products(): void {
+		$product_a = \WC_Helper_Product::create_simple_product();
+		$product_b = \WC_Helper_Product::create_simple_product();
+
+		$shared_id = $this->insert_gallery_attachment();
+		$other_a   = $this->insert_gallery_attachment( $product_a->get_id() );
+		$other_b   = $this->insert_gallery_attachment( $product_b->get_id() );
+
+		update_post_meta( $product_a->get_id(), '_product_image_gallery', $other_a . ',' . $shared_id );
+		update_post_meta( $product_b->get_id(), '_product_image_gallery', $shared_id . ',' . $other_b );
+
+		WC_Post_Data::remove_deleted_attachment_from_product_galleries( $shared_id );
+
+		$this->assertSame(
+			(string) $other_a,
+			get_post_meta( $product_a->get_id(), '_product_image_gallery', true ),
+			'Shared attachment ID should be removed from product A gallery meta.'
+		);
+		$this->assertSame(
+			(string) $other_b,
+			get_post_meta( $product_b->get_id(), '_product_image_gallery', true ),
+			'Shared attachment ID should be removed from product B gallery meta.'
+		);
+	}
+
+	/**
+	 * @testdox Should leave unrelated gallery meta untouched when an unrelated attachment is deleted.
+	 */
+	public function test_remove_deleted_attachment_from_product_galleries_leaves_unrelated_meta_intact(): void {
+		$product     = \WC_Helper_Product::create_simple_product();
+		$gallery_ids = array(
+			$this->insert_gallery_attachment( $product->get_id() ),
+			$this->insert_gallery_attachment( $product->get_id() ),
+		);
+
+		$gallery_meta = implode( ',', $gallery_ids );
+		update_post_meta( $product->get_id(), '_product_image_gallery', $gallery_meta );
+
+		$unrelated_id = $this->insert_gallery_attachment();
+
+		WC_Post_Data::remove_deleted_attachment_from_product_galleries( $unrelated_id );
+
+		$this->assertSame(
+			$gallery_meta,
+			get_post_meta( $product->get_id(), '_product_image_gallery', true ),
+			'Unrelated attachment deletion should not modify gallery meta.'
+		);
+	}
+
+	/**
+	 * @testdox Should not match partial numeric overlaps in gallery meta when an attachment is deleted.
+	 */
+	public function test_remove_deleted_attachment_from_product_galleries_avoids_substring_matches(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+
+		// Gallery meta containing IDs that share a numeric substring with the deleted ID (e.g. 123 vs 1234).
+		$gallery_meta = '1234,12345,123';
+		update_post_meta( $product->get_id(), '_product_image_gallery', $gallery_meta );
+
+		WC_Post_Data::remove_deleted_attachment_from_product_galleries( 12 );
+
+		$this->assertSame(
+			$gallery_meta,
+			get_post_meta( $product->get_id(), '_product_image_gallery', true ),
+			'Gallery meta must not be modified when the deleted ID only appears as a substring.'
+		);
+	}
+
+	/**
+	 * @testdox Should be triggered by the delete_attachment WordPress action.
+	 */
+	public function test_delete_attachment_hook_removes_id_from_gallery(): void {
+		$product       = \WC_Helper_Product::create_simple_product();
+		$attachment_id = $this->insert_gallery_attachment( $product->get_id() );
+		$keep_id       = $this->insert_gallery_attachment( $product->get_id() );
+
+		update_post_meta( $product->get_id(), '_product_image_gallery', $attachment_id . ',' . $keep_id );
+
+		wp_delete_attachment( $attachment_id, true );
+
+		$this->assertSame(
+			(string) $keep_id,
+			get_post_meta( $product->get_id(), '_product_image_gallery', true ),
+			'wp_delete_attachment should trigger gallery meta cleanup via the delete_attachment hook.'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/plugins/security/).
- [x] Since my code uses third-party libraries, I have included their licenses and attributions.
- [x] As far as possible, I have included tests for any new code or features I have added.

### Changes proposed in this Pull Request

Closes #39606. Linear: https://linear.app/a8c/issue/RSMAPGJ-413.

When an attachment that is part of a product's image gallery is permanently deleted from the Media Library, WordPress detaches the post-thumbnail relationship for featured images but leaves the `_product_image_gallery` meta untouched. The deleted ID lingers in the comma-separated list and renders as a blank slot on the storefront product page until the product is re-saved (which is when `WC_Meta_Box_Product_Images` strips empty attachment references).

This PR adds a `delete_attachment` action handler on `WC_Post_Data` that scans `_product_image_gallery` post meta for the deleted attachment ID, removes it from the gallery, and busts the affected product transients. The query uses targeted `LIKE` patterns anchored to comma delimiters to avoid substring matches between numerically overlapping IDs (e.g. `12` vs `123`).

### How to test the changes in this Pull Request

1. Create a simple product with a featured image plus 2-3 gallery images.
2. View the product page on the storefront and confirm the gallery renders correctly.
3. From `wp-admin > Media`, permanently delete one of the gallery images (not the featured one).
4. Reload the storefront product page.
   - **Before this PR:** the deleted image renders as a blank space in the gallery.
   - **After this PR:** the deleted image is gone; the remaining gallery images render without gaps.
5. (Optional) Inspect `_product_image_gallery` post meta directly and confirm the deleted ID is no longer present.

### Testing that has already taken place

- Added unit tests in `class-wc-post-data-test.php` covering: middle / trailing / sole ID removal, multi-product cleanup, leaving unrelated gallery meta untouched, avoiding numeric-substring false positives, and end-to-end coverage via `wp_delete_attachment` triggering the `delete_attachment` hook.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passes.
- `composer exec -- phpstan analyse includes/class-wc-post-data.php --memory-limit=2G` reports no errors.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance:** Patch
**Type:** Fix
**Message:** Remove deleted Media Library attachments from product gallery meta so they no longer render as blank slots on the product page.

</details>

---

RSMAPGJ AI Coder pipeline (pilot 2026-05-14)
