### PR TITLE
Fix manual order shipping instance id

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-410
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-410
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Persist the shipping method instance id when saving a manual order, so `get_instance_id()` returns the selected zone instance instead of zero.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -95,6 +95,7 @@ if ( wc_tax_enabled() ) {
 		<tbody id="order_shipping_line_items">
 			<?php
 			$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
+			$shipping_zones   = class_exists( 'WC_Shipping_Zones' ) ? WC_Shipping_Zones::get_zones() : array();
 			foreach ( $line_items_shipping as $item_id => $item ) {
 				include __DIR__ . '/html-order-shipping.php';
 			}

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -25,28 +25,71 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<input type="hidden" name="shipping_method_id[]" value="<?php echo esc_attr( $item_id ); ?>" />
 			<input type="text" class="shipping_method_name" placeholder="<?php esc_attr_e( 'Shipping name', 'woocommerce' ); ?>" name="shipping_method_title[<?php echo esc_attr( $item_id ); ?>]" value="<?php echo esc_attr( $item->get_name() ); ?>" />
 			<select class="shipping_method" name="shipping_method[<?php echo esc_attr( $item_id ); ?>]">
-				<optgroup label="<?php esc_attr_e( 'Shipping method', 'woocommerce' ); ?>">
-					<option value=""><?php esc_html_e( 'N/A', 'woocommerce' ); ?></option>
-					<?php
-					$found_method = false;
+				<option value=""><?php esc_html_e( 'N/A', 'woocommerce' ); ?></option>
+				<?php
+				$shipping_item       = $item instanceof WC_Order_Item_Shipping ? $item : null;
+				$found_method        = false;
+				$current_method_id   = $shipping_item ? $shipping_item->get_method_id() : '';
+				$current_instance_id = $shipping_item ? $shipping_item->get_instance_id() : 0;
+				$current_value       = $current_instance_id ? $current_method_id . ':' . $current_instance_id : $current_method_id;
+				$zones               = isset( $shipping_zones ) && is_array( $shipping_zones ) ? $shipping_zones : array();
 
-					foreach ( $shipping_methods as $method ) {
-						$is_active = $item->get_method_id() === $method->id;
+				// List shipping methods grouped by zone so the saved value carries the instance id.
+				// See https://github.com/woocommerce/woocommerce/issues/38481.
+				foreach ( $zones as $zone ) {
+					if ( empty( $zone['shipping_methods'] ) ) {
+						continue;
+					}
 
-						echo '<option value="' . esc_attr( $method->id ) . '" ' . selected( true, $is_active, false ) . '>' . esc_html( $method->get_method_title() ) . '</option>';
+					$zone_label = ! empty( $zone['zone_name'] ) ? $zone['zone_name'] : __( 'Shipping zone', 'woocommerce' );
+
+					echo '<optgroup label="' . esc_attr( $zone_label ) . '">';
+
+					foreach ( $zone['shipping_methods'] as $zone_method ) {
+						/**
+						 * The zone method instance.
+						 *
+						 * @var WC_Shipping_Method $zone_method
+						 */
+						if ( empty( $zone_method->instance_id ) ) {
+							continue;
+						}
+
+						$value     = $zone_method->id . ':' . $zone_method->instance_id;
+						$is_active = $current_instance_id && (int) $current_instance_id === (int) $zone_method->instance_id;
 
 						if ( $is_active ) {
 							$found_method = true;
 						}
+
+						$method_label = $zone_method->get_title() ? $zone_method->get_title() : $zone_method->get_method_title();
+
+						echo '<option value="' . esc_attr( $value ) . '" ' . selected( true, $is_active, false ) . '>' . esc_html( $method_label ) . '</option>';
 					}
 
-					if ( ! $found_method && $item->get_method_id() ) {
-						echo '<option value="' . esc_attr( $item->get_method_id() ) . '" selected="selected">' . esc_html__( 'Other', 'woocommerce' ) . '</option>';
-					} else {
-						echo '<option value="other">' . esc_html__( 'Other', 'woocommerce' ) . '</option>';
+					echo '</optgroup>';
+				}
+
+				echo '<optgroup label="' . esc_attr__( 'Other shipping methods', 'woocommerce' ) . '">';
+
+				foreach ( $shipping_methods as $method ) {
+					$is_active = ! $current_instance_id && $current_method_id === $method->id;
+
+					echo '<option value="' . esc_attr( $method->id ) . '" ' . selected( true, $is_active, false ) . '>' . esc_html( $method->get_method_title() ) . '</option>';
+
+					if ( $is_active ) {
+						$found_method = true;
 					}
-					?>
-				</optgroup>
+				}
+
+				if ( ! $found_method && $current_method_id ) {
+					echo '<option value="' . esc_attr( $current_value ) . '" selected="selected">' . esc_html__( 'Other', 'woocommerce' ) . '</option>';
+				} else {
+					echo '<option value="other">' . esc_html__( 'Other', 'woocommerce' ) . '</option>';
+				}
+
+				echo '</optgroup>';
+				?>
 			</select>
 		</div>
 

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -416,9 +416,21 @@ function wc_save_order_items( $order_id, $items ) {
 				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wc_clean( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
 			}
 
+			// The shipping_method value may be either a plain method id (e.g. `flat_rate`)
+			// for backward compatibility, or `method_id:instance_id` (e.g. `flat_rate:3`)
+			// when the admin selected a specific zone instance. Split it so the saved item
+			// keeps both pieces in sync. See https://github.com/woocommerce/woocommerce/issues/38481.
+			$submitted_method_id = is_scalar( $item_data['shipping_method'] ) ? (string) $item_data['shipping_method'] : '';
+			$method_instance_id  = 0;
+			if ( false !== strpos( $submitted_method_id, ':' ) ) {
+				list( $submitted_method_id, $maybe_instance_id ) = explode( ':', $submitted_method_id, 2 );
+				$method_instance_id                              = absint( $maybe_instance_id );
+			}
+
 			$item->set_props(
 				array(
-					'method_id'    => $item_data['shipping_method'],
+					'method_id'    => $submitted_method_id,
+					'instance_id'  => $method_instance_id,
 					'method_title' => $item_data['shipping_method_title'],
 					'total'        => $item_data['shipping_cost'],
 					'taxes'        => array(

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1344,6 +1344,7 @@ class WC_AJAX {
 
 			$order_taxes      = $order->get_taxes();
 			$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
+			$shipping_zones   = class_exists( 'WC_Shipping_Zones' ) ? WC_Shipping_Zones::get_zones() : array();
 			$cogs_is_enabled  = wc_get_container()->get( CostOfGoodsSoldController::class )->feature_is_enabled();
 
 			// Add new shipping.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -6055,12 +6055,6 @@ parameters:
 			path: includes/admin/meta-boxes/views/html-order-refund.php
 
 		-
-			message: '#^Call to an undefined method object\:\:get_method_id\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: includes/admin/meta-boxes/views/html-order-shipping.php
-
-		-
 			message: '#^Call to an undefined method object\:\:get_name\(\)\.$#'
 			identifier: method.notFound
 			count: 3

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -535,4 +535,105 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$order_item = new WC_Order_Item_Product( $order_item_id );
 		$this->assertEquals( 4, $order_item->get_meta( '_reduced_stock', true ), 'Reduced stock meta should be updated to new quantity' );
 	}
+
+	/**
+	 * Helper to seed a shipping order item against a freshly persisted order.
+	 *
+	 * @return array{order:WC_Order,item_id:int}
+	 */
+	private function create_order_with_shipping_item() {
+		$order = wc_create_order();
+		$item  = new WC_Order_Item_Shipping();
+		$item->set_order_id( $order->get_id() );
+		$item->set_method_title( 'Placeholder' );
+		$item->set_method_id( 'placeholder' );
+		$item_id = $item->save();
+
+		return array(
+			'order'   => $order,
+			'item_id' => $item_id,
+		);
+	}
+
+	/**
+	 * @testdox Should split method_id:instance_id when saving a manual order shipping line.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/38481
+	 */
+	public function test_wc_save_order_items_splits_method_and_instance_id_for_shipping() {
+		$created = $this->create_order_with_shipping_item();
+		$order   = $created['order'];
+		$item_id = $created['item_id'];
+
+		$post_data = array(
+			'shipping_method_id'    => array( (string) $item_id ),
+			'shipping_method'       => array( $item_id => 'flat_rate:42' ),
+			'shipping_method_title' => array( $item_id => 'Zone Flat Rate' ),
+			'shipping_cost'         => array( $item_id => '5' ),
+		);
+
+		wc_save_order_items( $order->get_id(), $post_data );
+
+		$saved_order  = wc_get_order( $order->get_id() );
+		$shipping     = $saved_order->get_items( 'shipping' );
+		$shipping_row = reset( $shipping );
+
+		$this->assertSame( 'flat_rate', $shipping_row->get_method_id(), 'method_id should be the bare method identifier' );
+		$this->assertSame( 42, $shipping_row->get_instance_id(), 'instance_id should be parsed from the submitted value' );
+		$this->assertSame( 'Zone Flat Rate', $shipping_row->get_method_title(), 'method_title should round-trip through save' );
+	}
+
+	/**
+	 * @testdox Should keep instance_id at zero when only a bare method id is submitted.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/38481
+	 */
+	public function test_wc_save_order_items_preserves_legacy_bare_method_id() {
+		$created = $this->create_order_with_shipping_item();
+		$order   = $created['order'];
+		$item_id = $created['item_id'];
+
+		$post_data = array(
+			'shipping_method_id'    => array( (string) $item_id ),
+			'shipping_method'       => array( $item_id => 'flat_rate' ),
+			'shipping_method_title' => array( $item_id => 'Legacy Flat Rate' ),
+			'shipping_cost'         => array( $item_id => '7' ),
+		);
+
+		wc_save_order_items( $order->get_id(), $post_data );
+
+		$saved_order  = wc_get_order( $order->get_id() );
+		$shipping     = $saved_order->get_items( 'shipping' );
+		$shipping_row = reset( $shipping );
+
+		$this->assertSame( 'flat_rate', $shipping_row->get_method_id(), 'method_id should remain as submitted' );
+		$this->assertSame( 0, $shipping_row->get_instance_id(), 'instance_id should default to zero without a colon-separated value' );
+	}
+
+	/**
+	 * @testdox Should ignore stray colons in the instance segment when parsing the shipping method value.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/38481
+	 */
+	public function test_wc_save_order_items_absints_instance_segment() {
+		$created = $this->create_order_with_shipping_item();
+		$order   = $created['order'];
+		$item_id = $created['item_id'];
+
+		$post_data = array(
+			'shipping_method_id'    => array( (string) $item_id ),
+			'shipping_method'       => array( $item_id => 'flat_rate:13garbage' ),
+			'shipping_method_title' => array( $item_id => 'Zone Flat Rate' ),
+			'shipping_cost'         => array( $item_id => '5' ),
+		);
+
+		wc_save_order_items( $order->get_id(), $post_data );
+
+		$saved_order  = wc_get_order( $order->get_id() );
+		$shipping     = $saved_order->get_items( 'shipping' );
+		$shipping_row = reset( $shipping );
+
+		$this->assertSame( 'flat_rate', $shipping_row->get_method_id(), 'method_id should still be parsed from the prefix' );
+		$this->assertSame( 13, $shipping_row->get_instance_id(), 'instance_id should be coerced through absint()' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Repository Coding Guidelines](https://developer.woocommerce.com/docs/contribution/coding-guidelines/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

Closes #38481. Linear: https://linear.app/a8c/issue/RSMAPGJ-410

When creating a manual order from `wp-admin`, the shipping method `<select>` was populated from `WC()->shipping()->load_shipping_methods()`, which returns the *registered* shipping method classes (e.g. `flat_rate`). The submitted value was therefore a bare method id with no instance attached, and `wc_save_order_items()` stored only `method_id` on the shipping line item. Calling `get_instance_id()` on the resulting `WC_Order_Item_Shipping` always returned `0`, even though `get_method_id()` returned the correct method id.

This PR:

- Renders the manual-order shipping dropdown as zone-grouped options whose values carry both the method id and instance id (`method_id:instance_id`). Registered methods that don't belong to a zone remain available under an "Other shipping methods" group for backward compatibility.
- Updates `wc_save_order_items()` to split that value into `method_id` and `instance_id` when saving, so both pieces are persisted on the order item.
- Exposes `$shipping_zones` to the shipping-row template (and to the AJAX `add_order_shipping` flow that re-uses the template).
- Adds unit coverage for the parse-and-save behaviour, including the legacy bare `method_id` fallback path.

### How to test the changes in this Pull Request

1. From WooCommerce > Settings > Shipping create a zone and add a Flat rate method to it (note its instance id).
2. Create a manual order at WooCommerce > Orders > Add new with a product and a billing address that falls in that zone.
3. In the "Edit shipping" row select the zone instance Flat rate option, save the order.
4. In a snippet or `wp shell` run:

   ```php
   $order = wc_get_order( $order_id );
   $shipping = current( $order->get_items( 'shipping' ) );
   var_dump( $shipping->get_method_id(), $shipping->get_instance_id() );
   ```

   Before this PR: `method_id` is set correctly but `instance_id` is `0`. After this PR: both values match the chosen zone instance.

### Testing that has already taken place

- Added PHPUnit cases in `WC_Admin_Functions_Test` covering the new parsing logic and the legacy bare method id path.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- `composer exec -- phpstan analyse <changed files> --memory-limit=2G`

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can alternatively check the box below. Please note that changelog entries are required for all PRs unless the change is not publicly visible or does not affect functionality. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

**Changelog Entry Comment**

Significance: patch
Type: fix
Message: Persist the shipping method instance id when saving a manual order, so `get_instance_id()` returns the selected zone instance instead of zero.

---

_RSMAPGJ AI Coder pipeline (pilot 2026-05-14)_
