### PR TITLE
Apply the_title filter to product titles in cart and grouped templates

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-402
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-402
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply the WordPress `the_title` filter to product titles rendered in the cart and on the grouped product page so they receive the same transformations (smart quotes, etc.) as titles rendered elsewhere on the frontend.

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.8.0
+ * @version 10.9.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -53,6 +53,18 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 				if ( $_product instanceof WC_Product && $_product->exists() && $cart_item['quantity'] > 0 && $visible ) {
 					/**
+					 * Filters the product title in the cart.
+					 *
+					 * This is the WordPress core `the_title` filter, applied here so that
+					 * cart product titles receive the same transformations (smart quotes,
+					 * etc.) as titles rendered elsewhere on the frontend.
+					 *
+					 * @since 10.9.0
+					 * @param string $title Product title.
+					 * @param int    $id    Product ID.
+					 */
+					$filtered_product_name = apply_filters( 'the_title', $_product->get_name(), $product_id );
+					/**
 					 * Filter the product name.
 					 *
 					 * @since 2.1.0
@@ -60,7 +72,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 					 * @param array $cart_item The product in the cart.
 					 * @param string $cart_item_key Key for the product in the cart.
 					 */
-					$product_name      = apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key );
+					$product_name      = apply_filters( 'woocommerce_cart_item_name', $filtered_product_name, $cart_item, $cart_item_key );
 					$product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink( $cart_item ) : '', $cart_item, $cart_item_key );
 					?>
 					<tr class="woocommerce-cart-form__cart-item <?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
@@ -117,7 +129,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 							 *
 							 * @since 2.1.0
 							 */
-							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $_product->get_name() ), $cart_item, $cart_item_key ) );
+							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $filtered_product_name ), $cart_item, $cart_item_key ) );
 						}
 
 						do_action( 'woocommerce_after_cart_item_name', $cart_item, $cart_item_key );

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.2.0
+ * @version 10.9.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -102,8 +102,27 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 							$value = ob_get_clean();
 							break;
 						case 'label':
-							$value  = '<label for="product-' . esc_attr( $grouped_product_child->get_id() ) . '">';
-							$value .= $grouped_product_child->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', $grouped_product_child->get_permalink(), $grouped_product_child->get_id() ) ) . '">' . $grouped_product_child->get_name() . '</a>' : $grouped_product_child->get_name();
+							/**
+							 * Filters the grouped product child title.
+							 *
+							 * This is the WordPress core `the_title` filter, applied here so that
+							 * grouped product child titles receive the same transformations
+							 * (smart quotes, etc.) as titles rendered elsewhere on the frontend.
+							 *
+							 * @since 10.9.0
+							 * @param string $title Product title.
+							 * @param int    $id    Product ID.
+							 */
+							$grouped_product_child_title = apply_filters( 'the_title', $grouped_product_child->get_name(), $grouped_product_child->get_id() );
+							$value                       = '<label for="product-' . esc_attr( $grouped_product_child->get_id() ) . '">';
+							/**
+							 * Filter the permalink used for the grouped product child link in the list.
+							 *
+							 * @since 3.0.0
+							 * @param string $permalink  The grouped product child's permalink.
+							 * @param int    $product_id The grouped product child's ID.
+							 */
+							$value .= $grouped_product_child->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', $grouped_product_child->get_permalink(), $grouped_product_child->get_id() ) ) . '">' . $grouped_product_child_title . '</a>' : $grouped_product_child_title;
 							$value .= '</label>';
 							break;
 						case 'price':

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-the-title-filter-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-the-title-filter-test.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests that product titles are passed through the `the_title` filter in the
+ * cart and grouped product templates.
+ *
+ * @package WooCommerce\Tests\Templates
+ */
+
+/**
+ * Class WC_Template_The_Title_Filter_Test
+ */
+class WC_Template_The_Title_Filter_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Marker appended by the test `the_title` filter so the assertion can detect
+	 * that the filter actually ran for the product title.
+	 */
+	private const TITLE_MARKER = 'QA_THE_TITLE_RAN';
+
+	/**
+	 * Called before every test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'the_title', array( $this, 'append_marker_to_title' ), 10, 2 );
+	}
+
+	/**
+	 * Called after every test.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'the_title', array( $this, 'append_marker_to_title' ), 10 );
+
+		WC()->cart->empty_cart();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Appends a marker to the title so tests can detect whether `the_title`
+	 * actually ran on a product's name.
+	 *
+	 * @param string $title Title being filtered.
+	 * @param int    $id    Post ID, if provided.
+	 * @return string
+	 */
+	public function append_marker_to_title( $title, $id = 0 ) {
+		return $title . self::TITLE_MARKER;
+	}
+
+	/**
+	 * @testdox Cart template should pass product titles through the `the_title` filter.
+	 */
+	public function test_cart_template_applies_the_title_filter_to_product_name(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( "L'Eglise" );
+		$product->save();
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		ob_start();
+		wc_get_template( 'cart/cart.php' );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString(
+			"L'Eglise" . self::TITLE_MARKER,
+			$html,
+			'Cart template should run the product name through the `the_title` filter.'
+		);
+	}
+
+	/**
+	 * @testdox Grouped product template should pass child product titles through the `the_title` filter.
+	 */
+	public function test_grouped_template_applies_the_title_filter_to_child_product_name(): void {
+		$child = WC_Helper_Product::create_simple_product();
+		$child->set_name( "L'Eglise" );
+		$child->save();
+
+		$grouped = new WC_Product_Grouped();
+		$grouped->set_name( 'Groupe Test' );
+		$grouped->set_status( 'publish' );
+		$grouped->set_children( array( $child->get_id() ) );
+		$grouped->save();
+
+		// The grouped template expects globals + the $grouped_products array.
+		global $product, $post;
+		$previous_product = $product;
+		$previous_post    = $post;
+
+		$product           = $grouped; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post              = get_post( $grouped->get_id() ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$grouped_products  = array_filter( array_map( 'wc_get_product', $grouped->get_children() ) );
+
+		ob_start();
+		wc_get_template(
+			'single-product/add-to-cart/grouped.php',
+			array(
+				'grouped_products' => $grouped_products,
+			)
+		);
+		$html = ob_get_clean();
+
+		$product = $previous_product; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post    = $previous_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->assertStringContainsString(
+			"L'Eglise" . self::TITLE_MARKER,
+			$html,
+			'Grouped product template should run child product names through the `the_title` filter.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Product titles displayed in two frontend locations were rendered directly from `WC_Product::get_name()`, bypassing the WordPress `the_title` filter. Other frontend locations (single product title, loop title) already pass titles through `the_title`, so behaviors like the WordPress core conversion of straight quotes to typographic apostrophes were inconsistent.

This PR routes the product title through `apply_filters( 'the_title', ... )` before output in:

- `plugins/woocommerce/templates/cart/cart.php` – product names in cart rows (both the linked and non-linked variants), as well as the value the existing `woocommerce_cart_item_name` filter receives.
- `plugins/woocommerce/templates/single-product/add-to-cart/grouped.php` – the visible child product label on grouped product pages.

`@version` headers on both templates were bumped to `10.9.0`. The screen-reader-only `printf` strings in `grouped.php` and the `Remove %s from cart` aria-label in `cart.php` continue to use `get_name()` directly so that the marker text observed by assistive tech matches the original product name and doesn't grow when third parties append annotations via `the_title`.

Closes #35774.

Linear: https://linear.app/a8c/issue/RSMAPGJ-402

### How to test the changes in this Pull Request:

1. Add a `the_title` filter to your site (mu-plugin) that appends a marker:
   ```php
   add_filter( 'the_title', function ( $title ) { return $title . ' [filtered]'; } );
   ```
2. Create a Simple product named `L'Eglise` (use a straight apostrophe) and publish it. Confirm the single-product page title shows `L'Eglise [filtered]` (sanity check that `the_title` runs everywhere it already used to).
3. Add the product to the cart and visit the cart page. The cart row should now show `L'Eglise [filtered]` instead of `L'Eglise`.
4. Remove your custom filter and verify quotes are still rendered as smart quotes on the cart page (default WP `wptexturize` transformation on `the_title`).
5. Create a Grouped product whose children include the simple product from step 2. View the grouped product page; the child label should show `L'Eglise [filtered]` (when your filter is active) or `L'Église` (default WP transformations).
6. Run the PHPUnit coverage:
   ```sh
   pnpm test:php:env -- --filter WC_Template_The_Title_Filter_Test
   ```

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` (clean for changed files).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` (clean).
- `composer exec -- phpstan analyse templates/cart/cart.php templates/single-product/add-to-cart/grouped.php --memory-limit=2G` — only pre-existing baseline errors remain; no new errors introduced.
- New PHPUnit coverage in `tests/php/includes/class-wc-template-the-title-filter-test.php` exercises both templates through `wc_get_template()` with a marker `the_title` filter.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was added manually via `pnpm --filter=@woocommerce/plugin-woocommerce changelog add` (see `plugins/woocommerce/changelog/fix-rsmapgj-402`).

</details>

---

> Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>