### PR TITLE
Align order item cache shape between the order and order item data stores

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-390
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-390
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Align the fields cached by the individual order item data store with those cached by the order data store, so the `item-{order_item_id}` cache entry has a consistent shape regardless of which code path primed it.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -162,7 +162,10 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 		$data = wp_cache_get( 'item-' . $item->get_id(), 'order-items' );
 
 		if ( false === $data ) {
-			$data = $wpdb->get_row( $wpdb->prepare( "SELECT order_id, order_item_name FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item->get_id() ) );
+			// Fetch the same fields cached by the order data store's `read_items()` so the
+			// `item-{order_item_id}` cache entry has a consistent shape regardless of the
+			// code path that primed it. See `Abstract_WC_Order_Data_Store_CPT::read_items()`.
+			$data = $wpdb->get_row( $wpdb->prepare( "SELECT order_item_id, order_item_name, order_item_type, order_id FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item->get_id() ) );
 			wp_cache_set( 'item-' . $item->get_id(), $data, 'order-items' );
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-data-store.php
@@ -56,6 +56,57 @@ class WC_Tests_Order_Item_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that the `item-{order_item_id}` cache entry has the same fields regardless of which
+	 * data store path primed it (order data store `read_items()` vs. individual item data store
+	 * `read()`).
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/31656 where the order
+	 * data store cached 4 fields (order_item_type, order_item_id, order_id, order_item_name) but
+	 * the individual item data store only cached order_id and order_item_name.
+	 */
+	public function test_item_cache_shape_is_consistent_between_data_stores() {
+		$order      = WC_Helper_Order::create_order();
+		$items      = $order->get_items();
+		$order_item = reset( $items );
+		$item_id    = $order_item->get_id();
+
+		// PATH A: order data store `read_items()` populates the `item-` cache when the order's
+		// items collection is read. Trigger by clearing the cache and re-reading via a new order.
+		wp_cache_delete( 'item-' . $item_id, 'order-items' );
+		wp_cache_delete( 'order-items-' . $order->get_id(), 'orders' );
+		$fresh_order = wc_get_order( $order->get_id() );
+		$fresh_order->get_items();
+		$cached_via_order_store = wp_cache_get( 'item-' . $item_id, 'order-items' );
+		$this->assertNotFalse( $cached_via_order_store, 'Order data store should populate the item cache when reading order items.' );
+		$order_store_fields = array_keys( (array) $cached_via_order_store );
+
+		// PATH B: item data store `read()` populates the `item-` cache when an individual item
+		// is read. Trigger by clearing the cache and re-instantiating the item.
+		wp_cache_delete( 'item-' . $item_id, 'order-items' );
+		wp_cache_delete( 'order-items-' . $order->get_id(), 'orders' );
+		// Re-instantiating the item triggers the item data store's read() path.
+		new WC_Order_Item_Product( $item_id );
+		$cached_via_item_store = wp_cache_get( 'item-' . $item_id, 'order-items' );
+		$this->assertNotFalse( $cached_via_item_store, 'Item data store should populate the item cache when reading an individual item.' );
+		$item_store_fields = array_keys( (array) $cached_via_item_store );
+
+		sort( $order_store_fields );
+		sort( $item_store_fields );
+
+		$this->assertSame(
+			$order_store_fields,
+			$item_store_fields,
+			'The `item-{order_item_id}` cache entry should have the same fields regardless of which data store primed it.'
+		);
+
+		// Confirm the union includes the fields previously only set by the order data store.
+		$this->assertContains( 'order_item_type', $item_store_fields );
+		$this->assertContains( 'order_item_id', $item_store_fields );
+		$this->assertContains( 'order_id', $item_store_fields );
+		$this->assertContains( 'order_item_name', $item_store_fields );
+	}
+
+	/**
 	 * Tests that the cache is cleared when an order item is deleted.
 	 */
 	public function test_cache_cleared_on_item_deletion() {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)
- [x] I have run linting on the changes.

### Changes proposed in this Pull Request

Closes #31656.
Linear: https://linear.app/a8c/issue/RSMAPGJ-390

The order data store's `read_items()` primes the `item-{order_item_id}` cache entry (group `order-items`) with four columns:

```
order_item_type, order_item_id, order_id, order_item_name
```

The individual order item data store's `read()` writes to the same cache key but only selects two columns:

```
order_id, order_item_name
```

That means the same cache entry has different shapes depending on which code path populated it. Anything reading the cached row directly (for example `WC_Order_Factory::get_order_item()`, which dispatches on `order_item_type` / `order_item_id`) will see different fields depending on whether the order data store or the item data store wrote the entry last.

This PR aligns the individual item data store's `SELECT` with the order data store's, so the cached row always carries the same four fields.

### Why this direction

The order data store path is the more complete one. Its cached entry is shaped to be consumed by `WC_Order_Factory::get_order_item()` (which needs `order_item_type` and `order_item_id`). The item data store path was caching a strict subset, which is what produced the inconsistency. Adding the two missing fields is a one-column-each change and removes the discrepancy without changing any consumer.

### Screenshots or screen recordings

n/a — backend cache shape only.

### How to test the changes in this Pull Request

A scripted reproduction is provided in the Linear issue. The short version:

1. Create an order with at least one line item.
2. From a fresh cache, call `$order->get_items()` (PATH A) and read `wp_cache_get( 'item-' . $item_id, 'order-items' )` — observe four fields.
3. Flush cache, instantiate a `WC_Order_Item_Product( $item_id )` directly (PATH B) and read the same cache entry — before this PR it had two fields; after this PR it has the same four fields as PATH A.

A regression test asserting this is included in `tests/legacy/unit-tests/order-items/class-wc-tests-order-item-data-store.php`.

### Testing that has already taken place

- PHPCS (`pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`) — clean.
- PHPStan on the modified production file (`includes/data-stores/abstract-wc-order-item-type-data-store.php`) — clean.
- Regression PHPUnit test added (not executed locally per pipeline policy).

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry committed: `plugins/woocommerce/changelog/fix-rsmapgj-390`.

<!-- RSMAPGJ AI Coder pipeline (pilot 2026-05-14) -->
