### PR TITLE
Fix password reset flow when SameSite=Strict drops the reset cookie

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-375
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-375
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix password reset flow failing when `SameSite=Strict` cookies cause the `wp-resetpass-COOKIEHASH` cookie to be dropped on the cross-site navigation from a webmail or messaging client. The reset link redirect now also carries a one-time token that is consumed server-side as a fallback when the cookie is unavailable.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -63,12 +63,22 @@ class WC_Form_Handler {
 			$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
 			$value   = sprintf( '%d:%s', $user_id, wp_unslash( $_GET['key'] ) ); // phpcs:ignore
 			WC_Shortcode_My_Account::set_reset_password_cookie( $value );
+
+			$redirect_args = array(
+				'show-reset-form' => 'true',
+				'action'          => $action,
+			);
+
+			// Issue a one-time token as a fallback for browsers that drop the reset cookie on
+			// the cross-site redirect (e.g. SameSite=Strict navigations from webmail clients).
+			$token = WC_Shortcode_My_Account::set_password_reset_token( $value );
+			if ( $token ) {
+				$redirect_args['wc-resetpass-token'] = $token;
+			}
+
 			wp_safe_redirect(
 				add_query_arg(
-					array(
-						'show-reset-form' => 'true',
-						'action'          => $action,
-					),
+					$redirect_args,
 					wc_lostpassword_url()
 				)
 			);

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -287,16 +287,20 @@ class WC_Shortcode_My_Account {
 	 * @return array|false An associative array with `id` (string) and `key` (string) keys, or
 	 *                     false when no valid credentials can be retrieved.
 	 */
-	protected static function get_password_reset_credentials() {
+	public static function get_password_reset_credentials() {
 		$cookie_name = 'wp-resetpass-' . COOKIEHASH;
 
-		if ( isset( $_COOKIE[ $cookie_name ] ) && 0 < strpos( $_COOKIE[ $cookie_name ], ':' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			list( $rp_id, $rp_key ) = array_map( 'wc_clean', explode( ':', wp_unslash( $_COOKIE[ $cookie_name ] ), 2 ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( isset( $_COOKIE[ $cookie_name ] ) ) {
+			$cookie_value = wp_unslash( $_COOKIE[ $cookie_name ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-			return array(
-				'id'  => $rp_id,
-				'key' => $rp_key,
-			);
+			if ( is_string( $cookie_value ) && 0 < strpos( $cookie_value, ':' ) ) {
+				list( $rp_id, $rp_key ) = array_map( 'wc_clean', explode( ':', $cookie_value, 2 ) );
+
+				return array(
+					'id'  => $rp_id,
+					'key' => $rp_key,
+				);
+			}
 		}
 
 		// Fallback path for SameSite=Strict (and similar) cookie drops on cross-site navigations.
@@ -334,7 +338,7 @@ class WC_Shortcode_My_Account {
 			return false;
 		}
 
-		$token = wp_generate_password( 32, false );
+		$token  = wp_generate_password( 32, false );
 		$stored = set_transient( '_wc_resetpass_token_' . $token, $value, 10 * MINUTE_IN_SECONDS );
 
 		return $stored ? $token : false;
@@ -348,7 +352,7 @@ class WC_Shortcode_My_Account {
 	 * @param string $token Token previously returned by {@see self::set_password_reset_token()}.
 	 * @return string|false Stored value, or false when the token is unknown or expired.
 	 */
-	protected static function get_password_reset_token_value( $token ) {
+	public static function get_password_reset_token_value( $token ) {
 		if ( ! is_string( $token ) || '' === $token ) {
 			return false;
 		}

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -241,11 +241,14 @@ class WC_Shortcode_My_Account {
 			 * Process reset key / login from email confirmation link
 			 */
 		} elseif ( ! empty( $_GET['show-reset-form'] ) ) { // WPCS: input var ok, CSRF ok.
-			if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) {  // @codingStandardsIgnoreLine
-				list( $rp_id, $rp_key ) = array_map( 'wc_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) ); // @codingStandardsIgnoreLine
-				$userdata               = get_userdata( absint( $rp_id ) );
-				$rp_login               = $userdata ? $userdata->user_login : '';
-				$user                   = self::check_password_reset_key( $rp_key, $rp_login );
+			$reset_credentials = self::get_password_reset_credentials();
+
+			if ( is_array( $reset_credentials ) ) {
+				$rp_id    = $reset_credentials['id'];
+				$rp_key   = $reset_credentials['key'];
+				$userdata = get_userdata( absint( $rp_id ) );
+				$rp_login = $userdata ? $userdata->user_login : '';
+				$user     = self::check_password_reset_key( $rp_key, $rp_login );
 
 				// Reset key / login is correct, display reset password form with hidden key / login values.
 				if ( is_object( $user ) ) {
@@ -268,6 +271,99 @@ class WC_Shortcode_My_Account {
 				'form' => 'lost_password',
 			)
 		);
+	}
+
+	/**
+	 * Retrieve the password reset credentials (user ID and reset key) for the current request.
+	 *
+	 * Prefers the `wp-resetpass-COOKIEHASH` cookie, which is the historical mechanism. When the
+	 * cookie is missing (for example, because the browser dropped it on a cross-site navigation
+	 * such as a `SameSite=Strict` link clicked from a webmail client), falls back to a one-time
+	 * token passed via the `wc-resetpass-token` query parameter, which is resolved against a
+	 * short-lived transient written by `WC_Form_Handler::redirect_reset_password_link()`.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return array|false An associative array with `id` (string) and `key` (string) keys, or
+	 *                     false when no valid credentials can be retrieved.
+	 */
+	protected static function get_password_reset_credentials() {
+		$cookie_name = 'wp-resetpass-' . COOKIEHASH;
+
+		if ( isset( $_COOKIE[ $cookie_name ] ) && 0 < strpos( $_COOKIE[ $cookie_name ], ':' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			list( $rp_id, $rp_key ) = array_map( 'wc_clean', explode( ':', wp_unslash( $_COOKIE[ $cookie_name ] ), 2 ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+			return array(
+				'id'  => $rp_id,
+				'key' => $rp_key,
+			);
+		}
+
+		// Fallback path for SameSite=Strict (and similar) cookie drops on cross-site navigations.
+		if ( ! empty( $_GET['wc-resetpass-token'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$token = sanitize_text_field( wp_unslash( $_GET['wc-resetpass-token'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$value = self::get_password_reset_token_value( $token );
+
+			if ( is_string( $value ) && 0 < strpos( $value, ':' ) ) {
+				list( $rp_id, $rp_key ) = array_map( 'wc_clean', explode( ':', $value, 2 ) );
+
+				return array(
+					'id'  => $rp_id,
+					'key' => $rp_key,
+				);
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Store a one-time token mapping to a `user_id:key` reset value.
+	 *
+	 * The token is a random opaque identifier returned to the caller. The stored transient is
+	 * short-lived (10 minutes — matching WordPress' own reset key expiration window) and is
+	 * deleted on first successful read in {@see self::get_password_reset_token_value()}.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param string $value Value to store, in `user_id:key` format.
+	 * @return string|false Generated token on success, false on failure.
+	 */
+	public static function set_password_reset_token( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return false;
+		}
+
+		$token = wp_generate_password( 32, false );
+		$stored = set_transient( '_wc_resetpass_token_' . $token, $value, 10 * MINUTE_IN_SECONDS );
+
+		return $stored ? $token : false;
+	}
+
+	/**
+	 * Look up and consume a one-time password reset token.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param string $token Token previously returned by {@see self::set_password_reset_token()}.
+	 * @return string|false Stored value, or false when the token is unknown or expired.
+	 */
+	protected static function get_password_reset_token_value( $token ) {
+		if ( ! is_string( $token ) || '' === $token ) {
+			return false;
+		}
+
+		$key   = '_wc_resetpass_token_' . $token;
+		$value = get_transient( $key );
+
+		if ( false === $value ) {
+			return false;
+		}
+
+		// Single-use: invalidate after consumption.
+		delete_transient( $key );
+
+		return is_string( $value ) ? $value : false;
 	}
 
 	/**

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -31920,7 +31920,7 @@ parameters:
 		-
 			message: '#^Constant COOKIEHASH not found\.$#'
 			identifier: constant.notFound
-			count: 4
+			count: 2
 			path: includes/shortcodes/class-wc-shortcode-my-account.php
 
 		-

--- a/plugins/woocommerce/tests/legacy/unit-tests/shortcodes/my-account.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/shortcodes/my-account.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Tests for WC_Shortcode_My_Account.
+ *
+ * @package WooCommerce\Tests\Shortcodes
+ */
+
+/**
+ * Test class exposing protected helpers on WC_Shortcode_My_Account.
+ */
+class WC_Test_Shortcode_My_Account_Proxy extends WC_Shortcode_My_Account {
+	/**
+	 * Public wrapper around the protected credentials helper.
+	 *
+	 * @return array|false
+	 */
+	public static function get_credentials() {
+		return self::get_password_reset_credentials();
+	}
+
+	/**
+	 * Public wrapper around the protected token consumer.
+	 *
+	 * @param string $token Token.
+	 * @return string|false
+	 */
+	public static function get_token_value( $token ) {
+		return self::get_password_reset_token_value( $token );
+	}
+}
+
+/**
+ * Class WC_Test_Shortcode_My_Account.
+ */
+class WC_Test_Shortcode_My_Account extends WC_Unit_Test_Case {
+
+	/**
+	 * Tear down test fixtures: clear request-scope superglobals to avoid leaking state
+	 * between tests in this file.
+	 */
+	public function tearDown(): void {
+		unset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] );
+		unset( $_GET['wc-resetpass-token'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox set_password_reset_token returns a non-empty opaque token and stores the value.
+	 */
+	public function test_set_password_reset_token_stores_value(): void {
+		$value = '42:somekey';
+
+		$token = WC_Shortcode_My_Account::set_password_reset_token( $value );
+
+		$this->assertIsString( $token, 'Token should be a string on success.' );
+		$this->assertNotEmpty( $token, 'Token should not be empty.' );
+		$this->assertSame( $value, get_transient( '_wc_resetpass_token_' . $token ), 'Transient should hold the original value.' );
+	}
+
+	/**
+	 * @testdox set_password_reset_token rejects empty or non-string values.
+	 */
+	public function test_set_password_reset_token_rejects_invalid_input(): void {
+		$this->assertFalse( WC_Shortcode_My_Account::set_password_reset_token( '' ), 'Empty string should be rejected.' );
+		$this->assertFalse( WC_Shortcode_My_Account::set_password_reset_token( null ), 'Null should be rejected.' );
+		$this->assertFalse( WC_Shortcode_My_Account::set_password_reset_token( 123 ), 'Non-string should be rejected.' );
+	}
+
+	/**
+	 * @testdox get_password_reset_token_value returns the stored value once and then invalidates it.
+	 */
+	public function test_get_password_reset_token_value_is_single_use(): void {
+		$value = '7:abc123';
+		$token = WC_Shortcode_My_Account::set_password_reset_token( $value );
+		$this->assertIsString( $token );
+
+		$first  = WC_Test_Shortcode_My_Account_Proxy::get_token_value( $token );
+		$second = WC_Test_Shortcode_My_Account_Proxy::get_token_value( $token );
+
+		$this->assertSame( $value, $first, 'First read should return stored value.' );
+		$this->assertFalse( $second, 'Second read should fail; token is single-use.' );
+	}
+
+	/**
+	 * @testdox get_password_reset_token_value returns false for unknown or empty tokens.
+	 */
+	public function test_get_password_reset_token_value_unknown(): void {
+		$this->assertFalse( WC_Test_Shortcode_My_Account_Proxy::get_token_value( '' ) );
+		$this->assertFalse( WC_Test_Shortcode_My_Account_Proxy::get_token_value( 'no-such-token' ) );
+	}
+
+	/**
+	 * @testdox get_password_reset_credentials prefers the wp-resetpass cookie when set.
+	 */
+	public function test_get_password_reset_credentials_uses_cookie(): void {
+		$_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] = '13:cookie-key';
+
+		$creds = WC_Test_Shortcode_My_Account_Proxy::get_credentials();
+
+		$this->assertIsArray( $creds, 'Credentials should be returned as an array.' );
+		$this->assertSame( '13', $creds['id'] );
+		$this->assertSame( 'cookie-key', $creds['key'] );
+	}
+
+	/**
+	 * @testdox get_password_reset_credentials falls back to the query token when the cookie is missing.
+	 */
+	public function test_get_password_reset_credentials_falls_back_to_token(): void {
+		$value = '21:fallback-key';
+		$token = WC_Shortcode_My_Account::set_password_reset_token( $value );
+		$this->assertIsString( $token );
+
+		// No cookie, only the token query param (simulating SameSite=Strict drop).
+		$_GET['wc-resetpass-token'] = $token;
+
+		$creds = WC_Test_Shortcode_My_Account_Proxy::get_credentials();
+
+		$this->assertIsArray( $creds, 'Fallback path should produce credentials.' );
+		$this->assertSame( '21', $creds['id'] );
+		$this->assertSame( 'fallback-key', $creds['key'] );
+	}
+
+	/**
+	 * @testdox get_password_reset_credentials returns false when neither cookie nor token is present.
+	 */
+	public function test_get_password_reset_credentials_returns_false_when_nothing_present(): void {
+		$this->assertFalse( WC_Test_Shortcode_My_Account_Proxy::get_credentials() );
+	}
+
+	/**
+	 * @testdox get_password_reset_credentials ignores a malformed cookie without a colon separator.
+	 */
+	public function test_get_password_reset_credentials_ignores_malformed_cookie(): void {
+		$_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] = 'no-colon-value';
+
+		$this->assertFalse( WC_Test_Shortcode_My_Account_Proxy::get_credentials() );
+	}
+
+	/**
+	 * @testdox Fallback token cannot be replayed after the credentials have been consumed once.
+	 */
+	public function test_token_cannot_be_replayed(): void {
+		$value = '99:one-shot';
+		$token = WC_Shortcode_My_Account::set_password_reset_token( $value );
+		$this->assertIsString( $token );
+
+		$_GET['wc-resetpass-token'] = $token;
+
+		$first  = WC_Test_Shortcode_My_Account_Proxy::get_credentials();
+		$second = WC_Test_Shortcode_My_Account_Proxy::get_credentials();
+
+		$this->assertIsArray( $first );
+		$this->assertFalse( $second, 'Token should be invalidated after first credential lookup.' );
+	}
+}

--- a/plugins/woocommerce/tests/legacy/unit-tests/shortcodes/my-account.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/shortcodes/my-account.php
@@ -1,10 +1,11 @@
 <?php
-declare( strict_types = 1 );
 /**
  * Tests for WC_Shortcode_My_Account.
  *
  * @package WooCommerce\Tests\Shortcodes
  */
+
+declare( strict_types = 1 );
 
 /**
  * Class WC_Test_Shortcode_My_Account.

--- a/plugins/woocommerce/tests/legacy/unit-tests/shortcodes/my-account.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/shortcodes/my-account.php
@@ -1,33 +1,10 @@
 <?php
+declare( strict_types = 1 );
 /**
  * Tests for WC_Shortcode_My_Account.
  *
  * @package WooCommerce\Tests\Shortcodes
  */
-
-/**
- * Test class exposing protected helpers on WC_Shortcode_My_Account.
- */
-class WC_Test_Shortcode_My_Account_Proxy extends WC_Shortcode_My_Account {
-	/**
-	 * Public wrapper around the protected credentials helper.
-	 *
-	 * @return array|false
-	 */
-	public static function get_credentials() {
-		return self::get_password_reset_credentials();
-	}
-
-	/**
-	 * Public wrapper around the protected token consumer.
-	 *
-	 * @param string $token Token.
-	 * @return string|false
-	 */
-	public static function get_token_value( $token ) {
-		return self::get_password_reset_token_value( $token );
-	}
-}
 
 /**
  * Class WC_Test_Shortcode_My_Account.
@@ -74,8 +51,8 @@ class WC_Test_Shortcode_My_Account extends WC_Unit_Test_Case {
 		$token = WC_Shortcode_My_Account::set_password_reset_token( $value );
 		$this->assertIsString( $token );
 
-		$first  = WC_Test_Shortcode_My_Account_Proxy::get_token_value( $token );
-		$second = WC_Test_Shortcode_My_Account_Proxy::get_token_value( $token );
+		$first  = WC_Shortcode_My_Account::get_password_reset_token_value( $token );
+		$second = WC_Shortcode_My_Account::get_password_reset_token_value( $token );
 
 		$this->assertSame( $value, $first, 'First read should return stored value.' );
 		$this->assertFalse( $second, 'Second read should fail; token is single-use.' );
@@ -85,8 +62,8 @@ class WC_Test_Shortcode_My_Account extends WC_Unit_Test_Case {
 	 * @testdox get_password_reset_token_value returns false for unknown or empty tokens.
 	 */
 	public function test_get_password_reset_token_value_unknown(): void {
-		$this->assertFalse( WC_Test_Shortcode_My_Account_Proxy::get_token_value( '' ) );
-		$this->assertFalse( WC_Test_Shortcode_My_Account_Proxy::get_token_value( 'no-such-token' ) );
+		$this->assertFalse( WC_Shortcode_My_Account::get_password_reset_token_value( '' ) );
+		$this->assertFalse( WC_Shortcode_My_Account::get_password_reset_token_value( 'no-such-token' ) );
 	}
 
 	/**
@@ -95,7 +72,7 @@ class WC_Test_Shortcode_My_Account extends WC_Unit_Test_Case {
 	public function test_get_password_reset_credentials_uses_cookie(): void {
 		$_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] = '13:cookie-key';
 
-		$creds = WC_Test_Shortcode_My_Account_Proxy::get_credentials();
+		$creds = WC_Shortcode_My_Account::get_password_reset_credentials();
 
 		$this->assertIsArray( $creds, 'Credentials should be returned as an array.' );
 		$this->assertSame( '13', $creds['id'] );
@@ -113,7 +90,7 @@ class WC_Test_Shortcode_My_Account extends WC_Unit_Test_Case {
 		// No cookie, only the token query param (simulating SameSite=Strict drop).
 		$_GET['wc-resetpass-token'] = $token;
 
-		$creds = WC_Test_Shortcode_My_Account_Proxy::get_credentials();
+		$creds = WC_Shortcode_My_Account::get_password_reset_credentials();
 
 		$this->assertIsArray( $creds, 'Fallback path should produce credentials.' );
 		$this->assertSame( '21', $creds['id'] );
@@ -124,7 +101,7 @@ class WC_Test_Shortcode_My_Account extends WC_Unit_Test_Case {
 	 * @testdox get_password_reset_credentials returns false when neither cookie nor token is present.
 	 */
 	public function test_get_password_reset_credentials_returns_false_when_nothing_present(): void {
-		$this->assertFalse( WC_Test_Shortcode_My_Account_Proxy::get_credentials() );
+		$this->assertFalse( WC_Shortcode_My_Account::get_password_reset_credentials() );
 	}
 
 	/**
@@ -133,7 +110,7 @@ class WC_Test_Shortcode_My_Account extends WC_Unit_Test_Case {
 	public function test_get_password_reset_credentials_ignores_malformed_cookie(): void {
 		$_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] = 'no-colon-value';
 
-		$this->assertFalse( WC_Test_Shortcode_My_Account_Proxy::get_credentials() );
+		$this->assertFalse( WC_Shortcode_My_Account::get_password_reset_credentials() );
 	}
 
 	/**
@@ -146,8 +123,8 @@ class WC_Test_Shortcode_My_Account extends WC_Unit_Test_Case {
 
 		$_GET['wc-resetpass-token'] = $token;
 
-		$first  = WC_Test_Shortcode_My_Account_Proxy::get_credentials();
-		$second = WC_Test_Shortcode_My_Account_Proxy::get_credentials();
+		$first  = WC_Shortcode_My_Account::get_password_reset_credentials();
+		$second = WC_Shortcode_My_Account::get_password_reset_credentials();
 
 		$this->assertIsArray( $first );
 		$this->assertFalse( $second, 'Token should be invalidated after first credential lookup.' );


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request

Closes #39652.

Linear: https://linear.app/a8c/issue/RSMAPGJ-375

The WooCommerce password reset flow stores the user ID and reset key in a `wp-resetpass-COOKIEHASH` cookie set by `WC_Form_Handler::redirect_reset_password_link()`, then validates that cookie in `WC_Shortcode_My_Account::lost_password()` to render the reset form. Under `SameSite=Strict`, when the user follows the reset email link from a cross-site context (webmail, Slack, etc.) the browser strips the freshly set cookie on the redirect request, so the cookie check fails and the shopper is silently bounced back to the "Lost password" request form instead of getting the actual reset form.

This PR keeps the cookie as the primary mechanism (no behaviour change for the common path) and adds a one-time, transient-backed token as a fallback the redirect target can consume when the cookie is missing.

Specifically:

1. `WC_Form_Handler::redirect_reset_password_link()` now also calls `WC_Shortcode_My_Account::set_password_reset_token( "$user_id:$key" )` and appends the resulting opaque token as `?wc-resetpass-token=...` on the redirect URL. The token maps to the value via a 10-minute transient (`_wc_resetpass_token_<token>`), matching WordPress' own reset key TTL.
2. The cookie/credential lookup in `lost_password()` is extracted into `WC_Shortcode_My_Account::get_password_reset_credentials()`. It still prefers `$_COOKIE['wp-resetpass-COOKIEHASH']`; if missing, it consumes the token via `get_password_reset_token_value()`. Successful lookups delete the transient, so the token is strictly single-use.
3. The validated credentials continue to flow through `check_password_reset_key()`, which enforces WordPress core's existing key validation — the new path does not weaken that check, it just unblocks delivery of the credentials when the cookie was dropped in transit.

The reset key itself is never put in the URL (token is an opaque 32-char string), which preserves the existing protection against referer leakage of the actual reset key.

### How to test the changes in this Pull Request

1. Apply this branch and configure your site to send `SameSite=Strict` on cookies (Apache: `Header always edit Set-Cookie (.*)$ "$1; SameSite=Strict; HttpOnly"`).
2. From a non-logged-in browser, request a password reset via `/my-account/lost-password/`.
3. Open the resulting email in a webmail client (Gmail in another tab works) and click the reset link. The URL should be `/?key=...&id=...`.
4. Expected: the redirect target includes `?show-reset-form=true&action=...&wc-resetpass-token=...`, and the "Enter a new password" form is rendered. Set a new password and confirm login works.
5. Repeat without the SameSite=Strict header configured — the cookie path still works exactly as before.
6. Negative: replay the same `wc-resetpass-token=...` URL in a fresh tab after a successful reset — the token is single-use, so the page falls through to the "Lost password" form.

### Testing that has already taken place

- New PHPUnit coverage in `tests/legacy/unit-tests/shortcodes/my-account.php` exercises the cookie-preferred path, the fallback-token path, single-use token invalidation, rejection of malformed cookies, and rejection of invalid/empty tokens.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/shortcodes/class-wc-shortcode-my-account.php includes/class-wc-form-handler.php --memory-limit=2G` — clean (one stale baseline entry shrunk from `count: 4` to `count: 2` to reflect the refactor; no additions to the baseline).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog file `plugins/woocommerce/changelog/fix-rsmapgj-375` has been added manually.)

---

Submitted via the RSMAPGJ AI Coder pilot. Pipeline: \`[pipeline] impl rev 1\`.