### PR TITLE
Fix duplicate variation attributes on Order Pay, My Account, and emails

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-397
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-397
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent variation attributes from appearing twice on Order Pay, My Account orders, and emails when the `woocommerce_product_variation_title_include_attributes` filter is enabled.

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -339,6 +339,16 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		$product           = is_callable( array( $this, 'get_product' ) ) ? $this->get_product() : false;
 		$order_item_name   = $this->get_name();
 
+		/*
+		 * Also dedupe against the variation's live title, which reflects the current
+		 * `woocommerce_product_variation_title_include_attributes` filter state. Orders
+		 * placed before the filter was enabled have the legacy item name in the database,
+		 * but the title shown via `get_name()` on the live product object now includes
+		 * the attributes, and without this we would render them again as item meta below
+		 * the title on the Order Pay, My Account orders, and email templates.
+		 */
+		$product_name = ( $product && $product->is_type( ProductType::VARIATION ) ) ? $product->get_name() : '';
+
 		foreach ( $meta_data as $meta ) {
 			if ( empty( $meta->id ) || '' === $meta->value || ! is_scalar( $meta->value ) || ( $hideprefix_length && substr( $meta->key, 0, $hideprefix_length ) === $hideprefix ) ) {
 				continue;
@@ -358,7 +368,10 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			}
 
 			// Skip items with values already in the product details area of the product name.
-			if ( ! $include_all && $product && $product->is_type( ProductType::VARIATION ) && wc_is_attribute_in_product_name( $display_value, $order_item_name ) ) {
+			if ( ! $include_all && $product && $product->is_type( ProductType::VARIATION ) && (
+				wc_is_attribute_in_product_name( $display_value, $order_item_name ) ||
+				( '' !== $product_name && wc_is_attribute_in_product_name( $display_value, $product_name ) )
+			) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
@@ -383,6 +383,109 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Variation attribute meta should be deduped against the live variation title when
+	 * the `woocommerce_product_variation_title_include_attributes` filter is enabled,
+	 * even if the order item's stored name still reflects the legacy (pre-filter) title.
+	 *
+	 * Regression test for the Order Pay, My Account orders, and email templates duplicating
+	 * variation attributes both in the product title and again in the item meta below it.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_get_formatted_meta_data_dedupes_against_live_variation_title() {
+		$parent_product = new WC_Product_Variable();
+		$parent_product->set_name( 'Test Parent' );
+		$parent_product->save();
+
+		$variation_product = new WC_Product_Variation();
+		$variation_product->set_parent_id( $parent_product->get_id() );
+		$variation_product->set_attributes(
+			array(
+				'color'  => 'Red',
+				'size'   => 'Medium',
+				'sleeve' => 'Long',
+			)
+		);
+		$variation_product->save();
+
+		$product_item = new WC_Order_Item_Product();
+		$product_item->set_product( $variation_product );
+		// Simulate an order item whose stored name was captured before the filter was enabled
+		// (e.g. an order placed prior to the site adding the filter via a mu-plugin).
+		$product_item->set_name( 'Test Parent' );
+		$product_item->save();
+
+		add_filter( 'woocommerce_product_variation_title_include_attributes', '__return_true' );
+
+		try {
+			// Reload the product so the live title reflects the filter.
+			$variation_product = wc_get_product( $variation_product->get_id() );
+			$this->assertStringContainsString( 'Red', $variation_product->get_name() );
+			$this->assertStringContainsString( 'Medium', $variation_product->get_name() );
+			$this->assertStringContainsString( 'Long', $variation_product->get_name() );
+
+			// Reset the item's cached product so it picks up the reloaded variation.
+			$product_item->set_product( $variation_product );
+
+			$formatted = $product_item->get_formatted_meta_data( '_', false );
+
+			$keys = array();
+			foreach ( $formatted as $meta ) {
+				$keys[] = $meta->key;
+			}
+
+			// The three attribute metas should all be deduped against the live title.
+			$this->assertNotContains( 'color', $keys );
+			$this->assertNotContains( 'size', $keys );
+			$this->assertNotContains( 'sleeve', $keys );
+		} finally {
+			remove_filter( 'woocommerce_product_variation_title_include_attributes', '__return_true' );
+		}
+	}
+
+	/**
+	 * When the filter is not enabled, variation attribute meta should still be returned
+	 * (i.e. the live-title dedup must not unexpectedly hide attributes that are part of
+	 * the variation but not present in the title).
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_get_formatted_meta_data_keeps_attributes_when_title_excludes_them() {
+		$parent_product = new WC_Product_Variable();
+		$parent_product->set_name( 'Plain Parent' );
+		$parent_product->save();
+
+		$variation_product = new WC_Product_Variation();
+		$variation_product->set_parent_id( $parent_product->get_id() );
+		$variation_product->set_attributes(
+			array(
+				'color'  => 'Purple',
+				'size'   => 'XS',
+				'sleeve' => 'Cropped',
+			)
+		);
+		$variation_product->save();
+
+		// With 3+ attributes and no filter, the title excludes the attributes.
+		$this->assertStringNotContainsString( 'Purple', $variation_product->get_name() );
+
+		$product_item = new WC_Order_Item_Product();
+		$product_item->set_product( $variation_product );
+		$product_item->save();
+
+		$formatted = $product_item->get_formatted_meta_data( '_', false );
+
+		$keys = array();
+		foreach ( $formatted as $meta ) {
+			$keys[] = $meta->key;
+		}
+
+		$this->assertContains( 'color', $keys );
+		$this->assertContains( 'size', $keys );
+		$this->assertContains( 'sleeve', $keys );
+	}
+
+	/**
 	 * Test the Array Access methods.
 	 *
 	 * @since 3.3.0


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

When `woocommerce_product_variation_title_include_attributes` returns `true`, the variation title is rendered as `Parent - Value1, Value2, Value3`. The cart and checkout already strip those attribute values out of the item-meta list below the title via `wc_get_formatted_cart_item_data()`. For orders, the equivalent dedupe lives in `WC_Order_Item::get_formatted_meta_data()` and only compares attribute values against the order item's *stored* name (`$this->get_name()`), which is captured at order placement time.

That falls down for orders placed before the filter was enabled: the stored name was generated without attributes, the live variation title now includes them, and so the Order Pay endpoint, My Account orders list, and transactional email templates render the attributes twice — once in the title and once again in the meta list below.

This PR extends the dedupe so that for variation line items we also check the live product's current `get_name()`. That title reflects the filter at render time, so the duplicate meta entries are suppressed regardless of when the filter was enabled.

Bug introduced over time as more rendering surfaces adopted the filter for the title but kept relying on the stored item name for dedupe; reported in #34819.

Closes #34819
Linear: https://linear.app/a8c/issue/RSMAPGJ-397

### Screenshots or screen recordings

N/A — fix is rendering-only on existing templates, and is exercised via PHPUnit.

### How to test the changes in this Pull Request

1. Add an mu-plugin or snippet:
   ```php
   add_filter( 'woocommerce_product_variation_title_include_attributes', '__return_true' );
   ```
2. Create a variable product with 3+ attributes (e.g. Color, Size, Sleeve) and one variation.
3. Place a pending/unpaid order containing that variation.
4. Visit:
   - The "Order Pay" link (`/checkout/order-pay/<order_id>/...`).
   - The "My Account → Orders" view for that order.
   - The "New order" / "Customer invoice" / "Order completed" transactional email previews under WooCommerce → Settings → Emails.
5. Confirm that for each surface, the variation title shows the attribute values inline (e.g. `Hoodie - Red, Medium, Long`) and no separate `Color: Red`, `Size: Medium`, `Sleeve: Long` rows appear below it.
6. Toggle the filter off and confirm pre-existing behavior is unchanged: the attribute rows appear below the title as before.

### Testing that has already taken place

- New PHPUnit coverage in `WC_Tests_Order_Item_Product`:
  - `test_get_formatted_meta_data_dedupes_against_live_variation_title` — order item stored with the legacy (no-attributes) name; after enabling the filter, all three attribute meta entries are suppressed.
  - `test_get_formatted_meta_data_keeps_attributes_when_title_excludes_them` — filter off + 3 attributes; all three attribute metas still surface (guards against over-eager dedupe).
- Existing `test_get_formatted_meta_data` / `test_get_all_formatted_meta_data` continue to assert prior behavior.
- PHPStan analysis on `includes/class-wc-order-item.php` passes with no new errors.

### Changelog entry

- [x] Automatically create a changelog entry from the details.

Changelog file added at `plugins/woocommerce/changelog/fix-rsmapgj-397`.

---

🤖 RSMAPGJ AI Coder pipeline (pilot 2026-05-14)
