### PR TITLE
Preserve order item meta keys when rendering formatted meta (RSMAPGJ-293)

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-293
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-293
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix the selected variation option line being missing in the new order when "Order Again" is used and the variation attribute name uses 2-byte characters.

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -344,14 +344,18 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 				continue;
 			}
 
-			$meta->key     = rawurldecode( (string) $meta->key );
-			$meta->value   = rawurldecode( (string) $meta->value );
-			$attribute_key = str_replace( 'attribute_', '', $meta->key );
+			// Decode for display only; do not mutate the underlying meta object so that
+			// the original (possibly URL-encoded) keys/values remain intact for later
+			// reads such as Order Again, which relies on matching variation attribute
+			// keys produced by sanitize_title() (URL-encoded for multibyte characters).
+			$decoded_key   = rawurldecode( (string) $meta->key );
+			$decoded_value = rawurldecode( (string) $meta->value );
+			$attribute_key = str_replace( 'attribute_', '', $decoded_key );
 			$display_key   = wc_attribute_label( $attribute_key, $product );
-			$display_value = wp_kses_post( $meta->value );
+			$display_value = wp_kses_post( $decoded_value );
 
 			if ( taxonomy_exists( $attribute_key ) ) {
-				$term = get_term_by( 'slug', $meta->value, $attribute_key );
+				$term = get_term_by( 'slug', $decoded_value, $attribute_key );
 				if ( ! is_wp_error( $term ) && is_object( $term ) && $term->name ) {
 					$display_value = $term->name;
 				}
@@ -363,8 +367,8 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			}
 
 			$formatted_meta[ $meta->id ] = (object) array(
-				'key'           => $meta->key,
-				'value'         => $meta->value,
+				'key'           => $decoded_key,
+				'value'         => $decoded_value,
 				'display_key'   => apply_filters( 'woocommerce_order_item_display_meta_key', $display_key, $meta, $this ),
 				'display_value' => wpautop( make_clickable( apply_filters( 'woocommerce_order_item_display_meta_value', $display_value, $meta, $this ) ) ),
 			);

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -12975,7 +12975,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$key\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 2
 			path: includes/class-wc-order-item.php
 
 		-

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -113,6 +113,134 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Order Again preserves the selected variation option meta when a custom attribute uses multibyte (2-byte) characters.
+	 *
+	 * Regression test for woocommerce#36781 (RSMAPGJ-293). Rendering the formatted
+	 * meta for a completed order must not mutate the underlying meta keys/values
+	 * via rawurldecode(), otherwise subsequent code paths that match against
+	 * sanitize_title()-generated keys (such as populate_cart_from_order) lose the
+	 * variation attribute when 2-byte characters are involved.
+	 */
+	public function test_order_again_preserves_multibyte_custom_variation_attribute() {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		WC()->session = new WC_Session_Handler();
+		WC()->session->init();
+		WC()->session->set_customer_session_cookie( true );
+
+		WC()->cart->empty_cart();
+		WC()->session->set( 'wc_notices', null );
+
+		// Build a variable product whose only attribute is a non-taxonomy attribute
+		// whose name contains Japanese (2-byte) characters.
+		$attribute_name  = '色';
+		$attribute_value = '赤';
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( 0 );
+		$attribute->set_name( $attribute_name );
+		$attribute->set_options( array( $attribute_value, '青' ) );
+		$attribute->set_variation( true );
+		$attribute->set_visible( true );
+
+		$variable_product = new WC_Product_Variable();
+		$variable_product->set_name( 'JP Variable' );
+		$variable_product->set_status( 'publish' );
+		$variable_product->set_attributes( array( $attribute ) );
+		$variable_product->save();
+
+		// Custom variation attributes must be stored under the sanitize_title()
+		// version of the parent attribute name (matches how the admin UI persists
+		// them and how WC_Product::set_attributes() keys the attribute array).
+		$sanitized_attribute_key = sanitize_title( $attribute_name );
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $variable_product->get_id() );
+		$variation->set_attributes( array( $sanitized_attribute_key => $attribute_value ) );
+		$variation->set_regular_price( '10' );
+		$variation->set_status( 'publish' );
+		$variation->save();
+
+		// Refresh references after save so the parent picks up the variation child.
+		$variable_product = wc_get_product( $variable_product->get_id() );
+		$variation        = wc_get_product( $variation->get_id() );
+
+		// Create a completed order containing the variation. The order item meta is
+		// stored under the sanitized (URL-encoded for multibyte chars) key, which is
+		// what wc_get_product_variation_attributes()/get_variation_attributes() emit.
+		$order = wc_create_order( array( 'customer_id' => $user_id ) );
+		$item  = new WC_Order_Item_Product();
+		$item->set_product( $variation );
+		$item->set_quantity( 1 );
+		$item->set_order_id( $order->get_id() );
+		$item->save();
+		$order->add_item( $item );
+		$order->set_billing_email( 'jp-customer@example.com' );
+		$order->calculate_totals();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		// Force any deferred formatted-meta rendering (e.g. transactional emails)
+		// to run by reloading the order and asking for its formatted meta. Before
+		// the fix, get_formatted_meta_data() mutated $meta->key in place via
+		// rawurldecode(), and the next $order->save() persisted the corrupted key.
+		$order_after_save = wc_get_order( $order->get_id() );
+		foreach ( $order_after_save->get_items() as $reloaded_item ) {
+			$reloaded_item->get_formatted_meta_data();
+		}
+		$order_after_save->update_meta_data( '_test_marker', '1' );
+		$order_after_save->save();
+
+		// Original order item meta must still use the sanitized (URL-encoded)
+		// attribute key so that Order Again can match it against the parent
+		// product's attribute keys.
+		$reloaded_order = wc_get_order( $order->get_id() );
+		$item_meta_keys = array();
+		foreach ( $reloaded_order->get_items() as $reloaded_item ) {
+			foreach ( $reloaded_item->get_meta_data() as $meta ) {
+				$item_meta_keys[] = $meta->key;
+			}
+		}
+		$this->assertContains(
+			$sanitized_attribute_key,
+			$item_meta_keys,
+			'Original order item meta key should remain URL-encoded (sanitize_title form) after status transitions and re-saves.'
+		);
+		$this->assertNotContains(
+			$attribute_name,
+			$item_meta_keys,
+			'Original order item meta key should not be rewritten to the raw multibyte attribute name.'
+		);
+
+		// Run the Order Again populate path.
+		$cart_session = new WC_Cart_Session( WC()->cart );
+		$ref          = new ReflectionClass( WC_Cart_Session::class );
+		$method       = $ref->getMethod( 'populate_cart_from_order' );
+		$method->setAccessible( true );
+		$populated = $method->invoke( $cart_session, $order->get_id(), array() );
+
+		$this->assertIsArray( $populated, 'populate_cart_from_order should return an array.' );
+		$this->assertCount( 1, $populated, 'Re-ordered cart should contain the variation.' );
+
+		$only_cart_item = array_values( $populated )[0];
+		$this->assertNotEmpty(
+			$only_cart_item['variation'],
+			'Re-ordered cart item should carry the variation attribute(s) selected on the original order.'
+		);
+		$this->assertSame(
+			$attribute_value,
+			$only_cart_item['variation'][ 'attribute_' . $sanitized_attribute_key ] ?? null,
+			'Re-ordered cart item variation should preserve the multibyte attribute value under the sanitize_title()-keyed slot.'
+		);
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+		$variation->delete( true );
+		$variable_product->delete( true );
+		wp_delete_user( $user_id );
+	}
+
+	/**
 	 * @testdox check_cart_items should reduce quantity to 1 when product is marked as sold individually after being added to cart
 	 */
 	public function test_check_cart_items_reduces_sold_individually_quantity() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Order_Item::get_formatted_meta_data()` was mutating `$meta->key` and `$meta->value` in place via `rawurldecode()`. When a variable product's attribute name contained multibyte (2-byte) characters, the order item meta key was stored as the URL-encoded `sanitize_title()` form (e.g. an attribute named `色` is keyed as `%e8%89%b2`). Calling `get_formatted_meta_data()` - which happens during transactional email rendering on status changes, among other paths - overwrote the in-memory key with the raw multibyte name. The next `$order->save()` (e.g. the New Order email handler recording `_new_order_email_sent`) persisted the corrupted key to `wp_woocommerce_order_itemmeta`.

That broke **Order Again**: `WC_Cart_Session::populate_cart_from_order` matches each meta key against the variable product's `get_attributes()` keys, which are `sanitize_title()`-encoded. Once the key had been rewritten to its raw multibyte form, `meta_is_product_attribute()` returned false and the variation attribute was dropped from the re-ordered cart - so the new order had no variation option line.

This PR decodes for display only via local variables and leaves the underlying `WC_Meta_Data` objects untouched, so downstream consumers continue to see the canonical `sanitize_title()` keys.

A PHPUnit regression test in `tests/php/includes/class-wc-cart-test.php` exercises the full Japanese-attribute reorder flow.

Closes #36781.

Linear: https://linear.app/a8c/issue/RSMAPGJ-293

### How to test the changes in this Pull Request:

1. Create a variable product with a non-taxonomy attribute whose name uses Japanese (2-byte) characters - e.g. name `色`, options `赤`, `青`. Mark the attribute "Used for variations".
2. Create at least one variation (e.g. `色 = 赤`) at a non-zero price and publish.
3. Place an order for that variation as a customer, then mark the order Completed in **WooCommerce → Orders**.
4. Visit **My Account → Orders** and click **Order again** for that order.
5. Complete checkout and place the new order.
6. Open the newly created order in **WooCommerce → Orders**. Confirm the variation line `色: 赤` is shown under the product (it was missing before this fix).
7. As a sanity check, the original (completed) order must still display `色: 赤` after the status transition.

### Testing that has already taken place:

- Reproduced the bug end-to-end against an HPOS-enabled wp-env site using the Linear repro blueprint (Japanese custom attribute, completed order, Order Again): the new order had no variation meta.
- Verified the fix with the same scenario: the new order now stores the variation meta under the URL-encoded `sanitize_title()` key (e.g. `%e8%89%b2 = 赤`) and `get_formatted_meta_data()` renders the line as `色: 赤`.
- Confirmed the original completed order's stored meta key remains the URL-encoded form after status transitions and email rendering.
- Added `test_order_again_preserves_multibyte_custom_variation_attribute` to `WC_Cart_Test`.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.
- `composer exec -- phpstan analyse includes/class-wc-order-item.php --memory-limit=2G` clean (existing `object::$key` baseline entry shrunk from `count: 3` to `count: 2`).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog file `plugins/woocommerce/changelog/fix-rsmapgj-293` was added manually with `Significance: patch`, `Type: fix`.

</details>

---

Submitted by the RSMAPGJ AI Coder pipeline.