### PR TITLE
Fix invisible characters not stripped from checkout phone numbers

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-435
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-435
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Strip additional invisible Unicode characters (variation selectors, directional isolates, object replacement) so checkout phone numbers copy-pasted from PDFs validate correctly.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1641,8 +1641,11 @@ function wc_sanitize_endpoint_slug( $raw_value ) {
  * - **Soft hyphen (`U+00AD`)** – Invisible unless text is broken across lines.
  * - **Zero-width spaces & joiners (`U+200B–U+200D`)** – Invisible and can cause copy/paste issues.
  * - **Directional markers (`U+200E–U+200F`, `U+202A–U+202E`)** – Can affect text rendering.
+ * - **Directional isolates (`U+2066–U+2069`)** – Can affect text rendering.
+ * - **Variation selectors (`U+FE0D`, `U+FE0F`)** – Commonly introduced when copy-pasting from PDF documents.
  * - **Byte Order Mark (BOM) (`U+FEFF`)** – Can interfere with encoding.
  * - **Interlinear annotation characters (`U+FFF9–U+FFFB`)** – Rarely used and unnecessary in checkout fields.
+ * - **Object replacement character (`U+FFFC`)** – Placeholder for embedded objects, not user-meaningful in plain text.
  *
  * It does **not** remove:
  *
@@ -1667,10 +1670,24 @@ function wc_remove_non_displayable_chars( string $raw_value ): string {
 		"\u{202C}", // Pop Directional Formatting.
 		"\u{202D}", // Left-to-Right Override.
 		"\u{202E}", // Right-to-Left Override.
+		// Left-to-Right Isolate.
+		"\u{2066}",
+		// Right-to-Left Isolate.
+		"\u{2067}",
+		// First Strong Isolate.
+		"\u{2068}",
+		// Pop Directional Isolate.
+		"\u{2069}",
+		// Variation Selector-14 (commonly appears in PDF copy-paste).
+		"\u{FE0D}",
+		// Variation Selector-16.
+		"\u{FE0F}",
 		"\u{FEFF}", // Byte Order Mark (BOM).
 		"\u{FFF9}", // Interlinear Annotation Anchor.
 		"\u{FFFA}", // Interlinear Annotation Separator.
 		"\u{FFFB}", // Interlinear Annotation Terminator.
+		// Object Replacement Character.
+		"\u{FFFC}",
 	);
 
 	return str_replace( $remove_chars, '', $raw_value );

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -1135,5 +1135,22 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 		// String with word joiner (U+2060), should be preserved.
 		$this->assertEquals( "Join\xE2\x81\xA0Me", wc_remove_non_displayable_chars( "Join\xE2\x81\xA0Me" ) );
+
+		// String with variation selector-14 (U+FE0D), should be removed.
+		// This is the specific character causing checkout phone validation failures when copy-pasted from PDFs.
+		$this->assertEquals( '+1-555-123-4567', wc_remove_non_displayable_chars( "+1\xEF\xB8\x8D-555-123-4567" ) );
+
+		// String with variation selector-16 (U+FE0F), should be removed.
+		$this->assertEquals( '+1-555-123-4567', wc_remove_non_displayable_chars( "+1\xEF\xB8\x8F-555-123-4567" ) );
+
+		// String with directional isolates (U+2066 - U+2069), should be removed.
+		$this->assertEquals( 'abc', wc_remove_non_displayable_chars( "\xE2\x81\xA6abc\xE2\x81\xA9" ) );
+		$this->assertEquals( 'abc', wc_remove_non_displayable_chars( "\xE2\x81\xA7abc\xE2\x81\xA8" ) );
+
+		// String with object replacement character (U+FFFC), should be removed.
+		$this->assertEquals( 'Hello', wc_remove_non_displayable_chars( "Hello\xEF\xBF\xBC" ) );
+
+		// Phone number with multiple invisible chars sprinkled throughout (real-world copy-paste from PDF).
+		$this->assertEquals( '+15551234567', wc_remove_non_displayable_chars( "+1\xEF\xB8\x8D5\xE2\x80\x8B5\xE2\x80\x8E5\xC2\xAD1234567" ) );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have reviewed and followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] My code adheres to the [coding guidelines](https://developer.woocommerce.com/docs/contribution/coding-guidelines/).

### Changes proposed in this Pull Request

`wc_remove_non_displayable_chars()` (added in #56402) was missing several invisible Unicode codepoints that are commonly inserted when text is copy-pasted from PDFs, Word documents, and other rich-text sources. The most user-visible symptom is that a phone number such as `+1︍-555-123-4567` (the dash-looking character is U+FE0D, Variation Selector-14) fails checkout validation because the function does not strip it before validation runs.

This PR extends the strip list with the additional invisibles flagged in #58000:

- `U+2066`–`U+2069` (directional isolates)
- `U+FE0D` (Variation Selector-14) and `U+FE0F` (Variation Selector-16)
- `U+FFFC` (Object Replacement Character)

Existing behaviour is preserved: non-breaking space (`U+00A0`) and word joiner (`U+2060`) are still left intact, since they have legitimate uses in address and script rendering.

Bug introduced in PR #56402.

Closes #58000.

Linear: https://linear.app/a8c/issue/RSMAPGJ-435

### Screenshots or screen recordings

N/A — backend sanitization only, no UI changes.

### How to test the changes in this Pull Request

1. Add a product to the cart and go to the Checkout block.
2. Paste the following exact string (it contains an invisible U+FE0D between `1` and `-`) into the Phone field: `+1︍-555-123-4567`
3. Fill in the remaining required fields and click **Place order**.
4. The order should now be created successfully — before this patch, validation would fail because of the invisible character.

You can also exercise the function directly:

```php
var_dump( wc_remove_non_displayable_chars( "+1\u{FE0D}-555-123-4567" ) );
// string(15) "+1-555-123-4567"
```

### Testing that has already taken place

- New PHPUnit cases were added to `tests/legacy/unit-tests/formatting/functions.php` covering `U+FE0D`, `U+FE0F`, the four directional isolates, `U+FFFC`, and a real-world phone-number scenario with multiple invisibles sprinkled through it.
- Existing assertions in that test method still hold, so non-breaking space and word joiner remain preserved.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- Ran `composer exec -- phpstan analyse includes/wc-formatting-functions.php --memory-limit=2G` — no errors.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance**: patch
**Type**: fix

Strip additional invisible Unicode characters (variation selectors, directional isolates, object replacement) so checkout phone numbers copy-pasted from PDFs validate correctly.

</details>

---

_This pull request was created by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14)._
