### PR TITLE
Reject refunds that exceed a line item's remaining total or quantity

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-379
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-379
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent refunds that exceed a line item's total or quantity (e.g. refunding $20 against a $10 fee).

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -612,6 +612,39 @@ function wc_create_refund( $args = array() ) {
 					continue;
 				}
 
+				/*
+				 * Validate per-line-item refund totals so they cannot exceed the line's remaining
+				 * (non-refunded) total. Without this check, callers could refund $20 against a $10
+				 * fee/shipping/product line. The order-level $remaining_refund_amount check above
+				 * does not catch this when the order total is larger than the line total.
+				 *
+				 * Items returned by get_items( array( 'line_item', 'fee', 'shipping' ) ) are
+				 * subclasses (WC_Order_Item_Product/Fee/Shipping) that all expose get_total().
+				 * $order is a WC_Order here, so its refund helpers are safe to call.
+				 */
+				$item_total                  = (float) ( method_exists( $item, 'get_total' ) ? $item->get_total() : 0 );
+				$item_already_refunded_total = $order instanceof WC_Order
+					? (float) $order->get_total_refunded_for_item( $item_id, $item->get_type() )
+					: 0.0;
+				$item_remaining_total        = abs( $item_total ) - abs( $item_already_refunded_total );
+				$requested_refund_total      = abs( (float) $refund_total );
+
+				if ( $requested_refund_total - $item_remaining_total > 0.000001 ) {
+					throw new Exception( __( 'Invalid refund amount for line item.', 'woocommerce' ) );
+				}
+
+				if ( $qty && method_exists( $item, 'get_quantity' ) ) {
+					$item_qty                  = (float) $item->get_quantity();
+					$item_already_refunded_qty = $order instanceof WC_Order
+						? (float) $order->get_qty_refunded_for_item( $item_id, $item->get_type() )
+						: 0.0;
+					$item_remaining_qty        = abs( $item_qty ) - abs( $item_already_refunded_qty );
+
+					if ( abs( (float) $qty ) - $item_remaining_qty > 0.000001 ) {
+						throw new Exception( __( 'Invalid refund quantity for line item.', 'woocommerce' ) );
+					}
+				}
+
 				// array of order id and product id which were refunded.
 				// later to be used for revoking download permission.
 				// checking if the item is a product, as we only need to revoke download permission for products.

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -252,6 +252,128 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that wc_create_refund() rejects per-line refund_total values larger than
+	 * the line item's own total. Regression test for woocommerce/woocommerce#25248.
+	 */
+	public function test_wc_create_refund_rejects_over_refund_on_fee_line() {
+		$order = new WC_Order();
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_name( 'Fee under test' );
+		$fee->set_amount( 10 );
+		$fee->set_total( 10 );
+		$fee->set_tax_status( 'none' );
+		$order->add_item( $fee );
+
+		$order->calculate_totals();
+		$order->save();
+
+		$fee_id = 0;
+		foreach ( $order->get_items( 'fee' ) as $item_id => $item ) {
+			$fee_id = $item_id;
+		}
+
+		// Attempt to refund $20 against a $10 fee — should be blocked.
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 20,
+				'line_items' => array(
+					$fee_id => array(
+						'qty'          => 0,
+						'refund_total' => 20,
+						'refund_tax'   => array(),
+					),
+				),
+			)
+		);
+
+		$this->assertWPError( $refund, 'Refunding more than the fee total should return a WP_Error.' );
+		$this->assertSame( 0.0, (float) $order->get_total_refunded(), 'No refund should be recorded against the order.' );
+	}
+
+	/**
+	 * Test that wc_create_refund() rejects a per-line refund quantity larger than the line's quantity.
+	 */
+	public function test_wc_create_refund_rejects_over_refund_qty_on_product_line() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 5 );
+		$product->save();
+
+		$order = new WC_Order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 1,
+				'total'    => 5,
+			)
+		);
+		$order->add_item( $item );
+		$order->calculate_totals();
+		$order->save();
+
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Attempt to refund 2 units of a 1-unit product line — should be blocked.
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 5,
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 2,
+						'refund_total' => 5,
+					),
+				),
+			)
+		);
+
+		$this->assertWPError( $refund, 'Refunding more units than purchased should return a WP_Error.' );
+	}
+
+	/**
+	 * Test that wc_create_refund() still permits a valid partial per-line refund
+	 * (sanity check that the validation does not over-block).
+	 */
+	public function test_wc_create_refund_allows_valid_partial_refund_on_fee_line() {
+		$order = new WC_Order();
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_name( 'Fee under test' );
+		$fee->set_amount( 10 );
+		$fee->set_total( 10 );
+		$fee->set_tax_status( 'none' );
+		$order->add_item( $fee );
+
+		$order->calculate_totals();
+		$order->save();
+
+		$fee_id = 0;
+		foreach ( $order->get_items( 'fee' ) as $item_id => $item ) {
+			$fee_id = $item_id;
+		}
+
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 4,
+				'line_items' => array(
+					$fee_id => array(
+						'qty'          => 0,
+						'refund_total' => 4,
+						'refund_tax'   => array(),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'A valid partial refund on a fee line should succeed.' );
+		$this->assertEquals( 4, $order->get_total_refunded_for_item( $fee_id, 'fee' ) );
+	}
+
+	/**
 	 * Test that creating a full refund with free items triggers fully refunded action.
 	 */
 	public function test_full_refund_with_free_items() {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contribution guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] I have added (or updated) appropriate tests if applicable.

### Changes proposed in this Pull Request

When the order total is larger than a single line's total (for example a $50 order that also has a $10 fee), `wc_create_refund()` previously allowed callers to refund more against a single line than the line was worth. Passing `refund_total => 20` for a `$10` fee line was accepted because only the order-level remaining-refund amount was checked.

This PR adds per-item validation inside `wc_create_refund()` that compares the requested `refund_total` and `qty` for each line against the item's own remaining (line total minus what has already been refunded for that item), throwing an "Invalid refund amount/quantity for line item." exception when the requested refund would over-refund the line. Comparisons use absolute values so negative-total fee lines (discount-style fees) are handled correctly, and use a tiny tolerance to absorb float rounding.

Closes #25248

### How to test the changes in this Pull Request

1. Place an order on the site.
2. Change the order status to `on hold` to reveal more options for order editing.
3. Click on `Add item(s)` -> `Add fee`. Add any fee amount, e.g. `$10.00`.
4. Recalculate and save.
5. Click on `Refund` and try to refund `$20.00` against the fee line.
6. Verify the refund is **rejected** with the error message `Invalid refund amount for line item.`.
7. Verify that valid partial/full refunds of the fee line (`<= $10.00`) still succeed.
8. Repeat the check with a product line: try refunding 2 of a 1-quantity line item and verify it's rejected with the quantity error.

### Testing that has already taken place

- New PHPUnit tests in `WC_Order_Functions_Test`:
  - `test_wc_create_refund_rejects_over_refund_on_fee_line` — `$20` refund against a `$10` fee returns `WP_Error` and leaves the order with `0` refunded.
  - `test_wc_create_refund_rejects_over_refund_qty_on_product_line` — refunding 2 units of a 1-unit line returns `WP_Error`.
  - `test_wc_create_refund_allows_valid_partial_refund_on_fee_line` — `$4` of a `$10` fee still succeeds.
- PHPCS via `phpcs-changed` against trunk and HEAD: clean for the changed files.
- PHPStan on `includes/wc-order-functions.php`: `No errors`.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

Significance: Patch
Type: Fix
Message: Prevent refunds that exceed a line item's total or quantity (for example, refunding $20 against a $10 fee).

Linear: https://linear.app/a8c/issue/RSMAPGJ-379