### PR TITLE
Fix product CSV importer for pre-registered media via deep paths and IDs

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-351
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-351
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Product CSV importer now attaches pre-registered media when referenced by a relative path containing slashes or by a numeric attachment ID.

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -575,7 +575,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	/**
 	 * Get attachment ID.
 	 *
-	 * @param  string $url        Attachment URL.
+	 * @param  string $url        Attachment URL, relative path, filename, or numeric attachment ID.
 	 * @param  int    $product_id Product ID.
 	 * @return int
 	 * @throws Exception If attachment cannot be loaded.
@@ -583,6 +583,17 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	public function get_attachment_id_from_url( $url, $product_id ) {
 		if ( empty( $url ) ) {
 			return 0;
+		}
+
+		// If the value is a numeric attachment ID, resolve it directly so pre-registered media can be reused.
+		if ( ctype_digit( (string) $url ) ) {
+			$attachment_id = absint( $url );
+			if ( $attachment_id && 'attachment' === get_post_type( $attachment_id ) ) {
+				return $attachment_id;
+			}
+
+			/* translators: %s: image identifier */
+			throw new Exception( esc_html( sprintf( __( 'Unable to use image "%s".', 'woocommerce' ), $url ) ), 400 );
 		}
 
 		$id         = 0;

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -558,7 +558,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
-	 * Parse images list from a CSV. Images can be filenames or URLs.
+	 * Parse images list from a CSV. Images can be filenames, relative paths,
+	 * URLs, or numeric attachment IDs referencing pre-registered media.
 	 *
 	 * @param string $value Field value.
 	 *
@@ -573,8 +574,28 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		$separator = apply_filters( 'woocommerce_product_import_image_separator', ',' );
 
 		foreach ( $this->explode_values( $value, $separator ) as $image ) {
+			$image = trim( $image );
+
+			if ( '' === $image ) {
+				continue;
+			}
+
 			if ( stristr( $image, '://' ) ) {
 				$images[] = esc_url_raw( $image );
+			} elseif ( ctype_digit( (string) $image ) ) {
+				// Numeric attachment ID — preserve as-is so it can be resolved to a pre-registered media item.
+				$images[] = $image;
+			} elseif ( false !== strpos( $image, '/' ) ) {
+				// Relative path (e.g. "media/image/ab/cd/ef/foo.jpg") — sanitize each segment so the
+				// directory separators are preserved while still cleaning each part of the path.
+				$segments = array_map( 'sanitize_file_name', explode( '/', $image ) );
+				$segments = array_filter(
+					$segments,
+					static function ( $segment ) {
+						return '' !== (string) $segment;
+					}
+				);
+				$images[] = implode( '/', $segments );
 			} else {
 				$images[] = sanitize_file_name( $image );
 			}

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -28,7 +28,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox variations need to set the status back to published if parent product is a draft
 	 */
 	public function test_expand_data_with_draft_variable() {
-		$csv_file = dirname( __FILE__ ) . '/sample.csv';
+		$csv_file = __DIR__ . '/sample.csv';
 		$raw_data = array(
 			array(
 				'type'      => ProductType::VARIABLE,
@@ -223,5 +223,123 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $product->get_id() );
 		wc_delete_attribute( $color_attr_id );
 		wc_delete_attribute( $size_attr_id );
+	}
+
+	/**
+	 * @testdox parse_images_field preserves slashes in relative paths so deep paths can be matched against the media library.
+	 */
+	public function test_parse_images_field_preserves_relative_paths() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$result = $importer->parse_images_field( 'media/image/ab/cd/ef/qa-test-image-001.jpg' );
+
+		$this->assertSame( array( 'media/image/ab/cd/ef/qa-test-image-001.jpg' ), $result );
+	}
+
+	/**
+	 * @testdox parse_images_field preserves numeric attachment IDs so pre-registered media can be attached.
+	 */
+	public function test_parse_images_field_preserves_numeric_attachment_ids() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$result = $importer->parse_images_field( '38191' );
+
+		$this->assertSame( array( '38191' ), $result );
+	}
+
+	/**
+	 * @testdox parse_images_field still sanitizes plain filenames.
+	 */
+	public function test_parse_images_field_sanitizes_plain_filenames() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$result = $importer->parse_images_field( 'image with spaces.jpg' );
+
+		$this->assertSame( array( 'image-with-spaces.jpg' ), $result );
+	}
+
+	/**
+	 * @testdox parse_images_field accepts a mixed list of URLs, paths, IDs and filenames.
+	 */
+	public function test_parse_images_field_mixed_inputs() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$result = $importer->parse_images_field( 'https://example.com/foo.jpg, media/image/ab/cd/ef/bar.jpg, 38191, plain.jpg' );
+
+		$this->assertSame(
+			array(
+				'https://example.com/foo.jpg',
+				'media/image/ab/cd/ef/bar.jpg',
+				'38191',
+				'plain.jpg',
+			),
+			$result
+		);
+	}
+
+	/**
+	 * @testdox get_attachment_id_from_url resolves a numeric value to an existing attachment post ID.
+	 */
+	public function test_get_attachment_id_from_url_resolves_numeric_attachment_id() {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_title'     => 'qa-test-image-001',
+				'post_status'    => 'inherit',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$resolved = $importer->get_attachment_id_from_url( (string) $attachment_id, 0 );
+
+		$this->assertSame( (int) $attachment_id, $resolved );
+
+		wp_delete_post( $attachment_id, true );
+	}
+
+	/**
+	 * @testdox get_attachment_id_from_url throws when a numeric value does not correspond to an attachment.
+	 */
+	public function test_get_attachment_id_from_url_throws_for_unknown_numeric_id() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unable to use image "999999999"' );
+
+		$importer->get_attachment_id_from_url( '999999999', 0 );
+	}
+
+	/**
+	 * @testdox get_attachment_id_from_url matches an attachment registered at a deep nested upload path.
+	 */
+	public function test_get_attachment_id_from_url_matches_deep_relative_path() {
+		$relative_path = 'media/image/ab/cd/ef/qa-test-image-001.jpg';
+
+		$attachment_id = wp_insert_post(
+			array(
+				'post_title'     => 'qa-test-image-001',
+				'post_status'    => 'inherit',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', $relative_path );
+
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$resolved = $importer->get_attachment_id_from_url( $relative_path, 0 );
+
+		$this->assertSame( (int) $attachment_id, $resolved );
+
+		wp_delete_post( $attachment_id, true );
 	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Two bugs in the WooCommerce product CSV importer prevented users from attaching media library items that were already registered (a common pattern when bulk-registering uploaded files via WP-CLI):

1. `WC_Product_CSV_Importer::parse_images_field()` ran every non-URL value through `sanitize_file_name()`, which strips slashes. A path like `media/image/ab/cd/ef/foo.jpg` was rewritten to `mediaimageabcdefoo.jpg` before the lookup ran, so the importer never found the attachment and reported `Unable to use image "mediaimageabcdefoo.jpg"`.
2. `WC_Product_Importer::get_attachment_id_from_url()` had no branch for numeric attachment IDs. Supplying `38191` in the Images column also failed with `Unable to use image "38191"`.

This PR:

- Preserves relative paths in `parse_images_field()` by sanitising each path segment independently rather than the full string, so deep upload paths survive the parse.
- Preserves numeric attachment IDs as-is in `parse_images_field()`.
- Adds a numeric-ID short-circuit to `get_attachment_id_from_url()` that resolves to the matching attachment post (or throws the same `Unable to use image` if the ID is unknown).
- Adds PHPUnit coverage for `parse_images_field` (relative path, numeric ID, plain filename, mixed list) and `get_attachment_id_from_url` (numeric resolution, missing numeric, deep-path lookup).

Closes #30135

Linear: https://linear.app/a8c/issue/RSMAPGJ-351

### How to test the changes in this Pull Request:

1. In `wp-admin`, register an image at a deep upload path (e.g. via WP-CLI `wp media import` or by inserting an attachment whose `_wp_attached_file` meta is `media/image/ab/cd/ef/foo.jpg`).
2. Prepare a CSV with an `Images` column containing the relative path `media/image/ab/cd/ef/foo.jpg`, and another row whose `Images` column is the numeric attachment ID.
3. Run the WooCommerce product importer (Products → Import) and import the CSV.
4. Confirm both rows complete without `Unable to use image …` errors and that the products have the pre-registered attachment set as the featured image.
5. Run the new unit tests:
   ```
   pnpm --filter=@woocommerce/plugin-woocommerce test:php -- --filter WC_Product_CSV_Importer_Test
   ```

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/import/abstract-wc-product-importer.php includes/import/class-wc-product-csv-importer.php --memory-limit=2G` — clean, no baseline additions.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance**: Patch
**Type**: Fix
**Message**: Product CSV importer now attaches pre-registered media when referenced by a relative path containing slashes or by a numeric attachment ID.

</details>

---

Generated by an AI coder pilot agent (RSMAPGJ-351). Reviewed and shepherded by the assigned engineer.