### PR TITLE
Fix: sync checked attribute on checkout payment method radios

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-312
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-312
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sync the `checked` HTML attribute on checkout payment method radios so CSS and jQuery selectors targeting `[checked]` reflect the current selection.

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -274,6 +274,17 @@ jQuery( function ( $ ) {
 		payment_method_selected: function ( e ) {
 			e.stopPropagation();
 
+			// Sync the `checked` HTML attribute with the selected radio so that
+			// CSS / jQuery selectors targeting `[checked]` reflect the current
+			// selection (the browser updates the `checked` *property* on click
+			// but never the attribute, leaving the originally-rendered method
+			// marked as checked in the DOM source). See #25887.
+			var $payment_method_radios = $(
+				'input[name="payment_method"]'
+			);
+			$payment_method_radios.removeAttr( 'checked' );
+			$( this ).attr( 'checked', 'checked' );
+
 			if ( $( '.payment_methods input.input-radio' ).length > 1 ) {
 				var target_payment_box = $(
 						'div.payment_box.' + $( this ).attr( 'ID' )

--- a/plugins/woocommerce/client/legacy/js/frontend/test/checkout-payment-method-selected.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/checkout-payment-method-selected.js
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment jest-fixed-jsdom
+ *
+ * Regression tests for the payment method radio click handler in
+ * `checkout.js`. See issue woo#25887 (RSMAPGJ-312): clicking a payment method
+ * radio must keep the HTML `checked` attribute in sync with the selection so
+ * that CSS / jQuery selectors targeting `[checked]` reflect the current state.
+ */
+
+describe( 'checkout.js payment_method_selected', () => {
+	let $form;
+	let $paymentRadios;
+	let paymentClickHandler;
+	let nodeWrappers;
+
+	beforeEach( () => {
+		nodeWrappers = new Map();
+
+		// Reset window state.
+		delete global.window.wc;
+
+		// Tracks attr/removeAttr calls on the radio collection.
+		$paymentRadios = {
+			length: 2,
+			removeAttr: jest.fn( () => $paymentRadios ),
+		};
+
+		const createDefaultMock = () => {
+			const mock = {
+				length: 0,
+				on: jest.fn( () => mock ),
+				off: jest.fn( () => mock ),
+				attr: jest.fn( () => mock ),
+				removeAttr: jest.fn( () => mock ),
+				find: jest.fn( () => createDefaultMock() ),
+				first: jest.fn( () => createDefaultMock() ),
+				filter: jest.fn( () => createDefaultMock() ),
+				eq: jest.fn( () => createDefaultMock() ),
+				trigger: jest.fn( () => mock ),
+				val: jest.fn(),
+				prop: jest.fn( () => mock ),
+				each: jest.fn( () => mock ),
+				data: jest.fn(),
+				serialize: jest.fn( () => '' ),
+				addClass: jest.fn( () => mock ),
+				removeClass: jest.fn( () => mock ),
+				hasClass: jest.fn( () => false ),
+				is: jest.fn( () => false ),
+				get: jest.fn( () => [] ),
+				text: jest.fn( () => '' ),
+				html: jest.fn( () => '' ),
+				closest: jest.fn( () => createDefaultMock() ),
+				parent: jest.fn( () => createDefaultMock() ),
+				parents: jest.fn( () => createDefaultMock() ),
+				siblings: jest.fn( () => createDefaultMock() ),
+				children: jest.fn( () => createDefaultMock() ),
+				append: jest.fn( () => mock ),
+				prepend: jest.fn( () => mock ),
+				remove: jest.fn( () => mock ),
+				empty: jest.fn( () => mock ),
+				show: jest.fn( () => mock ),
+				hide: jest.fn( () => mock ),
+				css: jest.fn( () => mock ),
+				slideUp: jest.fn( () => mock ),
+				slideDown: jest.fn( () => mock ),
+				fadeIn: jest.fn( () => mock ),
+				fadeOut: jest.fn( () => mock ),
+				offset: jest.fn( () => ( { top: 0, left: 0 } ) ),
+				width: jest.fn( () => 0 ),
+				height: jest.fn( () => 0 ),
+				outerWidth: jest.fn( () => 0 ),
+				outerHeight: jest.fn( () => 0 ),
+				scrollTop: jest.fn( () => 0 ),
+				focus: jest.fn( () => mock ),
+				blur: jest.fn( () => mock ),
+				block: jest.fn( () => mock ),
+				unblock: jest.fn( () => mock ),
+			};
+			return mock;
+		};
+
+		// Capture the delegated click handler bound to the payment method radios.
+		paymentClickHandler = null;
+		$form = {
+			length: 1,
+			on: jest.fn( ( event, selectorOrHandler, maybeHandler ) => {
+				if (
+					event === 'click' &&
+					selectorOrHandler === 'input[name="payment_method"]'
+				) {
+					paymentClickHandler = maybeHandler;
+				}
+				return $form;
+			} ),
+			attr: jest.fn( () => $form ),
+			trigger: jest.fn( () => $form ),
+			find: jest.fn( () => createDefaultMock() ),
+		};
+
+		const bodyEventHandlers = {};
+		const mockBody = {
+			on: jest.fn( ( event, handler ) => {
+				bodyEventHandlers[ event ] = ( bodyEventHandlers[ event ] || [] ).concat(
+					handler
+				);
+				return mockBody;
+			} ),
+			trigger: jest.fn( ( event, args ) => {
+				( bodyEventHandlers[ event ] || [] ).forEach( ( h ) =>
+					h( {}, ...( args || [] ) )
+				);
+				return mockBody;
+			} ),
+			hasClass: jest.fn( () => false ),
+		};
+
+		const jQueryMock = jest.fn( ( selectorOrCallback ) => {
+			if ( typeof selectorOrCallback === 'function' ) {
+				selectorOrCallback( jQueryMock );
+				return jQueryMock;
+			}
+			if (
+				selectorOrCallback &&
+				typeof selectorOrCallback === 'object' &&
+				nodeWrappers.has( selectorOrCallback )
+			) {
+				return nodeWrappers.get( selectorOrCallback );
+			}
+			if ( selectorOrCallback === 'form.checkout' ) {
+				return $form;
+			}
+			if ( selectorOrCallback === '#order_review' ) {
+				return {
+					length: 0,
+					on: jest.fn(),
+					attr: jest.fn(),
+					find: jest.fn( () => ( { length: 0, val: jest.fn() } ) ),
+				};
+			}
+			if ( selectorOrCallback === 'html, body' ) {
+				return { animate: jest.fn() };
+			}
+			if ( selectorOrCallback === document.body ) {
+				return mockBody;
+			}
+			if ( selectorOrCallback === 'input[name="payment_method"]' ) {
+				return $paymentRadios;
+			}
+			return createDefaultMock();
+		} );
+		jQueryMock.blockUI = { defaults: { overlayCSS: {} } };
+
+		global.window.jQuery = jQueryMock;
+		global.window.$ = jQueryMock;
+		global.jQuery = jQueryMock;
+		global.$ = jQueryMock;
+
+		global.window.wc_checkout_params = {
+			gateways_with_custom_place_order_button: [],
+		};
+
+		global.window.wc = {
+			customPlaceOrderButton: {
+				__getForm: jest.fn( () => $form ),
+				__maybeShow: jest.fn(),
+				__maybeHideDefaultButtonOnInit: jest.fn(),
+				__cleanup: jest.fn(),
+			},
+		};
+
+		jest.resetModules();
+		require( '../checkout' );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'binds a click handler on payment method radios during init', () => {
+		expect( paymentClickHandler ).toEqual( expect.any( Function ) );
+	} );
+
+	test( 'clears the checked attribute on all payment method radios when a method is clicked', () => {
+		// Mock `this` (the clicked radio) with the minimum jQuery surface used
+		// by the handler.
+		const $clickedRadio = {
+			attr: jest.fn( () => $clickedRadio ),
+			is: jest.fn( () => true ),
+			val: jest.fn( () => 'cod' ),
+			data: jest.fn(),
+		};
+
+		// The handler calls `$( this )` — register the raw node so the
+		// captured `$` returns our mock wrapper.
+		const rawNode = {};
+		nodeWrappers.set( rawNode, $clickedRadio );
+
+		paymentClickHandler.call( rawNode, { stopPropagation: jest.fn() } );
+
+		expect( $paymentRadios.removeAttr ).toHaveBeenCalledWith( 'checked' );
+		expect( $clickedRadio.attr ).toHaveBeenCalledWith(
+			'checked',
+			'checked'
+		);
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

On the legacy shortcode checkout, clicking a payment method radio updates the `checked` *property* but never the `checked` *attribute*, so the HTML source keeps `checked="checked"` on whichever method was rendered server-side, no matter which radio the user actually selected. Selectors like `input[name="payment_method"][checked]` (CSS or jQuery) therefore stop reflecting the live selection.

This PR updates the `payment_method_selected` click handler in `plugins/woocommerce/client/legacy/js/frontend/checkout.js` to:

- Clear the `checked` attribute on every `input[name="payment_method"]` radio.
- Set `checked="checked"` on the clicked radio.

This keeps the attribute in sync with the property without changing any other behavior (the existing `slideUp` / `slideDown` of payment boxes, the `payment_method_selected` event, the custom place order button hook, etc., are untouched).

Closes #25887.
Linear: https://linear.app/a8c/issue/RSMAPGJ-312

### Screenshots or screen recordings

N/A — DOM-only fix; visually identical.

### How to test the changes in this Pull Request

1. On a clean install, enable two payment methods (e.g. Cash on Delivery + any other gateway).
2. Add a product to the cart and go to the shortcode checkout (`/checkout/`).
3. Open the browser devtools Elements panel and inspect the `<input name="payment_method">` radios under `#payment`.
4. Click the second payment method.
5. Confirm in the Elements panel that the `checked="checked"` attribute has moved to the newly-selected radio and has been removed from the previously-selected one.
6. Run the unit tests: `pnpm --filter=@woocommerce/classic-assets test:js --testPathPattern=checkout-payment-method-selected`.

### Testing that has already taken place

- New Jest unit test `js/frontend/test/checkout-payment-method-selected.js` covers the click handler.
- Full `@woocommerce/classic-assets` Jest suite passes (6 suites, 127 tests).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean (no PHP changes).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean (only pre-existing `no-console` warnings on unrelated lines).
- ESLint on the modified file: only pre-existing warnings, no new ones.

### Milestone

- [x] Auto-assign milestone.

### Changelog entry

- [x] Changelog entry added manually: `plugins/woocommerce/changelog/fix-rsmapgj-312` (`Significance: patch`, `Type: fix`).

---

_Submitted by the RSMAPGJ AI Coder pipeline._