### PR TITLE
Initialise product term `order` meta in non-admin contexts

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-396
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-396
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Ensure the `order` term meta key is initialised when product category and product attribute terms are created outside of the admin (e.g. via the REST API or WP-CLI), and clean up any stale legacy `order_{$taxonomy}` meta key when the sort order is updated, so the two keys can no longer diverge.
+
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -50,8 +50,9 @@ class WC_Admin_Taxonomies {
 		// Default category ID.
 		$this->default_cat_id = get_option( 'default_product_cat', 0 );
 
-		// Category/term ordering.
-		add_action( 'create_term', array( $this, 'create_term' ), 5, 3 );
+		// Category/term ordering. The `create_term` action is now handled globally
+		// by `wc_init_term_order_meta()` in `wc-term-functions.php` so the `order`
+		// meta key is initialised in every context, not just the admin.
 		add_action(
 			'delete_product_cat',
 			function () {
@@ -114,16 +115,16 @@ class WC_Admin_Taxonomies {
 	/**
 	 * Order term when created (put in position 0).
 	 *
+	 * @deprecated 10.9.0 Use `wc_init_term_order_meta()` instead; the global helper runs
+	 *                   in every context so the `order` meta key is initialised even when
+	 *                   terms are inserted outside the admin (e.g. REST API, WP-CLI, cron).
+	 *
 	 * @param mixed  $term_id Term ID.
 	 * @param mixed  $tt_id Term taxonomy ID.
 	 * @param string $taxonomy Taxonomy slug.
 	 */
 	public function create_term( $term_id, $tt_id = '', $taxonomy = '' ) {
-		if ( 'product_cat' !== $taxonomy && ! taxonomy_is_product_attribute( $taxonomy ) ) {
-			return;
-		}
-
-		update_term_meta( $term_id, 'order', 0 );
+		wc_init_term_order_meta( (int) $term_id, (int) $tt_id, (string) $taxonomy );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -367,6 +367,14 @@ function wc_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
 
 	update_term_meta( $term_id, 'order', $index );
 
+	// Clean up the legacy `order_{$taxonomy}` meta key, which was used in older versions of WooCommerce.
+	// Keeping it around causes confusion because creation paths used the legacy key while updates
+	// used the unified `order` key, leading to divergent values for the same term.
+	// See https://github.com/woocommerce/woocommerce/issues/34213.
+	if ( is_string( $taxonomy ) && '' !== $taxonomy ) {
+		delete_term_meta( $term_id, 'order_' . $taxonomy );
+	}
+
 	if ( ! $recursive ) {
 		return $index;
 	}
@@ -382,6 +390,40 @@ function wc_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
 
 	return $index;
 }
+
+/**
+ * Initialise the `order` term meta key for newly-created product category and
+ * product attribute terms, so that the sort order can be edited from the admin UI
+ * straight away (the admin UI reads and writes the `order` meta key, not
+ * `order_{$taxonomy}`).
+ *
+ * Runs in every context (including REST API, WP-CLI and cron), not just admin,
+ * to guarantee the term has a value under the canonical meta key regardless of
+ * how it was inserted.
+ *
+ * @since 10.9.0
+ *
+ * @param int    $term_id  Term ID.
+ * @param int    $tt_id    Term taxonomy ID.
+ * @param string $taxonomy Taxonomy slug.
+ * @return void
+ */
+function wc_init_term_order_meta( $term_id, $tt_id = 0, $taxonomy = '' ) {
+	if ( ! is_string( $taxonomy ) || '' === $taxonomy ) {
+		return;
+	}
+
+	if ( 'product_cat' !== $taxonomy && ! taxonomy_is_product_attribute( $taxonomy ) ) {
+		return;
+	}
+
+	// Only initialise the meta if it isn't set yet, so we don't clobber a
+	// value supplied by the caller via `menu_order` or similar.
+	if ( '' === get_term_meta( (int) $term_id, 'order', true ) ) {
+		update_term_meta( (int) $term_id, 'order', 0 );
+	}
+}
+add_action( 'create_term', 'wc_init_term_order_meta', 5, 3 );
 
 /**
  * Function for recounting product terms, ignoring hidden products.

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -219,4 +219,158 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$featured_product->delete();
 		$regular_product->delete();
 	}
+
+	/**
+	 * Insert a term and return its term_id, failing the test if `wp_insert_term`
+	 * returns a `WP_Error`. Centralises the type-narrowing for the regression
+	 * tests below.
+	 *
+	 * @param string               $name     Term name.
+	 * @param string               $taxonomy Taxonomy slug.
+	 * @param array<string, mixed> $args     Optional. Extra args for `wp_insert_term`.
+	 * @return array{term_id: int, term_taxonomy_id: int}
+	 */
+	private function insert_term_or_fail( string $name, string $taxonomy, array $args = array() ): array {
+		$result = wp_insert_term( $name, $taxonomy, $args );
+		if ( is_wp_error( $result ) ) {
+			$this->fail( 'wp_insert_term failed: ' . $result->get_error_message() );
+		}
+
+		return array(
+			'term_id'          => (int) $result['term_id'],
+			'term_taxonomy_id' => (int) $result['term_taxonomy_id'],
+		);
+	}
+
+	/**
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/34213.
+	 *
+	 * When a `product_cat` term is created in a non-admin context (e.g. REST API
+	 * or WP-CLI), the `order` meta key should still be initialised to `0` so the
+	 * admin UI's sort order remains consistent with the read/write key.
+	 *
+	 * @testdox Creating a product_cat term initialises the `order` meta key in any context.
+	 */
+	public function test_create_term_initialises_order_meta_for_product_cat(): void {
+		$term = $this->insert_term_or_fail( 'RSMAPGJ-396 Category', 'product_cat' );
+
+		$order_meta = get_term_meta( $term['term_id'], 'order', true );
+
+		$this->assertNotSame( '', $order_meta, 'The `order` meta key should be initialised on term creation.' );
+		$this->assertSame( 0, (int) $order_meta );
+
+		wp_delete_term( $term['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/34213.
+	 *
+	 * Programmatically inserting a product attribute term (which is what the
+	 * REST API and WP-CLI do) must initialise the `order` meta key under the
+	 * canonical key, not the legacy `order_{$taxonomy}` key.
+	 *
+	 * @testdox Creating a product attribute term initialises the `order` meta key, not the legacy key.
+	 */
+	public function test_create_term_initialises_order_meta_for_attribute_taxonomy(): void {
+		$attribute_id = wc_create_attribute(
+			array(
+				'name'     => 'RSMAPGJ-396 Color',
+				'slug'     => 'rsmapgj396color',
+				'order_by' => 'menu_order',
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		$taxonomy = wc_attribute_taxonomy_name( 'rsmapgj396color' );
+		register_taxonomy( $taxonomy, array( 'product' ) );
+
+		$term = $this->insert_term_or_fail( 'Red', $taxonomy, array( 'slug' => 'rsmapgj-396-red' ) );
+
+		$order_meta        = get_term_meta( $term['term_id'], 'order', true );
+		$legacy_order_meta = get_term_meta( $term['term_id'], 'order_' . $taxonomy, true );
+
+		$this->assertSame( 0, (int) $order_meta, 'The canonical `order` meta key should be initialised.' );
+		$this->assertSame( '', $legacy_order_meta, 'The legacy `order_{$taxonomy}` meta key should not be written.' );
+
+		wp_delete_term( $term['term_id'], $taxonomy );
+		wc_delete_attribute( (int) $attribute_id );
+	}
+
+	/**
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/34213.
+	 *
+	 * If a term still has a stale `order_{$taxonomy}` meta key around from a
+	 * legacy WooCommerce version, calling `wc_set_term_order()` must clean it
+	 * up so the two keys cannot diverge.
+	 *
+	 * @testdox wc_set_term_order() removes the legacy `order_{$taxonomy}` meta key.
+	 */
+	public function test_set_term_order_cleans_up_legacy_meta_key(): void {
+		$attribute_id = wc_create_attribute(
+			array(
+				'name'     => 'RSMAPGJ-396 Size',
+				'slug'     => 'rsmapgj396size',
+				'order_by' => 'menu_order',
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		$taxonomy = wc_attribute_taxonomy_name( 'rsmapgj396size' );
+		register_taxonomy( $taxonomy, array( 'product' ) );
+
+		$term = $this->insert_term_or_fail( 'Large', $taxonomy, array( 'slug' => 'rsmapgj-396-large' ) );
+
+		// Simulate a stale legacy meta key written by an old WooCommerce version.
+		update_term_meta( $term['term_id'], 'order_' . $taxonomy, 99 );
+
+		wc_set_term_order( $term['term_id'], 4, $taxonomy );
+
+		$this->assertSame( 4, (int) get_term_meta( $term['term_id'], 'order', true ) );
+		$this->assertSame(
+			'',
+			get_term_meta( $term['term_id'], 'order_' . $taxonomy, true ),
+			'The legacy `order_{$taxonomy}` meta key should be removed after updating order.'
+		);
+
+		wp_delete_term( $term['term_id'], $taxonomy );
+		wc_delete_attribute( (int) $attribute_id );
+	}
+
+	/**
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/34213.
+	 *
+	 * The legacy `WC_Admin_Taxonomies::create_term()` method must continue to
+	 * initialise the `order` meta key for back-compat with any third-party code
+	 * that calls it directly.
+	 *
+	 * @testdox WC_Admin_Taxonomies::create_term() still initialises the `order` meta key.
+	 */
+	public function test_legacy_admin_create_term_still_initialises_order_meta(): void {
+		require_once WC_ABSPATH . 'includes/admin/class-wc-admin-taxonomies.php';
+
+		$term = $this->insert_term_or_fail( 'RSMAPGJ-396 Manual Category', 'product_cat' );
+
+		// Wipe the meta the global helper just set, then verify the admin method still sets it.
+		delete_term_meta( $term['term_id'], 'order' );
+
+		WC_Admin_Taxonomies::get_instance()->create_term( $term['term_id'], $term['term_taxonomy_id'], 'product_cat' );
+
+		$this->assertSame( 0, (int) get_term_meta( $term['term_id'], 'order', true ) );
+
+		wp_delete_term( $term['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * Non-product taxonomies (e.g. `category`, `post_tag`) should not have their
+	 * `order` meta initialised by the WooCommerce helper.
+	 *
+	 * @testdox wc_init_term_order_meta() ignores non-product taxonomies.
+	 */
+	public function test_init_term_order_meta_ignores_non_product_taxonomies(): void {
+		$term = $this->insert_term_or_fail( 'RSMAPGJ-396 Generic Tag', 'post_tag' );
+
+		$this->assertSame( '', get_term_meta( $term['term_id'], 'order', true ) );
+
+		wp_delete_term( $term['term_id'], 'post_tag' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

Closes #34213.
Linear: https://linear.app/a8c/issue/RSMAPGJ-396

When a product category or product attribute term was created outside of the admin (e.g. via the REST API, WP-CLI, or any code path that calls `wp_insert_term()` directly without the admin being loaded), the `order` term meta key was never initialised. The admin sort-order UI both reads from and writes to that same `order` key, so the term would silently fall back to a default of `0` and any later sort change written by the admin would land in `order` while older legacy data still sat under `order_{$taxonomy}` — making the two keys diverge for the same term.

This PR:

1. Moves the responsibility of initialising the `order` meta key into `wc-term-functions.php` so it runs in every context, not just admin. The previous admin-only `WC_Admin_Taxonomies::create_term()` callback now delegates to the new global helper for back-compat.
2. Makes `wc_set_term_order()` proactively delete any stale `order_{$taxonomy}` meta key for the term when writing the canonical `order` value. This way, even if a site still has legacy data left over from before the 3.6 migration, the keys can no longer diverge after a sort update.

### How to test the changes in this Pull Request

1. Apply the branch.
2. Create a product attribute (e.g. _Color_) and add an option via the REST API (or `wp_insert_term()` from a cron / CLI context — not the admin UI):
   ```sh
   wp eval 'wp_insert_term( "Red", "pa_color", array( "slug" => "red" ) );'
   ```
3. Inspect the term meta in the DB:
   - Before this PR: there is no `order` meta key for the term.
   - After this PR: `order = 0` is present for the term.
4. Sort the option via the admin (drag to a new position) and re-check `wp_termmeta`:
   - Only the `order` key should change; no `order_pa_color` should appear.
5. To simulate the legacy state, manually `update_term_meta( $id, 'order_pa_color', 99 )` for a term, then trigger a sort update via the admin or call `wc_set_term_order()`. The stale `order_pa_color` row should be removed and only `order` should remain.

### Testing that has already taken place

- Added regression tests in `WC_Term_Functions_Tests` covering:
  - `order` meta is initialised on `create_term` for `product_cat` and product attribute taxonomies in any context.
  - Non-product taxonomies (`post_tag`, `category`, etc.) are not touched.
  - `wc_set_term_order()` removes stale legacy `order_{$taxonomy}` meta keys.
  - The deprecated `WC_Admin_Taxonomies::create_term()` method still initialises the meta for direct callers (back-compat).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passes.
- PHPStan on `includes/wc-term-functions.php` and `includes/admin/class-wc-admin-taxonomies.php` reports no new errors.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog file was created manually under `plugins/woocommerce/changelog/fix-rsmapgj-396`.)

---

🤖 Generated by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14).
