### PR TITLE
Fix catalog_visibility filter on legacy products REST API

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-401
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-401
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+REST API: Honor the `catalog_visibility` query parameter when listing products via `wc/v3/products` so results are filtered by the requested visibility.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -336,6 +336,44 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			);
 		}
 
+		// Filter by catalog visibility.
+		if ( ! empty( $request['catalog_visibility'] ) ) {
+			switch ( $request['catalog_visibility'] ) {
+				case CatalogVisibility::SEARCH:
+					$args['tax_query'][] = array(
+						'taxonomy' => 'product_visibility',
+						'field'    => 'slug',
+						'terms'    => array( 'exclude-from-search' ),
+						'operator' => 'NOT IN',
+					);
+					break;
+				case CatalogVisibility::CATALOG:
+					$args['tax_query'][] = array(
+						'taxonomy' => 'product_visibility',
+						'field'    => 'slug',
+						'terms'    => array( 'exclude-from-catalog' ),
+						'operator' => 'NOT IN',
+					);
+					break;
+				case CatalogVisibility::VISIBLE:
+					$args['tax_query'][] = array(
+						'taxonomy' => 'product_visibility',
+						'field'    => 'slug',
+						'terms'    => array( 'exclude-from-catalog', 'exclude-from-search' ),
+						'operator' => 'NOT IN',
+					);
+					break;
+				case CatalogVisibility::HIDDEN:
+					$args['tax_query'][] = array(
+						'taxonomy' => 'product_visibility',
+						'field'    => 'slug',
+						'terms'    => array( 'exclude-from-catalog', 'exclude-from-search' ),
+						'operator' => 'AND',
+					);
+					break;
+			}
+		}
+
 		// Filter by visibility in POS.
 		if ( true === $request['pos_products_only'] ) {
 			$args['tax_query'][] = array(
@@ -1966,6 +2004,14 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			'description'       => __( 'Limit result set to products visible in Point of Sale.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'sanitize_callback' => 'wc_string_to_bool',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['catalog_visibility'] = array(
+			'description'       => __( 'Limit result set to products with a specific catalog visibility.', 'woocommerce' ),
+			'type'              => 'string',
+			'enum'              => CatalogVisibility::get_all(),
+			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -2118,6 +2118,97 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Data provider for catalog_visibility filter tests.
+	 *
+	 * @return array
+	 */
+	public function catalog_visibility_filter_provider(): array {
+		return array(
+			'visible only' => array(
+				'visibility'        => 'visible',
+				'expected_includes' => array( 'visible' ),
+				'expected_excludes' => array( 'catalog', 'search', 'hidden' ),
+			),
+			'catalog only' => array(
+				'visibility'        => 'catalog',
+				'expected_includes' => array( 'visible', 'catalog' ),
+				'expected_excludes' => array( 'search', 'hidden' ),
+			),
+			'search only'  => array(
+				'visibility'        => 'search',
+				'expected_includes' => array( 'visible', 'search' ),
+				'expected_excludes' => array( 'catalog', 'hidden' ),
+			),
+			'hidden only'  => array(
+				'visibility'        => 'hidden',
+				'expected_includes' => array( 'hidden' ),
+				'expected_excludes' => array( 'visible', 'catalog', 'search' ),
+			),
+		);
+	}
+
+	/**
+	 * @testdox catalog_visibility collection parameter limits results to products matching the given visibility.
+	 * @dataProvider catalog_visibility_filter_provider
+	 *
+	 * @param string $visibility        Visibility value passed via the catalog_visibility query parameter.
+	 * @param array  $expected_includes Visibility keys that should be present in the response.
+	 * @param array  $expected_excludes Visibility keys that should be absent from the response.
+	 */
+	public function test_collection_filter_catalog_visibility( string $visibility, array $expected_includes, array $expected_excludes ): void {
+		$products = array(
+			'visible' => WC_Helper_Product::create_simple_product(),
+			'catalog' => WC_Helper_Product::create_simple_product(),
+			'search'  => WC_Helper_Product::create_simple_product(),
+			'hidden'  => WC_Helper_Product::create_simple_product(),
+		);
+
+		foreach ( $products as $key => $product ) {
+			$product->set_catalog_visibility( $key );
+			$product->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'catalog_visibility', $visibility );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$product_ids = wp_list_pluck( $response->get_data(), 'id' );
+
+		foreach ( $expected_includes as $key ) {
+			$this->assertContains(
+				$products[ $key ]->get_id(),
+				$product_ids,
+				sprintf( 'Product with catalog_visibility "%s" should be present when filtering by "%s".', $key, $visibility )
+			);
+		}
+
+		foreach ( $expected_excludes as $key ) {
+			$this->assertNotContains(
+				$products[ $key ]->get_id(),
+				$product_ids,
+				sprintf( 'Product with catalog_visibility "%s" should be absent when filtering by "%s".', $key, $visibility )
+			);
+		}
+
+		foreach ( $products as $product ) {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
+
+	/**
+	 * @testdox An invalid catalog_visibility value results in a 400 error.
+	 */
+	public function test_collection_filter_catalog_visibility_invalid_value(): void {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'catalog_visibility', 'not-a-real-value' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
 	 * @testdox Updating a product with incomplete meta_data entries does not cause errors.
 	 */
 	public function test_update_meta_data_with_incomplete_entries(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The legacy `wc/v3/products` endpoint advertises `catalog_visibility` in its response schema, but the collection endpoint silently ignored the `catalog_visibility` query parameter so requests like `GET /wp-json/wc/v3/products?catalog_visibility=visible` returned every product regardless of visibility.

This PR:

- Adds `catalog_visibility` to `WC_REST_Products_Controller::get_collection_params()` with the same enum (`visible`, `catalog`, `search`, `hidden`) used elsewhere by the data store.
- Wires the parameter into `prepare_objects_query()` as a `product_visibility` taxonomy query, mirroring the semantics used by `WC_Product_Data_Store_CPT::query()` so behaviour matches `wc_get_products( [ 'visibility' => ... ] )`.

The new Store API (`wc/store/v1`) already filters by visibility correctly, so it is not affected.

Closes #35719

Linear: https://linear.app/a8c/issue/RSMAPGJ-401

### How to test the changes in this Pull Request:

1. Create at least four simple products in `wp-admin > Products`, one with each "Catalog visibility" value: *Shop and search results*, *Shop only*, *Search results only*, *Hidden*. (`get_catalog_visibility()` will report `visible`, `catalog`, `search`, `hidden` respectively.)
2. Create a REST API key under **WooCommerce > Settings > Advanced > REST API** with Read permissions.
3. Hit the legacy REST endpoint with the new param, e.g.

   ```
   curl -u CK:CS 'https://example.test/wp-json/wc/v3/products?catalog_visibility=visible'
   curl -u CK:CS 'https://example.test/wp-json/wc/v3/products?catalog_visibility=hidden'
   curl -u CK:CS 'https://example.test/wp-json/wc/v3/products?catalog_visibility=catalog'
   curl -u CK:CS 'https://example.test/wp-json/wc/v3/products?catalog_visibility=search'
   ```

   For each call, verify the returned products match the expected visibility (`visible` returns only fully visible, `hidden` returns only fully hidden, `catalog` and `search` return the appropriate combinations).
4. Confirm omitting the param keeps the previous behaviour (all products returned).
5. Pass an invalid value (e.g. `?catalog_visibility=foo`) and confirm a 400 response, consistent with other enum params.

### Testing that has already taken place:

- Added PHPUnit coverage in `class-wc-rest-products-controller-tests.php` covering all four enum values plus the invalid-value 400 case (`test_collection_filter_catalog_visibility`, `test_collection_filter_catalog_visibility_invalid_value`).
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` (clean) and `lint:changes:branch` (clean).
- Ran `composer exec -- phpstan analyse` on the modified controller (no errors).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry committed manually at `plugins/woocommerce/changelog/fix-rsmapgj-401` (patch / fix).

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**

---

Generated by Claude as part of the RSMAPGJ AI Coder pilot.