### PR TITLE
Clarify checkout/cart block default-page inspector prompt

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-496
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-496
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clarify checkout/cart block inspector prompt by separating the automatic page-assign action from a manual link to settings.

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/default-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/default-notice/index.tsx
@@ -7,6 +7,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { CHECKOUT_PAGE_ID, CART_PAGE_ID } from '@woocommerce/block-settings';
+import { getAdminLink } from '@woocommerce/settings';
 import { CORE_EDITOR_STORE } from '@woocommerce/utils';
 
 import {
@@ -99,18 +100,33 @@ export function DefaultNotice( { block }: { block: string } ) {
 		slug,
 	] );
 
+	const settingsUrl = getAdminLink(
+		'admin.php?page=wc-settings&tab=advanced'
+	);
+
 	let noticeContent;
 	if ( block === 'checkout' ) {
 		noticeContent = createInterpolateElement(
 			__(
-				'If you would like to use this block as your default checkout, <a>update your page settings</a>.',
+				'To set this as your store’s default checkout, either <assign>assign this page automatically</assign>, or <settings>update your page settings manually</settings>.',
 				'woocommerce'
 			),
 			{
-				a: (
+				assign: (
 					// eslint-disable-next-line jsx-a11y/anchor-is-valid
 					<a href="#" onClick={ updatePage }>
-						{ __( 'update your page settings', 'woocommerce' ) }
+						{ __(
+							'assign this page automatically',
+							'woocommerce'
+						) }
+					</a>
+				),
+				settings: (
+					<a href={ settingsUrl }>
+						{ __(
+							'update your page settings manually',
+							'woocommerce'
+						) }
 					</a>
 				),
 			}
@@ -118,14 +134,25 @@ export function DefaultNotice( { block }: { block: string } ) {
 	} else {
 		noticeContent = createInterpolateElement(
 			__(
-				'If you would like to use this block as your default cart, <a>update your page settings</a>.',
+				'To set this as your store’s default cart, either <assign>assign this page automatically</assign>, or <settings>update your page settings manually</settings>.',
 				'woocommerce'
 			),
 			{
-				a: (
+				assign: (
 					// eslint-disable-next-line jsx-a11y/anchor-is-valid
 					<a href="#" onClick={ updatePage }>
-						{ __( 'update your page settings', 'woocommerce' ) }
+						{ __(
+							'assign this page automatically',
+							'woocommerce'
+						) }
+					</a>
+				),
+				settings: (
+					<a href={ settingsUrl }>
+						{ __(
+							'update your page settings manually',
+							'woocommerce'
+						) }
 					</a>
 				),
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/default-notice/test/index.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/default-notice/test/index.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { DefaultNotice } from '../index';
+
+jest.mock( '@wordpress/data', () => {
+	const originalModule = jest.requireActual( '@wordpress/data' );
+	return {
+		...originalModule,
+		useSelect: jest.fn( () => ( {
+			slug: 'checkout-2',
+			postPublished: true,
+			currentPostId: 99,
+		} ) ),
+		useDispatch: jest.fn( () => ( {
+			saveEntityRecord: jest.fn(),
+			editPost: jest.fn(),
+			savePost: jest.fn(),
+		} ) ),
+	};
+} );
+
+jest.mock( '@woocommerce/block-settings', () => ( {
+	CHECKOUT_PAGE_ID: 10,
+	CART_PAGE_ID: 11,
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getAdminLink: jest.fn(
+		( path: string ) => `https://example.test/wp-admin/${ path }`
+	),
+} ) );
+
+jest.mock( '@woocommerce/utils', () => ( {
+	CORE_EDITOR_STORE: 'core/editor',
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn( () => Promise.resolve( {} ) ),
+} ) );
+
+describe( 'DefaultNotice', () => {
+	it( 'renders the checkout notice with both automatic and manual options', () => {
+		const { container } = render( <DefaultNotice block="checkout" /> );
+
+		// The leading copy clarifies the user is choosing between two actions.
+		expect( container.textContent ).toMatch(
+			/To set this as your store.+default checkout/
+		);
+
+		// Two distinct links: one for the auto-assign action, one for settings.
+		const assignLinks = screen.getAllByRole( 'link', {
+			name: /assign this page automatically/i,
+		} );
+		expect( assignLinks.length ).toBeGreaterThan( 0 );
+		expect( assignLinks[ 0 ] ).toHaveAttribute( 'href', '#' );
+
+		const settingsLinks = screen.getAllByRole( 'link', {
+			name: /update your page settings manually/i,
+		} );
+		expect( settingsLinks.length ).toBeGreaterThan( 0 );
+		expect( settingsLinks[ 0 ].getAttribute( 'href' ) ).toMatch(
+			/page=wc-settings&tab=advanced/
+		);
+	} );
+
+	it( 'renders the cart notice with both automatic and manual options', () => {
+		const { container } = render( <DefaultNotice block="cart" /> );
+
+		expect( container.textContent ).toMatch(
+			/To set this as your store.+default cart/
+		);
+		expect(
+			screen.getAllByRole( 'link', {
+				name: /assign this page automatically/i,
+			} ).length
+		).toBeGreaterThan( 0 );
+		expect(
+			screen.getAllByRole( 'link', {
+				name: /update your page settings manually/i,
+			} ).length
+		).toBeGreaterThan( 0 );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Coding Standards and Guidelines](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines-and-Development-Standards).

### Changes proposed in this Pull Request

Closes #56635
Linear: https://linear.app/a8c/issue/RSMAPGJ-496

When editing a non-default page that contains the Checkout (or Cart) block, the sidebar Inspector shows a notice prompting the user to set the page as default. The current copy is:

> If you would like to use this block as your default checkout, [update your page settings](#).

That reads like a link to a settings page, but clicking it silently auto-assigns the current page as the default checkout (calls the `wc/v3/settings/advanced/woocommerce_checkout_page_id` endpoint) and reslugs both pages. Users have reported this surprising behaviour ([discussion #56264](https://github.com/woocommerce/woocommerce/discussions/56264)).

This PR rewrites the prompt to make both options explicit:

> To set this as your store's default checkout, either [assign this page automatically](#), or [update your page settings manually](...).

- "Assign this page automatically" preserves the existing one-click auto-assign behaviour.
- "Update your page settings manually" is now a real link to `admin.php?page=wc-settings&tab=advanced` (the WooCommerce > Settings > Advanced > Page setup screen).

The same fix is applied to the Cart block notice.

### Screenshots or screen recordings

Before: single "update your page settings" link that silently auto-assigns the page.
After: two clearly labeled actions — one for the automatic action, one for the manual settings page.

### How to test the changes in this Pull Request

1. On a fresh site, ensure the default Checkout page is set under WooCommerce > Settings > Advanced > Page setup.
2. Create a new page (e.g. "Alt Checkout") and insert the Checkout block.
3. Select the Checkout block; the Inspector sidebar shows the notice.
4. Verify the new copy: "To set this as your store's default checkout, either assign this page automatically, or update your page settings manually."
5. Confirm "assign this page automatically" still performs the auto-assign and that "update your page settings manually" opens `wp-admin/admin.php?page=wc-settings&tab=advanced` in the same tab.
6. Repeat with the Cart block on a separate page (copy should say "default cart").

### Testing that has already taken place

- Added Jest tests in `default-notice/test/index.test.tsx` covering both link affordances for checkout and cart. `pnpm test:js --testPathPattern=default-notice` passes (2/2).
- ESLint clean for changed lines (one pre-existing `react-hooks/exhaustive-deps` warning unrelated to this PR).

- [x] Covered with tests (Jest unit tests).

### Changelog entry

- [x] Added manually under `plugins/woocommerce/changelog/fix-rsmapgj-496` (significance: patch, type: fix).

### Milestone

- [x] Auto-assign to first available milestone.

---

Submitted via the RSMAPGJ AI Coder pipeline.