### PR TITLE
Fix single product description CSS in Twenty * classic themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-403
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-403
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix single product description styles in Twenty Nineteen, Twenty Twenty and Twenty Twenty-One themes: tab link styles no longer apply to all unordered lists in the description, and all direct descendants of the description tab now span the full width.

--- a/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
@@ -437,7 +437,7 @@ table.variations {
 .woocommerce-tabs {
 	margin: 0 0 2rem;
 
-	ul {
+	ul.tabs {
 		margin: 0 0 1.5rem;
 		padding: 0;
 		font-family: $headings;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -682,8 +682,7 @@ a.reset_variations {
 
 	/* reset description tab width to full width */
 	#tab-description {
-		h2,
-		p {
+		> * {
 			max-width: 100vw;
 			width: 100%;
 		}
@@ -709,7 +708,7 @@ a.reset_variations {
 		}
 	}
 
-	ul {
+	ul.tabs {
 		margin: 0 0 1.5rem;
 		padding: 0;
 		font-family: $headings;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -608,8 +608,7 @@ a.reset_variations {
 
 	/* reset description tab width to full width */
 	#tab-description {
-		h2,
-		p {
+		> * {
 			max-width: 100vw;
 			width: 100%;
 		}
@@ -635,7 +634,7 @@ a.reset_variations {
 		}
 	}
 
-	ul {
+	ul.tabs {
 		margin: 0 0 1.5rem;
 		padding: 0;
 		font-family: $headings;


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you used [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) in your code (PSR-12 for newly created classes)?

### Changes proposed in this Pull Request:

Closes #35844
Linear: https://linear.app/a8c/issue/RSMAPGJ-403

Fixes two CSS selector bugs in WooCommerce's theme-specific stylesheets for the WordPress classic Twenty Nineteen, Twenty Twenty and Twenty Twenty-One themes.

1. **Description tab — width override too narrow.** `#tab-description { h2, p { max-width: 100vw; width: 100% } }` only fills the tab width for h2 and p elements. Other direct descendants (h3-h6, lists, blockquotes, etc.) inherit the parent's constrained max-width and look misaligned. The selector is widened to `> *` so all direct children of the description tab span the full width.

2. **Tab nav styles bleeding into description lists.** `.woocommerce-tabs ul { ... }` matches any unordered list inside the tabs wrapper, including lists in the product description tab content. Those lists pick up the horizontal tab-link layout (`display: inline-flex` and friends) instead of normal list rendering. The selector is restricted to `ul.tabs` so it only targets the tabs navigation list.

### How to test the changes in this Pull Request:

1. Activate Twenty Nineteen, Twenty Twenty or Twenty Twenty-One as the active theme.
2. Create a product whose description contains:
   - Headings h2, h3, h4
   - An unordered list with multiple items
   - Paragraphs
3. View the product page on the frontend.
4. Expected:
   - All direct children of the description tab (headings, paragraphs, list) span the full width of the tab.
   - The unordered list renders vertically with list markers — not as horizontal tab-style links.
   - The actual tab navigation (Description / Additional information / Reviews) is unchanged.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable? — Pure CSS selector change; no behavioural code paths to unit test.
- [x] Have you successfully run tests with your changes locally? — Lint passes locally; PHP/JS unit tests deferred to PR CI (no PHP/JS code changed).

<!-- Mandatory. Replace [ ] with [x] to check the box below. -->

- [x] Add the milestone to the PR using the [Milestone GitHub action](https://github.com/woocommerce/woocommerce/actions/workflows/pr-assign-milestone.yml). This action will assign the milestone of the next development cycle to the PR.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below) <!-- Use this if you didn't manually create a changelog entry and want to skip the addition of a changelog. -->

> **Note**
> Changelog entry was created manually at \`plugins/woocommerce/changelog/fix-rsmapgj-403\`.

---

Submitted by **RSMAPGJ AI Coder pipeline**. Tests deferred to PR CI.