### PR TITLE
Fix elongated checkboxes/radios on single product page in legacy themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-384
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-384
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Scope the single product `form.cart input` width rule to `input[type="number"]` only in the Twenty Nineteen and Twenty Seventeen themes so checkboxes and radio buttons are no longer elongated.

--- a/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
@@ -313,7 +313,7 @@ dl.variation,
 			margin-right: 0.5rem;
 		}
 
-		input {
+		input[type="number"] {
 			width: 5em;
 		}
 	}

--- a/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
@@ -309,7 +309,7 @@ dl.variation,
 			margin-right: 0.5em;
 		}
 
-		input {
+		input[type="number"] {
 			width: 5em;
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The legacy single product CSS rule `.single-product form.cart input { width: 5em }` was applied via a bare `input` selector in Twenty Nineteen and Twenty Seventeen theme styles. This caused checkboxes and radio buttons rendered inside the add-to-cart form (e.g. added by extensions) to be drawn 5em wide, making them noticeably wider than tall.

This PR scopes the rule to `input[type="number"]` for both themes, matching the fix that has already shipped for Twenty Twenty and Twenty Twenty-One.

Files changed:
- `plugins/woocommerce/client/legacy/css/twenty-nineteen.scss`
- `plugins/woocommerce/client/legacy/css/twenty-seventeen.scss`

The RTL variants are generated from the same SCSS source via the build pipeline, so they pick up the fix automatically.

Closes #29264

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Checkboxes/radios in `.single-product form.cart` are stretched to 5em wide. | Only `input[type="number"]` (the quantity input) is 5em wide; checkboxes/radios use their default size. |

### How to test the changes in this Pull Request:

1. Activate the Twenty Nineteen (or Twenty Seventeen) theme.
2. On a single product page, add a checkbox or radio input inside the add-to-cart form (e.g. with a simple snippet that hooks into `woocommerce_before_add_to_cart_button` and outputs `<input type="checkbox">` / `<input type="radio">`).
3. Before the fix: the checkbox/radio is rendered ~5em wide.
4. After the fix: the checkbox/radio renders at its native browser size, while the quantity `<input type="number">` still uses the 5em width.
5. Confirm there is no regression on the quantity input width on the single product page.

### Testing that has already taken place:

- Reviewed the four legacy theme SCSS files in `plugins/woocommerce/client/legacy/css/`. Twenty Twenty (`twenty-twenty.scss:445`) and Twenty Twenty-One (`twenty-twenty-one.scss:509`) already use the scoped `input[type="number"]` selector; this PR brings Twenty Nineteen and Twenty Seventeen in line with the same pattern.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch` both pass (no PHP changes detected).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was added manually at `plugins/woocommerce/changelog/fix-rsmapgj-384` (significance: patch, type: fix).

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-384

_Submitted via the RSMAPGJ AI Coder pipeline._