### PR TITLE
Fix stale session notices persisting on Block Checkout (classic themes)

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-446
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-446
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Clear stale session error notices when the Checkout block initially renders in classic themes, so errors from a previous request (e.g. a failed `?add-to-cart=` attempt for a sold-individually product) no longer persist across requests and block subsequent checkout actions.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -250,6 +250,8 @@ class Checkout extends AbstractBlock {
 			return wp_is_block_theme() ? do_shortcode( '[woocommerce_checkout]' ) : '[woocommerce_checkout]';
 		}
 
+		$this->maybe_clear_stale_notices();
+
 		// Dequeue the core scripts when rendering this block.
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ), 20 );
 
@@ -342,6 +344,49 @@ class Checkout extends AbstractBlock {
 	 */
 	protected function is_checkout_endpoint() {
 		return is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'order-received' );
+	}
+
+	/**
+	 * Clear stale session notices on initial page load of the Checkout block in classic themes.
+	 *
+	 * Classic themes don't include the Store Notices block (or the legacy
+	 * `woocommerce_before_checkout_form` notice output) in their checkout template, so any
+	 * error notices left in the session from a previous request (e.g. a failed
+	 * `?add-to-cart=` attempt for a sold-individually product) persist indefinitely. They
+	 * then re-surface in Store API responses on the next user action (apply coupon, place
+	 * order), blocking checkout even though the cart is otherwise valid.
+	 *
+	 * Block themes are unaffected because the checkout template includes the Store Notices
+	 * block, which prints and clears notices on render.
+	 *
+	 * Mirrors the classic `[woocommerce_checkout]` shortcode behaviour, which clears
+	 * notices via `wc_clear_notices()` after `wc_print_notices()` on initial render.
+	 *
+	 * Only runs on the initial GET render, never during form submissions (POST), to avoid
+	 * discarding notices added during the current request that the client still needs.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return void
+	 */
+	protected function maybe_clear_stale_notices() {
+		// Only applies to classic themes; block themes clear notices via the Store Notices block.
+		if ( wp_is_block_theme() ) {
+			return;
+		}
+
+		// Skip during form submissions so notices added during the current request are preserved.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! empty( $_POST ) ) {
+			return;
+		}
+
+		// Notice functions are only loaded on frontend requests; bail if unavailable.
+		if ( ! function_exists( 'wc_clear_notices' ) ) {
+			return;
+		}
+
+		wc_clear_notices();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/Checkout.php
@@ -141,4 +141,71 @@ class Checkout extends \WP_UnitTestCase {
 	public function override_wc_logger() {
 		return $this->mock_logger;
 	}
+
+	/**
+	 * Returns whether the current theme is treated as a block theme by wp_is_block_theme().
+	 *
+	 * Tests inspect this rather than calling the function directly so they can short-circuit
+	 * if the test environment ever flips defaults.
+	 *
+	 * @return bool
+	 */
+	private function is_block_theme(): bool {
+		return function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
+
+	/**
+	 * Notices added to the session via wc_add_notice() should be cleared on the initial
+	 * (non-POST) render of the Checkout block in classic themes, so they do not persist
+	 * across requests and re-surface in Store API responses (RSMAPGJ-446 / woo#62855).
+	 *
+	 * @return void
+	 */
+	public function test_render_clears_stale_session_notices_on_classic_themes() {
+		if ( $this->is_block_theme() ) {
+			$this->markTestSkipped( 'This regression only affects classic themes.' );
+		}
+
+		// Ensure no POST state leaks in from another test.
+		$saved_post = $_POST;
+		$_POST      = array();
+
+		wc_clear_notices();
+		wc_add_notice( 'You cannot add another "Exclusive Product" to your cart.', 'error' );
+		$this->assertSame( 1, wc_notice_count( 'error' ), 'Precondition: error notice should be queued.' );
+
+		$checkout = new CheckoutMock( $this->asset_api, $this->registry, $this->integration_registry, 'checkout-mock' );
+		$checkout->call_render( array(), '<div class="wp-block-woocommerce-checkout"></div>', null );
+
+		$this->assertSame( 0, wc_notice_count( 'error' ), 'Stale error notice should be cleared on initial render.' );
+
+		$_POST = $saved_post;
+	}
+
+	/**
+	 * During form submissions (POST requests) notices added by the current request must
+	 * be preserved so the client can surface them. The render path therefore must not
+	 * clear notices when $_POST is non-empty.
+	 *
+	 * @return void
+	 */
+	public function test_render_preserves_notices_during_post_requests() {
+		if ( $this->is_block_theme() ) {
+			$this->markTestSkipped( 'Only the classic-theme branch performs explicit clearing.' );
+		}
+
+		$saved_post = $_POST;
+		$_POST      = array( 'woocommerce-process-checkout-nonce' => 'placeholder' );
+
+		wc_clear_notices();
+		wc_add_notice( 'A notice added during this request.', 'error' );
+
+		$checkout = new CheckoutMock( $this->asset_api, $this->registry, $this->integration_registry, 'checkout-mock' );
+		$checkout->call_render( array(), '<div class="wp-block-woocommerce-checkout"></div>', null );
+
+		$this->assertSame( 1, wc_notice_count( 'error' ), 'Notices added during a POST request should be preserved.' );
+
+		wc_clear_notices();
+		$_POST = $saved_post;
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/CheckoutMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/CheckoutMock.php
@@ -18,4 +18,16 @@ class CheckoutMock extends Checkout {
 	public function mock_enqueue_data() {
 		$this->enqueue_data();
 	}
+
+	/**
+	 * Expose the protected render method so tests can exercise it directly.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @param mixed  $block      Block instance.
+	 * @return string
+	 */
+	public function call_render( $attributes = array(), $content = '', $block = null ) {
+		return $this->render( $attributes, $content, $block );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) for this project.
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same change.

### Changes proposed in this Pull Request

Closes #62855
Linear: https://linear.app/a8c/issue/RSMAPGJ-446

Error notices added to the WooCommerce session (for example by `wc_add_notice( ..., 'error' )` from a failed `?add-to-cart=` attempt against a sold-individually product) can persist on the Block Checkout page across requests. The Store API responses surface these stale notices on subsequent actions such as applying a coupon or placing the order, blocking checkout even though the cart is valid.

Classic themes don't include a Store Notices block in the checkout template, and the Checkout block has no equivalent of the legacy `[woocommerce_checkout]` shortcode's `wc_clear_notices()` call after the `woocommerce_before_checkout_form_cart_notices` notice output. So notices added to the session never get cleared.

This PR adds a `maybe_clear_stale_notices()` helper that runs at the start of the Checkout block's `render()`. It clears the session notice queue on the initial (GET) page load when:

* the active theme is a classic theme (`! wp_is_block_theme()`) — block themes are unaffected because their checkout template renders the Store Notices block, which prints and clears notices on render;
* `$_POST` is empty — during form submissions notices added by the current request must be preserved so the client can surface them.

Block themes and form-submission flows are explicitly skipped, so behaviour there is unchanged. The behaviour now mirrors the classic `[woocommerce_checkout]` shortcode, which already clears notices after printing them in `class-wc-shortcode-checkout.php`.

### How to test the changes in this Pull Request

1. Activate a classic theme such as **Storefront**.
2. Create a Simple product and tick **Sold individually** in the Inventory tab.
3. Visit `/checkout/?add-to-cart=<product_id>` and let the page load.
4. Refresh the same URL. WooCommerce will queue the `You cannot add another "<product>" to your cart.` error into the session.
5. Visit `/checkout/` (without the query string).

   * **Before this fix**: applying a coupon or pressing **Place order** surfaces the stale "cannot add another" notice.
   * **After this fix**: no stale notice is shown; checkout proceeds normally.

6. As a regression check, confirm that block themes (e.g. **Twenty Twenty-Four**) still display notices via the Store Notices block as before, and that form-submission errors during a checkout POST are still displayed.

### Testing that has already taken place

* New PHPUnit tests `test_render_clears_stale_session_notices_on_classic_themes` and `test_render_preserves_notices_during_post_requests` in `tests/php/src/Blocks/BlockTypes/Checkout.php` cover the GET (clear) and POST (preserve) branches.
* `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
* `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
* `composer exec -- phpstan analyse src/Blocks/BlockTypes/Checkout.php --memory-limit=2G` — no errors.

### Changelog entry

- [x] Added a changelog entry at `plugins/woocommerce/changelog/fix-rsmapgj-446`.

---

🤖 RSMAPGJ AI Coder pipeline (pilot 2026-05-14)
