### PR TITLE
Fix Analytics crash when customer-effort-score-tracks feature is disabled

### DIFF
--- a/packages/js/customer-effort-score/changelog/fix-rsmapgj-319
+++ b/packages/js/customer-effort-score/changelog/fix-rsmapgj-319
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Analytics crashing with "Cannot destructure property 'createSuccessNotice'" when the customer-effort-score-tracks feature is disabled.

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
@@ -16,7 +16,19 @@ import { ADMIN_INSTALL_TIMESTAMP_OPTION_NAME } from '../../constants';
 import store from '../../store';
 
 export const CustomerEffortScoreModalContainer = () => {
-	const { createSuccessNotice } = useDispatch( 'core/notices' );
+	// The `core/notices` store is provided by WordPress core. In some
+	// environments (e.g. when the `customer-effort-score-tracks` feature is
+	// disabled and the notices script dependency isn't enqueued) `useDispatch`
+	// can return `null`, which would otherwise crash with a TypeError when
+	// destructuring. Fall back to a no-op so Analytics and other pages that
+	// render this container do not break.
+	const noticesDispatch = useDispatch( 'core/notices' ) as {
+		createSuccessNotice?: (
+			content: string,
+			options?: Record< string, unknown >
+		) => void;
+	} | null;
+	const createSuccessNotice = noticesDispatch?.createSuccessNotice;
 	const { hideCesModal } = useDispatch( store );
 	const {
 		storeAgeInWeeks,
@@ -59,14 +71,16 @@ export const CustomerEffortScoreModalContainer = () => {
 			...visibleCESModalData.tracksProps,
 		} );
 
-		createSuccessNotice(
-			visibleCESModalData.onSubmitLabel ||
-				__(
-					"Thanks for the feedback. We'll put it to good use!",
-					'woocommerce'
-				),
-			visibleCESModalData.onSubmitNoticeProps || {}
-		);
+		if ( createSuccessNotice ) {
+			createSuccessNotice(
+				visibleCESModalData.onSubmitLabel ||
+					__(
+						"Thanks for the feedback. We'll put it to good use!",
+						'woocommerce'
+					),
+				visibleCESModalData.onSubmitNoticeProps || {}
+			);
+		}
 	};
 
 	if ( ! visibleCESModalData || isLoading ) {

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/test/index.tsx
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/test/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { CustomerEffortScoreModalContainer } from '..';
+
+jest.mock( '@wordpress/data', () => {
+	const originalModule = jest.requireActual( '@wordpress/data' );
+
+	return {
+		__esModule: true,
+		...originalModule,
+		useDispatch: jest.fn(),
+		useSelect: jest.fn(),
+	};
+} );
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+const mockedUseDispatch = useDispatch as jest.Mock;
+const mockedUseSelect = useSelect as jest.Mock;
+
+describe( 'CustomerEffortScoreModalContainer', () => {
+	beforeEach( () => {
+		mockedUseSelect.mockReturnValue( {
+			storeAgeInWeeks: 1,
+			resolving: false,
+			visibleCESModalData: null,
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should not throw when the core/notices store dispatch is null', () => {
+		// Simulate the bug condition: useDispatch( 'core/notices' ) returns
+		// null because the WordPress notices script dependency is missing
+		// (reproduced when the customer-effort-score-tracks feature is
+		// disabled and the notices store isn't registered).
+		mockedUseDispatch.mockImplementation( ( storeKey: string ) => {
+			if ( storeKey === 'core/notices' ) {
+				return null;
+			}
+			return { hideCesModal: jest.fn() };
+		} );
+
+		expect( () =>
+			render( <CustomerEffortScoreModalContainer /> )
+		).not.toThrow();
+	} );
+
+	it( 'should render null when no visible CES modal data', () => {
+		mockedUseDispatch.mockImplementation( ( storeKey: string ) => {
+			if ( storeKey === 'core/notices' ) {
+				return { createSuccessNotice: jest.fn() };
+			}
+			return { hideCesModal: jest.fn() };
+		} );
+
+		const { container } = render( <CustomerEffortScoreModalContainer /> );
+		expect( container.firstChild ).toBeNull();
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-rsmapgj-319
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-319
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Bumps the @woocommerce/customer-effort-score dependency which contains the bug fix.
+
+Fix Analytics crashing with "Cannot destructure property 'createSuccessNotice'" when the customer-effort-score-tracks feature is disabled.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the `customer-effort-score-tracks` feature flag is disabled, the WordPress core `core/notices` store is not registered for the Analytics admin pages. `useDispatch( 'core/notices' )` returns `null` in `CustomerEffortScoreModalContainer`, and destructuring `createSuccessNotice` crashed every Analytics page with:

```
TypeError: Cannot destructure property 'createSuccessNotice' of '(0 , i.useDispatch)(...)' as it is null.
```

This took down all Analytics pages with the "Oops, something went wrong" overlay.

This PR hardens `CustomerEffortScoreModalContainer` by reading the `createSuccessNotice` action defensively and skipping the success-notice call when the dispatcher isn't available. The container is a non-essential UI surface in this state, so silent degradation is preferable to crashing the host page.

Closes #63745
Linear: https://linear.app/a8c/issue/RSMAPGJ-319

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment):

1. Add a mu-plugin (`wp-content/mu-plugins/disable-ces-tracks.php`) that disables the `customer-effort-score-tracks` feature flag:
   ```php
   <?php
   add_filter( 'woocommerce_admin_get_feature_config', function( $features ) {
       if ( isset( $features['customer-effort-score-tracks'] ) ) {
           $features['customer-effort-score-tracks'] = false;
       }
       return $features;
   } );
   ```
2. Navigate to **WooCommerce → Analytics → Overview** (`/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`).
3. **Before this PR:** the page crashes with the "Oops, something went wrong" error overlay and the console logs the destructuring `TypeError`.
4. **After this PR:** the Analytics page renders normally, and no `createSuccessNotice` console error appears.
5. Repeat for other Analytics pages (Revenue, Orders, Products, etc.) to confirm none crash.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<!-- Use one of the values below for the significance: patch, minor, major. -->

**Significance:** patch

<!-- Use one of the values below for the type: fix, add, update, dev, tweak, performance, enhancement. -->

**Type:** fix

**Message:** Fix Analytics crashing with "Cannot destructure property 'createSuccessNotice'" when the customer-effort-score-tracks feature is disabled.

---

_Submitted via the RSMAPGJ AI Coder pipeline._