### PR TITLE
Align Images field label spacing in experimental products app

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-images-field-label-spacing
+++ b/packages/js/experimental-products-app/changelog/fix-images-field-label-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Align the gap between the Images field label and its upload area with other form fields

--- a/packages/js/experimental-products-app/src/fields/images/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/images/field.tsx
@@ -233,7 +233,7 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 		}, [ images, handleRemoveImage ] );
 
 		return (
-			<Fieldset.Root>
+			<Fieldset.Root className="woocommerce-fields-control__images-fieldset">
 				<Fieldset.Legend>{ field.label }</Fieldset.Legend>
 				<DragDropProvider onDragEnd={ handleDragEnd }>
 					<div className="woocommerce-fields-control__featured-image">

--- a/packages/js/experimental-products-app/src/fields/images/style.scss
+++ b/packages/js/experimental-products-app/src/fields/images/style.scss
@@ -1,3 +1,7 @@
+.woocommerce-fields-control__images-fieldset {
+	gap: 8px;
+}
+
 .woocommerce-fields-control__featured-image {
 	display: grid;
 	gap: 8px;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Images field in the experimental products app edit drawer sat noticeably closer to its label than every other field. This is because it renders inside `Fieldset.Root` (gap `--wpds-dimension-gap-xs`, 4px), whereas the other fields use `SelectControl`, which renders `Field.Root` with an 8px `Stack` gap. This PR overrides the Fieldset gap to 8px so the Images field aligns visually with its neighbors.

### Screenshots or screen recordings:

| Before | After |
| 4px | 8px |
|        |       |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open a product in the edit drawer.
2. Scroll to the Images field.
3. Confirm the gap between the "IMAGES" label and the upload thumbnail box matches the gap above every other field's control (e.g. Status, Catalog visibility, Stock).

### Testing that has already taken place:

Verified the new spacing visually in the edit drawer at `localhost:8888`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually and is included in this PR under `packages/js/experimental-products-app/changelog/`.

</details>