### PR TITLE
Fix Order Notes timestamps not following site timezone changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-328
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-328
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Order Notes timestamps now follow the site's current timezone instead of the timezone that was active when the note was created.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1176,11 +1176,33 @@ function wc_get_order_note( $data ) {
 		return null;
 	}
 
+	/*
+	 * Build the note's date from `comment_date_gmt` (which is stored in UTC) so
+	 * that the rendered timestamp reflects the site's *current* timezone setting
+	 * rather than the timezone that was in effect when the note was created.
+	 * Using `comment_date` (local time at insertion) would otherwise be reinterpreted
+	 * under the new timezone, which is the cause of woocommerce/woocommerce#48953.
+	 *
+	 * Fallback to `comment_date` if `comment_date_gmt` is empty (legacy data).
+	 */
+	if ( ! empty( $data->comment_date_gmt ) && '0000-00-00 00:00:00' !== $data->comment_date_gmt ) {
+		$timestamp = wc_string_to_timestamp( $data->comment_date_gmt );
+		$datetime  = new WC_DateTime( "@{$timestamp}", new DateTimeZone( 'UTC' ) );
+
+		if ( get_option( 'timezone_string' ) ) {
+			$datetime->setTimezone( new DateTimeZone( wc_timezone_string() ) );
+		} else {
+			$datetime->set_utc_offset( (int) wc_timezone_offset() );
+		}
+	} else {
+		$datetime = wc_string_to_datetime( $data->comment_date );
+	}
+
 	return (object) apply_filters(
 		'woocommerce_get_order_note',
 		array(
 			'id'            => (int) $data->comment_ID,
-			'date_created'  => wc_string_to_datetime( $data->comment_date ),
+			'date_created'  => $datetime,
 			'content'       => $data->comment_content,
 			'customer_note' => (bool) get_comment_meta( $data->comment_ID, 'is_customer_note', true ),
 			'added_by'      => __( 'WooCommerce', 'woocommerce' ) === $data->comment_author ? 'system' : $data->comment_author,

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1482,6 +1482,35 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Order note timestamps should reflect the site's *current* timezone, not
+	 * the timezone in effect when the note was created. Regression test for
+	 * woocommerce/woocommerce#48953.
+	 */
+	public function test_wc_get_order_note_uses_current_site_timezone() {
+		$original_tz = get_option( 'timezone_string' );
+
+		// Create the note while the site is in America/New_York.
+		update_option( 'timezone_string', 'America/New_York' );
+		$order   = WC_Helper_Order::create_order();
+		$note_id = (int) $order->add_order_note( 'Timezone test note' );
+
+		// Switch the site timezone to Asia/Tokyo.
+		update_option( 'timezone_string', 'Asia/Tokyo' );
+
+		$note = wc_get_order_note( $note_id );
+		$this->assertInstanceOf( 'WC_DateTime', $note->date_created );
+		$this->assertSame( 'Asia/Tokyo', $note->date_created->getTimezone()->getName() );
+
+		// Same UTC moment, both representations.
+		$comment      = get_comment( $note_id );
+		$expected_utc = strtotime( $comment->comment_date_gmt . ' UTC' );
+		$this->assertSame( $expected_utc, $note->date_created->getTimestamp() );
+
+		// Restore.
+		update_option( 'timezone_string', $original_tz );
+	}
+
+	/**
 	 * Test wc_get_order_notes().
 	 *
 	 * @since 3.2.0


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #48953.

Order Notes were resolving their displayed time via `wc_string_to_datetime( $data->comment_date )`, which interprets the stored value as the site's *current* local timezone. When the site timezone changes after a note is created, that local-time string gets reinterpreted under the new timezone, leaving the displayed note timestamp visually unchanged while the rest of the order screen (which is backed by GMT values) updates correctly.

This PR switches the source of truth in `wc_get_order_note()` to `comment_date_gmt` (which the comments table stores in UTC), builds the `WC_DateTime` from that UTC moment, and then applies the site's current timezone for display. The fallback path for legacy rows that never received a `comment_date_gmt` value continues to use the existing behaviour.

Linear: https://linear.app/a8c/issue/RSMAPGJ-328

### Screenshots or screen recordings:

N/A — display-only fix (timestamp string only).

### How to test the changes in this Pull Request:

1. In Settings → General, set the site timezone to a clearly distinct offset (e.g. `America/New_York`) and save.
2. Create a new order (any method) and mark it as `Completed` so a system order note is written. Open the order page and note the timestamp shown under Order Notes and the "Paid" timestamp at the top.
3. Go back to Settings → General and switch the timezone to another clearly distinct value (e.g. `Asia/Tokyo`, +14h from NY). Save.
4. Reload the order page. Confirm that:
   - The "Paid" timestamp at the top reflects the new timezone (this already worked).
   - The Order Notes timestamp now *also* reflects the new timezone (this is what was broken).
5. Switch the timezone back to the original and confirm the Order Notes timestamp returns to the original local time.

### Testing that has already taken place:

- Added a regression PHPUnit test `test_wc_get_order_note_uses_current_site_timezone` in `tests/legacy/unit-tests/order/class-wc-tests-order-functions.php` that creates a note under `America/New_York`, switches the site to `Asia/Tokyo`, and asserts the returned `WC_DateTime` is in `Asia/Tokyo` while still pointing at the same UTC moment as `comment_date_gmt`.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse includes/wc-order-functions.php --memory-limit=2G` — clean (no new baseline entries).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually at `plugins/woocommerce/changelog/fix-rsmapgj-328` (patch / fix).

---

Submitted via the RSMAPGJ AI Coder pipeline.