### PR TITLE
Fix In stock availability notice when stock management is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-158
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-158
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the "In stock" availability notice on the product page for in-stock products that have stock management disabled.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -2369,7 +2369,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		} elseif ( $this->managing_stock() ) {
 			$availability = wc_format_stock_for_display( $this );
 		} else {
-			$availability = '';
+			$availability = __( 'In stock', 'woocommerce' );
 		}
 		return apply_filters( 'woocommerce_get_availability_text', $availability, $this );
 	}

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -338,4 +338,53 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		$product->set_cogs_value( 12.34 );
 		$this->assertEquals( 123.4, $product->get_cogs_value() );
 	}
+
+	/**
+	 * @testdox An in-stock product with stock management disabled exposes an "In stock" availability text so the front-end notice renders.
+	 *
+	 * Regression test for woocommerce/woocommerce#26258: previously, when "Manage stock?" was unchecked and the
+	 * stock status was set to "In stock", get_availability() returned an empty availability string, which caused
+	 * wc_get_stock_html() to skip rendering the stock notice on the product page entirely.
+	 */
+	public function test_get_availability_in_stock_without_manage_stock() {
+		$product = new WC_Product_Simple();
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'instock' );
+		$product->save();
+
+		$availability = $product->get_availability();
+
+		$this->assertSame( 'In stock', $availability['availability'] );
+		$this->assertSame( 'in-stock', $availability['class'] );
+	}
+
+	/**
+	 * @testdox An out-of-stock product with stock management disabled still reports the "Out of stock" availability text.
+	 */
+	public function test_get_availability_out_of_stock_without_manage_stock() {
+		$product = new WC_Product_Simple();
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'outofstock' );
+		$product->save();
+
+		$availability = $product->get_availability();
+
+		$this->assertSame( 'Out of stock', $availability['availability'] );
+		$this->assertSame( 'out-of-stock', $availability['class'] );
+	}
+
+	/**
+	 * @testdox wc_get_stock_html() renders a stock notice for an in-stock product even when stock management is disabled.
+	 */
+	public function test_wc_get_stock_html_in_stock_without_manage_stock() {
+		$product = new WC_Product_Simple();
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'instock' );
+		$product->save();
+
+		$html = wc_get_stock_html( $product );
+
+		$this->assertStringContainsString( 'In stock', $html );
+		$this->assertStringContainsString( 'in-stock', $html );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Coding Standards](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

<!-- Please describe what you have changed or added -->

### Changes proposed in this Pull Request:

Closes #26258.

Linear: https://linear.app/a8c/issue/RSMAPGJ-158

When a simple product is marked **In stock** and **Manage stock?** is left unchecked, the front-end "In stock" availability notice was missing from the single product page. The "Out of stock" notice rendered correctly under the same conditions, and the admin tooltip explicitly states the notice will appear on the front end.

The root cause is in `WC_Abstract_Product::get_availability_text()`: the branch that handles in-stock products without stock management and without backorders fell through to an empty string. `wc_get_stock_html()` then short-circuits when the availability string is empty, so the `<p class="stock in-stock">` element never reached the template.

This PR returns the translatable string `In stock` for that branch, restoring the documented behavior. The availability class (`in-stock`) was already correct, so the template now renders the same markup it does for managed in-stock products that have a numeric "x in stock" string.

### Screenshots:

<!-- Bug is a missing element; no screenshots needed for the fix. -->

### How to test the changes in this Pull Request:

Using the WooCommerce Test Drive or any local environment with only WooCommerce active:

1. Create a Simple Product. Set a regular price.
2. Under **Inventory**, leave **Manage stock?** unchecked and set **Stock status** to **In stock**. Save.
3. Visit the product on the front end.
4. Confirm a `<p class="stock in-stock">In stock</p>` element appears (in Storefront/Twenty Twenty-Five it shows under the price/short description).
5. Set the same product to **Out of stock** and confirm "Out of stock" still renders (regression check).
6. Enable **Manage stock?**, set stock quantity to e.g. `5`, and confirm "5 in stock" (or whatever `wc_format_stock_for_display()` returns based on settings) still renders unchanged.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<!-- If you didn't add a changelog entry, the bot will pick this one up. -->

- Significance: Patch
- Type: Fix
- Message: Show the "In stock" availability notice on the product page for in-stock products that have stock management disabled.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>