### PR TITLE
RSM: better detection for saved for later block on cart page

### DIFF
--- a/plugins/woocommerce/changelog/fix-shopper-collection-hooked-block-flag
+++ b/plugins/woocommerce/changelog/fix-shopper-collection-hooked-block-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set `cartPageHasSavedForLater` from the Shopper Collection block itself so the cart "Save for later" link shows when the block is auto-injected as a hooked block (which `has_block()` does not detect).

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -264,10 +264,6 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'isBlockTheme', wp_is_block_theme() );
 		$this->asset_data_registry->add( 'shippingMethodsExist', CartCheckoutUtils::shipping_methods_exist() > 0 );
 
-		if ( has_block( 'woocommerce/shopper-collection' ) ) {
-			$this->asset_data_registry->add( 'cartPageHasSavedForLater', true );
-		}
-
 		$is_block_editor = $this->is_block_editor();
 
 		// Check `current_user_can` so we can show notices about incompatible extensions in the front-end to admins too.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -151,6 +151,14 @@ final class ShopperCollection extends AbstractBlock {
 			$list_slug = 'saved-for-later';
 		}
 
+		// Signals to the cart line items that a Saved-for-later target is present on this
+		// page, so the per-row "Save for later" button can show. Set here (rather than from
+		// Cart::enqueue_data via has_block()) because this block is typically auto-injected
+		// as a hooked block and never lives in the cart page's stored post_content.
+		if ( 'saved-for-later' === $list_slug ) {
+			$this->asset_data_registry->add( 'cartPageHasSavedForLater', true );
+		}
+
 		// Clamp to the 2-6 range the SCSS `@for $i from 2 through 6` loop and
 		// the editor `RangeControl` both support. `absint()` first defends
 		// against a code-editor override (the attribute can be set to any

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
 
 /**
  * Shopper Collection block.
@@ -153,7 +154,7 @@ final class ShopperCollection extends AbstractBlock {
 
 		// Set from render() (not Cart::enqueue_data via has_block()) so it works when this
 		// block is auto-injected via the Block Hooks API and isn't in stored post_content.
-		if ( 'saved-for-later' === $list_slug && is_cart() ) {
+		if ( 'saved-for-later' === $list_slug && wc_get_container()->get( LegacyProxy::class )->call_function( 'is_cart' ) ) {
 			$this->asset_data_registry->add( 'cartPageHasSavedForLater', true );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -151,11 +151,8 @@ final class ShopperCollection extends AbstractBlock {
 			$list_slug = 'saved-for-later';
 		}
 
-		// Signals to the cart line items that a Saved-for-later target is present on this
-		// page, so the per-row "Save for later" button can show. Set here (rather than from
-		// Cart::enqueue_data via has_block()) because this block is typically auto-injected
-		// as a hooked block and never lives in the cart page's stored post_content. Scoped
-		// to the cart page so the flag stays accurate if the block is placed elsewhere.
+		// Set from render() (not Cart::enqueue_data via has_block()) so it works when this
+		// block is auto-injected via the Block Hooks API and isn't in stored post_content.
 		if ( 'saved-for-later' === $list_slug && is_cart() ) {
 			$this->asset_data_registry->add( 'cartPageHasSavedForLater', true );
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -154,8 +154,9 @@ final class ShopperCollection extends AbstractBlock {
 		// Signals to the cart line items that a Saved-for-later target is present on this
 		// page, so the per-row "Save for later" button can show. Set here (rather than from
 		// Cart::enqueue_data via has_block()) because this block is typically auto-injected
-		// as a hooked block and never lives in the cart page's stored post_content.
-		if ( 'saved-for-later' === $list_slug ) {
+		// as a hooked block and never lives in the cart page's stored post_content. Scoped
+		// to the cart page so the flag stays accurate if the block is placed elsewhere.
+		if ( 'saved-for-later' === $list_slug && is_cart() ) {
 			$this->asset_data_registry->add( 'cartPageHasSavedForLater', true );
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
 use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AssetDataRegistryMock;
 use ReflectionClass;
 use ReflectionMethod;
@@ -31,22 +31,11 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	private ShopperCollection $sut;
 
 	/**
-	 * Instantiate the block without invoking its constructor, inject a
-	 * registry mock so render() can call `->add()` without NPEing, and
-	 * reset `CartCheckoutUtils::$is_cart_page` so a cached `true` from a
-	 * prior test doesn't poison `is_cart()` checks in this one.
+	 * Instantiate the block without invoking its constructor and inject a
+	 * registry mock so render() can call `->add()` without NPEing.
 	 */
 	public function setUp(): void {
 		parent::setUp();
-
-		// `WP_UnitTestCase` doesn't restore WC-specific filters between tests, so
-		// a `__return_true` added by a prior data-provider row leaks into the next
-		// one. See `Gateways/PayPal/ButtonsTest::tearDown()` for the same pattern.
-		remove_all_filters( 'woocommerce_is_cart' );
-
-		$cache_prop = new ReflectionProperty( CartCheckoutUtils::class, 'is_cart_page' );
-		$cache_prop->setAccessible( true );
-		$cache_prop->setValue( null, null );
 
 		$reflection = new ReflectionClass( ShopperCollection::class );
 		$this->sut  = $reflection->newInstanceWithoutConstructor();
@@ -403,9 +392,20 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 		bool $expected
 	): void {
 		wp_set_current_user( $logged_in ? self::factory()->user->create( array( 'role' => 'customer' ) ) : 0 );
-		if ( $is_cart ) {
-			add_filter( 'woocommerce_is_cart', '__return_true' );
-		}
+
+		// Mock the is_cart() call routed through LegacyProxy in render(). Filter/cache
+		// approaches don't work in CI: upstream tests can define `WOOCOMMERCE_CART` via
+		// `wc_maybe_define_constant`, which makes is_cart() short-circuit to true
+		// irreversibly for the rest of the process.
+		$legacy_proxy = wc_get_container()->get( LegacyProxy::class );
+		$legacy_proxy->reset();
+		$legacy_proxy->register_function_mocks(
+			array(
+				'is_cart' => function () use ( $is_cart ) {
+					return $is_cart;
+				},
+			)
+		);
 
 		$registry = $this->invoke_render_with_registry_mock( array( 'listName' => 'saved-for-later' ) );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -6,9 +6,11 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
 use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AssetDataRegistryMock;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionProperty;
 use WP_UnitTestCase;
 
 /**
@@ -29,13 +31,32 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	private ShopperCollection $sut;
 
 	/**
-	 * Instantiate the block without invoking its constructor.
+	 * Instantiate the block without invoking its constructor, inject a
+	 * registry mock so render() can call `->add()` without NPEing, and
+	 * reset `CartCheckoutUtils::$is_cart_page` so a cached `true` from a
+	 * prior test doesn't poison `is_cart()` checks in this one.
 	 */
 	public function setUp(): void {
 		parent::setUp();
 
+		// `WP_UnitTestCase` doesn't restore WC-specific filters between tests, so
+		// a `__return_true` added by a prior data-provider row leaks into the next
+		// one. See `Gateways/PayPal/ButtonsTest::tearDown()` for the same pattern.
+		remove_all_filters( 'woocommerce_is_cart' );
+
+		$cache_prop = new ReflectionProperty( CartCheckoutUtils::class, 'is_cart_page' );
+		$cache_prop->setAccessible( true );
+		$cache_prop->setValue( null, null );
+
 		$reflection = new ReflectionClass( ShopperCollection::class );
 		$this->sut  = $reflection->newInstanceWithoutConstructor();
+
+		$registry_prop = new ReflectionProperty( ShopperCollection::class, 'asset_data_registry' );
+		$registry_prop->setAccessible( true );
+		$registry_prop->setValue(
+			$this->sut,
+			new AssetDataRegistryMock( Package::container()->get( Api::class ) )
+		);
 	}
 
 	/**
@@ -325,49 +346,42 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Inject an AssetDataRegistry mock into the SUT and invoke render() via
-	 * reflection. `ShopperCollection` is final, so we can't subclass it for the
-	 * test — set the inherited `$asset_data_registry` property directly instead.
-	 * Render is wrapped in a try/catch because its downstream calls (REST
-	 * prefetch, interactivity bootstrap) need bits of the request lifecycle
-	 * that aren't set up in unit tests; the flag-setting branch runs before any
-	 * of that, so a later fatal doesn't change what we assert on.
+	 * Invoke render() against the SUT (which already has a registry injected
+	 * in setUp). Render is wrapped in a try/catch because its downstream calls
+	 * (REST prefetch, interactivity bootstrap) need bits of the request
+	 * lifecycle that aren't set up in unit tests; the flag-setting branch
+	 * runs before any of that, so a later fatal doesn't change what we
+	 * assert on.
 	 *
 	 * @param array<string, mixed> $attributes Block attributes.
-	 * @return AssetDataRegistryMock The mock registry, ready to inspect.
+	 * @return AssetDataRegistryMock The injected registry, ready to inspect.
 	 */
 	private function invoke_render_with_registry_mock( array $attributes ): AssetDataRegistryMock {
-		$asset_api = Package::container()->get( Api::class );
-		$registry  = new AssetDataRegistryMock( $asset_api );
-
-		$reflection    = new ReflectionClass( ShopperCollection::class );
-		$registry_prop = $reflection->getProperty( 'asset_data_registry' );
-		$registry_prop->setAccessible( true );
-		$registry_prop->setValue( $this->sut, $registry );
-
 		$render = new ReflectionMethod( ShopperCollection::class, 'render' );
 		$render->setAccessible( true );
 
 		try {
 			$render->invoke( $this->sut, $attributes, '', null );
 		} catch ( \Throwable $e ) {
-			// Ignored: the flag-setting branch runs before the parts of render()
-			// that need a full request lifecycle.
+			// Ignored: flag-setting runs before the parts of render() that need a full request lifecycle.
+			unset( $e );
 		}
 
-		return $registry;
+		$registry_prop = new ReflectionProperty( ShopperCollection::class, 'asset_data_registry' );
+		$registry_prop->setAccessible( true );
+
+		return $registry_prop->getValue( $this->sut );
 	}
 
 	/**
-	 * @return array<string, array{bool, bool, string, bool}>
+	 * @return array<string, array{bool, bool, bool}>
 	 */
 	public function provider_cart_page_has_saved_for_later_flag(): array {
 		return array(
-			// label                          => array( logged_in, is_cart, list_name,         expected ).
-			'set on cart with sfl list'       => array( true, true, 'saved-for-later', true ),
-			'not set off the cart page'       => array( true, false, 'saved-for-later', false ),
-			'not set for guests'              => array( false, true, 'saved-for-later', false ),
-			'not set for non-saved-for-later' => array( true, true, 'wishlist', false ),
+			// label                    => array( logged_in, is_cart, expected ).
+			'set on cart, logged-in'    => array( true, true, true ),
+			'not set off the cart page' => array( true, false, false ),
+			'not set for guests'        => array( false, true, false ),
 		);
 	}
 
@@ -378,11 +392,14 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	 * logged-in shopper — every other combination must leave it unset.
 	 *
 	 * @dataProvider provider_cart_page_has_saved_for_later_flag
+	 *
+	 * @param bool $logged_in Whether the test runs as a logged-in customer.
+	 * @param bool $is_cart   Whether `is_cart()` is forced to return true.
+	 * @param bool $expected  Whether the flag is expected to be registered.
 	 */
 	public function test_cart_page_has_saved_for_later_flag(
 		bool $logged_in,
 		bool $is_cart,
-		string $list_name,
 		bool $expected
 	): void {
 		wp_set_current_user( $logged_in ? self::factory()->user->create( array( 'role' => 'customer' ) ) : 0 );
@@ -390,7 +407,7 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 			add_filter( 'woocommerce_is_cart', '__return_true' );
 		}
 
-		$registry = $this->invoke_render_with_registry_mock( array( 'listName' => $list_name ) );
+		$registry = $this->invoke_render_with_registry_mock( array( 'listName' => 'saved-for-later' ) );
 
 		$this->assertSame(
 			$expected,

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -3,7 +3,10 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\BlockTypes\ShopperCollection;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AssetDataRegistryMock;
 use ReflectionClass;
 use ReflectionMethod;
 use WP_UnitTestCase;
@@ -318,6 +321,80 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 			'/<div[^>]*class="wc-block-shopper-collection__header"[^>]*data-wp-bind--hidden="!context\.hasShownItems"[^>]*\bhidden\b[^>]*>.*Saved for later/s',
 			$markup,
 			'Header wrapper must be initially hidden for an empty list so a fresh-load empty SC does not show an orphaned heading.'
+		);
+	}
+
+	/**
+	 * Inject an AssetDataRegistry mock into the SUT and invoke render() via
+	 * reflection. `ShopperCollection` is final, so we can't subclass it for the
+	 * test — set the inherited `$asset_data_registry` property directly instead.
+	 * Render is wrapped in a try/catch because its downstream calls (REST
+	 * prefetch, interactivity bootstrap) need bits of the request lifecycle
+	 * that aren't set up in unit tests; the flag-setting branch runs before any
+	 * of that, so a later fatal doesn't change what we assert on.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @return AssetDataRegistryMock The mock registry, ready to inspect.
+	 */
+	private function invoke_render_with_registry_mock( array $attributes ): AssetDataRegistryMock {
+		$asset_api = Package::container()->get( Api::class );
+		$registry  = new AssetDataRegistryMock( $asset_api );
+
+		$reflection    = new ReflectionClass( ShopperCollection::class );
+		$registry_prop = $reflection->getProperty( 'asset_data_registry' );
+		$registry_prop->setAccessible( true );
+		$registry_prop->setValue( $this->sut, $registry );
+
+		$render = new ReflectionMethod( ShopperCollection::class, 'render' );
+		$render->setAccessible( true );
+
+		try {
+			$render->invoke( $this->sut, $attributes, '', null );
+		} catch ( \Throwable $e ) {
+			// Ignored: the flag-setting branch runs before the parts of render()
+			// that need a full request lifecycle.
+		}
+
+		return $registry;
+	}
+
+	/**
+	 * @return array<string, array{bool, bool, string, bool}>
+	 */
+	public function provider_cart_page_has_saved_for_later_flag(): array {
+		return array(
+			// label                          => array( logged_in, is_cart, list_name,         expected ).
+			'set on cart with sfl list'       => array( true, true, 'saved-for-later', true ),
+			'not set off the cart page'       => array( true, false, 'saved-for-later', false ),
+			'not set for guests'              => array( false, true, 'saved-for-later', false ),
+			'not set for non-saved-for-later' => array( true, true, 'wishlist', false ),
+		);
+	}
+
+	/**
+	 * `cartPageHasSavedForLater` is the wcSettings flag the cart line item row reads
+	 * to decide whether to render the "Save for later" link. The block sets it
+	 * only when rendering the saved-for-later list, on the cart page, for a
+	 * logged-in shopper — every other combination must leave it unset.
+	 *
+	 * @dataProvider provider_cart_page_has_saved_for_later_flag
+	 */
+	public function test_cart_page_has_saved_for_later_flag(
+		bool $logged_in,
+		bool $is_cart,
+		string $list_name,
+		bool $expected
+	): void {
+		wp_set_current_user( $logged_in ? self::factory()->user->create( array( 'role' => 'customer' ) ) : 0 );
+		if ( $is_cart ) {
+			add_filter( 'woocommerce_is_cart', '__return_true' );
+		}
+
+		$registry = $this->invoke_render_with_registry_mock( array( 'listName' => $list_name ) );
+
+		$this->assertSame(
+			$expected,
+			array_key_exists( 'cartPageHasSavedForLater', $registry->get() )
 		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `woocommerce/shopper-collection` block is auto-injected after `woocommerce/cart` via the `hooked_block_types` filter, so on a default (un-edited) cart page it never lives in the page's stored `post_content`. Core's `has_block()` only parses stored content, so the check in `Cart::enqueue_data` returned `false`, `cartPageHasSavedForLater` was never set in `wcSettings`, and the per-row "Save for later" link stayed hidden even though the block rendered on the page.

This PR moves the flag into `ShopperCollection::render()` so it's set whenever the block actually renders.

Closes WOOPRD-3532.

### How to test the changes in this Pull Request:

Prereqs: logged in as a customer with at least one product in cart. Throughout, "verify the flag" means open `/cart/`, then in devtools run `wcSettings.cartPageHasSavedForLater`.

0. Log into your test site and add at least a few products in the cart.
1. **Reset the cart page** to its default content and disable the saved for later feature:

   ```sh
   wp post delete $(wp option get woocommerce_cart_page_id) --force
   wp option delete woocommerce_cart_page_id
   wp wc tool run install_pages --user=1
   wp option update woocommerce_cart_save_for_later_enabled no
   ```
2. Visit the cart page and expect no saved for later block below the cart and no save for later link on any line items. `wcSettings.cartPageHasSavedForLater` should also be `undefined`.
3. Enable saved for later in WooCommerce → Settings → Advanced → Features and reload the cart page:
   1. Confirm that the saved for later block should render, as well as the "save for later" links on cart items.
   1. Confirm that the cart page code itself doesn't have the block in its content:
      `wp post get $(wp option get woocommerce_cart_page_id) --field=post_content`
4. Edit the cart page on the backend making any change and leaving the hooked block intact. Confirm on the frontend that rendering of links and the saved for later block is still correct.
5. Disable the saved for later feature in the admin settings or via `wp option update woocommerce_cart_save_for_later_enabled no`. Reload the cart page and confirm that the block isn't rendered and no save for later link is added to cart items.
6. **Re-enable the feature flag**, then reset the cart page again so the hooked block code is triggered again:

   ```sh
   wp option update woocommerce_cart_save_for_later_enabled yes
   wp post delete $(wp option get woocommerce_cart_page_id) --force
   wp option delete woocommerce_cart_page_id
   wp wc tool run install_pages --user=1
   ```
7. Edit the cart page by manually deleting the hooked saved for later block. Reload the cart page on the frontend and confirm that the block isn't rendered and the save for later links on cart items aren't as well.


### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->