### PR TITLE
Fix country name in /wc/v3/data/continents returning currency name

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-391
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-391
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix `name` field for countries in the `GET /wc/v3/data/continents` REST endpoint returning the currency name instead of the country name.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-data-continents-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-data-continents-controller.php
@@ -131,6 +131,11 @@ class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
 						)
 					);
 
+					// Remove keys that would clobber the country fields. In particular, locale-info.php
+					// uses `name`/`singular`/`plural` to describe the country's currency (e.g. "Euro"),
+					// which must not overwrite the country's display name set above.
+					unset( $country_data['name'], $country_data['singular'], $country_data['plural'] );
+
 					$country = array_merge( $country, $country_data );
 				}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/data-continents.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/data-continents.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tests for the Data Continents REST API.
+ *
+ * @package WooCommerce\Tests\API
+ */
+
+/**
+ * Class Data_Continents.
+ */
+class Data_Continents extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->endpoint = new WC_REST_Data_Continents_Controller();
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/v3/data/continents', $routes );
+		$this->assertArrayHasKey( '/wc/v3/data/continents/(?P<location>[\w-]+)', $routes );
+	}
+
+	/**
+	 * Test getting a single continent.
+	 */
+	public function test_get_continent() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/continents/eu' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'EU', $data['code'] );
+		$this->assertEquals( 'Europe', $data['name'] );
+		$this->assertNotEmpty( $data['countries'] );
+	}
+
+	/**
+	 * Country `name` must be the country's display name, not the currency name
+	 * derived from locale-info.php (regression test for #31853 / RSMAPGJ-391).
+	 */
+	public function test_country_name_is_not_currency_name() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/continents/eu' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$countries = WC()->countries->get_countries();
+
+		$asserted_any = false;
+		foreach ( $data['countries'] as $country ) {
+			$this->assertArrayHasKey( 'code', $country );
+			$this->assertArrayHasKey( 'name', $country );
+
+			// The country's `name` must equal the canonical country name from WC_Countries,
+			// not e.g. the currency name like "Euro".
+			if ( isset( $countries[ $country['code'] ] ) ) {
+				$this->assertSame(
+					$countries[ $country['code'] ],
+					$country['name'],
+					sprintf( 'Country %s should have its country name, not the currency name.', $country['code'] )
+				);
+				$asserted_any = true;
+			}
+
+			$this->assertNotEquals(
+				'Euro',
+				$country['name'],
+				sprintf( 'Country %s name must not be the currency name "Euro".', $country['code'] )
+			);
+		}
+
+		$this->assertTrue( $asserted_any, 'Expected to assert country names against WC_Countries for at least one country.' );
+	}
+
+	/**
+	 * Locale-derived fields (currency_code, decimal_sep, etc.) must still be present.
+	 */
+	public function test_locale_fields_are_present_for_known_country() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/continents/eu' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$ad = null;
+		foreach ( $data['countries'] as $country ) {
+			if ( 'AD' === $country['code'] ) {
+				$ad = $country;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $ad, 'Expected AD to be present in the EU continent response.' );
+		$this->assertSame( 'EUR', $ad['currency_code'] );
+		$this->assertSame( 'right_space', $ad['currency_pos'] );
+		$this->assertSame( 'cm', $ad['dimension_unit'] );
+		$this->assertSame( 'kg', $ad['weight_unit'] );
+		$this->assertArrayNotHasKey( 'singular', $ad, 'Currency `singular` field must not leak into the country response.' );
+		$this->assertArrayNotHasKey( 'plural', $ad, 'Currency `plural` field must not leak into the country response.' );
+	}
+
+	/**
+	 * Test getting all continents.
+	 */
+	public function test_get_continents() {
+		wp_set_current_user( $this->user );
+
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/continents' ) );
+		$continents = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNotEmpty( $continents );
+
+		$codes = wp_list_pluck( $continents, 'code' );
+		$this->assertContains( 'EU', $codes );
+	}
+
+	/**
+	 * Test that an invalid continent returns 404.
+	 */
+	public function test_get_continent_invalid() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/continents/zz' ) );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

`GET /wc/v3/data/continents` and `GET /wc/v3/data/continents/{code}` were returning the country's **currency name** in the country `name` field (e.g. `"name": "Euro"` for `AD`) instead of the country's display name.

The controller merges entries from `i18n/locale-info.php` into each country to expose locale fields (`currency_code`, `decimal_sep`, etc.). Those locale entries also carry a `name` key describing the country's *currency* (and `singular`/`plural` for the currency unit), which were silently overwriting the country name set from `WC()->countries->get_countries()`.

Fix: strip the currency-describing `name`/`singular`/`plural` keys from the locale data before merging.

Bug reported as `wc/v3/data/continents/eu` returning `"name": "Euro"` for AD. The same fix covers all continents.

### Screenshots or screen recordings

N/A — REST response payload only.

Before (excerpt):
```json
{ "code": "AD", "name": "Euro", "currency_code": "EUR", ... }
```

After:
```json
{ "code": "AD", "name": "Andorra", "currency_code": "EUR", ... }
```

### How to test the changes in this Pull Request

1. From an authenticated request, call `GET /wp-json/wc/v3/data/continents/eu`.
2. Verify each entry in `countries[]` has its country name in `name` (e.g. `Andorra`, `Albania`, `Austria`, ...), not the currency name.
3. Confirm locale fields (`currency_code`, `currency_pos`, `decimal_sep`, `thousand_sep`, `num_decimals`, `dimension_unit`, `weight_unit`) are still present and unchanged.
4. Spot-check other continents (`/data/continents/na`, `/data/continents/as`) to confirm parity.
5. Confirm `GET /wp-json/wc/v3/data/continents` (the list endpoint) is also fixed.

### Testing that has already taken place

- Added PHPUnit regression tests in `tests/legacy/unit-tests/rest-api/Tests/Version3/data-continents.php` covering:
  - Country `name` matches `WC()->countries->get_countries()` for every country returned for `/eu`.
  - Country `name` is never literally `"Euro"`.
  - `currency_code`, `currency_pos`, `dimension_unit`, `weight_unit` remain present for a known country (`AD`).
  - `singular`/`plural` currency fields do not leak into the country payload.
  - List route and 404 path.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — pass.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — pass.
- `composer exec -- phpstan analyse includes/rest-api/Controllers/Version3/class-wc-rest-data-continents-controller.php --memory-limit=2G` — no errors.
- PHPUnit was not executed locally (no Docker in this environment).

### Changelog entry

- [x] This PR includes a changelog entry. See `plugins/woocommerce/changelog/fix-rsmapgj-391`.

Closes #31853

Linear: https://linear.app/a8c/issue/RSMAPGJ-391

---

_Submitted by the RSMAPGJ AI Coder pipeline (pilot 2026-05-14)._
