### PR TITLE
Fix current-menu-item class on shop page link in Navigation block

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-398
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-398
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add the current-menu-item class to the shop page link in the Navigation block on FSE themes.

--- a/plugins/woocommerce/includes/wc-page-functions.php
+++ b/plugins/woocommerce/includes/wc-page-functions.php
@@ -238,6 +238,88 @@ function wc_nav_menu_inner_blocks( $inner_blocks ) {
 add_filter( 'block_core_navigation_render_inner_blocks', 'wc_nav_menu_inner_blocks' );
 
 /**
+ * Fix active class on shop page links rendered by the Navigation block.
+ *
+ * The legacy `wp_nav_menu_objects` filter (handled by `wc_nav_menu_item_classes`)
+ * does not run for block-based navigation. Block themes / the Navigation block use
+ * the `core/navigation-link` block, which determines the "current" state by
+ * comparing the linked post ID against `get_queried_object_id()`. On the Shop
+ * page WooCommerce sets up a product archive, so the queried object is not the
+ * Shop page and the comparison fails, leaving the navigation item without the
+ * `current-menu-item` class. This filter restores parity with classic menus by
+ * adding `current-menu-item` / `current_page_item` (and `aria-current="page"`)
+ * to the navigation link that points to the Shop page when viewing the shop,
+ * and `current_page_parent` when viewing a single product.
+ *
+ * @since 10.9.0
+ *
+ * @param string $block_content The rendered block HTML.
+ * @param array  $block         Parsed block array.
+ * @return string Possibly amended block HTML.
+ */
+function wc_nav_menu_link_block_current_shop( $block_content, $block ) {
+	if ( empty( $block_content ) || empty( $block['blockName'] ) || 'core/navigation-link' !== $block['blockName'] ) {
+		return $block_content;
+	}
+
+	if ( ! function_exists( 'is_shop' ) || ! function_exists( 'wc_get_page_id' ) ) {
+		return $block_content;
+	}
+
+	$attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+	$id    = isset( $attrs['id'] ) ? (int) $attrs['id'] : 0;
+
+	if ( $id <= 0 ) {
+		return $block_content;
+	}
+
+	$shop_page_id = (int) wc_get_page_id( 'shop' );
+
+	if ( $shop_page_id <= 0 || $shop_page_id !== $id ) {
+		return $block_content;
+	}
+
+	$is_shop_view    = is_shop();
+	$is_product_view = is_singular( 'product' );
+
+	if ( ! $is_shop_view && ! $is_product_view ) {
+		return $block_content;
+	}
+
+	if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
+		return $block_content;
+	}
+
+	$processor = new WP_HTML_Tag_Processor( $block_content );
+
+	if ( ! $processor->next_tag( array( 'tag_name' => 'LI' ) ) ) {
+		return $block_content;
+	}
+
+	if ( $is_shop_view ) {
+		$processor->add_class( 'current-menu-item' );
+		$processor->add_class( 'current_page_item' );
+	} elseif ( $is_product_view ) {
+		$processor->add_class( 'current-menu-ancestor' );
+		$processor->add_class( 'current_page_parent' );
+	}
+
+	$updated = $processor->get_updated_html();
+
+	if ( $is_shop_view ) {
+		$anchor = new WP_HTML_Tag_Processor( $updated );
+
+		if ( $anchor->next_tag( array( 'tag_name' => 'A' ) ) ) {
+			$anchor->set_attribute( 'aria-current', 'page' );
+			$updated = $anchor->get_updated_html();
+		}
+	}
+
+	return $updated;
+}
+add_filter( 'render_block', 'wc_nav_menu_link_block_current_shop', 10, 2 );
+
+/**
  * Fix active class in nav for shop page.
  *
  * @param array $menu_items Menu items.

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/page-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/page-functions.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Tests for WooCommerce page functions, specifically nav-related helpers.
+ *
+ * @package WooCommerce\Tests\Util
+ */
+
+/**
+ * Class WC_Tests_Page_Functions
+ */
+class WC_Tests_Page_Functions extends WC_Unit_Test_Case {
+
+	/**
+	 * The original "shop" page id, restored in tearDown.
+	 *
+	 * @var int
+	 */
+	private $original_shop_page_id;
+
+	/**
+	 * Set up: ensure a shop page is configured.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_shop_page_id = (int) get_option( 'woocommerce_shop_page_id', 0 );
+
+		if ( $this->original_shop_page_id <= 0 ) {
+			$page_id = wp_insert_post(
+				array(
+					'post_title'  => 'Shop',
+					'post_status' => 'publish',
+					'post_type'   => 'page',
+					'post_name'   => 'shop',
+				)
+			);
+
+			update_option( 'woocommerce_shop_page_id', $page_id );
+		}
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		update_option( 'woocommerce_shop_page_id', $this->original_shop_page_id );
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a minimal core/navigation-link parsed-block array.
+	 *
+	 * @param int $id Linked post id.
+	 * @return array
+	 */
+	private function make_nav_link_block( $id ) {
+		return array(
+			'blockName'    => 'core/navigation-link',
+			'attrs'        => array(
+				'id'    => $id,
+				'label' => 'Shop',
+				'url'   => 'http://example.com/shop/',
+				'kind'  => 'post-type',
+				'type'  => 'page',
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+		);
+	}
+
+	/**
+	 * @testdox Adds current-menu-item class to navigation-link block targeting the shop page when viewing the shop.
+	 */
+	public function test_navigation_link_block_gets_current_menu_item_on_shop() {
+		$shop_id = (int) wc_get_page_id( 'shop' );
+		$this->assertGreaterThan( 0, $shop_id, 'Shop page must exist for this test.' );
+
+		// Put WP into a state where is_shop() returns true. The simplest route in unit tests
+		// is to "visit" the configured shop page, which makes is_page( shop_id ) true.
+		$this->go_to( get_permalink( $shop_id ) );
+
+		$this->assertTrue( is_shop(), 'Pre-condition: is_shop() should be true after navigating to the shop page.' );
+
+		$rendered = '<li class="wp-block-navigation-item"><a href="http://example.com/shop/">Shop</a></li>';
+		$block    = $this->make_nav_link_block( $shop_id );
+
+		$result = wc_nav_menu_link_block_current_shop( $rendered, $block );
+
+		$this->assertStringContainsString( 'current-menu-item', $result, 'Shop link should receive current-menu-item class on shop view.' );
+		$this->assertStringContainsString( 'current_page_item', $result, 'Shop link should also receive current_page_item class for parity with classic menus.' );
+		$this->assertStringContainsString( 'aria-current="page"', $result, 'Shop link anchor should advertise aria-current="page" for assistive tech.' );
+	}
+
+	/**
+	 * @testdox Adds current_page_parent class on single product view for the shop nav link.
+	 */
+	public function test_navigation_link_block_gets_current_parent_on_product() {
+		$shop_id = (int) wc_get_page_id( 'shop' );
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test product' );
+		$product->save();
+
+		$this->go_to( get_permalink( $product->get_id() ) );
+
+		if ( ! is_singular( 'product' ) ) {
+			$this->markTestSkipped( 'Could not enter single product context in this test environment.' );
+		}
+
+		$rendered = '<li class="wp-block-navigation-item"><a href="http://example.com/shop/">Shop</a></li>';
+		$block    = $this->make_nav_link_block( $shop_id );
+
+		$result = wc_nav_menu_link_block_current_shop( $rendered, $block );
+
+		$this->assertStringContainsString( 'current_page_parent', $result, 'Shop link should receive current_page_parent on single product views.' );
+		$this->assertStringContainsString( 'current-menu-ancestor', $result, 'Shop link should also receive current-menu-ancestor on single product views.' );
+		$this->assertStringNotContainsString( 'aria-current=', $result, 'aria-current must not be set on ancestor links.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Leaves non-navigation-link blocks untouched.
+	 */
+	public function test_other_blocks_are_untouched() {
+		$shop_id = (int) wc_get_page_id( 'shop' );
+
+		$rendered = '<p>some content</p>';
+		$block    = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array( 'id' => $shop_id ),
+		);
+
+		$this->assertSame( $rendered, wc_nav_menu_link_block_current_shop( $rendered, $block ) );
+	}
+
+	/**
+	 * @testdox Leaves navigation-link blocks pointing at non-shop pages untouched.
+	 */
+	public function test_non_shop_navigation_link_is_untouched() {
+		$other_page_id = wp_insert_post(
+			array(
+				'post_title'  => 'About',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+
+		$rendered = '<li class="wp-block-navigation-item"><a href="http://example.com/about/">About</a></li>';
+		$block    = $this->make_nav_link_block( (int) $other_page_id );
+
+		$this->assertSame( $rendered, wc_nav_menu_link_block_current_shop( $rendered, $block ) );
+	}
+
+	/**
+	 * @testdox Leaves shop navigation-link untouched when not viewing shop or a product.
+	 */
+	public function test_shop_navigation_link_untouched_when_not_on_shop_or_product() {
+		$shop_id = (int) wc_get_page_id( 'shop' );
+
+		// Navigate to the homepage so neither is_shop() nor is_singular( 'product' ) is true.
+		$this->go_to( home_url( '/' ) );
+
+		if ( is_shop() || is_singular( 'product' ) ) {
+			$this->markTestSkipped( 'Unable to leave shop/product context in this test environment.' );
+		}
+
+		$rendered = '<li class="wp-block-navigation-item"><a href="http://example.com/shop/">Shop</a></li>';
+		$block    = $this->make_nav_link_block( $shop_id );
+
+		$this->assertSame( $rendered, wc_nav_menu_link_block_current_shop( $rendered, $block ) );
+	}
+
+	/**
+	 * @testdox Returns empty content unchanged.
+	 */
+	public function test_empty_block_content_is_passthrough() {
+		$shop_id = (int) wc_get_page_id( 'shop' );
+
+		$this->assertSame( '', wc_nav_menu_link_block_current_shop( '', $this->make_nav_link_block( $shop_id ) ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [Contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

Closes #34827.

On FSE themes the Navigation block does not give the navigation link to the Shop page the `current-menu-item` CSS class when the Shop page is being viewed. Cart, Checkout, and My Account links pick it up correctly. The root cause: WP's `core/navigation-link` block decides the "current" state by comparing the linked post id against `get_queried_object_id()`. On the Shop page WooCommerce sets up the product archive, so the queried object is not the Shop page and the comparison fails. The existing `wc_nav_menu_item_classes` filter handles this for classic menus (`wp_nav_menu_objects`) but does not run for the block-based navigation.

This PR adds a `render_block` filter for `core/navigation-link` that, when the block targets the configured Shop page, augments the rendered `<li>` with:

- `current-menu-item` + `current_page_item` (and `aria-current="page"` on the anchor) when `is_shop()` is true.
- `current-menu-ancestor` + `current_page_parent` when viewing a single product, matching the behaviour of classic menus.

The HTML is mutated via `WP_HTML_Tag_Processor` to avoid string surgery on rendered block markup.

### Screenshots or screen recordings

n/a — class-level change. Inspect the rendered navigation `<li>` for the Shop link on the front end.

### How to test the changes in this Pull Request

1. Activate an FSE theme such as Twenty Twenty Two.
2. In `WooCommerce > Settings > Products > General`, confirm a Shop page is set.
3. In the site editor, add a Navigation block to the header (or template part) containing a link to the Shop page (and to Cart / Checkout / My Account).
4. Visit the Shop page on the front end and open dev tools. The `<li>` wrapping the Shop link should now contain `current-menu-item` and `current_page_item`, and the `<a>` should advertise `aria-current="page"`.
5. Visit a single product. The Shop link `<li>` should contain `current-menu-ancestor` / `current_page_parent`.
6. Visit Cart, Checkout, My Account. Their links should still get `current-menu-item` (unchanged from before).
7. Visit the homepage. The Shop link should have **no** current-* classes.

### Testing that has already taken place

- Added PHPUnit coverage in `tests/legacy/unit-tests/util/page-functions.php` exercising:
  - shop view → current-menu-item / current_page_item / aria-current
  - single product view → current-menu-ancestor / current_page_parent
  - non-shop link untouched
  - non-navigation-link blocks untouched
  - empty content passthrough
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passes.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passes.
- `composer exec -- phpstan analyse includes/wc-page-functions.php` passes (no new errors, no baseline additions).

<!-- Choose ONE option, delete the others. -->

- [x] **Auto-assign milestone** (recommended).

### Changelog entry

- [x] Changelog entry has been created manually.

Linear: https://linear.app/a8c/issue/RSMAPGJ-398