### PR TITLE
Fix: preserve product description list formatting through REST round-trips

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-429
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-429
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Strip whitespace inserted between structural list tags (`<ul>`/`<ol>`/`<li>`) when saving product descriptions through the REST API, so descriptions authored in the classic editor survive a round-trip through the block editor without spurious line breaks between list items.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -764,12 +764,12 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		// Post content.
 		if ( isset( $request['description'] ) ) {
-			$product->set_description( wp_filter_post_kses( $request['description'] ) );
+			$product->set_description( wp_filter_post_kses( wc_normalize_product_description_list_whitespace( $request['description'] ) ) );
 		}
 
 		// Post excerpt.
 		if ( isset( $request['short_description'] ) ) {
-			$product->set_short_description( wp_filter_post_kses( $request['short_description'] ) );
+			$product->set_short_description( wp_filter_post_kses( wc_normalize_product_description_list_whitespace( $request['short_description'] ) ) );
 		}
 
 		// Post status.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1676,6 +1676,56 @@ function wc_remove_non_displayable_chars( string $raw_value ): string {
 	return str_replace( $remove_chars, '', $raw_value );
 }
 
+/**
+ * Collapse whitespace inserted between structural list tags in a product description.
+ *
+ * The new product (block) editor round-trips raw HTML descriptions through Gutenberg's
+ * block parser/serializer. When a description authored in the classic editor only contains
+ * structural HTML such as `<ul><li>A</li><li>B</li></ul>`, that round-trip wraps each list
+ * item in block delimiters and the serializer reintroduces whitespace (typically `\n` or
+ * `\n\n`) between siblings. Once stored back, the description differs from the classic
+ * input even though the user added no new content there.
+ *
+ * This helper normalizes only the whitespace that appears strictly between adjacent list
+ * structural tags (`<ul>`/`<ol>`/`</ul>`/`</ol>` and `<li>`/`</li>`). Any whitespace that
+ * sits inside the visible content of an `<li>` is left untouched.
+ *
+ * @since 10.9.0
+ *
+ * @param string $description Raw product description HTML.
+ * @return string Description with structural inter-list whitespace collapsed.
+ */
+function wc_normalize_product_description_list_whitespace( $description ) {
+	if ( ! is_string( $description ) || '' === $description ) {
+		return '';
+	}
+
+	// Only run the regex pass when at least one `<li>` is present; otherwise it's a no-op.
+	if ( false === stripos( $description, '<li' ) ) {
+		return $description;
+	}
+
+	$patterns = array(
+		// Whitespace between sibling list items: </li>\s+<li> -> </li><li>.
+		'#</li>\s+<li([\s>])#i',
+		// Whitespace between the list container open and the first item: <ul>\s+<li> -> <ul><li>.
+		'#<(ul|ol)([^>]*)>\s+<li([\s>])#i',
+		// Whitespace between the last item and the list container close: </li>\s+</ul> -> </li></ul>.
+		'#</li>\s+</(ul|ol)>#i',
+	);
+
+	$replacements = array(
+		'</li><li$1',
+		'<$1$2><li$3',
+		'</li></$1>',
+	);
+
+	$normalized = preg_replace( $patterns, $replacements, $description );
+
+	// preg_replace returns null on a PCRE failure; in that case fall back to the input untouched.
+	return null === $normalized ? $description : $normalized;
+}
+
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_checkout_pay_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_checkout_order_received_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_add_payment_method_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );

--- a/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
@@ -106,4 +106,64 @@ class WC_Formatting_Functions_Test extends \WC_Unit_Test_Case {
 		add_filter( 'woocommerce_stock_amount', 'intval' );
 		$this->assertTrue( wc_is_stock_amount_integer(), 'Should return true when intval is applied to stock amount filter.' );
 	}
+
+	/**
+	 * Data provider for `test_wc_normalize_product_description_list_whitespace`.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function provide_list_whitespace_samples(): array {
+		return array(
+			'collapses single newline between list items' => array(
+				'<ul><li>Feature one</li>' . "\n" . '<li>Feature two</li></ul>',
+				'<ul><li>Feature one</li><li>Feature two</li></ul>',
+			),
+			'collapses double newline between list items' => array(
+				'<ul><li>Feature one</li>' . "\n\n" . '<li>Feature two</li></ul>',
+				'<ul><li>Feature one</li><li>Feature two</li></ul>',
+			),
+			'collapses whitespace inside an ordered list' => array(
+				"<ol>\n<li>one</li>\n<li>two</li>\n</ol>",
+				'<ol><li>one</li><li>two</li></ol>',
+			),
+			'preserves whitespace inside the visible content of an <li>' => array(
+				"<ul><li>Feature   one</li>\n<li>Feature\ntwo</li></ul>",
+				"<ul><li>Feature   one</li><li>Feature\ntwo</li></ul>",
+			),
+			'leaves descriptions without list items untouched' => array(
+				"<p>Hello</p>\n\n<p>World</p>",
+				"<p>Hello</p>\n\n<p>World</p>",
+			),
+			'preserves attributes on the list container'  => array(
+				"<ul class=\"x\">\n<li>a</li>\n<li>b</li>\n</ul>",
+				'<ul class="x"><li>a</li><li>b</li></ul>',
+			),
+			'handles empty input'                         => array(
+				'',
+				'',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider provide_list_whitespace_samples
+	 *
+	 * @testdox wc_normalize_product_description_list_whitespace collapses structural list whitespace introduced by block round-trips.
+	 *
+	 * @param string $input    Raw input HTML.
+	 * @param string $expected Normalized output HTML.
+	 */
+	public function test_wc_normalize_product_description_list_whitespace( string $input, string $expected ): void {
+		$this->assertSame( $expected, wc_normalize_product_description_list_whitespace( $input ) );
+	}
+
+	/**
+	 * Non-string inputs should yield an empty string and never trigger a PHP warning.
+	 *
+	 * @testdox wc_normalize_product_description_list_whitespace returns an empty string for non-string inputs.
+	 */
+	public function test_wc_normalize_product_description_list_whitespace_non_string_input(): void {
+		// @phpstan-ignore-next-line - intentionally passing a non-string to verify defensive handling.
+		$this->assertSame( '', wc_normalize_product_description_list_whitespace( null ) );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CODE_OF_CONDUCT.md).

### Changes proposed in this Pull Request

When a product description authored in the classic editor only contains structural HTML (e.g. `<ul><li>A</li><li>B</li></ul>`), saving the product through the new (block) product editor causes Gutenberg's parser/serializer to reintroduce whitespace (`\n` / `\n\n`) between sibling `<li>` elements and around the surrounding `<ul>`/`<ol>` container. Once persisted via the REST API, the description differs from the original even though the user did not edit those bullets.

This PR introduces `wc_normalize_product_description_list_whitespace()` and applies it inside `WC_REST_Products_Controller::prepare_object_for_database()` to both `description` and `short_description` immediately before `wp_filter_post_kses`. The helper:

- Collapses whitespace strictly between adjacent `<li>` siblings.
- Collapses whitespace between `<ul>`/`<ol>` open tags and the first `<li>`.
- Collapses whitespace between the last `<li>` and `</ul>`/`</ol>`.
- Leaves whitespace inside the visible content of any `<li>` untouched.
- Is a no-op when the description contains no `<li>`.

### Screenshots or screen recordings

N/A (server-side normalization; visible result is the absence of stray blank lines between bullets after a classic -> block -> classic round-trip).

### How to test the changes in this Pull Request

1. In the classic product editor, set a description such as:
   ```
   <ul><li>Feature one</li><li>Feature two</li></ul>
   ```
2. Enable the new (block) product editor and open the same product.
3. Save the product (no manual edits to the bullet list).
4. Disable the new editor and re-open the product in the classic editor.
5. Confirm the description still renders as a clean list and `wp_posts.post_content` no longer contains line breaks between `</li>` and `<li>`, or between `<ul>`/`<ol>` and their first/last child.

Unit:

```
phpunit --filter test_wc_normalize_product_description_list_whitespace
```

### Testing that has already taken place

- New PHPUnit data-driven coverage for `wc_normalize_product_description_list_whitespace` (round-trip, attribute preservation, content-whitespace preservation, no-op, empty/null input).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` (clean).
- `composer exec -- phpstan analyse <changed files> --memory-limit=2G` (clean, no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` (clean).

### Changelog entry

- [x] Added under `plugins/woocommerce/changelog/fix-rsmapgj-429` (significance: patch, type: fix).

---

Closes #50796
Linear: https://linear.app/a8c/issue/RSMAPGJ-429

Signed-off-by: RSMAPGJ AI Coder pipeline