### PR TITLE
Fix [products] shortcode notice when global post is missing

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-352
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-352
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Undefined index: post" notice raised by the [products] shortcode when rendered in contexts without a global post (e.g. AJAX callbacks).

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php
@@ -637,7 +637,9 @@ class WC_Shortcode_Products {
 				)
 			);
 
-			$original_post = $GLOBALS['post'];
+			// Preserve the original global post so we can restore it after the loop.
+			// In contexts without a global post (e.g. AJAX callbacks), $GLOBALS['post'] may be unset.
+			$original_post = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 
 			do_action( "woocommerce_shortcode_before_{$this->type}_loop", $this->attributes );
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
@@ -447,6 +447,52 @@ class WC_Shortcodes_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Ensure the `[products]` shortcode does not emit an "Undefined index: post" notice
+	 * when $GLOBALS['post'] is not set (e.g. in AJAX request contexts).
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/30073.
+	 */
+	public function test_products_shortcode_without_global_post() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Test AJAX Products Shortcode' );
+		$product->save();
+
+		// Simulate an AJAX/bare context where the global post is not defined.
+		$had_post      = array_key_exists( 'post', $GLOBALS );
+		$original_post = $had_post ? $GLOBALS['post'] : null;
+		unset( $GLOBALS['post'] );
+
+		$caught_notice = null;
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Required to assert that no PHP notice is emitted.
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$caught_notice ) {
+				if ( false !== stripos( $errstr, 'Undefined index: post' )
+					|| false !== stripos( $errstr, 'Undefined array key "post"' ) ) {
+					$caught_notice = $errstr;
+				}
+				return false;
+			},
+			E_NOTICE | E_WARNING | E_USER_NOTICE | E_USER_WARNING
+		);
+
+		try {
+			$this->disable_deprecation_notice();
+			$shortcode = new WC_Shortcode_Products( array( 'limit' => '1' ) );
+			$output    = $shortcode->get_content();
+			$this->enable_deprecation_notice();
+		} finally {
+			restore_error_handler();
+			if ( $had_post ) {
+				$GLOBALS['post'] = $original_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			}
+		}
+
+		$this->assertNull( $caught_notice, 'No "Undefined index: post" notice should be emitted when global post is missing.' );
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'Test AJAX Products Shortcode', $output );
+	}
+
+	/**
 	 * Ensure the `product_page` shortcode renders the password prompt for a protected product belonging to any user.
 	 */
 	public function test_product_page_shortcode_protected_product() {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `[products]` shortcode (`WC_Shortcode_Products::product_loop()`) reads `$GLOBALS['post']` so it can restore the global post after iterating the loop. In contexts where no global post is set — for example, an AJAX action callback that calls `do_shortcode( '[products]' )` — accessing the index emits a `Undefined index: post` PHP notice (or `Undefined array key "post"` on PHP 8+).

This PR guards the read with `isset()` and defaults `$original_post` to `null` when the global is absent. The subsequent restore (line 672) was already safe — assigning `null` back to `$GLOBALS['post']` matches the pre-loop state.

Closes #30073.

Linear: https://linear.app/a8c/issue/RSMAPGJ-352

### How to test the changes in this Pull Request:

1. Drop a small mu-plugin that registers an AJAX action which unsets `$GLOBALS['post']` and runs `do_shortcode( '[products limit="1"]' )` with `WP_DEBUG` and `WP_DEBUG_DISPLAY` enabled. (See the Linear ticket for the exact snippet used by the repro pipeline.)
2. Hit `wp-admin/admin-ajax.php?action=<your-action>` while at least one published product exists.
3. Before the fix: the response contains `Undefined index: post` / `Undefined array key "post"`. After the fix: no such notice; the shortcode markup renders normally.
4. Run the regression test: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_products_shortcode_without_global_post`.

### Testing that has already taken place:

- Added a PHPUnit regression test (`WC_Shortcodes_Test::test_products_shortcode_without_global_post`) that unsets `$GLOBALS['post']`, registers a custom error handler, runs the `[products]` shortcode via `WC_Shortcode_Products`, and asserts no `Undefined index: post` / `Undefined array key "post"` notice is raised while the product markup is still produced.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/shortcodes/class-wc-shortcode-products.php --memory-limit=2G` — no errors; no baseline changes.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually at `plugins/woocommerce/changelog/fix-rsmapgj-352` (patch / fix).

---

Submitted via the RSMAPGJ AI Coder pipeline.