### PR TITLE
Fix: Render SKU block for variable products without a parent SKU

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-285
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-285
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render the Product SKU block with an "N/A" placeholder for variable products that have no parent SKU, so the interactive layer can swap in the variation SKU on selection (matching the classic theme's single-product/meta.php behavior).

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -63,14 +63,19 @@ class ProductSKU extends AbstractBlock {
 			return '';
 		}
 
-		$product_sku = $product->get_sku();
+		$product_sku                         = $product->get_sku();
+		$is_descendant_of_product_collection = isset( $block->context['query']['isProductCollectionBlock'] );
+		$is_variable_product                 = $product->is_type( ProductType::VARIABLE );
 
-		if ( ! $product_sku ) {
+		// Variable products may have no parent SKU while their variations do. In that case,
+		// render the block with a placeholder ("N/A") so the interactive layer can swap in
+		// the variation SKU once a variation is selected. This matches the classic theme's
+		// single-product/meta.php template behavior.
+		if ( ! $product_sku && ! $is_variable_product ) {
 			return '';
 		}
 
-		$is_descendant_of_product_collection = isset( $block->context['query']['isProductCollectionBlock'] );
-		$is_interactive                      = ! $is_descendant_of_product_collection && $product->is_type( ProductType::VARIABLE );
+		$is_interactive = ! $is_descendant_of_product_collection && $is_variable_product;
 
 		if ( $is_interactive ) {
 			wp_enqueue_script_module( 'woocommerce/product-elements' );
@@ -90,6 +95,10 @@ class ProductSKU extends AbstractBlock {
 
 		$interactive_attributes = $is_interactive ? 'data-wp-interactive="woocommerce/products" data-wp-text="state.productInContext.sku"' : '';
 
+		// When the parent product has no SKU (variable products only at this point), fall back
+		// to "N/A" until a variation is selected on the client, matching classic theme behavior.
+		$displayed_sku = $product_sku ? $product_sku : esc_html__( 'N/A', 'woocommerce' );
+
 		return sprintf(
 			'<div class="wc-block-components-product-sku wc-block-grid__product-sku wp-block-woocommerce-product-sku product_meta wp-block-post-terms %1$s" style="%2$s">
 				%3$s
@@ -100,7 +109,7 @@ class ProductSKU extends AbstractBlock {
 			esc_attr( $styles_and_classes['styles'] ?? '' ),
 			$prefix,
 			$interactive_attributes,
-			$product_sku,
+			$displayed_sku,
 			$suffix
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSKU.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+/**
+ * Tests for the ProductSKU block type.
+ */
+class ProductSKU extends \WP_UnitTestCase {
+
+	/**
+	 * Tests that the SKU block renders the product SKU for a simple product.
+	 */
+	public function test_renders_simple_product_sku() {
+		$product = new \WC_Product_Simple();
+		$product->set_sku( 'SIMPLE-SKU-001' );
+		$product_id = $product->save();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-sku /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'wp-block-woocommerce-product-sku', $markup, 'The Single Product Block contains the Product SKU block.' );
+		$this->assertStringContainsString( 'SIMPLE-SKU-001', $markup, 'The Product SKU block contains the simple product SKU.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * Tests that the SKU block does not render anything for a simple product with no SKU.
+	 */
+	public function test_does_not_render_for_simple_product_without_sku() {
+		$product = new \WC_Product_Simple();
+		$product->set_sku( '' );
+		$product_id = $product->save();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-sku /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringNotContainsString( 'wp-block-woocommerce-product-sku', $markup, 'The Product SKU block is not rendered when a simple product has no SKU.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * Tests that the SKU block renders the parent SKU for a variable product when one is set.
+	 */
+	public function test_renders_variable_product_parent_sku() {
+		$product = new \WC_Product_Variable();
+		$product->set_sku( 'VAR-PARENT-001' );
+		$product_id = $product->save();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-sku /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'wp-block-woocommerce-product-sku', $markup, 'The Product SKU block is rendered for a variable product with a parent SKU.' );
+		$this->assertStringContainsString( 'VAR-PARENT-001', $markup, 'The Product SKU block contains the variable product parent SKU.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * Tests that the SKU block renders the "N/A" placeholder for a variable product without a parent SKU.
+	 *
+	 * Regression test for woocommerce/woocommerce#46323: the SKU block was returning an empty string
+	 * when a variable product had no parent SKU, even when variation SKUs existed. Expected behavior
+	 * (matching the classic theme's single-product/meta.php template) is to render "N/A" so the
+	 * interactive layer can swap in the variation SKU once a variation is selected.
+	 */
+	public function test_renders_na_for_variable_product_without_parent_sku() {
+		$product = new \WC_Product_Variable();
+		$product->set_sku( '' );
+		$product_id = $product->save();
+
+		$variation = new \WC_Product_Variation();
+		$variation->set_parent_id( $product_id );
+		$variation->set_sku( 'VAR-CHILD-001' );
+		$variation->set_regular_price( '10.00' );
+		$variation->save();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-sku /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'wp-block-woocommerce-product-sku', $markup, 'The Product SKU block is rendered for a variable product even without a parent SKU.' );
+		$this->assertStringContainsString( 'N/A', $markup, 'The Product SKU block renders the "N/A" placeholder when the variable product has no parent SKU.' );
+		// The interactive directive should be present so the client can swap in the variation SKU.
+		$this->assertStringContainsString( 'data-wp-interactive="woocommerce/products"', $markup, 'The Product SKU block is interactive for variable products.' );
+		$this->assertStringContainsString( 'state.productInContext.sku', $markup, 'The Product SKU block binds to the productInContext SKU state.' );
+
+		$variation->delete( true );
+		$product->delete( true );
+	}
+}


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?
- [x] Have you used `WooCommerce` instead of `Woocommerce` or `woocommerce` in user-facing content?

### Changes proposed in this Pull Request:

On block-based themes, the `woocommerce/product-sku` block disappeared entirely when a variable product had no parent SKU, even when the variations themselves had SKUs. The classic theme template (`single-product/meta.php`) handles this case by rendering `N/A` until a variation is selected, then swapping in the variation SKU. This PR brings the block in line with that behavior.

Specifically, in `ProductSKU::render()`:
- For variable products, the block now renders even when the parent SKU is empty, displaying `N/A` as a placeholder.
- The existing interactive binding (`state.productInContext.sku`) is unchanged, so the variation SKU continues to swap in on the client once a variation is selected.
- Simple products with no SKU still produce no output, matching prior behavior.

Closes #46323
Linear: https://linear.app/a8c/issue/RSMAPGJ-285

### How to test the changes in this Pull Request:

Using a block theme (e.g. Twenty Twenty-Four):

1. Create a variable product. Leave the parent SKU blank.
2. Add at least two variations and give each a distinct SKU (e.g. `VAR-RED`, `VAR-BLUE`).
3. View the product on the front-end.
4. The SKU block should render with `SKU: N/A` initially.
5. Select a variation - the SKU should update to the chosen variation's SKU.
6. Repeat with a parent SKU set: the parent SKU should display, then update on variation selection.
7. Confirm a simple product with no SKU still renders no SKU block.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

### Changelog entry

> [!IMPORTANT]
> Changelog entry committed manually as `plugins/woocommerce/changelog/fix-rsmapgj-285`.

---

RSMAPGJ AI Coder pipeline