### PR TITLE
Fix order status transition not firing when trashing an order via HPOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-421
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-421
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Trigger order status transition actions (e.g. `woocommerce_order_status_X_to_trash`, `woocommerce_order_status_trash`, `woocommerce_order_status_changed`) and the corresponding order note when an order is trashed via the HPOS data store.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2665,39 +2665,26 @@ FROM $order_meta_table
 	 * @return void
 	 */
 	public function trash_order( $order ) {
-		global $wpdb;
-
 		if ( 'trash' === $order->get_status( 'edit' ) ) {
 			return;
 		}
 
 		$trash_metadata = array(
 			'_wp_trash_meta_status' => 'wc-' . $order->get_status( 'edit' ),
-			'_wp_trash_meta_time'   => time(),
+			'_wp_trash_meta_time'   => (string) time(),
 		);
 
-		$wpdb->update(
-			self::get_orders_table_name(),
-			array(
-				'status'           => 'trash',
-				'date_updated_gmt' => current_time( 'Y-m-d H:i:s', true ),
-			),
-			array( 'id' => $order->get_id() ),
-			array( '%s', '%s' ),
-			array( '%d' )
-		);
-
+		// Stage status change and trash metadata, then save so that WC_Order::status_transition()
+		// fires the standard transition actions (e.g. 'woocommerce_order_status_<old>_to_trash',
+		// 'woocommerce_order_status_trash', 'woocommerce_order_status_changed') and adds the
+		// transition order note. See: https://github.com/woocommerce/woocommerce/issues/46740.
 		$order->set_status( 'trash' );
 
 		foreach ( $trash_metadata as $meta_key => $meta_value ) {
-			$this->add_meta(
-				$order,
-				(object) array(
-					'key'   => $meta_key,
-					'value' => $meta_value,
-				)
-			);
+			$order->update_meta_data( $meta_key, $meta_value );
 		}
+
+		$order->save();
 
 		$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
 		if ( $data_synchronizer->data_sync_is_enabled() ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -596,6 +596,69 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 	}
 
 	/**
+	 * @testdox Trashing an order via the HPOS data store fires the standard status transition actions and adds a transition order note.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/46740.
+	 */
+	public function test_cot_datastore_trash_fires_status_transition_actions() {
+		$this->toggle_cot_feature_and_usage( true );
+
+		$order = $this->create_complex_cot_order();
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->save();
+		$order_id = $order->get_id();
+
+		$fired = array(
+			'specific' => 0,
+			'general'  => 0,
+			'changed'  => array(),
+		);
+
+		$specific_callback = function ( $id ) use ( &$fired, $order_id ) {
+			if ( (int) $id === (int) $order_id ) {
+				++$fired['specific'];
+			}
+		};
+		$general_callback  = function ( $id ) use ( &$fired, $order_id ) {
+			if ( (int) $id === (int) $order_id ) {
+				++$fired['general'];
+			}
+		};
+		$changed_callback  = function ( $id, $from, $to ) use ( &$fired, $order_id ) {
+			if ( (int) $id === (int) $order_id ) {
+				$fired['changed'][] = array( $from, $to );
+			}
+		};
+
+		add_action( 'woocommerce_order_status_on-hold_to_trash', $specific_callback );
+		add_action( 'woocommerce_order_status_trash', $general_callback );
+		add_action( 'woocommerce_order_status_changed', $changed_callback, 10, 3 );
+
+		try {
+			$this->sut->trash_order( $order );
+		} finally {
+			remove_action( 'woocommerce_order_status_on-hold_to_trash', $specific_callback );
+			remove_action( 'woocommerce_order_status_trash', $general_callback );
+			remove_action( 'woocommerce_order_status_changed', $changed_callback, 10 );
+		}
+
+		$this->assertSame( 1, $fired['specific'], "'woocommerce_order_status_on-hold_to_trash' should fire exactly once when trashing an order." );
+		$this->assertSame( 1, $fired['general'], "'woocommerce_order_status_trash' should fire exactly once when trashing an order." );
+		$this->assertCount( 1, $fired['changed'], "'woocommerce_order_status_changed' should fire exactly once when trashing an order." );
+		$this->assertSame( array( OrderStatus::ON_HOLD, OrderStatus::TRASH ), $fired['changed'][0] );
+
+		$order_notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
+		$found_note  = false;
+		foreach ( $order_notes as $note ) {
+			if ( false !== strpos( $note->content, 'On hold' ) && false !== strpos( $note->content, 'Trash' ) ) {
+				$found_note = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_note, 'A status transition order note (On hold -> Trash) should be added when trashing an order.' );
+	}
+
+	/**
 	 * @testDox Tests the `delete()` method on the COT datastore -- full deletes.
 	 *
 	 * @return void


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When an order is trashed through the admin (or any path that calls `$order->delete()` while HPOS is authoritative), `OrdersTableDataStore::trash_order()` wrote the row directly via `$wpdb->update` and set the in-memory status without invoking `$order->save()`. As a result `WC_Order::status_transition()` never ran, so:

- The standard transition action hooks (`woocommerce_order_status_<old>_to_trash`, `woocommerce_order_status_trash`, `woocommerce_order_status_changed`) never fired.
- The "Order status changed from X to Trash." order note was missing.

`untrash_order()` already used the `set_status()` + `save()` pattern, which is why restoring from trash worked correctly — only the trash side was broken. This is a clear asymmetry and the bug report points directly at the same gap.

This PR refactors `trash_order()` to stage the trash status change and the `_wp_trash_meta_*` metadata on the order object and then call `$order->save()`. The HPOS `update()` method already short-circuits the `woocommerce_update_order` action for trash/untrash transitions, so other consumers are not impacted while the `WC_Order::status_transition()` pipeline now runs correctly.

Closes #46740
Linear: https://linear.app/a8c/issue/RSMAPGJ-421

### How to test the changes in this Pull Request:

1. Ensure HPOS is enabled (default on modern installs).
2. Create a test order, e.g. in WP CLI: `wp wc shop_order create --status=on-hold --user=1`.
3. Hook a logger or temporarily add a plugin/mu-plugin like:
   ```php
   add_action( 'woocommerce_order_status_on-hold_to_trash', function ( $id ) { error_log( "on-hold_to_trash fired for #$id" ); } );
   add_action( 'woocommerce_order_status_trash',            function ( $id ) { error_log( "status_trash fired for #$id" ); } );
   add_action( 'woocommerce_order_status_changed',          function ( $id, $from, $to ) { error_log( "status_changed for #$id: $from -> $to" ); }, 10, 3 );
   ```
4. Navigate to **WooCommerce -> Orders**, select the order in the list, choose **Move to trash** from the bulk actions, and apply.
5. Confirm the log entries above are written. Open the trashed order and confirm an "Order status changed from On hold to Trash." order note is present.
6. Restore the order from trash and confirm everything still works (untrash already fired transitions; nothing should regress).

### Testing that has already taken place:

- Added a PHPUnit regression test `test_cot_datastore_trash_fires_status_transition_actions` in `OrdersTableDataStoreTests` covering all three action hooks and the transition order note.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse src/Internal/DataStores/Orders/OrdersTableDataStore.php --memory-limit=2G` — no errors. No baseline additions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

A changelog file was added manually at `plugins/woocommerce/changelog/fix-rsmapgj-421`.

---

Submitted by the RSMAPGJ AI Coder pipeline.