### PR TITLE
Update products quick edit fields

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-products-quick-edit-fields
+++ b/packages/js/experimental-products-app/changelog/update-products-quick-edit-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update quick edit fields for simple, variable parent, and variation products.

--- a/packages/js/experimental-products-app/src/fields/components/dimension.tsx
+++ b/packages/js/experimental-products-app/src/fields/components/dimension.tsx
@@ -14,10 +14,13 @@ import type { ProductEntityRecord, SettingsEntityRecord } from '../types';
 export type DimensionKey = 'height' | 'width' | 'length';
 
 export function isDimensionVisible( item: ProductEntityRecord ) {
-	return (
-		! item.virtual &&
-		( ( item.type === 'simple' && ! item.parent_id ) || item.downloadable )
-	);
+	const isSellableInstance =
+		( item.type === 'simple' && ! item.parent_id ) ||
+		( item.type === 'variable' && ! item.parent_id ) ||
+		item.type === 'variation' ||
+		Boolean( item.parent_id );
+
+	return ! item.virtual && ( isSellableInstance || item.downloadable );
 }
 
 export const createDimensionField = (

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -293,7 +293,6 @@ describe( 'product edit utils', () => {
 			'name',
 			'short_description',
 			'description',
-			'product_status',
 			'catalog_visibility',
 			'categories',
 			'brands',
@@ -357,6 +356,7 @@ describe( 'product edit utils', () => {
 				'categories',
 				'brands',
 				'tags',
+				'featured',
 				'weight',
 				'length',
 				'width',
@@ -374,7 +374,6 @@ describe( 'product edit utils', () => {
 				'tax_status',
 				'upsell_ids',
 				'cross_sell_ids',
-				'featured',
 			] );
 		} );
 
@@ -519,7 +518,7 @@ describe( 'product edit utils', () => {
 			] );
 		} );
 
-		it( 'hides parent pricing and downloads for variable products', () => {
+		it( 'shows variable parent fields in quick edit order', () => {
 			const fieldIds = getVisibleFieldIds( [
 				buildProduct( {
 					type: 'variable',
@@ -535,23 +534,31 @@ describe( 'product edit utils', () => {
 				'date_on_sale_to',
 				'downloadable',
 			] );
-			expect( fieldIds ).toEqual(
-				expect.arrayContaining( [
-					'sku',
-					'upsell_ids',
-					'cross_sell_ids',
-					'stock',
-					'manage_stock',
-					'shipping_class',
-					'tax_status',
-				] )
-			);
-			expectFieldsHidden( fieldIds, [
-				'stock_quantity',
-				'weight',
+			expect( fieldIds ).toEqual( [
+				'name',
+				'product_status',
+				'catalog_visibility',
+				'images',
+				'sku',
+				'manage_stock',
+				'stock',
+				'categories',
+				'brands',
+				'tags',
+				'featured',
+				'shipping_class',
 				'length',
 				'width',
 				'height',
+				'weight',
+			] );
+			expectFieldsHidden( fieldIds, [
+				'short_description',
+				'description',
+				'stock_quantity',
+				'tax_status',
+				'upsell_ids',
+				'cross_sell_ids',
 			] );
 		} );
 
@@ -579,20 +586,23 @@ describe( 'product edit utils', () => {
 					'product_status',
 					'catalog_visibility',
 					'categories',
+					'brands',
 					'tags',
-					...bulkSellableInstanceFieldIds,
+					'featured',
+					'images',
+					'manage_stock',
+					'weight',
+					'length',
+					'width',
+					'height',
 				] )
 			);
 			expectFieldsHidden( fieldIds, [
-				'featured',
 				'upsell_ids',
 				'cross_sell_ids',
 				'shipping_class',
 				'tax_status',
-				'weight',
-				'length',
-				'width',
-				'height',
+				'stock_quantity',
 			] );
 		} );
 
@@ -641,12 +651,18 @@ describe( 'product edit utils', () => {
 
 			expect( fieldIds ).toEqual(
 				expect.arrayContaining( [
+					'product_status',
 					'regular_price',
 					'sale_price',
 					'images',
 					'sku',
 					'manage_stock',
 					'stock_quantity',
+					'shipping_class',
+					'weight',
+					'length',
+					'width',
+					'height',
 				] )
 			);
 			expectFieldsHidden( fieldIds, [
@@ -657,7 +673,6 @@ describe( 'product edit utils', () => {
 				'schedule_sale',
 				'date_on_sale_from',
 				'date_on_sale_to',
-				...shippingFieldIds,
 				'tax_status',
 			] );
 		} );
@@ -682,6 +697,12 @@ describe( 'product edit utils', () => {
 					'sale_price',
 					'stock',
 					'manage_stock',
+					'product_status',
+					'shipping_class',
+					'weight',
+					'length',
+					'width',
+					'height',
 				] )
 			);
 			expectFieldsHidden( fieldIds, parentOwnedFieldIds );
@@ -690,12 +711,11 @@ describe( 'product edit utils', () => {
 				'schedule_sale',
 				'date_on_sale_from',
 				'date_on_sale_to',
-				...shippingFieldIds,
 				'tax_status',
 			] );
 		} );
 
-		it( 'shows downloads and hides shipping for virtual downloadable variations', () => {
+		it( 'hides shipping fields for virtual variations', () => {
 			const fieldIds = getVisibleFieldIds( [
 				buildProduct( {
 					id: 34,
@@ -706,24 +726,23 @@ describe( 'product edit utils', () => {
 				} ),
 			] );
 
-			expect( fieldIds ).toContain( 'downloadable' );
+			expectFieldsHidden( fieldIds, [ 'downloadable' ] );
 			expectFieldsHidden( fieldIds, shippingFieldIds );
 		} );
 
-		it( 'shows dimensions for physical downloadable variations', () => {
+		it( 'shows shipping and dimensions for physical variations', () => {
 			const fieldIds = getVisibleFieldIds( [
 				buildProduct( {
 					id: 34,
 					parent_id: 12,
 					type: 'variation',
 					virtual: false,
-					downloadable: true,
 				} ),
 			] );
 
 			expect( fieldIds ).toEqual(
 				expect.arrayContaining( [
-					'downloadable',
+					'shipping_class',
 					'weight',
 					'length',
 					'width',
@@ -802,7 +821,7 @@ describe( 'product edit utils', () => {
 			] );
 		} );
 
-		it( 'shows downloadable fields when every bulk sellable item is downloadable', () => {
+		it( 'hides downloadable fields for simple product and variation selections', () => {
 			const fieldIds = getVisibleFieldIds( [
 				buildProduct( {
 					id: 1,
@@ -817,7 +836,7 @@ describe( 'product edit utils', () => {
 				} ),
 			] );
 
-			expect( fieldIds ).toContain( 'downloadable' );
+			expectFieldsHidden( fieldIds, [ 'downloadable' ] );
 		} );
 
 		it( 'hides downloadable fields unless every bulk item supports downloads', () => {
@@ -856,14 +875,24 @@ describe( 'product edit utils', () => {
 			] );
 
 			expect( fieldIds ).toEqual(
-				expect.arrayContaining( [ ...managedStockFieldIds ] )
+				expect.arrayContaining( [
+					'product_status',
+					'images',
+					'manage_stock',
+					'shipping_class',
+					'weight',
+					'length',
+					'width',
+					'height',
+				] )
 			);
 			expectFieldsHidden( fieldIds, [
 				...parentOwnedFieldIds,
 				...priceFieldIds,
 				'downloadable',
 				'sku',
-				...shippingFieldIds,
+				'stock',
+				'stock_quantity',
 				'tax_status',
 			] );
 		} );
@@ -895,14 +924,24 @@ describe( 'product edit utils', () => {
 			] );
 
 			expect( fieldIds ).toEqual(
-				expect.arrayContaining( [ 'images', ...managedStockFieldIds ] )
+				expect.arrayContaining( [
+					'product_status',
+					'images',
+					'manage_stock',
+					'weight',
+					'length',
+					'width',
+					'height',
+				] )
 			);
 			expectFieldsHidden( fieldIds, [
 				...parentOwnedFieldIds,
 				...priceFieldIds,
 				'downloadable',
 				'sku',
-				...shippingFieldIds,
+				'stock',
+				'stock_quantity',
+				'shipping_class',
 				'tax_status',
 			] );
 		} );
@@ -951,12 +990,41 @@ describe( 'product edit utils', () => {
 				'categories',
 				'brands',
 				'tags',
+				'featured',
 				{
 					id: 'dimensions',
 					layout: { type: 'row' },
 					children: [ 'weight', 'length', 'width' ],
 				},
 				'height',
+			] );
+		} );
+
+		it( 'uses variable parent form config in design order', () => {
+			const product = buildProduct( {
+				type: 'variable',
+				virtual: false,
+			} );
+
+			expect( getProductTypeFormFields( [ product ] ) ).toEqual( [
+				'name',
+				'product_status',
+				'catalog_visibility',
+				'images',
+				'sku',
+				'manage_stock',
+				'stock',
+				'categories',
+				'brands',
+				'tags',
+				'featured',
+				'shipping_class',
+				{
+					id: 'parent-dimensions',
+					layout: { type: 'row' },
+					children: [ 'length', 'width', 'height' ],
+				},
+				'weight',
 			] );
 		} );
 
@@ -970,14 +1038,15 @@ describe( 'product edit utils', () => {
 			} );
 
 			expect( getProductTypeFormFields( [ product ] ) ).toEqual( [
+				'product_status',
 				'regular_price',
 				'sale_price',
 				'images',
-				'downloadable',
 				'sku',
-				'stock',
 				'manage_stock',
+				'stock',
 				'stock_quantity',
+				'shipping_class',
 				{
 					id: 'dimensions',
 					layout: { type: 'row' },

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -83,6 +83,12 @@ const DIMENSIONS_FORM_FIELD: ProductEditFormField = {
 	children: [ ...DIMENSION_GROUP_FIELD_IDS ],
 };
 
+const PARENT_DIMENSIONS_FORM_FIELD: ProductEditFormField = {
+	id: 'parent-dimensions',
+	layout: { type: 'row' as const },
+	children: [ 'length', 'width', 'height' ],
+};
+
 const SIMPLE_PRODUCT_EDIT_FORM_FIELDS = [
 	'name',
 	'product_status',
@@ -98,43 +104,40 @@ const SIMPLE_PRODUCT_EDIT_FORM_FIELDS = [
 	'categories',
 	'brands',
 	'tags',
+	'featured',
 	DIMENSIONS_FORM_FIELD,
 	'height',
 ] satisfies ProductEditFormField[];
 
 const VARIATION_PRODUCT_EDIT_FORM_FIELDS = [
+	'product_status',
 	'regular_price',
 	'sale_price',
 	'images',
-	'downloadable',
 	'sku',
-	'stock',
 	'manage_stock',
+	'stock',
 	'stock_quantity',
+	'shipping_class',
 	DIMENSIONS_FORM_FIELD,
 	'height',
 ] satisfies ProductEditFormField[];
 
 const VARIABLE_PRODUCT_EDIT_FORM_FIELDS = [
 	'name',
-	'short_description',
-	'description',
-	'images',
 	'product_status',
+	'catalog_visibility',
+	'images',
 	'sku',
-	'stock',
-	'stock_quantity',
 	'manage_stock',
-	'shipping_class',
-	'tax_status',
+	'stock',
 	'categories',
+	'brands',
 	'tags',
 	'featured',
-	'catalog_visibility',
-	'upsell_ids',
-	'cross_sell_ids',
-	DIMENSIONS_FORM_FIELD,
-	'height',
+	'shipping_class',
+	PARENT_DIMENSIONS_FORM_FIELD,
+	'weight',
 ] satisfies ProductEditFormField[];
 
 const EXTERNAL_PRODUCT_EDIT_FORM_FIELDS = [
@@ -178,7 +181,6 @@ const PARENT_OWNED_PRODUCT_EDIT_FIELD_ID_SET = new Set< ProductEditFieldId >( [
 	'name',
 	'short_description',
 	'description',
-	'product_status',
 	'catalog_visibility',
 	'categories',
 	'brands',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental products quick edit panel should expose field sets that match the supported editing surface for each product type. This updates the quick edit field order for simple products, variable product parents, and variations, including featured products for simple products and parent-level shipping/dimension fields for variable products.

Variation quick edit now keeps to variation-supported fields such as status, price, media, SKU, inventory, stock status, shipping class, and dimensions. Variable parent dimensions are now visible for physical products so the parent form can render length, width, height, and weight in the requested order.

### Screenshots or screen recordings:

Screenshots should be added before moving this PR out of draft.

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open the Products list.
2. Quick edit a simple product and confirm the panel includes Featured product after the product organization fields.
3. Quick edit a variable product parent and confirm the field order is name, status, catalog visibility, images, SKU, inventory controls, categories, brands, tags, featured product, shipping class, length, width, height, and weight.
4. Quick edit a product variation and confirm the panel includes status, price fields, images, SKU, inventory controls, stock status or quantity, shipping class, and dimensions.
5. Save edits in each panel and confirm the changed values persist after reopening quick edit.

### Testing that has already taken place:

- `pnpm test:js -- --runTestsByPath src/product-edit/utils.test.ts`
- `pnpm --filter @woocommerce/experimental-products-app build:project:esm`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually in `packages/js/experimental-products-app/changelog/update-products-quick-edit-fields`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
