### PR TITLE
Fix tax names containing percent-encoded-like sequences being stripped on order pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-418
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-418
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve percent-encoded sequences in tax rate names (e.g. "Test %15") when saving via admin settings or REST API, so they no longer disappear on the Thank You / order details page.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-tax.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-tax.php
@@ -307,7 +307,13 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		foreach ( $tax_rate_keys as $tax_rate_key ) {
 			if ( isset( $_POST[ $tax_rate_key ], $_POST[ $tax_rate_key ][ $key ] ) ) {
-				$tax_rate[ $tax_rate_key ] = wc_clean( wp_unslash( $_POST[ $tax_rate_key ][ $key ] ) );
+				if ( 'tax_rate_name' === $tax_rate_key ) {
+					// `wc_clean()` calls `sanitize_text_field()` which strips `%XX`-looking sequences.
+					// Tax names such as "Test %15" should be preserved verbatim, so use a tax-name-aware sanitizer.
+					$tax_rate[ $tax_rate_key ] = WC_Tax::sanitize_tax_rate_name( wp_unslash( $_POST[ $tax_rate_key ][ $key ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Custom tax-name sanitizer is applied via WC_Tax::sanitize_tax_rate_name().
+				} else {
+					$tax_rate[ $tax_rate_key ] = wc_clean( wp_unslash( $_POST[ $tax_rate_key ][ $key ] ) );
+				}
 			}
 		}
 

--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -1031,6 +1031,34 @@ class WC_Tax {
 	}
 
 	/**
+	 * Sanitize a tax rate name while preserving percent-encoded sequences.
+	 *
+	 * WordPress's `sanitize_text_field()` (used by `wc_clean()`) strips characters that look
+	 * like URL-encoded octets (e.g. `%15`), which mangles tax names such as "Test %15". This
+	 * helper performs the same cleanup as `sanitize_text_field()` but escapes `%` before the
+	 * call and restores it afterwards so legitimate user input is preserved.
+	 *
+	 * @since 10.4.0
+	 *
+	 * @param  string $name The raw tax rate name value.
+	 * @return string Sanitized name with `%XX`-like sequences intact.
+	 */
+	public static function sanitize_tax_rate_name( $name ) {
+		if ( ! is_scalar( $name ) ) {
+			return '';
+		}
+
+		// Replace `%` with a placeholder using only printable ASCII so `sanitize_text_field()`
+		// does not strip the marker itself. The token is intentionally long to avoid collisions
+		// with realistic user-entered tax names.
+		$placeholder = '__WC_TAX_RATE_NAME_PERCENT_PLACEHOLDER__';
+		$name        = str_replace( '%', $placeholder, (string) $name );
+		$name        = sanitize_text_field( $name );
+
+		return str_replace( $placeholder, '%', $name );
+	}
+
+	/**
 	 * Format the rate.
 	 *
 	 * @param  float $rate Value to format.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-taxes-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-taxes-v1-controller.php
@@ -385,6 +385,11 @@ class WC_REST_Taxes_V1_Controller extends WC_REST_Controller {
 				case 'tax_rate_class':
 					$data[ $field ] = 'standard' !== $request[ $key ] ? $request[ $key ] : '';
 					break;
+				case 'tax_rate_name':
+					// `wc_clean()` calls `sanitize_text_field()` which strips `%XX`-looking sequences.
+					// Tax names such as "Test %15" should be preserved verbatim.
+					$data[ $field ] = WC_Tax::sanitize_tax_rate_name( $request[ $key ] );
+					break;
 				default:
 					$data[ $field ] = wc_clean( $request[ $key ] );
 					break;

--- a/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
@@ -1011,4 +1011,32 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 
 		remove_filter( 'woocommerce_shipping_prices_include_tax', '__return_true' );
 	}
+
+	/**
+	 * `sanitize_tax_rate_name()` preserves `%XX`-like sequences while still cleaning the input.
+	 *
+	 * Regression coverage for https://github.com/woocommerce/woocommerce/issues/45103: tax names
+	 * such as "Test %15" were being mangled because `wc_clean()` -> `sanitize_text_field()` strips
+	 * percent-encoded octets.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_tax_rate_name_preserves_percent_sequences() {
+		// Percent followed by hex-like digits is preserved (this is the bug fix).
+		$this->assertSame( 'Test %15', WC_Tax::sanitize_tax_rate_name( 'Test %15' ) );
+		$this->assertSame( 'Test %25', WC_Tax::sanitize_tax_rate_name( 'Test %25' ) );
+		$this->assertSame( 'Test %1F', WC_Tax::sanitize_tax_rate_name( 'Test %1F' ) );
+
+		// Existing valid inputs are still preserved.
+		$this->assertSame( 'Test 15%', WC_Tax::sanitize_tax_rate_name( 'Test 15%' ) );
+		$this->assertSame( 'Test % 15', WC_Tax::sanitize_tax_rate_name( 'Test % 15' ) );
+		$this->assertSame( 'VAT', WC_Tax::sanitize_tax_rate_name( 'VAT' ) );
+
+		// Strips HTML tags and trims whitespace, like sanitize_text_field().
+		$this->assertSame( 'Bad %25', WC_Tax::sanitize_tax_rate_name( '<b>Bad</b> %25' ) );
+		$this->assertSame( 'multi line %ff', WC_Tax::sanitize_tax_rate_name( "  multi\nline  %ff  " ) );
+
+		// Non-scalar input returns empty string.
+		$this->assertSame( '', WC_Tax::sanitize_tax_rate_name( array( 'foo' ) ) );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Tax` saved tax rate names through `wc_clean()` (which calls `sanitize_text_field()`), and `sanitize_text_field()` strips `%XX`-looking sequences. As a result, naming a tax rate "Test %15" persisted it as "Test", and the Thank You / order details page rendered "Test" instead of "Test %15".

This PR:

- Adds a `WC_Tax::sanitize_tax_rate_name()` helper that performs the same cleanup as `sanitize_text_field()` (stripping tags, trimming, collapsing whitespace) while preserving `%` characters by swapping them through a placeholder around the call.
- Uses the new helper from the admin Tax settings save handler (`WC_Settings_Tax::get_posted_tax_rate()`).
- Uses the new helper from the REST tax controller (`WC_REST_Taxes_V1_Controller::create_or_update_tax()`), which V2 and V3 inherit.
- Adds unit coverage for the new helper alongside existing `WC_Tax` tests.

Closes #45103.

Linear: [RSMAPGJ-418](https://linear.app/a8c/issue/RSMAPGJ-418)

### How to test the changes in this Pull Request:

1. Go to **WooCommerce → Settings → Tax → Standard rates** and add a tax with the name `Test %15` and rate `15`. Save.
2. Reload the page; the name should still display as `Test %15` (previously it was saved as `Test`).
3. Place an order that uses this tax rate and complete checkout.
4. On the Thank You / order details page (and in the My Account → View order screen), confirm the tax row label reads `Test %15:` rather than `Test:`.
5. Repeat with REST: `POST /wc/v3/taxes` with `{ "country": "US", "rate": "10.0000", "name": "Test %25" }` and verify the persisted `name` is `Test %25`.
6. Sanity-check that other tax rate names (e.g. `VAT`, `Test 15%`, `Test % 15`) still save correctly.

### Testing that has already taken place:

- Added unit test `WC_Tax_Test::test_sanitize_tax_rate_name_preserves_percent_sequences()` covering percent-encoded inputs, HTML stripping, whitespace collapsing, and non-scalar input.
- Verified the new helper output against the original `sanitize_text_field()` behaviour for the documented bug inputs (`Test %15` is preserved; HTML tags are stripped; multiline whitespace is collapsed).
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch` — clean.
- Ran PHPStan on the touched production files — no errors.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was added manually in `plugins/woocommerce/changelog/fix-rsmapgj-418`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>