### PR TITLE
Add semantic <header>/<footer> tagName on bundled block templates

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-300
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-300
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add semantic tagName attribute to header and footer template parts in bundled block templates so shop and product pages render proper <header> and <footer> landmarks instead of <div>.

--- a/plugins/woocommerce/templates/templates/blockified/archive-product.html
+++ b/plugins/woocommerce/templates/templates/blockified/archive-product.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
 <main class="wp-block-group">
@@ -45,4 +45,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/plugins/woocommerce/templates/templates/blockified/order-confirmation.html
+++ b/plugins/woocommerce/templates/templates/blockified/order-confirmation.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
 <main class="wp-block-group"><!-- wp:woocommerce/order-confirmation-status {"fontSize":"large"} /-->
@@ -50,4 +50,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/plugins/woocommerce/templates/templates/blockified/product-search-results.html
+++ b/plugins/woocommerce/templates/templates/blockified/product-search-results.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
 <main class="wp-block-group">
@@ -40,4 +40,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/plugins/woocommerce/templates/templates/blockified/single-product.html
+++ b/plugins/woocommerce/templates/templates/blockified/single-product.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
 <main class="wp-block-group">
@@ -50,4 +50,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/plugins/woocommerce/templates/templates/blockified/taxonomy-product_attribute.html
+++ b/plugins/woocommerce/templates/templates/blockified/taxonomy-product_attribute.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
 <main class="wp-block-group">
@@ -47,4 +47,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/plugins/woocommerce/templates/templates/order-confirmation.html
+++ b/plugins/woocommerce/templates/templates/order-confirmation.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
 <main class="wp-block-group"><!-- wp:woocommerce/order-confirmation-status {"fontSize":"large"} /-->
@@ -50,4 +50,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/BundledBlockTemplatesSemanticTagsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/BundledBlockTemplatesSemanticTagsTest.php
@@ -1,0 +1,103 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Templates;
+
+use WP_UnitTestCase;
+
+/**
+ * Regression tests ensuring that bundled WooCommerce block templates declare
+ * the correct semantic tagName attribute on header/footer template parts.
+ *
+ * Without `tagName`, the WordPress block-renderer falls back to `<div>`, which
+ * breaks FSE semantics (e.g. sticky-footer CSS, accessibility landmarks).
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/32947
+ */
+class BundledBlockTemplatesSemanticTagsTest extends WP_UnitTestCase {
+
+	/**
+	 * Absolute path to the bundled templates root, e.g. ".../plugins/woocommerce/templates".
+	 *
+	 * @var string
+	 */
+	private $templates_root;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->templates_root = dirname( __DIR__, 5 ) . '/templates';
+	}
+
+	/**
+	 * Data provider listing all bundled top-level block templates that render
+	 * a header/footer template part.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function bundled_template_provider(): array {
+		return array(
+			'archive-product'                       => array( 'templates/archive-product.html' ),
+			'single-product'                        => array( 'templates/single-product.html' ),
+			'product-search-results'                => array( 'templates/product-search-results.html' ),
+			'taxonomy-product_attribute'            => array( 'templates/taxonomy-product_attribute.html' ),
+			'order-confirmation'                    => array( 'templates/order-confirmation.html' ),
+			'page-cart'                             => array( 'templates/page-cart.html' ),
+			'blockified/archive-product'            => array( 'templates/blockified/archive-product.html' ),
+			'blockified/single-product'             => array( 'templates/blockified/single-product.html' ),
+			'blockified/product-search-results'     => array( 'templates/blockified/product-search-results.html' ),
+			'blockified/taxonomy-product_attribute' => array( 'templates/blockified/taxonomy-product_attribute.html' ),
+			'blockified/order-confirmation'         => array( 'templates/blockified/order-confirmation.html' ),
+			'blockified/page-cart'                  => array( 'templates/blockified/page-cart.html' ),
+		);
+	}
+
+	/**
+	 * @testdox Bundled block templates should declare tagName on header and footer template parts.
+	 * @dataProvider bundled_template_provider
+	 */
+	public function test_header_and_footer_template_parts_declare_tag_name( string $relative_path ): void {
+		$absolute_path = $this->templates_root . '/' . $relative_path;
+
+		$this->assertFileExists( $absolute_path, "Expected bundled template at {$relative_path}" );
+
+		$content = file_get_contents( $absolute_path );
+		$this->assertIsString( $content );
+
+		$this->assert_template_part_has_tag_name( $content, 'header', $relative_path );
+		$this->assert_template_part_has_tag_name( $content, 'footer', $relative_path );
+	}
+
+	/**
+	 * Assert that every `wp:template-part` block referencing the given header/footer
+	 * slug declares the matching `tagName` attribute.
+	 *
+	 * Only slugs that exactly match `header` or `footer` are checked; templates such
+	 * as `checkout-header` already pin `tagName` explicitly via their own slugs.
+	 */
+	private function assert_template_part_has_tag_name( string $content, string $slug, string $relative_path ): void {
+		if ( ! preg_match_all( '/<!--\s*wp:template-part\s*(\{[^}]*\})\s*\/-->/', $content, $matches ) ) {
+			return;
+		}
+
+		foreach ( $matches[1] as $attrs_json ) {
+			$attrs = json_decode( $attrs_json, true );
+			if ( ! is_array( $attrs ) || ( $attrs['slug'] ?? '' ) !== $slug ) {
+				continue;
+			}
+
+			$this->assertSame(
+				$slug,
+				$attrs['tagName'] ?? null,
+				sprintf(
+					'Template "%s" must declare tagName="%s" on the %s template-part to preserve FSE semantic markup.',
+					$relative_path,
+					$slug,
+					$slug
+				)
+			);
+		}
+	}
+}


### PR DESCRIPTION
**Submission Review Guidelines:**

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Plugin Boilerplate Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/plugin-boilerplate-guidelines.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

<!-- Reviewers: Please remember to thank our contributors, even if the PR will not be merged. -->

### Changes proposed in this Pull Request

Bundled WooCommerce block templates referenced the `header` and `footer` template parts without a `tagName` attribute. Without `tagName`, the WordPress block renderer falls back to `<div>` instead of emitting the proper `<header>` and `<footer>` landmarks, breaking FSE semantics on shop, single product, archive, taxonomy, search results, and order confirmation pages (sticky-footer CSS stops working, accessibility landmarks disappear).

This PR:

- Adds `tagName:"header"` / `tagName:"footer"` to the affected bundled templates under `plugins/woocommerce/templates/templates/`:
  - `order-confirmation.html`
  - `blockified/archive-product.html`
  - `blockified/order-confirmation.html`
  - `blockified/product-search-results.html`
  - `blockified/single-product.html`
  - `blockified/taxonomy-product_attribute.html`
- Adds a regression test (`BundledBlockTemplatesSemanticTagsTest`) that asserts every bundled top-level template declares the correct `tagName` on its `header` / `footer` template parts.

Closes #32947.
Linear: https://linear.app/a8c/issue/RSMAPGJ-300

### Screenshots or screen recordings

UI change is at the markup level — affected pages now render `<header>` / `<footer>` instead of `<div>` for the template parts.

### How to test the changes in this Pull Request

1. Activate a block theme (e.g. Twenty Twenty-Four) on a fresh WooCommerce install so the bundled templates are used.
2. Visit the shop page, a single product page, a product category, a product search results page, and the order confirmation page.
3. View source / DevTools and verify the page emits `<header>` and `<footer>` elements wrapping the template parts (previously these were `<div>`).
4. Run the regression test:
   - `pnpm test:php:env -- --filter BundledBlockTemplatesSemanticTagsTest`

### Testing that has already taken place

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean
- `vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=4G` — no errors, no baseline additions
- Manual diff review of all six template changes confirms only the header/footer template-part attributes change.

<!-- Make sure that this PR is added to the correct milestone. -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix

#### Message

Add semantic tagName attribute to header and footer template parts in bundled block templates so shop and product pages render proper `<header>` and `<footer>` landmarks instead of `<div>`.

</details>

---

This PR was produced by the RSMAPGJ AI Coder pipeline; awaiting Codex review (rev 1).