### PR TITLE
Fix virtual product tax calculation when tax is based on shipping address

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-270
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-270
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix tax calculation falling back to the store base address for virtual products when "Calculate tax based on" is set to the customer shipping address. The taxable address now falls back to the customer billing address when no shipping country is set, matching how orders already resolve their tax location.

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -192,6 +192,12 @@ class WC_Customer extends WC_Legacy_Customer {
 			$tax_based_on = TaxBasedOn::BASE;
 		}
 
+		// Fall back to billing address when tax is based on shipping but no shipping country is
+		// available (e.g. cart contains only virtual products that don't require shipping).
+		if ( TaxBasedOn::SHIPPING === $tax_based_on && ! $this->get_shipping_country() ) {
+			$tax_based_on = TaxBasedOn::BILLING;
+		}
+
 		if ( TaxBasedOn::BASE === $tax_based_on ) {
 			$country  = WC()->countries->get_base_country();
 			$state    = WC()->countries->get_base_state();

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/customer.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/customer.php
@@ -54,6 +54,49 @@ class WC_Tests_Customer extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * When tax is calculated based on the shipping address but the customer has no shipping
+	 * address (for example, the cart contains only virtual products), the taxable address
+	 * should fall back to the customer's billing address rather than the store's base address.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/58206.
+	 */
+	public function test_get_taxable_address_falls_back_to_billing_when_shipping_country_is_empty() {
+		$original_tax_based_on     = WC_Helper_Customer::get_tax_based_on();
+		$original_customer_details = WC_Helper_Customer::get_customer_details();
+
+		// Build a customer with a billing address in Hungary and no shipping address (virtual product scenario).
+		$customer_data = array(
+			'id'                  => 0,
+			'date_modified'       => null,
+			'country'             => 'HU',
+			'state'               => '',
+			'postcode'            => '1051',
+			'city'                => 'Budapest',
+			'shipping_country'    => '',
+			'shipping_state'      => '',
+			'shipping_postcode'   => '',
+			'shipping_city'       => '',
+			'is_vat_exempt'       => false,
+			'calculated_shipping' => false,
+		);
+		WC_Helper_Customer::set_customer_details( $customer_data );
+
+		$customer = new WC_Customer( 0, true );
+
+		WC_Helper_Customer::set_tax_based_on( 'shipping' );
+
+		$this->assertEquals(
+			array( 'HU', '', '1051', 'Budapest' ),
+			$customer->get_taxable_address(),
+			'When tax is based on shipping but no shipping country is set, the taxable address should fall back to the billing address.'
+		);
+
+		// Reset.
+		WC_Helper_Customer::set_tax_based_on( $original_tax_based_on );
+		WC_Helper_Customer::set_customer_details( $original_customer_details );
+	}
+
+	/**
 	 * Test the is_customer_outside_base method.
 	 */
 	public function test_is_customer_outside_base() {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the testing instructions where applicable.

### Changes proposed in this Pull Request

Fixes incorrect tax calculation for virtual products when WooCommerce is configured to calculate taxes based on the customer shipping address.

When the cart contains only virtual products, the customer has no shipping address. `WC_Customer::get_taxable_address()` was returning empty values for country/state/postcode/city, which caused `WC_Tax::get_rates_from_location()` to find no matching rates. The cart then falls back to the store base address, producing the wrong tax.

This change mirrors the fallback that already exists in `WC_Abstract_Order::get_tax_location()`: when tax is based on shipping but no shipping country is set, use the customer's billing address instead.

Closes #58206

### How to test the changes in this Pull Request

1. WooCommerce > Settings > General: set the store address to a US state (e.g. California).
2. WooCommerce > Settings > Tax: enable taxes, set "Calculate tax based on" to "Customer shipping address".
3. WooCommerce > Settings > Tax > Standard rates: add a US 10% rate and a Hungary (HU) 27% rate (both shipping = yes).
4. Create a Simple product, mark it as "Virtual" and "Taxable", price 100.
5. As a guest, add the virtual product to the cart, go to checkout, and enter a Hungarian billing address (country HU, postcode 1051, city Budapest).
6. Expected: cart totals show the Hungary 27% (HU VAT) rate (27.00). Before the fix the cart used the US 10% rate.
7. Repeat with a non-virtual product to confirm the existing path still works.
8. Switch "Calculate tax based on" to "Customer billing address" and confirm taxes are still based on billing.
9. Add a non-virtual product to a cart with a local pickup shipping method to confirm the base-address fallback for local pickup is unaffected.

### Testing that has already taken place

- Added a regression unit test `WC_Tests_Customer::test_get_taxable_address_falls_back_to_billing_when_shipping_country_is_empty`.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `composer exec -- phpstan analyse includes/class-wc-customer.php --memory-limit=2G` clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Reason: changelog file added manually at `plugins/woocommerce/changelog/fix-rsmapgj-270`.)

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-270

Submitted via the RSMAPGJ AI Coder pipeline.