### PR TITLE
Fix missing priceCurrency at offers level in product structured data

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-439
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-439
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Always include `priceCurrency` at the top-level `offers` object in product structured data, so Google Search Console recognizes the field for products whose currency was previously only nested inside `priceSpecification`.

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -418,14 +418,13 @@ class WC_Structured_Data {
 					'url'   => $shop_url,
 				),
 			);
-			if (
-				( ! empty( $markup_offer['price'] ) ||
-					! empty( $markup_offer['lowPrice'] ) ||
-					! empty( $markup_offer['highPrice'] )
-				) && empty( $markup_offer['priceCurrency'] )
-			) {
-				$markup_offer['priceCurrency'] = $currency;
-			}
+			// Always include `priceCurrency` at the top-level `offers` object for
+			// Google Search Console (Merchant listings) compatibility, even when
+			// the price is only present inside `priceSpecification`. GSC reports a
+			// critical "Missing field priceCurrency" error otherwise, despite the
+			// nested value being valid per schema.org and Google Rich Results Test.
+			// See https://github.com/woocommerce/woocommerce/issues/60652.
+			$markup_offer['priceCurrency'] = $currency;
 
 			$markup['offers'] = array( apply_filters( 'woocommerce_structured_data_product_offer', $markup_offer, $product ) );
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-structured-data-test.php
@@ -80,4 +80,42 @@ class WC_Structured_Data_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( $this->structured_data->prepare_gtin( '+12345678' ), '12345678' );
 		$this->assertEquals( $this->structured_data->prepare_gtin( '123.4e-5' ), '12345' );
 	}
+
+	/**
+	 * Test that the generated Product structured data exposes `priceCurrency`
+	 * at the top-level `offers` object for simple products, in addition to the
+	 * value nested inside `priceSpecification`.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/60652
+	 * where Google Search Console reports a critical "Missing field priceCurrency"
+	 * error for products whose currency was only present inside `priceSpecification`.
+	 *
+	 * @return void
+	 */
+	public function test_simple_product_offer_includes_top_level_price_currency(): void {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => '97.00',
+			)
+		);
+
+		$this->structured_data->generate_product_data( $product );
+		$data = $this->structured_data->get_structured_data( array( 'product' ) );
+
+		$this->assertNotEmpty( $data, 'Expected Product structured data to be generated.' );
+		$this->assertArrayHasKey( 'offers', $data[0] );
+
+		$offer = $data[0]['offers'][0];
+
+		// The fix: priceCurrency must be present at the top-level offer object.
+		$this->assertArrayHasKey( 'priceCurrency', $offer );
+		$this->assertSame( get_woocommerce_currency(), $offer['priceCurrency'] );
+
+		// And the nested value inside priceSpecification should still be intact.
+		$this->assertArrayHasKey( 'priceSpecification', $offer );
+		$this->assertSame( get_woocommerce_currency(), $offer['priceSpecification'][0]['priceCurrency'] );
+
+		$product->delete( true );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommendations for Engineers](https://developer.woocommerce.com/docs/contribution/recommendations-for-engineers/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

Google Search Console reports a critical "Missing field priceCurrency (in offers.priceSpecification)" error for WooCommerce product pages, blocking Rich Results eligibility. WooCommerce already emits `priceCurrency` inside `priceSpecification` (which is valid schema.org), but the top-level `offers` object only received `priceCurrency` when `price`, `lowPrice`, or `highPrice` was set on the offer. Simple products that build `priceSpecification` never matched that conditional, so the field was missing at the offers level.

This change always sets `priceCurrency` on the top-level `offers` object. The nested `priceSpecification.priceCurrency` value is left untouched.

Closes #60652
Linear: https://linear.app/a8c/issue/RSMAPGJ-439

Bug introduced in PR #55043 (where simple-product offers were restructured to use `priceSpecification`).

### How to test the changes in this Pull Request

1. Create a simple product (downloadable/virtual is fine) with `regular_price = 97.00`, `sale_price = 79.00`, and a sale end date.
2. Visit the product permalink on the storefront.
3. View page source and locate the `<script type="application/ld+json">` block emitted by WooCommerce.
4. Confirm `offers[0].priceCurrency` is present at the top-level offer object (matching the store currency, e.g. `"USD"`).
5. Confirm `offers[0].priceSpecification[*].priceCurrency` is also still present (unchanged).
6. Repeat for a variable product where every variation has the same price, and for a grouped product, to confirm `priceCurrency` is present at the offers level in those paths too.

### Testing that has already taken place

- Added PHPUnit regression coverage in `WC_Structured_Data_Test::test_simple_product_offer_includes_top_level_price_currency` that asserts both placements of `priceCurrency` for a simple product offer. Tests run in PR CI.
- Local quality checks (run from worktree):
  - `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
  - `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
  - `composer exec -- phpstan analyse includes/class-wc-structured-data.php --memory-limit=2G` — no errors (no baseline additions).

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance**: Patch
**Type**: Fix

**Message**: Always include `priceCurrency` at the top-level `offers` object in product structured data, so Google Search Console recognizes the field for products whose currency was previously only nested inside `priceSpecification`.

</details>

---

Signoff: RSMAPGJ AI Coder pipeline