### PR TITLE
Populate wc_product_meta_lookup for WordPress importer

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-357
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-357
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc_product_meta_lookup not being populated when products are imported via the WordPress importer.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -400,6 +400,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\ProductFeed\ProductFeed::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Importer\WordPressImporterIntegration::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/src/Internal/Importer/WordPressImporterIntegration.php
+++ b/plugins/woocommerce/src/Internal/Importer/WordPressImporterIntegration.php
@@ -1,0 +1,113 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Importer;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use WC_Data_Store;
+
+/**
+ * Integrates WooCommerce with the WordPress importer (Tools > Import > WordPress).
+ *
+ * The WordPress importer inserts product posts and meta directly via the WP core
+ * functions (wp_insert_post, update_post_meta), bypassing WooCommerce's CRUD
+ * pipeline. As a result, rows in the wc_product_meta_lookup table are never
+ * populated for imported products, which causes blocks and APIs that rely on
+ * that table (e.g. the Filter Products by Price block) to behave incorrectly.
+ *
+ * This class watches the importer for product posts and refreshes the lookup
+ * table rows for each one when the import completes.
+ *
+ * @since 10.9.0
+ */
+class WordPressImporterIntegration implements RegisterHooksInterface {
+
+	/**
+	 * Product post IDs collected during an import run.
+	 *
+	 * @var int[]
+	 */
+	private array $imported_product_ids = array();
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_action( 'wp_import_insert_post', array( $this, 'track_imported_post' ), 10, 4 );
+		add_action( 'import_end', array( $this, 'refresh_lookup_for_imported_products' ) );
+	}
+
+	/**
+	 * Track product posts inserted by the WordPress importer.
+	 *
+	 * Fired by the WordPress importer for every post it inserts. We only retain
+	 * IDs that correspond to products or product variations, so that the lookup
+	 * table refresh on import_end is cheap.
+	 *
+	 * @param int                  $post_id          Newly inserted post ID.
+	 * @param int                  $original_post_id Original post ID from the WXR file (unused).
+	 * @param array<string, mixed> $postdata         Post data array passed to wp_insert_post (unused).
+	 * @param array<string, mixed> $post             Original post data from the WXR file.
+	 *
+	 * @return void
+	 */
+	public function track_imported_post( $post_id, $original_post_id, $postdata, $post ) {
+		$post_id = absint( $post_id );
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$post_type = '';
+		if ( is_array( $post ) && isset( $post['post_type'] ) ) {
+			$post_type = (string) $post['post_type'];
+		} else {
+			$post_type = (string) get_post_type( $post_id );
+		}
+
+		if ( 'product' !== $post_type && 'product_variation' !== $post_type ) {
+			return;
+		}
+
+		$this->imported_product_ids[ $post_id ] = $post_id;
+	}
+
+	/**
+	 * Refresh wc_product_meta_lookup rows for products imported in this run.
+	 *
+	 * Called on import_end (fired by both the canonical WordPress Importer and
+	 * the WP-CLI importer). After processing, the internal buffer is cleared so
+	 * a subsequent import run starts from a clean slate.
+	 *
+	 * @return void
+	 */
+	public function refresh_lookup_for_imported_products() {
+		if ( empty( $this->imported_product_ids ) ) {
+			return;
+		}
+
+		$product_ids                = $this->imported_product_ids;
+		$this->imported_product_ids = array();
+
+		$data_store = WC_Data_Store::load( 'product' );
+
+		foreach ( $product_ids as $product_id ) {
+			// `refresh_product_lookup_table` lives on WC_Product_Data_Store_CPT and is reached
+			// via WC_Data_Store::__call. PHPStan can't see through the magic method.
+			// @phpstan-ignore-next-line method.notFound
+			$data_store->refresh_product_lookup_table( $product_id );
+		}
+	}
+
+	/**
+	 * Return the IDs collected so far in the current run.
+	 *
+	 * Exposed for tests.
+	 *
+	 * @return int[]
+	 */
+	public function get_tracked_product_ids(): array {
+		return array_values( $this->imported_product_ids );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Importer/WordPressImporterIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Importer/WordPressImporterIntegrationTest.php
@@ -1,0 +1,172 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Importer;
+
+use Automattic\WooCommerce\Internal\Importer\WordPressImporterIntegration;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the WordPressImporterIntegration class.
+ *
+ * @see WordPressImporterIntegration
+ */
+class WordPressImporterIntegrationTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WordPressImporterIntegration
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new WordPressImporterIntegration();
+		$this->sut->register();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_action( 'wp_import_insert_post', array( $this->sut, 'track_imported_post' ), 10 );
+		remove_action( 'import_end', array( $this->sut, 'refresh_lookup_for_imported_products' ), 10 );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should track product post IDs when the WP importer inserts a product.
+	 */
+	public function test_tracks_product_posts(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Imported Product 1',
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+			)
+		);
+
+		do_action( 'wp_import_insert_post', $post_id, 123, array(), array( 'post_type' => 'product' ) );
+
+		$this->assertSame( array( (int) $post_id ), $this->sut->get_tracked_product_ids() );
+	}
+
+	/**
+	 * @testdox Should also track product_variation posts inserted by the WP importer.
+	 */
+	public function test_tracks_product_variations(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Imported Variation',
+				'post_type'   => 'product_variation',
+				'post_status' => 'publish',
+			)
+		);
+
+		do_action( 'wp_import_insert_post', $post_id, 124, array(), array( 'post_type' => 'product_variation' ) );
+
+		$this->assertSame( array( (int) $post_id ), $this->sut->get_tracked_product_ids() );
+	}
+
+	/**
+	 * @testdox Should ignore non-product posts inserted by the WP importer.
+	 */
+	public function test_ignores_non_product_posts(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Imported Page',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		do_action( 'wp_import_insert_post', $post_id, 125, array(), array( 'post_type' => 'page' ) );
+
+		$this->assertSame( array(), $this->sut->get_tracked_product_ids() );
+	}
+
+	/**
+	 * @testdox Should ignore an empty post ID.
+	 */
+	public function test_ignores_empty_post_id(): void {
+		do_action( 'wp_import_insert_post', 0, 126, array(), array( 'post_type' => 'product' ) );
+
+		$this->assertSame( array(), $this->sut->get_tracked_product_ids() );
+	}
+
+	/**
+	 * @testdox Should populate wc_product_meta_lookup for products imported via the WP importer on import_end.
+	 */
+	public function test_import_end_populates_lookup_table(): void {
+		global $wpdb;
+
+		// Simulate the WordPress importer: create a product post and meta directly,
+		// bypassing WooCommerce's CRUD pipeline so the lookup table is not populated.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Imported Simple Product',
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $post_id, '_price', '29.99' );
+		update_post_meta( $post_id, '_regular_price', '29.99' );
+		update_post_meta( $post_id, '_sku', 'IMPORTED-SKU-1' );
+		update_post_meta( $post_id, '_stock_status', 'instock' );
+		wp_set_object_terms( $post_id, 'simple', 'product_type' );
+
+		// Ensure the lookup table starts without a row for this product.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->delete( $wpdb->prefix . 'wc_product_meta_lookup', array( 'product_id' => $post_id ) );
+
+		// Confirm the lookup row is missing — this mirrors the buggy state described in #25698.
+		$pre_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_product_meta_lookup WHERE product_id = %d", $post_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$this->assertSame( 0, $pre_count, 'Pre-condition: lookup row should not exist for the imported product.' );
+
+		// Drive the importer hooks.
+		do_action( 'wp_import_insert_post', $post_id, 999, array(), array( 'post_type' => 'product' ) );
+		do_action( 'import_end' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT product_id, sku, min_price, max_price, stock_status FROM {$wpdb->prefix}wc_product_meta_lookup WHERE product_id = %d", $post_id ), ARRAY_A );
+
+		$this->assertIsArray( $row, 'Lookup row should exist after the importer finishes.' );
+		$this->assertSame( (string) $post_id, (string) $row['product_id'] );
+		$this->assertSame( 'IMPORTED-SKU-1', $row['sku'] );
+		$this->assertSame( 'instock', $row['stock_status'] );
+		$this->assertSame( '29.9900', $row['min_price'] );
+		$this->assertSame( '29.9900', $row['max_price'] );
+	}
+
+	/**
+	 * @testdox Should clear tracked IDs after import_end runs.
+	 */
+	public function test_buffer_is_cleared_after_import_end(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Imported Product 2',
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+			)
+		);
+
+		do_action( 'wp_import_insert_post', $post_id, 127, array(), array( 'post_type' => 'product' ) );
+		$this->assertNotEmpty( $this->sut->get_tracked_product_ids(), 'Pre-condition: buffer should hold the tracked product.' );
+
+		do_action( 'import_end' );
+
+		$this->assertSame( array(), $this->sut->get_tracked_product_ids(), 'Buffer should be empty after import_end.' );
+	}
+
+	/**
+	 * @testdox Should be a no-op when import_end fires without tracked products.
+	 */
+	public function test_import_end_no_op_when_buffer_empty(): void {
+		do_action( 'import_end' );
+		$this->assertSame( array(), $this->sut->get_tracked_product_ids() );
+	}
+}


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The WordPress importer (Tools > Import > WordPress) inserts product posts and meta directly via `wp_insert_post` / `update_post_meta`, bypassing WooCommerce's CRUD pipeline. As a result, rows in `wc_product_meta_lookup` are never populated for imported products. This breaks blocks and APIs that rely on the lookup table — most visibly, the *Filter Products by Price* block fails to render after a fresh import.

This PR adds a small integration class, `Automattic\WooCommerce\Internal\Importer\WordPressImporterIntegration`, that:

- Listens for `wp_import_insert_post` and remembers post IDs whose type is `product` or `product_variation`.
- On `import_end`, refreshes `wc_product_meta_lookup` for each tracked ID by calling the existing public `WC_Product_Data_Store_CPT::refresh_product_lookup_table()` method.
- Clears its buffer after running so it is reusable across imports in the same request.

The class is registered with the DI container alongside the other `RegisterHooksInterface` services in `class-woocommerce.php::init_hooks()`.

Closes #25698
Linear: [RSMAPGJ-357](https://linear.app/a8c/issue/RSMAPGJ-357)

### Closes

Closes #25698

### How to test the changes in this Pull Request:

1. On a clean site, delete all existing products (including from Trash).
2. Go to **Tools > Import > WordPress** and import `plugins/woocommerce/sample-data/sample_products.xml`.
3. Run the following SQL (replace `wp_` if your prefix is different) and confirm rows now exist for the imported products:
   ```sql
   SELECT product_id, sku, min_price, max_price, stock_status FROM wp_wc_product_meta_lookup;
   ```
4. Create a page with the **All Products** block and a **Filter Products by Price** block — the filter now renders and works.

### Testing that has already taken place:

- New PHPUnit coverage in `WordPressImporterIntegrationTest` covers: tracking products + variations, ignoring non-product posts and empty IDs, populating the lookup table on `import_end`, buffer reset, and no-op when nothing was tracked.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse <changed files> --memory-limit=2G` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance**: Patch
**Type**: Fix

Fix wc_product_meta_lookup not being populated when products are imported via the WordPress importer.

</details>

🤖 This is a draft PR submitted by an AI coding agent for the RSMAPGJ pilot.