### PR TITLE
Fix: Add region landmark to Store Notices block wrapper

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-437
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-437
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Add a region landmark and accessible name to the Store Notices block wrapper so assistive technology can identify the notices container.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
@@ -51,7 +51,9 @@ class StoreNotices extends AbstractBlock {
 			'<div %1$s>%2$s</div>',
 			get_block_wrapper_attributes(
 				array(
-					'class' => 'wc-block-store-notices woocommerce ' . esc_attr( $classes_and_styles['classes'] ),
+					'class'      => 'wc-block-store-notices woocommerce ' . esc_attr( $classes_and_styles['classes'] ),
+					'role'       => 'region',
+					'aria-label' => __( 'Store notices', 'woocommerce' ),
 				)
 			),
 			wc_kses_notice( $notices )

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/StoreNotices.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/StoreNotices.php
@@ -1,0 +1,109 @@
+<?php
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\StoreNotices as StoreNoticesBlockType;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
+/**
+ * Tests for the StoreNotices block type.
+ *
+ * @since 10.4.0
+ */
+class StoreNotices extends \WP_UnitTestCase {
+
+	/**
+	 * Instance of the block being tested.
+	 *
+	 * @var StoreNoticesBlockType
+	 */
+	protected $block;
+
+	/**
+	 * Setup test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( 'woocommerce/store-notices' ) ) {
+			$registry->unregister( 'woocommerce/store-notices' );
+		}
+
+		$this->block = new StoreNoticesBlockType(
+			Package::container()->get( Api::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry()
+		);
+
+		// Ensure the WC session is available so notices can be queued/printed.
+		if ( function_exists( 'WC' ) && WC()->session ) {
+			wc_clear_notices();
+		}
+	}
+
+	/**
+	 * Tear down test.
+	 */
+	public function tearDown(): void {
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( 'woocommerce/store-notices' ) ) {
+			$registry->unregister( 'woocommerce/store-notices' );
+		}
+
+		if ( function_exists( 'WC' ) && WC()->session ) {
+			wc_clear_notices();
+		}
+
+		unset( $this->block );
+		parent::tearDown();
+	}
+
+	/**
+	 * Invoke the protected render method.
+	 *
+	 * @return string|null
+	 */
+	private function invoke_render() {
+		$reflection = new \ReflectionClass( $this->block );
+		$method     = $reflection->getMethod( 'render' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->block, array(), '', null );
+	}
+
+	/**
+	 * The wrapper should expose a region landmark with an accessible name so
+	 * assistive technology can identify the notice container.
+	 */
+	public function test_wrapper_has_region_role_and_aria_label() {
+		if ( ! function_exists( 'wc_add_notice' ) ) {
+			$this->markTestSkipped( 'WooCommerce notice functions are unavailable.' );
+		}
+
+		wc_add_notice( 'Test error message', 'error' );
+
+		$markup = $this->invoke_render();
+
+		$this->assertIsString( $markup );
+		$this->assertStringContainsString( 'role="region"', $markup, 'StoreNotices wrapper should expose a region landmark.' );
+		$this->assertStringContainsString( 'aria-label="Store notices"', $markup, 'StoreNotices wrapper should have an accessible name.' );
+		$this->assertStringContainsString( 'wc-block-store-notices', $markup, 'StoreNotices wrapper class should be preserved.' );
+	}
+
+	/**
+	 * When there are no notices, the block should render nothing (no empty
+	 * landmark in the accessibility tree).
+	 */
+	public function test_renders_nothing_when_no_notices() {
+		if ( ! function_exists( 'wc_add_notice' ) ) {
+			$this->markTestSkipped( 'WooCommerce notice functions are unavailable.' );
+		}
+
+		$markup = $this->invoke_render();
+
+		$this->assertEmpty( $markup, 'StoreNotices should not render a wrapper when there are no notices.' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Store Notices block (`BlockTypes/StoreNotices.php`) renders a wrapping `<div>` that has no ARIA `role`, so assistive technology can't identify the notices container. The inner notice templates (`templates/notices/*.php` and `templates/block-notices/*.php`) already expose `role="alert"` (error/success) and `role="status"` (info) on each notice; this PR adds a `role="region"` landmark and a translatable `aria-label="Store notices"` to the outer wrapper so screen reader users can navigate to the notices area.

Closes #60261.

Linear: https://linear.app/a8c/issue/RSMAPGJ-437

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| `<div class="wc-block-store-notices woocommerce">` | `<div class="wc-block-store-notices woocommerce" role="region" aria-label="Store notices">` |

### How to test the changes in this Pull Request:

1. On a site running the changes, place the **Store Notices** block on a page (or use a checkout/cart page).
2. Trigger a notice (for example, add an invalid coupon or trigger a checkout validation error).
3. Inspect the rendered HTML and confirm the wrapping `<div class="wc-block-store-notices ...">` now includes `role="region"` and `aria-label="Store notices"`.
4. Confirm the inner notice elements still expose their existing `role="alert"` / `role="status"`.
5. Verify with a screen reader (VoiceOver, NVDA, etc.) that the notices container is announced as a region named "Store notices".

### Testing that has already taken place:

- PHPUnit coverage added in `plugins/woocommerce/tests/php/src/Blocks/BlockTypes/StoreNotices.php` covering the rendered wrapper attributes and the empty-state behavior.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passes.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passes.
- PHPStan on the changed source file reports no errors and no baseline entries were added.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was created manually at `plugins/woocommerce/changelog/fix-rsmapgj-437` (Significance: patch, Type: fix).

- [ ] This Pull Request does not require a changelog entry.

---

Submitted by the RSMAPGJ AI Coder pilot agent.