### PR TITLE
Fix wc_round_tax_total filter inconsistency for custom tax rounding

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-374
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-374
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix inconsistent application of the `wc_round_tax_total` filter for custom tax rounding (e.g. 5-cent rounding). The filter now receives a `$context` argument identifying the call site, allowing consumers to distinguish internal (in-cents) intermediate values from cart-facing totals so grand totals correctly account for rounded tax.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1604,7 +1604,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 					$taxes = array_sum( WC_Tax::calc_tax( $item_discount_amount, $this->get_tax_rates( $item->get_tax_class(), $tax_location ), $this->get_prices_include_tax() ) );
 					if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-						$taxes = wc_round_tax_total( $taxes );
+						$taxes = wc_round_tax_total( $taxes, null, 'order_coupon_discount_tax' );
 					}
 
 					$discount_tax += $taxes;
@@ -1938,7 +1938,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				$tax_amount = (float) $tax;
 
 				if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-					$tax_amount = wc_round_tax_total( $tax_amount );
+					$tax_amount = wc_round_tax_total( $tax_amount, null, 'order_shipping_tax' );
 				}
 
 				$shipping_taxes[ $tax_rate_id ] = isset( $shipping_taxes[ $tax_rate_id ] ) ? (float) $shipping_taxes[ $tax_rate_id ] + $tax_amount : $tax_amount;
@@ -2062,7 +2062,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		$this->set_discount_total( NumberUtil::round( $cart_subtotal - $cart_total, $price_decimals ) );
-		$this->set_discount_tax( wc_round_tax_total( $cart_subtotal_tax - $cart_total_tax ) );
+		$this->set_discount_tax( wc_round_tax_total( $cart_subtotal_tax - $cart_total_tax, null, 'order_discount_tax' ) );
 		$this->set_total( NumberUtil::round( $cart_total + $fees_total + (float) $this->get_shipping_total() + (float) $this->get_cart_tax() + (float) $this->get_shipping_tax(), $price_decimals ) );
 
 		if ( $this->has_cogs() && $this->cogs_is_enabled() ) {
@@ -2182,7 +2182,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		if ( is_callable( array( $item, 'get_total_tax' ) ) && $item->get_quantity() ) {
 			$tax = $item->get_total_tax() / $item->get_quantity();
-			$tax = $round ? wc_round_tax_total( $tax ) : $tax;
+			$tax = $round ? wc_round_tax_total( $tax, null, 'order_item_tax_per_qty' ) : $tax;
 		}
 
 		return apply_filters( 'woocommerce_order_amount_item_tax', $tax, $item, $round, $this );
@@ -2195,7 +2195,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_line_tax( $item ) {
-		return apply_filters( 'woocommerce_order_amount_line_tax', is_callable( array( $item, 'get_total_tax' ) ) ? wc_round_tax_total( $item->get_total_tax() ) : 0, $item, $this );
+		/**
+		 * Filter the rounded line tax total for an order item.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param float             $line_tax The (possibly rounded) line tax total.
+		 * @param mixed             $item     The order item.
+		 * @param WC_Abstract_Order $instance The order/refund instance.
+		 */
+		return apply_filters( 'woocommerce_order_amount_line_tax', is_callable( array( $item, 'get_total_tax' ) ) ? wc_round_tax_total( $item->get_total_tax(), null, 'order_line_tax' ) : 0, $item, $this );
 	}
 
 	/**
@@ -2251,9 +2260,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			if ( 'incl' === $tax_display ) {
 				$subtotal_taxes = 0;
 				foreach ( $this->get_items() as $item ) {
-					$subtotal_taxes += self::round_line_tax( (float) $item->get_subtotal_tax(), false );
+					$subtotal_taxes += self::round_line_tax( (float) $item->get_subtotal_tax(), false, 'order_subtotal_line_tax' );
 				}
-				$subtotal += wc_round_tax_total( $subtotal_taxes );
+				$subtotal += wc_round_tax_total( $subtotal_taxes, null, 'order_display_subtotal_tax' );
 			}
 
 			$subtotal = wc_price( $subtotal, array( 'currency' => $this->get_currency() ) );

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -569,7 +569,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function set_total_tax( $value ) {
 		// We round here because this is a total entry, as opposed to line items in other setters.
-		$this->totals['total_tax'] = wc_round_tax_total( $value );
+		$this->totals['total_tax'] = wc_round_tax_total( $value, null, 'cart_total_tax' );
 	}
 
 	/**
@@ -998,11 +998,11 @@ class WC_Cart extends WC_Legacy_Cart {
 
 				if ( isset( $shipping_taxes[ $key ] ) ) {
 					$tax -= $shipping_taxes[ $key ];
-					$tax  = wc_round_tax_total( $tax );
+					$tax  = wc_round_tax_total( $tax, null, 'cart_tax_totals' );
 					$tax += NumberUtil::round( $shipping_taxes[ $key ], wc_get_price_decimals() );
 					unset( $shipping_taxes[ $key ] );
 				}
-				$tax_totals[ $code ]->amount          += wc_round_tax_total( $tax );
+				$tax_totals[ $code ]->amount          += wc_round_tax_total( $tax, null, 'cart_tax_totals' );
 				$tax_totals[ $code ]->formatted_amount = wc_price( $tax_totals[ $code ]->amount );
 			}
 		}
@@ -2364,7 +2364,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string formatted price
 	 */
 	public function get_cart_tax() {
-		$cart_total_tax = wc_round_tax_total( $this->get_cart_contents_tax() + $this->get_shipping_tax() + $this->get_fee_tax() );
+		$cart_total_tax = wc_round_tax_total( $this->get_cart_contents_tax() + $this->get_shipping_tax() + $this->get_fee_tax(), null, 'cart_total_tax' );
 
 		return apply_filters( 'woocommerce_get_cart_tax', $cart_total_tax ? wc_price( $cart_total_tax ) : '' );
 	}

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -2462,7 +2462,7 @@ class WC_Order extends WC_Abstract_Order {
 				}
 			}
 		}
-		return wc_round_tax_total( $total ) * -1;
+		return wc_round_tax_total( $total, null, 'order_item_tax_refund' ) * -1;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/traits/trait-wc-item-totals.php
+++ b/plugins/woocommerce/includes/traits/trait-wc-item-totals.php
@@ -76,14 +76,23 @@ trait WC_Item_Totals {
 	/**
 	 * Apply rounding to an array of taxes before summing. Rounds to store DP setting, ignoring precision.
 	 *
+	 * The `$context` argument is forwarded to the `wc_round_tax_total` filter
+	 * so consumers can distinguish line tax calls (which may be made with
+	 * values multiplied by 100 for precision) from cart-facing totals. When
+	 * `$in_cents` is true, the context is suffixed with `_in_cents` to make
+	 * the unit explicit to filter callbacks.
+	 *
 	 * @since  3.2.6
-	 * @param  float $value    Tax value.
-	 * @param  bool  $in_cents Whether precision of value is in cents.
+	 * @since  10.9.0 Added the `$context` argument and `_in_cents` suffix.
+	 * @param  float  $value    Tax value.
+	 * @param  bool   $in_cents Whether precision of value is in cents.
+	 * @param  string $context  Optional. Call site identifier passed through to the
+	 *                          `wc_round_tax_total` filter. Defaults to `'line_tax'`.
 	 * @return float
 	 */
-	protected static function round_line_tax( $value, $in_cents = true ) {
+	protected static function round_line_tax( $value, $in_cents = true, $context = 'line_tax' ) {
 		if ( ! self::round_at_subtotal() ) {
-			$value = wc_round_tax_total( $value, $in_cents ? 0 : null );
+			$value = wc_round_tax_total( $value, $in_cents ? 0 : null, $context . ( $in_cents ? '_in_cents' : '' ) );
 		}
 		return $value;
 	}

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -227,15 +227,45 @@ function wc_trim_zeros( $price ) {
 /**
  * Round a tax amount.
  *
- * @param  double $value Amount to round.
+ * The optional `$context` string identifies the call site so filter consumers
+ * (such as 5-cent rounding plugins) can decide which totals should be rounded
+ * and which should be passed through. Internal call sites that pass values in
+ * cents (i.e. multiplied by 100 for precision) use a `_in_cents` suffix on
+ * their context string. See the `wc_round_tax_total` filter for details.
+ *
+ * @since 10.9.0 Added the `$context` parameter and passed it to the
+ *               `wc_round_tax_total` filter as a fifth argument.
+ *
+ * @param  double $value     Amount to round.
  * @param  int    $precision DP to round. Defaults to wc_get_price_decimals.
+ * @param  string $context   Optional. Identifier for the call site, e.g.
+ *                           `'cart_total_tax'`, `'order_discount_tax'`,
+ *                           `'line_tax'`, `'line_tax_in_cents'`. Empty
+ *                           string by default for back compat.
  * @return float
  */
-function wc_round_tax_total( $value, $precision = null ) {
+function wc_round_tax_total( $value, $precision = null, $context = '' ) {
 	$precision   = is_null( $precision ) ? wc_get_price_decimals() : intval( $precision );
 	$rounded_tax = NumberUtil::round( $value, $precision, wc_get_tax_rounding_mode() ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 
-	return apply_filters( 'wc_round_tax_total', $rounded_tax, $value, $precision, WC_TAX_ROUNDING_MODE );
+	/**
+	 * Filter the rounded tax total.
+	 *
+	 * @since 2.1.0
+	 * @since 10.9.0 Added the `$context` parameter so consumers can scope
+	 *                rounding to specific call sites and distinguish
+	 *                internal (in-cents) values from cart/display values.
+	 *
+	 * @param float           $rounded_tax   The rounded tax value.
+	 * @param float           $value         The original (pre-rounding) value.
+	 * @param int             $precision     Decimal places used for rounding.
+	 * @param int|string      $rounding_mode WC_TAX_ROUNDING_MODE constant (PHP rounding mode or `'auto'`).
+	 * @param string          $context       Call site identifier. May be an empty
+	 *                                       string for callers that do not specify one.
+	 *                                       Context strings ending in `_in_cents`
+	 *                                       indicate the value is multiplied by 100.
+	 */
+	return apply_filters( 'wc_round_tax_total', $rounded_tax, $value, $precision, WC_TAX_ROUNDING_MODE, $context );
 }
 
 /**

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -280,6 +280,97 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test wc_round_tax_total() back-compat: omitting `$context` still works
+	 * and the filter still fires with the existing positional arguments.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_wc_round_tax_total_filter_back_compat() {
+		$captured = array();
+		$capture  = function ( $rounded, $value, $precision, $rounding_mode ) use ( &$captured ) {
+			$captured[] = array(
+				'rounded'       => $rounded,
+				'value'         => $value,
+				'precision'     => $precision,
+				'rounding_mode' => $rounding_mode,
+			);
+			return $rounded;
+		};
+		add_filter( 'wc_round_tax_total', $capture, 10, 4 );
+
+		$out = wc_round_tax_total( 1.246 );
+
+		remove_filter( 'wc_round_tax_total', $capture, 10 );
+
+		$this->assertEquals( 1.25, $out );
+		$this->assertCount( 1, $captured );
+		$this->assertEquals( 1.25, $captured[0]['rounded'] );
+		$this->assertEquals( 1.246, $captured[0]['value'] );
+	}
+
+	/**
+	 * Test wc_round_tax_total() forwards the new `$context` argument to the
+	 * `wc_round_tax_total` filter as the fifth parameter.
+	 *
+	 * Regression coverage for RSMAPGJ-374 / woo#25679: the filter is applied
+	 * to both "internal" (in-cents) intermediate values and cart-facing
+	 * totals; consumers (e.g. 5-cent rounding) need a way to distinguish
+	 * call sites so the grand total accounts for the rounded tax.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_wc_round_tax_total_passes_context_to_filter() {
+		$captured_contexts = array();
+		$capture           = function ( $rounded, $value, $precision, $rounding_mode, $context ) use ( &$captured_contexts ) {
+			$captured_contexts[] = $context;
+			return $rounded;
+		};
+		add_filter( 'wc_round_tax_total', $capture, 10, 5 );
+
+		wc_round_tax_total( 1.246 );
+		wc_round_tax_total( 1.246, null, 'cart_total_tax' );
+		wc_round_tax_total( 100.0, 0, 'line_tax_in_cents' );
+
+		remove_filter( 'wc_round_tax_total', $capture, 10 );
+
+		$this->assertSame( array( '', 'cart_total_tax', 'line_tax_in_cents' ), $captured_contexts );
+	}
+
+	/**
+	 * Test the 5-cent rounding scenario from the original bug report.
+	 *
+	 * The filter consumer can now opt out of rounding for the "in cents"
+	 * (internal) call site by inspecting `$context`, so the cart-facing
+	 * total still benefits from 5-cent rounding without the internal
+	 * intermediate value being corrupted.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_wc_round_tax_total_5_cent_filter_can_skip_in_cents_contexts() {
+		$five_cent = function ( $rounded, $value, $precision, $rounding_mode, $context ) {
+			// Skip rounding for any internal in-cents call site.
+			$suffix = '_in_cents';
+			if ( '' !== $context && substr( $context, -strlen( $suffix ) ) === $suffix ) {
+				return $rounded;
+			}
+			// Apply 5-cent rounding to cart-facing values only.
+			return round( $value / 5, $precision ?? 2 ) * 5;
+		};
+		add_filter( 'wc_round_tax_total', $five_cent, 10, 5 );
+
+		// 28.481 (= 149.90 * 0.19) should round to 28.50 in cart context.
+		$cart_value = wc_round_tax_total( 28.481, null, 'cart_total_tax' );
+		// Internal "in cents" value (already × 100): a naive 5-cent filter
+		// would corrupt it; the context-aware filter leaves it alone.
+		$internal_value = wc_round_tax_total( 28.481, 0, 'line_tax_in_cents' );
+
+		remove_filter( 'wc_round_tax_total', $five_cent, 10 );
+
+		$this->assertEqualsWithDelta( 28.50, $cart_value, 0.0001 );
+		$this->assertEqualsWithDelta( 28.0, $internal_value, 0.0001 );
+	}
+
+	/**
 	 * Test wc_format_refund_total().
 	 *
 	 * @since 2.2


### PR DESCRIPTION
Closes #25679
Linear: https://linear.app/a8c/issue/RSMAPGJ-374

### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommendations for Engineers Working on WooCommerce](https://developer.woocommerce.com/recommendations-for-engineers-working-on-woocommerce/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

The `wc_round_tax_total` filter is currently fired from both:

1. **Internal** call sites that pass values multiplied by 100 (i.e. precision-in-cents intermediate sums in `WC_Cart_Totals` and `WC_Abstract_Order`).
2. **Cart-facing** totals (e.g. `set_total_tax`, `get_cart_tax`, order discount tax) where values are in the store's decimal precision.

A filter consumer (such as a 5-cent rounding plugin, the canonical example from the bug report) has no way to distinguish these contexts, so applying the same rounding rule corrupts internal precision values or leaves the grand total out of sync with the rounded tax — the "5-cent problem" reported in woo#25679.

This PR:

- Adds a new optional `$context` argument to `wc_round_tax_total( $value, $precision = null, $context = '' )`. The argument is passed to the filter as a fifth parameter. Backward compatible: existing 3-/4-arg callbacks continue to work.
- Forwards a context through `WC_Item_Totals::round_line_tax( $value, $in_cents, $context = 'line_tax' )`, suffixing with `_in_cents` when the value is in cents so a filter consumer can recognise internal calls.
- Annotates the cart- and order-facing call sites with descriptive context strings (`cart_total_tax`, `cart_tax_totals`, `order_discount_tax`, `order_shipping_tax`, `order_coupon_discount_tax`, `order_item_tax_per_qty`, `order_line_tax`, `order_subtotal_line_tax`, `order_display_subtotal_tax`, `order_item_tax_refund`).

This is a non-breaking extension of an existing public filter contract.

### Screenshots or screen recordings

N/A — pure backend filter API change.

### How to test the changes in this Pull Request

1. Set up a fresh WooCommerce store with the German VAT scenario from the bug report: 19% standard tax, prices excl. tax, `woocommerce_tax_round_at_subtotal=no`, `prices_include_tax=no`.
2. Add the following mu-plugin:

   ```php
   <?php
   add_filter( 'wc_round_tax_total', 'woocommerce_tax_round_5cent', 10, 5 );
   function woocommerce_tax_round_5cent( $rounded, $value, $precision, $rounding_mode, $context ) {
       // Skip rounding for any "in cents" internal call site.
       if ( '' !== $context && substr( $context, -strlen( '_in_cents' ) ) === '_in_cents' ) {
           return $rounded;
       }
       return round( $value / 5, $precision ?? 2 ) * 5;
   }
   ```

3. Create a product priced 14.99, add 10 to cart. Expected: subtotal 149.90, tax 28.50 (rounded up from 28.481), grand total **178.40**. Before this change, the grand total would be inconsistent with the displayed tax due to the filter being applied to in-cents values.
4. Verify legacy filter signatures still work — register a `wc_round_tax_total` filter with `accepted_args=4`, confirm no PHP warnings and the same rounded value is returned.
5. Run the new unit tests in `tests/legacy/unit-tests/formatting/functions.php`:
   - `test_wc_round_tax_total_filter_back_compat`
   - `test_wc_round_tax_total_passes_context_to_filter`
   - `test_wc_round_tax_total_5_cent_filter_can_skip_in_cents_contexts`

### Testing that has already taken place

- PHPUnit coverage added (three tests, see above).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse` on all modified PHP files — no errors, no baseline additions.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance**: patch
**Type**: fix
**Message**: Fix inconsistent application of the `wc_round_tax_total` filter for custom tax rounding (e.g. 5-cent rounding). The filter now receives a `$context` argument identifying the call site, allowing consumers to distinguish internal (in-cents) intermediate values from cart-facing totals so grand totals correctly account for rounded tax.

</details>

### Milestone

- [x] Add to the first available milestone that is not in the past.

---

*Submitted by the RSMAPGJ AI Coder pilot.*

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>