### PR TITLE
Fix Variation Selector: Attribute Name colors not being applied in the editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-attribute-name-color
+++ b/plugins/woocommerce/changelog/fix-attribute-name-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Variation Selector: Attribute Name colors not being applied in the editor

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-name/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-name/edit.tsx
@@ -48,7 +48,7 @@ export default function AttributeNameEdit(
 			spacingProps.className
 		),
 		style: {
-			...colorProps.stye,
+			...colorProps.style,
 			...typographyProps.style,
 			...spacingProps.style,
 		},

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -481,7 +481,8 @@ function wc_get_attribute( $id ) {
  *     @type string $name         Attribute name. Always required.
  *     @type string $slug         Attribute alphanumeric identifier.
  *     @type string $type         Type of attribute.
- *                                Core by default accepts: 'select' and 'text'.
+ *                                Core by default accepts: 'select' and
+ *                                'wc-visual' (which is experimental).
  *                                Default to 'select'.
  *     @type string $order_by     Sort order.
  *                                Accepts: 'menu_order', 'name', 'name_num' and 'id'.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Extracted from #64887 to reduce its surface area.

This PR fixes the colors of the Variation Selector: Attribute Name block colors not being correctly applied in the editor.

### How to test the changes in this Pull Request:

1. Edit the Single Product template, selecting the Add to Cart + Options block in the Variable Product view.
2. Select the Variation Selector: Attribute Name block.
3. Set its color to a custom Hex.
4. Verify the color is correctly applied in the editor and the frontend:

Before | After
--- | ---
<img width="1261" height="893" alt="imatge" src="https://github.com/user-attachments/assets/ce9f1b23-122e-4702-b0cf-3f9c405c547d" /> | <img width="1261" height="893" alt="imatge" src="https://github.com/user-attachments/assets/572ff91f-dcce-42d7-961b-62ff915c8c71" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
