### PR TITLE
Show shipping address on customer emails when shipping address is set

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-404
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the shipping address in customer-facing order emails when an order has a populated shipping address, even if no shipping method has been added (e.g. manually created orders).

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.6.0
+ * @version 10.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -23,6 +23,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $address  = $order->get_formatted_billing_address();
 $shipping = $order->get_formatted_shipping_address();
+
+/**
+ * Filter whether to show the shipping address in the email.
+ *
+ * By default, the shipping address is shown when the order needs a shipping
+ * address (i.e. it has a non-local-pickup shipping method) OR when the order
+ * already has a shipping address on file. The latter ensures manually created
+ * orders with a shipping address but no shipping method still surface the
+ * shipping address in the invoice email.
+ *
+ * @since 10.9.0
+ * @param bool     $show_shipping_address Whether to show the shipping address.
+ * @param WC_Order $order                 The order object.
+ */
+$show_shipping_address = (bool) apply_filters(
+	'woocommerce_email_show_shipping_address',
+	! wc_ship_to_billing_address_only() && ( $order->needs_shipping_address() || $order->has_shipping_address() ),
+	$order
+);
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
@@ -70,7 +89,7 @@ $display_section_divider = (bool) apply_filters( 'woocommerce_email_body_display
 				?>
 			</address>
 		</td>
-		<?php if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && $shipping ) : ?>
+		<?php if ( $show_shipping_address && $shipping ) : ?>
 			<td class="font-family text-align-left" style="padding:0;" valign="top" width="50%">
 				<?php if ( $email_improvements_enabled ) { ?>
 					<b class="address-title"><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></b>

--- a/plugins/woocommerce/templates/emails/plain/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/plain/email-addresses.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 8.6.0
+ * @version 10.9.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -40,7 +40,22 @@ if ( $order->get_billing_email() ) {
  */
 do_action( 'woocommerce_email_customer_address_section', 'billing', $order, $sent_to_admin, true );
 
-if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() ) {
+/**
+ * Filter whether to show the shipping address in the email.
+ *
+ * This filter is documented in templates/emails/email-addresses.php.
+ *
+ * @since 10.9.0
+ * @param bool     $show_shipping_address Whether to show the shipping address.
+ * @param WC_Order $order                 The order object.
+ */
+$show_shipping_address = (bool) apply_filters(
+	'woocommerce_email_show_shipping_address',
+	! wc_ship_to_billing_address_only() && ( $order->needs_shipping_address() || $order->has_shipping_address() ),
+	$order
+);
+
+if ( $show_shipping_address ) {
 	$shipping = $order->get_formatted_shipping_address();
 
 	if ( $shipping ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -121,4 +121,109 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'Test meta key', $content );
 		$this->assertStringContainsString( 'test_meta_value', $content );
 	}
+
+	/**
+	 * Build an order with a shipping address but no shipping line items.
+	 *
+	 * @return WC_Order
+	 */
+	private function create_order_with_shipping_address_only() {
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		// Drop any shipping line items the helper may have added so the order has
+		// a shipping address but no shipping method.
+		foreach ( $order->get_items( 'shipping' ) as $item_id => $item ) {
+			$order->remove_item( $item_id );
+		}
+
+		$order->set_shipping_first_name( 'Jane' );
+		$order->set_shipping_last_name( 'Doe' );
+		$order->set_shipping_address_1( '456 Shipping Ave' );
+		$order->set_shipping_city( 'Shipville' );
+		$order->set_shipping_state( 'NY' );
+		$order->set_shipping_postcode( '10001' );
+		$order->set_shipping_country( 'US' );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Render the email addresses template and return the markup.
+	 *
+	 * @param WC_Order $order      Order to render.
+	 * @param bool     $plain_text Whether to render the plain-text template.
+	 * @return string
+	 */
+	private function render_email_addresses( $order, $plain_text = false ) {
+		$email_object = new WC_Emails();
+		ob_start();
+		$email_object->email_addresses( $order, false, $plain_text );
+		$content = ob_get_contents();
+		ob_end_clean();
+		return $content;
+	}
+
+	/**
+	 * @testdox Should show the shipping address in HTML emails when the order has a shipping address but no shipping method.
+	 */
+	public function test_email_addresses_shows_shipping_address_when_no_shipping_method() {
+		$order = $this->create_order_with_shipping_address_only();
+
+		$this->assertFalse( $order->needs_shipping_address(), 'Sanity: order without a shipping method should not need a shipping address.' );
+		$this->assertTrue( $order->has_shipping_address(), 'Sanity: order should have a shipping address on file.' );
+
+		$content = $this->render_email_addresses( $order, false );
+
+		$this->assertStringContainsString( '456 Shipping Ave', $content, 'Shipping address line should appear in the HTML invoice when a shipping address is set, even without a shipping method.' );
+		$this->assertStringContainsString( 'Shipping address', $content, 'Shipping address heading should appear in the HTML invoice when a shipping address is set.' );
+	}
+
+	/**
+	 * @testdox Should show the shipping address in plain text emails when the order has a shipping address but no shipping method.
+	 */
+	public function test_email_addresses_plain_shows_shipping_address_when_no_shipping_method() {
+		$order = $this->create_order_with_shipping_address_only();
+
+		$content = $this->render_email_addresses( $order, true );
+
+		$this->assertStringContainsString( '456 Shipping Ave', $content, 'Shipping address line should appear in the plain-text invoice when a shipping address is set, even without a shipping method.' );
+		$this->assertStringContainsString( wc_strtoupper( 'Shipping address' ), $content, 'Shipping address heading should appear in the plain-text invoice when a shipping address is set.' );
+	}
+
+	/**
+	 * @testdox Should hide the shipping address when the store ships to the billing address only, even if a shipping address is set.
+	 */
+	public function test_email_addresses_hides_shipping_address_when_ship_to_billing_only() {
+		$order = $this->create_order_with_shipping_address_only();
+
+		add_filter( 'woocommerce_ship_to_billing_address_only', '__return_true' );
+		try {
+			$content       = $this->render_email_addresses( $order, false );
+			$content_plain = $this->render_email_addresses( $order, true );
+		} finally {
+			remove_filter( 'woocommerce_ship_to_billing_address_only', '__return_true' );
+		}
+
+		$this->assertStringNotContainsString( '456 Shipping Ave', $content, 'Shipping address should be hidden in HTML when ship-to-billing-only is enabled.' );
+		$this->assertStringNotContainsString( '456 Shipping Ave', $content_plain, 'Shipping address should be hidden in plain text when ship-to-billing-only is enabled.' );
+	}
+
+	/**
+	 * @testdox Should let the woocommerce_email_show_shipping_address filter override the default visibility.
+	 */
+	public function test_email_addresses_respects_show_shipping_address_filter() {
+		$order = $this->create_order_with_shipping_address_only();
+
+		add_filter( 'woocommerce_email_show_shipping_address', '__return_false' );
+		try {
+			$content       = $this->render_email_addresses( $order, false );
+			$content_plain = $this->render_email_addresses( $order, true );
+		} finally {
+			remove_filter( 'woocommerce_email_show_shipping_address', '__return_false' );
+		}
+
+		$this->assertStringNotContainsString( '456 Shipping Ave', $content, 'Filter returning false should suppress the shipping address in HTML emails.' );
+		$this->assertStringNotContainsString( '456 Shipping Ave', $content_plain, 'Filter returning false should suppress the shipping address in plain-text emails.' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #36048.

When manually creating an order with both billing and shipping addresses filled in but no shipping method, the customer "Email Invoice" omitted the shipping address. The visibility gate was tied to `WC_Order::needs_shipping_address()`, which only returns `true` when the order has a non-local-pickup shipping line item.

This PR renders the shipping address block in `templates/emails/email-addresses.php` (HTML + plain text) when the order needs a shipping address **or** already has a populated shipping address on file. The `wc_ship_to_billing_address_only()` toggle remains a hard suppressor. A new `woocommerce_email_show_shipping_address` filter is added so stores or extensions can override the heuristic.

### Screenshots / screen recordings:

n/a — server-side template change. Manual test plan below.

### How to test the changes in this Pull Request:

Using the Tester Account on this Pull Request:

1. WC > Orders > Add new.
2. Select a customer (or leave as Guest) and fill in the Billing **and** distinct Shipping addresses.
3. Add a product, recalculate, and create the order. **Do not** add a Shipping line item.
4. From Order Actions select "Email Invoice" and trigger it.
5. In the resulting customer email, confirm the Shipping address block appears alongside the Billing address.
6. Repeat with `add_filter( 'woocommerce_ship_to_billing_address_only', '__return_true' )` and confirm only the Billing address appears.
7. Repeat with `add_filter( 'woocommerce_email_show_shipping_address', '__return_false' )` and confirm only the Billing address appears.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [ ] Have you successfully run tests with your changes locally? Tests are written but deferred to PR CI per the RSMAPGJ AI Coder pipeline policy (no `pnpm test:php:env` from the agent).

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

This PR includes a changelog entry at `plugins/woocommerce/changelog/fix-rsmapgj-404`.

<details>

**Significance:** Patch
**Type:** Fix
**Message:** Show the shipping address in customer-facing order emails when an order has a populated shipping address, even if no shipping method has been added (e.g. manually created orders).

</details>

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-404

RSMAPGJ AI Coder pipeline