### PR TITLE
Store API: Return parent attribute ID for attribute term responses

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-416
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-416
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store API: Return the parent attribute ID in `parent` for terms exposed by `/wc/store/v1/products/attributes/{id}/terms`, so consumers can tell which attribute a term belongs to.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -85,4 +85,25 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 
 		return $this->get_terms_response( $attribute->slug, $request );
 	}
+
+	/**
+	 * Prepare a single attribute term for response.
+	 *
+	 * Product attribute taxonomies (`pa_*`) are non-hierarchical, so the underlying
+	 * `WP_Term::$parent` is always 0. For this endpoint we instead expose the parent
+	 * attribute ID (the `attribute_id` route parameter) so consumers can tell which
+	 * attribute a term belongs to without having to track it separately.
+	 *
+	 * @param mixed                                  $item Term object to format to schema.
+	 * @param \WP_REST_Request<array<string, mixed>> $request Request object.
+	 * @return \WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, \WP_REST_Request $request ) {
+		if ( $item instanceof \WP_Term && isset( $request['attribute_id'] ) ) {
+			$item         = clone $item;
+			$item->parent = (int) $request['attribute_id'];
+		}
+
+		return parent::prepare_item_for_response( $item, $request );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
@@ -32,7 +32,8 @@ class ProductAttributeTerms extends ControllerTestCase {
 	 * Test getting items.
 	 */
 	public function test_get_items() {
-		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/attributes/' . $this->attributes[0]['attribute_id'] . '/terms' );
+		$attribute_id = $this->attributes[0]['attribute_id'];
+		$request      = new \WP_REST_Request( 'GET', '/wc/store/v1/products/attributes/' . $attribute_id . '/terms' );
 		$request->set_param( 'hide_empty', false );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -44,6 +45,29 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$this->assertArrayHasKey( 'slug', $data[0] );
 		$this->assertArrayHasKey( 'description', $data[0] );
 		$this->assertArrayHasKey( 'count', $data[0] );
+		$this->assertArrayHasKey( 'parent', $data[0] );
+		// Attribute taxonomies are non-hierarchical; the route exposes the parent
+		// attribute ID so consumers know which attribute each term belongs to.
+		foreach ( $data as $item ) {
+			$this->assertEquals( (int) $attribute_id, $item['parent'] );
+		}
+	}
+
+	/**
+	 * Test prepare_item_for_response uses the attribute ID as the parent.
+	 */
+	public function test_prepare_item_uses_attribute_id_as_parent() {
+		$routes       = new \Automattic\WooCommerce\StoreApi\RoutesController( new \Automattic\WooCommerce\StoreApi\SchemaController( $this->mock_extend ) );
+		$controller   = $routes->get( 'product-attribute-terms' );
+		$attribute_id = $this->attributes[1]['attribute_id'];
+
+		$request = new \WP_REST_Request();
+		$request->set_param( 'attribute_id', $attribute_id );
+
+		$response = $controller->prepare_item_for_response( get_term_by( 'name', 'small', 'pa_size' ), $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( (int) $attribute_id, $data['parent'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Product attribute taxonomies (`pa_*`) are non-hierarchical, so `WP_Term::$parent` is always `0`. The Store API endpoint `GET /wc/store/v1/products/attributes/{id}/terms` exposed that raw `0` for every term, which meant API consumers had no way to tell which attribute a term belongs to without tracking the request URL separately. The reporter explicitly asked for `parent` to reflect the parent attribute ID (e.g. terms returned by `.../attributes/1/terms` should have `parent: 1`).

Fix: override `prepare_item_for_response` in `ProductAttributeTerms` to set the term's `parent` to the requested `attribute_id` for this endpoint only. The shared `TermSchema` is unchanged, so the other term routes (categories, brands) keep their existing semantics (parent term ID for hierarchical taxonomies, `0` otherwise).

Closes #42471

Linear: [RSMAPGJ-416](https://linear.app/a8c/issue/RSMAPGJ-416)

### How to test the changes in this Pull Request:

1. On a store with at least one attribute (e.g. Color) and some terms (e.g. Blue, Red), assigned to at least one product.
2. Find the attribute ID: `GET /wp-json/wc/store/v1/products/attributes` and note the `id` of the attribute.
3. `GET /wp-json/wc/store/v1/products/attributes/{id}/terms?hide_empty=false`.
4. Before this change: every term has `"parent": 0`. After: every term has `"parent": {id}` (the attribute ID from the URL).
5. Confirm the other term routes still behave as before, e.g. `GET /wp-json/wc/store/v1/products/categories` keeps returning the parent term ID for nested categories and `0` for top-level categories.

### Testing that has already taken place:

- New PHPUnit coverage in `tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php` (`test_get_items` now asserts `parent` equals the attribute ID; added `test_prepare_item_uses_attribute_id_as_parent`).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`: clean.
- `composer exec -- phpstan analyse src/StoreApi/Routes/V1/ProductAttributeTerms.php`: clean (no new errors, no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`: clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry committed manually at `plugins/woocommerce/changelog/fix-rsmapgj-416` (patch / fix).

- [ ] Automatically create a changelog entry from the details below.

---

🤖 This PR was authored by an AI agent (RSMAPGJ AI Coder pilot). Human review required.