### PR TITLE
Fix grouped product price meta when imported before children

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-380
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-380
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing `_price` meta and zero `min_price`/`max_price` lookup values for grouped products imported via CSV before their linked child products.

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -245,6 +245,12 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 				return $object;
 			}
 
+			// Track whether this product was a placeholder (created earlier as a relative
+			// reference from a row processed before its own row). If so, any grouped
+			// products that already reference it will have synced their `_price` meta
+			// against an empty placeholder and must be re-synced after this save.
+			$was_placeholder = ( $object->get_id() && 'importing' === $object->get_status() );
+
 			if ( $object->get_id() && 'importing' !== $object->get_status() ) {
 				$updating = true;
 			}
@@ -290,6 +296,14 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			$object = apply_filters( 'woocommerce_product_import_pre_insert_product_object', $object, $data );
 			$object->save();
 
+			// If this row resolved a placeholder created for a relative reference from
+			// an earlier row, any grouped products that already reference it as a child
+			// will have synced their price meta against an empty placeholder. Re-sync
+			// those parents now that this product has its real data (including price).
+			if ( $was_placeholder && ! $is_variation ) {
+				$this->resync_grouped_parents( $object->get_id() );
+			}
+
 			do_action( 'woocommerce_product_import_inserted_product_object', $object, $data );
 
 			return array(
@@ -299,6 +313,57 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			);
 		} catch ( Exception $e ) {
 			return new WP_Error( 'woocommerce_product_importer_error', $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Re-sync grouped products that reference a given child product.
+	 *
+	 * When a grouped product is imported before any of its children — typical when the
+	 * grouped row appears earlier in the CSV than its linked products — the importer
+	 * creates placeholder products for the missing children and `update_prices_from_children`
+	 * runs against those empty placeholders, leaving the grouped product with no `_price`
+	 * meta. That in turn leaves `min_price` / `max_price` at 0.00 in the product meta
+	 * lookup table and prevents the Regenerate Product Lookup Tables tool from fixing it.
+	 *
+	 * This method is invoked once a placeholder is resolved by its actual CSV row, so
+	 * any grouped parent that has it listed in `_children` can re-sync its prices.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $child_id Product ID whose placeholder was just replaced with real data.
+	 * @return void
+	 */
+	protected function resync_grouped_parents( $child_id ) {
+		$child_id = absint( $child_id );
+		if ( ! $child_id ) {
+			return;
+		}
+
+		global $wpdb;
+
+		// Children are stored as a serialized PHP array in the `_children` postmeta. Match
+		// on the serialized integer token to filter parents at the DB layer before loading.
+		$serialized_token = 'i:' . $child_id . ';';
+		$parent_ids       = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_children' AND meta_value LIKE %s",
+				'%' . $wpdb->esc_like( $serialized_token ) . '%'
+			)
+		);
+
+		if ( empty( $parent_ids ) ) {
+			return;
+		}
+
+		foreach ( $parent_ids as $parent_id ) {
+			$parent = wc_get_product( absint( $parent_id ) );
+			if ( $parent instanceof WC_Product_Grouped ) {
+				$children = $parent->get_children( 'edit' );
+				if ( in_array( $child_id, array_map( 'absint', (array) $children ), true ) ) {
+					WC_Product_Grouped::sync( $parent );
+				}
+			}
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -224,4 +224,64 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		wc_delete_attribute( $color_attr_id );
 		wc_delete_attribute( $size_attr_id );
 	}
+
+	/**
+	 * @testdox Grouped products imported before their children should still receive `_price` meta and lookup table rows once those children are imported (issue #25706).
+	 */
+	public function test_grouped_product_imported_before_children_25706() {
+		global $wpdb;
+
+		$csv_file = __DIR__ . '/import-grouped-before-children-25706-data.csv';
+		$args     = array(
+			'parse'   => true,
+			'mapping' => array(
+				'Type'             => 'type',
+				'SKU'              => 'sku',
+				'Name'             => 'name',
+				'Published'        => 'published',
+				'Regular price'    => 'regular_price',
+				'Grouped products' => 'grouped_products',
+			),
+		);
+		$importer = new WC_Product_CSV_Importer( $csv_file, $args );
+		$data     = $importer->import();
+
+		$this->assertEmpty( $data['failed'], 'Import should not produce failures, got: ' . wp_json_encode( $data['failed'] ) );
+
+		$grouped_id  = wc_get_product_id_by_sku( 'GROUP-25706' );
+		$child_a_id  = wc_get_product_id_by_sku( 'CHILD-A-25706' );
+		$child_b_id  = wc_get_product_id_by_sku( 'CHILD-B-25706' );
+
+		$this->assertGreaterThan( 0, $grouped_id, 'Grouped product should exist after import' );
+		$this->assertGreaterThan( 0, $child_a_id, 'Child A should exist after import' );
+		$this->assertGreaterThan( 0, $child_b_id, 'Child B should exist after import' );
+
+		$grouped = wc_get_product( $grouped_id );
+		$this->assertInstanceOf( WC_Product_Grouped::class, $grouped );
+
+		$children = array_map( 'absint', $grouped->get_children( 'edit' ) );
+		$this->assertContains( $child_a_id, $children, 'Grouped product should reference Child A' );
+		$this->assertContains( $child_b_id, $children, 'Grouped product should reference Child B' );
+
+		$price_meta = get_post_meta( $grouped_id, '_price', false );
+		$this->assertNotEmpty( $price_meta, 'Grouped product should have _price meta entries after its children are imported' );
+
+		$prices = array_map( 'floatval', $price_meta );
+		sort( $prices );
+		$this->assertSame( array( 10.0, 25.0 ), $prices, 'Grouped product _price meta should reflect child min and max prices' );
+
+		$lookup_row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT min_price, max_price FROM {$wpdb->wc_product_meta_lookup} WHERE product_id = %d",
+				$grouped_id
+			)
+		);
+		$this->assertNotNull( $lookup_row, 'Grouped product should have a row in the product meta lookup table' );
+		$this->assertSame( 10.0, (float) $lookup_row->min_price, 'min_price in lookup table should match the lowest child price' );
+		$this->assertSame( 25.0, (float) $lookup_row->max_price, 'max_price in lookup table should match the highest child price' );
+
+		WC_Helper_Product::delete_product( $grouped_id );
+		WC_Helper_Product::delete_product( $child_a_id );
+		WC_Helper_Product::delete_product( $child_b_id );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/importer/import-grouped-before-children-25706-data.csv
+++ b/plugins/woocommerce/tests/php/includes/importer/import-grouped-before-children-25706-data.csv
@@ -1,0 +1,4 @@
+Type,SKU,Name,Published,Regular price,Grouped products
+grouped,GROUP-25706,Logo Collection Broken,1,,"CHILD-A-25706, CHILD-B-25706"
+simple,CHILD-A-25706,Child A,1,10,
+simple,CHILD-B-25706,Child B,1,25,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #25706.

Linear: https://linear.app/a8c/issue/RSMAPGJ-380

When a CSV import processes a grouped product before any of its linked children, the importer creates placeholder simple products for the unresolved SKUs and `WC_Product_Grouped_Data_Store_CPT::update_prices_from_children()` runs against those empty placeholders. Because none of them have a `_price` yet, the grouped product is saved with **no `_price` postmeta entries** and `min_price` / `max_price` of `0.00` in `wp_wc_product_meta_lookup`. The "Regenerate product lookup tables" tool cannot recover this state because its SQL relies on the missing `_price` rows.

This PR teaches `WC_Product_Importer::process_item()` to track when a row resolves a placeholder (the previous status was `importing`), and after saving the real product, re-syncs any grouped products that already list it as a child. Membership is filtered at the DB layer by matching the serialized `i:<id>;` token inside `_children` postmeta so the lookup stays cheap for the common case of non-grouped imports.

### How to test the changes in this Pull Request:

1. Take the sample CSV from issue #25706 (or any CSV where a `grouped` row references SKUs that appear on later rows) and import it via **Products → Import** on a fresh install.
2. Open the resulting grouped product in admin and confirm its price range matches the imported children.
3. In the database, confirm `wp_postmeta` has two `_price` rows for the grouped product and `wp_wc_product_meta_lookup` has the expected `min_price` / `max_price`.
4. Confirm sorting by price on the shop page lists the grouped product in the right place.
5. Without the patch (revert the change to `abstract-wc-product-importer.php`), repeat step 1 and observe the grouped product has no `_price` meta and zeroed lookup values.
6. Run the new unit test:
   ```
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_grouped_product_imported_before_children_25706
   ```

### Testing that has already taken place:

- Added a PHPUnit test in `WC_Product_CSV_Importer_Test` that imports a grouped product before its children and asserts the grouped product ends up with the expected `_price` meta and lookup-table rows.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `phpstan analyse includes/import/abstract-wc-product-importer.php` clean (no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually at `plugins/woocommerce/changelog/fix-rsmapgj-380`.

---

This PR was generated as part of the RSMAPGJ AI Coder pilot.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>