### PR TITLE
[RSM] Shopper Collection: surface request errors via store-notices

### DIFF
--- a/plugins/woocommerce/changelog/replace-shopper-collection-error-row-with-store-notice
+++ b/plugins/woocommerce/changelog/replace-shopper-collection-error-row-with-store-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Shopper Collection: surface mutation errors via the store-notices banner instead of an in-list error row, and disable the affected row's controls while the request is in flight.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -204,6 +204,7 @@ const { state, actions } = store< Store >(
 					// loadList cannot clobber a fresh add/remove.
 					list.items = items;
 				} catch ( error ) {
+					yield actions.clearNotices();
 					actions.showNoticeError( error as Error );
 				} finally {
 					list.isLoading = false;
@@ -298,6 +299,11 @@ const { state, actions } = store< Store >(
 					type: 'error',
 					dismissible: true,
 				} );
+
+				// Surface the full Error (with stack) for ops debugging;
+				// the banner only shows the sanitised message.
+				// eslint-disable-next-line no-console
+				console.error( error );
 			},
 
 			// Wipe every notice in the closest store-notices context. Called

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -4,6 +4,7 @@
 import { store } from '@wordpress/interactivity';
 import type { AsyncAction, TypeYield } from '@wordpress/interactivity';
 import type { CurrencyResponse } from '@woocommerce/types';
+import type { Store as StoreNotices } from '@woocommerce/stores/store-notices';
 
 /**
  * Mirror of `Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListItemSchema::get_properties()`.
@@ -57,7 +58,6 @@ export type RawShopperListItem = {
 export type ShopperListState = {
 	items: RawShopperListItem[];
 	isLoading: boolean;
-	error: string | null;
 };
 
 export type AddItemPayload = {
@@ -85,6 +85,7 @@ export type Store = {
 		loadList: ( slug: string ) => Promise< void >;
 		addItem: ( slug: string, payload: AddItemPayload ) => Promise< void >;
 		removeItem: ( slug: string, key: string ) => Promise< void >;
+		showNoticeError: ( error: Error ) => Promise< void >;
 	};
 };
 
@@ -103,7 +104,7 @@ const ensureListState = (
 ): ShopperListState => {
 	let list = state.lists[ slug ];
 	if ( ! list ) {
-		list = { items: [], isLoading: false, error: null };
+		list = { items: [], isLoading: false };
 		state.lists[ slug ] = list;
 	}
 	return list;
@@ -170,14 +171,13 @@ async function restRequest< T >(
 // so an empty-string default would clobber the values seeded server-side via
 // `wp_interactivity_state`. State for those fields comes purely from PHP. Same
 // reason the cart store doesn't ship state defaults — see cart.ts.
-const { state } = store< Store >(
+const { state, actions } = store< Store >(
 	'woocommerce/shopper-lists',
 	{
 		actions: {
 			*loadList( slug: string ): AsyncAction< void > {
 				const list = ensureListState( state, slug );
 				list.isLoading = true;
-				list.error = null;
 
 				try {
 					const response = ( yield restRequest<
@@ -203,7 +203,7 @@ const { state } = store< Store >(
 					// loadList cannot clobber a fresh add/remove.
 					list.items = items;
 				} catch ( error ) {
-					list.error = ( error as Error ).message;
+					actions.showNoticeError( error as Error );
 				} finally {
 					list.isLoading = false;
 				}
@@ -214,7 +214,6 @@ const { state } = store< Store >(
 				payload: AddItemPayload
 			): AsyncAction< void > {
 				const list = ensureListState( state, slug );
-				list.error = null;
 
 				try {
 					const item = ( yield restRequest< RawShopperListItem >(
@@ -249,7 +248,7 @@ const { state } = store< Store >(
 						list.items.push( item );
 					}
 				} catch ( error ) {
-					list.error = ( error as Error ).message;
+					actions.showNoticeError( error as Error );
 				}
 			},
 
@@ -259,18 +258,14 @@ const { state } = store< Store >(
 					return;
 				}
 
-				const removedIndex = list.items.findIndex(
-					( i ) => i.key === key
-				);
-				if ( removedIndex < 0 ) {
+				if ( list.items.findIndex( ( i ) => i.key === key ) < 0 ) {
 					return;
 				}
-				const removed = list.items[ removedIndex ];
 
-				// Optimistic remove.
-				list.items.splice( removedIndex, 1 );
-				list.error = null;
-
+				// Pessimistic remove: leave the row in place until the
+				// server confirms to avoid a disappear/reappear flash on
+				// failure. Buttons are disabled while pending via the
+				// block store's `pendingKeys` context.
 				try {
 					yield restRequest(
 						state,
@@ -280,10 +275,34 @@ const { state } = store< Store >(
 						{ method: 'DELETE' }
 					);
 				} catch ( error ) {
-					// Restore the row at its original position.
-					list.items.splice( removedIndex, 0, removed );
-					list.error = ( error as Error ).message;
+					actions.showNoticeError( error as Error );
+					return;
 				}
+
+				// Re-find — the list may have mutated during the await.
+				const removedIndex = list.items.findIndex(
+					( i ) => i.key === key
+				);
+				if ( removedIndex >= 0 ) {
+					list.items.splice( removedIndex, 1 );
+				}
+			},
+
+			// Mirrors `cart.ts::showNoticeError`.
+			*showNoticeError( error: Error ): AsyncAction< void > {
+				// TODO: import directly once @woocommerce/stores/store-notices is public.
+				yield import( '@woocommerce/stores/store-notices' );
+				const { actions: noticeActions } = store< StoreNotices >(
+					'woocommerce/store-notices',
+					{},
+					{ lock: universalLock }
+				);
+
+				noticeActions.addNotice( {
+					notice: error.message,
+					type: 'error',
+					dismissible: true,
+				} );
 			},
 		},
 	},
@@ -322,5 +341,4 @@ window.addEventListener( 'wc-blocks_store_sync_required', ( event: Event ) => {
 	} else {
 		list.items.push( item );
 	}
-	list.error = null;
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -172,7 +172,7 @@ async function restRequest< T >(
 // so an empty-string default would clobber the values seeded server-side via
 // `wp_interactivity_state`. State for those fields comes purely from PHP. Same
 // reason the cart store doesn't ship state defaults — see cart.ts.
-const { state, actions } = store< Store >(
+const { state } = store< Store >(
 	'woocommerce/shopper-lists',
 	{
 		actions: {
@@ -204,8 +204,12 @@ const { state, actions } = store< Store >(
 					// loadList cannot clobber a fresh add/remove.
 					list.items = items;
 				} catch ( error ) {
-					yield actions.clearNotices();
-					actions.showNoticeError( error as Error );
+					// Background data-load failures don't surface a banner
+					// — there's no user-initiated trigger to attach one to,
+					// and the server message is rarely actionable. Log the
+					// underlying error so it's still discoverable in ops.
+					// eslint-disable-next-line no-console
+					console.error( error );
 				} finally {
 					list.isLoading = false;
 				}
@@ -284,9 +288,14 @@ const { state, actions } = store< Store >(
 				}
 			},
 
-			// Mirrors `cart.ts::showNoticeError`.
+			// Dispatches `error.message` verbatim as a store-notices
+			// banner. Callers are responsible for ensuring the message is
+			// HTML-safe — the notices region renders content via
+			// `innerHTML` (see `store-notices.ts::renderNoticeContent`).
+			// In practice every caller passes a fresh `new Error(...)`
+			// composed from a translated template plus schema-supplied
+			// fields, never raw server-supplied content.
 			*showNoticeError( error: Error ): AsyncAction< void > {
-				// TODO: import directly once @woocommerce/stores/store-notices is public.
 				yield import( '@woocommerce/stores/store-notices' );
 				const { actions: noticeActions } = store< StoreNotices >(
 					'woocommerce/store-notices',
@@ -299,11 +308,6 @@ const { state, actions } = store< Store >(
 					type: 'error',
 					dismissible: true,
 				} );
-
-				// Surface the full Error (with stack) for ops debugging;
-				// the banner only shows the sanitised message.
-				// eslint-disable-next-line no-console
-				console.error( error );
 			},
 
 			// Wipe every notice in the closest store-notices context. Called

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -209,46 +209,44 @@ const { state, actions } = store< Store >(
 				}
 			},
 
+			// Mutations (`addItem`, `removeItem`) intentionally do NOT
+			// catch — they let the caller decide the notice wording so
+			// per-row handlers in shopper-collection's `frontend.ts` can
+			// interpolate the item name. `loadList` still catches because
+			// its callers (page navigation, etc.) have no item context to
+			// add.
 			*addItem(
 				slug: string,
 				payload: AddItemPayload
 			): AsyncAction< void > {
 				const list = ensureListState( state, slug );
 
-				try {
-					const item = ( yield restRequest< RawShopperListItem >(
-						state,
-						`wc/store/v1/shopper-lists/${ encodeURIComponent(
-							slug
-						) }/items`,
-						{
-							method: 'POST',
-							body: JSON.stringify( payload ),
-						}
-					) ) as TypeYield<
-						typeof restRequest< RawShopperListItem >
-					>;
-
-					if ( ! isShopperListItem( item ) ) {
-						throw new Error(
-							'Invalid shopper list item response.'
-						);
+				const item = ( yield restRequest< RawShopperListItem >(
+					state,
+					`wc/store/v1/shopper-lists/${ encodeURIComponent(
+						slug
+					) }/items`,
+					{
+						method: 'POST',
+						body: JSON.stringify( payload ),
 					}
+				) ) as TypeYield< typeof restRequest< RawShopperListItem > >;
 
-					// Merge the returned item by key — replace if present,
-					// append otherwise. Re-saving the same product POSTs
-					// twice and the server merges quantity, so we mirror
-					// that behaviour locally.
-					const existingIndex = list.items.findIndex(
-						( i ) => i.key === item.key
-					);
-					if ( existingIndex >= 0 ) {
-						list.items[ existingIndex ] = item;
-					} else {
-						list.items.push( item );
-					}
-				} catch ( error ) {
-					actions.showNoticeError( error as Error );
+				if ( ! isShopperListItem( item ) ) {
+					throw new Error( 'Invalid shopper list item response.' );
+				}
+
+				// Merge the returned item by key — replace if present,
+				// append otherwise. Re-saving the same product POSTs
+				// twice and the server merges quantity, so we mirror
+				// that behaviour locally.
+				const existingIndex = list.items.findIndex(
+					( i ) => i.key === item.key
+				);
+				if ( existingIndex >= 0 ) {
+					list.items[ existingIndex ] = item;
+				} else {
+					list.items.push( item );
 				}
 			},
 
@@ -265,19 +263,15 @@ const { state, actions } = store< Store >(
 				// Pessimistic remove: leave the row in place until the
 				// server confirms to avoid a disappear/reappear flash on
 				// failure. Buttons are disabled while pending via the
-				// block store's `pendingKeys` context.
-				try {
-					yield restRequest(
-						state,
-						`wc/store/v1/shopper-lists/${ encodeURIComponent(
-							slug
-						) }/items/${ encodeURIComponent( key ) }`,
-						{ method: 'DELETE' }
-					);
-				} catch ( error ) {
-					actions.showNoticeError( error as Error );
-					return;
-				}
+				// block store's `pendingKeys` context. Errors bubble to
+				// the caller so it can compose a contextualised notice.
+				yield restRequest(
+					state,
+					`wc/store/v1/shopper-lists/${ encodeURIComponent(
+						slug
+					) }/items/${ encodeURIComponent( key ) }`,
+					{ method: 'DELETE' }
+				);
 
 				// Re-find — the list may have mutated during the await.
 				const removedIndex = list.items.findIndex(

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -86,6 +86,7 @@ export type Store = {
 		addItem: ( slug: string, payload: AddItemPayload ) => Promise< void >;
 		removeItem: ( slug: string, key: string ) => Promise< void >;
 		showNoticeError: ( error: Error ) => Promise< void >;
+		clearNotices: () => Promise< void >;
 	};
 };
 
@@ -297,6 +298,24 @@ const { state, actions } = store< Store >(
 					type: 'error',
 					dismissible: true,
 				} );
+			},
+
+			// Wipe every notice in the closest store-notices context. Called
+			// at the start of each mutation handler so a stale banner from a
+			// previous attempt doesn't survive a successful retry, and so a
+			// fresh failure replaces the old one instead of stacking. Notice
+			// IDs are snapshotted up front because `removeNotice` splices the
+			// array — iterating live would skip elements.
+			*clearNotices(): AsyncAction< void > {
+				yield import( '@woocommerce/stores/store-notices' );
+				const { state: noticeState, actions: noticeActions } =
+					store< StoreNotices >(
+						'woocommerce/store-notices',
+						{},
+						{ lock: universalLock }
+					);
+				const ids = noticeState.notices.map( ( n ) => n.id );
+				ids.forEach( ( id ) => noticeActions.removeNotice( id ) );
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -86,7 +86,6 @@ export type Store = {
 		addItem: ( slug: string, payload: AddItemPayload ) => Promise< void >;
 		removeItem: ( slug: string, key: string ) => Promise< void >;
 		showNoticeError: ( error: Error ) => Promise< void >;
-		clearNotices: () => Promise< void >;
 	};
 };
 
@@ -172,7 +171,7 @@ async function restRequest< T >(
 // so an empty-string default would clobber the values seeded server-side via
 // `wp_interactivity_state`. State for those fields comes purely from PHP. Same
 // reason the cart store doesn't ship state defaults — see cart.ts.
-const { state } = store< Store >(
+const { state, actions } = store< Store >(
 	'woocommerce/shopper-lists',
 	{
 		actions: {
@@ -204,10 +203,7 @@ const { state } = store< Store >(
 					// loadList cannot clobber a fresh add/remove.
 					list.items = items;
 				} catch ( error ) {
-					// Background data-load failures don't surface a banner
-					// — there's no user-initiated trigger to attach one to,
-					// and the server message is rarely actionable. Log the
-					// underlying error so it's still discoverable in ops.
+					// No user trigger to attach a banner to; log for ops.
 					// eslint-disable-next-line no-console
 					console.error( error );
 				} finally {
@@ -215,44 +211,46 @@ const { state } = store< Store >(
 				}
 			},
 
-			// Mutations (`addItem`, `removeItem`) intentionally do NOT
-			// catch — they let the caller decide the notice wording so
-			// per-row handlers in shopper-collection's `frontend.ts` can
-			// interpolate the item name. `loadList` still catches because
-			// its callers (page navigation, etc.) have no item context to
-			// add.
 			*addItem(
 				slug: string,
 				payload: AddItemPayload
 			): AsyncAction< void > {
 				const list = ensureListState( state, slug );
 
-				const item = ( yield restRequest< RawShopperListItem >(
-					state,
-					`wc/store/v1/shopper-lists/${ encodeURIComponent(
-						slug
-					) }/items`,
-					{
-						method: 'POST',
-						body: JSON.stringify( payload ),
+				try {
+					const item = ( yield restRequest< RawShopperListItem >(
+						state,
+						`wc/store/v1/shopper-lists/${ encodeURIComponent(
+							slug
+						) }/items`,
+						{
+							method: 'POST',
+							body: JSON.stringify( payload ),
+						}
+					) ) as TypeYield<
+						typeof restRequest< RawShopperListItem >
+					>;
+
+					if ( ! isShopperListItem( item ) ) {
+						throw new Error(
+							'Invalid shopper list item response.'
+						);
 					}
-				) ) as TypeYield< typeof restRequest< RawShopperListItem > >;
 
-				if ( ! isShopperListItem( item ) ) {
-					throw new Error( 'Invalid shopper list item response.' );
-				}
-
-				// Merge the returned item by key — replace if present,
-				// append otherwise. Re-saving the same product POSTs
-				// twice and the server merges quantity, so we mirror
-				// that behaviour locally.
-				const existingIndex = list.items.findIndex(
-					( i ) => i.key === item.key
-				);
-				if ( existingIndex >= 0 ) {
-					list.items[ existingIndex ] = item;
-				} else {
-					list.items.push( item );
+					// Merge the returned item by key — replace if present,
+					// append otherwise. Re-saving the same product POSTs
+					// twice and the server merges quantity, so we mirror
+					// that behaviour locally.
+					const existingIndex = list.items.findIndex(
+						( i ) => i.key === item.key
+					);
+					if ( existingIndex >= 0 ) {
+						list.items[ existingIndex ] = item;
+					} else {
+						list.items.push( item );
+					}
+				} catch ( error ) {
+					actions.showNoticeError( error as Error );
 				}
 			},
 
@@ -267,17 +265,20 @@ const { state } = store< Store >(
 				}
 
 				// Pessimistic remove: leave the row in place until the
-				// server confirms to avoid a disappear/reappear flash on
-				// failure. Buttons are disabled while pending via the
-				// block store's `pendingKeys` context. Errors bubble to
-				// the caller so it can compose a contextualised notice.
-				yield restRequest(
-					state,
-					`wc/store/v1/shopper-lists/${ encodeURIComponent(
-						slug
-					) }/items/${ encodeURIComponent( key ) }`,
-					{ method: 'DELETE' }
-				);
+				// server confirms, so failures don't flash. Buttons are
+				// disabled meanwhile via the block's `pendingKeys`.
+				try {
+					yield restRequest(
+						state,
+						`wc/store/v1/shopper-lists/${ encodeURIComponent(
+							slug
+						) }/items/${ encodeURIComponent( key ) }`,
+						{ method: 'DELETE' }
+					);
+				} catch ( error ) {
+					actions.showNoticeError( error as Error );
+					return;
+				}
 
 				// Re-find — the list may have mutated during the await.
 				const removedIndex = list.items.findIndex(
@@ -288,13 +289,7 @@ const { state } = store< Store >(
 				}
 			},
 
-			// Dispatches `error.message` verbatim as a store-notices
-			// banner. Callers are responsible for ensuring the message is
-			// HTML-safe — the notices region renders content via
-			// `innerHTML` (see `store-notices.ts::renderNoticeContent`).
-			// In practice every caller passes a fresh `new Error(...)`
-			// composed from a translated template plus schema-supplied
-			// fields, never raw server-supplied content.
+			// Mirrors `cart.ts::showNoticeError`.
 			*showNoticeError( error: Error ): AsyncAction< void > {
 				yield import( '@woocommerce/stores/store-notices' );
 				const { actions: noticeActions } = store< StoreNotices >(
@@ -308,24 +303,9 @@ const { state } = store< Store >(
 					type: 'error',
 					dismissible: true,
 				} );
-			},
 
-			// Wipe every notice in the closest store-notices context. Called
-			// at the start of each mutation handler so a stale banner from a
-			// previous attempt doesn't survive a successful retry, and so a
-			// fresh failure replaces the old one instead of stacking. Notice
-			// IDs are snapshotted up front because `removeNotice` splices the
-			// array — iterating live would skip elements.
-			*clearNotices(): AsyncAction< void > {
-				yield import( '@woocommerce/stores/store-notices' );
-				const { state: noticeState, actions: noticeActions } =
-					store< StoreNotices >(
-						'woocommerce/store-notices',
-						{},
-						{ lock: universalLock }
-					);
-				const ids = noticeState.notices.map( ( n ) => n.id );
-				ids.forEach( ( id ) => noticeActions.removeNotice( id ) );
+				// eslint-disable-next-line no-console
+				console.error( error );
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -8,6 +8,7 @@ import {
 	store,
 	type AsyncAction,
 } from '@wordpress/interactivity';
+import { __, sprintf } from '@wordpress/i18n';
 import '@woocommerce/stores/woocommerce/shopper-lists';
 import '@woocommerce/stores/woocommerce/cart';
 import type {
@@ -231,6 +232,25 @@ store< BlockStore >(
 						listSlug,
 						listItem.key
 					);
+				} catch ( error ) {
+					// `listItem.name` is already wp_kses'd by the schema
+					// (`HtmlFormatter::format`) and `error.message` originates
+					// from a server-side WP_Error, so both are safe for the
+					// notice region's innerHTML render path. Same trust model
+					// as cart.ts::showNoticeError.
+					yield shopperListsActions.showNoticeError(
+						new Error(
+							sprintf(
+								/* translators: 1: item name. 2: error message from the server. */
+								__(
+									'Couldn’t remove “%1$s” from your saved list: %2$s',
+									'woocommerce'
+								),
+								listItem.name,
+								( error as Error ).message
+							)
+						)
+					);
 				} finally {
 					delete pendingKeys[ listItem.key ];
 				}
@@ -291,10 +311,29 @@ store< BlockStore >(
 						return;
 					}
 
-					yield shopperListsActions.removeItem(
-						listSlug,
-						listItem.key
-					);
+					try {
+						yield shopperListsActions.removeItem(
+							listSlug,
+							listItem.key
+						);
+					} catch ( error ) {
+						// Cart-add already succeeded — only the saved-list
+						// cleanup failed. Surface the item context so the
+						// shopper knows which row is still hanging around.
+						yield shopperListsActions.showNoticeError(
+							new Error(
+								sprintf(
+									/* translators: 1: item name. 2: error message from the server. */
+									__(
+										'Couldn’t remove “%1$s” from your saved list: %2$s',
+										'woocommerce'
+									),
+									listItem.name,
+									( error as Error ).message
+								)
+							)
+						);
+					}
 				} finally {
 					delete pendingKeys[ listItem.key ];
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -23,7 +23,6 @@ const universalLock =
 type ShopperCollectionConfig = {
 	quantityLabelTemplate: string;
 	removeLabelTemplate: string;
-	removeErrorTemplate: string;
 };
 
 type BlockContext = {
@@ -228,33 +227,10 @@ store< BlockStore >(
 				}
 				pendingKeys[ listItem.key ] = true;
 				try {
-					yield shopperListsActions.clearNotices();
 					yield shopperListsActions.removeItem(
 						listSlug,
 						listItem.key
 					);
-				} catch ( error ) {
-					// Surface a generic, item-scoped notice. The
-					// underlying error is console-logged for ops/debug
-					// but not shown to the shopper: server messages on
-					// these routes (auth, nonce, internal errors) are
-					// rarely actionable for end users, and routing
-					// extension-supplied WP_Error content into the
-					// store-notices innerHTML render path is a trust
-					// surface we'd rather not maintain. Template comes
-					// from PHP (`wp_interactivity_config`) because iAPI
-					// script modules can't import `@wordpress/i18n`;
-					// `listItem.name` is wp_kses'd by the schema.
-					const { removeErrorTemplate } = getConfig(
-						'woocommerce/shopper-collection'
-					) as ShopperCollectionConfig;
-					yield shopperListsActions.showNoticeError(
-						new Error(
-							removeErrorTemplate.replace( '%s', listItem.name )
-						)
-					);
-					// eslint-disable-next-line no-console
-					console.error( error );
 				} finally {
 					delete pendingKeys[ listItem.key ];
 				}
@@ -301,7 +277,6 @@ store< BlockStore >(
 
 				pendingKeys[ listItem.key ] = true;
 				try {
-					yield shopperListsActions.clearNotices();
 					yield cartActions.addCartItem( {
 						id: listItem.id,
 						quantityToAdd: listItem.quantity,
@@ -316,31 +291,10 @@ store< BlockStore >(
 						return;
 					}
 
-					try {
-						yield shopperListsActions.removeItem(
-							listSlug,
-							listItem.key
-						);
-					} catch ( error ) {
-						// Cart-add already succeeded — only the saved-list
-						// cleanup failed. Surface the item context so the
-						// shopper knows which row is still hanging around;
-						// underlying error goes to the console only (same
-						// rationale as `onClickRemove`).
-						const { removeErrorTemplate } = getConfig(
-							'woocommerce/shopper-collection'
-						) as ShopperCollectionConfig;
-						yield shopperListsActions.showNoticeError(
-							new Error(
-								removeErrorTemplate.replace(
-									'%s',
-									listItem.name
-								)
-							)
-						);
-						// eslint-disable-next-line no-console
-						console.error( error );
-					}
+					yield shopperListsActions.removeItem(
+						listSlug,
+						listItem.key
+					);
 				} finally {
 					delete pendingKeys[ listItem.key ];
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -228,6 +228,7 @@ store< BlockStore >(
 				}
 				pendingKeys[ listItem.key ] = true;
 				try {
+					yield shopperListsActions.clearNotices();
 					yield shopperListsActions.removeItem(
 						listSlug,
 						listItem.key
@@ -247,10 +248,7 @@ store< BlockStore >(
 						new Error(
 							removeErrorTemplate
 								.replace( '%1$s', listItem.name )
-								.replace(
-									'%2$s',
-									( error as Error ).message
-								)
+								.replace( '%2$s', ( error as Error ).message )
 						)
 					);
 				} finally {
@@ -299,6 +297,7 @@ store< BlockStore >(
 
 				pendingKeys[ listItem.key ] = true;
 				try {
+					yield shopperListsActions.clearNotices();
 					yield cartActions.addCartItem( {
 						id: listItem.id,
 						quantityToAdd: listItem.quantity,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -234,23 +234,27 @@ store< BlockStore >(
 						listItem.key
 					);
 				} catch ( error ) {
-					// `listItem.name` is already wp_kses'd by the schema
-					// (`HtmlFormatter::format`) and `error.message` originates
-					// from a server-side WP_Error, so both are safe for the
-					// notice region's innerHTML render path. Same trust model
-					// as cart.ts::showNoticeError. Template comes from PHP
-					// (`wp_interactivity_config`) because iAPI script modules
-					// can't import `@wordpress/i18n`.
+					// Surface a generic, item-scoped notice. The
+					// underlying error is console-logged for ops/debug
+					// but not shown to the shopper: server messages on
+					// these routes (auth, nonce, internal errors) are
+					// rarely actionable for end users, and routing
+					// extension-supplied WP_Error content into the
+					// store-notices innerHTML render path is a trust
+					// surface we'd rather not maintain. Template comes
+					// from PHP (`wp_interactivity_config`) because iAPI
+					// script modules can't import `@wordpress/i18n`;
+					// `listItem.name` is wp_kses'd by the schema.
 					const { removeErrorTemplate } = getConfig(
 						'woocommerce/shopper-collection'
 					) as ShopperCollectionConfig;
 					yield shopperListsActions.showNoticeError(
 						new Error(
-							removeErrorTemplate
-								.replace( '%1$s', listItem.name )
-								.replace( '%2$s', ( error as Error ).message )
+							removeErrorTemplate.replace( '%s', listItem.name )
 						)
 					);
+					// eslint-disable-next-line no-console
+					console.error( error );
 				} finally {
 					delete pendingKeys[ listItem.key ];
 				}
@@ -320,20 +324,22 @@ store< BlockStore >(
 					} catch ( error ) {
 						// Cart-add already succeeded — only the saved-list
 						// cleanup failed. Surface the item context so the
-						// shopper knows which row is still hanging around.
+						// shopper knows which row is still hanging around;
+						// underlying error goes to the console only (same
+						// rationale as `onClickRemove`).
 						const { removeErrorTemplate } = getConfig(
 							'woocommerce/shopper-collection'
 						) as ShopperCollectionConfig;
 						yield shopperListsActions.showNoticeError(
 							new Error(
-								removeErrorTemplate
-									.replace( '%1$s', listItem.name )
-									.replace(
-										'%2$s',
-										( error as Error ).message
-									)
+								removeErrorTemplate.replace(
+									'%s',
+									listItem.name
+								)
 							)
 						);
+						// eslint-disable-next-line no-console
+						console.error( error );
 					}
 				} finally {
 					delete pendingKeys[ listItem.key ];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -34,13 +34,14 @@ type BlockContext = {
 	hasShownItems: boolean;
 	listItem?: RawShopperListItem;
 	htmlField?: 'price_html' | 'image_html';
+	// Item keys currently mid-mutation, used to disable per-row buttons.
+	pendingKeys: Record< string, true >;
 };
 
 type BlockStore = {
 	state: {
 		currentItems: RawShopperListItem[];
-		hasError: boolean;
-		errorMessage: string;
+		isCurrentItemPending: boolean;
 		isEmpty: boolean;
 		isMoveToCartHidden: boolean;
 		isPriceHidden: boolean;
@@ -141,14 +142,9 @@ store< BlockStore >(
 				return getList( listSlug )?.items ?? [];
 			},
 
-			get hasError(): boolean {
-				const { listSlug } = getContext< BlockContext >();
-				return !! getList( listSlug )?.error;
-			},
-
-			get errorMessage(): string {
-				const { listSlug } = getContext< BlockContext >();
-				return getList( listSlug )?.error ?? '';
+			get isCurrentItemPending(): boolean {
+				const { listItem, pendingKeys } = getContext< BlockContext >();
+				return !! listItem && !! pendingKeys[ listItem.key ];
 			},
 
 			get isEmpty(): boolean {
@@ -224,16 +220,30 @@ store< BlockStore >(
 
 		actions: {
 			*onClickRemove(): AsyncAction< void > {
-				const { listSlug, listItem } = getContext< BlockContext >();
-				if ( ! listItem ) {
+				const { listSlug, listItem, pendingKeys } =
+					getContext< BlockContext >();
+				if ( ! listItem || pendingKeys[ listItem.key ] ) {
 					return;
 				}
-				yield shopperListsActions.removeItem( listSlug, listItem.key );
+				pendingKeys[ listItem.key ] = true;
+				try {
+					yield shopperListsActions.removeItem(
+						listSlug,
+						listItem.key
+					);
+				} finally {
+					delete pendingKeys[ listItem.key ];
+				}
 			},
 
 			*onClickMoveToCart(): AsyncAction< void > {
-				const { listSlug, listItem } = getContext< BlockContext >();
-				if ( ! listItem || ! listItem.is_purchasable ) {
+				const { listSlug, listItem, pendingKeys } =
+					getContext< BlockContext >();
+				if (
+					! listItem ||
+					! listItem.is_purchasable ||
+					pendingKeys[ listItem.key ]
+				) {
 					return;
 				}
 
@@ -265,21 +275,29 @@ store< BlockStore >(
 				const beforeItem = cartState.findItemInCart( lookup );
 				const beforeQuantity = beforeItem?.quantity ?? 0;
 
-				yield cartActions.addCartItem( {
-					id: listItem.id,
-					quantityToAdd: listItem.quantity,
-					type: isVariation ? 'variation' : 'simple',
-					...( isVariation && { variation } ),
-				} );
+				pendingKeys[ listItem.key ] = true;
+				try {
+					yield cartActions.addCartItem( {
+						id: listItem.id,
+						quantityToAdd: listItem.quantity,
+						type: isVariation ? 'variation' : 'simple',
+						...( isVariation && { variation } ),
+					} );
 
-				const afterItem = cartState.findItemInCart( lookup );
-				const afterQuantity = afterItem?.quantity ?? 0;
+					const afterItem = cartState.findItemInCart( lookup );
+					const afterQuantity = afterItem?.quantity ?? 0;
 
-				if ( afterQuantity <= beforeQuantity ) {
-					return;
+					if ( afterQuantity <= beforeQuantity ) {
+						return;
+					}
+
+					yield shopperListsActions.removeItem(
+						listSlug,
+						listItem.key
+					);
+				} finally {
+					delete pendingKeys[ listItem.key ];
 				}
-
-				yield shopperListsActions.removeItem( listSlug, listItem.key );
 			},
 		},
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -8,7 +8,6 @@ import {
 	store,
 	type AsyncAction,
 } from '@wordpress/interactivity';
-import { __, sprintf } from '@wordpress/i18n';
 import '@woocommerce/stores/woocommerce/shopper-lists';
 import '@woocommerce/stores/woocommerce/cart';
 import type {
@@ -24,6 +23,7 @@ const universalLock =
 type ShopperCollectionConfig = {
 	quantityLabelTemplate: string;
 	removeLabelTemplate: string;
+	removeErrorTemplate: string;
 };
 
 type BlockContext = {
@@ -237,18 +237,20 @@ store< BlockStore >(
 					// (`HtmlFormatter::format`) and `error.message` originates
 					// from a server-side WP_Error, so both are safe for the
 					// notice region's innerHTML render path. Same trust model
-					// as cart.ts::showNoticeError.
+					// as cart.ts::showNoticeError. Template comes from PHP
+					// (`wp_interactivity_config`) because iAPI script modules
+					// can't import `@wordpress/i18n`.
+					const { removeErrorTemplate } = getConfig(
+						'woocommerce/shopper-collection'
+					) as ShopperCollectionConfig;
 					yield shopperListsActions.showNoticeError(
 						new Error(
-							sprintf(
-								/* translators: 1: item name. 2: error message from the server. */
-								__(
-									'Couldn’t remove “%1$s” from your saved list: %2$s',
-									'woocommerce'
-								),
-								listItem.name,
-								( error as Error ).message
-							)
+							removeErrorTemplate
+								.replace( '%1$s', listItem.name )
+								.replace(
+									'%2$s',
+									( error as Error ).message
+								)
 						)
 					);
 				} finally {
@@ -320,17 +322,17 @@ store< BlockStore >(
 						// Cart-add already succeeded — only the saved-list
 						// cleanup failed. Surface the item context so the
 						// shopper knows which row is still hanging around.
+						const { removeErrorTemplate } = getConfig(
+							'woocommerce/shopper-collection'
+						) as ShopperCollectionConfig;
 						yield shopperListsActions.showNoticeError(
 							new Error(
-								sprintf(
-									/* translators: 1: item name. 2: error message from the server. */
-									__(
-										'Couldn’t remove “%1$s” from your saved list: %2$s',
-										'woocommerce'
-									),
-									listItem.name,
-									( error as Error ).message
-								)
+								removeErrorTemplate
+									.replace( '%1$s', listItem.name )
+									.replace(
+										'%2$s',
+										( error as Error ).message
+									)
 							)
 						);
 					}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -152,12 +152,3 @@ $grid-gap: var(--wp--style--block-gap, 1.5em);
 	padding: 1em 0;
 	text-align: left;
 }
-
-// Notices region is a block-level sibling of the items `<ul>`, not a grid
-// cell, so it spans naturally without `grid-column: 1 / -1`. The PHP
-// emits the wrapper with `hidden` and `data-wp-bind--hidden="!context.notices.length"`,
-// so on first paint and whenever the notices array is empty the entire
-// region collapses — no empty banner box reserving space above the list.
-.wc-block-shopper-collection__notices {
-	list-style: none;
-}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -153,12 +153,11 @@ $grid-gap: var(--wp--style--block-gap, 1.5em);
 	text-align: left;
 }
 
-// Error state spans every grid column so it reads as a single alert
-// rather than a badly-sized cell when the collection has a multi-column
-// layout. Same treatment as the empty state above for symmetry.
-.wc-block-shopper-collection__error {
-	color: #b91c1c;
-	grid-column: 1 / -1;
-	padding: 1em 0;
-	text-align: center;
+// Notices region is a block-level sibling of the items `<ul>`, not a grid
+// cell, so it spans naturally without `grid-column: 1 / -1`. The PHP
+// emits the wrapper with `hidden` and `data-wp-bind--hidden="!context.notices.length"`,
+// so on first paint and whenever the notices array is empty the entire
+// region collapses — no empty banner box reserving space above the list.
+.wc-block-shopper-collection__notices {
+	list-style: none;
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -224,8 +224,9 @@ final class ShopperCollection extends AbstractBlock {
 		wp_interactivity_config(
 			'woocommerce/shopper-collection',
 			array(
-				'quantityLabelTemplate' => $variation['quantityLabelTemplate'],
-				'removeLabelTemplate'   => $variation['removeLabelTemplate'],
+				'quantityLabelTemplate'   => $variation['quantityLabelTemplate'],
+				'removeLabelTemplate'     => $variation['removeLabelTemplate'],
+				'removeErrorTemplate'     => $variation['removeErrorTemplate'],
 			)
 		);
 
@@ -319,6 +320,8 @@ final class ShopperCollection extends AbstractBlock {
 			'removeLabelTemplate'   => __( 'Remove %s from Saved for later list', 'woocommerce' ),
 			/* translators: %d: quantity of saved items. */
 			'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
+			/* translators: 1: product name. 2: error message from the server. */
+			'removeErrorTemplate'   => __( 'Couldn’t remove “%1$s” from your saved list: %2$s', 'woocommerce' ),
 			'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
 			'actionDirective'       => 'actions.onClickMoveToCart',
 			'showAction'            => true,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -242,19 +242,37 @@ final class ShopperCollection extends AbstractBlock {
 		// flag is set *and* the list is currently empty. The flag lives in
 		// the per-block context, so it naturally resets on every full page
 		// load — no extra Store API field or persisted flag needed.
+		// `data-wp-context---notices` seeds the store-notices namespace
+		// on the `<section>` wrapper so a single ancestor scopes both the
+		// `woocommerce/shopper-collection` context (per-block state) and
+		// the `woocommerce/store-notices` context (the notices array). The
+		// notices region and the per-row mutation handlers below share
+		// this ancestor for context resolution — same shape mini-cart and
+		// AddToCartWithOptions use.
 		$wrapper_attributes = array(
-			'class'               => $wrapper_class,
-			'data-wp-interactive' => 'woocommerce/shopper-collection',
-			'data-wp-context'     => (string) wp_json_encode(
+			'class'                     => $wrapper_class,
+			'data-wp-interactive'       => 'woocommerce/shopper-collection',
+			'data-wp-context'           => (string) wp_json_encode(
 				array(
 					'listSlug'      => $list_slug,
 					'hasShownItems' => ! empty( $items ),
+					// Keyed map of item keys mid-mutation. The block store
+					// flips an entry on at the start of `onClickRemove` /
+					// `onClickMoveToCart` and clears it in a `finally`, so a
+					// per-row `state.isCurrentItemPending` getter can drive
+					// `data-wp-bind--disabled` on the trash and Move-to-cart
+					// buttons. `stdClass` so the empty value serialises as
+					// `{}` instead of `[]` — iAPI's reactive proxy treats
+					// arrays and objects differently, and arbitrary string-
+					// key writes only fire updates on objects.
+					'pendingKeys'   => new \stdClass(),
 				)
 			),
-			'data-wp-watch'       => 'callbacks.trackShownItems',
+			'data-wp-context---notices' => 'woocommerce/store-notices::' . (string) wp_json_encode( array( 'notices' => array() ) ),
+			'data-wp-watch'             => 'callbacks.trackShownItems',
 			// Deterministic key derived from the list slug so iAPI router
 			// navigations land on the same block identity across renders.
-			'data-wp-key'         => $this->get_full_block_name() . '-' . $list_slug,
+			'data-wp-key'               => $this->get_full_block_name() . '-' . $list_slug,
 		);
 
 		$list_class = sprintf( 'wc-block-shopper-collection__list columns-%d', $column_count );
@@ -267,13 +285,13 @@ final class ShopperCollection extends AbstractBlock {
 		// would be visible even on a fresh empty page, with no list under
 		// it — visually disconnected from anything.
 		return sprintf(
-			'<section %1$s>%6$s<ul class="%7$s">%2$s%3$s%4$s%5$s</ul></section>',
+			'<section %1$s>%5$s%6$s<ul class="%7$s">%2$s%3$s%4$s</ul></section>',
 			get_block_wrapper_attributes( $wrapper_attributes ),
 			$this->render_template_markup( $variation ),
 			$this->render_items_markup( $items, $variation ),
 			$this->render_empty_markup( $variation ),
-			$this->render_error_markup(),
 			$this->render_header_markup( $content, empty( $items ) ),
+			$this->render_interactivity_notices_region(),
 			esc_attr( $list_class )
 		);
 	}
@@ -614,27 +632,48 @@ final class ShopperCollection extends AbstractBlock {
 	}
 
 	/**
-	 * Render the error-state markup. Hidden on initial paint and toggled on
-	 * by the JS-side `state.hasError` getter when a request fails. The text
-	 * content is left empty here on purpose: errors only happen post-hydration,
-	 * and `data-wp-text="state.errorMessage"` writes the actual server-supplied
-	 * message — surfacing that is more useful than a generic fallback.
-	 *
-	 * phpcs:disable Generic.Commenting.Todo.TaskFound
-	 *
-	 * TODO: replace this in-list error row with a `store-notices` notice
-	 * rendered above the list. Mini-cart's pattern (cart.ts → showNoticeError →
-	 * `@woocommerce/stores/store-notices`) is the right reference: dispatch
-	 * the server message there from the JS catch blocks in shopper-lists.ts
-	 * instead of holding it on `list.error`. That gives users a dismissible,
-	 * stylistically-aligned notice rather than a row tucked into the grid.
-	 *
-	 * phpcs:enable Generic.Commenting.Todo.TaskFound
+	 * Render the iAPI store-notices region. Sibling of the items `<ul>` so
+	 * the banner reads as a block-level alert, not a list item. Mirrors
+	 * `AddToCartWithOptions::render_interactivity_notices_region()` — keep
+	 * in sync if the shape changes. The shopper-lists store dispatches
+	 * `addNotice` through `woocommerce/store-notices` on mutation failures,
+	 * and the `<template data-wp-each--notice>` below renders each one.
 	 *
 	 * @return string
 	 */
-	private function render_error_markup(): string {
-		return '<li class="wc-block-shopper-collection__error" role="alert" data-wp-bind--hidden="!state.hasError" data-wp-text="state.errorMessage" hidden></li>';
+	private function render_interactivity_notices_region(): string {
+		ob_start();
+		?>
+		<div class="wc-block-shopper-collection__notices wc-block-components-notices" data-wp-interactive="woocommerce/store-notices" data-wp-bind--hidden="!context.notices.length" hidden>
+			<template data-wp-each--notice="context.notices" data-wp-each-key="context.notice.id">
+				<div
+					class="wc-block-components-notice-banner"
+					data-wp-class--is-error="state.isError"
+					data-wp-class--is-success="state.isSuccess"
+					data-wp-class--is-info="state.isInfo"
+					data-wp-class--is-dismissible="context.notice.dismissible"
+					data-wp-bind--role="state.role"
+					data-wp-watch="callbacks.injectIcon"
+				>
+					<div class="wc-block-components-notice-banner__content">
+						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive" aria-atomic="true"></span>
+					</div>
+					<button
+						type="button"
+						data-wp-bind--hidden="!context.notice.dismissible"
+						class="wc-block-components-button wp-element-button wc-block-components-notice-banner__dismiss contained"
+						aria-label="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce' ); ?>"
+						data-wp-on--click="actions.removeNotice"
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+							<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z" />
+						</svg>
+					</button>
+				</div>
+			</template>
+		</div>
+		<?php
+		return (string) ob_get_clean();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -224,9 +224,9 @@ final class ShopperCollection extends AbstractBlock {
 		wp_interactivity_config(
 			'woocommerce/shopper-collection',
 			array(
-				'quantityLabelTemplate'   => $variation['quantityLabelTemplate'],
-				'removeLabelTemplate'     => $variation['removeLabelTemplate'],
-				'removeErrorTemplate'     => $variation['removeErrorTemplate'],
+				'quantityLabelTemplate' => $variation['quantityLabelTemplate'],
+				'removeLabelTemplate'   => $variation['removeLabelTemplate'],
+				'removeErrorTemplate'   => $variation['removeErrorTemplate'],
 			)
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -196,7 +196,6 @@ final class ShopperCollection extends AbstractBlock {
 					$list_slug => array(
 						'items'     => $items,
 						'isLoading' => false,
-						'error'     => null,
 					),
 				),
 			)
@@ -415,6 +414,7 @@ final class ShopperCollection extends AbstractBlock {
 						class="wc-block-shopper-collection-item__remove"
 						data-wp-on--click="actions.onClickRemove"
 						data-wp-bind--aria-label="state.currentItemRemoveLabel"
+						data-wp-bind--disabled="state.isCurrentItemPending"
 					>
 						<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
 					</button>
@@ -431,6 +431,7 @@ final class ShopperCollection extends AbstractBlock {
 							type="button"
 							class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
 							data-wp-on--click="<?php echo esc_attr( $variation['actionDirective'] ); ?>"
+							data-wp-bind--disabled="state.isCurrentItemPending"
 						>
 							<?php echo esc_html( $variation['actionLabel'] ); ?>
 						</button>
@@ -525,6 +526,7 @@ final class ShopperCollection extends AbstractBlock {
 					aria-label="<?php echo esc_attr( $remove_aria ); ?>"
 					data-wp-on--click="actions.onClickRemove"
 					data-wp-bind--aria-label="state.currentItemRemoveLabel"
+					data-wp-bind--disabled="state.isCurrentItemPending"
 				>
 					<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
 				</button>
@@ -584,6 +586,7 @@ final class ShopperCollection extends AbstractBlock {
 					type="button"
 					class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
 					data-wp-on--click="<?php echo esc_attr( $variation['actionDirective'] ); ?>"
+					data-wp-bind--disabled="state.isCurrentItemPending"
 				>
 					<?php echo esc_html( $variation['actionLabel'] ); ?>
 				</button>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -225,7 +225,6 @@ final class ShopperCollection extends AbstractBlock {
 			array(
 				'quantityLabelTemplate' => $variation['quantityLabelTemplate'],
 				'removeLabelTemplate'   => $variation['removeLabelTemplate'],
-				'removeErrorTemplate'   => $variation['removeErrorTemplate'],
 			)
 		);
 
@@ -243,12 +242,7 @@ final class ShopperCollection extends AbstractBlock {
 		// the per-block context, so it naturally resets on every full page
 		// load — no extra Store API field or persisted flag needed.
 		// `data-wp-context---notices` seeds the store-notices namespace
-		// on the `<section>` wrapper so a single ancestor scopes both the
-		// `woocommerce/shopper-collection` context (per-block state) and
-		// the `woocommerce/store-notices` context (the notices array). The
-		// notices region and the per-row mutation handlers below share
-		// this ancestor for context resolution — same shape mini-cart and
-		// AddToCartWithOptions use.
+		// alongside the block's own context on the same wrapper.
 		$wrapper_attributes = array(
 			'class'                     => $wrapper_class,
 			'data-wp-interactive'       => 'woocommerce/shopper-collection',
@@ -256,15 +250,9 @@ final class ShopperCollection extends AbstractBlock {
 				array(
 					'listSlug'      => $list_slug,
 					'hasShownItems' => ! empty( $items ),
-					// Keyed map of item keys mid-mutation. The block store
-					// flips an entry on at the start of `onClickRemove` /
-					// `onClickMoveToCart` and clears it in a `finally`, so a
-					// per-row `state.isCurrentItemPending` getter can drive
-					// `data-wp-bind--disabled` on the trash and Move-to-cart
-					// buttons. `stdClass` so the empty value serialises as
-					// `{}` instead of `[]` — iAPI's reactive proxy treats
-					// arrays and objects differently, and arbitrary string-
-					// key writes only fire updates on objects.
+					// `stdClass` so it serialises as `{}`, not `[]` —
+					// iAPI's reactive proxy only fires updates on object
+					// writes, not array expandos.
 					'pendingKeys'   => new \stdClass(),
 				)
 			),
@@ -319,8 +307,6 @@ final class ShopperCollection extends AbstractBlock {
 			'removeLabelTemplate'   => __( 'Remove %s from Saved for later list', 'woocommerce' ),
 			/* translators: %d: quantity of saved items. */
 			'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
-			/* translators: %s: product name. */
-			'removeErrorTemplate'   => __( 'Couldn’t remove “%s” from your saved list. Please try again.', 'woocommerce' ),
 			'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
 			'actionDirective'       => 'actions.onClickMoveToCart',
 			'showAction'            => true,
@@ -638,12 +624,9 @@ final class ShopperCollection extends AbstractBlock {
 	}
 
 	/**
-	 * Render the iAPI store-notices region. Sibling of the items `<ul>` so
-	 * the banner reads as a block-level alert, not a list item. Mirrors
-	 * `AddToCartWithOptions::render_interactivity_notices_region()` — keep
-	 * in sync if the shape changes. The shopper-lists store dispatches
-	 * `addNotice` through `woocommerce/store-notices` on mutation failures,
-	 * and the `<template data-wp-each--notice>` below renders each one.
+	 * Render the iAPI store-notices region. Mirrors
+	 * `AddToCartWithOptions::render_interactivity_notices_region()` —
+	 * keep in sync if the shape changes.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -319,8 +319,8 @@ final class ShopperCollection extends AbstractBlock {
 			'removeLabelTemplate'   => __( 'Remove %s from Saved for later list', 'woocommerce' ),
 			/* translators: %d: quantity of saved items. */
 			'quantityLabelTemplate' => __( 'Quantity: %d', 'woocommerce' ),
-			/* translators: 1: product name. 2: error message from the server. */
-			'removeErrorTemplate'   => __( 'Couldn’t remove “%1$s” from your saved list: %2$s', 'woocommerce' ),
+			/* translators: %s: product name. */
+			'removeErrorTemplate'   => __( 'Couldn’t remove “%s” from your saved list. Please try again.', 'woocommerce' ),
 			'actionLabel'           => __( 'Move to cart', 'woocommerce' ),
 			'actionDirective'       => 'actions.onClickMoveToCart',
 			'showAction'            => true,

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -132,7 +132,7 @@ class ShopperListItems extends AbstractRoute {
 	protected function get_route_response( \WP_REST_Request $request ) {
 		$list = ShopperList::get_by_slug( (string) $request['slug'] );
 		if ( ! $list ) {
-			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Your saved list isn\'t available right now.', 'woocommerce' ), 404 );
 		}
 
 		$items = array_values( $list->get_items() );
@@ -161,7 +161,7 @@ class ShopperListItems extends AbstractRoute {
 		$list = ShopperList::get_by_slug( (string) $request['slug'] );
 
 		if ( ! $list ) {
-			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Your saved list isn\'t available right now.', 'woocommerce' ), 404 );
 		}
 
 		[ $lookup_id, $variation, $quantity ] = $this->resolve_item_payload( $request );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -88,11 +88,11 @@ class ShopperListItemsByKey extends AbstractRoute {
 		$list = ShopperList::get_by_slug( (string) $request['slug'] );
 
 		if ( ! $list ) {
-			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Your saved list isn\'t available right now.', 'woocommerce' ), 404 );
 		}
 
 		if ( ! $list->remove_item( (string) $request['key'] ) ) {
-			throw new RouteException( 'woocommerce_rest_shopper_list_item_not_found', esc_html__( 'No saved item exists for the supplied key.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_shopper_list_item_not_found', esc_html__( 'That item isn\'t in your saved list anymore.', 'woocommerce' ), 404 );
 		}
 
 		$list->save();

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
@@ -84,7 +84,7 @@ class ShopperListsBySlug extends AbstractRoute {
 		$list = ShopperList::get_by_slug( (string) $request['slug'] );
 
 		if ( ! $list ) {
-			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Shopper list not found.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_shopper_list_not_found', esc_html__( 'Your saved list isn\'t available right now.', 'woocommerce' ), 404 );
 		}
 
 		return rest_ensure_response( $this->prepare_item_for_response( $list, $request ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Replaces the in-list error row on the shopper collection block with an iAPI store-notices region rendered above the items. The `woocommerce/shopper-lists` store now dispatches `showNoticeError` from its catch blocks, and the list seeds a `woocommerce/store-notices`-namespaced context via `data-wp-context---notices` so banners write into the block's own notices array.

The `showNoticeError` action mirrors `cart.ts::showNoticeError` and the banner markup on the PHP side mirrors `AddToCartWithOptions::render_interactivity_notices_region()`.

This PR also changes the removal operation to be **pessimistic** so the row stays in place until the DELETE confirms to prevent flashes of content (items disappearing and reappearing in the grid when the request failed). Via `pendingKeys` we now handle items that are mid-mutation.

Closes WOOPRD-3525.


### How to test the changes in this Pull Request:

1. Enable the **Save for Later in Cart** feature at **WooCommerce → Settings → Advanced → Features**.
2. Log in as a shopper and add a few products to the cart.
3. On the cart page, click the **Save for later** link on one or two cart line items so they move into the **Saved for later** block that auto-injects below the cart.
4. To simulate server-side failures, drop the snippet below into `wp-content/mu-plugins/wc-shopper-lists-error-sim.php`. It forces both the add and remove endpoints to return an error. Delete the file when done testing.
    ```php
    <?php
    add_filter( 'rest_pre_dispatch', function ( $result, $server, $request ) {
        $route  = $request->get_route();
        $method = $request->get_method();
        $is_add    = 'POST' === $method   && preg_match( '#^/wc/store/v1/shopper-lists/[^/]+/items$#', $route );
        $is_remove = 'DELETE' === $method && preg_match( '#^/wc/store/v1/shopper-lists/[^/]+/items/[^/]+$#', $route );
        if ( $is_add || $is_remove ) {
            return new WP_Error(
                'woocommerce_rest_shopper_list_simulated_error',
                'List is temporarily unavailable.',
                array( 'status' => 500 )
            );
        }
        return $result;
    }, 10, 3 );
    ```
5. With the snippet in place, click the trash icon on a saved item. Expected: the row remains visible while the request is in flight, then a dismissible error banner appears above the list. The trash and Move-to-cart buttons for that row are disabled while the request is pending so no double click is possible.
6. Still with the snippet in place, click **Move to cart** on a saved item. Expected: an error banner appears, the row is not removed, and the buttons re-enable when the request settles.
7. Remove the snippet file. Click the trash icon again — the row is removed once the server confirms. Exercise **Move to cart** on simple and variation products and confirm both cart-add and list-removal happen successfully.

### Testing that has already taken place:

Manual testing of the happy and failure paths described above in a local wp-env environment with the **Save for Later in Cart** feature enabled.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry already added manually in `plugins/woocommerce/changelog/replace-shopper-collection-error-row-with-store-notice`.

</details>