### PR TITLE
Fix malformed regexes in CSV importer get_formatting_callback()

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-346
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-346
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product CSV importer: anchor the special-column regexes in get_formatting_callback() so headings like "metamask" or "hellometa:" no longer match the meta-field pattern and are no longer formatted with the more lenient wp_kses_post callback.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -824,12 +824,16 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		/**
 		 * Match special column names.
 		 */
+		// Patterns are anchored with `^` so they only match column headings that
+		// begin with the given prefix (e.g. `meta:foo`, but not `metamask` or
+		// `hellometa:foo`). `wp_kses_post` is used for `meta:` columns to allow
+		// some HTML in meta fields; other matches use stricter parsers.
 		$regex_match_data_formatting = array(
-			'/attributes:value*/'    => array( $this, 'parse_comma_field' ),
-			'/attributes:visible*/'  => array( $this, 'parse_bool_field' ),
-			'/attributes:taxonomy*/' => array( $this, 'parse_bool_field' ),
-			'/downloads:url*/'       => array( $this, 'parse_download_file_field' ),
-			'/meta:*/'               => 'wp_kses_post', // Allow some HTML in meta fields.
+			'/^attributes:value/'    => array( $this, 'parse_comma_field' ),
+			'/^attributes:visible/'  => array( $this, 'parse_bool_field' ),
+			'/^attributes:taxonomy/' => array( $this, 'parse_bool_field' ),
+			'/^downloads:url/'       => array( $this, 'parse_download_file_field' ),
+			'/^meta:/'               => 'wp_kses_post',
 		);
 
 		$callbacks = array();

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -224,4 +224,63 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		wc_delete_attribute( $color_attr_id );
 		wc_delete_attribute( $size_attr_id );
 	}
+
+	/**
+	 * @testdox get_formatting_callback() anchors special-column regexes so unrelated headings (e.g. "metamask") don't match the meta callback.
+	 *
+	 * Regression test for woo#33773 / RSMAPGJ-346.
+	 */
+	public function test_get_formatting_callback_anchors_special_column_regexes() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$reflection       = new ReflectionClass( WC_Product_CSV_Importer::class );
+		$mapped_keys_prop = $reflection->getProperty( 'mapped_keys' );
+		$mapped_keys_prop->setAccessible( true );
+
+		$get_formatting_cb = $reflection->getMethod( 'get_formatting_callback' );
+		$get_formatting_cb->setAccessible( true );
+
+		/*
+		 * Headings exercised here:
+		 *   0: meta:my_field        - real meta column, should use wp_kses_post.
+		 *   1: metamask             - previously matched malformed /meta:*\/ regex; must fall back to wc_clean.
+		 *   2: hellometa:foo        - previously matched malformed /meta:*\/ regex; must fall back to wc_clean.
+		 *   3: meta:::::_myfield    - still begins with meta:, so use wp_kses_post.
+		 *   4: attributes:value1    - must use parse_comma_field.
+		 *   5: fooattributes:value  - must NOT match attributes:value (not anchored at start).
+		 *   6: downloads:url0       - must use parse_download_file_field.
+		 *   7: plain_heading        - must fall back to wc_clean.
+		 */
+		$mapped_keys_prop->setValue(
+			$importer,
+			array(
+				'meta:my_field',
+				'metamask',
+				'hellometa:foo',
+				'meta:::::_myfield',
+				'attributes:value1',
+				'fooattributes:value',
+				'downloads:url0',
+				'plain_heading',
+			)
+		);
+
+		$callbacks = $get_formatting_cb->invoke( $importer );
+
+		$this->assertSame( 'wp_kses_post', $callbacks[0], 'meta:my_field should use wp_kses_post' );
+		$this->assertSame( 'wc_clean', $callbacks[1], 'metamask must not match the meta: regex' );
+		$this->assertSame( 'wc_clean', $callbacks[2], 'hellometa:foo must not match the meta: regex' );
+		$this->assertSame( 'wp_kses_post', $callbacks[3], 'meta:::::_myfield begins with meta: so should use wp_kses_post' );
+
+		$this->assertIsArray( $callbacks[4] );
+		$this->assertSame( 'parse_comma_field', $callbacks[4][1], 'attributes:value1 should use parse_comma_field' );
+
+		$this->assertSame( 'wc_clean', $callbacks[5], 'fooattributes:value must not match attributes:value regex' );
+
+		$this->assertIsArray( $callbacks[6] );
+		$this->assertSame( 'parse_download_file_field', $callbacks[6][1], 'downloads:url0 should use parse_download_file_field' );
+
+		$this->assertSame( 'wc_clean', $callbacks[7], 'plain_heading should fall back to wc_clean' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you checked that the issue isn't already fixed?

### Changes proposed in this Pull Request:

`WC_Product_CSV_Importer::get_formatting_callback()` declared its special-column patterns as UNIX glob-style strings without anchors (e.g. `/meta:*/`, `/attributes:value*/`). When passed to `preg_match()` these are interpreted as PCRE: the `*` quantifier matches the previous char zero or more times, so `/meta:*/` matched any heading containing `meta` followed by zero or more colons, anywhere in the string. Consequences:

- `metamask` matched `/meta:*/` → formatted with `wp_kses_post` instead of `wc_clean`.
- `hellometa:foo` matched → same incorrect callback.
- `fooattributes:value` matched `/attributes:value*/` → wrong parser.

`wp_kses_post` allows HTML where the importer would normally strip it via `wc_clean`, which can be abused with crafted CSV headers.

This PR anchors each pattern with `^` and drops the trailing `*`, so only headings that **begin** with the intended prefix are matched.

Bug introduced when this method was first added; no specific bug-introducing PR identified.

### Closes

Closes #33773
Linear: https://linear.app/a8c/issue/RSMAPGJ-346

### How to test the changes in this Pull Request:

Automated:

1. From `plugins/woocommerce`, run the regression test:
   ```sh
   pnpm test:php:env -- --filter test_get_formatting_callback_anchors_special_column_regexes
   ```
   It exercises `get_formatting_callback()` with headings including `meta:my_field`, `metamask`, `hellometa:foo`, `meta:::::_myfield`, `attributes:value1`, `fooattributes:value`, `downloads:url0`, `plain_heading` and asserts each one resolves to the expected callback.

Manual:

1. Prepare a CSV whose header row contains a column literally named `metamask` and another named `hellometa:foo`.
2. Go to **Products → Import**, upload the CSV, and complete the mapping step.
3. Inspect the data being parsed: values in those columns should be cleaned via `wc_clean` (HTML stripped), not `wp_kses_post`.
4. A column literally named `meta:foo` should still allow some HTML via `wp_kses_post` (unchanged behavior).

### Testing instructions for Lead Developer (or AI):

Confirm:

- `/^meta:/` only matches headings starting with `meta:`.
- `/^attributes:value/`, `/^attributes:visible/`, `/^attributes:taxonomy/`, `/^downloads:url/` only match headings starting with those exact prefixes.
- No behavior change for valid `meta:`, `attributes:value*`, `attributes:visible*`, `attributes:taxonomy*`, `downloads:url*` column families.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

Patch

#### Type

Fix

#### Message

Product CSV importer: anchor the special-column regexes in `get_formatting_callback()` so headings like `metamask` or `hellometa:` no longer match the meta-field pattern and are no longer formatted with the more lenient `wp_kses_post` callback.

</details>

---

Submitted by the RSMAPGJ AI Coder pilot.