### PR TITLE
Fix customer.deleted webhook not firing for non-customer roles

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-294
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-294
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fire the customer.deleted webhook for any deleted WordPress user, matching the behavior of customer.created and customer.updated.

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -190,9 +190,6 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			case 'untrashed_post':
 				$return = $this->is_valid_post_action( $arg );
 				break;
-			case 'delete_user':
-				$return = $this->is_valid_user_action( $arg );
-				break;
 		}
 
 		if ( 0 === strpos( $current_action, 'woocommerce_process_shop' ) || 0 === strpos( $current_action, 'woocommerce_process_product' ) ) {
@@ -219,24 +216,6 @@ class WC_Webhook extends WC_Legacy_Webhook {
 		if ( isset( $GLOBALS['post_type'] ) && str_replace( 'shop_', '', $GLOBALS['post_type'] ) !== $this->get_resource() ) {
 			return false;
 		}
-		return true;
-	}
-
-	/**
-	 * Validates user actions.
-	 *
-	 * @since  3.6.0
-	 * @param  mixed $arg First hook argument.
-	 * @return bool       True if validation passes.
-	 */
-	private function is_valid_user_action( $arg ) {
-		$user = get_userdata( absint( $arg ) );
-
-		// Only deliver deleted customer event for users with customer role.
-		if ( ! $user || ! in_array( 'customer', (array) $user->roles, true ) ) {
-			return false;
-		}
-
 		return true;
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
@@ -112,4 +112,71 @@ class WC_Webhook_Test extends WC_Unit_Test_Case {
 		$this->assertSame( 999, $webhook2->get_user_id() );
 	}
 
+	/**
+	 * @testDox The customer.deleted webhook should be considered valid for any deleted user regardless of role.
+	 *
+	 * Mirrors the behavior of customer.created (user_register) and customer.updated (profile_update),
+	 * which fire for any user. Previously the delete_user hook was gated to users with the
+	 * 'customer' role only, which caused customer.deleted to silently skip non-customer users.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/36734
+	 */
+	public function test_customer_deleted_webhook_is_enqueued_for_any_role() {
+		$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'rsmapgj_294_subscriber',
+				'user_email' => 'rsmapgj_294_subscriber@example.com',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+
+		$customer_id = wp_insert_user(
+			array(
+				'user_login' => 'rsmapgj_294_customer',
+				'user_email' => 'rsmapgj_294_customer@example.com',
+				'user_pass'  => 'password',
+				'role'       => 'customer',
+			)
+		);
+
+		$webhook = new WC_Webhook();
+		$webhook->set_name( 'rsmapgj-294-customer-deleted' );
+		$webhook->set_topic( 'customer.deleted' );
+		$webhook->set_status( 'active' );
+		$webhook->set_delivery_url( 'https://example.test/webhook' );
+		$webhook->set_secret( 'secret' );
+		$webhook->save();
+
+		// Spy on enqueued deliveries via the woocommerce_webhook_should_deliver filter,
+		// which receives the webhook, the hook arg, and the current_action() at the point of evaluation.
+		$delivered_for = array();
+		$spy           = function ( $should_deliver, $hook_webhook, $arg ) use ( $webhook, &$delivered_for ) {
+			if ( $hook_webhook->get_id() === $webhook->get_id() && $should_deliver ) {
+				$delivered_for[] = (int) $arg;
+			}
+			// Prevent actual HTTP delivery in the test.
+			return false;
+		};
+		add_filter( 'woocommerce_webhook_should_deliver', $spy, 10, 3 );
+
+		try {
+			wp_delete_user( $subscriber_id );
+			wp_delete_user( $customer_id );
+		} finally {
+			remove_filter( 'woocommerce_webhook_should_deliver', $spy, 10 );
+		}
+
+		$this->assertContains(
+			$subscriber_id,
+			$delivered_for,
+			'customer.deleted should be enqueued for a deleted subscriber user.'
+		);
+		$this->assertContains(
+			$customer_id,
+			$delivered_for,
+			'customer.deleted should be enqueued for a deleted customer user.'
+		);
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `customer.deleted` webhook silently skipped any deleted user whose primary role was not `customer` (subscribers, shop managers, administrators, etc.), even though `customer.created` and `customer.updated` fire for every user regardless of role. The asymmetry came from `WC_Webhook::is_valid_user_action()`, which gated the `delete_user` hook on `in_array( 'customer', $user->roles, true )`.

This PR removes that gate so `customer.deleted` is delivered for any deleted WordPress user, matching the behavior of the other two `customer.*` topics and the WooCommerce webhook contract.

Closes #36734.

Linear: https://linear.app/a8c/issue/RSMAPGJ-294

### How to test the changes in this Pull Request:

1. In WP Admin, create a user with a non-customer role (e.g. `subscriber` or `shop_manager`).
2. Go to **WooCommerce → Settings → Advanced → Webhooks** and add an active webhook with topic `Customer deleted`, pointing at a sink you can inspect (e.g. https://webhook.site).
3. Delete the subscriber from **Users → All Users**.
4. Confirm a `customer.deleted` payload was delivered to the sink.
5. Repeat with a user that has the `customer` role and confirm delivery still works (regression check).

### Testing that has already taken place:

- Added a new unit test (`test_customer_deleted_webhook_is_enqueued_for_any_role`) in `class-wc-webhook-tests.php` that creates a subscriber and a customer, deletes both, and asserts the `customer.deleted` webhook was enqueued for each via the `woocommerce_webhook_should_deliver` filter spy.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/class-wc-webhook.php --memory-limit=2G` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.
- [x] This Pull Request does not require a changelog entry. (Changelog entry already added: `plugins/woocommerce/changelog/fix-rsmapgj-294`.)

<details>

**Significance**: Patch
**Type**: Fix

Fire the customer.deleted webhook for any deleted WordPress user, matching the behavior of customer.created and customer.updated.

</details>

---

_Submitted by the RSMAPGJ AI Coder pipeline._
