### PR TITLE
Replace PanelBody with ToolsPanel in PageSelector component

### DIFF
--- a/plugins/woocommerce/changelog/refactor-59464-use-toolspanel-in-page-selector
+++ b/plugins/woocommerce/changelog/refactor-59464-use-toolspanel-in-page-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace PanelBody with ToolsPanel in the PageSelector component.

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/page-selector/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/page-selector/index.js
@@ -2,8 +2,15 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import {
+	SelectControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
@@ -21,25 +28,37 @@ const PageSelector = ( { setPageId, pageId, labels } ) => {
 		}, [] ) || null;
 	if ( pages ) {
 		return (
-			<PanelBody title={ labels.title }>
-				<SelectControl
+			<ToolsPanel
+				label={ labels.title }
+				resetAll={ () => setPageId( 0 ) }
+			>
+				<ToolsPanelItem
 					label={ __( 'Link to', 'woocommerce' ) }
-					value={ pageId }
-					options={ [
-						{
-							label: labels.default,
-							value: 0,
-						},
-						...pages.map( ( page ) => {
-							return {
-								label: formatTitle( page, pages ),
-								value: parseInt( page.id, 10 ),
-							};
-						} ),
-					] }
-					onChange={ ( value ) => setPageId( parseInt( value, 10 ) ) }
-				/>
-			</PanelBody>
+					hasValue={ () => pageId !== 0 }
+					onDeselect={ () => setPageId( 0 ) }
+					isShownByDefault
+				>
+					<SelectControl
+						label={ __( 'Link to', 'woocommerce' ) }
+						value={ pageId }
+						options={ [
+							{
+								label: labels.default,
+								value: 0,
+							},
+							...pages.map( ( page ) => {
+								return {
+									label: formatTitle( page, pages ),
+									value: parseInt( page.id, 10 ),
+								};
+							} ),
+						] }
+						onChange={ ( value ) =>
+							setPageId( parseInt( value, 10 ) )
+						}
+					/>
+				</ToolsPanelItem>
+			</ToolsPanel>
 		);
 	}
 	return null;

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/page-selector/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/page-selector/index.js
@@ -34,7 +34,9 @@ const PageSelector = ( { setPageId, pageId, labels } ) => {
 			>
 				<ToolsPanelItem
 					label={ __( 'Link to', 'woocommerce' ) }
-					hasValue={ () => pageId !== 0 }
+					hasValue={ () =>
+						typeof pageId === 'number' && pageId !== 0
+					}
 					onDeselect={ () => setPageId( 0 ) }
 					isShownByDefault
 				>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR removes PanelBody and replaces it with ToolsPanel in the PageSelector editor component.

Part of #59464 

### Screenshots or screen recordings:

#### Before
https://github.com/user-attachments/assets/82c8a5fc-bc5d-4797-9a5e-f3a31c67aceb

#### After
https://github.com/user-attachments/assets/2000a40f-9548-4e80-89f6-e18dcb16e96f

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to **Appearance → Editor** in the WordPress admin.
2. Open **Templates → WooCommerce** and ensure both the Cart and Checkout pages are configured.
3. Navigate to **Pages → Cart** and open the page in the block editor.
4. Select the **Proceed to Checkout** inner block inside the Cart block.
5. Open the **Inspector Controls** sidebar.
6. Verify that the page selector panel now uses **ToolsPanel**.
7. Change the selected Checkout page to a different page temporarily.
8. Click **Reset All** and verify the selection resets back to the default WooCommerce Checkout page.

### Testing that has already taken place:
- `hasValue` correctly identifies `0` as the unset/default state.
- `resetAll` reset pageId to 0, falling back to the default WooCommerce page URL.
- `isShownByDefault` preserves the previous PanelBody behavior of always showing the control.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
