### PR TITLE
Fix analytics including trashed orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-408
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-408
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Analytics: exclude trashed orders from reports by resyncing the order stats row when an order is trashed or untrashed.

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -105,6 +105,14 @@ class OrdersScheduler extends ImportScheduler {
 			add_action( 'woocommerce_schedule_import', array( __CLASS__, 'possibly_schedule_import' ) );
 		}
 
+		// Trashed and untrashed orders need an analytics resync regardless of the
+		// import mode: in HPOS, trashing/untrashing bypasses `woocommerce_update_order`
+		// and updates `wc_orders.status` directly, leaving the existing `wc_order_stats`
+		// row stale and causing trashed orders to still appear in Analytics reports.
+		// See https://github.com/woocommerce/woocommerce/issues/36747.
+		add_action( 'woocommerce_trash_order', array( __CLASS__, 'sync_on_order_trash_change' ) );
+		add_action( 'woocommerce_untrash_order', array( __CLASS__, 'sync_on_order_trash_change' ) );
+
 		if ( Features::is_enabled( 'analytics-scheduled-import' ) ) {
 			// Watch for changes to the scheduled import option.
 			add_action( 'add_option_' . self::SCHEDULED_IMPORT_OPTION, array( __CLASS__, 'handle_scheduled_import_option_added' ), 10, 2 );
@@ -326,6 +334,46 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 
 		self::schedule_action( 'import', array( $order_id ) );
 		return $order_id;
+	}
+
+	/**
+	 * Re-sync the analytics lookup tables after an order is trashed or untrashed.
+	 *
+	 * Trashing and untrashing an order does not fire `woocommerce_update_order`
+	 * (especially in HPOS where the status column is updated directly), so the
+	 * existing `wc_order_stats` row keeps its previous status and trashed orders
+	 * keep contributing to Analytics totals. Re-running the import refreshes the
+	 * row with the new status (`wc-trash` or the restored status), letting the
+	 * existing excluded-status filtering keep trashed orders out of reports while
+	 * untrashed orders return to them.
+	 *
+	 * Triggers an immediate Action Scheduler import in immediate-mode, and runs
+	 * the import inline in scheduled-mode so the change is reflected without
+	 * waiting for the next batch (which would skip trashed orders entirely).
+	 *
+	 * @internal
+	 * @param int $order_id Order ID.
+	 * @return void
+	 */
+	public static function sync_on_order_trash_change( $order_id ) {
+		$order_id = (int) $order_id;
+		if ( ! $order_id ) {
+			return;
+		}
+
+		if ( ! OrderUtil::is_order( $order_id, array( 'shop_order' ) ) ) {
+			return;
+		}
+
+		if ( self::is_scheduled_import_enabled() ) {
+			// In scheduled-import mode the recurring batch processor filters out
+			// trashed orders, so stale rows would never be refreshed. Run the
+			// import inline instead.
+			self::import( $order_id );
+			return;
+		}
+
+		self::schedule_action( 'import', array( $order_id ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
@@ -444,6 +444,112 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Trashing an order should resync analytics so the stats row reflects the trash status.
+	 */
+	public function test_trashing_order_updates_order_stats_status_to_wc_trash(): void {
+		// Run in immediate-import mode and force the import to run inline rather
+		// than being queued via Action Scheduler.
+		Features::disable( 'analytics-scheduled-import' );
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'no' );
+		add_filter( 'woocommerce_analytics_disable_action_scheduling', '__return_true' );
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'wc_order_stats';
+
+		$order = \WC_Helper_Order::create_order();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Ensure the row exists with the processing status before trashing.
+		OrdersScheduler::import( $order->get_id() );
+		$status_before = $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$table} WHERE order_id = %d", $order->get_id() ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$this->assertSame( 'wc-processing', $status_before );
+
+		// Trash the order through the standard data-store entry point so the
+		// woocommerce_trash_order hook fires.
+		$order->delete( false );
+
+		$status_after = $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$table} WHERE order_id = %d", $order->get_id() ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$this->assertSame(
+			'wc-trash',
+			$status_after,
+			'Trashing an order should refresh the wc_order_stats row so trashed orders stop affecting analytics totals.'
+		);
+
+		remove_filter( 'woocommerce_analytics_disable_action_scheduling', '__return_true' );
+	}
+
+	/**
+	 * @testdox Untrashing an order should resync analytics so the stats row reflects the restored status.
+	 */
+	public function test_untrashing_order_updates_order_stats_status(): void {
+		Features::disable( 'analytics-scheduled-import' );
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'no' );
+		add_filter( 'woocommerce_analytics_disable_action_scheduling', '__return_true' );
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'wc_order_stats';
+
+		$order = \WC_Helper_Order::create_order();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		OrdersScheduler::import( $order->get_id() );
+		$order->delete( false );
+
+		$this->assertSame(
+			'wc-trash',
+			$wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$table} WHERE order_id = %d", $order->get_id() ) ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		// Untrash the order via the data store.
+		$order->get_data_store()->untrash_order( $order );
+
+		$status_after = $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$table} WHERE order_id = %d", $order->get_id() ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$this->assertSame(
+			'wc-processing',
+			$status_after,
+			'Untrashing an order should restore the original status in wc_order_stats so it counts toward analytics again.'
+		);
+
+		remove_filter( 'woocommerce_analytics_disable_action_scheduling', '__return_true' );
+	}
+
+	/**
+	 * @testdox sync_on_order_trash_change should ignore non-order IDs.
+	 */
+	public function test_sync_on_order_trash_change_ignores_non_orders(): void {
+		Features::disable( 'analytics-scheduled-import' );
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'no' );
+
+		// Use a post ID that is not an order.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Not an order',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		// Should not throw or schedule anything.
+		OrdersScheduler::sync_on_order_trash_change( $post_id );
+
+		$action_hook = OrdersScheduler::get_action( 'import' );
+		$scheduled   = as_get_scheduled_actions(
+			array(
+				'hook'     => $action_hook,
+				'args'     => array( (int) $post_id ),
+				'status'   => 'pending',
+				'per_page' => 1,
+			),
+			ARRAY_A
+		);
+		$this->assertEmpty( $scheduled, 'No import action should be scheduled for a non-order post.' );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
 	 * Clear any scheduled batch processor actions.
 	 *
 	 * @return void


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/CODE_OF_CONDUCT.md)?
- [x] Does your code follow the [WordPress Coding Guidelines](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/)?
- [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Trashing an order in WooCommerce currently leaves its row in `wc_order_stats` untouched. In HPOS the trash operation updates `wc_orders.status` directly without firing `woocommerce_update_order`, so the analytics row keeps its previous status (`wc-processing`, `wc-completed`, etc.) and trashed orders keep contributing to Gross Sales, Net Sales, and friends. Permanently deleting the order does clean things up because `delete_post` / `woocommerce_before_delete_order` are wired up, but soft delete is not.

This PR hooks `woocommerce_trash_order` and `woocommerce_untrash_order` in `OrdersScheduler::init()` so that the affected order is re-synced into the analytics lookup tables. After a resync:

- A trashed order's `wc_order_stats.status` becomes `wc-trash`, which is already in the excluded statuses list (`DataStore::get_excluded_report_order_statuses()`), so the order drops out of report queries.
- An untrashed order is refreshed back to its restored status and counts toward analytics again.

The handler runs the import inline in scheduled-import mode (the recurring batch processor skips trashed orders, so we cannot rely on it to refresh the stale row) and schedules the existing import action otherwise.

Closes #36747.

Linear: https://linear.app/a8c/issue/RSMAPGJ-408

### How to test the changes in this Pull Request:

1. On a fresh WooCommerce site, place a frontend order for, e.g., 100 EUR (no taxes for simplicity) and ensure it lands in `Processing`.
2. Open Analytics > Revenue. Confirm Gross Sales / Net Sales reflect the order.
3. Go to Orders, move the order to the trash.
4. Reload Analytics > Revenue. Without this PR the totals stay; with this PR they drop to zero.
5. Restore the order from the trash. Analytics totals come back.
6. Repeat 1-5 with HPOS enabled (with and without compatibility sync) and with HPOS disabled.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

<!-- Mark applicable items with an [x]. -->

### Changelog entry

> Added in `plugins/woocommerce/changelog/fix-rsmapgj-408`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>