### PR TITLE
Skip review-request email when the order has nothing reviewable

### DIFF
--- a/plugins/woocommerce/changelog/64960-wooplug-6704-skip-scheduling-review-request-email-when-nothing-is
+++ b/plugins/woocommerce/changelog/64960-wooplug-6704-skip-scheduling-review-request-email-when-nothing-is
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip scheduling and sending the customer review-request email when the order has no reviewable items (every product has reviews disabled per-product or site-wide, or every reviewable item is already reviewed for that order).

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Internal\OrderReviews\ItemEligibility;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -141,7 +142,16 @@ if ( ! class_exists( 'WC_Email_Customer_Review_Request', false ) ) :
 				$this->object
 			);
 
-			return in_array( $this->object->get_status(), $eligible_statuses, true );
+			if ( ! in_array( $this->object->get_status(), $eligible_statuses, true ) ) {
+				return false;
+			}
+
+			// Eligibility can change between scheduling and sending (e.g. the
+			// admin disables site-wide reviews during the delay window, or the
+			// customer reviews everything via another entry point). Re-check at
+			// send time so the email is silently dropped instead of pointing
+			// the customer at the empty-state page.
+			return ItemEligibility::has_actionable_items( $this->object );
 		}
 
 		/**

--- a/plugins/woocommerce/src/Internal/OrderReviews/ItemEligibility.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/ItemEligibility.php
@@ -242,6 +242,45 @@ class ItemEligibility {
 	}
 
 	/**
+	 * Whether an order has at least one item the customer can still review.
+	 *
+	 * Walks the same eligible-items list and per-item decisions the page
+	 * renders, so the answer matches what `customer-review-order.php` would
+	 * show: items with `STATUS_SKIP` (reviews disabled on the product, or
+	 * site-wide via `woocommerce_enable_reviews`) and items already reviewed
+	 * on this order are excluded. Any remaining `STATUS_FORM` row without a
+	 * matching review counts as actionable.
+	 *
+	 * Callers in the email pipeline use this to short-circuit scheduling and
+	 * sending when the customer would otherwise land on the empty-state page.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order Order being inspected.
+	 * @return bool True when at least one item is still reviewable.
+	 */
+	public static function has_actionable_items( WC_Order $order ): bool {
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- documented on customer-review-order.php template.
+		$items = (array) apply_filters( 'woocommerce_review_order_eligible_items', $order->get_items(), $order );
+		self::preload_for_items( $items, $order );
+
+		foreach ( $items as $item ) {
+			if ( ! $item instanceof WC_Order_Item_Product ) {
+				continue;
+			}
+			$decision = self::decide( $item, $order );
+			if ( self::STATUS_SKIP === $decision['status'] ) {
+				continue;
+			}
+			if ( ! ( $decision['comment'] instanceof WP_Comment ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Drop fully-refunded line items from the eligible-items list.
 	 *
 	 * Default callback wired onto `woocommerce_review_order_eligible_items`

--- a/plugins/woocommerce/src/Internal/OrderReviews/ItemEligibility.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/ItemEligibility.php
@@ -260,7 +260,18 @@ class ItemEligibility {
 	 * @return bool True when at least one item is still reviewable.
 	 */
 	public static function has_actionable_items( WC_Order $order ): bool {
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- documented on customer-review-order.php template.
+		/**
+		 * Filter the eligible items considered when deciding whether the
+		 * Customer Review Request email should fire for an order.
+		 *
+		 * Same hook the page template, submission handler, and endpoint use,
+		 * so all four entry points agree on the eligible-items set.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param WC_Order_Item[] $items Order line items.
+		 * @param WC_Order        $order The order being inspected.
+		 */
 		$items = (array) apply_filters( 'woocommerce_review_order_eligible_items', $order->get_items(), $order );
 		self::preload_for_items( $items, $order );
 

--- a/plugins/woocommerce/src/Internal/OrderReviews/Scheduler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Scheduler.php
@@ -154,6 +154,15 @@ class Scheduler {
 			return;
 		}
 
+		// Don't queue an email whose link would land on the empty-state page:
+		// every product on the order has reviews disabled (per-product or
+		// site-wide via `woocommerce_enable_reviews`), or every reviewable
+		// item already has a review tied to this order.
+		if ( ! ItemEligibility::has_actionable_items( $order ) ) {
+			$this->log_skip( $order_id, 'no reviewable items' );
+			return;
+		}
+
 		$when = time() + $email->get_delay_seconds();
 		as_schedule_single_action( $when, self::ACTION_HOOK, array( $order_id ) );
 

--- a/plugins/woocommerce/templates/order/customer-review-order-empty.php
+++ b/plugins/woocommerce/templates/order/customer-review-order-empty.php
@@ -30,6 +30,9 @@ $meta_parts = \Automattic\WooCommerce\Internal\OrderReviews\Meta::parts_for_orde
 		if ( $reviewed_count > 0 ) {
 			esc_html_e( 'Thank you for your reviews', 'woocommerce' );
 		} else {
+			// Defensive fallback for direct-URL visits (bookmark, admin-shared link).
+			// The email pipeline never schedules or sends when an order has no
+			// reviewable items, so customers don't reach this branch via the email.
 			esc_html_e( 'Nothing to review here', 'woocommerce' );
 		}
 		?>

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-review-request-test.php
@@ -257,6 +257,33 @@ class WC_Email_Customer_Review_Request_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox trigger() skips orders whose items all have reviews disabled.
+	 *
+	 * Eligibility can change between scheduling and sending — e.g. the admin
+	 * disables product reviews site-wide during the delay window — so the
+	 * email gates on `ItemEligibility::has_actionable_items()` at send time.
+	 */
+	public function test_trigger_skips_when_no_actionable_items(): void {
+		$this->sut->update_option( 'enabled', 'yes' );
+		$this->sut->enabled = 'yes';
+
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_reviews_allowed( false );
+		$product->save();
+
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$before = count( $mailer->mock_sent );
+		$this->sut->trigger( $order->get_id() );
+		$after = count( $mailer->mock_sent );
+
+		$this->assertSame( $before, $after, 'Review-request email must not dispatch when nothing on the order is reviewable.' );
+	}
+
+	/**
 	 * @testdox The woocommerce_review_order_eligible_statuses filter widens the eligible set for trigger().
 	 */
 	public function test_trigger_eligible_statuses_filter_can_widen(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/ItemEligibilityTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/ItemEligibilityTest.php
@@ -278,4 +278,54 @@ class ItemEligibilityTest extends WC_Unit_Test_Case {
 		$this->assertNotNull( $decision['comment'] );
 		$this->assertSame( 0, $call_count, 'decide() should not query when preload_for_items() has cached the result.' );
 	}
+
+	/**
+	 * @testdox has_actionable_items() returns true when at least one item is reviewable.
+	 */
+	public function test_has_actionable_items_true_for_default_order(): void {
+		$built = $this->make_order();
+
+		$this->assertTrue( ItemEligibility::has_actionable_items( $built['order'] ) );
+	}
+
+	/**
+	 * @testdox has_actionable_items() returns false when every product has reviews disabled.
+	 */
+	public function test_has_actionable_items_false_when_all_items_disabled(): void {
+		$built   = $this->make_order();
+		$product = wc_get_product( $built['product_id'] );
+		$product->set_reviews_allowed( false );
+		$product->save();
+
+		$this->assertFalse( ItemEligibility::has_actionable_items( $built['order'] ) );
+	}
+
+	/**
+	 * @testdox has_actionable_items() returns false when reviews are disabled site-wide.
+	 */
+	public function test_has_actionable_items_false_when_site_wide_reviews_disabled(): void {
+		$built    = $this->make_order();
+		$previous = get_option( 'woocommerce_enable_reviews', 'yes' );
+		update_option( 'woocommerce_enable_reviews', 'no' );
+		remove_post_type_support( 'product', 'comments' );
+
+		try {
+			$this->assertFalse( ItemEligibility::has_actionable_items( $built['order'] ) );
+		} finally {
+			update_option( 'woocommerce_enable_reviews', $previous );
+			if ( 'yes' === $previous ) {
+				add_post_type_support( 'product', 'comments' );
+			}
+		}
+	}
+
+	/**
+	 * @testdox has_actionable_items() returns false once every reviewable item is reviewed.
+	 */
+	public function test_has_actionable_items_false_when_all_items_reviewed(): void {
+		$built = $this->make_order( 'all-done@example.test' );
+		$this->insert_review( $built['product_id'], 'all-done@example.test', 'Done.', 5, (int) $built['order']->get_id() );
+
+		$this->assertFalse( ItemEligibility::has_actionable_items( $built['order'] ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SchedulerTest.php
@@ -6,7 +6,9 @@ namespace Automattic\WooCommerce\Tests\Internal\OrderReviews;
 use Automattic\WooCommerce\Internal\OrderReviews\Scheduler;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use WC_Email_Customer_Review_Request;
+use WC_Helper_Product;
 use WC_Order;
+use WC_Order_Item_Product;
 use WC_Unit_Test_Case;
 
 /**
@@ -103,6 +105,79 @@ class SchedulerTest extends WC_Unit_Test_Case {
 		$second = (int) wc_get_order( $order->get_id() )->get_meta( Scheduler::SCHEDULED_META_KEY );
 
 		$this->assertSame( $first, $second, 'Scheduled-at meta should not change on re-completion.' );
+	}
+
+	/**
+	 * @testdox Scheduling is skipped when every product on the order has reviews disabled per-product.
+	 */
+	public function test_skips_when_all_items_have_reviews_disabled(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_reviews_allowed( false );
+		$product->save();
+
+		$order = $this->create_pending_order_with_product( $product );
+		$order->update_status( 'completed' );
+
+		$this->assertFalse( (bool) as_next_scheduled_action( Scheduler::ACTION_HOOK, array( $order->get_id() ) ) );
+		$this->assertEmpty( wc_get_order( $order->get_id() )->get_meta( Scheduler::SCHEDULED_META_KEY ) );
+	}
+
+	/**
+	 * @testdox Scheduling is skipped when site-wide reviews are disabled.
+	 *
+	 * The `woocommerce_enable_reviews=no` setting removes `comments` support
+	 * from the product post type so `comments_open()` returns false for every
+	 * product, which `ItemEligibility::has_actionable_items()` reads.
+	 */
+	public function test_skips_when_site_wide_reviews_disabled(): void {
+		$previous = get_option( 'woocommerce_enable_reviews', 'yes' );
+		update_option( 'woocommerce_enable_reviews', 'no' );
+		// `comments` post-type support is registered at init based on the
+		// option, so reflect the option change for the rest of this test.
+		remove_post_type_support( 'product', 'comments' );
+
+		try {
+			$order = $this->create_pending_order();
+			$order->update_status( 'completed' );
+
+			$this->assertFalse( (bool) as_next_scheduled_action( Scheduler::ACTION_HOOK, array( $order->get_id() ) ) );
+			$this->assertEmpty( wc_get_order( $order->get_id() )->get_meta( Scheduler::SCHEDULED_META_KEY ) );
+		} finally {
+			update_option( 'woocommerce_enable_reviews', $previous );
+			if ( 'yes' === $previous ) {
+				add_post_type_support( 'product', 'comments' );
+			}
+		}
+	}
+
+	/**
+	 * @testdox A mixed order with at least one reviewable item still schedules.
+	 */
+	public function test_schedules_when_at_least_one_item_is_reviewable(): void {
+		$reviewable = WC_Helper_Product::create_simple_product();
+		$disabled   = WC_Helper_Product::create_simple_product();
+		$disabled->set_reviews_allowed( false );
+		$disabled->save();
+
+		$order = OrderHelper::create_order( 1, $reviewable );
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $disabled,
+				'quantity' => 1,
+				'subtotal' => wc_get_price_excluding_tax( $disabled ),
+				'total'    => wc_get_price_excluding_tax( $disabled ),
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+		$order->set_status( 'pending' );
+		$order->calculate_totals();
+		$order->save();
+
+		$order->update_status( 'completed' );
+
+		$this->assertTrue( (bool) as_next_scheduled_action( Scheduler::ACTION_HOOK, array( $order->get_id() ) ) );
 	}
 
 	/**
@@ -231,6 +306,18 @@ class SchedulerTest extends WC_Unit_Test_Case {
 	 */
 	private function create_pending_order(): WC_Order {
 		$order = OrderHelper::create_order();
+		$order->set_status( 'pending' );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Create a pending order whose single line item is the provided product.
+	 *
+	 * @param \WC_Product $product Product to add to the order.
+	 */
+	private function create_pending_order_with_product( \WC_Product $product ): WC_Order {
+		$order = OrderHelper::create_order( 1, $product );
 		$order->set_status( 'pending' );
 		$order->save();
 		return $order;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`Scheduler::handle_woocommerce_order_status_completed()` previously queued the `woocommerce_send_review_request` action for every completed order, and `WC_Email_Customer_Review_Request::is_order_eligible_for_send()` only checked the order status. Neither looked at whether anything on the order was actually reviewable, so the customer could receive an email that lands on the empty-state "Nothing to review here" page when site-wide reviews are off or every product on the order has reviews disabled per-product.

This PR adds a new `ItemEligibility::has_actionable_items()` helper that walks the same eligible-items list the page renders (so the answer matches what the customer would see) and short-circuits both the schedule path and the send-time path when no row remains actionable. The send-time check also covers eligibility loss between scheduling and sending (e.g. the admin disables site-wide reviews during the delay window).

### How to test the changes in this Pull Request:

**Setup once** (any time):

1. Enable the **Customer review request (beta)** flag in **WooCommerce → Settings → Advanced → Features**.
2. Open **WooCommerce → Settings → Emails → Review request** and tick **Enable this email notification**.

**A. Per-product reviews disabled — email is NOT scheduled**

1. Create one product, open **Product data → Advanced**, untick **Enable reviews**, publish.
2. Place an order on the storefront with just that product.
3. In **WooCommerce → Orders**, change the order to **Completed** and **Update**.
4. Open **WooCommerce → Status → Scheduled Actions** and filter by hook `woocommerce_send_review_request`.
5. **Expected:** there is no pending action for this order. **WooCommerce → Status → Logs** shows a `review-request` source entry: *"Skipped scheduling review-request email for order N: no reviewable items."*

**B. Site-wide reviews disabled — email is NOT scheduled**

1. Open **WooCommerce → Settings → Products → General**, untick **Enable product reviews**, save.
2. Place an order with any product and complete it (as above).
3. **Expected:** no pending `woocommerce_send_review_request` action; the same log entry appears.
4. Re-tick **Enable product reviews** for the rest of the testing.

**C. Mixed order with at least one reviewable item — email IS scheduled**

1. Create two products: A (reviews **enabled**) and B (reviews **disabled**).
2. Place an order containing both, complete it.
3. **Expected:** a pending action for the order is present in **Scheduled Actions** as before.

**D. Eligibility lost during the delay window — email is dropped at send time**

1. Place an order, mark Completed (a pending action is created — the default 7-day delay leaves it pending plenty long enough).
2. While the action is pending, untick **Enable product reviews** site-wide.
3. Trigger the pending action via the **Run** link on the Scheduled Actions row.
4. **Expected:** no email is dispatched (visible in your mail-catching plugin / Mailpit). The order's existing flow is unchanged.

### Testing that has already taken place:

- Manual UI walkthrough end-to-end on `release/10.8` with the WOOPLUG-6696 feature gate, covering each of the four scenarios above.
- New PHPUnit cases in `SchedulerTest`, `ItemEligibilityTest`, and `WC_Email_Customer_Review_Request_Test` cover the three skip paths and the mixed-order positive case.
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "SchedulerTest|ItemEligibilityTest|WC_Email_Customer_Review_Request_Test"` — 67 tests / 118 assertions pass.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.
- `composer exec -- phpstan analyse` clean on the three changed source files.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Skip scheduling and sending the customer review-request email when the order has no reviewable items (every product has reviews disabled per-product or site-wide, or every reviewable item is already reviewed for that order).

</details>

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**