### PR TITLE
Increase default input height in the Add to Cart + Options Quantity Selector and add styles when Mini-Cart is missing

### DIFF
--- a/plugins/woocommerce/changelog/fix-default-input-height-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/fix-default-input-height-add-to-cart-with-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Increase default input height in the Add to Cart + Options Quantity Selector
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
@@ -32,7 +32,6 @@
 		margin: 0;
 		min-width: 40px;
 		order: 2;
-		padding: 0.4em 0;
 		text-align: center;
 		vertical-align: middle;
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
@@ -86,6 +86,10 @@
 	}
 }
 
+:where(.wc-block-components-quantity-selector .wc-block-components-quantity-selector__input) {
+	padding: 0.4em 0;
+}
+
 .theme-twentyseventeen {
 	.wc-block-components-quantity-selector
 		.wc-block-components-quantity-selector__button {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -79,7 +79,9 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 
 	const templatePartId = addToCartWithOptionsTemplatePartIds?.[ productType ];
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: 'wc-block-add-to-cart-with-options',
+	} );
 
 	const { canEditTemplatePart, isLoading } = useSelect(
 		( select ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -25,7 +25,9 @@ const AddToCartOptionsEdit = (
 	props: BlockEditProps< Attributes > & { context?: { postId?: number } }
 ) => {
 	const { product } = useProduct( props.context?.postId );
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: 'wc-block-add-to-cart-with-options',
+	} );
 	const blockClientId = blockProps?.id;
 
 	const {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -12,6 +12,5 @@
 		"interactivity": true
 	},
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"style": "file:../woocommerce/add-to-cart-with-options-quantity-selector-style.css",
 	"viewScriptModule": "woocommerce/add-to-cart-with-options-quantity-selector"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/style.scss
@@ -1,1 +1,0 @@
-@import "../../../base/components/quantity-selector/style";

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -16,10 +16,6 @@
 // templates), the quantity selector will stretch to the height of the container.
 :where(.wc-block-add-to-cart-with-options__quantity-selector .wc-block-components-quantity-selector) {
 	height: 100%;
-
-	:where(input[type="number"].qty) {
-		padding: 0.7rem 0;
-	}
 }
 
 :where(.wc-block-add-to-cart-with-options) {
@@ -52,7 +48,7 @@
 			margin: 0;
 			font-size: 0.8em;
 			box-sizing: content-box;
-			padding: 0.9rem 0;
+			padding: 0.9em 0;
 			margin-right: unset;
 			max-width: 3.631em; /* This value is based on the WC core styles. */
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -5,16 +5,6 @@
 		display: inline-flex;
 		align-items: stretch;
 	}
-
-	/**
-	* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
-	*
-	* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
-	*/
-	:where(.quantity .input-text) {
-		font-size: var(--wp--preset--font-size--small);
-		padding: 0.9rem 1.1rem;
-	}
 }
 
 :where(.wc-block-add-to-cart-with-options__quantity-selector--hidden) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -60,17 +60,13 @@
 			margin: 0;
 			font-size: 0.8em;
 			box-sizing: content-box;
+			padding: 0.9rem 0;
 			margin-right: unset;
 			max-width: 3.631em; /* This value is based on the WC core styles. */
 
 			&:focus {
 				border-radius: unset;
 			}
-		}
-
-		/* We need some extra specificity in the padding to override the styles from the default quantity selector. */
-		input[type="number"].qty.qty {
-			padding: 0.9rem 0;
 		}
 
 		:where(input[type="number"]::-webkit-inner-spin-button),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -1,3 +1,5 @@
+@import "../../base/components/quantity-selector/style";
+
 :where(.wc-block-add-to-cart-with-options) {
 	:where(.quantity) {
 		display: inline-flex;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -60,13 +60,17 @@
 			margin: 0;
 			font-size: 0.8em;
 			box-sizing: content-box;
-			padding: 0.9rem 0;
 			margin-right: unset;
 			max-width: 3.631em; /* This value is based on the WC core styles. */
 
 			&:focus {
 				border-radius: unset;
 			}
+		}
+
+		/* We need some extra specificity in the padding to override the styles from the default quantity selector. */
+		input[type="number"].qty.qty {
+			padding: 0.9rem 0;
 		}
 
 		:where(input[type="number"]::-webkit-inner-spin-button),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -165,6 +165,10 @@ h2.wc-block-mini-cart__title {
 	}
 }
 
+:where(.wc-block-mini-cart__items .wc-block-components-quantity-selector .wc-block-components-quantity-selector__input) {
+	padding: 0.4em 0;
+}
+
 .wc-block-mini-cart__footer {
 	border-top: 1px solid $universal-translucent-border-color;
 	padding: $gap-large $gap;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -165,10 +165,6 @@ h2.wc-block-mini-cart__title {
 	}
 }
 
-:where(.wc-block-mini-cart__items .wc-block-components-quantity-selector .wc-block-components-quantity-selector__input) {
-	padding: 0.4em 0;
-}
-
 .wc-block-mini-cart__footer {
 	border-top: 1px solid $universal-translucent-border-color;
 	padding: $gap-large $gap;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Bug introduced in PR #62893.

While working on #64819, I noticed a few more bugs caused by #62893 in combination with 3rd-party plugins:

- If the Mini-Cart block is not on the screen, the input styles are not loaded (fixed in 6400e9864538801ca0755d4eb0e19e0187aba2d8).
- Inputs' height was too small as it was following the Mini-Cart styles.

While the _Add to Cart + Options_ block is in beta, I'm adding the 10.8 milestone as the missing styles is a significant regression if it happens.

### How to test the changes in this Pull Request:

1. Install WooCommerce Bundles.
2. Create a Bundle product, with one of the bundled items that has a max quantity higher than 1.
3. In the frontend, verify the quantity inputs have a reasonable height.

Non-blockified Add to Cart with Options<br>with Stepper mode | Add to Cart + Options<br>in WC 10.7 | Add to Cart + Options<br>`trunk` | Add to Cart + Options<br>This branch
--- | --- | --- | ---
<img width="934" height="1015" alt="imatge" src="https://github.com/user-attachments/assets/72703049-2f2e-48f9-9f0f-cde539727530" /> | <img width="934" height="1015" alt="imatge" src="https://github.com/user-attachments/assets/2a63644e-5e81-49d7-8ab5-16b14fd9f6bb" /> | <img width="934" height="1015" alt="imatge" src="https://github.com/user-attachments/assets/b09a3bfe-cae7-4f39-9c56-6ca78fd9c3f5" /> | <img width="934" height="1015" alt="imatge" src="https://github.com/user-attachments/assets/a29c6746-d748-4167-bb57-01bab9672c49" />


4. Remove the Mini-Cart block from the store header if it's there.
5. Reload the page in the frontend. Verify the quantity inputs are still rendered correctly.

Before | After
--- | ---
<img width="934" height="1015" alt="imatge" src="https://github.com/user-attachments/assets/f8eff3d1-d182-42f8-b1cd-76e285679531" /> | <img width="934" height="1015" alt="imatge" src="https://github.com/user-attachments/assets/a29c6746-d748-4167-bb57-01bab9672c49" />
