### PR TITLE
Fix My Account update blocked when display name matches email

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-392
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-392
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow customers whose display name matches their email (e.g., registered with email as username) to save account details without hitting the "Display name cannot be changed to email address" error when the display name is unchanged.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -275,8 +275,13 @@ class WC_Form_Handler {
 		$user->last_name    = $account_last_name;
 		$user->display_name = $account_display_name;
 
-		// Prevent display name to be changed to email.
-		if ( is_email( $account_display_name ) ) {
+		// Prevent display name from being changed to an email address. Allow
+		// submissions where the display name already matches the stored value
+		// (e.g., when the user registered with their email as the username and
+		// the display name was pre-populated from that username), so that other
+		// account fields can still be updated.
+		$current_display_name = $current_user ? $current_user->display_name : '';
+		if ( is_email( $account_display_name ) && $account_display_name !== $current_display_name ) {
 			wc_add_notice( __( 'Display name cannot be changed to email address due to privacy concern.', 'woocommerce' ), 'error' );
 		}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-save-account-details-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-save-account-details-test.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Class WC_Form_Handler_Save_Account_Details_Test file.
+ *
+ * @package WooCommerce\Tests\WC_Form_Handler.
+ */
+
+/**
+ * Tests for WC_Form_Handler::save_account_details() display-name-as-email validation.
+ *
+ * Regression coverage for https://github.com/woocommerce/woocommerce/issues/32001 :
+ * when a user registers with their email as their username, the display name is
+ * pre-populated from the username (i.e. the email address). Submitting the
+ * account-details form without altering the display name should not be blocked
+ * by the privacy-concern check, because the display name is not actually being
+ * changed to an email.
+ */
+class WC_Form_Handler_Save_Account_Details_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Backup of the $_POST and $_REQUEST superglobals.
+	 *
+	 * @var array
+	 */
+	private $post_backup;
+
+	/**
+	 * Backup of the $_REQUEST superglobal.
+	 *
+	 * @var array
+	 */
+	private $request_backup;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->post_backup    = $_POST;
+		$this->request_backup = $_REQUEST;
+
+		wc_clear_notices();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		$_POST    = $this->post_backup;
+		$_REQUEST = $this->request_backup;
+
+		wc_clear_notices();
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a valid $_POST payload for the save_account_details handler.
+	 *
+	 * @param array $overrides Field overrides.
+	 * @return array
+	 */
+	private function build_post_payload( array $overrides = array() ): array {
+		$defaults = array(
+			'action'                          => 'save_account_details',
+			'_wpnonce'                        => wp_create_nonce( 'save_account_details' ),
+			'save-account-details-nonce'      => wp_create_nonce( 'save_account_details' ),
+			'account_first_name'              => 'Jane',
+			'account_last_name'               => 'Doe',
+			'account_display_name'            => 'Jane',
+			'account_email'                   => 'jane@example.com',
+			'password_current'                => '',
+			'password_1'                      => '',
+			'password_2'                      => '',
+		);
+
+		return array_merge( $defaults, $overrides );
+	}
+
+	/**
+	 * Invoke the form handler via its public static entry point.
+	 */
+	private function invoke_handler(): void {
+		WC_Form_Handler::save_account_details();
+	}
+
+	/**
+	 * Returns true if the privacy-concern notice has been queued.
+	 *
+	 * @return bool
+	 */
+	private function has_display_name_email_error(): bool {
+		$notices = wc_get_notices( 'error' );
+		foreach ( $notices as $notice ) {
+			$message = is_array( $notice ) ? ( $notice['notice'] ?? '' ) : $notice;
+			if ( false !== strpos( (string) $message, 'Display name cannot be changed to email address' ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * @testdox Should not emit the email-as-display-name error when the display name is unchanged and already an email.
+	 */
+	public function test_unchanged_email_display_name_does_not_trigger_error(): void {
+		$email   = 'qa-test-user@example.com';
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login'   => $email,
+				'user_email'   => $email,
+				'display_name' => $email,
+				'role'         => 'customer',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$_POST = $_REQUEST = $this->build_post_payload(
+			array(
+				'account_first_name'   => 'Jane',
+				'account_last_name'    => 'Doe',
+				'account_display_name' => $email,
+				'account_email'        => $email,
+			)
+		);
+
+		$this->invoke_handler();
+
+		$this->assertFalse(
+			$this->has_display_name_email_error(),
+			'Unchanged email-as-display-name submissions must not trigger the privacy-concern notice.'
+		);
+
+		$refreshed = get_user_by( 'id', $user_id );
+		$this->assertSame( 'Jane', $refreshed->first_name, 'First name should be saved when display name is unchanged.' );
+		$this->assertSame( 'Doe', $refreshed->last_name, 'Last name should be saved when display name is unchanged.' );
+	}
+
+	/**
+	 * @testdox Should emit the email-as-display-name error when the display name is actively being changed to an email.
+	 */
+	public function test_changing_display_name_to_email_triggers_error(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login'   => 'janedoe',
+				'user_email'   => 'jane@example.com',
+				'display_name' => 'Jane Doe',
+				'role'         => 'customer',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$_POST = $_REQUEST = $this->build_post_payload(
+			array(
+				'account_first_name'   => 'Jane',
+				'account_last_name'    => 'Doe',
+				'account_display_name' => 'jane@example.com',
+				'account_email'        => 'jane@example.com',
+			)
+		);
+
+		$this->invoke_handler();
+
+		$this->assertTrue(
+			$this->has_display_name_email_error(),
+			'Changing the display name to an email address must still trigger the privacy-concern notice.'
+		);
+	}
+
+	/**
+	 * @testdox Should not emit the email-as-display-name error for a normal display-name update.
+	 */
+	public function test_normal_display_name_update_does_not_trigger_error(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login'   => 'janedoe',
+				'user_email'   => 'jane@example.com',
+				'display_name' => 'Jane Doe',
+				'role'         => 'customer',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$_POST = $_REQUEST = $this->build_post_payload(
+			array(
+				'account_first_name'   => 'Jane',
+				'account_last_name'    => 'Doe',
+				'account_display_name' => 'Janey',
+				'account_email'        => 'jane@example.com',
+			)
+		);
+
+		$this->invoke_handler();
+
+		$this->assertFalse(
+			$this->has_display_name_email_error(),
+			'A plain display-name update must not be flagged as an email.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Coding Standards](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines).

### Changes proposed in this Pull Request

Closes #32001.

Linear: https://linear.app/a8c/issue/RSMAPGJ-392

When a store allows registration with email as username (Settings → Accounts & Privacy → uncheck "automatically generate an account username"), customers who sign up are stored with `user_login == user_email`. WordPress then pre-populates `display_name` from `user_login`, so the My Account → Account Details form is rendered with the customer's email pre-filled as the display name.

On submit, `WC_Form_Handler::save_account_details()` rejected any submission whose `account_display_name` was an email address, regardless of whether it was actually being changed. Result: these customers could not update first name, last name, or any other account field without first manually changing their display name.

The fix narrows the privacy-concern guard to fire only when the submitted display name is an email **and** differs from the stored display name. Submitting the form with the pre-populated value now passes through, while deliberately changing the display name to an email is still blocked.

### Screenshots or screen recordings

Not applicable — the change is server-side validation.

### How to test the changes in this Pull Request

1. Go to **WooCommerce → Settings → Accounts & Privacy** and enable "Allow customers to create an account on the 'My account' page". Ensure "When creating an account, automatically generate an account username for the customer based on their name, surname or email" is **unchecked**.
2. Sign out, go to `/my-account/`, and register a new customer using the same email address for both the username and email fields, e.g. `qa-test-user@example.com`.
3. After auto-login, navigate to **My Account → Account Details**.
4. Without changing the display name, fill in a first name and last name and click **Save changes**.
5. Expected: the changes save and a success notice appears. Before the fix: a "Display name cannot be changed to email address due to privacy concern" error blocked the save.
6. Also verify: setting the display name to a different email (e.g. `someone-else@example.com`) is still blocked with the privacy-concern error.

### Testing that has already taken place

- Added PHPUnit coverage in `tests/php/includes/class-wc-form-handler-save-account-details-test.php` covering:
  - Unchanged email display name does not trigger the privacy-concern notice and other fields are saved.
  - Changing the display name to an email still triggers the notice.
  - A normal display-name change does not trigger the notice.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passes.
- `composer --working-dir=plugins/woocommerce exec -- phpstan analyse includes/class-wc-form-handler.php --memory-limit=2G` passes with no new errors and no baseline additions.

### Changelog entry

- [x] Added changelog entry: `plugins/woocommerce/changelog/fix-rsmapgj-392`.

---

RSMAPGJ AI Coder pipeline (pilot 2026-05-14).
