### PR TITLE
Fix product quick edit saving NULL stock quantity with empty input

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-441
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-441
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix product quick edit saving stock quantity as NULL instead of 0 when manage stock is enabled with an empty quantity field, which caused incorrect backorder messages.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -508,7 +508,17 @@ class WC_Admin_Post_Types {
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
-			$stock_amount = 'yes' === $manage_stock && isset( $request_data['_stock'] ) && is_numeric( wp_unslash( $request_data['_stock'] ) ) ? wc_stock_amount( wp_unslash( $request_data['_stock'] ) ) : '';
+			if ( 'yes' === $manage_stock && isset( $request_data['_stock'] ) ) {
+				// Use wc_stock_amount for any provided value (including empty strings),
+				// matching the full product edit screen behavior. This ensures an empty
+				// stock quantity field saves as 0 instead of NULL when stock management
+				// is enabled, so arithmetic on backorder calculations works correctly.
+				$stock_amount = is_numeric( wp_unslash( $request_data['_stock'] ) )
+					? wc_stock_amount( wp_unslash( $request_data['_stock'] ) )
+					: wc_stock_amount( 0 );
+			} else {
+				$stock_amount = '';
+			}
 			$product->set_stock_quantity( $stock_amount );
 		}
 

--- a/plugins/woocommerce/tests/unit-tests/admin/class-wc-tests-admin-post-types.php
+++ b/plugins/woocommerce/tests/unit-tests/admin/class-wc-tests-admin-post-types.php
@@ -112,6 +112,102 @@ class WC_Tests_Admin_Post_Types extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Data for quick_edit_stock_quantity_saves_zero_when_manage_stock_enabled test.
+	 *
+	 * @return array
+	 */
+	public function data_provider_quick_edit_stock_quantity_with_manage_stock() {
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+		// $stock_value, $expected_stock_quantity
+		return array(
+			'empty string saves as 0'       => array( '', 0 ),
+			'whitespace saves as 0'         => array( '   ', 0 ),
+			'non-numeric string saves as 0' => array( 'abc', 0 ),
+			'numeric string 5 saves as 5'   => array( '5', 5 ),
+			'numeric string 0 saves as 0'   => array( '0', 0 ),
+		);
+	}
+
+	/**
+	 * @test
+	 * @testdox When quick editing with manage stock enabled, an empty or non-numeric stock quantity should save as 0 rather than NULL.
+	 * @dataProvider data_provider_quick_edit_stock_quantity_with_manage_stock
+	 *
+	 * @param string $stock_value             The value of '_stock' from the request.
+	 * @param int    $expected_stock_quantity Expected stock quantity after save.
+	 */
+	public function quick_edit_stock_quantity_saves_zero_when_manage_stock_enabled( $stock_value, $expected_stock_quantity ) {
+		$original_manage_stock_option = get_option( 'woocommerce_manage_stock' );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( false );
+		$product->save();
+
+		$this->login_as_administrator();
+
+		$request_data = array(
+			'woocommerce_quick_edit'       => '1',
+			'_manage_stock'                => 'yes',
+			'_backorders'                  => 'yes',
+			'_stock'                       => $stock_value,
+			'_stock_status'                => ProductStockStatus::IN_STOCK,
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+		);
+
+		$sut = $this->get_sut_with_request_data( $request_data );
+		$sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		$saved_product = wc_get_product( $product->get_id() );
+		$this->assertTrue( $saved_product->get_manage_stock(), 'Manage stock should be enabled.' );
+		$this->assertSame( $expected_stock_quantity, $saved_product->get_stock_quantity(), 'Stock quantity should match the expected value rather than NULL.' );
+		$this->assertNotNull( $saved_product->get_stock_quantity(), 'Stock quantity should never be NULL when managing stock.' );
+
+		// Cleanup.
+		if ( false === $original_manage_stock_option ) {
+			delete_option( 'woocommerce_manage_stock' );
+		} else {
+			update_option( 'woocommerce_manage_stock', $original_manage_stock_option );
+		}
+	}
+
+	/**
+	 * @test
+	 * @testdox When quick editing without manage stock enabled, the stock quantity should be cleared.
+	 */
+	public function quick_edit_stock_quantity_cleared_when_manage_stock_disabled() {
+		$original_manage_stock_option = get_option( 'woocommerce_manage_stock' );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->save();
+
+		$this->login_as_administrator();
+
+		$request_data = array(
+			'woocommerce_quick_edit'       => '1',
+			'_stock_status'                => ProductStockStatus::IN_STOCK,
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+		);
+
+		$sut = $this->get_sut_with_request_data( $request_data );
+		$sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		$saved_product = wc_get_product( $product->get_id() );
+		$this->assertFalse( $saved_product->get_manage_stock(), 'Manage stock should be disabled.' );
+		$this->assertNull( $saved_product->get_stock_quantity(), 'Stock quantity should be cleared (NULL) when stock management is off.' );
+
+		// Cleanup.
+		if ( false === $original_manage_stock_option ) {
+			delete_option( 'woocommerce_manage_stock' );
+		} else {
+			update_option( 'woocommerce_manage_stock', $original_manage_stock_option );
+		}
+	}
+
+	/**
 	 * @test
 	 * @testdox Prices should change appropriately when a price change is requested via bulk edit.
 	 * @dataProvider data_provider_bulk_change_price


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

Closes #61598.
Linear: https://linear.app/a8c/issue/RSMAPGJ-441

### Changes proposed in this Pull Request

When using **Quick Edit** on the product list, enabling **Manage stock**, and leaving the **Stock quantity** field empty, WooCommerce was saving the value as `NULL` in `_stock`. This produced inconsistent UI (list shows `0`, full edit shows `1`) and broke downstream arithmetic, e.g. the order admin notice "**0** units have been backordered" instead of the actual unit count.

The full product edit screen handles the same empty input correctly by running it through `wc_stock_amount()`, which coerces non-numeric values to `0`. This PR aligns quick edit with that behavior:

- In `WC_Admin_Post_Types::quick_edit_save()`, when `_manage_stock` is `yes` and `_stock` is posted (even as an empty string), the value is now saved as `wc_stock_amount(0)` instead of `''` when not numeric.
- When `_manage_stock` is `no`, the stock quantity is still cleared (empty string), preserving existing behavior.

### How to test the changes in this Pull Request

1. Enable global stock management at WooCommerce > Settings > Products > Inventory.
2. Create a simple product, enable Manage stock, and allow backorders. Save.
3. Go to **Products** list, click **Quick Edit** on the product.
4. Enable **Manage stock** in the quick edit row, leave **Stock quantity** blank, click **Update**.
5. Open the product in the full edit screen — Stock quantity should now show `0` (was `1`).
6. Check the database: `_stock` postmeta should be `0`, not `NULL`/empty.
7. Place an order requiring backorder; admin should see the correct unit count in the "X units have been backordered" message.

Regression coverage:

- Quick edit with `manage_stock=no` (no `_stock` posted) should still clear stock quantity to `NULL` — covered by the new `quick_edit_stock_quantity_cleared_when_manage_stock_disabled` test.
- Numeric values still save correctly (`5` → 5, `0` → 0) — covered by data provider cases.

### Testing that has already taken place

- Added PHPUnit tests in `WC_Tests_Admin_Post_Types`:
  - `quick_edit_stock_quantity_saves_zero_when_manage_stock_enabled` (data provider: empty string, whitespace, non-numeric, numeric `5`, numeric `0`).
  - `quick_edit_stock_quantity_cleared_when_manage_stock_disabled` (regression for the disabled path).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse plugins/woocommerce/includes/admin/class-wc-admin-post-types.php --memory-limit=2G` — no errors.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance:** Patch
**Type:** Fix
**Message:** Fix product quick edit saving stock quantity as NULL instead of 0 when manage stock is enabled with an empty quantity field, which caused incorrect backorder messages.

</details>

---

_RSMAPGJ AI Coder pipeline (pilot 2026-05-14)_
