### PR TITLE
Product Collection: preserve lifted control on Filters Reset All

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-436
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-436
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: prevent the Filters panel "Reset All" from clearing the lifted collection-specific control (Hand-Picked products, By Category/Tag/Brand taxonomy) on initial block insert.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -25,7 +25,11 @@ import {
 	LayoutOptions,
 	CoreCollectionNames,
 } from '../../types';
-import { setQueryAttribute, getDefaultSettings } from '../../utils';
+import {
+	setQueryAttribute,
+	getDefaultSettings,
+	getLiftedControlQueryToPreserve,
+} from '../../utils';
 import ColumnsControl from './columns-control';
 import {
 	InheritQueryControl,
@@ -250,9 +254,26 @@ const ProductCollectionInspectorControls = (
 				<ToolsPanel
 					label={ __( 'Filters', 'woocommerce' ) }
 					resetAll={ ( resetAllFilters: ( () => void )[] ) => {
+						// Capture values managed by lifted (collection-specific)
+						// controls at the top of the inspector before running
+						// the filter resets. These controls live outside the
+						// Filters panel and must not be cleared by "Reset All".
+						const preservedQuery = getLiftedControlQueryToPreserve(
+							collection,
+							query
+						);
+
 						resetAllFilters.forEach( ( resetFilter ) => {
 							resetFilter();
 						} );
+
+						// Restore preserved lifted-control values if any reset
+						// callback cleared them (this can happen on initial
+						// insert before the block's `hideControls` attribute
+						// has fully propagated through the editor state).
+						if ( preservedQuery ) {
+							setQueryAttributeBind( preservedQuery );
+						}
 					} }
 					className="wc-block-editor-product-collection-inspector-toolspanel__filters"
 				>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/test/get-lifted-control-query-to-preserve.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/test/get-lifted-control-query-to-preserve.ts
@@ -1,0 +1,135 @@
+/**
+ * Internal dependencies
+ */
+import { getLiftedControlQueryToPreserve } from '../utils';
+import { CoreCollectionNames, ProductCollectionQuery } from '../types';
+
+const buildQuery = (
+	overrides: Partial< ProductCollectionQuery > = {}
+): ProductCollectionQuery =>
+	( {
+		exclude: [],
+		inherit: false,
+		offset: 0,
+		order: 'desc',
+		orderBy: 'date',
+		pages: 0,
+		perPage: 9,
+		postType: 'product',
+		search: '',
+		taxQuery: {},
+		featured: false,
+		woocommerceOnSale: false,
+		woocommerceStockStatus: [],
+		woocommerceAttributes: [],
+		woocommerceHandPickedProducts: [],
+		filterable: false,
+		...overrides,
+	} as unknown as ProductCollectionQuery );
+
+describe( 'getLiftedControlQueryToPreserve', () => {
+	it( 'returns null when collection is undefined', () => {
+		expect(
+			getLiftedControlQueryToPreserve( undefined, buildQuery() )
+		).toBeNull();
+	} );
+
+	it( 'returns null for a collection without a lifted control', () => {
+		expect(
+			getLiftedControlQueryToPreserve(
+				CoreCollectionNames.ON_SALE,
+				buildQuery( {
+					woocommerceHandPickedProducts: [ '1', '2' ],
+				} )
+			)
+		).toBeNull();
+	} );
+
+	it( 'returns null when Hand-Picked collection has no selected products', () => {
+		expect(
+			getLiftedControlQueryToPreserve(
+				CoreCollectionNames.HAND_PICKED,
+				buildQuery()
+			)
+		).toBeNull();
+	} );
+
+	it( 'preserves Hand-Picked product IDs for the Hand-Picked collection', () => {
+		const ids = [ '10', '20', '30' ];
+		const result = getLiftedControlQueryToPreserve(
+			CoreCollectionNames.HAND_PICKED,
+			buildQuery( { woocommerceHandPickedProducts: ids } )
+		);
+		expect( result ).toEqual( {
+			woocommerceHandPickedProducts: ids,
+		} );
+	} );
+
+	it( 'preserves the product_cat tax query for the BY_CATEGORY collection', () => {
+		const result = getLiftedControlQueryToPreserve(
+			CoreCollectionNames.BY_CATEGORY,
+			buildQuery( {
+				taxQuery: { product_cat: [ 5, 6 ], product_tag: [ 9 ] },
+			} )
+		);
+		expect( result ).toEqual( {
+			taxQuery: { product_cat: [ 5, 6 ], product_tag: [ 9 ] },
+		} );
+	} );
+
+	it( 'preserves the product_tag tax query for the BY_TAG collection', () => {
+		const result = getLiftedControlQueryToPreserve(
+			CoreCollectionNames.BY_TAG,
+			buildQuery( {
+				taxQuery: { product_tag: [ 42 ] },
+			} )
+		);
+		expect( result ).toEqual( {
+			taxQuery: { product_tag: [ 42 ] },
+		} );
+	} );
+
+	it( 'preserves the product_brand tax query for the BY_BRAND collection', () => {
+		const result = getLiftedControlQueryToPreserve(
+			CoreCollectionNames.BY_BRAND,
+			buildQuery( {
+				taxQuery: { product_brand: [ 7 ] },
+			} )
+		);
+		expect( result ).toEqual( {
+			taxQuery: { product_brand: [ 7 ] },
+		} );
+	} );
+
+	it( 'returns null when the taxonomy collection has no terms selected', () => {
+		expect(
+			getLiftedControlQueryToPreserve(
+				CoreCollectionNames.BY_CATEGORY,
+				buildQuery( { taxQuery: { product_cat: [] } } )
+			)
+		).toBeNull();
+
+		expect(
+			getLiftedControlQueryToPreserve(
+				CoreCollectionNames.BY_TAG,
+				buildQuery( { taxQuery: {} } )
+			)
+		).toBeNull();
+	} );
+
+	it( 'preserves both Hand-Picked products and tax query when applicable', () => {
+		// Although Hand-Picked and taxonomy-based collections are distinct,
+		// guard against future overlap by exercising both branches together.
+		const result = getLiftedControlQueryToPreserve(
+			CoreCollectionNames.HAND_PICKED,
+			buildQuery( {
+				woocommerceHandPickedProducts: [ '1' ],
+				taxQuery: { product_cat: [ 5 ] },
+			} )
+		);
+		// Hand-Picked collection only preserves the product list.
+		expect( result ).toEqual( {
+			woocommerceHandPickedProducts: [ '1' ],
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -509,6 +509,65 @@ export const getDefaultSettings = (
 	dimensions: DEFAULT_ATTRIBUTES.dimensions,
 } );
 
+/**
+ * For collections that lift one of the filter controls to the top of the
+ * inspector (e.g. Hand-Picked Products lifts the product picker, and the
+ * Products by Category/Tag/Brand collections lift their respective taxonomy
+ * picker), the Filters panel's "Reset All" button must preserve the value of
+ * the lifted control. The lifted control is not rendered inside the Filters
+ * panel — resetting it would unexpectedly clear the user's collection-defining
+ * selection.
+ *
+ * This helper returns the partial query that should be re-applied after the
+ * Filters panel's `resetAll` runs, so the lifted control's value is restored.
+ *
+ * @param collection The collection variation name.
+ * @param query      The current query attributes (captured before reset).
+ * @return A partial query, or `null` if nothing needs to be preserved.
+ */
+export const getLiftedControlQueryToPreserve = (
+	collection: string | undefined,
+	query: ProductCollectionQuery
+): Partial< ProductCollectionQuery > | null => {
+	if ( ! collection ) {
+		return null;
+	}
+
+	const preserved: Partial< ProductCollectionQuery > = {};
+
+	if ( collection === CoreCollectionNames.HAND_PICKED ) {
+		const ids = query.woocommerceHandPickedProducts;
+		if ( Array.isArray( ids ) && ids.length > 0 ) {
+			preserved.woocommerceHandPickedProducts = ids;
+		}
+	}
+
+	const taxonomySlug = ( () => {
+		if ( collection === CoreCollectionNames.BY_CATEGORY ) {
+			return 'product_cat';
+		}
+		if ( collection === CoreCollectionNames.BY_TAG ) {
+			return 'product_tag';
+		}
+		if ( collection === CoreCollectionNames.BY_BRAND ) {
+			return 'product_brand';
+		}
+		return null;
+	} )();
+
+	if ( taxonomySlug ) {
+		const termIds = query.taxQuery?.[ taxonomySlug ];
+		if ( Array.isArray( termIds ) && termIds.length > 0 ) {
+			preserved.taxQuery = {
+				...( query.taxQuery || {} ),
+				[ taxonomySlug ]: termIds,
+			};
+		}
+	}
+
+	return Object.keys( preserved ).length > 0 ? preserved : null;
+};
+
 export const getDefaultProductCollection = () =>
 	createBlock(
 		blockJson.name,


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a Product Collection variation that lifts one of its filter controls to the top of the inspector (Hand-Picked Products, Products by Category/Tag/Brand) is inserted into a post, clicking **Reset All** in the Filters panel also clears the user's lifted-control selection on the very first interaction (before save/refresh). Once the post is saved and reloaded, the same flow behaves correctly.

Root cause: the Filters panel's `ToolsPanel` `resetAll` callback invokes every registered `ToolsPanelItem` reset. On initial insert, the collection variation's `hideControls` attribute has not yet fully propagated through the editor state, so the lifted control's `ToolsPanelItem` is still registered with the Filters panel and gets reset alongside the legitimate filter controls — wiping the collection-defining selection.

Fix: capture the lifted control's query slice (`woocommerceHandPickedProducts` for Hand-Picked; the relevant `taxQuery[product_cat|product_tag|product_brand]` for Products by Category/Tag/Brand) before invoking the reset callbacks, then re-apply it via `setQueryAttribute` afterward. Net effect: **Reset All** only resets the items inside the Filters panel; the lifted control above the panel is preserved.

Closes #59238

Linear: https://linear.app/a8c/issue/RSMAPGJ-436

### Screenshots or screen recordings:

See the recordings in #59238.

### How to test the changes in this Pull Request:

1. Create a new post or page in the block editor.
2. Insert a **Product Collection** block and pick a variation with a lifted control: **Hand-Picked Products**, **Products by Category**, **Products by Tag**, or **Products by Brand**.
3. Use the lifted control at the top of the inspector to add a product (or category/tag/brand). Verify the selection sticks.
4. **Without saving or refreshing**, open the Filters panel further down the inspector and apply some filters (e.g. On Sale, Stock Status).
5. Click **Reset All** in the Filters panel.
6. Expected: filters inside the panel are cleared; the lifted control at the top still shows the original selection.
7. Save and refresh — repeat steps 3–6 to confirm the post-save flow still works.
8. Try the same flow with a non-lifted variation (e.g. *On Sale*) to confirm normal Reset All behavior is unchanged.

### Testing that has already taken place:

- Added Jest unit tests for the new `getLiftedControlQueryToPreserve` helper covering: undefined collection, collection without a lifted control, Hand-Picked with/without selection, BY_CATEGORY/BY_TAG/BY_BRAND with/without selection, and combined-payload guard. All 9 tests pass under `wp-scripts test-unit-js`.
- ESLint clean on the modified files (only pre-existing `react-hooks/exhaustive-deps` warnings in `utils.tsx` unrelated to this change).
- TypeScript: no new errors introduced (the one pre-existing `TS2769` overload mismatch on the `ToolsPanel` `resetAll` signature was already present on trunk at the same line).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

Changelog file added manually at `plugins/woocommerce/changelog/fix-rsmapgj-436` (significance: patch, type: fix).

</details>

---

This pull request was authored by an AI coding agent as part of an Automattic pilot program. It has been pushed as a draft for human review.
