### PR TITLE
Fix product attribute filter for Cyrillic (non-ASCII) term slugs

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-345
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-345
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product attribute filter widget returning no results when attribute term slugs use non-ASCII (e.g. Cyrillic) characters

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -1049,9 +1049,13 @@ class WC_Query {
 							continue;
 						}
 
-						$attribute    = wc_sanitize_taxonomy_name( str_replace( 'filter_', '', $key ) );
-						$taxonomy     = wc_attribute_taxonomy_name( $attribute );
-						$filter_terms = ! empty( $value ) ? explode( ',', wc_clean( wp_unslash( $value ) ) ) : array();
+						$attribute = wc_sanitize_taxonomy_name( str_replace( 'filter_', '', $key ) );
+						$taxonomy  = wc_attribute_taxonomy_name( $attribute );
+						// Note: do not pass the raw value through `wc_clean()`/`sanitize_text_field()` here,
+						// because those strip percent-encoded octets (e.g. `%d1%87...`) used by WordPress to
+						// represent non-ASCII term slugs such as Cyrillic. `sanitize_title()` is applied to
+						// each individual term below and handles the necessary encoding/cleanup.
+						$filter_terms = ! empty( $value ) ? array_filter( explode( ',', wp_unslash( $value ) ) ) : array();
 
 						if ( empty( $filter_terms ) || ! taxonomy_exists( $taxonomy ) || ! wc_attribute_taxonomy_id_by_name( $attribute ) ) {
 							continue;

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -75,10 +75,15 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 							continue;
 						}
 
-						$filter_name    = 'filter_' . wc_attribute_taxonomy_slug( $taxonomy );
-						$current_filter = isset( $_GET[ $filter_name ] ) ? explode( ',', wc_clean( wp_unslash( $_GET[ $filter_name ] ) ) ) : array(); // WPCS: input var ok, CSRF ok.
-						$current_filter = array_map( 'sanitize_title', $current_filter );
-						$new_filter     = array_diff( $current_filter, array( $term_slug ) );
+						$filter_name = 'filter_' . wc_attribute_taxonomy_slug( $taxonomy );
+						// Note: do not pass the raw value through `wc_clean()`/`sanitize_text_field()` here,
+						// because those strip percent-encoded octets (e.g. `%d1%87...`) used by WordPress to
+						// represent non-ASCII term slugs such as Cyrillic. `sanitize_title()` below handles cleanup.
+						// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+						$raw_filter_value = isset( $_GET[ $filter_name ] ) && is_string( $_GET[ $filter_name ] ) ? wp_unslash( $_GET[ $filter_name ] ) : '';
+						$current_filter   = '' !== $raw_filter_value ? explode( ',', $raw_filter_value ) : array();
+						$current_filter   = array_filter( array_map( 'sanitize_title', $current_filter ) );
+						$new_filter       = array_diff( $current_filter, array( $term_slug ) );
 
 						$link = remove_query_arg( array( 'add-to-cart', $filter_name ), $base_link );
 

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav.php
@@ -416,9 +416,13 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			}
 
 			$filter_name = 'filter_' . wc_attribute_taxonomy_slug( $taxonomy );
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$current_filter = isset( $_GET[ $filter_name ] ) ? explode( ',', wc_clean( wp_unslash( $_GET[ $filter_name ] ) ) ) : array();
-			$current_filter = array_map( 'sanitize_title', $current_filter );
+			// Note: do not pass the raw value through `wc_clean()`/`sanitize_text_field()` here,
+			// because those strip percent-encoded octets (e.g. `%d1%87...`) used by WordPress to
+			// represent non-ASCII term slugs such as Cyrillic. `sanitize_title()` below handles cleanup.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$raw_filter_value = isset( $_GET[ $filter_name ] ) && is_string( $_GET[ $filter_name ] ) ? wp_unslash( $_GET[ $filter_name ] ) : '';
+			$current_filter   = '' !== $raw_filter_value ? explode( ',', $raw_filter_value ) : array();
+			$current_filter   = array_filter( array_map( 'sanitize_title', $current_filter ) );
 
 			if ( ! in_array( $term->slug, $current_filter, true ) ) {
 				$current_filter[] = $term->slug;

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -562,9 +562,13 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 		foreach ( $query_vars as $key => $value ) {
 			if ( 0 === strpos( $key, 'filter_' ) ) {
-				$attribute    = wc_sanitize_taxonomy_name( str_replace( 'filter_', '', $key ) );
-				$taxonomy     = wc_attribute_taxonomy_name( $attribute );
-				$filter_terms = ! empty( $value ) ? explode( ',', wc_clean( wp_unslash( $value ) ) ) : array();
+				$attribute = wc_sanitize_taxonomy_name( str_replace( 'filter_', '', $key ) );
+				$taxonomy  = wc_attribute_taxonomy_name( $attribute );
+				// Note: do not pass the raw value through `wc_clean()`/`sanitize_text_field()` here,
+				// because those strip percent-encoded octets (e.g. `%d1%87...`) used by WordPress to
+				// represent non-ASCII term slugs such as Cyrillic. `sanitize_title()` is applied to
+				// each individual term below and handles the necessary encoding/cleanup.
+				$filter_terms = ! empty( $value ) && ( is_string( $value ) || is_numeric( $value ) ) ? array_filter( explode( ',', wp_unslash( (string) $value ) ) ) : array();
 
 				if ( empty( $filter_terms ) || ! taxonomy_exists( $taxonomy ) || ! wc_attribute_taxonomy_id_by_name( $attribute ) ) {
 					continue;

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -241,6 +241,132 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox 'get_layered_nav_chosen_attributes' preserves Cyrillic (percent-encoded) term slugs in $_GET filter values.
+	 *
+	 * Regression test for woo#33971 / RSMAPGJ-345: percent-encoded octets in the filter value
+	 * (the form WordPress uses for non-ASCII term slugs such as Cyrillic) were being stripped
+	 * by `sanitize_text_field`, causing the filter to silently match no products.
+	 */
+	public function test_get_layered_nav_chosen_attributes_preserves_cyrillic_slugs() {
+		// Create the attribute taxonomy and a term with a Cyrillic name so WordPress generates
+		// a percent-encoded slug, mirroring the real-world data the bug reporter has.
+		$attribute_id = wc_create_attribute(
+			array(
+				'name' => 'Цвят',
+				'slug' => 'cyat',
+				'type' => 'select',
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		$taxonomy = wc_attribute_taxonomy_name( 'cyat' );
+		register_taxonomy( $taxonomy, 'product' );
+
+		$term = wp_insert_term( 'червен', $taxonomy );
+		$this->assertIsArray( $term );
+		$expected_slug = get_term( $term['term_id'], $taxonomy )->slug;
+		$this->assertSame( '%d1%87%d0%b5%d1%80%d0%b2%d0%b5%d0%bd', $expected_slug );
+
+		// Simulate `$_GET['filter_cyat']` with the percent-encoded slug, as built by the
+		// layered nav widget and rebroadcast by the browser through PHP's auto-decode.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$previous_get = $_GET;
+		$_GET         = array( 'filter_cyat' => $expected_slug );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		WC_Query::reset_chosen_attributes();
+		$chosen = WC_Query::get_layered_nav_chosen_attributes();
+
+		$this->assertArrayHasKey( $taxonomy, $chosen );
+		$this->assertSame( array( $expected_slug ), $chosen[ $taxonomy ]['terms'] );
+
+		// Cleanup.
+		$_GET = $previous_get;
+		WC_Query::reset_chosen_attributes();
+		wp_delete_term( $term['term_id'], $taxonomy );
+		wc_delete_attribute( $attribute_id );
+	}
+
+	/**
+	 * @testdox 'get_layered_nav_chosen_attributes' continues to handle ASCII slugs correctly after the Cyrillic fix.
+	 */
+	public function test_get_layered_nav_chosen_attributes_handles_ascii_slugs() {
+		$attribute_id = wc_create_attribute(
+			array(
+				'name' => 'Color',
+				'slug' => 'color',
+				'type' => 'select',
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		$taxonomy = wc_attribute_taxonomy_name( 'color' );
+		register_taxonomy( $taxonomy, 'product' );
+
+		$term = wp_insert_term( 'Red', $taxonomy );
+		$this->assertIsArray( $term );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$previous_get = $_GET;
+		$_GET         = array( 'filter_color' => 'red' );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		WC_Query::reset_chosen_attributes();
+		$chosen = WC_Query::get_layered_nav_chosen_attributes();
+
+		$this->assertArrayHasKey( $taxonomy, $chosen );
+		$this->assertSame( array( 'red' ), $chosen[ $taxonomy ]['terms'] );
+
+		$_GET = $previous_get;
+		WC_Query::reset_chosen_attributes();
+		wp_delete_term( $term['term_id'], $taxonomy );
+		wc_delete_attribute( $attribute_id );
+	}
+
+	/**
+	 * @testdox 'get_layered_nav_chosen_attributes' splits comma-separated filter values.
+	 */
+	public function test_get_layered_nav_chosen_attributes_splits_comma_separated_values() {
+		$attribute_id = wc_create_attribute(
+			array(
+				'name' => 'Size',
+				'slug' => 'size',
+				'type' => 'select',
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		$taxonomy = wc_attribute_taxonomy_name( 'size' );
+		register_taxonomy( $taxonomy, 'product' );
+
+		$small  = wp_insert_term( 'Small', $taxonomy );
+		$medium = wp_insert_term( 'Medium', $taxonomy );
+		$this->assertIsArray( $small );
+		$this->assertIsArray( $medium );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$previous_get = $_GET;
+		$_GET         = array(
+			'filter_size'     => 'small,medium',
+			'query_type_size' => 'or',
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		WC_Query::reset_chosen_attributes();
+		$chosen = WC_Query::get_layered_nav_chosen_attributes();
+
+		$this->assertArrayHasKey( $taxonomy, $chosen );
+		$this->assertSame( array( 'small', 'medium' ), array_values( $chosen[ $taxonomy ]['terms'] ) );
+		$this->assertSame( 'or', $chosen[ $taxonomy ]['query_type'] );
+
+		$_GET = $previous_get;
+		WC_Query::reset_chosen_attributes();
+		wp_delete_term( $small['term_id'], $taxonomy );
+		wp_delete_term( $medium['term_id'], $taxonomy );
+		wc_delete_attribute( $attribute_id );
+	}
+
+	/**
 	 * @testdox A tax_query set by another plugin or hook before WC_Query's pre_get_posts survives the visibility merge.
 	 */
 	public function test_search_preserves_existing_tax_query() {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

The "Filter products by attribute" widget silently returned no results whenever the attribute term slug used non-ASCII characters (Bulgarian / Cyrillic in the original report). The same filter worked fine with English (ASCII) slugs.

Root cause: WordPress represents non-ASCII slugs as percent-encoded octets, e.g. `червен` is stored as `%d1%87%d0%b5%d1%80%d0%b2%d0%b5%d0%bd`. When the layered nav reads the query string back, it passes the value through `wc_clean()` → `sanitize_text_field()`, which contains:

```php
$filtered = preg_replace( '/%[a-f0-9]{2}/i', '', $filtered );
```

That strips every percent-encoded octet, leaving an empty string. The subsequent `sanitize_title()` then has nothing to work with, so the chosen-attributes list ends up empty and the SQL clause matches zero products.

`sanitize_title()` already produces a safe, correctly-encoded slug, so the intermediate `sanitize_text_field()` pass is unnecessary - and harmful for multibyte slugs. This PR drops it from the four code paths that read `filter_*` query args:

- `WC_Query::get_layered_nav_chosen_attributes` (classic shop layered nav)
- `Automattic\WooCommerce\Internal\ProductFilters\QueryClauses::get_chosen_attributes` (block-based filters)
- `WC_Widget_Layered_Nav` (filter link generation)
- `WC_Widget_Layered_Nav_Filters` (active filters widget)

Closes #33971
Linear: https://linear.app/a8c/issue/RSMAPGJ-345

### How to test the changes in this Pull Request

1. In wp-admin, create a product attribute (Products → Attributes) with slug `cyat`.
2. Add a term whose name is `червен` (Bulgarian for "red") - WordPress will generate the slug `%d1%87%d0%b5%d1%80%d0%b2%d0%b5%d0%bd`.
3. Create a simple product, assign the `cyat` attribute and the `червен` term, mark the attribute "Visible on the product page".
4. Add the "Filter Products by Attribute" widget (or block) configured for the `cyat` attribute to the shop sidebar.
5. Visit `/shop/?filter_cyat=%D1%87%D0%B5%D1%80%D0%B2%D0%B5%D0%BD`.

**Before the fix:** the page shows "No products were found matching your selection."
**After the fix:** the seeded product appears.

Repeat with an English attribute (e.g. `pa_color=red`) to confirm there is no regression for ASCII slugs.

### Testing that has already taken place

- Added three regression tests in `tests/php/includes/class-wc-query-test.php` (Cyrillic, ASCII, comma-separated).
- `phpcs-changed` (WooCommerce + WordPress rulesets) passes with no errors or warnings.
- `composer exec -- phpstan analyse` passes with no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passes.
- Verified directly via `wp eval` that the new code path preserves percent-encoded slugs (returning `%d1%87...`) where the old code returned an empty array.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (`changelog/fix-rsmapgj-345` already committed.)

### Milestone

- [x] Auto-assign milestone

---

_Submitted via the RSMAPGJ AI Coder pipeline._