### PR TITLE
Fix empty paragraph in payment method on Order-pay page

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-432
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-432
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove blank lines from checkout/payment-method.php template so wpautop on the Order-pay page no longer wraps the payment method label in an empty paragraph.

--- a/plugins/woocommerce/templates/checkout/payment-method.php
+++ b/plugins/woocommerce/templates/checkout/payment-method.php
@@ -12,22 +12,15 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     3.5.0
+ * @version     10.9.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<li class="wc_payment_method payment_method_<?php echo esc_attr( $gateway->id ); ?>">
-	<input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" />
-
-	<label for="payment_method_<?php echo esc_attr( $gateway->id ); ?>">
-		<?php echo $gateway->get_title(); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?> <?php echo $gateway->get_icon(); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?>
-	</label>
+<li class="wc_payment_method payment_method_<?php echo esc_attr( $gateway->id ); ?>"><input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" /> <label for="payment_method_<?php echo esc_attr( $gateway->id ); ?>"><?php echo $gateway->get_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> <?php echo $gateway->get_icon(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></label>
 	<?php if ( $gateway->has_fields() || $gateway->get_description() ) : ?>
-		<div class="payment_box payment_method_<?php echo esc_attr( $gateway->id ); ?>" <?php if ( ! $gateway->chosen ) : /* phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace */ ?>style="display:none;"<?php endif; /* phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace */ ?>>
-			<?php $gateway->payment_fields(); ?>
-		</div>
+		<div class="payment_box payment_method_<?php echo esc_attr( $gateway->id ); ?>" <?php if ( ! $gateway->chosen ) : /* phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace */ ?>style="display:none;"<?php endif; /* phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace */ ?>><?php $gateway->payment_fields(); ?></div>
 	<?php endif; ?>
 </li>

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/payment-method.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/payment-method.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests for the checkout/payment-method.php template.
+ *
+ * @package WooCommerce\Tests\Templates
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Class WC_Tests_Template_Payment_Method
+ *
+ * Regression coverage for woo#53551 / RSMAPGJ-432: the order-pay page rendered
+ * the payment method list inside a content area that runs `wpautop()`, which
+ * turned the blank line between the radio input and the <label> into an empty
+ * <p></p> tag and wrapped the label text in an additional, useless paragraph.
+ *
+ * The template should not introduce blank lines or stray newlines between the
+ * radio input and its label, so applying `wpautop()` to its rendered output
+ * produces no empty <p> tags inside the <li>.
+ */
+class WC_Tests_Template_Payment_Method extends WC_Unit_Test_Case {
+
+	/**
+	 * Render the payment-method.php template for a given gateway and return the
+	 * resulting HTML.
+	 *
+	 * @param WC_Payment_Gateway $gateway Gateway to render the markup for.
+	 * @return string
+	 */
+	private function render_template( WC_Payment_Gateway $gateway ) {
+		ob_start();
+		wc_get_template( 'checkout/payment-method.php', array( 'gateway' => $gateway ) );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Build a minimal mock gateway with neither fields nor a description, which
+	 * is the simplest configuration that hits the markup at the top of the
+	 * template (the radio input + label only, no payment_box <div>).
+	 *
+	 * @return WC_Payment_Gateway
+	 */
+	private function make_minimal_gateway() {
+		$gateway              = new WC_Mock_Payment_Gateway();
+		$gateway->id          = 'wc_tests_minimal_gateway';
+		$gateway->chosen      = false;
+		$gateway->title       = 'Minimal Test Gateway';
+		$gateway->description = '';
+		$gateway->has_fields  = false;
+		return $gateway;
+	}
+
+	/**
+	 * Regression test for woo#53551: ensure rendering the template through
+	 * `wpautop()` (the same filter applied by the_content on the order-pay
+	 * page) does not yield empty <p></p> tags inside the rendered <li>.
+	 */
+	public function test_template_output_does_not_produce_empty_paragraphs_via_wpautop() {
+		$gateway = $this->make_minimal_gateway();
+		$html    = $this->render_template( $gateway );
+
+		// The template output itself must not contain an empty paragraph.
+		$this->assertDoesNotMatchRegularExpression(
+			'#<p[^>]*>\s*</p>#i',
+			$html,
+			'Raw template output should not contain empty <p> tags.'
+		);
+
+		// And running wpautop over it (mirroring the_content on order-pay)
+		// must not introduce one either. This is the exact symptom reported.
+		$autop = wpautop( $html );
+		$this->assertDoesNotMatchRegularExpression(
+			'#<p[^>]*>\s*</p>#i',
+			$autop,
+			'wpautop() applied to the template output should not create empty <p> tags.'
+		);
+	}
+
+	/**
+	 * The radio input and the label must remain on the same logical line (no
+	 * intervening blank line). A blank line between them is what wpautop()
+	 * historically converted into an empty paragraph on the order-pay page.
+	 */
+	public function test_no_blank_line_between_radio_input_and_label() {
+		$gateway = $this->make_minimal_gateway();
+		$html    = $this->render_template( $gateway );
+
+		// Match the </input>-equivalent self-closing radio followed by any
+		// whitespace up to the opening of the <label>. There must be no
+		// double-newline (blank line) in that gap.
+		if ( preg_match( '#/>\s*<label\b#s', $html, $matches ) ) {
+			$this->assertStringNotContainsString( "\n\n", $matches[0], 'No blank line should separate the radio input and the label.' );
+		} else {
+			$this->fail( 'Expected to find the radio input followed by a <label> in the rendered template output.' );
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

On the Order-pay page (`/checkout/order-pay/<id>/`) the included `checkout/payment-method.php` template was rendered through WordPress's `wpautop()` filter, which turned the blank line between the radio `<input>` and the `<label>` into an empty `<p></p>` and additionally wrapped the label text in another useless paragraph. The same template is used on the Checkout page but is not affected there, because that shortcode's output is not re-processed by `wpautop()` for the same content.

This PR collapses the blank lines and stray inter-tag newlines in `payment-method.php` so the rendered markup no longer presents `wpautop()` with any blank lines to wrap, while keeping the existing escaping and `phpcs:ignore` semantics for the (intentionally) unescaped gateway title/icon HTML. The `phpcs:ignore` annotations were updated from the deprecated `WordPress.XSS.EscapeOutput.OutputNotEscaped` sniff to the current `WordPress.Security.EscapeOutput.OutputNotEscaped` so the changed lines pass the branch lint.

Closes #53551

Linear: https://linear.app/a8c/issue/RSMAPGJ-432

### How to test the changes in this Pull Request:

Using the WooCommerce e2e setup (or any local install):

1. Add a pending-payment order to the store and copy its pay URL (`get_checkout_payment_url()`), e.g. `/checkout/order-pay/<order_id>/?pay_for_order=true&key=<order_key>`.
2. Visit the URL in the browser.
3. In DevTools, inspect the `<ul class="wc_payment_methods">` and confirm there are no empty `<p></p>` tags inside the payment method `<li>` items, and the gateway label is not wrapped in an extra `<p>`.
4. Visit the standard Checkout page and confirm payment methods still render normally.
5. Run the regression test:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce test:php -- --filter WC_Tests_Template_Payment_Method
   ```

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Added in `plugins/woocommerce/changelog/fix-rsmapgj-432` (patch / fix).

---

Submitted by the RSMAPGJ AI Coder pipeline.