### PR TITLE
Refresh cart cross-sells after AJAX item removal

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-395
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-395
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Refresh cross-sell suggestions on the cart page when a product is removed via AJAX, so stale cross-sells for the removed product no longer linger until a page reload.

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -88,6 +88,7 @@ jQuery( function ( $ ) {
 		var $html = $.parseHTML( html_str );
 		var $new_form = $( '.woocommerce-cart-form', $html );
 		var $new_totals = $( '.cart_totals', $html );
+		var $new_cross_sells = $( '.cross-sells', $html );
 		var $notices = remove_duplicate_notices(
 			$(
 				'.woocommerce-error, .woocommerce-message, .woocommerce-info, .is-error, .is-info, .is-success',
@@ -164,6 +165,7 @@ jQuery( function ( $ ) {
 			}
 
 			update_cart_totals_div( $new_totals );
+			update_cross_sells_div( $new_cross_sells );
 		}
 
 		$( document.body ).trigger( 'updated_wc_div' );
@@ -177,6 +179,38 @@ jQuery( function ( $ ) {
 	var update_cart_totals_div = function ( html_str ) {
 		$( '.cart_totals' ).replaceWith( html_str );
 		$( document.body ).trigger( 'updated_cart_totals' );
+	};
+
+	/**
+	 * Update the .cross-sells div with the new contents from the response.
+	 *
+	 * When a cart item is removed via AJAX, the cross-sell suggestions may
+	 * change because cross-sells are derived from the products in the cart.
+	 * Replace the existing .cross-sells element with the one from the new
+	 * HTML, or remove it if the new HTML no longer contains cross-sells.
+	 *
+	 * @param {JQuery Object} $new_cross_sells The new cross-sells element parsed from the response.
+	 */
+	var update_cross_sells_div = function ( $new_cross_sells ) {
+		var $current_cross_sells = $( '.cross-sells' );
+
+		if ( $new_cross_sells.length > 0 ) {
+			if ( $current_cross_sells.length > 0 ) {
+				$current_cross_sells.replaceWith( $new_cross_sells );
+			} else {
+				// No previous cross-sells on the page; insert before .cart_totals to match template order.
+				var $cart_totals = $( '.cart-collaterals .cart_totals' );
+				if ( $cart_totals.length > 0 ) {
+					$cart_totals.before( $new_cross_sells );
+				} else {
+					$( '.cart-collaterals' ).prepend( $new_cross_sells );
+				}
+			}
+		} else if ( $current_cross_sells.length > 0 ) {
+			$current_cross_sells.remove();
+		}
+
+		$( document.body ).trigger( 'updated_cross_sells' );
 	};
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

Closes #34051.
Linear: https://linear.app/a8c/issue/RSMAPGJ-395

On the classic (shortcode-based) cart page, removing a cart item via the AJAX trash-can icon updated the cart form and totals, but the cross-sell suggestions below were left untouched. They continued to advertise products linked to the just-removed cart item until a manual page reload.

The AJAX remove handler in `cart.js` already fetches the full cart page HTML and extracts `.woocommerce-cart-form` and `.cart_totals` from it via `update_wc_div`. It just didn't touch `.cross-sells`.

This PR teaches `update_wc_div` to also reconcile the `.cross-sells` block:

- If the new HTML still has `.cross-sells`, replace the existing one (so the suggestions reflect the new cart contents).
- If the new HTML no longer has `.cross-sells` (cart is empty of cross-sells or every cross-sell is already in the cart), remove the stale block.
- If there was no existing `.cross-sells` but the new HTML does have one (cross-sells just became applicable), insert it in the right slot of `.cart-collaterals`, before `.cart_totals`, to match the template's hook order.

A new `updated_cross_sells` event is fired on `document.body` after the swap, mirroring the existing `updated_cart_totals` event, so themes/extensions that style or rebind on cross-sells can hook in.

The empty-cart branch already replaces the surrounding `.woocommerce` wrapper wholesale, so no change is needed there.

### Screenshots or screen recordings

N/A — fix is a DOM-update tweak; no new UI.

### How to test the changes in this Pull Request

1. In WP admin, create three simple products: `CrossSell-Alpha`, `ProductA` (set `CrossSell-Alpha` as its cross-sell under the Linked Products tab), and `ProductB` (no cross-sells, or a different cross-sell).
2. As a shopper, add both `ProductA` and `ProductB` to the cart, then go to the classic cart page (`/cart/`).
3. Confirm `CrossSell-Alpha` appears in the "You may be interested in…" section below the cart.
4. Click the trash-can (×) icon next to `ProductA` to remove it via AJAX.
5. Expected: the cart totals refresh **and** the cross-sells section refreshes — `CrossSell-Alpha` should disappear because `ProductA` is no longer in the cart.
6. Without this fix, `CrossSell-Alpha` would persist until the page is manually reloaded.

Also re-test the inverse: start with only `ProductB` in the cart (no cross-sells displayed), add `ProductA` (with cross-sell), then on the cart page remove `ProductB` — the cross-sells block should remain correctly populated. Empty the entire cart and confirm the empty-cart state still renders normally.

### Testing that has already taken place

- Read through `update_wc_div` and the `item_remove_clicked` AJAX handler to confirm that the response is the full HTML of the cart page, so `.cross-sells` can be extracted from it the same way `.cart_totals` already is.
- Verified `node -c` syntax check on the modified file.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance**: Patch
**Type**: Fix

**Message**: Refresh cross-sell suggestions on the cart page when a product is removed via AJAX, so stale cross-sells for the removed product no longer linger until a page reload.

</details>

---
<sub>RSMAPGJ AI Coder pipeline (pilot 2026-05-14). Generated for human review — do not merge without sign-off.</sub>
