### PR TITLE
Guard OrdersTableQuery against TypeError on malformed date args

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-320
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-320
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Guard OrdersTableQuery date arg processing against non-scalar and unparseable inputs so wc_get_orders() returns an empty result set instead of producing a TypeError when an extension or snippet passes malformed arguments.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -346,6 +346,7 @@ class OrdersTableQuery {
 	 *
 	 * @param mixed $date The date. Can be a {@see \WC_DateTime}, a timestamp or a string.
 	 * @return array An array with keys 'year', 'month', 'day' and possibly 'hour', 'minute' and 'second'.
+	 * @throws \Exception If $date is not a supported type or cannot be parsed.
 	 */
 	private function date_to_date_query_arg( $date ): array {
 		$result = array(
@@ -359,9 +360,20 @@ class OrdersTableQuery {
 			$date      = new \WC_DateTime( "@{$date}", new \DateTimeZone( 'UTC' ) );
 			$precision = 'second';
 		} elseif ( ! is_a( $date, 'WC_DateTime' ) ) {
+			if ( ! is_string( $date ) ) {
+				// Reject non-scalar/non-string inputs (e.g. arrays or objects passed in error)
+				// so that strtotime() is never invoked with an unsupported type.
+				throw new \Exception( 'Invalid date_query' );
+			}
+
+			$timestamp = strtotime( $date );
+			if ( false === $timestamp ) {
+				throw new \Exception( 'Invalid date_query' );
+			}
+
 			// For backwards compat (see https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-orders/#date)
 			// only YYYY-MM-DD is considered for date values. Timestamps do support second precision.
-			$date      = wc_string_to_datetime( date( 'Y-m-d', strtotime( $date ) ) );
+			$date      = wc_string_to_datetime( date( 'Y-m-d', $timestamp ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- preserves original local-time parsing behaviour.
 			$precision = 'day';
 		}
 
@@ -385,17 +397,42 @@ class OrdersTableQuery {
 	 * @param  string $operator One of the operators supported by date queries (<, <=, =, ..., >, >=).
 	 * @return array Partial date query arg with relevant dates now UTC-based.
 	 *
-	 * @throws \Exception If an invalid date shorthand operator is specified.
+	 * @throws \Exception If an invalid date shorthand operator is specified, or if $dates_raw contains values that cannot be parsed as dates.
 	 *
 	 * @since 8.2.0
 	 */
 	private function local_time_to_gmt_date_query( $dates_raw, $operator ) {
 		$result = array();
 
+		if ( ! is_array( $dates_raw ) || empty( $dates_raw ) ) {
+			throw new \Exception( 'Invalid date_query' );
+		}
+
 		// Convert YYYY-MM-DD to UTC timestamp. Per https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-orders/#date only date is relevant (time is ignored).
 		foreach ( $dates_raw as &$raw_date ) {
-			$raw_date = is_numeric( $raw_date ) ? $raw_date : strtotime( get_gmt_from_date( date( 'Y-m-d', strtotime( $raw_date ) ) ) );
+			if ( is_numeric( $raw_date ) ) {
+				continue;
+			}
+
+			if ( ! is_string( $raw_date ) ) {
+				// Guard against non-scalar input (e.g. arrays/objects passed by extensions) that would
+				// otherwise trigger a TypeError inside strtotime().
+				throw new \Exception( 'Invalid date_query' );
+			}
+
+			$local_timestamp = strtotime( $raw_date );
+			if ( false === $local_timestamp ) {
+				throw new \Exception( 'Invalid date_query' );
+			}
+
+			$gmt_timestamp = strtotime( get_gmt_from_date( date( 'Y-m-d', $local_timestamp ) ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- preserves original local-time parsing behaviour.
+			if ( false === $gmt_timestamp ) {
+				throw new \Exception( 'Invalid date_query' );
+			}
+
+			$raw_date = $gmt_timestamp;
 		}
+		unset( $raw_date );
 
 		$date1 = end( $dates_raw );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -790,4 +790,57 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 		$order2->delete( true );
 		$order3->delete( true );
 	}
+
+	/**
+	 * @testDox Invalid (non-scalar) date arguments are rejected with an Exception instead of triggering a TypeError fatal.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/58259 where third-party snippets
+	 * passing junk (arrays/non-parseable strings) to `wc_get_orders` could fatal inside `OrdersTableQuery`.
+	 *
+	 * @dataProvider data_invalid_date_inputs_are_rejected
+	 *
+	 * @param mixed $bad_value Bad date value to feed the query.
+	 */
+	public function test_invalid_date_inputs_are_rejected( $bad_value ): void {
+		$this->expectException( \Exception::class );
+
+		new OrdersTableQuery(
+			array(
+				'date_created' => $bad_value,
+				'return'       => 'ids',
+			)
+		);
+	}
+
+	/**
+	 * Data provider with bad inputs that historically reached `strtotime()` and produced a TypeError.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function data_invalid_date_inputs_are_rejected(): array {
+		return array(
+			'array given for date'           => array( array( 'not-an-array-but-passed-one' ) ),
+			'unparseable date string'        => array( 'this-is-not-a-date' ),
+			'boolean given for date'         => array( true ),
+			'array of arrays via date_query' => array( array( array( 'foo' ) ) ),
+		);
+	}
+
+	/**
+	 * @testDox The OrdersTableDataStore boundary swallows invalid date_query input and returns an empty result set.
+	 *
+	 * Confirms that the controlled \Exception thrown by OrdersTableQuery does not bubble out of
+	 * `wc_get_orders` and therefore replaces the historical fatal with an empty result.
+	 */
+	public function test_invalid_date_input_results_in_empty_orders_via_wc_get_orders(): void {
+		$result = wc_get_orders(
+			array(
+				'date_created' => array( 'unexpected', 'array' ),
+				'return'       => 'ids',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When third-party snippet plugins or extensions pass non-scalar or unparseable values to `wc_get_orders()` (for example `'date_created' => ['foo']` or `'date_paid' => 'not-a-date'`), the date-arg processing path in `OrdersTableQuery` could invoke `strtotime()` with a non-string argument and trigger a PHP `TypeError`. This took down admin requests and produced fatal-error spikes attributed to the `code-snippets` plugin in production logs.

This PR:

- Adds controlled type guards in `OrdersTableQuery::date_to_date_query_arg()` and `OrdersTableQuery::local_time_to_gmt_date_query()` that reject non-scalar inputs and unparseable date strings (where `strtotime()` returns `false`) with a regular `\Exception('Invalid date_query')` instead of letting the values reach `strtotime()`.
- Keeps existing behaviour for all valid inputs.
- Relies on the existing `OrdersTableDataStore::query()` `catch ( \Exception $e )` boundary which already swallows query-construction exceptions and returns an empty result set. The net effect is that malformed `wc_get_orders()` calls now return `[]` instead of fatalling.

Closes #58259

Tracking: [RSMAPGJ-320](https://linear.app/a8c/issue/RSMAPGJ-320)

### How to test the changes in this Pull Request:

1. With HPOS enabled, drop the following into a mu-plugin (e.g. `wp-content/mu-plugins/qa-bad-wc-get-orders.php`):
   ```php
   <?php
   add_action( 'init', function () {
       if ( isset( $_GET['qa_trigger_bad_orders'] ) ) {
           $orders = wc_get_orders( array(
               'date_created' => array( 'not-an-array-but-passed-one' ),
               'return'       => 'ids',
           ) );
           echo '<!-- QA: orders=' . count( (array) $orders ) . ' -->';
       }
   } );
   ```
2. Visit `/wp-admin/?qa_trigger_bad_orders=1`.
3. **Before this PR:** the request returns HTTP 500 with a `TypeError: strtotime(): Argument #1 ($datetime) must be of type string, array given` fatal originating in `OrdersTableQuery.php`.
4. **After this PR:** the request renders normally and the HTML source contains `<!-- QA: orders=0 -->`.
5. Sanity check that valid date queries still work: `wc_get_orders( array( 'date_created' => '2024-01-01...2024-12-31', 'return' => 'ids' ) )` returns matching order IDs as before.

### Testing that has already taken place:

- Added unit tests in `OrdersTableQueryTests` covering arrays, booleans, unparseable strings, and nested-array inputs to `date_created`, and asserting that `wc_get_orders()` returns an empty array (instead of fatalling) at the data-store boundary.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `composer exec -- phpstan analyse src/Internal/DataStores/Orders/OrdersTableQuery.php --memory-limit=2G` clean (no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog file `plugins/woocommerce/changelog/fix-rsmapgj-320` added manually.)

---

_Submitted via the **RSMAPGJ AI Coder pipeline**._