### PR TITLE
Fire generic woocommerce_shipping_instance_form_fields filter on every shipping method

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-332
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-332
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fire a generic `woocommerce_shipping_instance_form_fields` filter alongside the existing per-method `woocommerce_shipping_instance_form_fields_{$id}` filter so integrations can add or modify instance-level settings for every shipping method.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
@@ -562,7 +562,30 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @return array
 	 */
 	public function get_instance_form_fields() {
-		return apply_filters( 'woocommerce_shipping_instance_form_fields_' . $this->id, array_map( array( $this, 'set_defaults' ), $this->instance_form_fields ) );
+		$form_fields = array_map( array( $this, 'set_defaults' ), $this->instance_form_fields );
+
+		/**
+		 * Filters the instance settings fields for a specific shipping method by ID.
+		 *
+		 * @param array $form_fields The instance form fields keyed by field ID.
+		 *
+		 * @since 2.6.0
+		 */
+		$form_fields = apply_filters( 'woocommerce_shipping_instance_form_fields_' . $this->id, $form_fields );
+
+		/**
+		 * Filters the instance settings fields for all shipping methods.
+		 *
+		 * Fires after the per-method `woocommerce_shipping_instance_form_fields_{$id}` filter so
+		 * integrations can add or modify instance-level settings for every shipping method without
+		 * needing to target each method individually.
+		 *
+		 * @param array              $form_fields     The instance form fields keyed by field ID.
+		 * @param WC_Shipping_Method $shipping_method The shipping method instance.
+		 *
+		 * @since 10.9.0
+		 */
+		return apply_filters( 'woocommerce_shipping_instance_form_fields', $form_fields, $this );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-shipping-method-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-shipping-method-test.php
@@ -1,0 +1,117 @@
+<?php
+declare( strict_types = 1 );
+
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- backcompat nomenclature.
+
+/**
+ * Tests for WC_Shipping_Method abstract class.
+ */
+class WC_Shipping_Method_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Shipping_Flat_Rate
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut                       = new WC_Shipping_Flat_Rate();
+		$this->sut->instance_form_fields = array(
+			'title' => array(
+				'title'   => 'Method title',
+				'type'    => 'text',
+				'default' => 'Flat rate',
+			),
+		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_shipping_instance_form_fields' );
+		remove_all_filters( 'woocommerce_shipping_instance_form_fields_flat_rate' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should fire the per-method woocommerce_shipping_instance_form_fields_{id} filter.
+	 */
+	public function test_get_instance_form_fields_fires_per_method_filter(): void {
+		add_filter(
+			'woocommerce_shipping_instance_form_fields_flat_rate',
+			function ( $fields ) {
+				$fields['per_method_field'] = array(
+					'title' => 'Per-method field',
+					'type'  => 'text',
+				);
+				return $fields;
+			}
+		);
+
+		$fields = $this->sut->get_instance_form_fields();
+
+		$this->assertArrayHasKey( 'per_method_field', $fields, 'Per-method filter should add fields.' );
+	}
+
+	/**
+	 * @testdox Should fire the generic woocommerce_shipping_instance_form_fields filter for every shipping method.
+	 */
+	public function test_get_instance_form_fields_fires_generic_filter(): void {
+		$received_method = null;
+
+		add_filter(
+			'woocommerce_shipping_instance_form_fields',
+			function ( $fields, $method ) use ( &$received_method ) {
+				$received_method            = $method;
+				$fields['custom_test_field'] = array(
+					'title'   => 'Custom Hook Test Field',
+					'type'    => 'text',
+					'default' => 'hook_fired',
+				);
+				return $fields;
+			},
+			10,
+			2
+		);
+
+		$fields = $this->sut->get_instance_form_fields();
+
+		$this->assertArrayHasKey( 'custom_test_field', $fields, 'Generic filter should add custom fields to every shipping method.' );
+		$this->assertSame( $this->sut, $received_method, 'Generic filter should pass the shipping method instance.' );
+	}
+
+	/**
+	 * @testdox Should fire the generic filter after the per-method filter so generic callbacks can see per-method additions.
+	 */
+	public function test_get_instance_form_fields_filter_ordering(): void {
+		add_filter(
+			'woocommerce_shipping_instance_form_fields_flat_rate',
+			function ( $fields ) {
+				$fields['per_method_field'] = array(
+					'title' => 'Per-method field',
+					'type'  => 'text',
+				);
+				return $fields;
+			}
+		);
+
+		$seen_keys = array();
+		add_filter(
+			'woocommerce_shipping_instance_form_fields',
+			function ( $fields ) use ( &$seen_keys ) {
+				$seen_keys = array_keys( $fields );
+				return $fields;
+			}
+		);
+
+		$this->sut->get_instance_form_fields();
+
+		$this->assertContains( 'per_method_field', $seen_keys, 'Generic filter should run after per-method filter.' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The reporter of #44415 expected `woocommerce_shipping_instance_form_fields` (no `_{$id}` suffix) to fire when WooCommerce builds the instance settings for a shipping method, but the abstract only ever fired the per-method `woocommerce_shipping_instance_form_fields_{$id}` variant. Custom fields added through the generic hook in `functions.php` therefore never appeared in the shipping method settings modal.

This change adds a new generic `woocommerce_shipping_instance_form_fields` filter that runs *after* the existing per-method filter inside `WC_Shipping_Method::get_instance_form_fields()`. Integrations can now add or modify instance-level settings across every shipping method without having to target each method by ID, while existing per-method callbacks continue to work unchanged.

Closes #44415

Linear: https://linear.app/a8c/issue/RSMAPGJ-332

### How to test the changes in this Pull Request:

1. Drop a mu-plugin (or add to `functions.php`) with:
   ```php
   add_filter( 'woocommerce_shipping_instance_form_fields', function ( $fields, $method ) {
       $fields['custom_test_field'] = array(
           'title'       => 'Custom Hook Test Field',
           'type'        => 'text',
           'description' => 'Added via woocommerce_shipping_instance_form_fields',
           'default'     => 'hook_fired',
       );
       return $fields;
   }, 10, 2 );
   ```
2. Go to **WooCommerce > Settings > Shipping**, open any zone, and edit a shipping method (Flat rate, Free shipping, Local pickup).
3. The "Custom Hook Test Field" row should appear in the settings modal for every method.
4. Confirm existing per-method usage still works by also adding `woocommerce_shipping_instance_form_fields_flat_rate` and verifying its fields render on Flat rate only.

### Testing that has already taken place:

- New PHPUnit coverage in `tests/php/includes/abstracts/class-wc-shipping-method-test.php` exercising the per-method filter, the new generic filter (with `WC_Shipping_Method` instance arg), and the ordering so the generic callback observes per-method additions.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/abstracts/abstract-wc-shipping-method.php --memory-limit=2G` — no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry committed manually at `plugins/woocommerce/changelog/fix-rsmapgj-332` (patch / fix).

---

Submitted via the RSMAPGJ AI Coder pipeline.