### PR TITLE
Fix CES shop_order_update survey on HPOS order edit page

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-433
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-433
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix CES `shop_order_update` feedback survey not appearing after updating an order when HPOS is enabled.

--- a/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php
+++ b/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php
@@ -129,6 +129,23 @@ class CustomerEffortScoreTracks {
 				3
 			);
 		}
+		// When HPOS is enabled, orders are edited on the wc-orders admin page
+		// rather than post.php, so transition_post_status is not fired. Hook
+		// into the order save action instead. The CES queue already dedupes by
+		// action name, so a legacy double-fire would be a no-op.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading $_GET only to scope hook registration; the action handler itself does not act on user input.
+		$current_page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+		if ( 'admin.php' === $pagenow && 'wc-orders' === $current_page ) {
+			add_action(
+				'woocommerce_process_shop_order_meta',
+				array(
+					$this,
+					'run_on_woocommerce_process_shop_order_meta',
+				),
+				10,
+				2
+			);
+		}
 		$this->onsubmit_label = __( 'Thank you for your feedback!', 'woocommerce' );
 	}
 
@@ -407,9 +424,31 @@ class CustomerEffortScoreTracks {
 	}
 
 	/**
-	 * Enqueue the CES survey trigger for an existing shop order.
+	 * Hook into the HPOS order save action. Fired by
+	 * Automattic\WooCommerce\Internal\Admin\Orders\Edit::handle_order_update
+	 * when an order is updated via the HPOS order edit screen.
+	 *
+	 * @param int       $order_id The order ID.
+	 * @param \WC_Order $order    The order object.
 	 */
-	private function enqueue_ces_survey_for_edited_shop_order() {
+	public function run_on_woocommerce_process_shop_order_meta( $order_id, $order = null ): void {
+		unset( $order_id, $order );
+		// On the HPOS order edit page, window.pagenow and window.adminpage are
+		// set to the screen ID "woocommerce_page_wc-orders", so target that
+		// page when displaying the survey.
+		$this->enqueue_ces_survey_for_edited_shop_order( 'woocommerce_page_wc-orders', 'woocommerce_page_wc-orders' );
+	}
+
+	/**
+	 * Enqueue the CES survey trigger for an existing shop order.
+	 *
+	 * @param string $pagenow   Value of window.pagenow that the survey should
+	 *                          be displayed on. Defaults to 'shop_order' (the
+	 *                          legacy, non-HPOS edit screen).
+	 * @param string $adminpage Value of window.adminpage that the survey
+	 *                          should be displayed on. Defaults to 'post-php'.
+	 */
+	private function enqueue_ces_survey_for_edited_shop_order( $pagenow = 'shop_order', $adminpage = 'post-php' ) {
 		if ( $this->has_been_shown( self::SHOP_ORDER_UPDATE_ACTION_NAME ) ) {
 			return;
 		}
@@ -430,8 +469,8 @@ class CustomerEffortScoreTracks {
 					'woocommerce'
 				),
 				'onsubmit_label' => $this->onsubmit_label,
-				'pagenow'        => 'shop_order',
-				'adminpage'      => 'post-php',
+				'pagenow'        => $pagenow,
+				'adminpage'      => $adminpage,
 				'props'          => array(
 					'order_count' => $this->get_shop_order_count(),
 				),

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-ces-tracks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-ces-tracks.php
@@ -118,6 +118,113 @@ class WC_Admin_Tests_CES_Tracks extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Helper to set the HPOS order edit page context for a test.
+	 *
+	 * @param string|null $page Value to set for $_GET['page'], or null to
+	 *                          unset it.
+	 * @return array{pagenow:string|null,page:string|null} Previous values for
+	 *                          restoration in tearDown_hpos_context().
+	 */
+	private function setUp_hpos_context( $page = 'wc-orders' ) {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test helper: temporarily faking $pagenow to simulate the HPOS order edit page.
+		$GLOBALS['pagenow'] = 'admin.php';
+		$previous           = array(
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading $_GET in test helper to back up state.
+			'page' => isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : null,
+		);
+		if ( null === $page ) {
+			unset( $_GET['page'] );
+		} else {
+			$_GET['page'] = $page;
+		}
+		return $previous;
+	}
+
+	/**
+	 * Restore $_GET['page'] to its pre-test value.
+	 *
+	 * @param array $previous The map returned by setUp_hpos_context().
+	 */
+	private function tearDown_hpos_context( $previous ) {
+		if ( null === $previous['page'] ) {
+			unset( $_GET['page'] );
+		} else {
+			$_GET['page'] = $previous['page'];
+		}
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test helper: restoring $pagenow that this test temporarily modified.
+		unset( $GLOBALS['pagenow'] );
+	}
+
+	/**
+	 * Verify that the HPOS order save action enqueues the shop_order_update
+	 * survey. This guards against the regression where switching to HPOS
+	 * stopped firing the survey because it relied on transition_post_status,
+	 * which is never invoked on the HPOS order edit screen.
+	 */
+	public function test_shop_order_update_triggers_ces_on_hpos_save() {
+		$previous = $this->setUp_hpos_context( 'wc-orders' );
+		delete_option( CustomerEffortScoreTracks::CES_TRACKS_QUEUE_OPTION_NAME );
+
+		new CustomerEffortScoreTracks();
+
+		/**
+		 * Simulate the order save fired by HPOS Edit::handle_order_update.
+		 *
+		 * @since 10.9.0
+		 */
+		do_action( 'woocommerce_process_shop_order_meta', 123, null );
+
+		$queue_items = get_option( CustomerEffortScoreTracks::CES_TRACKS_QUEUE_OPTION_NAME, array() );
+
+		$this->tearDown_hpos_context( $previous );
+
+		$shop_order_items = array_values(
+			array_filter(
+				$queue_items,
+				function ( $item ) {
+					return CustomerEffortScoreTracks::SHOP_ORDER_UPDATE_ACTION_NAME === $item['action'];
+				}
+			)
+		);
+
+		$this->assertCount( 1, $shop_order_items );
+		$this->assertSame( 'woocommerce_page_wc-orders', $shop_order_items[0]['pagenow'] );
+		$this->assertSame( 'woocommerce_page_wc-orders', $shop_order_items[0]['adminpage'] );
+	}
+
+	/**
+	 * Verify that the HPOS-specific hook is only registered on the wc-orders
+	 * admin page, so saving an order via some other code path does not
+	 * accidentally enqueue the survey.
+	 */
+	public function test_shop_order_update_does_not_trigger_ces_outside_hpos_edit_page() {
+		$previous = $this->setUp_hpos_context( null );
+		delete_option( CustomerEffortScoreTracks::CES_TRACKS_QUEUE_OPTION_NAME );
+
+		new CustomerEffortScoreTracks();
+
+		/**
+		 * Simulate the order save fired outside the HPOS edit page.
+		 *
+		 * @since 10.9.0
+		 */
+		do_action( 'woocommerce_process_shop_order_meta', 123, null );
+
+		$queue_items = get_option( CustomerEffortScoreTracks::CES_TRACKS_QUEUE_OPTION_NAME, array() );
+
+		$this->tearDown_hpos_context( $previous );
+
+		$shop_order_items = array_filter(
+			$queue_items,
+			function ( $item ) {
+				return CustomerEffortScoreTracks::SHOP_ORDER_UPDATE_ACTION_NAME === $item['action'];
+			}
+		);
+
+		$this->assertCount( 0, $shop_order_items );
+	}
+
+	/**
 	 * Verify that it adds `settings_area` prop.
 	 */
 	public function test_settings_area_included_in_event_props() {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The CES `shop_order_update` feedback survey ("How easy was it to update an order?") stopped appearing for users with tracking enabled after HPOS became the default. The survey was wired exclusively to `transition_post_status`, which only fires when editing orders via `post.php`. With HPOS enabled, orders are edited on `admin.php?page=wc-orders` where post status transitions never run.

This PR registers an additional handler on `woocommerce_process_shop_order_meta` (fired by `Internal\Admin\Orders\Edit::handle_order_update` when an HPOS order is saved), scoped to the wc-orders admin page so it does not interfere with non-edit code paths. The queued survey targets the `woocommerce_page_wc-orders` screen, which matches `window.pagenow`/`window.adminpage` on the HPOS order edit page after the post-save redirect. The CES queue already dedupes by action name, so any legacy double-fire is a no-op.

Closes #54776

Linear: [RSMAPGJ-433](https://linear.app/a8c/issue/RSMAPGJ-433)

### How to test the changes in this Pull Request:

1. On a fresh site, complete the onboarding wizard and enable tracking (or enable it under **WooCommerce > Settings > Advanced > WooCommerce.com**).
2. Confirm HPOS is enabled under **WooCommerce > Settings > Advanced > Features**.
3. Go to **WooCommerce > Orders** and create a new order or open an existing one.
4. Change something on the order (e.g. status, note) and click **Update**.
5. After the page reloads, the CES notice **"How easy was it to update an order?"** with a **Give feedback** button should appear.
6. Repeat the test with HPOS disabled to confirm the legacy flow still works.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse src/Internal/Admin/CustomerEffortScoreTracks.php --memory-limit=2G` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- Two new PHPUnit cases added in `class-wc-tests-ces-tracks.php` covering the HPOS save path and the scoping guard.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog file added manually: `plugins/woocommerce/changelog/fix-rsmapgj-433` (patch / fix).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
