### PR TITLE
Fix: fire order.updated webhook when a refund is deleted

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-373
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-373
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fire the order.updated webhook when a refund is deleted so consumers see the parent order's effective state change. Fixes #26532.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -928,6 +928,31 @@ function wc_order_fully_refunded( $order_id ) {
 add_action( 'woocommerce_order_status_refunded', 'wc_order_fully_refunded' );
 
 /**
+ * Fire the `woocommerce_update_order` action when a refund is deleted so that
+ * the parent order is treated as updated. Without this, the `order.updated`
+ * webhook (and any other listener of `woocommerce_update_order`) does not run
+ * on refund deletion, even though deleting a refund changes the order's
+ * effective state (e.g. its total refunded amount).
+ *
+ * @internal
+ *
+ * @since 10.9.0
+ *
+ * @param int $refund_id The deleted refund ID.
+ * @param int $order_id  The parent order ID.
+ */
+function wc_refund_deleted_trigger_order_update( $refund_id, $order_id ): void {
+	$order_id = absint( $order_id );
+	if ( ! $order_id ) {
+		return;
+	}
+
+	// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Re-firing an existing documented hook.
+	do_action( 'woocommerce_update_order', $order_id );
+}
+add_action( 'woocommerce_refund_deleted', 'wc_refund_deleted_trigger_order_update', 10, 2 );
+
+/**
  * Search orders.
  *
  * @since  2.6.0

--- a/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
@@ -80,6 +80,60 @@ class WC_Webhook_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox `order.updated` webhook is enqueued when a refund is deleted via the `woocommerce_refund_deleted` action.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/26532 - deleting a refund
+	 * did not fire the `order.updated` webhook because the deletion code path only triggered
+	 * `woocommerce_refund_deleted`, which was not bound to the `order.updated` topic.
+	 */
+	public function test_order_updated_webhook_fires_on_refund_deletion() {
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$webhook = new WC_Webhook();
+		$webhook->set_name( 'Test order.updated on refund deletion' );
+		$webhook->set_topic( 'order.updated' );
+		$webhook->set_delivery_url( 'http://example.com/wc-webhook-sink' );
+		$webhook->set_status( 'active' );
+		$webhook->set_user_id( 1 );
+		$webhook->save();
+		$webhook->enqueue();
+
+		$captured = array();
+		$listener = function ( $wh, $arg ) use ( &$captured ) {
+			$captured[] = array(
+				'topic' => $wh->get_topic(),
+				'arg'   => $arg,
+			);
+		};
+		add_action( 'woocommerce_webhook_process_delivery', $listener, 10, 2 );
+
+		try {
+			// Simulate the AJAX refund deletion path: `class-wc-ajax.php::delete_refund()`
+			// fires `woocommerce_refund_deleted` with ( $refund_id, $order_id ).
+			$refund_id = 987654321;
+			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test code re-firing existing hook.
+			do_action( 'woocommerce_refund_deleted', $refund_id, $order->get_id() );
+
+			$matched = array_filter(
+				$captured,
+				function ( $entry ) use ( $order ) {
+					return 'order.updated' === $entry['topic'] && (int) $entry['arg'] === $order->get_id();
+				}
+			);
+
+			$this->assertCount(
+				1,
+				$matched,
+				'The order.updated webhook should be enqueued exactly once for the parent order when a refund is deleted.'
+			);
+		} finally {
+			remove_action( 'woocommerce_webhook_process_delivery', $listener, 10 );
+		}
+	}
+
+	/**
 	 * @testDox Check that a deleted administrator user (without content re-assigned to another user)
 	 * has all webhooks changed to user_id zero.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

When a refund is added to an order, the `order.updated` webhook fires (refund creation goes through `wc_create_refund` -> `$order->save()` -> `woocommerce_update_order`).

When a refund is **deleted**, however, the admin-side AJAX path (`WC_AJAX::delete_refund()`) only fires `woocommerce_refund_deleted`, which is not bound to any webhook topic. As a result, no webhook is delivered even though the order's effective state (total refunded, refund-related status) has changed.

This PR adds a small bridge in `wc-order-functions.php` that listens for `woocommerce_refund_deleted` and re-fires the existing `woocommerce_update_order` action with the parent order ID. That existing action is already mapped to the `order.updated` webhook topic via `WC_Webhook::get_default_topic_hooks()`, so webhook consumers automatically start receiving the missing delivery without any change to the webhook subsystem itself.

Closes #26532
Linear: https://linear.app/a8c/issue/RSMAPGJ-373

### How to test the changes in this Pull Request

1. Activate an `order.updated` webhook (WooCommerce -> Settings -> Advanced -> Webhooks) pointing at a request bin / RequestCatcher / `webhook.site`.
2. Open an existing order in wp-admin and add a manual refund. Confirm an `order.updated` delivery appears (existing behavior).
3. Delete that refund from the same order screen.
4. Before this fix: no delivery is created. After this fix: a new `order.updated` delivery appears for the parent order.

You can also exercise the new unit test:

```sh
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_order_updated_webhook_fires_on_refund_deletion
```

### Testing that has already taken place

- New PHPUnit test covers the bridge by enqueueing an `order.updated` webhook, firing `woocommerce_refund_deleted`, and asserting that `woocommerce_webhook_process_delivery` runs exactly once with the parent order ID.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `composer exec phpstan analyse includes/wc-order-functions.php --memory-limit=2G` clean (no new errors, no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Added manually: `plugins/woocommerce/changelog/fix-rsmapgj-373` (patch / fix).

---

Submitted via the RSMAPGJ AI Coder pipeline.