### PR TITLE
Fix admin Product Reviews reply not auto-approving parent review

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-407
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-407
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix admin Product Reviews "Reply" not auto-approving the parent review due to a strict comparison between an int post ID and the string WP_Comment::comment_post_ID property.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -326,7 +326,7 @@ class Reviews {
 		if ( ! empty( $_POST['approve_parent'] ) ) {
 			$parent = get_comment( $comment_parent );
 
-			if ( $parent && '0' === $parent->comment_approved && $parent->comment_post_ID === $comment_post_ID ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			if ( $parent && '0' === $parent->comment_approved && (int) $parent->comment_post_ID === $comment_post_ID ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				if ( ! current_user_can( 'edit_comment', $parent->comment_ID ) ) {
 					wp_die( -1 );
 				}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -597,4 +597,84 @@ test2</p></div>',
 		$this->assertSame( 'http://' . WP_TESTS_DOMAIN . '/wp-admin/edit.php?post_type=product&page=product-reviews', Reviews::get_reviews_page_url() );
 	}
 
+	/**
+	 * @testdox `handle_reply_to_review` auto-approves the parent review when its `comment_post_ID` (string from DB) matches the posted product ID (int).
+	 *
+	 * Regression test for the strict-comparison bug where `$parent->comment_post_ID` (string)
+	 * was compared with `===` against the casted-to-int `$comment_post_ID`, causing the
+	 * comparison to always fail and the parent review to never auto-approve.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::handle_reply_to_review()
+	 *
+	 * @return void
+	 */
+	public function test_handle_reply_to_review_auto_approves_parent_with_matching_post_id() : void {
+		// Need an admin user so capability checks pass.
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$product_id = $this->factory()->post->create( [ 'post_type' => 'product' ] );
+
+		$parent_review_id = $this->factory()->comment->create(
+			[
+				'comment_type'     => 'review',
+				'comment_post_ID'  => $product_id,
+				'comment_approved' => '0',
+			]
+		);
+
+		// Sanity: the parent starts unapproved.
+		$parent_before = get_comment( $parent_review_id );
+		$this->assertSame( '0', $parent_before->comment_approved );
+		// Sanity: WP_Comment::comment_post_ID is a string, which is the property that triggered the original bug.
+		$this->assertIsString( $parent_before->comment_post_ID );
+
+		// Simulate the WP admin replyto-comment AJAX request payload.
+		$_POST                                  = [];
+		$_POST['action']                        = 'replyto-comment';
+		$_POST['comment_post_ID']               = (string) $product_id;
+		$_POST['comment_ID']                    = (string) $parent_review_id;
+		$_POST['content']                       = 'A reply body.';
+		$_POST['comment_type']                  = 'comment';
+		$_POST['approve_parent']                = '1';
+		$_POST['_ajax_nonce-replyto-comment']   = wp_create_nonce( 'replyto-comment' );
+
+		$reviews = wc_get_container()->get( Reviews::class );
+
+		// `handle_reply_to_review` calls `wp_die()` on success/failure; suppress the JSON response output
+		// and the wp_die exit, then verify the side effect we care about (parent approval).
+		add_filter( 'wp_die_ajax_handler', [ $this, 'get_wp_die_ajax_handler' ] );
+
+		ob_start();
+		try {
+			$reviews->handle_reply_to_review();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected: wp_die was hit after the parent-approval logic ran.
+		} finally {
+			ob_end_clean();
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'get_wp_die_ajax_handler' ] );
+			$_POST = [];
+		}
+
+		clean_comment_cache( $parent_review_id );
+		$parent_after = get_comment( $parent_review_id );
+
+		$this->assertSame(
+			'1',
+			$parent_after->comment_approved,
+			'Parent review should be auto-approved after a reply when approve_parent is set.'
+		);
+	}
+
+	/**
+	 * Returns an ajax wp_die handler that throws so the test can continue post-wp_die.
+	 *
+	 * @return callable
+	 */
+	public function get_wp_die_ajax_handler() : callable {
+		return static function () {
+			throw new \RuntimeException( 'wp_die called' );
+		};
+	}
+
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

In `Reviews::handle_reply_to_review()` (`plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php`), the check that auto-approves the parent review when a reply is posted uses `===` to compare the locally-casted `(int) $_POST['comment_post_ID']` against `$parent->comment_post_ID`. The `WP_Comment::$comment_post_ID` property is always a string, so the strict comparison always fails and the parent review is never auto-approved.

This PR casts `$parent->comment_post_ID` to `int` before the strict comparison so the original (pre-7.3.0) behavior is restored.

Bug introduced in WooCommerce 7.3.0.

Closes #36619

Linear: https://linear.app/a8c/issue/RSMAPGJ-407

### How to test the changes in this Pull Request:

Using the WooCommerce Beta Tester or a local dev env:

1. Create a product and a pending product review (Products → Reviews shows it as "Pending").
2. From the Reviews list, click "Reply" on the pending review and post a reply.
3. Confirm the original review is now "Approved" (parent comment status changed from `0` to `1`).

Before this fix the parent review stays unapproved; after the fix it gets approved as expected.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (A changelog entry was added manually under `plugins/woocommerce/changelog/fix-rsmapgj-407`.)

### Other notes

Added a regression PHPUnit test (`tests/php/src/Internal/Admin/ProductReviews/ReviewsTest::test_handle_reply_to_review_auto_approves_parent_with_matching_post_id`) that simulates the admin reply AJAX flow and asserts the parent review ends up approved.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>