### PR TITLE
Fix grouped product price range across variable children

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-383
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-383
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix grouped product price range to span the full min-to-max range across variable child products, instead of showing only the lowest variation prices.

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -93,17 +93,29 @@ class WC_Product_Grouped extends WC_Product {
 	public function get_price_html( $price = '' ) {
 		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
 		$child_prices     = array();
+		$min_prices       = array();
+		$max_prices       = array();
 		$children         = $this->get_primed_visible_children();
 
 		foreach ( $children as $child ) {
-			if ( '' !== $child->get_price() ) {
-				$child_prices[] = 'incl' === $tax_display_mode ? wc_get_price_including_tax( $child ) : wc_get_price_excluding_tax( $child );
+			if ( '' === $child->get_price() ) {
+				continue;
 			}
+
+			list( $child_min, $child_max ) = $this->get_child_display_price_range( $child, $tax_display_mode );
+
+			if ( '' === $child_min ) {
+				continue;
+			}
+
+			$min_prices[]   = $child_min;
+			$max_prices[]   = $child_max;
+			$child_prices[] = $child_min;
 		}
 
-		if ( ! empty( $child_prices ) ) {
-			$min_price = min( $child_prices );
-			$max_price = max( $child_prices );
+		if ( ! empty( $min_prices ) && ! empty( $max_prices ) ) {
+			$min_price = min( $min_prices );
+			$max_price = max( $max_prices );
 		} else {
 			$min_price = '';
 			$max_price = '';
@@ -128,6 +140,38 @@ class WC_Product_Grouped extends WC_Product {
 		}
 
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );
+	}
+
+	/**
+	 * Get the display min and max price for a child product, taking the
+	 * shop tax display setting into account. For variable products this
+	 * returns the lowest and highest variation prices so the grouped
+	 * product can display the correct overall range.
+	 *
+	 * @since 10.9.0
+	 * @param WC_Product $child            Child product.
+	 * @param string     $tax_display_mode Either 'incl' or 'excl'.
+	 * @return array Two-element array of [ min_price, max_price ]. Either value can be an empty string if not available.
+	 */
+	private function get_child_display_price_range( $child, $tax_display_mode ) {
+		if ( $child instanceof WC_Product_Variable ) {
+			$min_price = $child->get_variation_price( 'min', true );
+			$max_price = $child->get_variation_price( 'max', true );
+
+			if ( '' === $min_price || '' === $max_price ) {
+				return array( '', '' );
+			}
+
+			return array( (float) $min_price, (float) $max_price );
+		}
+
+		$price = 'incl' === $tax_display_mode ? wc_get_price_including_tax( $child ) : wc_get_price_excluding_tax( $child );
+
+		if ( '' === $price ) {
+			return array( '', '' );
+		}
+
+		return array( $price, $price );
 	}
 
 	/*
@@ -165,31 +209,65 @@ class WC_Product_Grouped extends WC_Product {
 	 * @return string Minimum price or empty string if no children
 	 */
 	public function get_min_price() {
-		$children = $this->get_primed_visible_children();
-		$prices   = array_map( 'wc_get_price_to_display', $children );
+		list( $min_price, ) = $this->get_child_price_extremes();
 
-		if ( empty( $prices ) ) {
+		if ( '' === $min_price ) {
 			return '';
 		}
 
-		return wc_format_decimal( min( $prices ) );
+		return wc_format_decimal( $min_price );
 	}
 
 	/**
 	 * Get the maximum price from visible child products.
 	 *
+	 * For child variable products, the highest variation price is used so
+	 * the grouped product reflects the full price range of all its
+	 * children.
+	 *
 	 * @since 10.1.0
 	 * @return string Maximum price or empty string if no children
 	 */
 	public function get_max_price() {
-		$children = $this->get_primed_visible_children();
-		$prices   = array_map( 'wc_get_price_to_display', $children );
+		list( , $max_price ) = $this->get_child_price_extremes();
 
-		if ( empty( $prices ) ) {
+		if ( '' === $max_price ) {
 			return '';
 		}
 
-		return wc_format_decimal( max( $prices ) );
+		return wc_format_decimal( $max_price );
+	}
+
+	/**
+	 * Aggregate the lowest and highest display prices across all visible
+	 * child products. For variable children the variation min and max are
+	 * used, so the returned range spans the full set of purchasable prices.
+	 *
+	 * @since 10.9.0
+	 * @return array Two-element array of [ min_price, max_price ]. Empty strings when no priced children exist.
+	 */
+	private function get_child_price_extremes() {
+		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
+		$children         = $this->get_primed_visible_children();
+		$min_prices       = array();
+		$max_prices       = array();
+
+		foreach ( $children as $child ) {
+			list( $child_min, $child_max ) = $this->get_child_display_price_range( $child, $tax_display_mode );
+
+			if ( '' === $child_min ) {
+				continue;
+			}
+
+			$min_prices[] = $child_min;
+			$max_prices[] = $child_max;
+		}
+
+		if ( empty( $min_prices ) || empty( $max_prices ) ) {
+			return array( '', '' );
+		}
+
+		return array( min( $min_prices ), max( $max_prices ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-grouped.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-grouped.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Unit tests for the WC_Product_Grouped class.
+ *
+ * @package WooCommerce\Tests\Product
+ */
+
+/**
+ * Class WC_Tests_Product_Grouped.
+ */
+class WC_Tests_Product_Grouped extends WC_Unit_Test_Case {
+
+	/**
+	 * Build a variable product with two variations at the given prices.
+	 *
+	 * @param float|int $low_price  Lower variation price.
+	 * @param float|int $high_price Higher variation price.
+	 * @return WC_Product_Variable
+	 */
+	private function create_variable_product_with_prices( $low_price, $high_price ) {
+		$variable = new WC_Product_Variable();
+		$variable->set_name( 'Variable ' . $low_price . '-' . $high_price );
+		$variable->set_status( 'publish' );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( 0 );
+		$attribute->set_name( 'size' );
+		$attribute->set_options( array( 'small', 'large' ) );
+		$attribute->set_position( 0 );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+		$variable->set_attributes( array( $attribute ) );
+		$variable->save();
+
+		$low = new WC_Product_Variation();
+		$low->set_parent_id( $variable->get_id() );
+		$low->set_attributes( array( 'size' => 'small' ) );
+		$low->set_regular_price( (string) $low_price );
+		$low->set_status( 'publish' );
+		$low->save();
+
+		$high = new WC_Product_Variation();
+		$high->set_parent_id( $variable->get_id() );
+		$high->set_attributes( array( 'size' => 'large' ) );
+		$high->set_regular_price( (string) $high_price );
+		$high->set_status( 'publish' );
+		$high->save();
+
+		WC_Product_Variable::sync( $variable->get_id() );
+
+		return wc_get_product( $variable->get_id() );
+	}
+
+	/**
+	 * Ensure tax display is set to 'excl' so the price HTML reflects raw
+	 * regular prices without any base location tax adjustments.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		update_option( 'woocommerce_tax_display_shop', 'excl' );
+		update_option( 'woocommerce_calc_taxes', 'no' );
+	}
+
+	/**
+	 * @testdox Grouped product price HTML should span the lowest min and highest max of variable children.
+	 */
+	public function test_get_price_html_uses_full_range_of_variable_children() {
+		$var1 = $this->create_variable_product_with_prices( 10, 50 );
+		$var2 = $this->create_variable_product_with_prices( 20, 100 );
+
+		$grouped = new WC_Product_Grouped();
+		$grouped->set_name( 'Grouped with Variables' );
+		$grouped->set_status( 'publish' );
+		$grouped->set_children( array( $var1->get_id(), $var2->get_id() ) );
+		$grouped->save();
+
+		$grouped     = wc_get_product( $grouped->get_id() );
+		$price_html  = $grouped->get_price_html();
+		$plain_price = wp_strip_all_tags( html_entity_decode( $price_html ) );
+
+		$this->assertStringContainsString( '10', $plain_price, 'Grouped price HTML should include the lowest variation price (10).' );
+		$this->assertStringContainsString( '100', $plain_price, 'Grouped price HTML should include the highest variation price (100).' );
+		$this->assertStringNotContainsString( '50.00 &ndash; 50.00', $price_html, 'Grouped price HTML must not collapse the range to the highest of the minimums.' );
+	}
+
+	/**
+	 * @testdox Grouped get_max_price() should return the highest variation price across all variable children.
+	 */
+	public function test_get_max_price_returns_highest_variation_price() {
+		$var1 = $this->create_variable_product_with_prices( 10, 50 );
+		$var2 = $this->create_variable_product_with_prices( 20, 100 );
+
+		$grouped = new WC_Product_Grouped();
+		$grouped->set_children( array( $var1->get_id(), $var2->get_id() ) );
+		$grouped->save();
+
+		$grouped = wc_get_product( $grouped->get_id() );
+
+		$this->assertSame( wc_format_decimal( 10 ), $grouped->get_min_price(), 'Min price should be the smallest variation price.' );
+		$this->assertSame( wc_format_decimal( 100 ), $grouped->get_max_price(), 'Max price should be the largest variation price.' );
+	}
+
+	/**
+	 * @testdox Grouped get_min/max_price() should remain correct for simple children.
+	 */
+	public function test_min_and_max_price_for_simple_children() {
+		$simple_low = new WC_Product_Simple();
+		$simple_low->set_name( 'Simple low' );
+		$simple_low->set_regular_price( '5' );
+		$simple_low->set_price( '5' );
+		$simple_low->set_status( 'publish' );
+		$simple_low->save();
+
+		$simple_high = new WC_Product_Simple();
+		$simple_high->set_name( 'Simple high' );
+		$simple_high->set_regular_price( '25' );
+		$simple_high->set_price( '25' );
+		$simple_high->set_status( 'publish' );
+		$simple_high->save();
+
+		$grouped = new WC_Product_Grouped();
+		$grouped->set_children( array( $simple_low->get_id(), $simple_high->get_id() ) );
+		$grouped->save();
+
+		$grouped = wc_get_product( $grouped->get_id() );
+
+		$this->assertSame( wc_format_decimal( 5 ), $grouped->get_min_price(), 'Min price should match the cheapest simple child.' );
+		$this->assertSame( wc_format_decimal( 25 ), $grouped->get_max_price(), 'Max price should match the most expensive simple child.' );
+
+		$price_html  = $grouped->get_price_html();
+		$plain_price = wp_strip_all_tags( html_entity_decode( $price_html ) );
+		$this->assertStringContainsString( '5', $plain_price, 'Simple children price range should include the cheapest price.' );
+		$this->assertStringContainsString( '25', $plain_price, 'Simple children price range should include the most expensive price.' );
+	}
+
+	/**
+	 * @testdox Grouped product mixing simple and variable children should display the combined min/max range.
+	 */
+	public function test_mixed_simple_and_variable_children_range() {
+		$simple = new WC_Product_Simple();
+		$simple->set_name( 'Simple mid' );
+		$simple->set_regular_price( '30' );
+		$simple->set_price( '30' );
+		$simple->set_status( 'publish' );
+		$simple->save();
+
+		$variable = $this->create_variable_product_with_prices( 5, 200 );
+
+		$grouped = new WC_Product_Grouped();
+		$grouped->set_children( array( $simple->get_id(), $variable->get_id() ) );
+		$grouped->save();
+
+		$grouped = wc_get_product( $grouped->get_id() );
+
+		$this->assertSame( wc_format_decimal( 5 ), $grouped->get_min_price(), 'Min should be lowest across all children (variable variation $5).' );
+		$this->assertSame( wc_format_decimal( 200 ), $grouped->get_max_price(), 'Max should be highest across all children (variable variation $200).' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

When a grouped product contained variable product children, `WC_Product_Grouped::get_price_html()` (and the newer `get_min_price()` / `get_max_price()` accessors added in 10.1.0) only looked at each child's `get_price()`. For variable products that returns the minimum variation price, so the displayed range collapsed to "lowest min – highest min" instead of "lowest min – highest max".

This PR fixes the aggregation by:

- Extracting a `get_child_display_price_range()` helper that returns the full `[min, max]` range for each child, honoring `woocommerce_tax_display_shop`.
- For variable children, using `get_variation_price( 'min', true )` and `get_variation_price( 'max', true )` so the highest variation price contributes to the grouped product's max.
- For non-variable children, preserving the existing `wc_get_price_including_tax` / `wc_get_price_excluding_tax` path so behavior is unchanged.
- Reusing the same helper in `get_min_price()` and `get_max_price()` so consumers of the new API see correct extremes.

Closes #28163.

Linear: https://linear.app/a8c/issue/RSMAPGJ-383

### Screenshots or screen recordings

n/a — text/HTML-only change.

### How to test the changes in this Pull Request

1. Create two variable products:
   - Variable A with variations at $10 and $50.
   - Variable B with variations at $20 and $100.
2. Create a grouped product and link both variable products as children.
3. Visit the grouped product on the front end.
4. Confirm the displayed price range is `$10.00 – $100.00` (previously it was `$10.00 – $50.00`).
5. Also verify a grouped product containing only simple products still displays the correct range (no regression).
6. Optionally call `$grouped->get_min_price()` / `$grouped->get_max_price()` programmatically and confirm they return `10` / `100` for the above setup.

### Testing that has already taken place

- Added `WC_Tests_Product_Grouped` covering: all-variable children, all-simple children, and mixed simple + variable children.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` is clean.
- `composer exec -- phpstan analyse includes/class-wc-product-grouped.php --memory-limit=2G` reports no errors and does not add to the baseline.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` is clean.

### Milestone

- [x] Auto-assign milestone.

### Changelog entry

- [x] Changelog entry added: `plugins/woocommerce/changelog/fix-rsmapgj-383`.

---

RSMAPGJ AI Coder pipeline (pilot 2026-05-14).
