### PR TITLE
Fix JS console error when editing the Cart template in the Site Editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-336
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-336
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: No user-facing changelog entry needed — internal fix for an editor-only console error.
+
+Declare `postId` and `postType` attributes on the `woocommerce/page-content-wrapper` block to back the existing `providesContext` mapping, and stabilize the related `useEffect` dependencies. Fixes a JS console error when editing the Cart/Checkout templates in the Site Editor.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/block.json
@@ -14,6 +14,12 @@
 		"page": {
 			"type": "string",
 			"default": ""
+		},
+		"postId": {
+			"type": "number"
+		},
+		"postType": {
+			"type": "string"
 		}
 	},
 	"providesContext": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/index.tsx
@@ -50,7 +50,7 @@ const Edit = ( {
 				setAttributes( { postId, postType: 'page' } );
 			}
 		}
-	}, [ attributes, setAttributes ] );
+	}, [ attributes.page, attributes.postId, setAttributes ] );
 
 	return (
 		<div { ...blockProps }>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/test/block.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/test/block.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import metadata from '../block.json';
+
+describe( 'woocommerce/page-content-wrapper block metadata', () => {
+	it( 'declares the `postId` attribute that backs the `providesContext` mapping', () => {
+		// `providesContext.postId` maps to an attribute of the same name, so
+		// the attribute MUST be declared, otherwise inner blocks such as
+		// `core/post-title` / `core/post-content` receive an undefined
+		// context value and can throw in the editor.
+		expect( metadata.providesContext.postId ).toBe( 'postId' );
+		expect( metadata.attributes.postId ).toBeDefined();
+		expect( metadata.attributes.postId.type ).toBe( 'number' );
+	} );
+
+	it( 'declares the `postType` attribute that backs the `providesContext` mapping', () => {
+		expect( metadata.providesContext.postType ).toBe( 'postType' );
+		expect( metadata.attributes.postType ).toBeDefined();
+		expect( metadata.attributes.postType.type ).toBe( 'string' );
+	} );
+
+	it( 'still declares the original `page` attribute used by variations', () => {
+		expect( metadata.attributes.page ).toBeDefined();
+		expect( metadata.attributes.page.type ).toBe( 'string' );
+		expect( metadata.attributes.page.default ).toBe( '' );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines

<!-- Generated by the RSMAPGJ AI Coder pipeline. -->

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Best Practices for Pull Requests](https://github.com/woocommerce/woocommerce/wiki/Best-practices-for-Pull-Requests).

### Changes proposed in this Pull Request

The `woocommerce/page-content-wrapper` block declares `providesContext` for `postId` and `postType` so inner blocks (`core/post-title`, `core/post-content`) know which post to render. However the underlying attributes were never declared in `block.json`, so the context values remained undefined and downstream consumers in `@wordpress/core-data` and `@wordpress/block-editor` could throw `Cannot read properties of undefined (reading 'selection')` while loading the Page: Cart / Page: Checkout templates.

This PR:

- Adds `postId` (number) and `postType` (string) attributes to `block.json` so the `providesContext` mapping is actually backed by persisted attributes.
- Narrows the `useEffect` dependency list in `index.tsx` to the specific attribute fields the effect reads, preventing it from re-running on every unrelated render of the parent block.

Closes #42037
Linear: https://linear.app/a8c/issue/RSMAPGJ-336

### How to test the changes in this Pull Request

1. Activate a block theme (e.g. Twenty Twenty-Four).
2. Open the Site Editor → Templates and open the **Page: Cart** template with the browser console open.
3. Confirm no `Cannot read properties of undefined (reading 'selection')` JS error appears.
4. Repeat for the **Page: Checkout** template.

### Testing that has already taken place

- Added a Jest unit test for the block metadata; `pnpm --filter=@woocommerce/block-library test:js -- assets/js/blocks/page-content-wrapper` passes 3/3.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean (no PHP changes).
- ESLint clean on the modified TS/TSX files.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Added at `plugins/woocommerce/changelog/fix-rsmapgj-336`.

---

_This PR was prepared by the RSMAPGJ AI Coder pipeline._