### PR TITLE
Set viewport-aware sizes attribute for product thumbnails

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-347
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-347
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Provide a viewport-aware sizes attribute for product thumbnails so mobile browsers download an appropriately sized image source instead of a much larger one.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1598,6 +1598,85 @@ if ( ! function_exists( 'woocommerce_get_product_thumbnail' ) ) {
 	}
 }
 
+/**
+ * Filter the `sizes` attribute for product thumbnails so that the browser can
+ * pick an appropriately sized image source on small viewports.
+ *
+ * Core's default `wp_calculate_image_sizes()` returns
+ * `(max-width: {width}px) 100vw, {width}px` for an image registered at
+ * `{width}px`. For product thumbnails this is inaccurate on mobile where
+ * the grid typically renders multiple columns at well below the registered
+ * width, which causes browsers to download a larger source (often the 2x
+ * intrinsic size) than the rendered footprint warrants.
+ *
+ * When the requested size matches the `woocommerce_thumbnail` image size,
+ * we generate a `sizes` value that accounts for narrow viewports and the
+ * configured column count of the current product loop, so the responsive
+ * `srcset` selection lines up with what is actually painted.
+ *
+ * @since 10.9.0
+ *
+ * @param string       $sizes The computed sizes attribute value.
+ * @param string|int[] $size  The requested image size (registered name or `[width, height]`).
+ * @return string Adjusted sizes attribute value.
+ */
+function wc_calculate_image_sizes_for_thumbnails( $sizes, $size ) {
+	// Bail if another filter has already returned a non-string sizes value.
+	if ( ! is_string( $sizes ) || '' === $sizes ) {
+		return $sizes;
+	}
+
+	$thumbnail_dimensions = wc_get_image_size( 'woocommerce_thumbnail' );
+	$thumbnail_width      = isset( $thumbnail_dimensions['width'] ) ? absint( $thumbnail_dimensions['width'] ) : 0;
+
+	if ( $thumbnail_width <= 0 ) {
+		return $sizes;
+	}
+
+	// Determine whether the requested size matches the WooCommerce thumbnail size.
+	$is_thumbnail_size = false;
+	if ( is_string( $size ) ) {
+		$is_thumbnail_size = ( 'woocommerce_thumbnail' === $size );
+	} elseif ( is_array( $size ) && isset( $size[0] ) ) {
+		$is_thumbnail_size = ( absint( $size[0] ) === $thumbnail_width );
+	}
+
+	if ( ! $is_thumbnail_size ) {
+		return $sizes;
+	}
+
+	// Use the column count of the active loop when available, falling back
+	// to the configured catalog columns. Storefront and most catalog
+	// templates render 2 columns on mobile and the configured number on
+	// larger viewports, which matches the breakpoints below.
+	$loop_columns = wc_get_loop_prop( 'columns' );
+	$columns      = absint( '' !== $loop_columns ? $loop_columns : wc_get_default_products_per_row() );
+	$columns      = max( 1, $columns );
+
+	// Build a viewport-aware sizes value. The desktop slot caps at the
+	// configured thumbnail width so we never advertise a slot larger than
+	// the registered source.
+	$desktop_slot_width = max( 1, (int) floor( 100 / $columns ) );
+	$new_sizes          = sprintf(
+		'(max-width: 480px) 100vw, (max-width: 900px) 50vw, (max-width: 1200px) %1$dvw, %2$dpx',
+		$desktop_slot_width,
+		$thumbnail_width
+	);
+
+	/**
+	 * Filter the computed `sizes` attribute for WooCommerce product thumbnails.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param string       $new_sizes  The new sizes attribute value.
+	 * @param string       $sizes      The original sizes attribute value.
+	 * @param string|int[] $size       The requested image size.
+	 * @param int          $columns    The current loop column count.
+	 */
+	return apply_filters( 'woocommerce_product_thumbnail_sizes_attr', $new_sizes, $sizes, $size, $columns );
+}
+add_filter( 'wp_calculate_image_sizes', 'wc_calculate_image_sizes_for_thumbnails', 10, 2 );
+
 if ( ! function_exists( 'woocommerce_result_count' ) ) {
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -558,4 +558,91 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( '<select', $actual_html );
 		$this->assertStringNotContainsString( 'type="hidden"', $actual_html );
 	}
+
+	/**
+	 * The default core `sizes` attribute is replaced with a viewport-aware
+	 * value when the requested size matches the WooCommerce thumbnail size.
+	 *
+	 * @covers ::wc_calculate_image_sizes_for_thumbnails
+	 */
+	public function test_wc_calculate_image_sizes_for_thumbnails_replaces_core_sizes_for_named_size() {
+		$thumbnail = wc_get_image_size( 'woocommerce_thumbnail' );
+		$width     = absint( $thumbnail['width'] );
+
+		$result = wc_calculate_image_sizes_for_thumbnails(
+			'(max-width: ' . $width . 'px) 100vw, ' . $width . 'px',
+			'woocommerce_thumbnail'
+		);
+
+		$this->assertStringContainsString( '(max-width: 480px) 100vw', $result );
+		$this->assertStringContainsString( '(max-width: 900px) 50vw', $result );
+		$this->assertStringContainsString( $width . 'px', $result );
+	}
+
+	/**
+	 * Size arrays whose first dimension matches the thumbnail width are
+	 * treated as thumbnail-sized images.
+	 *
+	 * @covers ::wc_calculate_image_sizes_for_thumbnails
+	 */
+	public function test_wc_calculate_image_sizes_for_thumbnails_matches_size_array() {
+		$thumbnail = wc_get_image_size( 'woocommerce_thumbnail' );
+		$width     = absint( $thumbnail['width'] );
+		$height    = absint( $thumbnail['height'] );
+
+		$result = wc_calculate_image_sizes_for_thumbnails(
+			'(max-width: ' . $width . 'px) 100vw, ' . $width . 'px',
+			array( $width, $height )
+		);
+
+		$this->assertStringContainsString( '(max-width: 480px) 100vw', $result );
+	}
+
+	/**
+	 * The sizes attribute is left untouched when the requested size is not
+	 * the WooCommerce thumbnail size.
+	 *
+	 * @covers ::wc_calculate_image_sizes_for_thumbnails
+	 */
+	public function test_wc_calculate_image_sizes_for_thumbnails_preserves_other_sizes() {
+		$result = wc_calculate_image_sizes_for_thumbnails(
+			'(max-width: 1024px) 100vw, 1024px',
+			'medium_large'
+		);
+
+		$this->assertSame( '(max-width: 1024px) 100vw, 1024px', $result );
+	}
+
+	/**
+	 * Non-string sizes values (e.g. `false` from another filter) are
+	 * returned untouched so the filter remains side-effect free.
+	 *
+	 * @covers ::wc_calculate_image_sizes_for_thumbnails
+	 */
+	public function test_wc_calculate_image_sizes_for_thumbnails_passes_through_non_string_sizes() {
+		$this->assertFalse( wc_calculate_image_sizes_for_thumbnails( false, 'woocommerce_thumbnail' ) );
+		$this->assertSame( '', wc_calculate_image_sizes_for_thumbnails( '', 'woocommerce_thumbnail' ) );
+	}
+
+	/**
+	 * The `woocommerce_product_thumbnail_sizes_attr` filter is applied to
+	 * the final value so themes and extensions can fine-tune the output.
+	 *
+	 * @covers ::wc_calculate_image_sizes_for_thumbnails
+	 */
+	public function test_wc_calculate_image_sizes_for_thumbnails_is_filterable() {
+		$callback = static function () {
+			return '100vw';
+		};
+		add_filter( 'woocommerce_product_thumbnail_sizes_attr', $callback );
+
+		$result = wc_calculate_image_sizes_for_thumbnails(
+			'(max-width: 280px) 100vw, 280px',
+			'woocommerce_thumbnail'
+		);
+
+		remove_filter( 'woocommerce_product_thumbnail_sizes_attr', $callback );
+
+		$this->assertSame( '100vw', $result );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have read the [Submission Review Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

Closes #32299
Linear: https://linear.app/a8c/issue/RSMAPGJ-347

On mobile, WooCommerce product thumbnails were downloading an oversized image from `srcset` (e.g. 580x580 in the original bug report) even though the rendered footprint is much smaller (e.g. 188x188 at 2 columns).

The root cause is that WordPress core's `wp_calculate_image_sizes()` emits `(max-width: {w}px) 100vw, {w}px` for an image registered at `{w}px`. For a `woocommerce_thumbnail` registered at 280px wide, this resolves to `(max-width: 280px) 100vw, 280px`, which tells the browser the slot is 280 CSS px on any viewport wider than 280px. On a 375 CSS-px phone with a 2 dpi screen and a 2-column grid, the browser then picks the closest `srcset` candidate to 560 device px (the ~580 source) rather than the ~188 px actually painted.

This PR adds a `wp_calculate_image_sizes` filter that, when the requested size is `woocommerce_thumbnail`, builds a viewport-aware `sizes` value accounting for narrow viewports and the active product loop's column count:

`(max-width: 480px) 100vw, (max-width: 900px) 50vw, (max-width: 1200px) {100/columns}vw, {thumbnail_width}px`

A new filter, `woocommerce_product_thumbnail_sizes_attr`, is also exposed so themes and extensions can fine-tune the output.

### Screenshots or screen recordings

N/A - bug is observable via DevTools network and the rendered `sizes`/`srcset` attributes on the shop page.

### How to test the changes in this Pull Request

1. Install Storefront theme and activate it.
2. Create a simple product with a 600x600 image as its thumbnail.
3. Visit the shop page on a mobile-width viewport (DevTools, 375px wide is fine).
4. Inspect the product loop `<img>` element.
   - Before: `sizes` is `(max-width: 280px) 100vw, 280px` and the browser loads the 580x580 source.
   - After: `sizes` starts with `(max-width: 480px) 100vw, (max-width: 900px) 50vw, ...` and the browser loads a smaller source matching the rendered footprint.
5. Confirm desktop behavior is unchanged - the larger thumbnail source is still selected at desktop widths.

### Testing that has already taken place

- Added PHPUnit coverage in `tests/legacy/unit-tests/templates/functions.php` for:
  - Named `woocommerce_thumbnail` size replacement.
  - Size array matching the thumbnail width.
  - Non-thumbnail sizes passing through untouched.
  - Non-string `$sizes` input passing through.
  - `woocommerce_product_thumbnail_sizes_attr` filter applied.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.
- PHPStan on the modified file: no errors (no baseline additions).

### Changelog entry

- [x] Automatically create a changelog entry from the details above.

Manual entry added at `plugins/woocommerce/changelog/fix-rsmapgj-347`.

---

Bug introduced predates the current branch history; this is a long-standing markup defect, not a regression.