### PR TITLE
Preserve PHP-defined state ordering in Checkout block

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-368
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-368
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve PHP-defined state ordering in the Checkout block state dropdown for countries with numeric state codes (e.g. US Minor Outlying Islands).

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/state-input/state-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/state-input/state-input.tsx
@@ -4,6 +4,7 @@
 import { decodeEntities } from '@wordpress/html-entities';
 import { useCallback, useMemo, useEffect, useRef } from '@wordpress/element';
 import { ValidatedTextInput } from '@woocommerce/blocks-components';
+import { STATE_ORDER } from '@woocommerce/block-settings';
 import { clsx } from 'clsx';
 
 /**
@@ -38,13 +39,32 @@ const StateInput = ( {
 	const countryStates = states[ country ];
 	const options = useMemo< SelectOption[] >( () => {
 		if ( countryStates && Object.keys( countryStates ).length > 0 ) {
-			return Object.keys( countryStates ).map( ( key ) => ( {
+			// Prefer the PHP-defined ordering. Object.keys reorders integer-like
+			// string keys (e.g. "81") numerically, which loses the
+			// merchant-defined order set via the `woocommerce_states` filter for
+			// countries whose state codes are numeric. Fall back to Object.keys
+			// when no explicit order is available (older payloads or
+			// non-standard state lists injected by extensions).
+			const orderedKeys = (
+				STATE_ORDER[ country ]?.filter(
+					( key ) => key in countryStates
+				) ?? []
+			).concat(
+				Object.keys( countryStates ).filter(
+					( key ) => ! STATE_ORDER[ country ]?.includes( key )
+				)
+			);
+			const keys =
+				orderedKeys.length > 0
+					? orderedKeys
+					: Object.keys( countryStates );
+			return keys.map( ( key ) => ( {
 				value: key,
 				label: decodeEntities( countryStates[ key ] ),
 			} ) );
 		}
 		return [];
-	}, [ countryStates ] );
+	}, [ countryStates, country ] );
 
 	/**
 	 * Handles state selection onChange events. Finds a matching state by key or value.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/state-input/test/state-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/state-input/test/state-input.tsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+
+/**
+ * Mock @woocommerce/block-settings to expose a deterministic STATE_ORDER so
+ * the test does not depend on the global wcSettings shape. We preserve all
+ * other exports from the module so transitive dependencies (cart data store,
+ * etc.) still find ADDRESS_FORM_KEYS and friends.
+ */
+jest.mock( '@woocommerce/block-settings', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@woocommerce/block-settings' ),
+	STATE_ORDER: {
+		// Insertion order differs from alphabetical order, and includes a
+		// numeric-like key ("99") that JavaScript would otherwise reorder
+		// numerically when iterating with Object.keys.
+		XX: [ '99', 'CA', 'AL' ],
+	},
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import StateInput from '../state-input';
+
+describe( 'StateInput', () => {
+	it( 'renders state options in the PHP-defined order, not the order JavaScript imposes on integer-like keys', () => {
+		render(
+			<StateInput
+				id="state"
+				label="State"
+				country="XX"
+				value=""
+				onChange={ () => undefined }
+				states={ {
+					// Object literal: JS reorders integer-like keys first.
+					// Without STATE_ORDER, the dropdown would render "99" first,
+					// then "AL", "CA" — losing the merchant-defined order.
+					XX: {
+						AL: 'Army Last',
+						CA: 'California',
+						'99': 'Zone 99',
+					},
+				} }
+			/>
+		);
+
+		const select = screen.getByLabelText( 'State' ) as HTMLSelectElement;
+		const optionLabels = within( select )
+			.getAllByRole( 'option' )
+			.map( ( option ) => option.textContent );
+
+		// The first option is the placeholder "Select a state". Subsequent
+		// options should match the PHP-defined order from STATE_ORDER.
+		expect( optionLabels.slice( 1 ) ).toEqual( [
+			'Zone 99',
+			'California',
+			'Army Last',
+		] );
+	} );
+
+	it( 'falls back to Object.keys when STATE_ORDER is not available for the country', () => {
+		render(
+			<StateInput
+				id="state"
+				label="State"
+				country="ZZ"
+				value=""
+				onChange={ () => undefined }
+				states={ {
+					ZZ: {
+						AA: 'Alpha',
+						BB: 'Beta',
+					},
+				} }
+			/>
+		);
+
+		const select = screen.getByLabelText( 'State' ) as HTMLSelectElement;
+		const optionLabels = within( select )
+			.getAllByRole( 'option' )
+			.map( ( option ) => option.textContent );
+
+		expect( optionLabels.slice( 1 ) ).toEqual( [ 'Alpha', 'Beta' ] );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
@@ -110,6 +110,25 @@ export const STATES = Object.fromEntries(
 	} )
 );
 
+/**
+ * PHP-defined ordering of state keys, keyed by country code.
+ *
+ * Consumers MUST prefer this over Object.keys(STATES[ country ]) when rendering
+ * lists of states. JavaScript reorders integer-like string keys (e.g. "81")
+ * numerically when iterating an object's keys, which loses the merchant-defined
+ * ordering applied via the `woocommerce_states` filter for countries whose
+ * state codes are numeric.
+ */
+export const STATE_ORDER: Record< string, string[] > = Object.fromEntries(
+	Object.keys( COUNTRIES ).map( ( countryCode ) => {
+		const data = countryData[ countryCode ];
+		const order = Array.isArray( data?.stateOrder )
+			? data.stateOrder
+			: Object.keys( data?.states || {} );
+		return [ countryCode, order ];
+	} )
+);
+
 export const COUNTRY_LOCALE = Object.fromEntries(
 	Object.keys( COUNTRIES ).map( ( countryCode ) => {
 		return [ countryCode, countryData[ countryCode ].locale || {} ];

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/countries.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/countries.ts
@@ -7,6 +7,13 @@ export type CountryData = {
 	allowBilling: boolean;
 	allowShipping: boolean;
 	states: Record< string, string >;
+	/**
+	 * PHP-defined ordering of state keys. Use this when iterating states because
+	 * JavaScript reorders integer-like string keys numerically when using
+	 * Object.keys/Object.entries, which would otherwise lose the merchant-defined
+	 * order set via the `woocommerce_states` filter.
+	 */
+	stateOrder?: string[];
 	locale: Record< keyof FormFields, FieldLocaleOverrides >;
 	format?: string;
 };

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -372,10 +372,22 @@ class CartCheckoutUtils {
 		$country_data = array();
 
 		foreach ( array_keys( $all_countries ) as $country_code ) {
+			$states = $country_states[ $country_code ] ?? array();
+
+			// Provide an explicit, PHP-defined ordering of state keys alongside the states
+			// map. This is required because JavaScript object iteration reorders
+			// integer-like string keys (e.g. "81") numerically, which can lose the
+			// merchant-defined ordering set via the `woocommerce_states` filter for
+			// countries whose state codes are numeric (US Minor Outlying Islands,
+			// Philippines, etc.). Keys are cast to strings so they round-trip through
+			// JSON and JavaScript Object.keys() without further reordering.
+			$state_order = array_map( 'strval', array_keys( $states ) );
+
 			$country_data[ $country_code ] = array(
 				'allowBilling'  => isset( $billing_countries[ $country_code ] ),
 				'allowShipping' => isset( $shipping_countries[ $country_code ] ),
-				'states'        => $country_states[ $country_code ] ?? array(),
+				'states'        => $states,
+				'stateOrder'    => $state_order,
 				'locale'        => $country_locales[ $country_code ] ?? array(),
 			);
 		}

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
@@ -328,4 +328,67 @@ class CartCheckoutUtilsTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	/**
+	 * Test get_country_data() exposes a stateOrder array alongside states so
+	 * the JavaScript layer can preserve the PHP-defined ordering even when
+	 * state codes are integer-like strings (which Object.keys/Object.entries
+	 * would reorder numerically).
+	 *
+	 * Regression: PHP states.php order was lost in the Checkout block dropdown
+	 * for countries with numeric state codes (e.g. US Minor Outlying Islands).
+	 */
+	public function test_get_country_data_exposes_state_order_for_numeric_keys() {
+		// Reorder US states via the woocommerce_states filter: move Alabama (AL)
+		// to the end so insertion order differs from alphabetical order, and
+		// inject a fake numeric-key state at the start that would otherwise be
+		// reordered by Object.keys() in JavaScript.
+		$filter = static function ( $states ) {
+			if ( isset( $states['US'] ) ) {
+				$al = $states['US']['AL'];
+				unset( $states['US']['AL'] );
+				$states['US'] = array_merge( array( '99' => 'Zone 99' ), $states['US'], array( 'AL' => $al ) );
+			}
+			return $states;
+		};
+		add_filter( 'woocommerce_states', $filter );
+
+		// Reset the cached states on WC()->countries so the filter is
+		// re-applied. The geo_cache property is private; use Reflection.
+		$reset_geo_cache = static function () {
+			$countries = WC()->countries;
+			$ref       = new \ReflectionClass( $countries );
+			$prop      = $ref->getProperty( 'geo_cache' );
+			$prop->setAccessible( true );
+			$prop->setValue( $countries, array() );
+		};
+		$reset_geo_cache();
+
+		$country_data = CartCheckoutUtils::get_country_data();
+
+		remove_filter( 'woocommerce_states', $filter );
+		$reset_geo_cache();
+
+		$this->assertArrayHasKey( 'US', $country_data, 'US country data should be present.' );
+		$this->assertArrayHasKey( 'stateOrder', $country_data['US'], 'US country data should expose stateOrder.' );
+
+		$state_order = $country_data['US']['stateOrder'];
+		$this->assertIsArray( $state_order );
+		$this->assertSame( '99', reset( $state_order ), 'Numeric-keyed state should appear first per PHP-defined order.' );
+		$this->assertSame( 'AL', end( $state_order ), 'Alabama should appear last per PHP-defined order.' );
+
+		// All entries should be strings so the order round-trips through JSON
+		// without JavaScript reordering integer-like string keys numerically.
+		foreach ( $state_order as $key ) {
+			$this->assertIsString( $key, 'stateOrder entries must be strings.' );
+		}
+
+		// The states map should still contain the same set of keys as
+		// stateOrder, so consumers can look up labels by key.
+		$this->assertEqualsCanonicalizing(
+			$state_order,
+			array_map( 'strval', array_keys( $country_data['US']['states'] ) ),
+			'stateOrder and states keys must match (order-insensitive).'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Checkout block reads states from the `countryData` payload via `Object.keys(states)` to build the state dropdown options. JavaScript reorders integer-like string keys (e.g. `"81"`) numerically when iterating an object's keys, which loses the merchant-defined ordering set via the `woocommerce_states` filter for countries whose state codes are numeric (US Minor Outlying Islands, Philippines, etc.).

This PR fixes the issue by:

- Exposing an explicit `stateOrder` array alongside the `states` map from `CartCheckoutUtils::get_country_data()`. PHP arrays preserve insertion order, and casting keys to strings keeps them round-trip-safe through JSON without numeric reordering on the JS side.
- Adding a `STATE_ORDER` export to `@woocommerce/block-settings` that derives from the new payload, with a graceful fallback to `Object.keys` for older payloads or extensions that inject custom state lists.
- Updating `state-input.tsx` to iterate `STATE_ORDER[ country ]` first, then concatenate any states present in the map but missing from the order array (defensive against extensions that inject extra entries).

The change is backward-compatible — the `states` map keeps its original shape, only an additional `stateOrder` field is added to each country in `countryData`.

Closes #44071.
Linear: https://linear.app/a8c/issue/RSMAPGJ-368

### Screenshots or screen recordings:

Not applicable — payload-shape and ordering change. Functional behavior is verified via the new PHP and Jest tests.

### How to test the changes in this Pull Request:

1. Activate the WooCommerce plugin and ensure a Checkout block-based checkout page exists.
2. Add the following snippet to a mu-plugin to reorder US states, moving Alabama to the end and injecting a fake numeric-keyed state at the start:
   ``\`php
   add_filter( 'woocommerce_states', function ( \$states ) {
       if ( isset( \$states['US'] ) ) {
           \$al = \$states['US']['AL'];
           unset( \$states['US']['AL'] );
           \$states['US'] = array_merge( array( '99' => 'Zone 99' ), \$states['US'], array( 'AL' => \$al ) );
       }
       return \$states;
   } );
   ``\`
3. Visit the block-based checkout page, set Country to **United States**, and open the State dropdown.
4. Verify that **Zone 99** appears first, the other states follow in PHP-defined order, and **Alabama** appears last — i.e. the dropdown matches the order produced by `WC()->countries->get_states()` rather than the order JavaScript imposes on integer-like keys.
5. Switch country to **Canada** (no numeric state codes) and confirm provinces still render correctly.

### Testing that has already taken place:

- New PHP unit test (`CartCheckoutUtilsTest::test_get_country_data_exposes_state_order_for_numeric_keys`) asserts that `get_country_data()` exposes `stateOrder` and preserves the PHP-defined order — including numeric-keyed states — when the `woocommerce_states` filter rearranges entries.
- New Jest test (`assets/js/base/components/state-input/test/state-input.tsx`) renders `StateInput` with a state list containing an integer-like key out of insertion order and asserts the dropdown options appear in the `STATE_ORDER`-defined order, plus a fallback case for when `STATE_ORDER` is unavailable.
- PHPStan runs clean on the modified `CartCheckoutUtils.php`.
- `pnpm lint:php:changes` and `pnpm lint:changes:branch` run clean for the branch.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Changelog entry has been created (`plugins/woocommerce/changelog/fix-rsmapgj-368`).

---

> This PR was prepared through the RSMAPGJ AI Coder pilot (Linear: [RSMAPGJ-368](https://linear.app/a8c/issue/RSMAPGJ-368)). Signed off by the impl pipeline; rev 1.