### PR TITLE
Fix server errors when downloadable product images appear in media library

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-399
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-399
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Always swap `woocommerce_uploads/` image URLs for the placeholder in the media library, even for admins, so the `.htaccess`-protected directory no longer triggers server errors or fail2ban lockouts.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -890,17 +890,13 @@ add_action( 'woocommerce_scheduled_sales', 'wc_scheduled_sales' );
  */
 function wc_get_attachment_image_attributes( $attr ) {
 	/*
-	 * If the user can manage woocommerce, allow them to
-	 * see the image content.
-	 */
-	if ( current_user_can( 'manage_woocommerce' ) ) {
-		return $attr;
-	}
-
-	/*
-	 * If the user does not have the right capabilities,
-	 * filter out the image source and replace with placeholder
-	 * image.
+	 * Filter out the image source for files stored under `woocommerce_uploads/`
+	 * and replace it with a placeholder image, regardless of the current user's
+	 * capabilities. Those files are protected by an auto-generated `.htaccess`
+	 * with "deny from all", so loading them from the browser (e.g. in the media
+	 * library modal while editing a product) produces "client denied by server
+	 * configuration" errors. On servers running fail2ban or similar tooling,
+	 * those errors can lock admins out of their own sites (see #35166).
 	 */
 	if ( isset( $attr['src'] ) && strstr( $attr['src'], 'woocommerce_uploads/' ) ) {
 		$attr['src'] = wc_placeholder_img_src();
@@ -922,20 +918,19 @@ add_filter( 'wp_get_attachment_image_attributes', 'wc_get_attachment_image_attri
  */
 function wc_prepare_attachment_for_js( $response ) {
 	/*
-	 * If the user can manage woocommerce, allow them to
-	 * see the image content.
-	 */
-	if ( current_user_can( 'manage_woocommerce' ) ) {
-		return $response;
-	}
-
-	/*
-	 * If the user does not have the right capabilities,
-	 * filter out the image source and replace with placeholder
-	 * image.
+	 * Replace the URLs of attachments living under `woocommerce_uploads/` with a
+	 * placeholder image for every user, including users with `manage_woocommerce`.
+	 * The `woocommerce_uploads` directory ships with an auto-generated `.htaccess`
+	 * that denies direct HTTP access, so leaving the real URLs in place causes the
+	 * media library (and any other JS consumer of attachment data) to issue
+	 * requests that the server rejects, generating server-error log entries and,
+	 * on hosts running fail2ban, lockouts for legitimate admins (see #35166).
 	 */
 	if ( isset( $response['url'] ) && strstr( $response['url'], 'woocommerce_uploads/' ) ) {
-		$response['full']['url'] = wc_placeholder_img_src();
+		$response['url'] = wc_placeholder_img_src();
+		if ( isset( $response['full'] ) ) {
+			$response['full']['url'] = wc_placeholder_img_src();
+		}
 		if ( isset( $response['sizes'] ) ) {
 			foreach ( $response['sizes'] as $size => $value ) {
 				$response['sizes'][ $size ]['url'] = wc_placeholder_img_src();

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/functions.php
@@ -1166,7 +1166,65 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		// Test image hosted in woocommerce_uploads which is not allowed, think shops selling photos.
 		$this->assertEquals( $expected_attr, wc_get_attachment_image_attributes( $image_attr ) );
 
+		// Regression for #35166: even users who can manage WooCommerce should
+		// get the placeholder for woocommerce_uploads/* URLs, because that
+		// directory is `.htaccess` deny-all and the real URL produces server
+		// errors / fail2ban lockouts when the browser tries to render it.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( current_user_can( 'manage_woocommerce' ) );
+		$this->assertEquals( $expected_attr, wc_get_attachment_image_attributes( $image_attr ) );
+		wp_set_current_user( 0 );
+
 		unset( $image_attr, $expected_attr );
+	}
+
+	/**
+	 * Test: wc_prepare_attachment_for_js replaces woocommerce_uploads URLs with a placeholder.
+	 *
+	 * Regression test for #35166 — admins editing products were served the real
+	 * woocommerce_uploads URL through the media library, which is `.htaccess`
+	 * deny-all and triggers `client denied by server configuration` errors plus
+	 * fail2ban lockouts.
+	 */
+	public function test_wc_prepare_attachment_for_js() {
+		$placeholder = wc_placeholder_img_src();
+
+		// Non-woocommerce_uploads URL is left alone.
+		$response = array(
+			'url'   => 'https://wc.local/wp-content/uploads/2024/01/safe-image.jpg',
+			'full'  => array( 'url' => 'https://wc.local/wp-content/uploads/2024/01/safe-image.jpg' ),
+			'sizes' => array(
+				'thumbnail' => array( 'url' => 'https://wc.local/wp-content/uploads/2024/01/safe-image-150x150.jpg' ),
+			),
+		);
+		$this->assertEquals( $response, wc_prepare_attachment_for_js( $response ) );
+
+		$blocked_response = array(
+			'url'   => 'https://wc.local/wp-content/uploads/woocommerce_uploads/2024/01/secret.jpg',
+			'full'  => array( 'url' => 'https://wc.local/wp-content/uploads/woocommerce_uploads/2024/01/secret.jpg' ),
+			'sizes' => array(
+				'thumbnail' => array( 'url' => 'https://wc.local/wp-content/uploads/woocommerce_uploads/2024/01/secret-150x150.jpg' ),
+				'medium'    => array( 'url' => 'https://wc.local/wp-content/uploads/woocommerce_uploads/2024/01/secret-300x300.jpg' ),
+			),
+		);
+
+		$result = wc_prepare_attachment_for_js( $blocked_response );
+		$this->assertEquals( $placeholder, $result['url'] );
+		$this->assertEquals( $placeholder, $result['full']['url'] );
+		$this->assertEquals( $placeholder, $result['sizes']['thumbnail']['url'] );
+		$this->assertEquals( $placeholder, $result['sizes']['medium']['url'] );
+
+		// Admins must also receive the placeholder.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( current_user_can( 'manage_woocommerce' ) );
+		$result = wc_prepare_attachment_for_js( $blocked_response );
+		$this->assertEquals( $placeholder, $result['url'] );
+		$this->assertEquals( $placeholder, $result['full']['url'] );
+		$this->assertEquals( $placeholder, $result['sizes']['thumbnail']['url'] );
+		$this->assertEquals( $placeholder, $result['sizes']['medium']['url'] );
+		wp_set_current_user( 0 );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I checked there isn't already a similar open PR.

### Changes proposed in this Pull Request

Closes #35166.

Bug introduced in PR #30385.

`wc_get_attachment_image_attributes()` and `wc_prepare_attachment_for_js()` short-circuit and return the unmodified attachment data whenever the current user can `manage_woocommerce`. For downloadable-product files stored under `wp-content/uploads/woocommerce_uploads/` that means the real URL is sent back to the media library.

The `woocommerce_uploads` directory ships with an auto-generated `.htaccess` containing `deny from all`. When the media-library JS tries to render a thumbnail from one of those URLs, the server replies with a 403 and logs `client denied by server configuration`. On hosts running fail2ban (or any tool that bans on repeated 403s) admins editing products are eventually locked out of their own sites.

This PR:

- Removes the `current_user_can( 'manage_woocommerce' )` early return in both filters so every user, including admins, gets a placeholder image for `woocommerce_uploads/*` URLs. The placeholder restores the pre-WC 5.7 behavior the issue reporter explicitly asks for ("display of a generic picture icon would be preferable to an error situation").
- Also rewrites the top-level `url` (not just `full`/`sizes`) in `wc_prepare_attachment_for_js`, which is the field the media modal actually reads when rendering attachment tiles.
- Adds regression tests covering both filters for non-admin and admin contexts.

### How to test the changes in this Pull Request

1. On a server where directory `.htaccess` files are honoured (Apache / LiteSpeed) and `error_log` is reachable, install WooCommerce from this branch.
2. Edit a product, switch to **Downloadable**, and attach an image file as a downloadable file (uploaded fresh so it lands in `wp-content/uploads/woocommerce_uploads/...`).
3. As an admin user, open the product edit screen and click **Set product image** (or the **Media** menu in WP admin).
4. Confirm the downloadable image entry now shows the WooCommerce placeholder rather than triggering a 403 / showing a broken-image tile.
5. Tail `error_log` and verify no `client denied by server configuration` entries for `woocommerce_uploads/...` are produced while browsing the media library.

### Testing that has already taken place

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` (clean).
- `composer exec -- phpstan analyse includes/wc-product-functions.php --memory-limit=2G` (no errors).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` (clean).
- Added PHPUnit cases extending `test_wc_get_attachment_image_attributes` and a new `test_wc_prepare_attachment_for_js` cover both anonymous and admin users.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog entry created manually in `plugins/woocommerce/changelog/fix-rsmapgj-399`.)

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-399

🤖 Generated with [Claude Code](https://claude.com/claude-code) for the RSMAPGJ AI Coder pilot.