### PR TITLE
Empty chosen_shipping_methods session when no shipping methods posted

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-430
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-430
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Empty the session 'chosen_shipping_methods' on checkout when no shipping methods are posted (e.g. cart becomes virtual-only), so stale selections do not persist.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -406,12 +406,23 @@ class WC_AJAX {
 		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
 		$posted_shipping_methods = isset( $_POST['shipping_method'] ) ? wc_clean( wp_unslash( $_POST['shipping_method'] ) ) : array();
 
+		if ( ! is_array( $chosen_shipping_methods ) ) {
+			$chosen_shipping_methods = array();
+		}
+
 		if ( is_array( $posted_shipping_methods ) ) {
-			foreach ( $posted_shipping_methods as $i => $value ) {
-				if ( ! is_string( $value ) ) {
-					continue;
+			if ( empty( $posted_shipping_methods ) ) {
+				// When no shipping methods are posted (e.g. cart no longer needs shipping
+				// because all remaining items are virtual), clear the previously chosen
+				// shipping methods so stale selections do not persist in the session.
+				$chosen_shipping_methods = array();
+			} else {
+				foreach ( $posted_shipping_methods as $i => $value ) {
+					if ( ! is_string( $value ) ) {
+						continue;
+					}
+					$chosen_shipping_methods[ $i ] = $value;
 				}
-				$chosen_shipping_methods[ $i ] = $value;
 			}
 		}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -553,6 +553,84 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * The session-stored chosen_shipping_methods should be cleared when update_order_review
+	 * runs with no shipping methods posted (e.g. cart transitioned to virtual-only items
+	 * and the checkout no longer needs shipping).
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/51197.
+	 */
+	public function test_update_order_review_clears_chosen_shipping_methods_when_none_posted(): void {
+		// Add a product so the cart is non-empty and update_order_review proceeds.
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		// Pre-seed the session with a previously chosen shipping method.
+		WC()->session->set( 'chosen_shipping_methods', array( 'free_shipping:1' ) );
+
+		$_POST                   = array();
+		$_POST['security']       = wp_create_nonce( 'update-order-review' );
+		$_POST['payment_method'] = '';
+		// Note: $_POST['shipping_method'] intentionally unset to simulate an all-virtual cart.
+
+		try {
+			$this->_handleAjax( 'woocommerce_update_order_review' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// wp_send_json triggers wp_die; this is expected and produces a continue exception.
+			unset( $e );
+		} catch ( WPAjaxDieStopException $e ) {
+			// Also acceptable if the AJAX flow terminates early via wp_die().
+			unset( $e );
+		}
+
+		$chosen_after = WC()->session->get( 'chosen_shipping_methods' );
+
+		$this->assertIsArray( $chosen_after, 'Session value should be an array.' );
+		$this->assertSame( array(), $chosen_after, 'chosen_shipping_methods should be emptied when no shipping method is posted.' );
+
+		// Clean up.
+		WC()->cart->empty_cart();
+		WC()->session->set( 'chosen_shipping_methods', array() );
+		$product->delete( true );
+	}
+
+	/**
+	 * When shipping methods are posted, update_order_review should preserve/overwrite them
+	 * (existing behaviour).
+	 */
+	public function test_update_order_review_sets_chosen_shipping_methods_from_post(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:99' ) );
+
+		$_POST                    = array();
+		$_POST['security']        = wp_create_nonce( 'update-order-review' );
+		$_POST['payment_method']  = '';
+		$_POST['shipping_method'] = array( 'free_shipping:1' );
+
+		try {
+			$this->_handleAjax( 'woocommerce_update_order_review' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected: wp_send_json triggers wp_die.
+			unset( $e );
+		} catch ( WPAjaxDieStopException $e ) {
+			// Also acceptable if the AJAX flow terminates early via wp_die().
+			unset( $e );
+		}
+
+		$chosen_after = WC()->session->get( 'chosen_shipping_methods' );
+
+		$this->assertIsArray( $chosen_after );
+		$this->assertSame( 'free_shipping:1', $chosen_after[0] ?? null, 'Posted shipping method should be applied to the session.' );
+
+		WC()->cart->empty_cart();
+		WC()->session->set( 'chosen_shipping_methods', array() );
+		$product->delete( true );
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Tools and Workflow](https://github.com/woocommerce/woocommerce/wiki/Recommended-Tools-and-Workflow) when applicable.

### Changes proposed in this Pull Request

When a checkout cart transitions to virtual-only items, the AJAX `update_order_review` request stops posting any `shipping_method` values. The existing loop in `WC_AJAX::update_order_review()` could overwrite/append to the session's `chosen_shipping_methods` array but never clear it, so a stale shipping selection remained in the session.

This PR clears `chosen_shipping_methods` when an empty (but valid) `shipping_method` array is posted, matching the user's expectation that the session no longer references a shipping method that is no longer applicable.

Closes #51197

### Screenshots or screen recordings

N/A — server-side session fix, no UI change.

### How to test the changes in this Pull Request

1. Add a non-virtual product and a virtual product to the cart.
2. On the classic checkout, confirm a shipping method is selected (this writes `chosen_shipping_methods` into the session).
3. Update the cart so only the virtual product remains, so the checkout no longer needs shipping.
4. After the AJAX `update_order_review` fires, inspect `WC()->session->get( 'chosen_shipping_methods' )`.

   - Before the fix: still contains the previously selected shipping method.
   - After the fix: returns an empty array.

5. Verify normal flow still works: with a physical product in the cart, choosing a shipping method on checkout still updates the session as expected.

### Testing that has already taken place

- Added two PHPUnit tests in `WC_AJAX_Test` covering the cleared-on-empty and populated-on-post code paths.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/class-wc-ajax.php --memory-limit=2G` — no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance:** Patch
**Type:** Fix

Empty the session `chosen_shipping_methods` on checkout when no shipping methods are posted (e.g. cart becomes virtual-only), so stale selections do not persist.

</details>

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-430

Generated with [Claude Code](https://claude.com/claude-code)