### PR TITLE
Fix refunded_payment missing from V1 order refunds POST response

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-355
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-355
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+REST API: Include the read-only `refunded_payment` (and `refunded_by`) properties in V1 order refund responses so POST and GET return matching shapes.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php
@@ -135,12 +135,16 @@ class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {
 
 		$dp = is_null( $request['dp'] ) ? wc_get_price_decimals() : absint( $request['dp'] );
 
+		$refund_data = $refund->get_data();
+
 		$data = array(
-			'id'           => $refund->get_id(),
-			'date_created' => wc_rest_prepare_date_response( $refund->get_date_created() ),
-			'amount'       => wc_format_decimal( $refund->get_amount(), $dp ),
-			'reason'       => $refund->get_reason(),
-			'line_items'   => array(),
+			'id'               => $refund->get_id(),
+			'date_created'     => wc_rest_prepare_date_response( $refund->get_date_created() ),
+			'amount'           => wc_format_decimal( $refund->get_amount(), $dp ),
+			'reason'           => $refund->get_reason(),
+			'refunded_by'      => isset( $refund_data['refunded_by'] ) ? (int) $refund_data['refunded_by'] : 0,
+			'refunded_payment' => isset( $refund_data['refunded_payment'] ) ? (bool) $refund_data['refunded_payment'] : false,
+			'line_items'       => array(),
 		);
 
 		// Add line items.
@@ -340,29 +344,41 @@ class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {
 			'title'      => $this->post_type,
 			'type'       => 'object',
 			'properties' => array(
-				'id' => array(
+				'id'               => array(
 					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'date_created' => array(
+				'date_created'     => array(
 					'description' => __( "The date the order refund was created, in the site's timezone.", 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'amount' => array(
+				'amount'           => array(
 					'description' => __( 'Refund amount.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'reason' => array(
+				'reason'           => array(
 					'description' => __( 'Reason for refund.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'line_items' => array(
+				'refunded_by'      => array(
+					'description' => __( 'User ID of user who created the refund.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'refunded_payment' => array(
+					'description' => __( 'If the payment was refunded via the API.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'line_items'       => array(
 					'description' => __( 'Line items data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller-tests.php
@@ -1,0 +1,73 @@
+<?php
+
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+
+/**
+ * Tests relating to WC_REST_Order_Refunds_V1_Controller.
+ */
+class WC_REST_Order_Refunds_V1_Controller_Tests extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Stores the previous HPOS state.
+	 *
+	 * @var bool
+	 */
+	private static $hpos_prev_state;
+
+	/**
+	 * Prepare for running the tests. Disables HPOS, as the V1 REST API operates on legacy posts.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$hpos_prev_state = \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+		OrderHelper::toggle_cot_feature_and_usage( false );
+	}
+
+	/**
+	 * Restore the previous HPOS state once the tests have finished.
+	 */
+	public static function tearDownAfterClass(): void {
+		OrderHelper::toggle_cot_feature_and_usage( self::$hpos_prev_state );
+
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Test that the V1 POST response on the refunds endpoint includes the
+	 * read-only refunded_payment property, matching the GET response.
+	 *
+	 * Regression test for woocommerce#27296.
+	 */
+	public function test_create_refund_response_includes_refunded_payment() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$request = new WP_REST_Request( 'POST', '/wc/v1/orders/' . $order->get_id() . '/refunds' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'amount'     => '1.00',
+					'api_refund' => false,
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'refunded_payment', $data );
+		$this->assertFalse( $data['refunded_payment'] );
+
+		// Confirm parity with the GET response for the same refund.
+		$get_request  = new WP_REST_Request( 'GET', '/wc/v1/orders/' . $order->get_id() . '/refunds/' . $data['id'] );
+		$get_response = $this->server->dispatch( $get_request );
+		$get_data     = $get_response->get_data();
+		$this->assertArrayHasKey( 'refunded_payment', $get_data );
+		$this->assertSame( $data['refunded_payment'], $get_data['refunded_payment'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller-test.php
@@ -90,4 +90,42 @@ class WC_REST_Order_Refunds_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 
 		$this->assert_incomplete_meta_data_handled_correctly( wc_get_order( $response->get_data()['id'] ) );
 	}
+
+	/**
+	 * Test that the V2 POST response on the refunds endpoint includes the
+	 * read-only refunded_payment property, matching the GET response.
+	 *
+	 * Regression test for woocommerce#27296.
+	 */
+	public function test_create_refund_response_includes_refunded_payment() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$request = new WP_REST_Request( 'POST', '/wc/v2/orders/' . $order->get_id() . '/refunds' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'amount'     => '1.00',
+					'api_refund' => false,
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'refunded_payment', $data );
+		$this->assertFalse( $data['refunded_payment'] );
+
+		// Confirm parity with the GET response for the same refund.
+		$get_request  = new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() . '/refunds/' . $data['id'] );
+		$get_response = $this->server->dispatch( $get_request );
+		$get_data     = $get_response->get_data();
+		$this->assertArrayHasKey( 'refunded_payment', $get_data );
+		$this->assertSame( $data['refunded_payment'], $get_data['refunded_payment'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller-test.php
@@ -90,4 +90,42 @@ class WC_REST_Order_Refunds_Controller_Test extends WC_REST_Unit_Test_Case {
 
 		$this->assert_incomplete_meta_data_handled_correctly( wc_get_order( $response->get_data()['id'] ) );
 	}
+
+	/**
+	 * Test that the POST response on the refunds endpoint includes the
+	 * read-only refunded_payment property, matching the GET response.
+	 *
+	 * Regression test for woocommerce#27296.
+	 */
+	public function test_create_refund_response_includes_refunded_payment() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() . '/refunds' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'amount'     => '1.00',
+					'api_refund' => false,
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'refunded_payment', $data );
+		$this->assertFalse( $data['refunded_payment'] );
+
+		// Confirm parity with the GET response for the same refund.
+		$get_request  = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() . '/refunds/' . $data['id'] );
+		$get_response = $this->server->dispatch( $get_request );
+		$get_data     = $get_response->get_data();
+		$this->assertArrayHasKey( 'refunded_payment', $get_data );
+		$this->assertSame( $data['refunded_payment'], $get_data['refunded_payment'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Best Practices for Contributors](https://github.com/woocommerce/woocommerce/wiki/Recommended-Best-Practices-for-Contributors).

### Changes proposed in this Pull Request

The V1 order refunds REST API controller (`/wc/v1/orders/{order_id}/refunds`) did not include the read-only `refunded_payment` (and `refunded_by`) properties in its response data array or its JSON schema, despite being documented as part of the resource. As a result the V1 POST response was inconsistent with the documented shape and with the V2 / V3 GET response shape.

This PR:

- Adds `refunded_payment` (and `refunded_by`) to the data array in `WC_REST_Order_Refunds_V1_Controller::prepare_item_for_response()`.
- Adds matching schema entries with `context: ['view', 'edit']` and `readonly: true`.
- Reads the values via `$refund->get_data()` to avoid PHPStan having to narrow `WC_Order|WC_Order_Refund`.
- Adds regression tests at V1, V2 and V3 asserting `refunded_payment` is present in the POST response and matches the GET response for the same refund.

Closes #27296
Linear: https://linear.app/a8c/issue/RSMAPGJ-355

### How to test the changes in this Pull Request

1. Run the new regression tests:
   - `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_create_refund_response_includes_refunded_payment`
2. Manually:
   - Create a processing order in WooCommerce.
   - POST to `/wp-json/wc/v1/orders/{order_id}/refunds` (and `/wc/v2`, `/wc/v3`) with `{ "amount": "1.00", "api_refund": false }`.
   - Verify that the response JSON contains a `refunded_payment` field set to `false`.
   - GET the same refund; the field should be identical.

### Testing that has already taken place

- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` (clean)
- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` (clean)
- [x] `composer exec -- phpstan analyse includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php --memory-limit=2G` (no errors, no baseline additions)

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

> Already created at `plugins/woocommerce/changelog/fix-rsmapgj-355`.