### PR TITLE
Fix manual order shipping method name truncated to "Shipping" in emails

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-406
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-406
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix manual orders showing a truncated "Shipping" label instead of the real shipping method title (e.g. "Free Shipping") in invoice, new order, and customer emails.

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -403,6 +403,8 @@ function wc_save_order_items( $order_id, $items ) {
 			'shipping_taxes'        => array(),
 		);
 
+		$registered_shipping_methods = null;
+
 		foreach ( $items['shipping_method_id'] as $item_id ) {
 			$item = WC_Order_Factory::get_order_item( absint( $item_id ) );
 
@@ -414,6 +416,30 @@ function wc_save_order_items( $order_id, $items ) {
 
 			foreach ( $data_keys as $key => $default ) {
 				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wc_clean( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
+			}
+
+			/*
+			 * When admins add a shipping line on a manual order and select a method from the dropdown
+			 * without typing a custom name, the posted title may be empty or stuck on the localized
+			 * "Shipping" fallback rendered by WC_Order_Item_Shipping::get_method_title(). In that case,
+			 * derive the title from the chosen registered shipping method so emails and order details
+			 * display the real method name (e.g. "Free Shipping") instead of the generic "Shipping".
+			 */
+			$posted_title         = is_string( $item_data['shipping_method_title'] ) ? $item_data['shipping_method_title'] : '';
+			$posted_method        = is_string( $item_data['shipping_method'] ) ? $item_data['shipping_method'] : '';
+			$default_method_title = __( 'Shipping', 'woocommerce' );
+
+			if ( '' !== $posted_method && 'other' !== $posted_method && ( '' === $posted_title || $default_method_title === $posted_title ) ) {
+				if ( null === $registered_shipping_methods ) {
+					$registered_shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
+				}
+
+				if ( isset( $registered_shipping_methods[ $posted_method ] ) && is_a( $registered_shipping_methods[ $posted_method ], 'WC_Shipping_Method' ) ) {
+					$resolved_title = $registered_shipping_methods[ $posted_method ]->get_method_title();
+					if ( '' !== $resolved_title ) {
+						$item_data['shipping_method_title'] = $resolved_title;
+					}
+				}
 			}
 
 			$item->set_props(

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -535,4 +535,97 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$order_item = new WC_Order_Item_Product( $order_item_id );
 		$this->assertEquals( 4, $order_item->get_meta( '_reduced_stock', true ), 'Reduced stock meta should be updated to new quantity' );
 	}
+
+	/**
+	 * Regression test for woo#36049 / RSMAPGJ-406.
+	 *
+	 * When an admin adds a shipping line to a manual order and selects a method (e.g. Free Shipping)
+	 * from the dropdown without typing a custom title, the posted shipping_method_title arrives as
+	 * either the empty string or the localized "Shipping" fallback rendered by
+	 * WC_Order_Item_Shipping::get_method_title(). wc_save_order_items() must resolve the real
+	 * registered method title in that case so emails do not display a truncated "Shipping" label.
+	 */
+	public function test_wc_save_order_items_resolves_shipping_title_for_manual_orders() {
+		// Seed a shipping zone with a free_shipping method whose configured title is "Free Shipping".
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( 'RSMAPGJ-406 zone' );
+		$zone->save();
+
+		$instance_id = $zone->add_shipping_method( 'free_shipping' );
+		$this->assertGreaterThan( 0, $instance_id );
+
+		update_option(
+			'woocommerce_free_shipping_' . $instance_id . '_settings',
+			array(
+				'title'      => 'Free Shipping',
+				'requires'   => '',
+				'min_amount' => '',
+			)
+		);
+
+		// Create a manual order with an empty-titled shipping line.
+		$order = WC_Helper_Order::create_order();
+		foreach ( $order->get_items( 'shipping' ) as $existing_shipping ) {
+			$order->remove_item( $existing_shipping->get_id() );
+		}
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_method_id( 'free_shipping:' . $instance_id );
+		$shipping_item->set_total( '0.00' );
+		$order->add_item( $shipping_item );
+		$order->save();
+
+		// Re-read the shipping item id from the saved order.
+		$shipping_items = $order->get_items( 'shipping' );
+		$this->assertCount( 1, $shipping_items );
+		$saved_shipping = reset( $shipping_items );
+		$item_id        = $saved_shipping->get_id();
+
+		// Case 1: empty posted title. wc_save_order_items should resolve it from the registered method.
+		$items_empty_title = array(
+			'order_id'              => $order->get_id(),
+			'shipping_method_id'    => array( $item_id ),
+			'shipping_method'       => array( $item_id => 'free_shipping:' . $instance_id ),
+			'shipping_method_title' => array( $item_id => '' ),
+			'shipping_cost'         => array( $item_id => '0.00' ),
+		);
+
+		wc_save_order_items( $order->get_id(), $items_empty_title );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$shipping  = reset( $refreshed->get_items( 'shipping' ) );
+		$this->assertSame( 'Free Shipping', $shipping->get_name(), 'Empty posted title should resolve to the registered method title.' );
+		$this->assertSame( 'Free Shipping', $shipping->get_method_title( 'edit' ) );
+
+		// Case 2: posted title equals the localized "Shipping" fallback (what the edit input shows
+		// when the item was created without a title) — should still resolve to the real method title.
+		$items_fallback_title = array(
+			'order_id'              => $order->get_id(),
+			'shipping_method_id'    => array( $item_id ),
+			'shipping_method'       => array( $item_id => 'free_shipping:' . $instance_id ),
+			'shipping_method_title' => array( $item_id => __( 'Shipping', 'woocommerce' ) ),
+			'shipping_cost'         => array( $item_id => '0.00' ),
+		);
+
+		wc_save_order_items( $order->get_id(), $items_fallback_title );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$shipping  = reset( $refreshed->get_items( 'shipping' ) );
+		$this->assertSame( 'Free Shipping', $shipping->get_name(), 'Localized "Shipping" fallback should be replaced with the registered method title.' );
+		$this->assertSame( 'Free Shipping', $shipping->get_method_title( 'edit' ) );
+
+		// Case 3: admin typed a custom title — must be preserved verbatim, not overwritten.
+		$items_custom_title = array(
+			'order_id'              => $order->get_id(),
+			'shipping_method_id'    => array( $item_id ),
+			'shipping_method'       => array( $item_id => 'free_shipping:' . $instance_id ),
+			'shipping_method_title' => array( $item_id => 'My Custom Carrier' ),
+			'shipping_cost'         => array( $item_id => '0.00' ),
+		);
+
+		wc_save_order_items( $order->get_id(), $items_custom_title );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$shipping  = reset( $refreshed->get_items( 'shipping' ) );
+		$this->assertSame( 'My Custom Carrier', $shipping->get_method_title( 'edit' ), 'Custom titles entered by the admin must not be overwritten.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When an admin creates a manual order in the WooCommerce admin and assigns a shipping method (e.g. "Free Shipping"), all order emails (invoice, new order, customer confirmation) display a truncated "Shipping" label instead of the actual method title. Customer-created orders are unaffected.

Root cause: the admin shipping line edit input is pre-filled with `WC_Order_Item_Shipping::get_name()`, which falls back to the localized string "Shipping" when the underlying `method_title` is empty. When the admin saves without typing a custom name, that fallback string is POSTed back as `shipping_method_title` and persisted verbatim on the order item, so emails render it as the line label.

Fix: in `wc_save_order_items()`, whenever the posted shipping line title is either empty or exactly the localized "Shipping" fallback and a valid registered method ID was selected, resolve the title from the chosen registered shipping method (e.g. "Free Shipping") and persist that instead. Custom titles typed by the admin are preserved unchanged.

Closes #36049

Linear: https://linear.app/a8c/issue/RSMAPGJ-406

### Screenshots or screen recordings:

N/A — fix is in stored data; visible only in resulting emails which match the customer-created order baseline shown in the upstream issue.

### How to test the changes in this Pull Request:

1. In a fresh WooCommerce site, go to **WooCommerce → Settings → Shipping** and add a zone with a "Free Shipping" method (default title "Free Shipping").
2. Go to **WooCommerce → Orders → Add new**.
3. Pick any customer (or "Guest"), add a product, then **Add shipping**.
4. Click the pencil to edit the shipping line, pick "Free Shipping" in the dropdown, and **without** typing anything in the name field, click **Save** then **Create**.
5. From **Order actions → Email invoice** trigger an email, and change order status to trigger the new order / customer notification emails.
6. **Expected:** All emails show **Free Shipping**, not "Shipping".
7. Repeat with a custom typed name (e.g. "Express Friday"): emails must show the custom name verbatim.

### Testing that has already taken place:

- New PHPUnit coverage in `class-wc-admin-functions-test.php` exercising three cases for `wc_save_order_items()`: empty posted title, posted "Shipping" fallback, and a custom typed title.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.
- PHPStan on the touched source file clean (`includes/admin/wc-admin-functions.php`).
- PHPUnit not executed locally; tests deferred to PR CI per the RSMAPGJ AI Coder pipeline policy.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Added manually as `plugins/woocommerce/changelog/fix-rsmapgj-406` (Significance: patch, Type: fix).

---

Submitted by the RSMAPGJ AI Coder pipeline.
