### PR TITLE
Resolve relative paths in `getNewPath` against the current path

### DIFF
--- a/packages/js/navigation/changelog/fix-rsmapgj-343
+++ b/packages/js/navigation/changelog/fix-rsmapgj-343
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `getNewPath` so a `path` argument starting with `./` or `../` is resolved against the current path, matching the documented behavior.

--- a/packages/js/navigation/src/test/index.js
+++ b/packages/js/navigation/src/test/index.js
@@ -152,6 +152,46 @@ describe( 'getNewPath', () => {
 
 		expect( path ).toEqual( 'admin.php?page=custom-page&path=' );
 	} );
+
+	describe( 'relative path resolution', () => {
+		beforeEach( () => {
+			// Put history into a known nested path so getPath() returns
+			// `/automatewoo/analytics` when called without an explicit path.
+			getHistory().push(
+				'admin.php?page=wc-admin&path=%2Fautomatewoo%2Fanalytics'
+			);
+		} );
+
+		it( 'should resolve "./<segment>" against the current path', () => {
+			const path = getNewPath( {}, './workflows' );
+
+			expect( path ).toEqual(
+				'admin.php?page=wc-admin&path=%2Fautomatewoo%2Fanalytics%2Fworkflows'
+			);
+		} );
+
+		it( 'should resolve "../<segment>" against the current path', () => {
+			const path = getNewPath( {}, '../reports' );
+
+			expect( path ).toEqual(
+				'admin.php?page=wc-admin&path=%2Fautomatewoo%2Freports'
+			);
+		} );
+
+		it( 'should leave absolute paths untouched', () => {
+			const path = getNewPath( {}, '/some/absolute/path' );
+
+			expect( path ).toEqual(
+				'admin.php?page=wc-admin&path=%2Fsome%2Fabsolute%2Fpath'
+			);
+		} );
+
+		it( 'should leave non-relative bare paths untouched', () => {
+			const path = getNewPath( {}, 'workflows' );
+
+			expect( path ).toEqual( 'admin.php?page=wc-admin&path=workflows' );
+		} );
+	} );
 } );
 
 describe( 'addHistoryListener', () => {

--- a/packages/js/navigation/src/url.js
+++ b/packages/js/navigation/src/url.js
@@ -31,10 +31,54 @@ export function getQuery() {
 }
 
 /**
+ * Resolve a relative path (starting with `./` or `../`) against a base
+ * path. Absolute paths and paths without a leading relative segment are
+ * returned unchanged.
+ *
+ * @param {string} path Path to resolve.
+ * @param {string} base Base path to resolve against.
+ * @return {string} Resolved path.
+ */
+function resolveRelativePath( path, base ) {
+	if (
+		typeof path !== 'string' ||
+		( ! path.startsWith( './' ) &&
+			! path.startsWith( '../' ) &&
+			path !== '.' &&
+			path !== '..' )
+	) {
+		return path;
+	}
+
+	// Determine the base segments. The current path coming from history is
+	// a pathname like `/automatewoo/analytics`, but the value tracked in the
+	// `path` query arg may also be the bare path (no leading slash). Treat
+	// the base as a directory so `./foo` joins onto it instead of replacing
+	// its last segment.
+	const baseSegments = ( base || '' ).split( '/' ).filter( Boolean );
+	const pathSegments = path.split( '/' );
+
+	for ( const segment of pathSegments ) {
+		if ( segment === '' || segment === '.' ) {
+			continue;
+		}
+		if ( segment === '..' ) {
+			baseSegments.pop();
+			continue;
+		}
+		baseSegments.push( segment );
+	}
+
+	return '/' + baseSegments.join( '/' );
+}
+
+/**
  * Return a URL with set query parameters.
  *
  * @param {Object} query        object of params to be updated.
- * @param {string} path         Relative path (defaults to current path).
+ * @param {string} path         Relative path (defaults to current path). Paths
+ *                              starting with `./` or `../` are resolved against
+ *                              the current path.
  * @param {Object} currentQuery object of current query params (defaults to current querystring).
  * @param {string} page         Page key (defaults to "wc-admin")
  * @return {string}  Updated URL merging query params into existing params.
@@ -45,9 +89,10 @@ export function getNewPath(
 	currentQuery = getQuery(),
 	page = 'wc-admin'
 ) {
+	const resolvedPath = resolveRelativePath( path, getPath() );
 	const args = { page, ...currentQuery, ...query };
-	if ( path !== '/' ) {
-		args.path = path;
+	if ( resolvedPath !== '/' ) {
+		args.path = resolvedPath;
 	}
 	return addQueryArgs( 'admin.php', args );
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommendations for Code Reviews](https://developer.woocommerce.com/docs/contribution/recommendations-for-code-reviews/).

### Changes proposed in this Pull Request

`@woocommerce/navigation`'s `getNewPath( query, path )` helper documents the `path` argument as a "Relative path (defaults to current path)", but historically passes the value through untouched. As a result, calling `getNewPath( {}, './workflows' )` from a page like `wp-admin/admin.php?page=wc-admin&path=/automatewoo/analytics` produced `path=.%2Fworkflows` instead of the expected `path=/automatewoo/analytics/workflows`.

This PR teaches `getNewPath` to resolve any `path` starting with `./` or `../` (or equal to `.` / `..`) against the current pathname obtained from history (`getPath()`), using simple POSIX-style segment joining. Absolute paths (`/foo/bar`) and bare segments (`workflows`) are left untouched to preserve current callers' behavior.

Closes #34789
Linear: https://linear.app/a8c/issue/RSMAPGJ-343

### Screenshots or screen recordings

N/A — pure utility-function behavior change.

### How to test the changes in this Pull Request

1. Open `wp-admin/admin.php?page=wc-admin&path=%2Fautomatewoo%2Fanalytics` (or any other WC Admin page with a nested `path` query arg).
2. In the browser devtools console run:
   ```js
   wc.navigation.getNewPath( {}, './workflows' );
   ```
   Expect `admin.php?page=wc-admin&path=%2Fautomatewoo%2Fanalytics%2Fworkflows`.
3. Also try `wc.navigation.getNewPath( {}, '../reports' )` — expect the last segment of the current path to be replaced (e.g. `path=%2Fautomatewoo%2Freports`).
4. Sanity-check existing callers: pass an absolute path (`/foo`) or a bare segment (`workflows`) and confirm the output is unchanged from before this PR.

### Testing that has already taken place

- New Jest cases covering `./<segment>`, `../<segment>`, absolute paths and bare segments in `packages/js/navigation/src/test/index.js`.
- Full Jest suite for `@woocommerce/navigation`: 55 tests pass.
- ESLint clean on the changed files.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance:** Patch
**Type:** Fix

Fix `getNewPath` so a `path` argument starting with `./` or `../` is resolved against the current path, matching the documented behavior.

</details>

---

Generated by an AI agent on the RSMAPGJ pilot.