### PR TITLE
Analytics: include all matching products in Products report search

### DIFF
--- a/packages/js/data/changelog/fix-rsmapgj-428
+++ b/packages/js/data/changelog/fix-rsmapgj-428
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Items store: paginate getItems resolver so search-based lookups (e.g. Analytics > Products) return all matching items instead of only the first page.

--- a/packages/js/data/src/items/resolvers.ts
+++ b/packages/js/data/src/items/resolvers.ts
@@ -4,16 +4,65 @@
 import { NAMESPACE } from '../constants';
 import { setError, setItems, setItemsTotalCount } from './actions';
 import { request } from '../utils';
-import { ItemType, Query } from './types';
+import { Item, ItemType, Query } from './types';
+
+/**
+ * Safety cap on the number of additional pages the resolver will fetch when
+ * paginating to gather all matching items. Combined with the caller's
+ * `per_page` (which defaults to the API's own page size), this keeps the
+ * resolver from issuing an unbounded number of requests against very large
+ * stores where a search term could match thousands of products.
+ */
+const MAX_PAGINATION_PAGES = 10;
 
 export function* getItems( itemType: ItemType, query: Query ) {
 	try {
 		const endpoint =
 			itemType === 'categories' ? 'products/categories' : itemType;
-		const { items, totalCount } = yield request(
-			`${ NAMESPACE }/${ endpoint }`,
-			query
+		const path = `${ NAMESPACE }/${ endpoint }`;
+
+		const firstPageQuery = { ...query, page: query.page ?? 1 };
+		const {
+			items: firstPageItems,
+			totalCount,
+		}: { items: Item[]; totalCount: number } = yield request(
+			path,
+			firstPageQuery
 		);
+
+		let items: Item[] = firstPageItems;
+
+		// When the caller didn't request a specific page and the response is
+		// paginated (i.e. total count exceeds the items returned), fetch the
+		// remaining pages so consumers like the Analytics search-and-filter
+		// flow don't silently drop matches beyond the first page.
+		const perPage = query.per_page ?? firstPageItems.length;
+		const isUnbounded = query.per_page === -1;
+		const requestedSpecificPage =
+			typeof query.page === 'number' && query.page > 1;
+
+		if (
+			! isUnbounded &&
+			! requestedSpecificPage &&
+			perPage > 0 &&
+			typeof totalCount === 'number' &&
+			totalCount > firstPageItems.length
+		) {
+			const totalPages = Math.ceil( totalCount / perPage );
+			const lastPage = Math.min( totalPages, 1 + MAX_PAGINATION_PAGES );
+
+			for ( let page = 2; page <= lastPage; page++ ) {
+				const pageQuery = { ...query, page };
+				const { items: pageItems }: { items: Item[] } = yield request(
+					path,
+					pageQuery
+				);
+				if ( ! pageItems || ! pageItems.length ) {
+					break;
+				}
+				items = items.concat( pageItems );
+			}
+		}
 
 		yield setItemsTotalCount( itemType, query, totalCount );
 		yield setItems( itemType, query, items );

--- a/packages/js/data/src/items/test/resolvers.ts
+++ b/packages/js/data/src/items/test/resolvers.ts
@@ -1,0 +1,132 @@
+/**
+ * Internal dependencies
+ */
+import { getItems } from '../resolvers';
+import { setItems, setItemsTotalCount, setError } from '../actions';
+
+describe( 'getItems resolver', () => {
+	it( 'fetches a single page when total count matches the first page', () => {
+		const query = { search: 'kingston', per_page: 100 };
+		const generator = getItems( 'products', query );
+
+		// First request is dispatched.
+		generator.next();
+		// Resolver receives the first page response.
+		const items = [
+			{ id: 1, name: 'one' },
+			{ id: 2, name: 'two' },
+		];
+		const setTotalAction = generator.next( {
+			items,
+			totalCount: items.length,
+		} ).value;
+
+		expect( setTotalAction ).toEqual(
+			setItemsTotalCount( 'products', query, items.length )
+		);
+
+		const setItemsAction = generator.next().value;
+		expect( setItemsAction ).toEqual(
+			setItems( 'products', query, items )
+		);
+
+		expect( generator.next().done ).toBe( true );
+	} );
+
+	it( 'paginates additional pages when the first page does not cover total count', () => {
+		const query = { search: 'kingston', per_page: 2 };
+		const generator = getItems( 'products', query );
+
+		// Page 1 request.
+		generator.next();
+
+		const pageOne = [
+			{ id: 1, name: 'one' },
+			{ id: 2, name: 'two' },
+		];
+		// First response yields total count of 5 → resolver must fetch pages 2 and 3.
+		generator.next( { items: pageOne, totalCount: 5 } );
+
+		const pageTwo = [
+			{ id: 3, name: 'three' },
+			{ id: 4, name: 'four' },
+		];
+		// Page 2 response.
+		generator.next( { items: pageTwo, totalCount: 5 } );
+
+		const pageThree = [ { id: 5, name: 'five' } ];
+		// Page 3 response → after this we set the accumulated items.
+		const setTotalAction = generator.next( {
+			items: pageThree,
+			totalCount: 5,
+		} ).value;
+
+		expect( setTotalAction ).toEqual(
+			setItemsTotalCount( 'products', query, 5 )
+		);
+
+		const setItemsAction = generator.next().value;
+		expect( setItemsAction ).toEqual(
+			setItems( 'products', query, [
+				...pageOne,
+				...pageTwo,
+				...pageThree,
+			] )
+		);
+
+		expect( generator.next().done ).toBe( true );
+	} );
+
+	it( 'does not paginate when the caller requested a specific page', () => {
+		const query = { search: 'kingston', per_page: 2, page: 2 };
+		const generator = getItems( 'products', query );
+
+		generator.next();
+		const items = [ { id: 10, name: 'ten' } ];
+		const setTotalAction = generator.next( {
+			items,
+			totalCount: 50,
+		} ).value;
+
+		expect( setTotalAction ).toEqual(
+			setItemsTotalCount( 'products', query, 50 )
+		);
+		const setItemsAction = generator.next().value;
+		expect( setItemsAction ).toEqual(
+			setItems( 'products', query, items )
+		);
+		expect( generator.next().done ).toBe( true );
+	} );
+
+	it( 'does not paginate for unbounded (per_page = -1) requests', () => {
+		const query = { search: 'kingston', per_page: -1 };
+		const generator = getItems( 'products', query );
+
+		generator.next();
+		const items = [ { id: 1, name: 'one' } ];
+		const setTotalAction = generator.next( {
+			items,
+			totalCount: items.length,
+		} ).value;
+
+		expect( setTotalAction ).toEqual(
+			setItemsTotalCount( 'products', query, items.length )
+		);
+		const setItemsAction = generator.next().value;
+		expect( setItemsAction ).toEqual(
+			setItems( 'products', query, items )
+		);
+		expect( generator.next().done ).toBe( true );
+	} );
+
+	it( 'dispatches setError when the request throws', () => {
+		const query = { search: 'kingston', per_page: 100 };
+		const generator = getItems( 'products', query );
+
+		generator.next();
+		const error = new Error( 'boom' );
+		const action = generator.throw( error ).value;
+		expect( action ).toEqual( setError( 'products', query, error ) );
+		expect( generator.next().done ).toBe( true );
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-rsmapgj-428
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-428
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Analytics > Products: include all matching products in the report when a search returns more than 100 results.


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the WordPress Coding Standards.
- [x] I have checked there are no other open PRs for the same change.
- [x] I have reviewed my code for security best practices.

### Changes proposed in this Pull Request

Analytics > Products instant search calls `/wc-analytics/products?search=...&per_page=100` to gather a set of matching product IDs, then passes those IDs into `/wc-analytics/reports/products?products=...`. The `@woocommerce/data` items store resolver (`getItems`) only fetched the first page of the results, so when a search matched more than `per_page` products (the call site uses 100), the report silently dropped every match beyond that first page — the user-visible bug reported in #50786.

The resolver now paginates after the first request when the response total exceeds the items returned, accumulating IDs across pages and dispatching a single `setItems` action against the original resource key. Pagination is skipped when the caller already asked for a specific `page` or when `per_page === -1` (unbounded), and a safety cap of 10 additional pages keeps very-large stores from issuing an unbounded number of requests.

Closes #50786
Linear: https://linear.app/a8c/issue/RSMAPGJ-428

### Screenshots or screen recordings

N/A — server-call pagination change, no visible UI difference beyond "all matching products now appear in the Products report".

### How to test the changes in this Pull Request

1. Set up a store with more than 100 products that share a common, searchable term in their titles (e.g. a brand name like `Kingston`). Make the first (oldest) product distinguishable, e.g. `Remember Me Kingston`.
2. Visit `WooCommerce > Analytics > Products` and type the common term into the search box.
3. Select `All products with titles that include <term>` from the autocomplete dropdown.
4. Open the network panel and confirm there are now multiple `wc-analytics/products?search=<term>&per_page=100&page=N` requests (page 1, 2, ... until the total is exhausted).
5. Confirm the resulting report table includes the distinguishable oldest product (`Remember Me Kingston`) — previously it was missing because only the first 100 IDs were sent to the report endpoint.
6. Repeat with a term that matches fewer than 100 products and confirm only a single page-1 request is issued.

### Testing that has already taken place

- Added a Jest unit test suite for the `getItems` resolver covering: single-page responses (no pagination), multi-page responses (accumulates items across pages), explicit-page requests (no pagination), unbounded (`per_page = -1`) requests, and error propagation. All 12 tests in `@woocommerce/data` items pass.
- ESLint clean on the changed files.
- No PHP changes; PHPUnit / PHPStan not applicable.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the next WooCommerce version
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entries were created manually under `packages/js/data/changelog/fix-rsmapgj-428` and `plugins/woocommerce/changelog/fix-rsmapgj-428`.

### Release Communication

- [ ] Feature Highlight
- [ ] Developer Advisory

---

This PR was authored by the RSMAPGJ AI Coder pilot agent.