### PR TITLE
Fix WC_Product_Variation::set_attributes() losing fraction term labels

### DIFF
--- a/plugins/woocommerce/changelog/65011-ai-agent-rsmapgj-356-1778843172
+++ b/plugins/woocommerce/changelog/65011-ai-agent-rsmapgj-356-1778843172
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `WC_Product_Variation::set_attributes()` losing taxonomy attribute values containing fraction or other non-slug characters (e.g. `6½`) when called programmatically.  #### Comment

--- a/plugins/woocommerce/changelog/fix-rsmapgj-356
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-356
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `WC_Product_Variation::set_attributes()` losing taxonomy attribute values containing fraction or other non-slug characters (e.g. `6½`) when called programmatically.

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -511,6 +511,12 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * Set attributes. Unlike the parent product which uses terms, variations are assigned
 	 * specific attributes using name value pairs.
 	 *
+	 * For taxonomy-backed (global) attributes, values are expected to be term slugs.
+	 * If a value matches an existing term name (e.g. '6½'), it is converted to the
+	 * term slug before being stored so that fraction/special characters survive
+	 * the slug round-trip when the variation editor reads back the value. This
+	 * mirrors how the REST API and admin metabox normalise the same input.
+	 *
 	 * @param array $raw_attributes array of raw attributes.
 	 */
 	public function set_attributes( $raw_attributes ) {
@@ -522,6 +528,20 @@ class WC_Product_Variation extends WC_Product_Simple {
 			if ( 0 === strpos( $key, 'attribute_' ) ) {
 				$key = substr( $key, 10 );
 			}
+
+			// For taxonomy-backed attributes the stored value must be a term slug.
+			// When callers pass a term label (e.g. '6½') look the term up by name
+			// and substitute its slug; otherwise fall back to sanitize_title so
+			// non-ASCII characters are normalised consistently with the admin path.
+			if ( is_string( $value ) && '' !== $value && taxonomy_exists( $key ) ) {
+				$term = get_term_by( 'name', $value, $key );
+				if ( $term && ! is_wp_error( $term ) ) {
+					$value = $term->slug;
+				} elseif ( sanitize_title( $value ) !== $value ) {
+					$value = sanitize_title( $value );
+				}
+			}
+
 			$attributes[ $key ] = $value;
 		}
 		$this->set_prop( 'attributes', $attributes );

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
@@ -121,4 +121,54 @@ class WC_Product_Variation_Test extends WC_Unit_Test_Case {
 		$this->assertIsString( $url );
 		$this->assertNotEmpty( $url );
 	}
+
+	/**
+	 * @testdox set_attributes() converts a taxonomy term label containing fraction/special characters to its slug so the variation editor can resolve it back to a term (regression for woo#26233 / RSMAPGJ-356).
+	 */
+	public function test_set_attributes_converts_fraction_term_label_to_slug() {
+		$attribute_data = WC_Helper_Product::create_attribute( 'shoe-size-frac', array( '6½', '7', '7½' ) );
+		$taxonomy       = $attribute_data['attribute_taxonomy'];
+
+		$term = get_term_by( 'name', '7½', $taxonomy );
+		$this->assertNotEmpty( $term, 'Term with fraction label should exist.' );
+		$this->assertNotSame( '7½', $term->slug, 'Slug should differ from label for fraction names.' );
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $this->parent_product->get_id() );
+		$variation->set_attributes( array( $taxonomy => '7½' ) );
+
+		$stored = $variation->get_attributes();
+		$this->assertArrayHasKey( $taxonomy, $stored );
+		$this->assertSame( $term->slug, $stored[ $taxonomy ], 'Fraction label should be converted to the term slug.' );
+
+		// And the slug should resolve back to the original display label via get_attribute().
+		$this->assertSame( '7½', $variation->get_attribute( $taxonomy ) );
+	}
+
+	/**
+	 * @testdox set_attributes() leaves an already-correct term slug untouched.
+	 */
+	public function test_set_attributes_preserves_existing_slug() {
+		$attribute_data = WC_Helper_Product::create_attribute( 'shoe-size-slug', array( 'small', 'medium' ) );
+		$taxonomy       = $attribute_data['attribute_taxonomy'];
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $this->parent_product->get_id() );
+		$variation->set_attributes( array( $taxonomy => 'small' ) );
+
+		$stored = $variation->get_attributes();
+		$this->assertSame( 'small', $stored[ $taxonomy ] );
+	}
+
+	/**
+	 * @testdox set_attributes() leaves non-taxonomy (custom) attribute values untouched.
+	 */
+	public function test_set_attributes_leaves_custom_attribute_values_untouched() {
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $this->parent_product->get_id() );
+		$variation->set_attributes( array( 'colour' => 'Royal Blue ½' ) );
+
+		$stored = $variation->get_attributes();
+		$this->assertSame( 'Royal Blue ½', $stored['colour'] );
+	}
 }


### PR DESCRIPTION
**All Submissions:**

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request

`WC_Product_Variation::set_attributes()` previously stored taxonomy attribute values verbatim. When a caller (a CLI script, custom importer, etc.) passes a term label that contains non-slug characters — e.g. `'pa_shoe-size' => '6½'` — that exact string is written to post meta. The variation editor later resolves attributes via `get_term_by( 'slug', $value, $taxonomy )`, which fails because the term slug is `6-frac12` / `6%c2%bd`, not `6½`. The variation's attribute dropdown then renders as empty.

This PR aligns the CRUD entry point with the REST API and admin metabox: when the attribute key is a registered taxonomy and the value matches a term *name*, swap it for the term's *slug* before storing. If no matching term exists, fall back to `sanitize_title()` so non-ASCII characters are normalised consistently with the admin path. Custom (non-taxonomy) attribute values are left untouched.

Closes #26233.
Linear: https://linear.app/a8c/issue/RSMAPGJ-356

### Screenshots or screen recordings

N/A — backend-only fix.

### How to test the changes in this Pull Request

1. Register a global attribute `pa_shoe-size` with terms `6½`, `7`, `7½` (the slugs will be auto-generated, e.g. `6-frac12`).
2. Run the snippet from the original issue (or the RSMAPGJ-356 reproduction blueprint) that programmatically creates a variable product and three variations via:
   ```php
   $variation->set_attributes( [ 'pa_shoe-size' => '7½' ] );
   $variation->save();
   ```
3. Open the variable product in **Products → Edit → Variations**. Expected: the `pa_shoe-size` `<select>` on each variation shows the correct fraction value (`6½`, `7`, `7½`). Before this fix: the fraction rows show empty.
4. Repeat with plain integer values to confirm no regression for the working case.
5. Edit a variation via the admin UI (no programmatic call) and confirm saving still works for both fraction and non-fraction terms.

### Testing that has already taken place

- Added PHPUnit coverage in `class-wc-product-variation-test.php` for: fraction label → slug conversion, already-correct slug pass-through, and non-taxonomy custom attribute pass-through.
- `lint:php:changes` and `lint:changes:branch` pass.
- `phpstan analyse` on the modified production file passes (no new errors, no baseline additions).

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Enhancement / New feature
- [x] Fix - Fixes an existing bug
- [ ] Performance
- [ ] Tweak
- [ ] Other

#### Message

Fix `WC_Product_Variation::set_attributes()` losing taxonomy attribute values containing fraction or other non-slug characters (e.g. `6½`) when called programmatically.

#### Comment

</details>

🤖 Generated as part of the RSMAPGJ AI Coder pilot.