### PR TITLE
Fire woocommerce_trash_order and woocommerce_delete_order from WP post hooks

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-394
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-394
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fire `woocommerce_trash_order`, `woocommerce_before_trash_order`, `woocommerce_delete_order` and `woocommerce_before_delete_order` when CPT-based orders are trashed or deleted from the wp-admin posts UI.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -32,6 +32,29 @@ class WC_Post_Data {
 	private static $editing_term = null;
 
 	/**
+	 * Order IDs whose delete/trash hooks are being fired by the order data store directly.
+	 *
+	 * Used to avoid double-firing `woocommerce_before_delete_order`, `woocommerce_delete_order`,
+	 * `woocommerce_before_trash_order` and `woocommerce_trash_order` from the WP-level
+	 * `wp_trash_post` / `before_delete_post` / `trashed_post` / `deleted_post` hook chain when
+	 * the data store is the one driving the deletion (and therefore firing those hooks itself).
+	 *
+	 * @var array<int,bool>
+	 */
+	private static $orders_handled_by_data_store = array();
+
+	/**
+	 * Order IDs currently being processed by `before_delete_order()`.
+	 *
+	 * Used to prevent the cleanup from running twice when `before_delete_order()` is invoked
+	 * both via `before_delete_post` and via `woocommerce_before_delete_order` for the same
+	 * order in a single delete operation.
+	 *
+	 * @var array<int,bool>
+	 */
+	private static $orders_currently_being_deleted = array();
+
+	/**
 	 * Hook in methods.
 	 *
 	 * @return void
@@ -62,8 +85,10 @@ class WC_Post_Data {
 		add_action( 'transition_post_status', array( __CLASS__, 'transition_post_status' ), 10, 3 );
 		add_action( 'delete_post', array( __CLASS__, 'delete_post_data' ) );
 		add_action( 'wp_trash_post', array( __CLASS__, 'trash_post' ) );
+		add_action( 'trashed_post', array( __CLASS__, 'trashed_order' ) );
 		add_action( 'untrashed_post', array( __CLASS__, 'untrash_post' ) );
 		add_action( 'before_delete_post', array( __CLASS__, 'before_delete_order' ) );
+		add_action( 'deleted_post', array( __CLASS__, 'deleted_order' ), 10, 2 );
 		add_action( 'woocommerce_before_delete_order', array( __CLASS__, 'before_delete_order' ) );
 
 		// Meta cache flushing.
@@ -487,6 +512,22 @@ class WC_Post_Data {
 		if ( in_array( $post_type, wc_get_order_types( 'order-count' ), true ) ) {
 			global $wpdb;
 
+			if ( ! self::is_order_handled_by_data_store( $id ) && OrderUtil::is_order( $id, wc_get_order_types() ) ) {
+				$order = wc_get_order( $id );
+
+				if ( $order instanceof WC_Order ) {
+					/**
+					 * Fires immediately before an order is trashed.
+					 *
+					 * @since 10.9.0
+					 *
+					 * @param int      $order_id ID of the order about to be trashed.
+					 * @param WC_Order $order    Instance of the order that is about to be trashed.
+					 */
+					do_action( 'woocommerce_before_trash_order', $id, $order );
+				}
+			}
+
 			$refunds = $wpdb->get_results( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = 'shop_order_refund' AND post_parent = %d", $id ) );
 
 			foreach ( $refunds as $refund ) {
@@ -503,6 +544,38 @@ class WC_Post_Data {
 		} elseif ( 'product_variation' === $post_type ) {
 			wc_get_container()->get( ProductAttributesLookupDataStore::class )->on_product_deleted( $id );
 		}
+	}
+
+	/**
+	 * Fire `woocommerce_trash_order` after an order has been trashed via WP post APIs.
+	 *
+	 * Hooked to WordPress `trashed_post` so the action fires for orders trashed from any
+	 * code path (admin posts list, bulk actions, single-order edit screen), not only from
+	 * the order data store's `delete()` method.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $id Post ID.
+	 *
+	 * @return void
+	 */
+	public static function trashed_order( $id ) {
+		if ( ! $id || self::is_order_handled_by_data_store( $id ) ) {
+			return;
+		}
+
+		if ( ! OrderUtil::is_order( $id, wc_get_order_types() ) ) {
+			return;
+		}
+
+		/**
+		 * Fires immediately after an order is trashed.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param int $order_id ID of the order that has been trashed.
+		 */
+		do_action( 'woocommerce_trash_order', $id );
 	}
 
 	/**
@@ -577,9 +650,46 @@ class WC_Post_Data {
 	 * @return void
 	 */
 	public static function before_delete_order( $order_id ) {
-		if ( OrderUtil::is_order( $order_id, wc_get_order_types() ) ) {
+		if ( ! OrderUtil::is_order( $order_id, wc_get_order_types() ) ) {
+			return;
+		}
+
+		// Re-entry guard: this handler is registered against both `before_delete_post` and
+		// `woocommerce_before_delete_order`, so it can be invoked twice for the same order
+		// when one fires the other. Run the cleanup (and bridge action) at most once per
+		// delete by remembering which order IDs are currently being processed.
+		if ( isset( self::$orders_currently_being_deleted[ $order_id ] ) ) {
+			return;
+		}
+
+		self::$orders_currently_being_deleted[ $order_id ] = true;
+
+		try {
 			// Clean up user.
 			$order = wc_get_order( $order_id );
+
+			// If a CPT-based order is being permanently deleted via the WP post APIs
+			// (e.g. from the admin posts list or "empty trash"), bridge the WP-level
+			// `before_delete_post` action into `woocommerce_before_delete_order` so
+			// integrations can subscribe to the WooCommerce action regardless of how
+			// the order is being deleted. The order data store fires the action itself
+			// in its delete() flow and marks the order via set_order_handled_by_data_store(),
+			// so we skip the bridge in that case to avoid double-firing.
+			if (
+				$order instanceof WC_Order
+				&& 'before_delete_post' === current_action()
+				&& ! self::is_order_handled_by_data_store( $order_id )
+			) {
+				/**
+				 * Fires immediately before an order is deleted from the database.
+				 *
+				 * @since 8.0.0
+				 *
+				 * @param int      $order_id ID of the order about to be deleted.
+				 * @param WC_Order $order    Instance of the order that is about to be deleted.
+				 */
+				do_action( 'woocommerce_before_delete_order', $order_id, $order );
+			}
 
 			// Check for `get_customer_id`, since this may be e.g. a refund order (which doesn't implement it).
 			$customer_id = is_callable( array( $order, 'get_customer_id' ) ) ? $order->get_customer_id() : 0;
@@ -602,7 +712,85 @@ class WC_Post_Data {
 			// Clean up items.
 			self::delete_order_items( $order_id );
 			self::delete_order_downloadable_permissions( $order_id );
+		} finally {
+			unset( self::$orders_currently_being_deleted[ $order_id ] );
 		}
+	}
+
+	/**
+	 * Fire `woocommerce_delete_order` after an order has been deleted via WP post APIs.
+	 *
+	 * Hooked to WordPress `deleted_post` so the action fires for orders deleted from any
+	 * code path (admin posts list, bulk actions, "empty trash"), not only from the order
+	 * data store's `delete()` method.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int          $id   Post ID.
+	 * @param WP_Post|null $post Post object, when available.
+	 *
+	 * @return void
+	 */
+	public static function deleted_order( $id, $post = null ) {
+		if ( ! $id || self::is_order_handled_by_data_store( $id ) ) {
+			return;
+		}
+
+		$post_type = $post instanceof WP_Post ? $post->post_type : '';
+
+		if ( '' === $post_type || ! in_array( $post_type, wc_get_order_types( 'order-count' ), true ) ) {
+			return;
+		}
+
+		/**
+		 * Fires immediately after an order is deleted.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param int $order_id ID of the order that has been deleted.
+		 */
+		do_action( 'woocommerce_delete_order', $id );
+	}
+
+	/**
+	 * Mark an order ID as currently being handled by the order data store's delete flow.
+	 *
+	 * The data store fires the `woocommerce_before_delete_order`, `woocommerce_delete_order`,
+	 * `woocommerce_before_trash_order` and `woocommerce_trash_order` actions itself; this
+	 * flag prevents the WP-level `wp_trash_post` / `before_delete_post` / `trashed_post` /
+	 * `deleted_post` listeners in this class from firing the same actions a second time.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int  $order_id Order ID.
+	 * @param bool $handled  Whether the data store is handling the order.
+	 *
+	 * @return void
+	 */
+	public static function set_order_handled_by_data_store( $order_id, $handled = true ) {
+		$order_id = (int) $order_id;
+		if ( $order_id <= 0 ) {
+			return;
+		}
+
+		if ( $handled ) {
+			self::$orders_handled_by_data_store[ $order_id ] = true;
+		} else {
+			unset( self::$orders_handled_by_data_store[ $order_id ] );
+		}
+	}
+
+	/**
+	 * Check whether an order ID is currently being handled by the order data store's delete flow.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $order_id Order ID.
+	 *
+	 * @return bool
+	 */
+	public static function is_order_handled_by_data_store( $order_id ) {
+		return ! empty( self::$orders_handled_by_data_store[ (int) $order_id ] );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -296,7 +296,12 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				do_action( 'woocommerce_before_delete_order', $id, $order );
 			}
 
-			wp_delete_post( $id );
+			WC_Post_Data::set_order_handled_by_data_store( $id );
+			try {
+				wp_delete_post( $id );
+			} finally {
+				WC_Post_Data::set_order_handled_by_data_store( $id, false );
+			}
 			$order->set_id( 0 );
 
 			if ( $do_filters ) {
@@ -322,7 +327,12 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				do_action( 'woocommerce_before_trash_order', $id, $order );
 			}
 
-			wp_trash_post( $id );
+			WC_Post_Data::set_order_handled_by_data_store( $id );
+			try {
+				wp_trash_post( $id );
+			} finally {
+				WC_Post_Data::set_order_handled_by_data_store( $id, false );
+			}
 			$order->set_status( OrderStatus::TRASH );
 
 			if ( $do_filters ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
@@ -5,10 +5,13 @@
  * @package WooCommerce\Tests\Post_Data.
  */
 
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+
 /**
  * Class WC_Post_Data_Test
  */
 class WC_Post_Data_Test extends \WC_Unit_Test_Case {
+	use HPOSToggleTrait;
 
 	/**
 	 * @testdox coupon code should be always sanitized.
@@ -161,5 +164,201 @@ class WC_Post_Data_Test extends \WC_Unit_Test_Case {
 
 		remove_action( 'woocommerce_product_published', $callback );
 		$product->delete( true );
+	}
+
+	/**
+	 * Helper: create a CPT-based shop_order post bypassing the order data store.
+	 *
+	 * Avoids triggering the data store's own delete hooks or HPOS sync, so we can
+	 * exercise the WP-level `wp_trash_post` / `before_delete_post` / `trashed_post`
+	 * / `deleted_post` hook chain on a real shop_order post regardless of whether
+	 * HPOS is authoritative in the test environment.
+	 *
+	 * @return int Post ID of the created order.
+	 */
+	private function create_cpt_shop_order_post(): int {
+		return wp_insert_post(
+			array(
+				'post_type'   => 'shop_order',
+				'post_status' => 'wc-pending',
+				'post_title'  => 'CPT order for hook test',
+			)
+		);
+	}
+
+	/**
+	 * Switch the active order data store to the CPT one so `OrderUtil::is_order()`
+	 * resolves against `wp_posts.post_type` for these hook tests.
+	 *
+	 * Disables HPOS sync first to avoid the "orders out of sync" guard when toggling.
+	 *
+	 * @return void
+	 */
+	private function switch_to_cpt_order_store(): void {
+		// Bypass the "orders out of sync" guard in CustomOrdersTableController so we
+		// can switch the authoritative store regardless of any HPOS leftovers from
+		// other tests in this class (HPOS custom tables are not rolled back by
+		// WP_UnitTestCase's transactions).
+		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+		$this->disable_cot_sync();
+		$this->toggle_cot_authoritative( false );
+	}
+
+	/**
+	 * Restore HPOS as the authoritative store after a CPT-mode test.
+	 *
+	 * @return void
+	 */
+	private function restore_hpos_order_store(): void {
+		$this->toggle_cot_authoritative( true );
+		remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+	}
+
+	/**
+	 * @testdox woocommerce_trash_order fires when a CPT-based order is trashed via wp_trash_post.
+	 */
+	public function test_wp_trash_post_fires_woocommerce_trash_order_for_cpt_order(): void {
+		$this->switch_to_cpt_order_store();
+
+		try {
+			$order_id = $this->create_cpt_shop_order_post();
+			$this->assertGreaterThan( 0, $order_id );
+
+			$before_trash_ids = array();
+			$trash_ids        = array();
+
+			$before_callback = static function ( $id ) use ( &$before_trash_ids ) {
+				$before_trash_ids[] = $id;
+			};
+			$after_callback  = static function ( $id ) use ( &$trash_ids ) {
+				$trash_ids[] = $id;
+			};
+
+			add_action( 'woocommerce_before_trash_order', $before_callback );
+			add_action( 'woocommerce_trash_order', $after_callback );
+
+			wp_trash_post( $order_id );
+
+			remove_action( 'woocommerce_before_trash_order', $before_callback );
+			remove_action( 'woocommerce_trash_order', $after_callback );
+
+			$this->assertSame( array( $order_id ), $before_trash_ids, 'woocommerce_before_trash_order should fire once for the trashed order.' );
+			$this->assertSame( array( $order_id ), $trash_ids, 'woocommerce_trash_order should fire once for the trashed order.' );
+		} finally {
+			$this->restore_hpos_order_store();
+		}
+	}
+
+	/**
+	 * @testdox woocommerce_delete_order fires when a CPT-based order is force-deleted via wp_delete_post.
+	 */
+	public function test_wp_delete_post_fires_woocommerce_delete_order_for_cpt_order(): void {
+		$this->switch_to_cpt_order_store();
+
+		try {
+			$order_id = $this->create_cpt_shop_order_post();
+			$this->assertGreaterThan( 0, $order_id );
+
+			$before_delete_ids = array();
+			$delete_ids        = array();
+
+			$before_callback = static function ( $id ) use ( &$before_delete_ids ) {
+				$before_delete_ids[] = $id;
+			};
+			$after_callback  = static function ( $id ) use ( &$delete_ids ) {
+				$delete_ids[] = $id;
+			};
+
+			add_action( 'woocommerce_before_delete_order', $before_callback );
+			add_action( 'woocommerce_delete_order', $after_callback );
+
+			wp_delete_post( $order_id, true );
+
+			remove_action( 'woocommerce_before_delete_order', $before_callback );
+			remove_action( 'woocommerce_delete_order', $after_callback );
+
+			$this->assertSame( array( $order_id ), $before_delete_ids, 'woocommerce_before_delete_order should fire once for the deleted order.' );
+			$this->assertSame( array( $order_id ), $delete_ids, 'woocommerce_delete_order should fire once for the deleted order.' );
+		} finally {
+			$this->restore_hpos_order_store();
+		}
+	}
+
+	/**
+	 * @testdox WP post hook chain does not fire CPT-order hooks when the data store has marked the order.
+	 */
+	public function test_wp_post_hooks_skip_firing_when_order_handled_by_data_store(): void {
+		$this->switch_to_cpt_order_store();
+		$order_id = $this->create_cpt_shop_order_post();
+		$this->assertGreaterThan( 0, $order_id );
+
+		$before_trash_ids = array();
+		$trash_ids        = array();
+		$before_delete    = array();
+		$delete_ids       = array();
+
+		$cb_bt = static function ( $id ) use ( &$before_trash_ids ) {
+			$before_trash_ids[] = $id;
+		};
+		$cb_t  = static function ( $id ) use ( &$trash_ids ) {
+			$trash_ids[] = $id;
+		};
+		$cb_bd = static function ( $id ) use ( &$before_delete ) {
+			$before_delete[] = $id;
+		};
+		$cb_d  = static function ( $id ) use ( &$delete_ids ) {
+			$delete_ids[] = $id;
+		};
+
+		add_action( 'woocommerce_before_trash_order', $cb_bt );
+		add_action( 'woocommerce_trash_order', $cb_t );
+		add_action( 'woocommerce_before_delete_order', $cb_bd );
+		add_action( 'woocommerce_delete_order', $cb_d );
+
+		WC_Post_Data::set_order_handled_by_data_store( $order_id, true );
+
+		try {
+			wp_trash_post( $order_id );
+			wp_delete_post( $order_id, true );
+		} finally {
+			WC_Post_Data::set_order_handled_by_data_store( $order_id, false );
+			$this->restore_hpos_order_store();
+		}
+
+		remove_action( 'woocommerce_before_trash_order', $cb_bt );
+		remove_action( 'woocommerce_trash_order', $cb_t );
+		remove_action( 'woocommerce_before_delete_order', $cb_bd );
+		remove_action( 'woocommerce_delete_order', $cb_d );
+
+		$this->assertSame( array(), $before_trash_ids, 'woocommerce_before_trash_order must not fire when the data store has marked the order.' );
+		$this->assertSame( array(), $trash_ids, 'woocommerce_trash_order must not fire when the data store has marked the order.' );
+		$this->assertSame( array(), $before_delete, 'woocommerce_before_delete_order must not fire when the data store has marked the order.' );
+		$this->assertSame( array(), $delete_ids, 'woocommerce_delete_order must not fire when the data store has marked the order.' );
+	}
+
+	/**
+	 * @testdox woocommerce_delete_order does not fire for non-order post types.
+	 */
+	public function test_wp_delete_post_does_not_fire_woocommerce_delete_order_for_non_orders(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Generic post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$delete_ids = array();
+		$callback   = static function ( $order_id ) use ( &$delete_ids ) {
+			$delete_ids[] = $order_id;
+		};
+
+		add_action( 'woocommerce_delete_order', $callback );
+
+		wp_delete_post( $post_id, true );
+
+		remove_action( 'woocommerce_delete_order', $callback );
+
+		$this->assertSame( array(), $delete_ids, 'woocommerce_delete_order should not fire for non-order post types.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #32543.
Linear: https://linear.app/a8c/issue/RSMAPGJ-394

When an order stored in the legacy CPT data store is trashed or permanently deleted from the wp-admin posts UI (`edit.php?post_type=shop_order`, the single-order edit screen, or "empty trash"), WordPress core calls `wp_trash_post()` / `wp_delete_post()` directly on the order post. That path bypasses `Abstract_WC_Order_Data_Store_CPT::delete()`, so the documented `woocommerce_before_trash_order`, `woocommerce_trash_order`, `woocommerce_before_delete_order` and `woocommerce_delete_order` actions never fired.

This PR:

- Bridges the WordPress-level `wp_trash_post` / `trashed_post` / `before_delete_post` / `deleted_post` hook chain in `WC_Post_Data` so the four WooCommerce order actions fire regardless of how a CPT-based order is trashed or deleted.
- Avoids double-firing when `Abstract_WC_Order_Data_Store_CPT::delete()` is the caller (the data store already fires the actions itself) by setting a static suppression flag via `WC_Post_Data::set_order_handled_by_data_store()` around its calls to `wp_delete_post()` / `wp_trash_post()`.
- Adds a re-entry guard in `WC_Post_Data::before_delete_order()` so the existing cleanup (order items, downloadable permissions, customer paying-state) runs at most once per delete, even though the handler is hooked to both `before_delete_post` and `woocommerce_before_delete_order`.

The HPOS path is unchanged — `OrdersTableDataStore` already fires these actions in its own `delete()` method.

### How to test the changes in this Pull Request:

1. Install the build on a site with HPOS **disabled** (Settings → Advanced → Features → High-performance order storage off).
2. In a mu-plugin or `functions.php`, log the actions:
   ```php
   add_action( 'woocommerce_before_trash_order', fn( $id ) => error_log( "before_trash_order: $id" ) );
   add_action( 'woocommerce_trash_order',        fn( $id ) => error_log( "trash_order: $id" ) );
   add_action( 'woocommerce_before_delete_order',fn( $id ) => error_log( "before_delete_order: $id" ) );
   add_action( 'woocommerce_delete_order',       fn( $id ) => error_log( "delete_order: $id" ) );
   ```
3. Create a test order. From `/wp-admin/edit.php?post_type=shop_order`, use the row "Move to Trash" link.
   - Expect `before_trash_order` and `trash_order` in the error log.
4. Open the order edit screen and click "Move to Trash" from there.
   - Expect `before_trash_order` and `trash_order`.
5. Use the bulk-actions "Move to Trash" on the orders list.
   - Expect one `before_trash_order` and one `trash_order` per selected order.
6. Go to `/wp-admin/edit.php?post_status=trash&post_type=shop_order` and click "Empty Trash" (or "Delete Permanently" on a single row).
   - Expect `before_delete_order` and `delete_order` for each order.
7. Verify each action fires **exactly once** per order (not duplicated).
8. Programmatically delete via `wc_get_order( $id )->delete( true )` and `->delete( false )` and confirm each action still fires exactly once (no regression on the data-store path).
9. Re-enable HPOS and repeat the trash/delete operations from the HPOS Orders screen to confirm no regression there.

### Testing that has already taken place:

- New PHPUnit coverage in `tests/php/includes/class-wc-post-data-test.php`:
  - `test_wp_trash_post_fires_woocommerce_trash_order_for_cpt_order`
  - `test_wp_delete_post_fires_woocommerce_delete_order_for_cpt_order`
  - `test_wp_post_hooks_skip_firing_when_order_handled_by_data_store`
  - `test_wp_delete_post_does_not_fire_woocommerce_delete_order_for_non_orders`
- Broader `WC_Post_Data_Test` and order data store tests (`WC_Order_Data_Store_CPT`, `OrdersTableDataStoreTests`, refund data store tests) all pass.
- `lint:php:changes`, `lint:changes:branch` and `phpstan analyse` on the modified files run clean (no baseline additions).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix

#### Message

Fire `woocommerce_trash_order`, `woocommerce_before_trash_order`, `woocommerce_delete_order` and `woocommerce_before_delete_order` when CPT-based orders are trashed or deleted from the wp-admin posts UI.

</details>

---

Generated by Claude Code (Opus 4.7) on behalf of @ayushpahwa.