### PR TITLE
Remove reserved avatar space in product reviews when avatars are disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-443
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-443
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove reserved avatar space in product reviews when avatars are disabled in WordPress Discussion settings.

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -730,7 +730,7 @@ p.demo_store,
 					}
 
 					.comment-text {
-						margin: 0 0 0 50px;
+						margin: 0;
 						border: 1px solid darken($secondary, 3%);
 						border-radius: 4px;
 						padding: 1em 1em 0;
@@ -745,22 +745,34 @@ p.demo_store,
 							font-size: 0.83em;
 						}
 					}
+
+					&:has(> img.avatar) .comment-text {
+						margin-left: 50px;
+					}
 				}
 
 				ul.children {
 					list-style: none outside;
-					margin: 20px 0 0 50px;
+					margin: 20px 0 0;
 
 					.star-rating {
 						display: none;
 					}
 				}
 
+				li:has(> img.avatar) ul.children {
+					margin-left: 50px;
+				}
+
 				#respond {
 					border: 1px solid darken($secondary, 3%);
 					border-radius: 4px;
 					padding: 1em 1em 0;
-					margin: 20px 0 0 50px;
+					margin: 20px 0 0;
+				}
+
+				li:has(> img.avatar) #respond {
+					margin-left: 50px;
 				}
 			}
 


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

When WordPress "Avatar Display" is disabled in Settings -> Discussion, `get_avatar()` returns an empty string. WooCommerce's product review styles, however, still reserved a 50px left margin on `.comment-text` (and a 50px indent on `ul.children` / `#respond`) for the avatar that is no longer rendered. The result was a visible blank gap to the left of review and reply text.

This PR scopes the 50px avatar offset to comment list items that actually contain an avatar element via `:has(> img.avatar)`. When avatars are disabled, `.comment-text` keeps a `margin` of `0`, and reply threads / reply form no longer indent under empty space.

Bug introduced in CSS that predates the current trunk; see [original code](https://github.com/woocommerce/woocommerce/blob/59bddfe5b22cf6645384035ff49d6009f7e5d7da/plugins/woocommerce/client/legacy/css/woocommerce.scss#L733).

### How to test the changes in this Pull Request

1. WP Admin -> Settings -> Discussion -> uncheck "Show Avatars" and save.
2. Visit a product page with at least one approved review (and ideally a nested reply).
3. Confirm review and reply text now sit flush with the left edge of the comment container instead of being shifted ~50px to the right.
4. Re-enable "Show Avatars" and verify the avatar still renders to the left and the text/reply remain offset by 50px as before.

### Testing that has already taken place

- Manually inspected the generated CSS rule structure and confirmed `:has(> img.avatar)` is already in use elsewhere in `client/legacy/css`.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<!-- If you have not provided a changelog entry, please uncheck the following box. -->

- [x] This Pull Request does not require a changelog entry. (Reason: changelog file added manually as `plugins/woocommerce/changelog/fix-rsmapgj-443`.)

Closes #62467

Linear: [RSMAPGJ-443](https://linear.app/a8c/issue/RSMAPGJ-443)