### PR TITLE
Fix stale sale price rendered after sale schedule ends

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-350
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-350
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product price HTML continuing to render an expired sale price when the cached active price has not yet been synced back to the regular price by the scheduled sales handler.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -2029,10 +2029,50 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		} elseif ( $this->is_on_sale() ) {
 			$price = wc_format_sale_price( wc_get_price_to_display( $this, array( 'price' => $this->get_regular_price() ) ), wc_get_price_to_display( $this ) ) . $this->get_price_suffix();
 		} else {
-			$price = wc_price( wc_get_price_to_display( $this ) ) . $this->get_price_suffix();
+			// If the sale has ended but the cached active price (`_price` meta) was not
+			// yet synced back to the regular price by the per-product Action Scheduler
+			// event or the daily `wc_scheduled_sales` cron, prefer the regular price for
+			// display so storefronts do not keep showing the expired sale price.
+			$display_price = $this->get_price_html_display_price();
+			$price         = wc_price( wc_get_price_to_display( $this, array( 'price' => $display_price ) ) ) . $this->get_price_suffix();
 		}
 
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );
+	}
+
+	/**
+	 * Resolve the price used for the non-sale branch of get_price_html().
+	 *
+	 * Falls back to the regular price when the cached active price still
+	 * matches an expired sale price (i.e. before the per-product or daily
+	 * scheduled sale event has synced `_price` back to the regular price).
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return string The price string to render.
+	 */
+	protected function get_price_html_display_price() {
+		$price         = (string) $this->get_price();
+		$sale_price    = (string) $this->get_sale_price();
+		$regular_price = (string) $this->get_regular_price();
+
+		if ( '' === $sale_price || '' === $regular_price ) {
+			return $price;
+		}
+
+		$date_on_sale_to = $this->get_date_on_sale_to();
+		$sale_ended      = $date_on_sale_to && $date_on_sale_to->getTimestamp() < time();
+
+		if ( ! $sale_ended ) {
+			return $price;
+		}
+
+		// Compare numerically so trailing zeros / formatting differences do not matter.
+		if ( '' !== $price && (float) $price === (float) $sale_price && (float) $sale_price !== (float) $regular_price ) {
+			return $regular_price;
+		}
+
+		return $price;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -235,6 +235,65 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox Price HTML falls back to the regular price when the cached active price is a stale, expired sale price.
+	 *
+	 * Simulates the window between the moment a sale's end date passes and the moment
+	 * `wc_scheduled_sales` / the per-product Action Scheduler event syncs `_price`
+	 * back to the regular price. In that window `_price` still holds the sale value,
+	 * but `is_on_sale()` already returns false. The storefront should show the
+	 * regular price, not the expired sale price.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/31048.
+	 */
+	public function test_get_price_html_falls_back_to_regular_price_when_sale_has_expired() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 50,
+				'sale_price'    => 25,
+			)
+		);
+
+		// Bypass CRUD so the dates land in the past without `handle_updated_props()`
+		// syncing `_price` back to the regular price — that is exactly the stale state
+		// the storefront sees between the sale's end time and the next scheduled sales run.
+		$product_id = $product->get_id();
+		update_post_meta( $product_id, '_sale_price_dates_from', time() - DAY_IN_SECONDS * 2 );
+		update_post_meta( $product_id, '_sale_price_dates_to', time() - DAY_IN_SECONDS );
+
+		// `_price` still equals the (now expired) sale price.
+		update_post_meta( $product_id, '_price', '25' );
+
+		$product = wc_get_product( $product_id );
+
+		$this->assertFalse( $product->is_on_sale(), 'Sale should be considered ended once date_on_sale_to is in the past.' );
+		$this->assertSame( '25', (string) $product->get_price(), 'Cached _price meta should remain stale prior to the scheduled sync.' );
+
+		$html = $product->get_price_html();
+
+		$this->assertStringContainsString( wc_price( 50 ), $html, 'Price HTML should display the regular price when the sale has expired.' );
+		$this->assertStringNotContainsString( '<ins', $html, 'Price HTML should not include the sale (<ins>) markup when the sale has expired.' );
+	}
+
+	/**
+	 * @testDox Price HTML still shows the active price unchanged for products without a sale schedule.
+	 */
+	public function test_get_price_html_unaffected_when_no_sale_schedule_is_set() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 50,
+				'sale_price'    => 25,
+			)
+		);
+
+		// Sale price is set but no end date — should keep showing the sale.
+		$this->assertTrue( $product->is_on_sale() );
+		$html = $product->get_price_html();
+		$this->assertStringContainsString( '<ins', $html );
+	}
+
+	/**
 	 * @testdox The Cost of Goods Sold value can be set and retrieved when the COGS feature is enabled.
 	 */
 	public function test_cogs_value_with_feature_enabled() {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #31048.
Linear: https://linear.app/a8c/issue/RSMAPGJ-350

When a sale schedule's end date passes, `WC_Abstract_Product::is_on_sale()` correctly flips to `false`. However, the cached `_price` meta is only synced back to the regular price when the per-product Action Scheduler event (`wc_product_end_scheduled_sale`) or the daily `wc_scheduled_sales` cron runs. Between the moment the sale ends and the next sync, the storefront kept rendering the expired sale price.

This PR keeps the price computation untouched but teaches `get_price_html()` to detect that stale window: if the active price still equals the (now expired) sale price and a higher regular price is set, the regular price is rendered instead — matching what shoppers expect immediately after the sale's end date.

### Screenshots or screen recordings:

n/a — markup change only; output reverts to the existing non-sale `wc_price()` rendering.

### How to test the changes in this Pull Request:

1. Create a simple product with a regular price of `50` and a sale price of `25`.
2. Set the sale schedule's start date in the past and the end date in the past as well (so the sale has expired) — for example via WP-CLI / direct meta edits so the daily cron does not run between save and check.
3. Visit the product on the storefront and confirm the displayed price is `$50` and there is no strikethrough sale markup.
4. Run the daily sales cron (or wait for the per-product Action Scheduler event) and confirm the rendered price stays `$50`.

### Testing that has already taken place:

- New PHPUnit tests in `class-wc-abstract-product-test.php` covering the stale-cache fallback and a regression check that an active sale without an end date keeps rendering the sale markup.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/abstracts/abstract-wc-product.php --memory-limit=2G` — no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)
- [ ] I have manually added a changelog entry using the [Changelogger tool](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/changelog.md).

Changelog entry committed at `plugins/woocommerce/changelog/fix-rsmapgj-350`.

---

🤖 Submitted by the RSMAPGJ AI Coder pilot.