### PR TITLE
Remove the 'On sale' toggle and always show the sale price field

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-always-show-sale-price
+++ b/packages/js/experimental-products-app/changelog/update-always-show-sale-price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove the "On sale" toggle from the product editor and always show the sale price field

--- a/packages/js/experimental-products-app/src/fields/sale_price/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/sale_price/field.tsx
@@ -24,9 +24,6 @@ const fieldDefinition = {
 
 export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 	...fieldDefinition,
-	isVisible: ( item ) => {
-		return !! item.on_sale || !! item.sale_price;
-	},
 	isValid: {
 		custom: ( item ) => validateSalePrice( item ),
 	},

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -308,13 +308,12 @@ describe( 'product edit utils', () => {
 		const priceFieldIds = [
 			'price',
 			'regular_price',
-			'on_sale',
 			'sale_price',
 			'schedule_sale',
 			'date_on_sale_from',
 			'date_on_sale_to',
 		];
-		const basePriceFieldIds = [ 'regular_price', 'on_sale' ];
+		const basePriceFieldIds = [ 'regular_price', 'sale_price' ];
 		const managedStockFieldIds = [ 'manage_stock', 'stock_quantity' ];
 		const stockStatusFieldIds = [ 'stock', 'manage_stock' ];
 		const shippingFieldIds = [
@@ -350,7 +349,6 @@ describe( 'product edit utils', () => {
 				'product_status',
 				'catalog_visibility',
 				'regular_price',
-				'on_sale',
 				'sale_price',
 				'images',
 				'sku',
@@ -402,11 +400,7 @@ describe( 'product edit utils', () => {
 				} ),
 			] );
 
-			expectFieldOrder( fieldIds, [
-				'regular_price',
-				'on_sale',
-				'sale_price',
-			] );
+			expectFieldOrder( fieldIds, [ 'regular_price', 'sale_price' ] );
 		} );
 
 		it( 'hides shipping fields for virtual simple products', () => {
@@ -501,7 +495,7 @@ describe( 'product edit utils', () => {
 				'product_status',
 				'catalog_visibility',
 				'regular_price',
-				'on_sale',
+				'sale_price',
 				'images',
 				'external_url',
 				'button_text',
@@ -513,7 +507,6 @@ describe( 'product edit utils', () => {
 			] );
 			expectFieldsHidden( fieldIds, [
 				'price',
-				'sale_price',
 				'schedule_sale',
 				'date_on_sale_from',
 				'date_on_sale_to',
@@ -536,7 +529,6 @@ describe( 'product edit utils', () => {
 			expectFieldsHidden( fieldIds, [
 				'price',
 				'regular_price',
-				'on_sale',
 				'sale_price',
 				'schedule_sale',
 				'date_on_sale_from',
@@ -627,7 +619,6 @@ describe( 'product edit utils', () => {
 				expect.arrayContaining( basePriceFieldIds )
 			);
 			expectFieldsHidden( fieldIds, [
-				'sale_price',
 				'schedule_sale',
 				'date_on_sale_from',
 				'date_on_sale_to',
@@ -651,7 +642,6 @@ describe( 'product edit utils', () => {
 			expect( fieldIds ).toEqual(
 				expect.arrayContaining( [
 					'regular_price',
-					'on_sale',
 					'sale_price',
 					'images',
 					'sku',
@@ -689,7 +679,6 @@ describe( 'product edit utils', () => {
 					'images',
 					'sku',
 					'regular_price',
-					'on_sale',
 					'sale_price',
 					'stock',
 					'manage_stock',
@@ -767,7 +756,6 @@ describe( 'product edit utils', () => {
 			expect( fieldIds ).toEqual(
 				expect.arrayContaining( [
 					'regular_price',
-					'on_sale',
 					'sale_price',
 					...bulkSellableInstanceFieldIds,
 				] )
@@ -953,7 +941,6 @@ describe( 'product edit utils', () => {
 				'product_status',
 				'catalog_visibility',
 				'regular_price',
-				'on_sale',
 				'sale_price',
 				'images',
 				'downloadable',
@@ -984,7 +971,6 @@ describe( 'product edit utils', () => {
 
 			expect( getProductTypeFormFields( [ product ] ) ).toEqual( [
 				'regular_price',
-				'on_sale',
 				'sale_price',
 				'images',
 				'downloadable',

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -88,7 +88,6 @@ const SIMPLE_PRODUCT_EDIT_FORM_FIELDS = [
 	'product_status',
 	'catalog_visibility',
 	'regular_price',
-	'on_sale',
 	'sale_price',
 	'images',
 	'downloadable',
@@ -105,7 +104,6 @@ const SIMPLE_PRODUCT_EDIT_FORM_FIELDS = [
 
 const VARIATION_PRODUCT_EDIT_FORM_FIELDS = [
 	'regular_price',
-	'on_sale',
 	'sale_price',
 	'images',
 	'downloadable',
@@ -144,7 +142,6 @@ const EXTERNAL_PRODUCT_EDIT_FORM_FIELDS = [
 	'product_status',
 	'catalog_visibility',
 	'regular_price',
-	'on_sale',
 	'sale_price',
 	'images',
 	'external_url',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The "On sale" boolean toggle gated whether the sale price field was visible, which felt like an unnecessary step — entering a sale price already implies the product is on sale. This PR removes the toggle and shows the sale price field by default in the experimental products app's edit drawer.

- Drop `on_sale` from the simple, variation, and external product edit form lists in `product-edit/utils.ts`.
- Remove the conditional `isVisible` from the `sale_price` field so it always renders alongside `regular_price`.
- Update form-order assertions in `utils.test.ts` to match the new layout (89 tests still pass).

The `on_sale` field itself stays registered (it's still part of the underlying product data model), it just no longer appears as a control in the form.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open a simple product in the edit drawer.
2. Confirm the "On sale" toggle no longer appears between Regular price and Sale price.
3. Confirm the Sale price field is visible by default (even when the product was previously not on sale).
4. Enter a sale price, save, and reload — verify the value persists and the product is treated as on sale.
5. Clear the sale price, save, and reload — verify the product is no longer on sale.
6. Repeat steps 1–5 on a variation and on an external product.

### Testing that has already taken place:

Ran `pnpm test:js` for the experimental-products-app package — all 89 tests pass after the form-order assertion updates. Verified the new form layout visually in the edit drawer at `localhost:8888`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually and is included in this PR under `packages/js/experimental-products-app/changelog/`.

</details>