### PR TITLE
Fix assorted typos

### DIFF
--- a/plugins/woocommerce/changelog/fix-consolidated-typos
+++ b/plugins/woocommerce/changelog/fix-consolidated-typos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix typos in comments and docblocks.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/edit.tsx
@@ -25,8 +25,8 @@ export default function Edit( { attributes, setAttributes }: EditProps ) {
 	const { color, storeOnly } = attributes;
 	const blockProps = { ...useBlockProps() };
 
-	// Existance of storeOnly attribute means it doesn't have a background color,
-	// absense of custom color attribute means it's post-v1 template,
+	// Existence of storeOnly attribute means it doesn't have a background color,
+	// absence of custom color attribute means it's post-v1 template,
 	// in both cases, no need to show the color picker.
 	if ( storeOnly || ! color ) {
 		return (

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -238,7 +238,7 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * @return object
 	 */
 	protected function prepare_package_destination_response( $package ) {
-		// If address_1 fails check address for back compatability.
+		// If address_1 fails check address for back compatibility.
 		$address = isset( $package['destination']['address_1'] ) ? $package['destination']['address_1'] : $package['destination']['address'];
 		return (object) $this->prepare_html_response(
 			[

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductItemTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductItemTrait.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Utilities;
 /**
  * ProductItemTrait
  *
- * Shared functionality for formating product item data.
+ * Shared functionality for formatting product item data.
  */
 trait ProductItemTrait {
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/EvaluateOverridesTest.php
@@ -69,7 +69,7 @@ class EvaluateOverridesTest extends WC_Unit_Test_Case {
 		$extensions = $this->get_extensions();
 		$result     = $evaluator->evaluate( array( $extensions[3] ) );
 
-		// Evaluation should pass and return the overriden value.
+		// Evaluation should pass and return the overridden value.
 		$this->assertEquals( 2, $result[0]->order );
 
 		// Reset the default country.

--- a/tools/monorepo-utils/src/ci-jobs/lib/package-file.ts
+++ b/tools/monorepo-utils/src/ci-jobs/lib/package-file.ts
@@ -23,7 +23,7 @@ const packageCache: { [ key: string ]: PackageJSON } = {};
  * @return {Object} The package file's contents.
  */
 export function loadPackage( packagePath: string ): PackageJSON {
-	// Use normalized paths to accomodate any path tokens.
+	// Use normalized paths to accommodate any path tokens.
 	packagePath = path.normalize( packagePath );
 	if ( packageCache[ packagePath ] ) {
 		return packageCache[ packagePath ];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Consolidates the comment and docblock typo fixes submitted by @asimsolehria in #64878 and #64908 into a single PR.

The code-identifier and CSS class-name typo fixes from #64879 are intentionally not included because changing typos in code can be risky for external usage. The non-comment error-message typo from #64878 is also excluded so this PR stays limited to comments and docblocks.

The combined commit is authored to Asim's GitHub-linked email so the contribution is credited in git history.

### How to test the changes in this Pull Request:

1. Review the diff and confirm the changes are limited to comments, docblocks, and the manual changelog entry.
2. Confirm #64879's code-identifier and CSS class-name typo fixes are not included.
3. Confirm the non-comment `wc-core-functions.php` error-message typo from #64878 is not included.

### Testing that has already taken place:

- `git diff --check origin/trunk...HEAD`
- `pnpm --dir plugins/woocommerce/client/blocks exec wp-scripts lint-js assets/js/blocks/coming-soon/edit.tsx --ext=js,ts,tsx --cache --cache-location=node_modules/.cache/eslint`
- `pnpm --filter=@woocommerce/monorepo-utils lint`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch:php`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A manual changelog entry is included in `plugins/woocommerce/changelog/fix-consolidated-typos`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
