### PR TITLE
Fix "Used for variations" checkbox not defaulting on simple-to-variable switch

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-411
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-411
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Default the "Used for variations" checkbox to checked on blank custom attribute rows when switching a product to Variable.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -163,6 +163,8 @@ jQuery( function ( $ ) {
 			show_and_hide_panels();
 			change_product_type_tip( get_product_tip_content( select_val ) );
 
+			update_blank_attribute_rows_for_product_type( select_val );
+
 			$( 'ul.wc-tabs li:visible' ).eq( 0 ).find( 'a' ).trigger( 'click' );
 
 			$( document.body ).trigger(
@@ -172,6 +174,46 @@ jQuery( function ( $ ) {
 			);
 		} )
 		.trigger( 'change' );
+
+	/**
+	 * When the product type changes, update the "Used for variations" checkbox
+	 * default on any blank (empty) custom attribute rows so it reflects the new
+	 * product type. Attribute rows that have already been filled in by the user
+	 * are left untouched so we never override an explicit user choice.
+	 *
+	 * @param {string} product_type The newly selected product type.
+	 */
+	function update_blank_attribute_rows_for_product_type( product_type ) {
+		var is_variable = 'variable' === product_type;
+
+		$( '.product_attributes .woocommerce_attribute' ).each( function () {
+			var $attribute = $( this );
+
+			// Only adjust custom (non-taxonomy) attribute rows.
+			var taxonomy = $attribute.attr( 'data-taxonomy' );
+			if ( taxonomy && '' !== taxonomy ) {
+				return;
+			}
+
+			var $name = $attribute.find( 'input[name^="attribute_names"]' );
+			var $values = $attribute.find(
+				'input[name^="attribute_values"], textarea[name^="attribute_values"]'
+			);
+
+			// Only update blank rows: no name and no value entered yet.
+			if ( $name.val() || $values.val() ) {
+				return;
+			}
+
+			var $variation_checkbox = $attribute.find(
+				'input.woocommerce_attribute_used_for_variations'
+			);
+
+			if ( $variation_checkbox.length ) {
+				$variation_checkbox.prop( 'checked', is_variable );
+			}
+		} );
+	}
 
 	$( 'input#_downloadable' ).on( 'change', function () {
 		show_and_hide_panels();


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Reported in #39578: when a custom attribute is added on a Simple product and the product type is then changed to Variable, the "Used for variations" checkbox becomes visible (via `.show_if_variable`) but is unchecked. That happens because the empty attribute row is generated server-side by the `woocommerce_add_attribute` AJAX, which uses the product type at the time the Attributes tab is first shown — so for Simple products it returns a row with `variation = 0`.

This PR adds a small JS handler that runs when the product-type `<select>` changes: for blank, custom (non-taxonomy) attribute rows where the user hasn't entered a name or value yet, the `Used for variations` checkbox is updated to reflect the new product type's default (checked for `variable`, unchecked otherwise). Rows that already have content are left untouched so we never override an explicit user choice.

Bug introduced in PR #39502.

### How to test the changes in this Pull Request:

1. WP Admin → Products → Add new.
2. Leave product type as **Simple**.
3. Open the **Attributes** tab. An empty custom attribute row appears.
4. Change product type to **Variable** (without filling the attribute fields).
5. Open the **Attributes** tab again. The `Used for variations` checkbox should now be **checked** by default for the blank row.
6. Without this fix, the checkbox is visible but unchecked.

Regression checks:
- New Variable product → empty attribute row's `Used for variations` is still checked by default.
- New Simple product → checkbox is hidden, no change.
- Switch Variable → Simple with a blank row: checkbox becomes unchecked (and is hidden by `.hide_if_*` rules).
- Save an attribute (name + value, toggle the checkbox), then switch product type: the saved attribute's checkbox state is preserved.

### Testing that has already taken place

Manual reasoning over the change; lint and branch lint pass.

PHP unit-test coverage was not added because the change is JS-only in legacy DOM-coupled code (`client/legacy/js/admin/meta-boxes-product.js`) and the file has no existing Jest harness.

### Changelog entry

A patch / fix changelog entry was created manually at `plugins/woocommerce/changelog/fix-rsmapgj-411`.

Closes #39578
Linear: https://linear.app/a8c/issue/RSMAPGJ-411

---

Generated by the RSMAPGJ AI Coder pipeline.