### PR TITLE
Fix PayPal Standard adding shipping cost on Free Shipping orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-376
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-376
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PayPal Standard adding its own shipping calculation on top of WooCommerce orders that use Free Shipping by sending `no_shipping=1` when the selected shipping method has zero cost.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -362,7 +362,14 @@ class WC_Gateway_Paypal_Request {
 		$shipping_args = array();
 		if ( $order->needs_shipping_address() ) {
 			$shipping_args['address_override'] = $this->gateway->get_option( 'address_override' ) === 'yes' ? 1 : 0;
-			$shipping_args['no_shipping']      = 0;
+			// If the order has a shipping method selected with zero cost (e.g. Free Shipping),
+			// set `no_shipping` to 1 so PayPal does not apply its own shipping calculations on
+			// top of the order total. When a non-zero shipping line is sent, PayPal honors it,
+			// so `no_shipping` can remain 0 in that case to keep the shipping address visible.
+			// See https://github.com/woocommerce/woocommerce/issues/24563.
+			$has_shipping_method          = count( $order->get_shipping_methods() ) > 0;
+			$shipping_total_is_zero       = 0.0 === (float) $order->get_shipping_total();
+			$shipping_args['no_shipping'] = ( $has_shipping_method && $shipping_total_is_zero ) ? 1 : 0;
 			if ( 'yes' === $this->gateway->get_option( 'send_shipping' ) ) {
 				// If we are sending shipping, send shipping address instead of billing.
 				$shipping_args['first_name'] = $this->limit_length( $order->get_shipping_first_name(), 32 );

--- a/plugins/woocommerce/tests/legacy/unit-tests/gateways/paypal/request.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/gateways/paypal/request.php
@@ -408,5 +408,113 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 
 	}
 
+	/**
+	 * Invoke the protected get_shipping_args() method via reflection.
+	 *
+	 * @param WC_Order $order Order to pass to get_shipping_args.
+	 * @return array
+	 */
+	protected function invoke_get_shipping_args( $order ) {
+		$reflection = new ReflectionClass( $this->paypal_request );
+		$method     = $reflection->getMethod( 'get_shipping_args' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->paypal_request, $order );
+	}
+
+	/**
+	 * When the order has a shipping method selected but the shipping total is zero
+	 * (e.g. Free Shipping), `no_shipping` must be sent as 1 so PayPal does not
+	 * apply its own shipping calculations on top of the order total.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/24563
+	 */
+	public function test_no_shipping_arg_when_free_shipping_method_selected() {
+		$order = WC_Helper_Order::create_order();
+
+		// Attach a shipping line item with zero cost (simulates Free Shipping).
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_props(
+			array(
+				'method_title' => 'Free shipping',
+				'method_id'    => 'free_shipping',
+				'total'        => 0,
+			)
+		);
+		$order->add_item( $shipping_item );
+		$order->save();
+
+		$args = $this->invoke_get_shipping_args( $order );
+
+		$this->assertArrayHasKey( 'no_shipping', $args );
+		$this->assertSame( 1, $args['no_shipping'] );
+	}
+
+	/**
+	 * When the order has a shipping method selected with a non-zero cost,
+	 * `no_shipping` should remain 0 so PayPal still displays the shipping
+	 * address and honors the shipping line item sent by WooCommerce.
+	 */
+	public function test_no_shipping_arg_when_paid_shipping_method_selected() {
+		$order = WC_Helper_Order::create_order();
+
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_props(
+			array(
+				'method_title' => 'Flat rate',
+				'method_id'    => 'flat_rate',
+				'total'        => 10,
+			)
+		);
+		$order->add_item( $shipping_item );
+		$order->save();
+
+		$args = $this->invoke_get_shipping_args( $order );
+
+		$this->assertArrayHasKey( 'no_shipping', $args );
+		$this->assertSame( 0, $args['no_shipping'] );
+	}
+
+	/**
+	 * When the order does not require a shipping address, `no_shipping` must be 1
+	 * regardless of any other state.
+	 */
+	public function test_no_shipping_arg_when_order_does_not_need_shipping() {
+		$order = WC_Helper_Order::create_order();
+
+		// Replace the default shippable product with a virtual one so the order
+		// does not need a shipping address.
+		foreach ( $order->get_items() as $item ) {
+			$order->remove_item( $item->get_id() );
+		}
+
+		$virtual_product = new WC_Product_Simple();
+		$virtual_product->set_props(
+			array(
+				'name'          => 'Virtual product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'virtual'       => true,
+			)
+		);
+		$virtual_product->save();
+
+		$item = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $virtual_product,
+				'quantity' => 1,
+				'subtotal' => 10,
+				'total'    => 10,
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+		$order->save();
+
+		$args = $this->invoke_get_shipping_args( $order );
+
+		$this->assertArrayHasKey( 'no_shipping', $args );
+		$this->assertSame( 1, $args['no_shipping'] );
+	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When an order needs a shipping address, `WC_Gateway_Paypal_Request::get_shipping_args()` unconditionally sent `no_shipping=0`. If the buyer selected a free shipping method, no `shipping_1` line item was sent either, so PayPal applied the merchant's own Shipping Calculations on top of the WooCommerce total, overcharging the buyer (and producing validation errors against the WC order total).

This PR sends `no_shipping=1` when the order has a shipping method selected with zero cost (e.g. Free Shipping). Behavior is unchanged otherwise:

| Order shipping state | `no_shipping` before | `no_shipping` after |
| --- | --- | --- |
| Doesn't need shipping address | 1 | 1 |
| Paid shipping method selected | 0 | 0 |
| Free shipping method selected | 0 | **1** |

Closes #24563.

Linear: https://linear.app/a8c/issue/RSMAPGJ-376

### Screenshots or screen recordings:

Not applicable (request-arg-only change, no UI).

### How to test the changes in this Pull Request:

1. In a sandbox PayPal Business account, enable a Shipping Calculations ruleset (Settings → Shipping Calculations). The PayPal Standard gateway must be enabled in WooCommerce.
2. In WooCommerce, add a Free Shipping zone/method that applies to your test country.
3. Place an order using PayPal Standard, with the Free Shipping method selected at checkout.
4. On the PayPal page, confirm the total matches the WooCommerce order total and that PayPal does not add its own shipping cost.
5. Repeat step 3 with a paid shipping method (e.g. Flat Rate) and confirm the WC shipping cost is shown on PayPal and the total matches.
6. Repeat with a virtual-only cart (no shipping address required) and confirm checkout still completes correctly.

### Testing that has already taken place:

- Added unit tests in `tests/legacy/unit-tests/gateways/paypal/request.php` covering the three cases (free shipping selected, paid shipping selected, no shipping needed).
- Verified `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch` pass.
- Verified PHPStan passes for the modified file.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix

#### Message

Fix PayPal Standard adding its own shipping cost on top of WooCommerce orders that use Free Shipping by sending `no_shipping=1` when the selected shipping method has zero cost.

</details>

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>