### PR TITLE
Fix: expand checkout address card when required fields are missing

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-271
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-271
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Expand the saved address block at checkout when a required field (e.g. postcode) is missing, so customers can fix it instead of checkout silently failing.

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/address.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/address.ts
@@ -176,3 +176,35 @@ export const hasAllFieldsForShippingRates = (
 		return isValidAddressKey( key, address ) && address[ key ] !== '';
 	} );
 };
+
+/**
+ * Checks if every required field in an address is populated, accounting for
+ * country-specific locale overrides (e.g. some countries do not require a
+ * state, others mark postcode as optional).
+ *
+ * Hidden fields and fields explicitly marked optional for the address country
+ * are ignored. If the address has no country we cannot determine the locale
+ * rules, so we fall back to the default field set.
+ *
+ * @param {Partial<BillingAddress | ShippingAddress>} address The address to validate.
+ * @return {boolean} True if all required address fields are filled, false otherwise.
+ */
+export const hasAllRequiredAddressFields = (
+	address: Partial< BillingAddress > | Partial< ShippingAddress >
+): boolean => {
+	const addressFormWithLocale = prepareFormFields(
+		ADDRESS_FORM_KEYS,
+		defaultFields,
+		address.country || ''
+	);
+
+	return addressFormWithLocale.every( ( { key, hidden, required } ) => {
+		if ( hidden === true || required === false ) {
+			return true;
+		}
+		const value = ( address as Record< string, string | undefined > )[
+			key
+		];
+		return typeof value === 'string' && value !== '';
+	} );
+};

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/test/address.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/test/address.ts
@@ -4,6 +4,7 @@
 import {
 	emptyHiddenAddressFields,
 	hasAllFieldsForShippingRates,
+	hasAllRequiredAddressFields,
 	formatShippingAddress,
 } from '@woocommerce/base-utils';
 
@@ -138,6 +139,93 @@ describe( 'hasAllFieldsForShippingRates', () => {
 
 		address.state = 'CA';
 		expect( hasAllFieldsForShippingRates( address ) ).toBe( true );
+	} );
+} );
+
+describe( 'hasAllRequiredAddressFields', () => {
+	it( 'returns false when a required field is missing (US address missing postcode)', () => {
+		const address = {
+			first_name: 'John',
+			last_name: 'Doe',
+			company: 'Company',
+			address_1: '409 Main Street',
+			address_2: 'Apt 1',
+			city: 'Sacramento',
+			postcode: '',
+			country: 'US',
+			state: 'CA',
+			email: 'john.doe@company',
+			phone: '+1234567890',
+		};
+		expect( hasAllRequiredAddressFields( address ) ).toBe( false );
+	} );
+
+	it( 'returns true when every required US field is populated', () => {
+		const address = {
+			first_name: 'John',
+			last_name: 'Doe',
+			company: 'Company',
+			address_1: '409 Main Street',
+			address_2: 'Apt 1',
+			city: 'Sacramento',
+			postcode: '95814',
+			country: 'US',
+			state: 'CA',
+			email: 'john.doe@company',
+			phone: '+1234567890',
+		};
+		expect( hasAllRequiredAddressFields( address ) ).toBe( true );
+	} );
+
+	it( 'respects country locale overrides — UK address without state is complete', () => {
+		const address = {
+			first_name: 'John',
+			last_name: 'Doe',
+			company: 'Company',
+			address_1: '409 Main Street',
+			address_2: 'Apt 1',
+			city: 'London',
+			postcode: 'W1T 4JG',
+			country: 'GB',
+			state: '',
+			email: 'john.doe@company',
+			phone: '+1234567890',
+		};
+		expect( hasAllRequiredAddressFields( address ) ).toBe( true );
+	} );
+
+	it( 'returns false when country is set but first_name is missing', () => {
+		const address = {
+			first_name: '',
+			last_name: 'Doe',
+			company: 'Company',
+			address_1: '409 Main Street',
+			address_2: 'Apt 1',
+			city: 'Sacramento',
+			postcode: '95814',
+			country: 'US',
+			state: 'CA',
+			email: 'john.doe@company',
+			phone: '+1234567890',
+		};
+		expect( hasAllRequiredAddressFields( address ) ).toBe( false );
+	} );
+
+	it( 'returns false for an empty address', () => {
+		const address = {
+			first_name: '',
+			last_name: '',
+			company: '',
+			address_1: '',
+			address_2: '',
+			city: '',
+			postcode: '',
+			country: '',
+			state: '',
+			email: '',
+			phone: '',
+		};
+		expect( hasAllRequiredAddressFields( address ) ).toBe( false );
 	} );
 } );
 

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/default-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/default-state.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { isSameAddress } from '@woocommerce/base-utils';
+import {
+	hasAllRequiredAddressFields,
+	isSameAddress,
+} from '@woocommerce/base-utils';
 import type { AddressFormType, OrderFormValues } from '@woocommerce/settings';
 
 /**
@@ -30,17 +33,24 @@ export type CheckoutState = {
 };
 
 // Default editing state for CustomerAddress component comes from the current address and whether or not we're in the editor.
-const hasBillingAddress = !! (
-	checkoutData.billing_address.address_1 &&
-	( checkoutData.billing_address.first_name ||
-		checkoutData.billing_address.last_name )
-);
+// An address is considered "complete enough" to collapse only when it has the
+// minimum identifying fields AND every locale-required field is populated.
+// This prevents the address card from rendering collapsed when a saved
+// address is missing a required value (e.g. postcode), which would otherwise
+// silently block checkout (see RSMAPGJ-271 / woo#58166).
+const hasBillingAddress =
+	!! (
+		checkoutData.billing_address.address_1 &&
+		( checkoutData.billing_address.first_name ||
+			checkoutData.billing_address.last_name )
+	) && hasAllRequiredAddressFields( checkoutData.billing_address );
 
-const hasShippingAddress = !! (
-	checkoutData.shipping_address.address_1 &&
-	( checkoutData.shipping_address.first_name ||
-		checkoutData.shipping_address.last_name )
-);
+const hasShippingAddress =
+	!! (
+		checkoutData.shipping_address.address_1 &&
+		( checkoutData.shipping_address.first_name ||
+			checkoutData.shipping_address.last_name )
+	) && hasAllRequiredAddressFields( checkoutData.shipping_address );
 
 const billingMatchesShipping = isSameAddress(
 	checkoutData.billing_address,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a saved customer address was missing a required field (e.g. postcode), the block checkout would collapse the saved address card on initial render and the customer had no visible way to fix the missing value — clicking "Place order" silently failed. The default state only checked that `address_1` plus a name were present, not whether all locale-required fields were filled in.

This PR:

- Adds a new utility `hasAllRequiredAddressFields()` in `assets/js/base/utils/address.ts` that walks the locale-aware form fields for an address country and verifies every visible, required field has a non-empty value.
- Uses it in the checkout data store default state (`assets/js/data/checkout/default-state.ts`) when deciding whether to start in editing mode for the billing and shipping address cards. If any required field is missing, the form is expanded by default so the customer can complete it.
- Adds Jest coverage for the new utility (empty, missing postcode for US, US complete, UK with no state required, missing first_name).

Closes #58166.

Linear: https://linear.app/a8c/issue/RSMAPGJ-271

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Saved address with missing postcode renders collapsed; checkout silently fails. | Saved address with missing postcode renders expanded so the customer can fill it in. |

### How to test the changes in this Pull Request:

1. Spin up the block checkout (`/checkout`) with a registered customer.
2. As that customer, go to `wp-admin -> Users -> Profile` and clear their billing postcode and shipping postcode. Save.
3. Add a simple product to the cart and visit `/checkout`.
4. Before this PR: the saved shipping (and billing) address card is collapsed even though postcode is missing, and clicking "Place order" silently fails.
5. With this PR: the address card is expanded on load with the postcode field visible and the customer can complete checkout normally.
6. Repeat with a UK customer (no postcode populated) — same expectation.
7. Sanity check: a fully populated saved address still renders collapsed (no regression).

### Testing that has already taken place:

- `pnpm --filter='@woocommerce/block-library' test:js` for the affected suites (`base/utils/test/address`, `checkout/inner-blocks/checkout-(shipping|billing)-address-block/test`, `data/checkout/test`) — all passing.
- `wp-scripts lint-js` on the changed TypeScript files — clean.
- `tsc --noEmit` on `client/blocks` — no new TS errors introduced (existing pre-existing errors in unrelated files unchanged).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A changelog entry was added manually as `plugins/woocommerce/changelog/fix-rsmapgj-271` (Significance: patch, Type: fix).

---

_Submitted via the RSMAPGJ AI Coder pipeline._
