### PR TITLE
fix: guard analytics cart handlers against missing cart item data

### DIFF
--- a/packages/php/woocommerce-analytics/changelog/fix-cart-item-warnings
+++ b/packages/php/woocommerce-analytics/changelog/fix-cart-item-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Guard cart hook handlers against missing cart item data to prevent PHP warnings.

--- a/packages/php/woocommerce-analytics/src/class-universal.php
+++ b/packages/php/woocommerce-analytics/src/class-universal.php
@@ -134,6 +134,10 @@ class Universal {
 	public function capture_remove_from_cart( $cart_item_key, $cart ) {
 		$item = $cart->removed_cart_contents[ $cart_item_key ] ?? null;
 
+		if ( ! is_array( $item ) || ! isset( $item['product_id'], $item['quantity'] ) ) {
+			return;
+		}
+
 		WC_Analytics_Tracking::record_event(
 			'remove_from_cart',
 			$this->get_cart_checkout_event_properties(
@@ -156,6 +160,10 @@ class Universal {
 	 * @return void
 	 */
 	public function capture_cart_quantity_update( $cart_item_key, $quantity, $old_quantity, $cart ) {
+		if ( ! isset( $cart->cart_contents[ $cart_item_key ]['product_id'] ) ) {
+			return;
+		}
+
 		$product_id = $cart->cart_contents[ $cart_item_key ]['product_id'];
 		if ( $quantity > $old_quantity ) {
 			WC_Analytics_Tracking::record_event(

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Test.php
@@ -90,4 +90,84 @@ class Universal_Test extends BaseTestCase {
 		// If we get here without errors, the method completed without processing a non-existent order.
 		$this->assertTrue( true, 'order_process should handle a missing order without throwing an exception.' );
 	}
+
+	/**
+	 * capture_remove_from_cart should return early — without raising a PHP
+	 * warning or queueing a pixel — when the cart key is not present in
+	 * removed_cart_contents. Reproduces the warnings reported on
+	 * line 141/142 of class-universal.php where third-party code fires the
+	 * woocommerce_cart_item_removed action with a key that was never copied
+	 * into removed_cart_contents.
+	 */
+	public function test_capture_remove_from_cart_skips_when_item_missing(): void {
+		$cart                        = new \stdClass();
+		$cart->removed_cart_contents = array();
+
+		$this->reset_pixel_batch_queue();
+
+		$universal = new Universal();
+		$universal->capture_remove_from_cart( 'unknown_key', $cart );
+
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel should be queued when the removed cart item is missing.' );
+	}
+
+	/**
+	 * capture_remove_from_cart should also bail when the entry exists but is
+	 * missing the product_id/quantity keys the event payload requires.
+	 */
+	public function test_capture_remove_from_cart_skips_when_item_missing_keys(): void {
+		$cart                        = new \stdClass();
+		$cart->removed_cart_contents = array(
+			'partial_key' => array( 'product_id' => 5 ), // No quantity key.
+		);
+
+		$this->reset_pixel_batch_queue();
+
+		$universal = new Universal();
+		$universal->capture_remove_from_cart( 'partial_key', $cart );
+
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel should be queued when the removed cart item lacks required keys.' );
+	}
+
+	/**
+	 * capture_cart_quantity_update should return early — without raising a
+	 * PHP warning or queueing a pixel — when the cart key is not present in
+	 * cart_contents. Reproduces the warning reported on line 159 of
+	 * class-universal.php.
+	 */
+	public function test_capture_cart_quantity_update_skips_when_item_missing(): void {
+		$cart                = new \stdClass();
+		$cart->cart_contents = array();
+
+		$this->reset_pixel_batch_queue();
+
+		$universal = new Universal();
+		$universal->capture_cart_quantity_update( 'unknown_key', 2, 1, $cart );
+
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel should be queued when the cart item is missing.' );
+	}
+
+	/**
+	 * Reset the WC_Analytics_Tracking::$pixel_batch_queue static so each
+	 * test starts from a known-empty state.
+	 */
+	private function reset_pixel_batch_queue(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$queue      = $reflection->getProperty( 'pixel_batch_queue' );
+		$queue->setAccessible( true );
+		$queue->setValue( null, array() );
+	}
+
+	/**
+	 * Read WC_Analytics_Tracking::$pixel_batch_queue via reflection to
+	 * verify whether a pixel was queued.
+	 *
+	 * @return array
+	 */
+	private function get_pixel_batch_queue(): array {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Two cart hook handlers in `Universal::class` access cart item array keys without first checking that the entry exists, producing PHP warnings on production sites:

- `capture_remove_from_cart()` — reads `$item['product_id']` / `$item['quantity']` after `$cart->removed_cart_contents[$cart_item_key] ?? null`, so a `null` `$item` triggers `Undefined array key` warnings.
- `capture_cart_quantity_update()` — reads `$cart->cart_contents[$cart_item_key]['product_id']` directly, with no isset guard.

These hooks are public, so third-party code (Store API flows, subscription plugins, custom checkout integrations) can fire them with keys that aren't in the expected bucket. A single Pressable site is the source of most of the warnings reported in p1778790366405009-slack-C06FSDTSN82, but the issue is general.

This PR adds early-return guards in both methods. We skip rather than record-with-defaults because `product_id` is the primary attribution key for `add_to_cart`/`remove_from_cart` events — recording `pi=0` would pollute downstream funnels and represent actions that didn't really happen.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A — backend-only fix, no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Setup**

1. On your WooCommerce test site, install the Jetpack plugin and connect it to a WordPress.com account so the `woocommerce-analytics` package gets loaded.
2. Enable `WP_DEBUG` and `WP_DEBUG_LOG` in `wp-config.php`, then tail: `tail -f wp-content/debug.log`. The `Undefined array key` warnings only show up here — they are server-side and do not surface in the browser.
3. Sync this branch's package source over Jetpack's installed copy so the guards are actually loaded:
   ```sh
   rsync -av --delete \
     packages/php/woocommerce-analytics/src/ \
     <wp-root>/wp-content/plugins/jetpack/jetpack_vendor/automattic/woocommerce-analytics/src/
   ```

**Failure path (warnings prevented)**

4. With `debug.log` tailed, trigger the affected actions with a key the cart doesn't know about — drop the snippet below into `wp-content/mu-plugins/test-wcanalytics-cart-warnings.php` and load any front-end page once:
   ```php
   <?php
   add_action( 'wp_loaded', function () {
     if ( ! isset( $_GET['wcanalytics_repro'] ) ) return;
     $cart = new stdClass();
     $cart->removed_cart_contents = array();
     $cart->cart_contents         = array();
     do_action( 'woocommerce_cart_item_removed', 'unknown_key', $cart );
     do_action( 'woocommerce_after_cart_item_quantity_update', 'unknown_key', 2, 1, $cart );
   } );
   ```
   Visit `/?wcanalytics_repro=1`.
5. Confirm in `debug.log`:
   - **No** `PHP Warning: Undefined array key "product_id"` line.
   - **No** `PHP Warning: Undefined array key "quantity"` line.
   - On `trunk` (without this PR), the same steps emit those warnings on lines 141, 142, and 159 of `class-universal.php`.


**Unit tests**

10. From `packages/php/woocommerce-analytics`, run `composer test-php` and confirm `Universal_Test` passes (76 tests / 110 assertions, including three new cases that fail without the guards because `phpunit.xml.dist` sets `failOnWarning="true"`).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `composer test-php` — 76 tests, 110 assertions, all passing (PHPUnit's `failOnWarning="true"` is enabled, so the new tests would fail if the guard were removed).
- `phpcs src/class-universal.php tests/php/Universal_Test.php` — no new violations on the touched lines.
- Reviewed the WC core call sites for both hooks (`WC_Cart::remove_cart_item()`, `WC_Cart::set_quantity()`) to confirm the guards do not regress the normal in-WC path; both methods populate the relevant array entry before firing the action.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entry was added manually under `packages/php/woocommerce-analytics/changelog/fix-cart-item-warnings` (significance: patch, type: fixed).

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Guard cart hook handlers against missing cart item data to prevent PHP warnings.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>