### PR TITLE
Prevent duplicate order actions on Update button double-click

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-372
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-372
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent duplicate order actions (status-change hooks, completion emails) when the Update button on the order edit screen is double-clicked.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -33,6 +33,60 @@ jQuery( function ( $ ) {
 			$( 'a.load_customer_billing' ).on( 'click', this.load_billing );
 			$( 'a.load_customer_shipping' ).on( 'click', this.load_shipping );
 			$( '#customer_user' ).on( 'change', this.change_customer_user );
+			this.prevent_double_submit();
+		},
+
+		/**
+		 * Prevent the order edit form from being submitted more than once when the
+		 * Update button is double-clicked. The browser captures form data at the
+		 * start of submission, so disabling the submit buttons after submission
+		 * starts is safe and does not drop the button's `name=save` value.
+		 *
+		 * This guards both the HPOS order edit form (`form#order`) and the legacy
+		 * post.php form (`form#post`), and also no-ops subsequent clicks on the
+		 * publish / save_order buttons.
+		 */
+		prevent_double_submit: function() {
+			var $form = $( '#woocommerce-order-actions' ).closest( 'form' );
+
+			// Fallback: HPOS uses form#order, legacy CPT uses form#post.
+			if ( ! $form.length ) {
+				$form = $( 'form#order, form#post' ).first();
+			}
+
+			if ( ! $form.length ) {
+				return;
+			}
+
+			// jQuery `.data()` keys are namespaced to avoid clashing with other
+			// scripts that may also attach state to the form element.
+			$form.on( 'submit.wc_prevent_double_submit', function() {
+				var $f = $( this );
+
+				if ( $f.data( 'wc-order-submitting' ) ) {
+					return false;
+				}
+
+				$f.data( 'wc-order-submitting', true );
+
+				// Disable the publish (legacy) and save_order (HPOS) buttons so
+				// the form cannot be resubmitted while the request is in flight.
+				$f.find( '#publish, button.save_order' )
+					.prop( 'disabled', true )
+					.addClass( 'disabled' );
+			} );
+
+			// Block direct clicks on the publish / save_order buttons once the
+			// form has been submitted, in case a click event fires after the
+			// initial submission but before the page navigates away.
+			$form.on( 'click.wc_prevent_double_submit', '#publish, button.save_order', function( e ) {
+				var $f = $( this ).closest( 'form' );
+
+				if ( $f.data( 'wc-order-submitting' ) ) {
+					e.preventDefault();
+					return false;
+				}
+			} );
 		},
 
 		change_country: function( e, stickValue ) {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #30759
Linear: [RSMAPGJ-372](https://linear.app/a8c/issue/RSMAPGJ-372)

Double-clicking the Update button on the order edit screen submits the form multiple times, firing downstream actions (order status change hooks, completion emails, third-party invoicing) more than once. The reporter on #30759 confirmed reproducibility with only WooCommerce active, with duplicate "Order status changed" notes as evidence.

This PR hardens the order edit form against accidental double-submits:

- On `submit` of the order edit form, set a sticky `wc-order-submitting` flag and disable the `#publish` (legacy CPT) and `button.save_order` (HPOS) submit buttons. The browser captures form data at the start of submission, so disabling after the submit event fires does not strip the button's `name=save` value from the POST.
- Subsequent `submit` events return `false`, and subsequent `click` events on the publish / save_order buttons are short-circuited with `preventDefault()`, so a queued second click cannot kick off another request before the page navigates.
- Both HPOS (`form#order`) and legacy CPT (`form#post`) order edit screens are covered, since the script is enqueued on both via `WC_Admin_Assets::is_order_meta_box_screen()`.

### Screenshots / screen recordings:

n/a — pure JS submit-guard, no UI change.

### How to test the changes in this Pull Request:

1. Build classic assets: `pnpm --filter=@woocommerce/classic-assets build` (or watch).
2. Create or open a `processing` order in the admin.
3. Open DevTools → Network. Change the order status to `Completed`.
4. Rapidly double-click the **Update** button.
5. Confirm only **one** `POST` request is sent to `admin.php` / `post.php`.
6. Verify the order has exactly **one** "Order status changed from Processing to Completed" note (previously two).
7. Repeat on the legacy CPT order edit screen if HPOS is disabled (`woocommerce_custom_orders_table_enabled` filter false). Behavior should match.

You can also run the reproduction harness from the triage repo:

```bash
python scripts/repro_bugs.py --phase execute --only 30759
# Success: new line in data/repro_attempts.jsonl with verdict=NOT_REPRODUCED
```

### Testing that has already taken place:

- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean (eslint + phpcs).
- [x] `node --check` on the modified JS file — syntax OK.
- [ ] Manual double-click smoke test against a local store — pending reviewer verification on a built environment.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.
<details>
<summary>Changelog Entry Details</summary>

**Significance**: Patch

**Type**: Fix

**Message**: Prevent duplicate order actions (status-change hooks, completion emails) when the Update button on the order edit screen is double-clicked.

</details>

---

This PR was prepared by the RSMAPGJ AI Coder pilot. Reviewer signoff is required before merge.