### PR TITLE
Fix BC of get_total_shipping_tax_refunded() for third-party order data stores

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-361
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-361
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Preserves backwards compatibility for third-party order data stores while ensuring the standard data store path now returns refunded shipping tax correctly. WC_Order_Data_Store_Interface is intentionally not extended.
+
+Fix backwards compatibility issue and silent zero return in WC_Order::get_total_shipping_tax_refunded() by replacing method_exists() with is_callable() so the WC_Data_Store proxy correctly delegates to the underlying data store while staying safe for third-party data stores that do not implement the method.

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -2295,6 +2295,13 @@ class WC_Order extends WC_Abstract_Order {
 	/**
 	 * Get the total shipping tax refunded.
 	 *
+	 * The data store method `get_total_shipping_tax_refunded()` is intentionally
+	 * not declared on `WC_Order_Data_Store_Interface` to preserve backwards
+	 * compatibility with third-party data stores that implement the interface
+	 * (adding it would force a fatal error on activation). When the configured
+	 * data store does not implement the method we fall back to `0` and a notice
+	 * is logged in WP_DEBUG mode so extension authors can detect missing support.
+	 *
 	 * @since  10.2.0
 	 * @return float
 	 */
@@ -2308,8 +2315,19 @@ class WC_Order extends WC_Abstract_Order {
 
 		$total_shipping_tax_refunded = 0;
 
-		if ( method_exists( $this->data_store, 'get_total_shipping_tax_refunded' ) ) {
+		if ( is_callable( array( $this->data_store, 'get_total_shipping_tax_refunded' ) ) ) {
 			$total_shipping_tax_refunded = $this->data_store->get_total_shipping_tax_refunded( $this );
+		} elseif ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$data_store_class = is_object( $this->data_store ) ? get_class( $this->data_store ) : 'unknown';
+			wc_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: data store class name */
+					esc_html__( 'The order data store "%s" does not implement get_total_shipping_tax_refunded(); returning 0. Implement this method to report refunded shipping tax accurately.', 'woocommerce' ),
+					esc_html( $data_store_class )
+				),
+				'10.9.0'
+			);
 		}
 
 		wp_cache_set( $cache_key, $total_shipping_tax_refunded, $this->cache_group );

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-shipping-tax-refunded-bc-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-shipping-tax-refunded-bc-test.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Regression test for backwards compatibility of WC_Order_Data_Store_Interface.
+ *
+ * Verifies that third-party order data stores which implement
+ * WC_Order_Data_Store_Interface without the get_total_shipping_tax_refunded()
+ * method continue to work without fatal errors. The interface intentionally
+ * does NOT declare get_total_shipping_tax_refunded() to preserve BC; this
+ * test guards against re-introducing that requirement.
+ *
+ * @package WooCommerce\Tests
+ */
+
+//phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Legacy class name.
+/**
+ * Class WC_Order_Shipping_Tax_Refunded_BC_Test.
+ */
+class WC_Order_Shipping_Tax_Refunded_BC_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Remove any data store overrides between tests so we don't leak state.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_order_data_store' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox WC_Order_Data_Store_Interface must not declare get_total_shipping_tax_refunded so third-party implementations remain BC-compatible.
+	 */
+	public function test_interface_does_not_require_get_total_shipping_tax_refunded(): void {
+		$reflection = new ReflectionClass( 'WC_Order_Data_Store_Interface' );
+		$this->assertFalse(
+			$reflection->hasMethod( 'get_total_shipping_tax_refunded' ),
+			'WC_Order_Data_Store_Interface must not declare get_total_shipping_tax_refunded(); adding it breaks third-party data stores. See https://github.com/woocommerce/woocommerce/issues/58369.'
+		);
+	}
+
+	/**
+	 * @testdox WC_Order::get_total_shipping_tax_refunded returns 0 without a fatal when the data store does not implement the method.
+	 */
+	public function test_returns_zero_when_data_store_missing_method(): void {
+		// Ensure the legacy BC data store class exists for this test run.
+		require_once __DIR__ . '/fixtures/class-wc-legacy-bc-order-data-store.php';
+
+		// Override at priority 1000 so we win against CustomOrdersTableController's
+		// priority-999 filter, regardless of HPOS state.
+		add_filter(
+			'woocommerce_order_data_store',
+			static function () {
+				return 'WC_Legacy_BC_Order_Data_Store';
+			},
+			1000
+		);
+
+		// Force a fresh data store lookup that picks up our filter.
+		$order = new WC_Order();
+
+		$data_store_class = $order->get_data_store()->get_current_class_name();
+		$this->assertSame(
+			'WC_Legacy_BC_Order_Data_Store',
+			$data_store_class,
+			'Test fixture data store should be in use for this order.'
+		);
+
+		$this->assertFalse(
+			method_exists( 'WC_Legacy_BC_Order_Data_Store', 'get_total_shipping_tax_refunded' ),
+			'Fixture must not declare get_total_shipping_tax_refunded() in order to exercise the BC code path.'
+		);
+
+		// The previous implementation used method_exists() against the WC_Data_Store
+		// proxy, which never reports magic-call methods, so even data stores that
+		// supported get_total_shipping_tax_refunded() silently returned 0. The
+		// is_callable() check now correctly delegates to the wrapped instance.
+		$this->assertSame(
+			0,
+			$order->get_total_shipping_tax_refunded(),
+			'WC_Order::get_total_shipping_tax_refunded() must safely fall back to 0 when the data store does not implement the method.'
+		);
+	}
+
+	/**
+	 * @testdox WC_Order::get_total_shipping_tax_refunded delegates to the data store when the underlying instance implements the method via __call proxy.
+	 */
+	public function test_delegates_to_data_store_via_proxy(): void {
+		// The default order data store (WC_Order_Data_Store_CPT or OrdersTableDataStore)
+		// implements get_total_shipping_tax_refunded() via Abstract_WC_Order_Data_Store_CPT.
+		// Reach it via the WC_Data_Store proxy to ensure is_callable() correctly
+		// detects __call-routed methods.
+		$order = new WC_Order();
+
+		$this->assertTrue(
+			is_callable( array( $order->get_data_store(), 'get_total_shipping_tax_refunded' ) ),
+			'Standard order data store must expose get_total_shipping_tax_refunded() via the WC_Data_Store proxy.'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/fixtures/class-wc-legacy-bc-order-data-store.php
+++ b/plugins/woocommerce/tests/php/includes/fixtures/class-wc-legacy-bc-order-data-store.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Test fixture: a minimal order data store that implements
+ * WC_Order_Data_Store_Interface WITHOUT the get_total_shipping_tax_refunded()
+ * method, simulating a legacy third-party order data store. Used to verify
+ * that adding get_total_shipping_tax_refunded() to the interface would be a
+ * BC break and to guard the fallback in WC_Order::get_total_shipping_tax_refunded().
+ *
+ * @package WooCommerce\Tests\Fixtures
+ */
+
+//phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Legacy class name kept for parity with WC interfaces.
+
+if ( class_exists( 'WC_Legacy_BC_Order_Data_Store' ) ) {
+	return;
+}
+
+/**
+ * Legacy-style order data store for BC regression coverage.
+ *
+ * Intentionally implements only the publicly required interfaces and omits
+ * get_total_shipping_tax_refunded() on purpose. Methods return safe defaults
+ * because no order persistence is exercised by the BC tests.
+ */
+class WC_Legacy_BC_Order_Data_Store implements WC_Object_Data_Store_Interface, WC_Order_Data_Store_Interface {
+
+	// --- WC_Object_Data_Store_Interface ---
+
+	/**
+	 * No-op create.
+	 *
+	 * @param WC_Data $data Data object.
+	 */
+	public function create( &$data ) {}
+
+	/**
+	 * No-op read.
+	 *
+	 * @param WC_Data $data Data object.
+	 */
+	public function read( &$data ) {}
+
+	/**
+	 * No-op update.
+	 *
+	 * @param WC_Data $data Data object.
+	 */
+	public function update( &$data ) {}
+
+	/**
+	 * No-op delete.
+	 *
+	 * @param WC_Data $data Data object.
+	 * @param array   $args Args.
+	 * @return bool
+	 */
+	public function delete( &$data, $args = array() ) {
+		return true;
+	}
+
+	/**
+	 * No-op read_meta.
+	 *
+	 * @param WC_Data $data Data object.
+	 * @return array
+	 */
+	public function read_meta( &$data ) {
+		return array();
+	}
+
+	/**
+	 * No-op delete_meta.
+	 *
+	 * @param WC_Data $data Data object.
+	 * @param object  $meta Meta.
+	 * @return array
+	 */
+	public function delete_meta( &$data, $meta ) {
+		return array();
+	}
+
+	/**
+	 * No-op add_meta.
+	 *
+	 * @param WC_Data $data Data object.
+	 * @param object  $meta Meta.
+	 * @return int
+	 */
+	public function add_meta( &$data, $meta ) {
+		return 0;
+	}
+
+	/**
+	 * No-op update_meta.
+	 *
+	 * @param WC_Data $data Data object.
+	 * @param object  $meta Meta.
+	 */
+	public function update_meta( &$data, $meta ) {}
+
+	// --- WC_Order_Data_Store_Interface ---
+
+	/**
+	 * Get amount already refunded.
+	 *
+	 * @param WC_Order $order Order.
+	 * @return float
+	 */
+	public function get_total_refunded( $order ) {
+		return 0.0;
+	}
+
+	/**
+	 * Get total tax refunded.
+	 *
+	 * @param WC_Order $order Order.
+	 * @return float
+	 */
+	public function get_total_tax_refunded( $order ) {
+		return 0.0;
+	}
+
+	/**
+	 * Get total shipping refunded.
+	 *
+	 * @param WC_Order $order Order.
+	 * @return float
+	 */
+	public function get_total_shipping_refunded( $order ) {
+		return 0.0;
+	}
+
+	/**
+	 * Finds an Order ID based on an order key.
+	 *
+	 * @param string $order_key Key.
+	 * @return int
+	 */
+	public function get_order_id_by_order_key( $order_key ) {
+		return 0;
+	}
+
+	/**
+	 * Return count of orders with a specific status.
+	 *
+	 * @param string $status Status.
+	 * @return int
+	 */
+	public function get_order_count( $status ) {
+		return 0;
+	}
+
+	/**
+	 * Get all orders matching the passed in args.
+	 *
+	 * @param array $args Args.
+	 * @return array
+	 */
+	public function get_orders( $args = array() ) {
+		return array();
+	}
+
+	/**
+	 * Get unpaid orders after a certain date.
+	 *
+	 * @param int $date Date.
+	 * @return array
+	 */
+	public function get_unpaid_orders( $date ) {
+		return array();
+	}
+
+	/**
+	 * Search orders.
+	 *
+	 * @param string $term Term.
+	 * @return array
+	 */
+	public function search_orders( $term ) {
+		return array();
+	}
+
+	/**
+	 * Get download permissions granted.
+	 *
+	 * @param WC_Order $order Order.
+	 * @return bool
+	 */
+	public function get_download_permissions_granted( $order ) {
+		return false;
+	}
+
+	/**
+	 * Set download permissions granted.
+	 *
+	 * @param WC_Order $order Order.
+	 * @param bool     $set   Value.
+	 */
+	public function set_download_permissions_granted( $order, $set ) {}
+
+	/**
+	 * Get recorded sales.
+	 *
+	 * @param WC_Order $order Order.
+	 * @return bool
+	 */
+	public function get_recorded_sales( $order ) {
+		return false;
+	}
+
+	/**
+	 * Set recorded sales.
+	 *
+	 * @param WC_Order $order Order.
+	 * @param bool     $set   Value.
+	 */
+	public function set_recorded_sales( $order, $set ) {}
+
+	/**
+	 * Get recorded coupon usage counts.
+	 *
+	 * @param WC_Order $order Order.
+	 * @return bool
+	 */
+	public function get_recorded_coupon_usage_counts( $order ) {
+		return false;
+	}
+
+	/**
+	 * Set recorded coupon usage counts.
+	 *
+	 * @param WC_Order $order Order.
+	 * @param bool     $set   Value.
+	 */
+	public function set_recorded_coupon_usage_counts( $order, $set ) {}
+
+	/**
+	 * Get order type.
+	 *
+	 * @param int $order_id ID.
+	 * @return string
+	 */
+	public function get_order_type( $order_id ) {
+		return 'shop_order';
+	}
+
+	// Intentionally NO get_total_shipping_tax_refunded() method here.
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Order::get_total_shipping_tax_refunded()` previously used `method_exists()` against the `WC_Data_Store` proxy, which never reports magic-call methods. As a result the method always fell through to `0` even for the standard data stores that implement it (via `Abstract_WC_Order_Data_Store_CPT::get_total_shipping_tax_refunded()`), which silently broke analytics that depend on refunded shipping tax.

This PR:

- Replaces `method_exists()` with `is_callable()` so the `WC_Data_Store::__call()` proxy is detected and the underlying data store is invoked.
- Keeps `WC_Order_Data_Store_Interface` free of the new method to preserve backwards compatibility for third-party order data stores that implement the interface (the previous attempt to add it caused fatal errors and was reverted in #58342). The class docblock now documents this intentional pattern.
- When a third-party data store does not implement the method, the method safely returns `0` and a `wc_doing_it_wrong()` debug notice is logged so extension authors can detect the gap.
- Adds a regression test plus a `WC_Legacy_BC_Order_Data_Store` fixture that implements `WC_Order_Data_Store_Interface` without `get_total_shipping_tax_refunded()`, exercising the BC fallback and guarding against the interface being re-extended.

Closes #58369.

Bug introduced in PR #53019 (reverted in #58342). Related tracking: woocommerce/woocommerce#58327, woocommerce/woocommerce#58345, woocommerce/woocommerce#58350.

Linear: https://linear.app/a8c/issue/RSMAPGJ-361

### How to test the changes in this Pull Request:

1. Drop the mu-plugin from the Linear repro plan into `wp-content/mu-plugins/qa-broken-order-data-store.php` (registers `QA_Broken_Order_Data_Store` implementing `WC_Order_Data_Store_Interface` without `get_total_shipping_tax_refunded`).
2. Navigate to `wp-admin/edit.php?post_type=shop_order` and confirm the page loads without a fatal (no "must be compatible with WC_Order_Data_Store_Interface" error).
3. With the default (CPT / HPOS) data stores, partially refund an order's shipping tax, then call `wc_get_order( $id )->get_total_shipping_tax_refunded()` from `wp shell` and confirm a non-zero refund is returned (previously returned `0`).
4. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Order_Shipping_Tax_Refunded_BC_Test` and confirm the regression tests pass.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`: clean.
- `composer exec -- phpstan analyse includes/class-wc-order.php --memory-limit=2G`: clean.
- Full repo `phpstan analyse --memory-limit=4G`: clean, no new errors, no baseline additions.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`: clean.
- `php -l` on all touched PHP files.

PHPUnit was not run locally for this submission (Docker test env unavailable in the agent worktree) — CI will exercise the new regression test (`WC_Order_Shipping_Tax_Refunded_BC_Test`).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

A patch / fix entry was added at `plugins/woocommerce/changelog/fix-rsmapgj-361`.

### Pipeline signoff

This PR was authored by an automated pipeline (RSMAPGJ AI Coder pilot). Human review is expected before merge.