### PR TITLE
Fix product review pagination order when sort is newest first

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-405
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-405
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honour the "Comments should be displayed with the" sort setting across paginated product reviews so page 1 shows the newest reviews when descending order is selected.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -88,6 +88,45 @@ class WC_Comments {
 
 		// Validate product reviews if requires verified owners.
 		add_action( 'pre_comment_on_post', array( __CLASS__, 'validate_product_review_verified_owners' ) );
+
+		// Honour the "Comments should be displayed with the" setting across paginated product reviews.
+		add_filter( 'comments_template_query_args', array( __CLASS__, 'order_product_reviews_query_args' ) );
+		add_filter( 'woocommerce_product_review_list_args', array( __CLASS__, 'order_product_reviews_list_args' ) );
+	}
+
+	/**
+	 * Ensure product reviews are fetched in the order configured by the "Comments should be displayed with the"
+	 * option so that pagination reflects the overall sort order rather than reversing each page individually.
+	 *
+	 * @since 10.9.0
+	 * @param array $comment_args Arguments passed to WP_Comment_Query by comments_template().
+	 * @return array
+	 */
+	public static function order_product_reviews_query_args( $comment_args ) {
+		if ( ! is_singular( 'product' ) ) {
+			return $comment_args;
+		}
+
+		$comment_args['order'] = ( 'desc' === strtolower( (string) get_option( 'comment_order' ) ) ) ? 'DESC' : 'ASC';
+
+		return $comment_args;
+	}
+
+	/**
+	 * Prevent wp_list_comments() from reversing the already-ordered product review list. Because the
+	 * comments_template_query_args filter fetches reviews in the final display order, the per-page
+	 * reversal that wp_list_comments() performs when comment_order=desc would otherwise break the
+	 * overall pagination order.
+	 *
+	 * @since 10.9.0
+	 * @param array $args Arguments passed to wp_list_comments() for product reviews.
+	 * @return array
+	 */
+	public static function order_product_reviews_list_args( $args ) {
+		$args['reverse_top_level'] = false;
+		$args['reverse_children']  = false;
+
+		return $args;
 	}
 
 	/**

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -54856,18 +54856,6 @@ parameters:
 			path: src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
 
 		-
-			message: '#^Parameter \#1 \$input of function array_reverse expects array, array\<int\|WP_Comment\>\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
-
-		-
-			message: '#^Parameter \#1 \$var of function count expects array\|Countable, array\<int\|WP_Comment\>\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
-
-		-
 			message: '#^Access to property \$parsed_block on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\Reviews\\WP_Block\.$#'
 			identifier: class.notFound
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
@@ -120,21 +120,27 @@ class ProductReviewTemplate extends AbstractBlock {
 			return;
 		}
 
-		$comment_query = new WP_Comment_Query(
-			build_comment_query_vars_from_block( $block )
-		);
+		$comment_vars  = build_comment_query_vars_from_block( $block );
+		$comment_order = strtolower( (string) get_option( 'comment_order' ) );
+
+		// Fetch reviews in the configured sort order so pagination reflects the overall order
+		// instead of reversing each page individually.
+		$comment_vars['order'] = ( 'desc' === $comment_order ) ? 'DESC' : 'ASC';
+
+		$comment_query = new WP_Comment_Query( $comment_vars );
 
 		// Get an array of comments for the current post.
 		$comments = $comment_query->get_comments();
-		if ( count( $comments ) === 0 ) {
+		if ( ! is_array( $comments ) || count( $comments ) === 0 ) {
 			return '';
 		}
 
-		$comment_order = get_option( 'comment_order' );
-
-		if ( 'desc' === $comment_order ) {
-			$comments = array_reverse( $comments );
-		}
+		$comments = array_filter(
+			$comments,
+			static function ( $comment ) {
+				return $comment instanceof WP_Comment;
+			}
+		);
 
 		$wrapper_attributes = get_block_wrapper_attributes();
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -151,4 +151,84 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertSame( array( 'order_note' ), apply_filters( 'akismet_excluded_comment_types', array() ) );
 	}
+
+	/**
+	 * Ensure the comments_template_query_args filter sets the query order to DESC when the
+	 * comment_order option is "desc" and we're on a singular product page.
+	 */
+	public function test_order_product_reviews_query_args_uses_desc_when_option_is_desc(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->go_to( get_permalink( $product->get_id() ) );
+
+		$previous_option = get_option( 'comment_order' );
+		update_option( 'comment_order', 'desc' );
+
+		$args = WC_Comments::order_product_reviews_query_args( array( 'order' => 'ASC' ) );
+
+		$this->assertSame( 'DESC', $args['order'] );
+
+		// Reset.
+		update_option( 'comment_order', $previous_option );
+		$this->go_to( '/' );
+	}
+
+	/**
+	 * Ensure the comments_template_query_args filter keeps the query order ASC when the option is "asc"
+	 * (or any non-desc value) on a singular product page.
+	 */
+	public function test_order_product_reviews_query_args_uses_asc_when_option_is_asc(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->go_to( get_permalink( $product->get_id() ) );
+
+		$previous_option = get_option( 'comment_order' );
+		update_option( 'comment_order', 'asc' );
+
+		$args = WC_Comments::order_product_reviews_query_args( array( 'order' => 'DESC' ) );
+
+		$this->assertSame( 'ASC', $args['order'] );
+
+		update_option( 'comment_order', $previous_option );
+		$this->go_to( '/' );
+	}
+
+	/**
+	 * Ensure the comments_template_query_args filter does not override the order when not on a product page.
+	 */
+	public function test_order_product_reviews_query_args_skips_when_not_on_product(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Blog Post',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		$this->go_to( get_permalink( $post_id ) );
+
+		$previous_option = get_option( 'comment_order' );
+		update_option( 'comment_order', 'desc' );
+
+		$args = WC_Comments::order_product_reviews_query_args( array( 'order' => 'ASC' ) );
+
+		$this->assertSame( 'ASC', $args['order'] );
+
+		update_option( 'comment_order', $previous_option );
+		wp_delete_post( $post_id, true );
+		$this->go_to( '/' );
+	}
+
+	/**
+	 * Ensure the wp_list_comments arguments disable the per-page reversal that would otherwise
+	 * fight the query-level ordering applied to product reviews.
+	 */
+	public function test_order_product_reviews_list_args_disables_reversal(): void {
+		$args = WC_Comments::order_product_reviews_list_args( array( 'callback' => 'woocommerce_comments' ) );
+
+		$this->assertArrayHasKey( 'reverse_top_level', $args );
+		$this->assertFalse( $args['reverse_top_level'] );
+		$this->assertArrayHasKey( 'reverse_children', $args );
+		$this->assertFalse( $args['reverse_children'] );
+	}
 }


### PR DESCRIPTION
## Summary

When the WordPress _Comments should be displayed with the_ setting is set to **newest**, product reviews are reversed per page rather than across the whole result set. With 12 reviews and 5 per page, the user sees page 1 = Dec 5 → 1 (oldest reversed) instead of the expected Dec 12 → 8 (newest).

This PR fetches reviews in the configured sort order at the query level (in both the classic single-product reviews template and the Product Reviews block) so that pagination reflects the overall sort order, and disables `wp_list_comments()` per-page reversal so the already-ordered list is rendered as-is.

## Changes

- `WC_Comments` registers two new filters:
  - `comments_template_query_args` to set the query `order` to `DESC` when on a singular product and `comment_order=desc`.
  - `woocommerce_product_review_list_args` to set `reverse_top_level`/`reverse_children` to `false` so the per-page reversal does not fight the query-level ordering.
- `ProductReviewTemplate` (Product Reviews block) passes `order` into the `WP_Comment_Query` vars instead of post-processing with `array_reverse()`.
- Tests cover both filter callbacks (DESC when option is desc, ASC otherwise, no-op when not on a product page, and the wp_list_comments args).
- Removes two obsolete phpstan-baseline entries that targeted the deleted `array_reverse()` / `count()` call sites.

## Test plan

- [ ] Create 12 approved reviews on a product spanning consecutive days.
- [ ] WP Admin → Settings → Discussion: set _Break comments into pages with_ to 5 and _Comments should be displayed with the_ to **older comments at the top**.
- [ ] Visit the product page; confirm page 1 shows reviews in ascending date order (Dec 1 → 5), page 2 Dec 6 → 10, page 3 Dec 11 → 12.
- [ ] Switch the option to **newer comments at the top**.
- [ ] Visit the product page; confirm page 1 now shows Dec 12 → 8, page 2 Dec 7 → 3, page 3 Dec 2 → 1.
- [ ] Repeat with the Product Reviews block in place of the classic template.
- [ ] Confirm WordPress post comments (on a regular post) are unaffected.

Closes #36050
Linear: https://linear.app/a8c/issue/RSMAPGJ-405