### PR TITLE
Fix coupon usage count missed for orders paid via My Account

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-388
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-388
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coupon usage count not incrementing when a coupon is added to a pending order and the order is later paid via the My Account "Pay" page.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1027,10 +1027,19 @@ function wc_update_coupon_usage_counts( $order_id ) {
 		$invalid_statuses
 	);
 
+	$coupon_codes = $order->get_coupon_codes();
+
 	if ( $order->has_status( $invalid_statuses ) && $has_recorded ) {
 		$action = 'reduce';
 		$order->get_data_store()->set_recorded_coupon_usage_counts( $order, false );
 	} elseif ( ! $order->has_status( $invalid_statuses ) && ! $has_recorded ) {
+		// Only mark coupon usage as recorded when the order actually has coupons to record.
+		// Otherwise, a later status transition that brings coupons in (for example, when an admin
+		// adds a coupon to a pending order that is then paid via the My Account "Pay" page) would
+		// be skipped because the flag was already flipped on the initial empty status transition.
+		if ( count( $coupon_codes ) === 0 ) {
+			return;
+		}
 		$action = 'increase';
 		$order->get_data_store()->set_recorded_coupon_usage_counts( $order, true );
 	} elseif ( $order->has_status( $invalid_statuses ) ) {
@@ -1040,8 +1049,8 @@ function wc_update_coupon_usage_counts( $order_id ) {
 		return;
 	}
 
-	if ( count( $order->get_coupon_codes() ) > 0 ) {
-		foreach ( $order->get_coupon_codes() as $code ) {
+	if ( count( $coupon_codes ) > 0 ) {
+		foreach ( $coupon_codes as $code ) {
 			if ( StringUtil::is_null_or_whitespace( $code ) ) {
 				continue;
 			}

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -187,6 +187,65 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Coupon usage counts should still increment when a coupon is added to a pending
+	 * order after the order was first created, then the order is paid via the My Account
+	 * "Pay" page (status transitions pending -> processing).
+	 *
+	 * Regression test for woocommerce/woocommerce#30845.
+	 */
+	public function test_wc_update_coupon_usage_counts_for_manual_order_paid_via_my_account() {
+		$coupon = WC_Helper_Coupon::create_coupon( 'manual-30845' );
+
+		// Step 1: Admin creates an empty pending order (no coupons yet). This mirrors the path
+		// where the order is created first and items/coupons are added later.
+		$order = wc_create_order(
+			array(
+				'status'      => OrderStatus::PENDING,
+				'customer_id' => 0,
+			)
+		);
+		$this->assertNotInstanceOf( WP_Error::class, $order );
+		$order_id = $order->get_id();
+
+		// At this point the order has no coupons.
+		$this->assertSame( array(), $order->get_coupon_codes() );
+		$this->assertEquals( 0, ( new WC_Coupon( $coupon->get_code() ) )->get_usage_count() );
+
+		// The flag should not have been set just because the order transitioned to pending
+		// while it had no coupons - otherwise a later coupon addition + payment would be skipped.
+		$this->assertEmpty( $order->get_data_store()->get_recorded_coupon_usage_counts( $order ) );
+
+		// Step 2: Admin adds a coupon line item to the existing pending order and saves it.
+		// This mirrors how a manually-created order has a coupon line attached without going
+		// through WC_Order::apply_coupon (which would have marked the order as recorded already).
+		$coupon_item = new WC_Order_Item_Coupon();
+		$coupon_item->set_code( $coupon->get_code() );
+		$coupon_item->set_discount( 1 );
+		$coupon_item->set_discount_tax( 0 );
+		$order->add_item( $coupon_item );
+		$order->save();
+
+		// The coupon usage count should still be zero - status hasn't transitioned yet.
+		$this->assertEquals( 0, ( new WC_Coupon( $coupon->get_code() ) )->get_usage_count() );
+
+		// Step 3: The customer pays the order via the My Account "Pay" page. This transitions
+		// the order from pending -> processing, which fires wc_update_coupon_usage_counts.
+		$order = wc_get_order( $order_id );
+		$order->update_status( OrderStatus::PROCESSING );
+
+		// After the payment-driven status transition, the coupon usage count must reflect
+		// the coupon that was added to the order. Before the fix this stayed at 0 because
+		// the recorded-usage flag was already true (set during the initial empty pending save),
+		// causing wc_update_coupon_usage_counts to return early.
+		$this->assertEquals( 1, ( new WC_Coupon( $coupon->get_code() ) )->get_usage_count() );
+		$this->assertEquals( 1, $order->get_data_store()->get_recorded_coupon_usage_counts( $order ) );
+
+		// The coupon line item should remain on the order so it still appears in coupon
+		// analytics / reporting that read coupon codes from the order.
+		$this->assertSame( array( $coupon->get_code() ), $order->get_coupon_codes() );
+	}
+
+	/**
 	 * Test getting total refunded for an item with and without refunds.
 	 */
 	public function test_get_total_refunded_for_item() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`wc_update_coupon_usage_counts()` flips an order's `_recorded_coupon_usage_counts` flag to `true` based purely on the order status, even when the order has no coupon line items at the moment the hook fires. That breaks the typical "manual order with coupon" flow:

1. Admin creates a pending order (no line items yet). `wc_create_order()` saves it, the `pending` status transition fires, and the flag is set to `true` even though there's nothing to record.
2. Admin adds a product + a `WC_Order_Item_Coupon` line item to that pending order.
3. The customer pays via **My Account > Orders > Pay**. The Cash on Delivery (or other) gateway calls `update_status('processing')`, which fires `woocommerce_order_status_processing` -> `wc_update_coupon_usage_counts()`.
4. Because `$has_recorded === true` and the status is valid, the function returns early. The coupon's `_usage_count` never moves, and the order is missing from **Marketing > Coupons** / **Analytics > Coupons** reporting.

This PR makes the increase branch a no-op when the order has zero coupons, so the recorded flag is only set the first time there's actually something to record. The reduce branch is unchanged.

Closes #30845

Linear: https://linear.app/a8c/issue/RSMAPGJ-388

### How to test the changes in this Pull Request:

Automated:

1. `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_wc_update_coupon_usage_counts` — both `test_wc_update_coupon_usage_counts` (existing) and the new `test_wc_update_coupon_usage_counts_for_manual_order_paid_via_my_account` should pass.

Manual:

1. Create a fixed-cart coupon (any code, any amount). Note its **Usage / Limit** value in **Marketing > Coupons**.
2. As an admin, create a **manual order** for a customer user: add a product, then add the coupon code. Leave the order in **Pending payment** and assign Cash on Delivery (or any gateway that auto-completes without external interaction).
3. Log in as that customer in another browser/incognito session.
4. Go to **My Account > Orders**, click **Pay** on the pending order, choose **Cash on Delivery**, and place the order.
5. Back in admin, refresh **Marketing > Coupons**. Before this patch the coupon's usage count stays unchanged; with the patch it increments by 1.
6. Also confirm the order still appears in **Analytics > Coupons** for that coupon.

Regression coverage worth re-running:

- Standard checkout with a coupon (cart -> place order) should still increment usage exactly once.
- Cancel / trash / un-trash of a coupon-bearing order should still decrement / re-increment as before (covered by the existing `test_wc_update_coupon_usage_counts`).

### Testing that has already taken place:

-   Added `WC_Order_Functions_Test::test_wc_update_coupon_usage_counts_for_manual_order_paid_via_my_account` to lock in the regression.
-   Re-traced the existing `test_wc_update_coupon_usage_counts` cases by hand against the new logic to confirm no behavioral change for the apply-coupon-via-WC_Order::apply_coupon path.
-   `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
-   `composer --working-dir=plugins/woocommerce exec -- phpstan analyse includes/wc-order-functions.php --memory-limit=2G` — clean (0 errors).
-   `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually at `plugins/woocommerce/changelog/fix-rsmapgj-388` (significance: patch, type: fix).