### PR TITLE
Update product list header layout

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-product-list-header-layout
+++ b/packages/js/experimental-products-app/changelog/update-product-list-header-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update the experimental product list header layout to match the compact prototype.

--- a/packages/js/experimental-products-app/src/product-list/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/index.tsx
@@ -10,7 +10,6 @@ import clsx from 'clsx';
 import { Button, Icon, Stack, Tabs } from '@wordpress/ui';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
-import { Page } from '@wordpress/admin-ui';
 import { addQueryArgs } from '@wordpress/url';
 import { getAdminLink } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
@@ -46,6 +45,7 @@ import {
 } from './utils';
 import { useProductActions } from '../dataviews-actions';
 import { ProductListEmptyState } from './empty-state';
+import { ProductListPage, ProductListPageHeader } from './page';
 
 const { Menu } = unlock( componentsPrivateApis );
 const { usePostActions } = unlock( editorPrivateApis );
@@ -309,16 +309,40 @@ export default function ProductList( {
 		</Stack>
 	);
 
+	const toolbar = (
+		<Stack
+			direction="row"
+			align="center"
+			justify="space-between"
+			gap="sm"
+			className="woocommerce-product-list__toolbar"
+		>
+			{ /* Tabs component should not be used: https://github.com/woocommerce/woocommerce/issues/64478 */ }
+			<Tabs.Root value={ selectedTab } onValueChange={ onChangeTab }>
+				<Tabs.List
+					variant="minimal"
+					aria-label={ __( 'Filter products by status', 'woocommerce' ) }
+				>
+					{ PRODUCT_LIST_TABS.map( ( tab ) => (
+						<Tabs.Tab key={ tab.value } value={ tab.value }>
+							{ tab.label }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.List>
+			</Tabs.Root>
+			<Stack direction="row" align="center" gap="xs">
+				<DataViews.Search label={ __( 'Search', 'woocommerce' ) } />
+				<DataViews.FiltersToggle />
+				<DataViews.LayoutSwitcher />
+				<DataViews.ViewConfig />
+			</Stack>
+		</Stack>
+	);
+
 	return (
-		<Page
+		<ProductListPage
 			className={ classes }
 			ariaLabel={ __( 'Products', 'woocommerce' ) }
-			subTitle={ __(
-				'Add, edit, and manage the products you sell in your store.',
-				'woocommerce'
-			) }
-			title={ __( 'Products', 'woocommerce' ) }
-			actions={ pageActions }
 		>
 			<DataViews
 				key={ activeView }
@@ -350,45 +374,19 @@ export default function ProductList( {
 					</a>
 				) }
 			>
-				<Stack
-					direction="row"
-					align="center"
-					justify="space-between"
-					gap="sm"
-					className="woocommerce-product-list__toolbar"
-				>
-					{ /* Tabs component should not be used: https://github.com/woocommerce/woocommerce/issues/64478 */ }
-					<Tabs.Root
-						value={ selectedTab }
-						onValueChange={ onChangeTab }
-					>
-						<Tabs.List
-							variant="minimal"
-							aria-label={ __(
-								'Filter products by status',
-								'woocommerce'
-							) }
-						>
-							{ PRODUCT_LIST_TABS.map( ( tab ) => (
-								<Tabs.Tab key={ tab.value } value={ tab.value }>
-									{ tab.label }
-								</Tabs.Tab>
-							) ) }
-						</Tabs.List>
-					</Tabs.Root>
-					<Stack direction="row" align="center" gap="xs">
-						<DataViews.Search
-							label={ __( 'Search', 'woocommerce' ) }
-						/>
-						<DataViews.FiltersToggle />
-						<DataViews.LayoutSwitcher />
-						<DataViews.ViewConfig />
-					</Stack>
-				</Stack>
+				<ProductListPageHeader
+					title={ __( 'Products', 'woocommerce' ) }
+					subTitle={ __(
+						'Add, edit, and manage the products you sell in your store.',
+						'woocommerce'
+					) }
+					actions={ pageActions }
+					toolbar={ toolbar }
+				/>
 				<DataViews.FiltersToggled className="woocommerce-product-list__filters" />
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>
-		</Page>
+		</ProductListPage>
 	);
 }

--- a/packages/js/experimental-products-app/src/product-list/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/index.tsx
@@ -321,7 +321,10 @@ export default function ProductList( {
 			<Tabs.Root value={ selectedTab } onValueChange={ onChangeTab }>
 				<Tabs.List
 					variant="minimal"
-					aria-label={ __( 'Filter products by status', 'woocommerce' ) }
+					aria-label={ __(
+						'Filter products by status',
+						'woocommerce'
+					) }
 				>
 					{ PRODUCT_LIST_TABS.map( ( tab ) => (
 						<Tabs.Tab key={ tab.value } value={ tab.value }>

--- a/packages/js/experimental-products-app/src/product-list/page/README.md
+++ b/packages/js/experimental-products-app/src/product-list/page/README.md
@@ -1,0 +1,7 @@
+# Product List Page
+
+This is a temporary wrapper around `@wordpress/admin-ui`'s `Page` for the experimental product list.
+
+The product list prototype uses a compact two-line header: title and actions in the first row, subtitle in the second row, then the DataViews toolbar immediately below. The current `Page` component does not expose a public option for this compact header spacing, so this wrapper lets the product list own the header markup without changing `@wordpress/admin-ui`.
+
+Remove this wrapper once `Page` supports this layout directly.

--- a/packages/js/experimental-products-app/src/product-list/page/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/page/index.tsx
@@ -38,12 +38,7 @@ export function ProductListPageHeader( {
 	return (
 		<header className="woocommerce-product-list-page__header">
 			<Stack direction="row" justify="space-between" gap="sm">
-				<Stack
-					direction="row"
-					gap="sm"
-					align="center"
-					justify="start"
-				>
+				<Stack direction="row" gap="sm" align="center" justify="start">
 					<h2 className="woocommerce-product-list-page__header-title">
 						{ title }
 					</h2>

--- a/packages/js/experimental-products-app/src/product-list/page/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/page/index.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { Stack } from '@wordpress/ui';
+
+type ProductListPageProps = {
+	ariaLabel: string;
+	children: React.ReactNode;
+	className?: string;
+};
+
+type ProductListPageHeaderProps = {
+	actions?: React.ReactNode;
+	subTitle?: React.ReactNode;
+	title: React.ReactNode;
+	toolbar?: React.ReactNode;
+};
+
+export function ProductListPage( {
+	ariaLabel,
+	children,
+	className,
+}: ProductListPageProps ) {
+	return (
+		<Page className={ className } ariaLabel={ ariaLabel }>
+			{ children }
+		</Page>
+	);
+}
+
+export function ProductListPageHeader( {
+	actions,
+	subTitle,
+	title,
+	toolbar,
+}: ProductListPageHeaderProps ) {
+	return (
+		<header className="woocommerce-product-list-page__header">
+			<Stack direction="row" justify="space-between" gap="sm">
+				<Stack
+					direction="row"
+					gap="sm"
+					align="center"
+					justify="start"
+				>
+					<h2 className="woocommerce-product-list-page__header-title">
+						{ title }
+					</h2>
+				</Stack>
+				<Stack
+					direction="row"
+					gap="sm"
+					className="woocommerce-product-list-page__header-actions"
+					align="center"
+				>
+					{ actions }
+				</Stack>
+			</Stack>
+			{ subTitle && (
+				<p className="woocommerce-product-list-page__header-subtitle">
+					{ subTitle }
+				</p>
+			) }
+			{ toolbar }
+		</header>
+	);
+}

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -8,6 +8,18 @@
 	background-color: unset;
 }
 
+.product_page_woocommerce-products-dashboard #wpcontent {
+	padding: 0;
+}
+
+.product_page_woocommerce-products-dashboard #wpbody-content {
+	padding-bottom: 0;
+}
+
+.product_page_woocommerce-products-dashboard #wpfooter {
+	display: none;
+}
+
 .product_page_woocommerce-products-dashboard,
 #woocommerce-variations-classic-root,
 .woocommerce-product-edit__drawer-portal {
@@ -36,15 +48,53 @@
 }
 
 .woocommerce-product-list {
-	height: 85vh;
+	height: calc(100vh - var(--wp-admin--admin-bar--height, 32px));
 }
 
 .woocommerce-product-list__toolbar {
+	margin: var(--wpds-dimension-padding-xs, 4px)
+		calc(var(--wpds-dimension-padding-2xl, 24px) * -1) 0;
 	padding: 0 var(--wpds-dimension-padding-2xl, 24px);
 }
 
 .woocommerce-product-list .dataviews-wrapper {
 	height: 100%;
+}
+
+.woocommerce-product-list-page__header {
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	padding: var(--wpds-dimension-padding-lg, 16px)
+		var(--wpds-dimension-padding-2xl, 24px)
+		0;
+	border-bottom: var(--wpds-border-width-xs, 1px) solid
+		var(--wpds-color-stroke-surface-neutral-weak, #ddd);
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+}
+
+.woocommerce-product-list-page__header-title {
+	margin: 0;
+	overflow: hidden;
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	font-family: var(--wpds-typography-font-family-heading);
+	font-size: var(--wpds-typography-font-size-lg, 15px);
+	font-weight: var(--wpds-typography-font-weight-medium, 500);
+	line-height: var(--wpds-typography-line-height-lg, 28px);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.woocommerce-product-list-page__header-actions {
+	width: auto;
+	flex-shrink: 0;
+}
+
+.woocommerce-product-list-page__header-subtitle {
+	margin: 0;
+	color: var(--wpds-color-fg-content-neutral-weak, #707070);
+	font-size: var(--wpds-typography-font-size-md, 13px);
+	line-height: var(--wpds-typography-line-height-md, 24px);
 }
 
 // Temporary override until DataViews supports title links without default underlines.

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -70,7 +70,6 @@
 		0;
 	border-bottom: var(--wpds-border-width-xs, 1px) solid
 		var(--wpds-color-stroke-surface-neutral-weak, #ddd);
-	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 }
 
 .woocommerce-product-list-page__header-title {
@@ -80,7 +79,6 @@
 	font-family: var(--wpds-typography-font-family-heading);
 	font-size: var(--wpds-typography-font-size-lg, 15px);
 	font-weight: var(--wpds-typography-font-weight-medium, 500);
-	line-height: var(--wpds-typography-line-height-lg, 28px);
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental product list header needs to match the compact prototype layout while preserving the existing Export, Import, and Add new actions. This PR introduces a temporary product-list-specific page header wrapper, moves the DataViews toolbar into that compact header, resets the surrounding wp-admin spacing, and documents that the wrapper should be removed once `Page` supports this layout directly.


### How to test the changes in this Pull Request:

1. Build or watch the experimental products app assets.
2. Open the experimental Products dashboard in wp-admin.
3. Confirm the header shows `Products`, the subtitle, and the Export, Import, and Add new actions.
4. Confirm the status tabs and DataViews controls sit in the compact header, with the active tab underline aligned to the divider.
5. Confirm `#wpcontent` has no left padding and the product table fills the remaining viewport height without an extra footer scrollbar.

### Testing that has already taken place:

-   Compared the local header against the product list prototype and iterated on the compact header spacing.
-   Ran `pnpm --filter=@woocommerce/experimental-products-app exec tsc --project tsconfig.json --noEmit`.
-   Ran `pnpm --filter=@woocommerce/experimental-products-app test:js`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Manual changelog entry added for `@woocommerce/experimental-products-app`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
