### PR TITLE
Fix wc/v3/reports/sales returning empty data on HPOS-only sites

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-425
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-425
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `wc/v3/reports/sales` returning empty totals on HPOS sites where order data is not synced to the legacy posts tables.

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -47,6 +48,16 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 	 * Get all data needed for this report and store in the class.
 	 */
 	private function query_report_data() {
+		// The legacy SQL-builder (`get_order_report_data`) targets `wp_posts`/`wp_postmeta`.
+		// When HPOS is the authoritative datastore and order data is no longer synced
+		// to the posts tables, those queries return no rows. Route through the
+		// HPOS-aware implementation in that case so the legacy sales reports REST
+		// endpoint (`/wc/v3/reports/sales`) keeps working.
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$this->query_report_data_hpos();
+			return;
+		}
+
 		$this->report_data = new stdClass();
 
 		$this->report_data->order_counts = (array) $this->get_order_report_data(
@@ -444,6 +455,372 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
 		// 3rd party filtering of report data
 		$this->report_data = apply_filters( 'woocommerce_admin_report_data', $this->report_data );
+	}
+
+	/**
+	 * HPOS-aware implementation of {@see self::query_report_data()}.
+	 *
+	 * Builds the same `$this->report_data` shape consumed by the legacy charts and
+	 * the `wc/v3/reports/sales` REST endpoint, but sources data from `wc_get_orders()`
+	 * instead of the legacy `wp_posts`/`wp_postmeta` SQL queries.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return void
+	 */
+	private function query_report_data_hpos() {
+		$this->report_data = new stdClass();
+
+		$count_statuses    = array( OrderStatus::COMPLETED, OrderStatus::PROCESSING, OrderStatus::ON_HOLD, OrderStatus::REFUNDED );
+		$count_order_types = wc_get_order_types( 'order-count' );
+		$sales_order_types = wc_get_order_types( 'sales-reports' );
+
+		$date_after  = gmdate( 'Y-m-d H:i:s', $this->start_date );
+		$date_before = gmdate( 'Y-m-d H:i:s', strtotime( '+1 DAY', $this->end_date ) - 1 );
+		$date_query  = $date_after . '...' . $date_before;
+
+		$grouping = $this->chart_groupby;
+
+		$bucket_for = function ( $order ) use ( $grouping ) {
+			$date = $order->get_date_created();
+			if ( ! $date ) {
+				return null;
+			}
+			$ts = $date->getOffsetTimestamp();
+			return 'day' === $grouping ? gmdate( 'Y-m-d', $ts ) : gmdate( 'Y-m', $ts );
+		};
+
+		$post_date_for = function ( $order ) {
+			$date = $order->get_date_created();
+			return $date ? $date->date( 'Y-m-d H:i:s' ) : '';
+		};
+
+		// 1) Counted orders (used for order_counts, order_items, coupons).
+		$counted_orders = $this->fetch_orders_for_report(
+			array(
+				'types'        => $count_order_types,
+				'status'       => $count_statuses,
+				'date_created' => $date_query,
+			)
+		);
+
+		// 2) Sales orders (used for total_sales/shipping/tax aggregation).
+		// Sales-report order types are typically a subset of order-count types, so reuse where possible.
+		if ( $count_order_types === $sales_order_types ) {
+			$sales_orders = $counted_orders;
+		} else {
+			$sales_orders = $this->fetch_orders_for_report(
+				array(
+					'types'        => $sales_order_types,
+					'status'       => $count_statuses,
+					'date_created' => $date_query,
+				)
+			);
+		}
+
+		// order_counts: one row per bucket with {count, post_date}.
+		$order_counts = array();
+		foreach ( $counted_orders as $order ) {
+			$bucket = $bucket_for( $order );
+			if ( null === $bucket ) {
+				continue;
+			}
+			if ( ! isset( $order_counts[ $bucket ] ) ) {
+				$order_counts[ $bucket ] = (object) array(
+					'count'     => 0,
+					'post_date' => $post_date_for( $order ),
+				);
+			}
+			++$order_counts[ $bucket ]->count;
+		}
+		ksort( $order_counts );
+		$this->report_data->order_counts = array_values( $order_counts );
+
+		// order_items: per-bucket sum of line-item quantities; coupons: per-bucket+code discount totals.
+		$order_items_buckets = array();
+		$coupon_buckets      = array();
+		foreach ( $counted_orders as $order ) {
+			$bucket = $bucket_for( $order );
+			if ( null === $bucket ) {
+				continue;
+			}
+			$pd = $post_date_for( $order );
+
+			if ( ! isset( $order_items_buckets[ $bucket ] ) ) {
+				$order_items_buckets[ $bucket ] = (object) array(
+					'order_item_count' => 0,
+					'post_date'        => $pd,
+				);
+			}
+			foreach ( $order->get_items( 'line_item' ) as $item ) {
+				$order_items_buckets[ $bucket ]->order_item_count += (int) $item->get_quantity();
+			}
+
+			foreach ( $order->get_items( 'coupon' ) as $coupon_item ) {
+				$code = $coupon_item->get_name();
+				$key  = $bucket . '|' . $code;
+				if ( ! isset( $coupon_buckets[ $key ] ) ) {
+					$coupon_buckets[ $key ] = (object) array(
+						'order_item_name' => $code,
+						'discount_amount' => 0.0,
+						'post_date'       => $pd,
+					);
+				}
+				if ( $coupon_item instanceof WC_Order_Item_Coupon ) {
+						$coupon_buckets[ $key ]->discount_amount += (float) $coupon_item->get_discount();
+				}
+			}
+		}
+		ksort( $order_items_buckets );
+		$this->report_data->order_items = array_values( $order_items_buckets );
+		$this->report_data->coupons     = array_values( $coupon_buckets );
+
+		// orders: per-bucket aggregates of order totals/shipping/tax/shipping-tax.
+		$orders_buckets = array();
+		foreach ( $sales_orders as $order ) {
+			$bucket = $bucket_for( $order );
+			if ( null === $bucket ) {
+				continue;
+			}
+			if ( ! isset( $orders_buckets[ $bucket ] ) ) {
+				$orders_buckets[ $bucket ] = (object) array(
+					'total_sales'        => 0.0,
+					'total_shipping'     => 0.0,
+					'total_tax'          => 0.0,
+					'total_shipping_tax' => 0.0,
+					'post_date'          => $post_date_for( $order ),
+				);
+			}
+			$orders_buckets[ $bucket ]->total_sales        += (float) $order->get_total();
+			$orders_buckets[ $bucket ]->total_shipping     += (float) $order->get_shipping_total();
+			$orders_buckets[ $bucket ]->total_tax          += (float) $order->get_cart_tax();
+			$orders_buckets[ $bucket ]->total_shipping_tax += (float) $order->get_shipping_tax();
+		}
+		ksort( $orders_buckets );
+		$this->report_data->orders = array_values( $orders_buckets );
+
+		// Refund-side data: iterate refunds in range and split into full vs. partial.
+		// Full refund = refund whose parent's status is 'refunded' (entire order refunded).
+		// Partial refund = refund whose parent is still completed/processing/on-hold.
+		$refunds = $this->fetch_orders_for_report(
+			array(
+				'types'        => array( 'shop_order_refund' ),
+				'status'       => array(),
+				'date_created' => $date_query,
+			)
+		);
+
+		$full_refunds    = array();
+		$partial_refunds = array();
+		$refund_lines    = array();
+		$seen_parents    = array();
+
+		foreach ( $refunds as $refund ) {
+			if ( ! $refund instanceof WC_Order_Refund ) {
+				continue;
+			}
+			$parent_id = (int) $refund->get_parent_id();
+			// wc_get_order() is backed by the order cache, so repeated lookups within this loop are cheap.
+			$parent = $parent_id ? wc_get_order( $parent_id ) : null;
+			if ( ! $parent ) {
+				continue;
+			}
+
+			$pd            = $post_date_for( $refund );
+			$parent_status = $parent->get_status();
+
+			// Refund lines covers partials on COMPLETED|PROCESSING|ON_HOLD|REFUNDED parents.
+			if ( in_array( $parent_status, array( OrderStatus::COMPLETED, OrderStatus::PROCESSING, OrderStatus::ON_HOLD, OrderStatus::REFUNDED ), true ) ) {
+				$item_count = 0;
+				foreach ( $refund->get_items( 'line_item' ) as $line ) {
+					$item_count += (int) $line->get_quantity();
+				}
+
+				$refund_line    = (object) array(
+					'refund_id'          => $refund->get_id(),
+					'total_refund'       => (float) $refund->get_amount(),
+					'post_date'          => $pd,
+					'item_type'          => $item_count > 0 ? 'line_item' : null,
+					'total_sales'        => (float) $parent->get_total(),
+					'total_shipping'     => (float) $refund->get_shipping_total(),
+					'total_tax'          => (float) $refund->get_cart_tax(),
+					'total_shipping_tax' => (float) $refund->get_shipping_tax(),
+					'order_item_count'   => $item_count,
+				);
+				$refund_lines[] = $refund_line;
+			}
+
+			if ( OrderStatus::REFUNDED === $parent_status ) {
+				if ( isset( $seen_parents[ $parent_id ] ) ) {
+					// Only count each fully-refunded parent once.
+					continue;
+				}
+				$seen_parents[ $parent_id ] = true;
+
+				$total_refund       = (float) $parent->get_total();
+				$total_shipping     = (float) $parent->get_shipping_total();
+				$total_tax          = (float) $parent->get_cart_tax();
+				$total_shipping_tax = (float) $parent->get_shipping_tax();
+				$full_refunds[]     = (object) array(
+					'total_refund'       => $total_refund,
+					'total_shipping'     => $total_shipping,
+					'total_tax'          => $total_tax,
+					'total_shipping_tax' => $total_shipping_tax,
+					'post_date'          => $pd,
+					'net_refund'         => $total_refund - ( $total_shipping + $total_tax + $total_shipping_tax ),
+				);
+			} elseif ( in_array( $parent_status, array( OrderStatus::COMPLETED, OrderStatus::PROCESSING, OrderStatus::ON_HOLD ), true ) ) {
+				$item_count = 0;
+				foreach ( $refund->get_items( 'line_item' ) as $line ) {
+					$item_count += (int) $line->get_quantity();
+				}
+
+				$total_refund       = (float) $refund->get_amount();
+				$total_shipping     = (float) $refund->get_shipping_total();
+				$total_tax          = (float) $refund->get_cart_tax();
+				$total_shipping_tax = (float) $refund->get_shipping_tax();
+				$partial            = (object) array(
+					'refund_id'          => $refund->get_id(),
+					'total_refund'       => $total_refund,
+					'post_date'          => $pd,
+					'item_type'          => $item_count > 0 ? 'line_item' : null,
+					'total_sales'        => (float) $parent->get_total(),
+					'total_shipping'     => $total_shipping,
+					'total_tax'          => $total_tax,
+					'total_shipping_tax' => $total_shipping_tax,
+					'order_item_count'   => $item_count,
+					'net_refund'         => $total_refund - ( $total_shipping + $total_tax + $total_shipping_tax ),
+				);
+				$partial_refunds[]  = $partial;
+			}
+		}
+
+		$this->report_data->full_refunds    = $full_refunds;
+		$this->report_data->partial_refunds = $partial_refunds;
+		$this->report_data->refund_lines    = $refund_lines;
+
+		// Refunded items aggregate: items in a fully-refunded order plus item counts on partial refunds.
+		$this->report_data->refunded_order_items = 0;
+		$refunded_only_orders                    = $this->fetch_orders_for_report(
+			array(
+				'types'        => $count_order_types,
+				'status'       => array( OrderStatus::REFUNDED ),
+				'date_created' => $date_query,
+			)
+		);
+		foreach ( $refunded_only_orders as $order ) {
+			foreach ( $order->get_items( 'line_item' ) as $line ) {
+				$this->report_data->refunded_order_items += (int) $line->get_quantity();
+			}
+		}
+
+		$refunded_orders                                = array_merge( $partial_refunds, $full_refunds );
+		$this->report_data->refunded_orders             = $refunded_orders;
+		$this->report_data->total_tax_refunded          = 0;
+		$this->report_data->total_shipping_refunded     = 0;
+		$this->report_data->total_shipping_tax_refunded = 0;
+		$this->report_data->total_refunds               = 0;
+
+		foreach ( $refunded_orders as $value ) {
+			$this->report_data->total_tax_refunded          += floatval( $value->total_tax < 0 ? $value->total_tax * -1 : $value->total_tax );
+			$this->report_data->total_refunds               += floatval( $value->total_refund );
+			$this->report_data->total_shipping_tax_refunded += floatval( $value->total_shipping_tax < 0 ? $value->total_shipping_tax * -1 : $value->total_shipping_tax );
+			$this->report_data->total_shipping_refunded     += floatval( $value->total_shipping < 0 ? $value->total_shipping * -1 : $value->total_shipping );
+
+			if ( isset( $value->order_item_count ) ) {
+				$this->report_data->refunded_order_items += floatval( $value->order_item_count < 0 ? $value->order_item_count * -1 : $value->order_item_count );
+			}
+		}
+
+		// Aggregate totals (mirrors logic in query_report_data()).
+		$sum_tax          = (float) array_sum( wp_list_pluck( $this->report_data->orders, 'total_tax' ) );
+		$sum_shipping     = (float) array_sum( wp_list_pluck( $this->report_data->orders, 'total_shipping' ) );
+		$sum_shipping_tax = (float) array_sum( wp_list_pluck( $this->report_data->orders, 'total_shipping_tax' ) );
+		$sum_sales        = (float) array_sum( wp_list_pluck( $this->report_data->orders, 'total_sales' ) );
+
+		$this->report_data->total_tax          = wc_format_decimal( $sum_tax - (float) $this->report_data->total_tax_refunded, 2 );
+		$this->report_data->total_shipping     = wc_format_decimal( $sum_shipping - (float) $this->report_data->total_shipping_refunded, 2 );
+		$this->report_data->total_shipping_tax = wc_format_decimal( $sum_shipping_tax - (float) $this->report_data->total_shipping_tax_refunded, 2 );
+
+		$this->report_data->total_sales = wc_format_decimal( $sum_sales - (float) $this->report_data->total_refunds, 2 );
+		$this->report_data->net_sales   = wc_format_decimal(
+			(float) $this->report_data->total_sales
+			- (float) $this->report_data->total_shipping
+			- max( 0.0, (float) $this->report_data->total_tax )
+			- max( 0.0, (float) $this->report_data->total_shipping_tax ),
+			2
+		);
+
+		$interval                               = (int) $this->chart_interval + 1;
+		$this->report_data->average_sales       = wc_format_decimal( (float) $this->report_data->net_sales / $interval, 2 );
+		$this->report_data->average_total_sales = wc_format_decimal( (float) $this->report_data->total_sales / $interval, 2 );
+
+		$this->report_data->total_coupons         = number_format( array_sum( wp_list_pluck( $this->report_data->coupons, 'discount_amount' ) ), 2, '.', '' );
+		$this->report_data->total_refunded_orders = absint( count( $this->report_data->full_refunds ) );
+
+		$this->report_data->total_orders = absint( array_sum( wp_list_pluck( $this->report_data->order_counts, 'count' ) ) );
+		$this->report_data->total_items  = absint( array_sum( wp_list_pluck( $this->report_data->order_items, 'order_item_count' ) ) );
+
+		/**
+		 * Filters the assembled admin report data.
+		 *
+		 * Mirrors the filter triggered in {@see self::query_report_data()} so callers can hook
+		 * a single filter regardless of whether HPOS or the legacy datastore is authoritative.
+		 *
+		 * @since 2.6.0
+		 *
+		 * @param stdClass $report_data The aggregated report data.
+		 */
+		$this->report_data = apply_filters( 'woocommerce_admin_report_data', $this->report_data );
+	}
+
+	/**
+	 * Page through `wc_get_orders` to fetch every order matching the supplied filters.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param array $args Filter args. Required keys: `types` (string[]), `status` (string[]), `date_created` (string).
+	 * @return WC_Order[]|WC_Abstract_Order[]
+	 */
+	private function fetch_orders_for_report( array $args ): array {
+		$collected = array();
+		$page      = 1;
+		$per_page  = 200;
+
+		$base_query = array(
+			'type'         => $args['types'],
+			'limit'        => $per_page,
+			'orderby'      => 'date',
+			'order'        => 'ASC',
+			'date_created' => $args['date_created'],
+			'return'       => 'objects',
+			'paginate'     => false,
+		);
+
+		if ( ! empty( $args['status'] ) ) {
+			$base_query['status'] = $args['status'];
+		} else {
+			$base_query['status'] = 'any';
+		}
+
+		do {
+			$query         = $base_query;
+			$query['page'] = $page;
+
+			$batch = wc_get_orders( $query );
+			if ( empty( $batch ) || ! is_array( $batch ) ) {
+				break;
+			}
+
+			foreach ( $batch as $order ) {
+				$collected[] = $order;
+			}
+
+			$batch_size = count( $batch );
+			++$page;
+		} while ( $batch_size === $per_page );
+
+		return $collected;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/reports/class-wc-report-sales-by-date-hpos-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/reports/class-wc-report-sales-by-date-hpos-test.php
@@ -1,0 +1,178 @@
+<?php
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+
+/**
+ * HPOS-aware test coverage for {@see WC_Report_Sales_By_Date}.
+ *
+ * Verifies the fix for woo#48903 / RSMAPGJ-425: the legacy
+ * `wc/v3/reports/sales` REST endpoint feeds off `WC_Report_Sales_By_Date`,
+ * which previously queried `wp_posts`/`wp_postmeta` directly and returned
+ * empty totals on HPOS-only sites. The HPOS path now sources data via
+ * `wc_get_orders()` so the report numbers match the underlying orders.
+ */
+class WC_Report_Sales_By_Date_HPOS_Test extends WC_Unit_Test_Case {
+
+	use HPOSToggleTrait;
+
+	/**
+	 * Load the necessary report files (mirrors the CPT test file's behavior).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-admin-report.php';
+		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-report-sales-by-date.php';
+	}
+
+	/**
+	 * Set up: switch on HPOS as the authoritative datastore.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->setup_cot();
+	}
+
+	/**
+	 * Tear down: restore the default datastore configuration.
+	 */
+	public function tearDown(): void {
+		$this->clean_up_cot_setup();
+		delete_transient( 'wc_report_sales_by_date' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a sales report covering the current month for the supplied report instance.
+	 */
+	private function build_report(): WC_Report_Sales_By_Date {
+		$report                 = new WC_Report_Sales_By_Date();
+		$report->start_date     = strtotime( gmdate( 'Y-m-01' ) );
+		$report->end_date       = time();
+		$report->chart_groupby  = 'day';
+		$report->chart_interval = 0;
+		$report->group_by_query = 'YEAR(posts.post_date), MONTH(posts.post_date), DAY(posts.post_date)';
+
+		return $report;
+	}
+
+	/**
+	 * Regression: with HPOS as authoritative datastore (no sync to posts), the
+	 * legacy sales report must return real totals instead of zeros.
+	 */
+	public function test_hpos_report_includes_orders_totals(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '50' );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 2 );
+		$order->calculate_totals();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$data = $this->build_report()->get_report_data();
+
+		$this->assertSame( 1, $data->total_orders, 'HPOS sales report should count the completed order.' );
+		$this->assertSame( 2, $data->total_items, 'HPOS sales report should count the line item quantities.' );
+		$this->assertGreaterThan( 0, (float) $data->total_sales, 'HPOS sales report total_sales must be non-zero when orders exist.' );
+		$this->assertSame(
+			wc_format_decimal( (float) $order->get_total(), 2 ),
+			$data->total_sales,
+			'HPOS sales report total_sales should match the order total.'
+		);
+	}
+
+	/**
+	 * Multiple orders within the range aggregate correctly per day bucket.
+	 */
+	public function test_hpos_report_aggregates_multiple_orders(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '20' );
+		$product->save();
+
+		$totals = 0.0;
+		for ( $i = 0; $i < 3; $i++ ) {
+			$order = wc_create_order();
+			$order->add_product( $product, 1 );
+			$order->calculate_totals();
+			$order->set_status( OrderStatus::COMPLETED );
+			$order->save();
+			$totals += (float) $order->get_total();
+		}
+
+		$data = $this->build_report()->get_report_data();
+
+		$this->assertSame( 3, $data->total_orders );
+		$this->assertSame( 3, $data->total_items );
+		$this->assertSame( wc_format_decimal( $totals, 2 ), $data->total_sales );
+	}
+
+	/**
+	 * Orders outside the date range must not affect the totals.
+	 */
+	public function test_hpos_report_excludes_out_of_range_orders(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '10' );
+		$product->save();
+
+		// In-range order.
+		$in_range_order = wc_create_order();
+		$in_range_order->add_product( $product, 1 );
+		$in_range_order->calculate_totals();
+		$in_range_order->set_status( OrderStatus::COMPLETED );
+		$in_range_order->save();
+
+		// Out-of-range order (one year in the past).
+		$past_order = wc_create_order();
+		$past_order->add_product( $product, 5 );
+		$past_order->calculate_totals();
+		$past_order->set_status( OrderStatus::COMPLETED );
+		$past_order->set_date_created( gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ) );
+		$past_order->save();
+
+		$data = $this->build_report()->get_report_data();
+
+		$this->assertSame( 1, $data->total_orders, 'Past order should not be counted in current-month totals.' );
+		$this->assertSame( 1, $data->total_items );
+		$this->assertSame(
+			wc_format_decimal( (float) $in_range_order->get_total(), 2 ),
+			$data->total_sales,
+			'Only the in-range order should contribute to total_sales.'
+		);
+	}
+
+	/**
+	 * Refunds within range subtract from totals and surface in the refund accumulators.
+	 */
+	public function test_hpos_report_accounts_for_partial_refund(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '40' );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->calculate_totals();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		wc_create_refund(
+			array(
+				'amount'   => 7,
+				'order_id' => $order->get_id(),
+			)
+		);
+
+		$data = $this->build_report()->get_report_data();
+
+		$this->assertSame( 1, $data->total_orders, 'The parent order should still be counted.' );
+		$this->assertEqualsWithDelta( 7.0, (float) $data->total_refunds, 0.001, 'The partial refund amount should be captured.' );
+		$this->assertSame(
+			wc_format_decimal( (float) $order->get_total() - 7.0, 2 ),
+			$data->total_sales,
+			'total_sales should subtract the refunded amount.'
+		);
+		$this->assertCount( 1, $data->refund_lines, 'A refund line should be recorded.' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I've followed [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and [WooCommerce Coding Guidelines](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines).
- [x] I've added/updated unit tests where appropriate.

### Changes proposed in this Pull Request

The legacy `wc/v3/reports/sales` REST endpoint is backed by `WC_Report_Sales_By_Date`, which queries `wp_posts` and `wp_postmeta` directly through `WC_Admin_Report::get_order_report_data()`. On HPOS sites where order data is no longer synced to the legacy tables, those queries return no rows, so the endpoint responds with `total_sales: "0.00"` and zeroed totals even when orders exist (the report's *own* admin UI happens to skip running on HPOS, but the REST endpoint always renders the structure with the zeroed result).

This PR adds an HPOS-aware path inside `WC_Report_Sales_By_Date::query_report_data()` that builds the same `$report_data` shape consumed by the legacy chart code and the REST endpoint, but sources data via `wc_get_orders()`. The legacy SQL path remains unchanged for non-HPOS sites.

Closes #48903.
Linear: https://linear.app/a8c/issue/RSMAPGJ-425

### Screenshots or screen recordings

N/A (REST-only response shape change).

### How to test the changes in this Pull Request

1. On a clean HPOS-authoritative site (HPOS enabled, sync disabled), create one or more completed orders with non-zero totals dated in 2024-06.
2. Authenticate against the REST API and hit `GET /wp-json/wc/v3/reports/sales?date_min=2024-06-01&date_max=2024-06-30`.
3. **Before this PR:** `total_sales: "0.00"`, all totals zero.
   **After this PR:** `total_sales` matches the sum of the orders in the range, `total_orders`/`total_items` reflect the seeded orders, and per-day buckets populate.
4. Re-test on a non-HPOS site (or HPOS with sync) and confirm the totals still match (no regression on the legacy path).

### Testing that has already taken place

- Added `WC_Report_Sales_By_Date_HPOS_Test` covering basic totals, multi-order aggregation, out-of-range filtering, and a partial-refund scenario.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- Ran `composer exec -- phpstan analyse <file> --memory-limit=2G` on the modified file — clean, no baseline additions.

### Milestone

- [x] Auto-assign milestone

### Changelog entry

- [x] Added changelog entry manually (`plugins/woocommerce/changelog/fix-rsmapgj-425`).

---

RSMAPGJ AI Coder pipeline (pilot 2026-05-14)