### PR TITLE
Update product editor field labels for clarity

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-product-status-and-catalog-visibility-dropdowns
+++ b/packages/js/experimental-products-app/changelog/update-product-status-and-catalog-visibility-dropdowns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Rename the stock dropdown's "Status" label to "Stock status" and the "Visibility" field to "Catalog visibility" (with updated option labels)

--- a/packages/js/experimental-products-app/src/fields/catalog_visibility/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/catalog_visibility/field.tsx
@@ -21,14 +21,20 @@ function isValidVisibility( value: string ) {
 }
 
 const fieldDefinition = {
-	label: __( 'Visibility', 'woocommerce' ),
+	label: __( 'Catalog visibility', 'woocommerce' ),
 	enableSorting: false,
 	enableHiding: false,
 	filterBy: false,
 	elements: [
-		{ label: __( 'Public', 'woocommerce' ), value: 'visible' },
-		{ label: __( 'Catalog', 'woocommerce' ), value: 'catalog' },
-		{ label: __( 'Search', 'woocommerce' ), value: 'search' },
+		{
+			label: __( 'Catalog and search results', 'woocommerce' ),
+			value: 'visible',
+		},
+		{ label: __( 'Catalog only', 'woocommerce' ), value: 'catalog' },
+		{
+			label: __( 'Search results only', 'woocommerce' ),
+			value: 'search',
+		},
 		{ label: __( 'Hidden', 'woocommerce' ), value: 'hidden' },
 	],
 } satisfies Partial< Field< ProductEntityRecord > >;

--- a/packages/js/experimental-products-app/src/fields/stock/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/stock/field.tsx
@@ -77,7 +77,7 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 
 		return (
 			<SelectControl
-				label={ __( 'Status', 'woocommerce' ) }
+				label={ __( 'Stock status', 'woocommerce' ) }
 				value={ selectedOption }
 				items={ options }
 				onValueChange={ ( option ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The "Visibility" field label and its option labels were ambiguous in the experimental products app's edit drawer — "Public", "Catalog", "Search" don't make their intent obvious at a glance. Likewise, the stock dropdown was labeled "Status", which clashed with the product status field of the same name.

- Rename the "Visibility" field to "Catalog visibility" and update its options to "Catalog and search results", "Catalog only", "Search results only", "Hidden" (underlying values unchanged).
- Rename the stock dropdown's "Status" label to "Stock status".

### Screenshots or screen recordings:

After

<img width="432" height="279" alt="image" src="https://github.com/user-attachments/assets/d51572d5-c6b4-47cd-a2d4-ed450099c502" />

<img width="431" height="90" alt="image" src="https://github.com/user-attachments/assets/3546fb9f-3eb9-4798-a90d-840195b3344f" />


### How to test the changes in this Pull Request:

1. Enable the experimental products app and open a product in the edit drawer.
2. Scroll to the visibility field — confirm the label reads "Catalog visibility" and the four options are "Catalog and search results", "Catalog only", "Search results only", "Hidden".
3. Change the selection between each option and save — verify the underlying value still maps correctly (no API regression).
4. Scroll to the stock field — confirm the dropdown label reads "Stock status" (the product publishing-state field above it remains labeled "Status").

### Testing that has already taken place:

Verified the new labels render correctly in the edit drawer at `localhost:8888` and that option values (`visible`/`catalog`/`search`/`hidden`) still flow through the form unchanged.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually and is included in this PR under `packages/js/experimental-products-app/changelog/`.

</details>