### PR TITLE
Fix duplicate wc_product_*_scheduled_sale entries in Action Scheduler

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-359
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-359
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent duplicate `wc_product_start_scheduled_sale` / `wc_product_end_scheduled_sale` entries in Action Scheduler by passing the `unique` flag when scheduling per-product sale events.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -574,6 +574,12 @@ function wc_get_formatted_variation( $variation, $flat = false, $include_names =
  * Uses Action Scheduler to fire events at the exact sale start/end times,
  * rather than relying on the daily cron.
  *
+ * The `$unique` flag is passed to `as_schedule_single_action()` so Action
+ * Scheduler refuses to insert a second pending action with the same hook,
+ * args, and group. This is the database-level guard against duplicates when
+ * re-entrant saves (from inside an AS sale handler) or the daily safety-net
+ * cron race with per-product AS events.
+ *
  * @since 10.5.0
  * @param WC_Product $product Product object.
  * @return void
@@ -590,7 +596,8 @@ function wc_schedule_product_sale_events( WC_Product $product ): void {
 				$start_ts,
 				'wc_product_start_scheduled_sale',
 				array( 'product_id' => $product_id ),
-				'woocommerce-sales'
+				'woocommerce-sales',
+				true
 			);
 		}
 	}
@@ -602,7 +609,8 @@ function wc_schedule_product_sale_events( WC_Product $product ): void {
 				$end_ts,
 				'wc_product_end_scheduled_sale',
 				array( 'product_id' => $product_id ),
-				'woocommerce-sales'
+				'woocommerce-sales',
+				true
 			);
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -473,6 +473,60 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox Repeated direct calls to wc_schedule_product_sale_events do not create duplicate pending Action Scheduler entries.
+	 *
+	 * Regression for woo#63517 / RSMAPGJ-359: prior to passing `$unique = true` to
+	 * `as_schedule_single_action()`, re-entrant saves and the daily cron safety net could
+	 * each insert a fresh pending action for the same product/hook/args because the
+	 * unschedule+schedule sequence is not atomic. With the unique flag set, Action
+	 * Scheduler refuses to insert a second pending row.
+	 */
+	public function test_wc_schedule_product_sale_events_does_not_duplicate_on_repeat_calls() {
+		$future_start = time() + 3600;
+		$future_end   = time() + 86400;
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_price( 100 );
+		$product->set_regular_price( 100 );
+		$product->set_sale_price( 50 );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', $future_start ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', $future_end ) );
+		$product->save();
+
+		// Simulate re-entrant / racing scheduling: skip the unschedule step that
+		// wc_maybe_schedule_product_sale_events() performs and call the raw scheduler
+		// three times in a row. Without `$unique=true` this would have produced
+		// three pending rows; with it, exactly one row survives.
+		wc_schedule_product_sale_events( $product );
+		wc_schedule_product_sale_events( $product );
+		wc_schedule_product_sale_events( $product );
+
+		$start_actions = as_get_scheduled_actions(
+			array(
+				'hook'     => 'wc_product_start_scheduled_sale',
+				'args'     => array( 'product_id' => $product->get_id() ),
+				'group'    => 'woocommerce-sales',
+				'status'   => ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => -1,
+			),
+			'ids'
+		);
+		$end_actions   = as_get_scheduled_actions(
+			array(
+				'hook'     => 'wc_product_end_scheduled_sale',
+				'args'     => array( 'product_id' => $product->get_id() ),
+				'group'    => 'woocommerce-sales',
+				'status'   => ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => -1,
+			),
+			'ids'
+		);
+
+		$this->assertCount( 1, $start_actions, 'Exactly one pending start sale action should exist after repeat scheduling.' );
+		$this->assertCount( 1, $end_actions, 'Exactly one pending end sale action should exist after repeat scheduling.' );
+	}
+
+	/**
 	 * @testDox Meta hook does not reschedule when sale date meta is written from inside the AS sale start handler.
 	 */
 	public function test_wc_schedule_sale_events_meta_hook_skips_when_inside_as_start_handler() {


### PR DESCRIPTION
## Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/woocommerce/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

## Changes proposed in this Pull Request

`wc_maybe_schedule_product_sale_events()` clears existing `wc_product_start_scheduled_sale` / `wc_product_end_scheduled_sale` actions and then schedules new ones. Because the unschedule+schedule sequence is not atomic and `as_unschedule_all_actions()` only targets PENDING rows, two concurrent paths can each "clear (find nothing) → schedule" and produce duplicate pending entries. Two paths in core can collide:

1. **Re-entrant `$product->save()` inside an AS sale handler.** `wc_apply_sale_state_for_product()` calls `$product->save()`, which writes sale-date meta and re-enters the scheduling code while the original AS action is still RUNNING (and therefore not unschedulable).
2. **Daily safety-net cron racing per-product AS events.** `wc_scheduled_sales()` processes the same products as the AS events and also drives `wc_apply_sale_state_for_product()`.

Fix: pass `$unique = true` (the 5th argument, available since Action Scheduler 3.3.0) to the `as_schedule_single_action()` calls in `wc_schedule_product_sale_events()`. AS then enforces uniqueness on `(hook, args, group)` at the database level and refuses a second pending row, regardless of how often the function is called.

Bug introduced in PR #62828.

Closes #63517.
Linear: https://linear.app/a8c/issue/RSMAPGJ-359

## Screenshots or screen recordings

N/A — backend-only.

## How to test the changes in this Pull Request

1. Create a Simple product with a future `Sale price from` and `Sale price to`.
2. Run the new unit test:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_wc_schedule_product_sale_events_does_not_duplicate_on_repeat_calls
   ```
3. (Optional manual repro from the issue) Repeatedly save the product (or re-run `wc_schedule_product_sale_events( $product )`); confirm that the Action Scheduler admin (`wp-admin/admin.php?page=wc-status&tab=action-scheduler&s=wc_product_end_scheduled_sale&status=pending`) shows exactly one pending row per hook/product, not multiple.

## Testing that has already taken place

- Added a PHPUnit regression test that invokes `wc_schedule_product_sale_events()` three times in a row and asserts exactly one pending action remains for each of the start and end hooks.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/wc-product-functions.php --memory-limit=2G` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.
  - Significance: patch
  - Type: fix

Filed under `plugins/woocommerce/changelog/fix-rsmapgj-359`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)