### PR TITLE
Fix Out of Stock count in dashboard status widget for unmanaged products

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-354
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-354
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Out of Stock count in the WooCommerce Status dashboard widget so it includes products whose stock status was manually set to out of stock with manage stock disabled.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -377,7 +377,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 							"SELECT COUNT( product_id )
 							FROM {$wpdb->wc_product_meta_lookup} AS lookup
 							INNER JOIN {$wpdb->posts} as posts ON lookup.product_id = posts.ID
-							WHERE stock_quantity <= %d
+							WHERE ( stock_status = 'outofstock' OR stock_quantity <= %d )
 							AND posts.post_status = 'publish'",
 							$nostock
 						)

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -55,8 +55,24 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 		delete_option( 'woocommerce_task_list_complete' );
 		remove_all_filters( 'pre_option_woocommerce_task_list_complete' );
 		remove_all_filters( 'pre_option_woocommerce_task_list_hidden' );
+		delete_transient( 'wc_outofstock_count' );
+		delete_transient( 'wc_low_stock_count' );
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Invoke the private status_widget_stock_rows method via reflection and capture output.
+	 *
+	 * @return string Captured output.
+	 */
+	private function capture_status_widget_stock_rows(): string {
+		$method = new ReflectionMethod( WC_Admin_Dashboard::class, 'status_widget_stock_rows' );
+		$method->setAccessible( true );
+
+		ob_start();
+		$method->invoke( $this->sut, '', '' );
+		return (string) ob_get_clean();
 	}
 
 	/**
@@ -130,6 +146,74 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 		$this->assertFalse(
 			$this->invoke_should_display_widget( $this->sut ),
 			'Widget should not display for users without proper capabilities'
+		);
+	}
+
+	/**
+	 * @testdox Out of stock widget counts a product with manage_stock disabled and stock_status outofstock.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/29698: when "Manage Stock"
+	 * is disabled and the user manually flips the stock status to "Out of Stock", the widget query
+	 * (which previously only looked at stock_quantity) missed the product because stock_quantity is
+	 * NULL for unmanaged products.
+	 */
+	public function test_outofstock_widget_counts_unmanaged_outofstock_product(): void {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Unmanaged Out Of Stock Product' );
+		$product->set_regular_price( '25' );
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'outofstock' );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		$output = $this->capture_status_widget_stock_rows();
+
+		$this->assertStringContainsString(
+			'1 product</strong> out of stock',
+			$output,
+			'Widget should count an unmanaged product whose stock_status was manually set to outofstock'
+		);
+	}
+
+	/**
+	 * @testdox Out of stock widget still counts products with stock_quantity <= 0 (managed stock path).
+	 */
+	public function test_outofstock_widget_counts_managed_zero_stock_product(): void {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Managed Zero Stock Product' );
+		$product->set_regular_price( '10' );
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 0 );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		$output = $this->capture_status_widget_stock_rows();
+
+		$this->assertStringContainsString(
+			'1 product</strong> out of stock',
+			$output,
+			'Widget should still count a managed product whose stock_quantity is zero'
+		);
+	}
+
+	/**
+	 * @testdox Out of stock widget does not count an in-stock product.
+	 */
+	public function test_outofstock_widget_does_not_count_instock_product(): void {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'In Stock Product' );
+		$product->set_regular_price( '15' );
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'instock' );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		$output = $this->capture_status_widget_stock_rows();
+
+		$this->assertStringContainsString(
+			'0 products</strong> out of stock',
+			$output,
+			'Widget should report zero out-of-stock products when the only product is in stock'
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the contributing guidelines for this project.

### Changes proposed in this Pull Request

When **Manage stock** is disabled on a product and its stock status is manually set to **Out of Stock**, the WooCommerce Status dashboard widget did not include the product in its "out of stock" count.

The widget query in `WC_Admin_Dashboard::status_widget_stock_rows()` filtered only on `wc_product_meta_lookup.stock_quantity <= 0`, but `stock_quantity` is `NULL` for products with `manage_stock = false`, so they were silently dropped from the count.

This PR broadens the predicate so the query also matches rows where `stock_status = 'outofstock'`, which is the canonical signal for both managed and unmanaged products. The managed-stock path is preserved via `OR`, keeping behavior unchanged for products that rely on the low-stock threshold.

Closes #29698
Linear: https://linear.app/a8c/issue/RSMAPGJ-354

### How to test the changes in this Pull Request

1. In a fresh test site, go to **Products → Add new** and create a Simple product.
2. Under **Inventory**, leave **Manage stock?** unchecked and set **Stock status** to **Out of stock**. Publish the product.
3. Ensure WooCommerce-wide stock management is on: **WooCommerce → Settings → Products → Inventory → Manage stock = enabled**.
4. Go to **Dashboard → Home** and look at the **WooCommerce Status** widget.
5. Confirm the widget shows **1 product out of stock** (or N matching the number you created). Before this fix the count stayed at 0.
6. (Optional) Repeat with a managed-stock product where stock quantity is 0 and confirm it is still counted.

Note: the widget caches the count in the `wc_outofstock_count` transient for 30 days. Delete it (`wp transient delete wc_outofstock_count`) after seeding test data if the count looks stale.

### Testing that has already taken place

- Added PHPUnit coverage in `plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php`:
  - Unmanaged product with `stock_status = outofstock` is counted.
  - Managed product with `stock_quantity = 0` is still counted (regression guard for the original code path).
  - In-stock product is not counted.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse includes/admin/class-wc-admin-dashboard.php` — no errors. (Pre-existing PHPStan noise on the test file is unrelated and not in the configured analysis paths.)

### Changelog entry

- [x] Added manually: `plugins/woocommerce/changelog/fix-rsmapgj-354` (significance: patch, type: fix).

### Milestone

- [x] Auto-assign milestone.

---

RSMAPGJ AI Coder pipeline