### PR TITLE
Preserve shipping rate precision when re-opening shipping zone method modal

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-417
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-417
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve the precision of shipping rates stored with more decimal places than the configured currency precision when the shipping method settings modal is re-opened, so silently re-saving the form no longer truncates the stored value.

--- a/plugins/woocommerce/client/legacy/Gruntfile.js
+++ b/plugins/woocommerce/client/legacy/Gruntfile.js
@@ -136,6 +136,7 @@ module.exports = function ( grunt ) {
 					'<%= dirs.jsDest %>/admin/wc-shipping-zone-methods.js': [
 						'<%= dirs.js %>/admin/utils/number-validation.js',
 						'<%= dirs.js %>/admin/utils/maybe-modify-decimal.js',
+						'<%= dirs.js %>/admin/utils/preserve-shipping-cost-precision.js',
 						'<%= dirs.jsDest %>/admin/wc-shipping-zone-methods.js',
 					],
 				},

--- a/plugins/woocommerce/client/legacy/js/admin/utils/preserve-shipping-cost-precision.js
+++ b/plugins/woocommerce/client/legacy/js/admin/utils/preserve-shipping-cost-precision.js
@@ -1,0 +1,63 @@
+/**
+ * Preserve shipping cost precision utility for the shipping zone methods admin UI.
+ *
+ * When a stored shipping cost has more decimal places than the configured currency
+ * precision, the form must still render the full stored value so the merchant does
+ * not silently lose precision by re-saving the modal. See #43838.
+ */
+
+/**
+ * Build a number formatting config that preserves the precision of the supplied
+ * cost value when it exceeds the currency's configured precision.
+ *
+ * The returned object is a shallow clone of `config` with `precision` adjusted
+ * upward to match the number of decimals actually present in `value`. If the
+ * value's precision is less than or equal to the configured precision, the
+ * original `config` is returned unchanged.
+ *
+ * @param {string} value  The shipping cost as a string, using `config.decimalSeparator`.
+ * @param {Object} config Number formatting configuration. Must include
+ *                        `decimalSeparator` and `precision`.
+ * @return {Object} A config object suitable for `localiseMonetaryValue`.
+ */
+function getPrecisionPreservingConfig( value, config ) {
+	if ( ! config || typeof config !== 'object' ) {
+		return config;
+	}
+
+	if ( typeof value !== 'string' || ! config.decimalSeparator ) {
+		return config;
+	}
+
+	const parts = value.split( config.decimalSeparator );
+	if ( parts.length < 2 ) {
+		return config;
+	}
+
+	if ( config.precision === null || config.precision === undefined ) {
+		// localiseMonetaryValue auto-detects precision from the value, so we don't need to override.
+		return config;
+	}
+
+	const valuePrecision = parts[ 1 ].length;
+	const configuredPrecision = Number( config.precision );
+	if ( ! Number.isFinite( configuredPrecision ) || valuePrecision <= configuredPrecision ) {
+		return config;
+	}
+
+	return Object.assign( {}, config, { precision: valuePrecision } );
+}
+
+// Export for different module systems
+if ( typeof module !== 'undefined' && module.exports ) {
+	// CommonJS (Node.js)
+	module.exports = { getPrecisionPreservingConfig };
+} else if ( typeof define === 'function' && define.amd ) {
+	// AMD
+	define( [], function () {
+		return { getPrecisionPreservingConfig };
+	} );
+} else {
+	// Browser global
+	window.WCPreserveShippingCostPrecision = { getPrecisionPreservingConfig };
+}

--- a/plugins/woocommerce/client/legacy/js/admin/utils/test/preserve-shipping-cost-precision.test.js
+++ b/plugins/woocommerce/client/legacy/js/admin/utils/test/preserve-shipping-cost-precision.test.js
@@ -1,0 +1,96 @@
+/**
+ * Test for getPrecisionPreservingConfig method from utils/preserve-shipping-cost-precision.js
+ */
+
+const {
+	getPrecisionPreservingConfig,
+} = require( '../preserve-shipping-cost-precision' );
+
+describe( 'Preserve Shipping Cost Precision - getPrecisionPreservingConfig', () => {
+	const baseConfig = {
+		precision: 2,
+		decimalSeparator: '.',
+		thousandSeparator: ',',
+	};
+
+	test( 'returns the config unchanged when value precision is at or below configured precision', () => {
+		expect( getPrecisionPreservingConfig( '4.59', baseConfig ) ).toBe(
+			baseConfig
+		);
+		expect( getPrecisionPreservingConfig( '4', baseConfig ) ).toBe(
+			baseConfig
+		);
+		expect( getPrecisionPreservingConfig( '4.5', baseConfig ) ).toBe(
+			baseConfig
+		);
+	} );
+
+	test( 'bumps precision to match the stored value when it has more decimals than configured', () => {
+		const result = getPrecisionPreservingConfig( '4.596', baseConfig );
+		expect( result ).not.toBe( baseConfig );
+		expect( result.precision ).toBe( 3 );
+		expect( result.decimalSeparator ).toBe( '.' );
+		expect( result.thousandSeparator ).toBe( ',' );
+	} );
+
+	test( 'preserves precision when decimal separator is a comma', () => {
+		const commaConfig = {
+			precision: 2,
+			decimalSeparator: ',',
+			thousandSeparator: '.',
+		};
+		const result = getPrecisionPreservingConfig( '4,596', commaConfig );
+		expect( result.precision ).toBe( 3 );
+	} );
+
+	test( 'returns the original config when value is not a string', () => {
+		expect( getPrecisionPreservingConfig( 4.596, baseConfig ) ).toBe(
+			baseConfig
+		);
+		expect( getPrecisionPreservingConfig( undefined, baseConfig ) ).toBe(
+			baseConfig
+		);
+		expect( getPrecisionPreservingConfig( null, baseConfig ) ).toBe(
+			baseConfig
+		);
+	} );
+
+	test( 'returns the original config when config is missing or invalid', () => {
+		expect( getPrecisionPreservingConfig( '4.596', null ) ).toBe( null );
+		expect( getPrecisionPreservingConfig( '4.596', undefined ) ).toBe(
+			undefined
+		);
+		expect( getPrecisionPreservingConfig( '4.596', 'invalid' ) ).toBe(
+			'invalid'
+		);
+	} );
+
+	test( 'returns the original config when configured precision is not numeric', () => {
+		const oddConfig = {
+			precision: null,
+			decimalSeparator: '.',
+			thousandSeparator: ',',
+		};
+		expect( getPrecisionPreservingConfig( '4.596', oddConfig ) ).toBe(
+			oddConfig
+		);
+	} );
+
+	test( 'returns the original config when decimalSeparator is missing', () => {
+		const noSep = { precision: 2, thousandSeparator: ',' };
+		expect( getPrecisionPreservingConfig( '4.596', noSep ) ).toBe( noSep );
+	} );
+
+	test( 'leaves formula values that lack a decimal separator untouched', () => {
+		expect( getPrecisionPreservingConfig( '10 * [qty]', baseConfig ) ).toBe(
+			baseConfig
+		);
+	} );
+
+	test( 'handles trailing decimal separator as zero precision delta', () => {
+		// "4." has an empty decimal part, which should not bump precision above the configured value.
+		expect( getPrecisionPreservingConfig( '4.', baseConfig ) ).toBe(
+			baseConfig
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -1,4 +1,4 @@
-/* global shippingZoneMethodsLocalizeScript, ajaxurl, WCNumberValidation, WCMaybeModifyDecimal */
+/* global shippingZoneMethodsLocalizeScript, ajaxurl, WCNumberValidation, WCMaybeModifyDecimal, WCPreserveShippingCostPrecision */
 ( function( $, data, wp, ajaxurl ) {
 	$( function() {
 		var $table          = $( '.wc-shipping-zone-methods' ),
@@ -517,7 +517,11 @@
 							// There was an error modifying the decimal, so we leave the original value as-is.
 							return;
 						}
-						const formattedValue = window.wc.currency.localiseMonetaryValue( config, value );
+						// Preserve the stored shipping cost's precision so that values stored with more
+						// decimals than the configured currency precision are not silently rounded when
+						// the settings modal is re-opened. See #43838.
+						const formatConfig = WCPreserveShippingCostPrecision.getPrecisionPreservingConfig( value, config );
+						const formattedValue = window.wc.currency.localiseMonetaryValue( formatConfig, value );
 						priceInput.attr( 'value', formattedValue );
 					} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When the shipping zone "edit method" modal renders the stored `Cost` value, `wc-shipping-zone-methods.js` runs the value through `localiseMonetaryValue`, which uses the configured currency `precision` and `toFixed()` to round before display. A merchant who deliberately stores a shipping rate with more decimals than the configured currency precision (e.g. `4.596` on a 2-decimal currency to land on a clean `5.70` after 24% tax) sees `4.60` in the input on re-open, and clicking Save persists the rounded value, silently destroying the stored precision.

This PR adds a small utility (`getPrecisionPreservingConfig`) that bumps the formatter's precision up to match the actual decimal count of the stored value when the stored value has more decimals than the currency precision. The currency precision is left untouched for everything else, so display formatting elsewhere is unaffected. The util is used only in the shipping zone modal renderer.

Closes #43838

Linear: https://linear.app/a8c/issue/RSMAPGJ-417

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Stored `4.596` displays as `4.60`; Save persists `4.60`. | Stored `4.596` displays as `4.596`; Save persists `4.596`. |

### How to test the changes in this Pull Request:

1. In **WooCommerce > Settings > General**, set "Number of decimals" to `2`.
2. Go to **WooCommerce > Settings > Shipping > Shipping zones**, edit a zone, and add a Flat rate method.
3. Edit the new method. In the **Cost** field enter `4.596` and save.
4. Re-open the same Flat rate method's edit modal.
   - Before: the Cost field shows `4.60` (precision lost).
   - After: the Cost field shows `4.596` (precision preserved).
5. Click **Save** without touching the value.
   - Before: the DB now stores `4.60`.
   - After: the DB still stores `4.596`.
6. Try a value at or below the configured precision (e.g. `4.59`) and confirm display formatting still applies thousand separators / locale decimal separator as before.
7. Try a formula value (e.g. `10 * [qty]`) and confirm it is rendered untouched.

### Testing that has already taken place:

- New unit tests added: `plugins/woocommerce/client/legacy/js/admin/utils/test/preserve-shipping-cost-precision.test.js` (9 cases covering precision bump, formula passthrough, alternate decimal separators, null/undefined inputs).
- `pnpm test:js` for `@woocommerce/classic-assets`: all 134 tests pass.
- `pnpm exec eslint` on changed files: clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`: clean.
- `grunt js` re-concatenates the new utility into the shipping-zone-methods bundle.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry committed manually at `plugins/woocommerce/changelog/fix-rsmapgj-417` (significance: patch, type: fix).

---

Generated by the RSMAPGJ AI Coder pilot agent.