### PR TITLE
Fix reviews blocks using oversized product image size

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-369
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-369
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reviews blocks now request the smaller WordPress `thumbnail` image size for the product image instead of `woocommerce_thumbnail`, avoiding an oversized image download for the ~3em display.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
@@ -79,10 +79,17 @@ class ImageAttachmentSchema extends AbstractSchema {
 	/**
 	 * Convert a WooCommerce product into an object suitable for the response.
 	 *
-	 * @param int $attachment_id Image attachment ID.
+	 * @param int    $attachment_id  Image attachment ID.
+	 * @param string $thumbnail_size Registered image size to use for the `thumbnail`
+	 *                               (and `thumbnail_srcset`/`thumbnail_sizes`) fields.
+	 *                               Defaults to `woocommerce_thumbnail`. Callers that render
+	 *                               the image at small dimensions (for example the reviews
+	 *                               blocks, which display a 3em avatar-style image) can pass
+	 *                               a smaller registered size such as `thumbnail` to avoid
+	 *                               serving an unnecessarily large image.
 	 * @return object|null
 	 */
-	public function get_item_response( $attachment_id ) {
+	public function get_item_response( $attachment_id, $thumbnail_size = 'woocommerce_thumbnail' ) {
 		if ( ! $attachment_id ) {
 			return null;
 		}
@@ -93,7 +100,7 @@ class ImageAttachmentSchema extends AbstractSchema {
 			return null;
 		}
 
-		$thumbnail = wp_get_attachment_image_src( $attachment_id, 'woocommerce_thumbnail' );
+		$thumbnail = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 
 		return (object) [
 			'id'               => (int) $attachment_id,
@@ -101,8 +108,8 @@ class ImageAttachmentSchema extends AbstractSchema {
 			'thumbnail'        => current( $thumbnail ),
 			'srcset'           => (string) wp_get_attachment_image_srcset( $attachment_id, 'full' ),
 			'sizes'            => (string) wp_get_attachment_image_sizes( $attachment_id, 'full' ),
-			'thumbnail_srcset' => (string) wp_get_attachment_image_srcset( $attachment_id, 'woocommerce_thumbnail' ),
-			'thumbnail_sizes'  => (string) wp_get_attachment_image_sizes( $attachment_id, 'woocommerce_thumbnail' ),
+			'thumbnail_srcset' => (string) wp_get_attachment_image_srcset( $attachment_id, $thumbnail_size ),
+			'thumbnail_sizes'  => (string) wp_get_attachment_image_sizes( $attachment_id, $thumbnail_size ),
 			'name'             => get_the_title( $attachment_id ),
 			'alt'              => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
 		];

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductReviewSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductReviewSchema.php
@@ -168,7 +168,10 @@ class ProductReviewSchema extends AbstractSchema {
 			'product_id'             => (int) $review->comment_post_ID,
 			'product_name'           => get_the_title( (int) $review->comment_post_ID ),
 			'product_permalink'      => get_permalink( (int) $review->comment_post_ID ),
-			'product_image'          => $this->image_attachment_schema->get_item_response( get_post_thumbnail_id( (int) $review->comment_post_ID ) ),
+			// Reviews render the product image at small (~3em) dimensions, so request the
+			// smallest registered image size (`thumbnail`) for the `thumbnail` field instead
+			// of `woocommerce_thumbnail`. See https://github.com/woocommerce/woocommerce/issues/42485.
+			'product_image'          => $this->image_attachment_schema->get_item_response( get_post_thumbnail_id( (int) $review->comment_post_ID ), 'thumbnail' ),
 			'reviewer'               => $review->comment_author,
 			'review'                 => wpautop( $review->comment_content ),
 			'rating'                 => $rating,

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
@@ -114,6 +114,33 @@ class ProductReviews extends ControllerTestCase {
 	}
 
 	/**
+	 * The product_image field should request the small `thumbnail` size, not `woocommerce_thumbnail`,
+	 * because the reviews blocks render the image at small (~3em) dimensions.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/42485.
+	 */
+	public function test_product_image_uses_thumbnail_size() {
+		$captured = array();
+		$capture  = function ( $image, $attachment_id, $size ) use ( &$captured ) {
+			if ( is_string( $size ) ) {
+				$captured[] = $size;
+			}
+			return $image;
+		};
+		add_filter( 'wp_get_attachment_image_src', $capture, 10, 3 );
+
+		try {
+			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' ) );
+			$this->assertSame( 200, $response->get_status() );
+		} finally {
+			remove_filter( 'wp_get_attachment_image_src', $capture, 10 );
+		}
+
+		$this->assertContains( 'thumbnail', $captured, 'Reviews endpoint should request the small thumbnail image size for product images.' );
+		$this->assertNotContains( 'woocommerce_thumbnail', $captured, 'Reviews endpoint should no longer request the larger woocommerce_thumbnail size for product images.' );
+	}
+
+	/**
 	 * Test getting reviews from a specific category.
 	 */
 	public function test_get_items_with_category_id_param() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ImageAttachmentSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ImageAttachmentSchemaTest.php
@@ -1,0 +1,121 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Schemas;
+
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ImageAttachmentSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * ImageAttachmentSchemaTest.
+ */
+class ImageAttachmentSchemaTest extends TestCase {
+	/**
+	 * The system under test.
+	 *
+	 * @var ImageAttachmentSchema
+	 */
+	private $sut;
+
+	/**
+	 * Image sizes requested via wp_get_attachment_image_src during a single call.
+	 *
+	 * @var array<string>
+	 */
+	private $requested_sizes = array();
+
+	/**
+	 * Attachment ID used for tests.
+	 *
+	 * @var int
+	 */
+	private $attachment_id;
+
+	/**
+	 * Set up before test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+		$extend_schema     = new ExtendSchema( $formatters );
+		$schema_controller = new SchemaController( $extend_schema );
+		$this->sut         = $schema_controller->get( ImageAttachmentSchema::IDENTIFIER );
+
+		$this->attachment_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Test Image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+				'guid'           => 'http://example.org/wp-content/uploads/test.jpg',
+			)
+		);
+
+		$this->requested_sizes = array();
+		add_filter( 'wp_get_attachment_image_src', array( $this, 'capture_image_size' ), 10, 3 );
+	}
+
+	/**
+	 * Tear down after test.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'wp_get_attachment_image_src', array( $this, 'capture_image_size' ) );
+		if ( $this->attachment_id ) {
+			wp_delete_attachment( $this->attachment_id, true );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Records the size requested for each call.
+	 *
+	 * @param array|false  $image         Image src array or false.
+	 * @param int          $attachment_id Attachment ID.
+	 * @param string|int[] $size          Requested image size.
+	 * @return array|false
+	 */
+	public function capture_image_size( $image, $attachment_id, $size ) {
+		if ( is_string( $size ) ) {
+			$this->requested_sizes[] = $size;
+		}
+		return $image;
+	}
+
+	/**
+	 * The default thumbnail size remains `woocommerce_thumbnail` for backwards compatibility.
+	 */
+	public function test_default_thumbnail_size_is_woocommerce_thumbnail() {
+		$this->sut->get_item_response( $this->attachment_id );
+
+		$this->assertContains( 'woocommerce_thumbnail', $this->requested_sizes, 'Expected woocommerce_thumbnail to be requested by default.' );
+		$this->assertContains( 'full', $this->requested_sizes, 'Expected full size to still be requested for src.' );
+	}
+
+	/**
+	 * Callers can request a smaller registered image size for the thumbnail fields.
+	 */
+	public function test_custom_thumbnail_size_is_passed_through() {
+		$this->sut->get_item_response( $this->attachment_id, 'thumbnail' );
+
+		$this->assertContains( 'thumbnail', $this->requested_sizes, 'Expected thumbnail size to be requested when explicitly passed.' );
+		$this->assertNotContains( 'woocommerce_thumbnail', $this->requested_sizes, 'woocommerce_thumbnail should not be requested when overridden.' );
+		$this->assertContains( 'full', $this->requested_sizes, 'full size should still be requested for src field.' );
+	}
+
+	/**
+	 * Returns null for a missing/invalid attachment id.
+	 */
+	public function test_returns_null_for_invalid_attachment() {
+		$this->assertNull( $this->sut->get_item_response( 0 ) );
+		$this->assertNull( $this->sut->get_item_response( 0, 'thumbnail' ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Store API's `/wc/store/v1/products/reviews` endpoint exposes `product_image` via `ImageAttachmentSchema`, whose `thumbnail` field uses the `woocommerce_thumbnail` registered image size (typically 300x300). The reviews blocks (e.g. "Reviews by Product") render that image at roughly 3em (~48px), so requesting 300x300 wastes bandwidth.

This PR:

- Adds an optional `$thumbnail_size` parameter to `ImageAttachmentSchema::get_item_response()` (default `woocommerce_thumbnail`, preserving existing behavior for all other callers such as the cart/checkout product image).
- Passes the smaller `thumbnail` registered size from `ProductReviewSchema`, so reviews now serve a 150x150 (or smaller, depending on site settings) image instead of 300x300.
- Adds unit coverage for both the new schema parameter and the reviews route.

The rendered output is visually identical (CSS still constrains the displayed dimensions); only the underlying image URL changes.

Closes #42485.

Linear: https://linear.app/a8c/issue/RSMAPGJ-369

### How to test the changes in this Pull Request:

1. Create a simple product and attach a featured image (any size that has multiple registered intermediate sizes).
2. Approve a review for the product.
3. Add the "Reviews by Product" block to a page. In the block settings, enable "Show product image".
4. View the page on the frontend and inspect the rendered product image inside the review.
5. Confirm the image `src` resolves to the WordPress `thumbnail` size (typically `*-150x150.jpg`) rather than the larger `woocommerce_thumbnail` (typically `*-300x300.jpg`).
6. Confirm the visible layout is unchanged.

### Testing that has already taken place:

- New PHPUnit coverage: `ImageAttachmentSchemaTest::test_default_thumbnail_size_is_woocommerce_thumbnail`, `test_custom_thumbnail_size_is_passed_through`, `test_returns_null_for_invalid_attachment`.
- New PHPUnit coverage: `ProductReviews::test_product_image_uses_thumbnail_size` asserts the reviews route requests the `thumbnail` size and no longer requests `woocommerce_thumbnail` for the product image.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `composer exec -- phpstan analyse <touched files>` clean (no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually (`plugins/woocommerce/changelog/fix-rsmapgj-369`, `patch`/`fix`).

---

This PR was authored by an AI coder as part of the RSMAPGJ pilot. Pipeline sign-off requested.