### PR TITLE
Fix regenerate product lookup tables to recompute total_sales from orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-382
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-382
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Recompute total_sales from existing orders when regenerating the product lookup tables so deleted orders no longer leave stale counts behind.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
@@ -18,6 +19,7 @@ use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\NumberUtil;
 use Automattic\WooCommerce\Internal\ProductImage\MatchImageBySKU;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -2047,16 +2049,19 @@ function wc_update_product_lookup_tables_column( $column ) {
 				"
 			);
 			break;
+		case 'total_sales':
+			// Recompute total_sales from existing orders so the regenerate tool corrects stale values
+			// left behind by previously deleted orders or missed status transitions. The result is
+			// written to both wp_postmeta (the source of truth for the product) and the lookup table.
+			wc_update_product_lookup_tables_total_sales();
+			break;
 		case 'sku':
 		case 'global_unique_id':
 		case 'stock_status':
 		case 'average_rating':
-		case 'total_sales':
 		case 'tax_class':
 		case 'tax_status':
-			if ( 'total_sales' === $column ) {
-				$meta_key = 'total_sales';
-			} elseif ( 'average_rating' === $column ) {
+			if ( 'average_rating' === $column ) {
 				$meta_key = '_wc_average_rating';
 			} else {
 				$meta_key = '_' . $column;
@@ -2133,6 +2138,115 @@ function wc_update_product_lookup_tables_column( $column ) {
 	}
 }
 add_action( 'wc_update_product_lookup_tables_column', 'wc_update_product_lookup_tables_column' );
+
+/**
+ * Recompute and persist `total_sales` for every product/variation from the current order data.
+ *
+ * Historically the regenerate-lookup-tables tool simply copied the value of the `total_sales`
+ * post meta into `wc_product_meta_lookup`. If `total_sales` ever drifted out of sync with the
+ * orders that actually exist (for example because orders were permanently deleted in a context
+ * that bypassed the normal sales-recording hooks), regenerating the lookup table preserved the
+ * stale value instead of correcting it. Recomputing from the order tables makes the tool
+ * authoritative again.
+ *
+ * Counts the sum of `_qty` across non-deleted shop_order line items whose parent order is in
+ * one of the statuses that increment `total_sales` in normal operation: completed, processing,
+ * and on-hold. Works against the HPOS orders table when enabled, falling back to the legacy
+ * `wp_posts` storage otherwise. The recomputed value is written to `wp_postmeta` (the per-product
+ * source of truth) and then mirrored into the lookup table.
+ *
+ * @since 10.9.0
+ */
+function wc_update_product_lookup_tables_total_sales(): void {
+	global $wpdb;
+
+	$counted_statuses    = array( OrderStatus::COMPLETED, OrderStatus::PROCESSING, OrderStatus::ON_HOLD );
+	$counted_statuses    = array_map(
+		static function ( $status ) {
+			return 0 === strpos( $status, 'wc-' ) ? $status : 'wc-' . $status;
+		},
+		$counted_statuses
+	);
+	$status_placeholders = implode( ',', array_fill( 0, count( $counted_statuses ), '%s' ) );
+
+	if ( class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		$orders_table = $wpdb->prefix . 'wc_orders';
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$query = $wpdb->prepare(
+			"
+			SELECT product_im.meta_value AS product_id, COALESCE( SUM( qty_im.meta_value + 0 ), 0 ) AS total_sales
+			FROM {$wpdb->prefix}woocommerce_order_items AS oi
+			INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS product_im
+				ON product_im.order_item_id = oi.order_item_id AND product_im.meta_key = '_product_id'
+			INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS qty_im
+				ON qty_im.order_item_id = oi.order_item_id AND qty_im.meta_key = '_qty'
+			INNER JOIN {$orders_table} AS o ON o.id = oi.order_id
+			WHERE oi.order_item_type = 'line_item'
+				AND o.type = 'shop_order'
+				AND o.status IN ( {$status_placeholders} )
+			GROUP BY product_im.meta_value
+			",
+			...$counted_statuses
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+	} else {
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$query = $wpdb->prepare(
+			"
+			SELECT product_im.meta_value AS product_id, COALESCE( SUM( qty_im.meta_value + 0 ), 0 ) AS total_sales
+			FROM {$wpdb->prefix}woocommerce_order_items AS oi
+			INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS product_im
+				ON product_im.order_item_id = oi.order_item_id AND product_im.meta_key = '_product_id'
+			INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS qty_im
+				ON qty_im.order_item_id = oi.order_item_id AND qty_im.meta_key = '_qty'
+			INNER JOIN {$wpdb->posts} AS p ON p.ID = oi.order_id
+			WHERE oi.order_item_type = 'line_item'
+				AND p.post_type = 'shop_order'
+				AND p.post_status IN ( {$status_placeholders} )
+			GROUP BY product_im.meta_value
+			",
+			...$counted_statuses
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	$totals_by_product = $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+	$totals_map = array();
+	if ( is_array( $totals_by_product ) ) {
+		foreach ( $totals_by_product as $row ) {
+			$product_id = absint( $row['product_id'] );
+			if ( $product_id ) {
+				$totals_map[ $product_id ] = (int) $row['total_sales'];
+			}
+		}
+	}
+
+	// Reset every product / variation's total_sales meta to zero so products that no longer have
+	// counted orders are corrected. Then overlay the freshly computed totals for those that do.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	$product_ids = $wpdb->get_col(
+		"SELECT ID FROM {$wpdb->posts} WHERE post_type IN ( 'product', 'product_variation' )"
+	);
+
+	foreach ( $product_ids as $product_id ) {
+		$product_id = (int) $product_id;
+		$total      = $totals_map[ $product_id ] ?? 0;
+		update_post_meta( $product_id, 'total_sales', $total );
+	}
+
+	// Mirror the post meta values into the lookup table.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	$wpdb->query(
+		"
+		UPDATE
+			{$wpdb->wc_product_meta_lookup} lookup_table
+			LEFT JOIN {$wpdb->postmeta} meta ON lookup_table.product_id = meta.post_id AND meta.meta_key = 'total_sales'
+		SET
+			lookup_table.total_sales = COALESCE( meta.meta_value, 0 )
+		"
+	);
+}
 
 /**
  * Populate rating count lookup table data for products.

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -7,6 +7,7 @@
 
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 
@@ -307,8 +308,10 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	 * @testDox Action Scheduler events are scheduled when product with sale dates is saved.
 	 */
 	public function test_wc_schedule_product_sale_events_on_save() {
-		$future_start = time() + 3600;  // 1 hour from now.
-		$future_end   = time() + 86400; // 24 hours from now.
+		$future_start = time() + 3600;
+		// 1 hour from now.
+		$future_end = time() + 86400;
+		// 24 hours from now.
 
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_price( 100 );
@@ -356,7 +359,8 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		);
 
 		// Update the sale dates.
-		$new_start = time() + 7200; // 2 hours from now.
+		$new_start = time() + 7200;
+		// 2 hours from now.
 		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', $new_start ) );
 		$product->save();
 
@@ -594,7 +598,8 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 
 		// Create a guest order with French billing address.
 		$order = wc_create_order();
-		$order->set_customer_id( 0 ); // Guest order.
+		$order->set_customer_id( 0 );
+		// Guest order.
 		$order->set_billing_country( 'FR' );
 		$order->set_billing_city( 'Paris' );
 		$order->set_billing_postcode( '75001' );
@@ -850,11 +855,13 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 				}
 				foreach ( $terms as $key => $term ) {
 					if ( $term->term_id === $category1_term['term_id'] ) {
-						unset( $terms[ $key ] ); // Intentionally don't re-index.
+						unset( $terms[ $key ] );
+						// Intentionally don't re-index.
 						break;
 					}
 				}
-				return $terms; // Returns array with non-sequential keys.
+				return $terms;
+				// Returns array with non-sequential keys.
 			};
 			add_filter( 'get_the_terms', $filter_callback, 10, 3 );
 
@@ -1017,6 +1024,129 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 			$wp_rewrite = $old_wp_rewrite; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox Regenerating the total_sales lookup column recomputes the value from current orders and clears stale counts.
+	 */
+	public function test_wc_update_product_lookup_tables_column_total_sales_recomputes_from_orders() {
+		global $wpdb;
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Simulate stale state: total_sales recorded as 7 in both postmeta and the lookup table even though
+		// no counted orders exist for this product. This is the state the regenerate tool needs to correct.
+		update_post_meta( $product->get_id(), 'total_sales', 7 );
+		$wpdb->update(
+			$wpdb->prefix . 'wc_product_meta_lookup',
+			array( 'total_sales' => 7 ),
+			array( 'product_id' => $product->get_id() ),
+			array( '%d' ),
+			array( '%d' )
+		);
+
+		wc_update_product_lookup_tables_column( 'total_sales' );
+
+		$lookup_total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT total_sales FROM {$wpdb->prefix}wc_product_meta_lookup WHERE product_id = %d",
+				$product->get_id()
+			)
+		);
+		$meta_total   = (int) get_post_meta( $product->get_id(), 'total_sales', true );
+
+		$this->assertSame( 0, $lookup_total, 'Lookup table total_sales should be reset to 0 when no counted orders reference the product.' );
+		$this->assertSame( 0, $meta_total, 'Postmeta total_sales should be reset to 0 when no counted orders reference the product.' );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox Regenerating the total_sales lookup column counts line item quantities from completed and processing orders.
+	 */
+	public function test_wc_update_product_lookup_tables_column_total_sales_sums_line_item_quantities() {
+		global $wpdb;
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Create two completed orders for the same product; WC_Helper_Order adds 4 units per order.
+		$order_a = WC_Helper_Order::create_order( 1, $product );
+		$order_a->set_status( OrderStatus::COMPLETED );
+		$order_a->save();
+
+		$order_b = WC_Helper_Order::create_order( 1, $product );
+		$order_b->set_status( OrderStatus::COMPLETED );
+		$order_b->save();
+
+		// Force stale lookup state so the assertion proves the regenerate tool corrected it, not that it was already correct.
+		update_post_meta( $product->get_id(), 'total_sales', 999 );
+		$wpdb->update(
+			$wpdb->prefix . 'wc_product_meta_lookup',
+			array( 'total_sales' => 999 ),
+			array( 'product_id' => $product->get_id() ),
+			array( '%d' ),
+			array( '%d' )
+		);
+
+		wc_update_product_lookup_tables_column( 'total_sales' );
+
+		$lookup_total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT total_sales FROM {$wpdb->prefix}wc_product_meta_lookup WHERE product_id = %d",
+				$product->get_id()
+			)
+		);
+		$meta_total   = (int) get_post_meta( $product->get_id(), 'total_sales', true );
+
+		$this->assertSame( 8, $lookup_total, 'Lookup table total_sales should equal the summed quantities (2 orders x 4 units) for completed orders.' );
+		$this->assertSame( 8, $meta_total, 'Postmeta total_sales should equal the summed quantities for completed orders.' );
+
+		$order_a->delete( true );
+		$order_b->delete( true );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * @testdox Regenerating the total_sales lookup column ignores orders in non-counted statuses such as pending or cancelled.
+	 */
+	public function test_wc_update_product_lookup_tables_column_total_sales_ignores_uncounted_statuses() {
+		global $wpdb;
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$pending_order = WC_Helper_Order::create_order( 1, $product );
+		$pending_order->set_status( OrderStatus::PENDING );
+		$pending_order->save();
+
+		$cancelled_order = WC_Helper_Order::create_order( 1, $product );
+		$cancelled_order->set_status( OrderStatus::CANCELLED );
+		$cancelled_order->save();
+
+		update_post_meta( $product->get_id(), 'total_sales', 42 );
+		$wpdb->update(
+			$wpdb->prefix . 'wc_product_meta_lookup',
+			array( 'total_sales' => 42 ),
+			array( 'product_id' => $product->get_id() ),
+			array( '%d' ),
+			array( '%d' )
+		);
+
+		wc_update_product_lookup_tables_column( 'total_sales' );
+
+		$lookup_total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT total_sales FROM {$wpdb->prefix}wc_product_meta_lookup WHERE product_id = %d",
+				$product->get_id()
+			)
+		);
+		$meta_total   = (int) get_post_meta( $product->get_id(), 'total_sales', true );
+
+		$this->assertSame( 0, $lookup_total, 'Pending and cancelled orders should not count toward total_sales in the lookup table.' );
+		$this->assertSame( 0, $meta_total, 'Pending and cancelled orders should not count toward total_sales in postmeta.' );
+
+		$pending_order->delete( true );
+		$cancelled_order->delete( true );
 		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have read and agree to the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] I have followed the [project coding standards and best practices](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

The "Regenerate product lookup tables" tool (WooCommerce > Status > Tools) used to copy `total_sales` straight from `wp_postmeta` into `wc_product_meta_lookup`. When the postmeta value itself was stale (for example because orders were permanently deleted in a context that bypassed the normal sales-recording hooks), running the tool preserved the stale value instead of correcting it.

This PR makes the regenerate tool authoritative again:

- A new `wc_update_product_lookup_tables_total_sales()` helper recomputes `total_sales` per product by summing line item `_qty` from orders in the counted statuses (`completed`, `processing`, `on-hold`).
- The aggregation is HPOS-aware: it joins against `wc_orders` when HPOS is enabled and falls back to `wp_posts` otherwise. Either way, permanently deleted orders no longer contribute to the recomputed total.
- The recomputed value is written to `wp_postmeta` (the per-product source of truth) and then mirrored into the lookup table. Products that no longer have any counted orders are correctly reset to `0`.

Closes #27359
Linear: https://linear.app/a8c/issue/RSMAPGJ-382

### How to test the changes in this Pull Request

1. Create a simple product and place 3 orders for it, mark each as completed.
2. Confirm `total_sales` shows `3` in both `wp_postmeta` (`meta_key = 'total_sales'`) and `wc_product_meta_lookup`.
3. Permanently delete the orders directly through the database (or via `$order->delete( true )` in a context that bypasses the sales-recording hooks) so postmeta is left stale.
4. Run WooCommerce > Status > Tools > "Regenerate product lookup tables".
5. Confirm both `wp_postmeta` and `wc_product_meta_lookup` now report `total_sales = 0`.
6. Repeat with at least one order in `pending` or `cancelled` status to confirm only counted statuses contribute.

### Testing that has already taken place

- Added three PHPUnit cases in `WC_Product_Functions_Tests` covering: stale state with no counted orders, summed quantities from completed orders, and exclusion of pending/cancelled orders.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` is clean for the touched files.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passes.
- PHPStan against `includes/wc-product-functions.php` reports no errors.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog already added at `plugins/woocommerce/changelog/fix-rsmapgj-382`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)