### PR TITLE
Fix related products query only surfacing lowest-ID products

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-387
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-387
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix related products only ever cycling through the lowest-ID products in a category. The data store now randomises the SQL query so every related product is reachable, regardless of how many products share the category or tag (#30140).

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1691,17 +1691,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		$query = array(
-			'fields' => "
+			'fields'  => "
 				SELECT DISTINCT ID FROM {$wpdb->posts} p
 			",
-			'join'   => '',
-			'where'  => "
+			'join'    => '',
+			'where'   => "
 				WHERE 1=1
 				AND p.post_status = 'publish'
 				AND p.post_type = 'product'
 
 			",
-			'limits' => '
+			'orderby' => '',
+			'limits'  => '
 				LIMIT ' . absint( $limit ) . '
 			',
 		);
@@ -1717,6 +1718,23 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( count( $exclude_ids ) ) {
 			$query['where'] .= ' AND p.ID NOT IN ( ' . implode( ',', array_map( 'absint', $exclude_ids ) ) . ' )';
+		}
+
+		/**
+		 * Filters whether related product queries should be randomised at the
+		 * SQL level. When true (the default), an `ORDER BY RAND()` clause is
+		 * added so the LIMIT selects a random subset across the full pool of
+		 * eligible products rather than always returning the same lowest-ID
+		 * rows. This ensures stores with more than ($limit + buffer) related
+		 * products can surface every product over time, instead of always
+		 * recycling the oldest ones (see #30140).
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param bool $shuffle Whether to randomise the SQL query. Default true.
+		 */
+		if ( apply_filters( 'woocommerce_product_related_posts_shuffle', true ) ) {
+			$query['orderby'] = ' ORDER BY RAND() ';
 		}
 
 		return $query;

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -676,6 +676,57 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox `wc_get_related_products` should be able to surface every product in the same
+	 *          category, not just the lowest-ID ones (see #30140). Run the lookup repeatedly
+	 *          and assert that, across runs, every related product is returned at least once.
+	 */
+	public function test_wc_get_related_products_reaches_all_products_in_large_category() {
+		$main_product = WC_Helper_Product::create_simple_product();
+
+		// Create enough related products to exceed the historical `LIMIT $limit + 10` cap that
+		// previously made high-ID products unreachable. 20 products with a `$limit` of 5 means
+		// the buggy implementation would only ever query the first 15 by post ID.
+		$category_term = wp_insert_term( 'Bug 30140 Category', 'product_cat' );
+		wp_set_object_terms( $main_product->get_id(), $category_term['term_id'], 'product_cat' );
+		$main_product->save();
+
+		$related_ids = array();
+		for ( $i = 0; $i < 20; $i++ ) {
+			$related = WC_Helper_Product::create_simple_product();
+			wp_set_object_terms( $related->get_id(), $category_term['term_id'], 'product_cat' );
+			$related->save();
+			$related_ids[] = $related->get_id();
+		}
+
+		// Bust the per-product transient between runs so the SQL query actually executes
+		// and the randomised result set varies. The transient name matches the function under test.
+		$seen = array();
+		for ( $run = 0; $run < 50; $run++ ) {
+			delete_transient( 'wc_related_' . $main_product->get_id() );
+			$results = wc_get_related_products( $main_product->get_id(), 5 );
+			foreach ( $results as $id ) {
+				$seen[ (int) $id ] = true;
+			}
+			if ( count( $seen ) === count( $related_ids ) ) {
+				break;
+			}
+		}
+
+		$unreached = array_diff( $related_ids, array_keys( $seen ) );
+		$this->assertEmpty(
+			$unreached,
+			'Every related product should be reachable; missed IDs: ' . implode( ',', $unreached )
+		);
+
+		// Clean up.
+		delete_transient( 'wc_related_' . $main_product->get_id() );
+		WC_Helper_Product::delete_product( $main_product->get_id() );
+		foreach ( $related_ids as $id ) {
+			WC_Helper_Product::delete_product( $id );
+		}
+	}
+
+	/**
 	 * @testdox Product permalink should use deepest category, not the one with highest parent term ID.
 	 */
 	public function test_wc_product_post_type_link_uses_deepest_category() {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #30140.
Linear: https://linear.app/a8c/issue/RSMAPGJ-387

`WC_Product_Data_Store_CPT::get_related_products_query()` builds the SQL for related-product lookups with no `ORDER BY` clause. Combined with `LIMIT $limit + 10`, MySQL returns the same lowest-ID rows on every call. Once the day-long `wc_related_<id>` transient caches that window, products outside it can never be shown as related, no matter how many times the storefront refreshes. With the 30-product test case from the bug report, products 26–30 are unreachable.

This PR adds `ORDER BY RAND()` to the query so the `LIMIT` selects a random subset across the full pool of eligible products. Over the lifetime of the transient (and at every regeneration) every related product is now reachable. The randomisation is gated on the existing `woocommerce_product_related_posts_shuffle` filter, so callers that depend on a deterministic order can opt out (same toggle that already governs the post-fetch PHP shuffle).

### How to test the changes in this Pull Request:

1. Create a category and 20+ products inside it.
2. Open one of the products on the storefront — note the related products shown.
3. Clear the related-products transient (`wp transient delete wc_related_<product_id>`) and reload — the related products should differ.
4. Repeat clearing the transient several times. Over multiple regenerations, you should see every product in the category surface as a related product at some point. Before this fix, only products with the lowest IDs ever appeared.
5. Confirm `wc_get_related_products()` still respects the `$limit` argument and the `woocommerce_product_related_posts_shuffle` filter (setting it to `__return_false` keeps deterministic order).

### Testing that has already taken place:

- New PHPUnit test `test_wc_get_related_products_reaches_all_products_in_large_category` creates 20 related products and asserts that, across repeated lookups (with the transient cleared between each), every product is returned at least once. The test fails on trunk and passes with this change.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- PHPStan on the modified data store file — no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request includes a changelog entry under `plugins/woocommerce/changelog/`.

---

Generated by the RSMAPGJ AI Coder pilot.
