### PR TITLE
Fix CSV import: store "date sale price ends" as end-of-day to match admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-400
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-400
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product CSV import: store date-only "date sale price ends" values as end-of-day (23:59:59) to match the product edit screen, so sales no longer end ~24 hours earlier when set via import.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -634,6 +634,47 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
+	 * Parse the "date on sale to" field from a CSV.
+	 *
+	 * When a date-only value (with no time component) is supplied, it is treated as the
+	 * end of that day (23:59:59) to match the behaviour of the product edit screen, where
+	 * the "On sale to" date input is stored with an end-of-day time.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param string $value Field value.
+	 *
+	 * @return string|null
+	 */
+	public function parse_date_on_sale_to_field( $value ) {
+		$parsed = $this->parse_datetime_field( $value );
+
+		if ( null === $parsed || '' === $parsed ) {
+			return $parsed;
+		}
+
+		// If the value is numeric (Unix timestamp) it was already normalised to an ISO8601
+		// string with an explicit time component by parse_datetime_field(), so leave it alone.
+		if ( is_numeric( $value ) ) {
+			return $parsed;
+		}
+
+		// Detect any time component in the original string (e.g. "2023-01-26 10:00",
+		// "2023-01-26T10:00:00Z"). If one is present, preserve the caller's intent.
+		if ( preg_match( '/\d{1,2}:\d{2}/', (string) $value ) ) {
+			return $parsed;
+		}
+
+		// Date-only value: align with admin behaviour by treating it as end-of-day.
+		$timestamp = strtotime( $parsed );
+		if ( false === $timestamp ) {
+			return $parsed;
+		}
+
+		return gmdate( 'Y-m-d 23:59:59', $timestamp );
+	}
+
+	/**
 	 * Parse backorders from a CSV.
 	 *
 	 * @param string $value Field value.
@@ -786,7 +827,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'published'         => array( $this, 'parse_published_field' ),
 			'featured'          => array( $this, 'parse_bool_field' ),
 			'date_on_sale_from' => array( $this, 'parse_datetime_field' ),
-			'date_on_sale_to'   => array( $this, 'parse_datetime_field' ),
+			'date_on_sale_to'   => array( $this, 'parse_date_on_sale_to_field' ),
 			'name'              => array( $this, 'parse_skip_field' ),
 			'short_description' => array( $this, 'parse_description_field' ),
 			'description'       => array( $this, 'parse_description_field' ),

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -279,10 +279,12 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$product->save();
 
 		$csv_path = tempnam( sys_get_temp_dir(), 'wc-csv-' ) . '.csv';
-		$fh       = fopen( $csv_path, 'w' );
-		fputcsv( $fh, array( 'ID', 'date sale price starts', 'date sale price ends', 'Sale price' ) );
-		fputcsv( $fh, array( $product->get_id(), '2022-10-25', '2099-01-26', '2.00' ) );
-		fclose( $fh );
+		$lines    = array(
+			'"ID","date sale price starts","date sale price ends","Sale price"',
+			sprintf( '%d,"2022-10-25","2099-01-26","2.00"', $product->get_id() ),
+		);
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tests write to a tmp file we control.
+		file_put_contents( $csv_path, implode( "\n", $lines ) . "\n" );
 
 		$importer = new WC_Product_CSV_Importer(
 			$csv_path,
@@ -299,9 +301,9 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		);
 		$importer->import();
 
-		$updated      = wc_get_product( $product->get_id() );
-		$date_to      = $updated->get_date_on_sale_to();
-		$date_from    = $updated->get_date_on_sale_from();
+		$updated   = wc_get_product( $product->get_id() );
+		$date_to   = $updated->get_date_on_sale_to();
+		$date_from = $updated->get_date_on_sale_from();
 
 		$this->assertNotNull( $date_to, 'date_on_sale_to should be set' );
 		$this->assertNotNull( $date_from, 'date_on_sale_from should be set' );
@@ -311,6 +313,6 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( '2022-10-25', $date_from->date( 'Y-m-d' ) );
 
 		WC_Helper_Product::delete_product( $product->get_id() );
-		@unlink( $csv_path );
+		wp_delete_file( $csv_path );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -224,4 +224,93 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		wc_delete_attribute( $color_attr_id );
 		wc_delete_attribute( $size_attr_id );
 	}
+
+	/**
+	 * @testdox Date-only "date on sale to" values are stored as end-of-day to match admin behaviour (RSMAPGJ-400 / #35321).
+	 */
+	public function test_parse_date_on_sale_to_field_date_only_is_end_of_day() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->assertSame( '2099-01-26 23:59:59', $importer->parse_date_on_sale_to_field( '2099-01-26' ) );
+		$this->assertSame( '2022-10-25 23:59:59', $importer->parse_date_on_sale_to_field( '2022-10-25' ) );
+	}
+
+	/**
+	 * @testdox "date on sale to" values that already include a time component are preserved.
+	 */
+	public function test_parse_date_on_sale_to_field_preserves_time_component() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->assertSame( '2099-01-26 10:30:00', $importer->parse_date_on_sale_to_field( '2099-01-26 10:30:00' ) );
+		$this->assertSame( '2099-01-26 10:30', $importer->parse_date_on_sale_to_field( '2099-01-26 10:30' ) );
+	}
+
+	/**
+	 * @testdox "date on sale to" Unix timestamps are normalised to ISO8601 without being shifted to end-of-day.
+	 */
+	public function test_parse_date_on_sale_to_field_unix_timestamp_preserved() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		// 2099-01-26 00:00:00 UTC.
+		$this->assertSame( '2099-01-26T00:00:00Z', $importer->parse_date_on_sale_to_field( '4072291200' ) );
+	}
+
+	/**
+	 * @testdox Empty / invalid "date on sale to" values are returned as null.
+	 */
+	public function test_parse_date_on_sale_to_field_empty_and_invalid() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->assertNull( $importer->parse_date_on_sale_to_field( '' ) );
+		$this->assertNull( $importer->parse_date_on_sale_to_field( 'not-a-date' ) );
+	}
+
+	/**
+	 * @testdox Importing a CSV with a date-only "date sale price ends" stores end-of-day, matching admin (RSMAPGJ-400 / #35321).
+	 */
+	public function test_import_date_on_sale_to_date_only_is_end_of_day() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'rsmapgj-400-sku' );
+		$product->set_regular_price( '10.00' );
+		$product->save();
+
+		$csv_path = tempnam( sys_get_temp_dir(), 'wc-csv-' ) . '.csv';
+		$fh       = fopen( $csv_path, 'w' );
+		fputcsv( $fh, array( 'ID', 'date sale price starts', 'date sale price ends', 'Sale price' ) );
+		fputcsv( $fh, array( $product->get_id(), '2022-10-25', '2099-01-26', '2.00' ) );
+		fclose( $fh );
+
+		$importer = new WC_Product_CSV_Importer(
+			$csv_path,
+			array(
+				'update_existing' => true,
+				'parse'           => true,
+				'mapping'         => array(
+					'ID'                     => 'id',
+					'date sale price starts' => 'date_on_sale_from',
+					'date sale price ends'   => 'date_on_sale_to',
+					'Sale price'             => 'sale_price',
+				),
+			)
+		);
+		$importer->import();
+
+		$updated      = wc_get_product( $product->get_id() );
+		$date_to      = $updated->get_date_on_sale_to();
+		$date_from    = $updated->get_date_on_sale_from();
+
+		$this->assertNotNull( $date_to, 'date_on_sale_to should be set' );
+		$this->assertNotNull( $date_from, 'date_on_sale_from should be set' );
+		$this->assertSame( '23:59:59', $date_to->date( 'H:i:s' ), 'date_on_sale_to should be end-of-day to match admin' );
+		$this->assertSame( '2099-01-26', $date_to->date( 'Y-m-d' ) );
+		$this->assertSame( '00:00:00', $date_from->date( 'H:i:s' ), 'date_on_sale_from should remain start-of-day' );
+		$this->assertSame( '2022-10-25', $date_from->date( 'Y-m-d' ) );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+		@unlink( $csv_path );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request

Closes #35321.

When a product is edited in the admin, the "On sale to" date input is stored with an end-of-day time (`23:59:59`). When the same date is supplied via the Product CSV importer's `date sale price ends` column, the value is stored as start-of-day (`00:00:00`), so the sale ends ~24 hours earlier than expected.

This PR aligns the CSV importer with admin behaviour:

- Adds `WC_Product_CSV_Importer::parse_date_on_sale_to_field()`, which:
  - Delegates to `parse_datetime_field()` for parsing/validation.
  - If the source value is a Unix timestamp or already has a time component, the parsed value is returned unchanged.
  - If the source value is date-only (e.g. `2099-01-26`), it is normalised to `Y-m-d 23:59:59` to match the admin's "end of day" semantics.
- Switches the `date_on_sale_to` formatting callback to use the new parser.
- `date_on_sale_from` keeps using `parse_datetime_field()` (start-of-day for date-only values is the correct/expected behaviour for the sale start).

### How to test the changes in this Pull Request

1. Create a simple product with a regular price (note its ID).
2. Create a CSV with these columns and a single row:

    ```csv
    "ID","date sale price starts","date sale price ends","Sale price"
    <product_id>,"2022-10-25","2099-01-26",2.00
    ```

3. Go to **WooCommerce > Products > Import**, check "Update existing products", and import the CSV.
4. In the database, verify `_sale_price_dates_to` corresponds to `2099-01-26 23:59:59` (in site local time), not `00:00:00`. `_sale_price_dates_from` should still be `2022-10-25 00:00:00`.
5. Open the product edit screen, save it without changes, and confirm the stored timestamp remains end-of-day (admin behaviour unchanged).
6. Re-import the CSV with an explicit time, e.g. `2099-01-26 10:30:00`, and confirm the time is preserved verbatim.

### Testing that has already taken place

- Added PHPUnit coverage in `WC_Product_CSV_Importer_Test`:
  - `test_parse_date_on_sale_to_field_date_only_is_end_of_day`
  - `test_parse_date_on_sale_to_field_preserves_time_component`
  - `test_parse_date_on_sale_to_field_unix_timestamp_preserved`
  - `test_parse_date_on_sale_to_field_empty_and_invalid`
  - `test_import_date_on_sale_to_date_only_is_end_of_day` (end-to-end through `WC_Product_CSV_Importer::import()`)
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- Ran `composer exec -- phpstan analyse includes/import/class-wc-product-csv-importer.php --memory-limit=2G` — no errors.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- PHPUnit suite execution deferred to PR CI (the local `pnpm test:php:env` was intentionally not run in this pipeline).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry committed manually at `plugins/woocommerce/changelog/fix-rsmapgj-400` (significance: patch, type: fix).

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-400

_Authored by the RSMAPGJ AI Coder pipeline._