### PR TITLE
Suppress duplicate add-to-cart notice from legacy product grid blocks on single product templates

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-415
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-415
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Prevent the legacy product grid blocks (On Sale Products, Best Selling Products, etc.) from showing a duplicate "added to cart" notice when their Add to Cart button is clicked from inside the Single Product template.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -12,6 +12,25 @@ use Automattic\WooCommerce\Enums\ProductStockStatus;
 abstract class AbstractProductGrid extends AbstractDynamicBlock {
 
 	/**
+	 * Query arg appended to add-to-cart URLs rendered by the legacy product
+	 * grid blocks when they are displayed on a single product page. It is
+	 * used to suppress the duplicate "added to cart" notice that would
+	 * otherwise be rendered alongside the single product page's own notices.
+	 *
+	 * @var string
+	 */
+	const SINGLE_PRODUCT_GRID_ATC_QUERY_ARG = '_wc_blocks_grid_atc';
+
+	/**
+	 * Tracks whether the notice suppression filter has been registered to
+	 * avoid attaching it multiple times when several legacy grid blocks
+	 * render on the same request.
+	 *
+	 * @var bool
+	 */
+	private static $single_product_grid_atc_filter_registered = false;
+
+	/**
 	 * Attributes.
 	 *
 	 * @var array
@@ -682,11 +701,73 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		 */
 		$attributes = apply_filters( 'woocommerce_blocks_product_grid_add_to_cart_attributes', $attributes, $product );
 
+		$add_to_cart_url = $product->add_to_cart_url();
+
+		/*
+		 * When a legacy product grid block (e.g. On Sale Products) is rendered
+		 * inside the Single Product template, the link-based add-to-cart action
+		 * causes a full-page reload that ends up displaying the standard
+		 * "added to cart" notice on top of the single product page. Modern
+		 * Interactivity-API-powered blocks do not exhibit this behaviour, so
+		 * we mark the URL with a query arg here and suppress the notice for
+		 * the corresponding request to keep parity between the two stacks.
+		 */
+		if ( function_exists( 'is_product' ) && is_product() ) {
+			$add_to_cart_url = add_query_arg( self::SINGLE_PRODUCT_GRID_ATC_QUERY_ARG, '1', $add_to_cart_url );
+		}
+
 		return sprintf(
 			'<a href="%s" %s>%s</a>',
-			esc_url( $product->add_to_cart_url() ),
+			esc_url( $add_to_cart_url ),
 			wc_implode_html_attributes( $attributes ),
 			esc_html( $product->add_to_cart_text() )
+		);
+	}
+
+	/**
+	 * Initialize this block type.
+	 *
+	 * Also wires up a filter that suppresses the standard "added to cart"
+	 * notice when the add-to-cart request originates from a legacy product
+	 * grid block rendered on a single product page (see
+	 * SINGLE_PRODUCT_GRID_ATC_QUERY_ARG).
+	 *
+	 * @return void
+	 */
+	protected function initialize() {
+		parent::initialize();
+		self::register_single_product_grid_atc_notice_filter();
+	}
+
+	/**
+	 * Register the filter that suppresses the legacy add-to-cart notice
+	 * when the request originates from a product grid block rendered on a
+	 * single product page. The filter is registered at most once per
+	 * request, regardless of how many grid blocks are registered.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return void
+	 */
+	private static function register_single_product_grid_atc_notice_filter() {
+		if ( self::$single_product_grid_atc_filter_registered ) {
+			return;
+		}
+
+		self::$single_product_grid_atc_filter_registered = true;
+
+		add_filter(
+			'wc_add_to_cart_message_html',
+			static function ( $message ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only marker; nonces are not applicable.
+				if ( isset( $_REQUEST[ self::SINGLE_PRODUCT_GRID_ATC_QUERY_ARG ] ) ) {
+					return '';
+				}
+
+				return $message;
+			},
+			10,
+			1
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductOnSaleTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductOnSaleTest.php
@@ -1,0 +1,89 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AbstractProductGrid;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\ProductOnSaleMock;
+
+/**
+ * Tests for the ProductOnSale block type, focused on the suppression of
+ * the standard "added to cart" notice when the legacy add-to-cart link
+ * originates from the block rendered on a single product page.
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/42156
+ */
+class ProductOnSaleTest extends \WP_UnitTestCase {
+
+	/**
+	 * Mock instance.
+	 *
+	 * @var ProductOnSaleMock
+	 */
+	private ProductOnSaleMock $mock;
+
+	/**
+	 * Snapshot of $_REQUEST so we can restore between tests.
+	 *
+	 * @var array
+	 */
+	private array $original_request = array();
+
+	/**
+	 * Setup test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_request = $_REQUEST;
+		$this->mock             = new ProductOnSaleMock();
+		$this->mock->trigger_filter_registration();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		$_REQUEST = $this->original_request;
+
+		// Remove any filters we added during the test so they do not leak
+		// into subsequent tests.
+		remove_all_filters( 'wc_add_to_cart_message_html' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The notice should be suppressed when the marker query arg is
+	 * present in the current request.
+	 */
+	public function test_notice_is_suppressed_when_marker_query_arg_is_present(): void {
+		$_REQUEST[ AbstractProductGrid::SINGLE_PRODUCT_GRID_ATC_QUERY_ARG ] = '1';
+
+		$filtered = apply_filters( 'wc_add_to_cart_message_html', 'Added "Foo" to your cart.', array( 1 => 1 ), false );
+
+		$this->assertSame( '', $filtered );
+	}
+
+	/**
+	 * The notice should pass through unchanged when the marker query arg
+	 * is not present in the current request.
+	 */
+	public function test_notice_passes_through_when_marker_query_arg_is_absent(): void {
+		unset( $_REQUEST[ AbstractProductGrid::SINGLE_PRODUCT_GRID_ATC_QUERY_ARG ] );
+
+		$message  = 'Added &ldquo;Foo&rdquo; to your cart.';
+		$filtered = apply_filters( 'wc_add_to_cart_message_html', $message, array( 1 => 1 ), false );
+
+		$this->assertSame( $message, $filtered );
+	}
+
+	/**
+	 * The query arg name is part of the contract between the rendered URL
+	 * and the suppression filter, so we lock it in via this test to
+	 * guard against accidental renames.
+	 */
+	public function test_marker_query_arg_constant_is_stable(): void {
+		$this->assertSame( '_wc_blocks_grid_atc', AbstractProductGrid::SINGLE_PRODUCT_GRID_ATC_QUERY_ARG );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductOnSaleMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductOnSaleMock.php
@@ -1,0 +1,49 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\BlockTypes\ProductOnSale;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+use Automattic\WooCommerce\Blocks\Package;
+
+/**
+ * ProductOnSaleMock exposes ProductOnSale (and its AbstractProductGrid
+ * base class) internals so they can be exercised from unit tests.
+ */
+class ProductOnSaleMock extends ProductOnSale {
+
+	/**
+	 * Initialize our mock class without re-running register_block_type to
+	 * avoid colliding with the globally registered block type.
+	 */
+	public function __construct() {
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$this->asset_api             = Package::container()->get( Api::class );
+		$this->asset_data_registry   = Package::container()->get( AssetDataRegistry::class );
+		$this->integration_registry  = new IntegrationRegistry();
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	}
+
+	/**
+	 * Re-run the AbstractProductGrid initialize() path to register the
+	 * add-to-cart notice suppression filter without re-registering the
+	 * block type with WordPress.
+	 *
+	 * @return void
+	 */
+	public function trigger_filter_registration(): void {
+		$reflection = new \ReflectionClass( ProductOnSale::class );
+
+		// Reset the static guard so the filter is (re-)registered for the test.
+		$prop = $reflection->getParentClass()->getProperty( 'single_product_grid_atc_filter_registered' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, false );
+
+		$method = $reflection->getParentClass()->getMethod( 'register_single_product_grid_atc_notice_filter' );
+		$method->setAccessible( true );
+		$method->invoke( null );
+	}
+}


### PR DESCRIPTION
<!-- Submission Review Guidelines -->
- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] I have added [unit/integration tests](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/README.md) (where applicable).
- [x] I have updated the relevant inline documentation (where applicable).

## Changes proposed in this Pull Request

Closes #42156.
Linear: https://linear.app/a8c/issue/RSMAPGJ-415

When the legacy product grid blocks (On Sale Products, Best Selling Products, Featured Products, etc., all of which extend `AbstractProductGrid`) are added to the **Single Product** template, clicking their Add to Cart link reloads the page with `?add-to-cart=ID`. The form handler then queues the standard "_X has been added to your cart_" notice, which is rendered by the Store Notices block that lives on the Single Product page. Modern Interactivity-API-powered blocks (Product Collection, Products (Beta)) never trigger this because they handle the cart mutation on the client and surface their own in-block notice.

This PR keeps the legacy markup, but:

1. Appends a `_wc_blocks_grid_atc=1` query arg to the add-to-cart URL rendered by `AbstractProductGrid` **only** when the block is being rendered on a single product page (`is_product()`).
2. Registers a one-time `wc_add_to_cart_message_html` filter that returns an empty string when this marker is present in the current request, which causes `wc_add_notice` to skip adding the duplicate notice (line `if ( ! empty( $message ) )` in `wc-notice-functions.php`).

The fix is intentionally narrow: it only fires when the request comes from a legacy product grid block on a single product page, so add-to-cart from the Shop / Product Catalog / archive pages remains unchanged and still shows the success notice as expected.

## How to test the changes in this Pull Request

1. Activate a block theme (e.g. Twenty Twenty-Four).
2. Go to Appearance > Editor > Templates > Single Product. If the template is the Classic Single Product, click _Transform into blocks_, then save.
3. Insert the **On Sale Products** block into the template. Save.
4. Create or pick a product that is on sale and one that is not. Visit the non-sale product on the storefront.
5. Click _Add to cart_ on a product inside the **On Sale Products** block.
6. **Expected:** No duplicate "added to cart" notice appears above the single product. The product is still added (verify in the mini-cart / cart page).
7. Repeat the same Add to cart action from the **Shop** page (Product Catalog template) to confirm the notice still appears there as expected.
8. Optional: with AJAX add to cart enabled (default), confirm there is no regression in the AJAX path either.

## Testing that has already taken place

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean on the changed lines (`phpcs-changed` reports nothing for the diff).
- `composer exec -- phpstan analyse src/Blocks/BlockTypes/AbstractProductGrid.php --memory-limit=2G` — OK, no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — passed.
- New PHPUnit test added: `tests/php/src/Blocks/BlockTypes/ProductOnSaleTest.php` covers the filter behaviour (suppression on / off, stable query-arg name). _Not executed locally per pipeline rules._

## Changelog entry

> [x] Automatically create a changelog entry from the details below.

- Significance: Patch
- Type: Fix
- Message: Prevent the legacy product grid blocks (On Sale Products, Best Selling Products, etc.) from showing a duplicate "added to cart" notice when their Add to Cart button is clicked from inside the Single Product template.

---

_RSMAPGJ AI Coder pipeline (pilot 2026-05-14)_
