### PR TITLE
Fix block product gallery ignoring remove_theme_support for zoom and slider

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-265
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-265
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect remove_theme_support() for wc-product-gallery-zoom, -slider and -lightbox when the block-based product image gallery (and the classic single product template block) renders, so themes and sites can opt out of these legacy gallery features again.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -160,9 +160,17 @@ class ClassicTemplate extends AbstractDynamicBlock {
 		}
 
 		if ( is_product() ) {
-			add_filter( 'woocommerce_single_product_zoom_enabled', '__return_true' );
-			add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_true' );
-			add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_true' );
+			// Force-enable gallery features only when the theme declares support for them.
+			// This allows themes and sites to opt out via remove_theme_support(). See #61248.
+			if ( current_theme_supports( 'wc-product-gallery-zoom' ) ) {
+				add_filter( 'woocommerce_single_product_zoom_enabled', '__return_true' );
+			}
+			if ( current_theme_supports( 'wc-product-gallery-lightbox' ) ) {
+				add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_true' );
+			}
+			if ( current_theme_supports( 'wc-product-gallery-slider' ) ) {
+				add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_true' );
+			}
 
 			return $this->render_single_product();
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImageGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImageGallery.php
@@ -107,9 +107,17 @@ class ProductImageGallery extends AbstractBlock {
 			return '';
 		}
 
-		add_filter( 'woocommerce_single_product_zoom_enabled', '__return_true' );
-		add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_true' );
-		add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_true' );
+		// Force-enable gallery features only when the theme declares support for them.
+		// This allows themes and sites to opt out via remove_theme_support(). See #61248.
+		if ( current_theme_supports( 'wc-product-gallery-zoom' ) ) {
+			add_filter( 'woocommerce_single_product_zoom_enabled', '__return_true' );
+		}
+		if ( current_theme_supports( 'wc-product-gallery-lightbox' ) ) {
+			add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_true' );
+		}
+		if ( current_theme_supports( 'wc-product-gallery-slider' ) ) {
+			add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_true' );
+		}
 
 		ob_start();
 		woocommerce_show_product_sale_flash();

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImageGallery.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImageGallery.php
@@ -1,0 +1,169 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WC_Helper_Product;
+
+/**
+ * Tests for the ProductImageGallery block type.
+ */
+class ProductImageGallery extends \WP_UnitTestCase {
+
+	/**
+	 * Theme support flags that should be restored after each test.
+	 *
+	 * @var string[]
+	 */
+	private $theme_support_flags = array(
+		'wc-product-gallery-zoom',
+		'wc-product-gallery-slider',
+		'wc-product-gallery-lightbox',
+	);
+
+	/**
+	 * Snapshot of which flags were enabled before the test.
+	 *
+	 * @var array<string, bool>
+	 */
+	private $theme_support_snapshot = array();
+
+	/**
+	 * Set up theme support snapshot so each test can mutate freely.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		foreach ( $this->theme_support_flags as $flag ) {
+			$this->theme_support_snapshot[ $flag ] = (bool) current_theme_supports( $flag );
+		}
+	}
+
+	/**
+	 * Restore theme support and filters after each test.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->theme_support_flags as $flag ) {
+			if ( $this->theme_support_snapshot[ $flag ] ) {
+				add_theme_support( $flag );
+			} else {
+				remove_theme_support( $flag );
+			}
+		}
+
+		remove_all_filters( 'woocommerce_single_product_zoom_enabled' );
+		remove_all_filters( 'woocommerce_single_product_photoswipe_enabled' );
+		remove_all_filters( 'woocommerce_single_product_flexslider_enabled' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Create a simple product with a featured image so the gallery has something to render.
+	 *
+	 * @return array{product: \WC_Product, image_id: int}
+	 */
+	private function create_product_with_image(): array {
+		$product  = WC_Helper_Product::create_simple_product();
+		$image_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Gallery Image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		$product->set_image_id( $image_id );
+		$product->save();
+
+		return array(
+			'product'  => $product,
+			'image_id' => $image_id,
+		);
+	}
+
+	/**
+	 * Render the block and return whether each gallery filter resolves to true after render.
+	 *
+	 * @param int $product_id Product to render.
+	 * @return array{zoom: bool, lightbox: bool, slider: bool}
+	 */
+	private function render_and_capture_filters( int $product_id ): array {
+		do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-image-gallery /--><!-- /wp:woocommerce/single-product -->' );
+
+		return array(
+			'zoom'     => (bool) apply_filters( 'woocommerce_single_product_zoom_enabled', get_theme_support( 'wc-product-gallery-zoom' ) ),
+			'lightbox' => (bool) apply_filters( 'woocommerce_single_product_photoswipe_enabled', get_theme_support( 'wc-product-gallery-lightbox' ) ),
+			'slider'   => (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) ),
+		);
+	}
+
+	/**
+	 * @testdox Should force gallery filters on when theme support is declared.
+	 */
+	public function test_render_forces_filters_on_when_theme_supports_features(): void {
+		$data = $this->create_product_with_image();
+
+		add_theme_support( 'wc-product-gallery-zoom' );
+		add_theme_support( 'wc-product-gallery-slider' );
+		add_theme_support( 'wc-product-gallery-lightbox' );
+
+		$filters = $this->render_and_capture_filters( $data['product']->get_id() );
+
+		$this->assertTrue( $filters['zoom'], 'Zoom should be enabled when theme support is declared.' );
+		$this->assertTrue( $filters['slider'], 'Slider should be enabled when theme support is declared.' );
+		$this->assertTrue( $filters['lightbox'], 'Lightbox should be enabled when theme support is declared.' );
+
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
+	}
+
+	/**
+	 * @testdox Should respect remove_theme_support for gallery zoom and slider when block is rendered.
+	 */
+	public function test_render_respects_remove_theme_support_for_zoom_and_slider(): void {
+		$data = $this->create_product_with_image();
+
+		add_theme_support( 'wc-product-gallery-lightbox' );
+		remove_theme_support( 'wc-product-gallery-zoom' );
+		remove_theme_support( 'wc-product-gallery-slider' );
+
+		$filters = $this->render_and_capture_filters( $data['product']->get_id() );
+
+		$this->assertFalse(
+			$filters['zoom'],
+			'Zoom must stay disabled when remove_theme_support( "wc-product-gallery-zoom" ) is in effect. See woocommerce/woocommerce#61248.'
+		);
+		$this->assertFalse(
+			$filters['slider'],
+			'Slider must stay disabled when remove_theme_support( "wc-product-gallery-slider" ) is in effect. See woocommerce/woocommerce#61248.'
+		);
+		$this->assertTrue(
+			$filters['lightbox'],
+			'Lightbox should remain enabled when its theme support is still declared.'
+		);
+
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
+	}
+
+	/**
+	 * @testdox Should not force any gallery filter on when all theme support is removed.
+	 */
+	public function test_render_does_not_force_filters_when_all_theme_support_removed(): void {
+		$data = $this->create_product_with_image();
+
+		foreach ( $this->theme_support_flags as $flag ) {
+			remove_theme_support( $flag );
+		}
+
+		$filters = $this->render_and_capture_filters( $data['product']->get_id() );
+
+		$this->assertFalse( $filters['zoom'], 'Zoom should be disabled when no theme support is declared.' );
+		$this->assertFalse( $filters['slider'], 'Slider should be disabled when no theme support is declared.' );
+		$this->assertFalse( $filters['lightbox'], 'Lightbox should be disabled when no theme support is declared.' );
+
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have read [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/code-of-conduct.md).
- [x] I have made my code reviewable, follow [the engineering guidelines](https://github.com/woocommerce/woocommerce/wiki/Engineering-Guidelines), and follow [our best practices](https://github.com/woocommerce/woocommerce/wiki/Best-Practices).

### Changes proposed in this Pull Request

Closes #61248.

Linear: https://linear.app/a8c/issue/RSMAPGJ-265

`ProductImageGallery::render()` and `ClassicTemplate::render()` were unconditionally calling

```php
add_filter( 'woocommerce_single_product_zoom_enabled',      '__return_true' );
add_filter( 'woocommerce_single_product_photoswipe_enabled','__return_true' );
add_filter( 'woocommerce_single_product_flexslider_enabled','__return_true' );
```

before invoking `woocommerce_show_product_images()`. Those filters defeated any `remove_theme_support( 'wc-product-gallery-zoom' )` / `…-slider` / `…-lightbox` call a theme or site made, because the filter return value was forced to `true` regardless of theme support.

This PR makes the override conditional on `current_theme_supports()` for each feature, mirroring the pattern PR #61205 already applied to legacy script enqueues. The block now respects the documented `remove_theme_support()` opt-out for the block product image gallery.

Bug introduced in PR #61013.

### Screenshots or screen recordings

UI behavior is unchanged when theme support is in place. The only visible change is that hover zoom / thumbnail slider no longer activate when a site disables them via `remove_theme_support()` — matching the pre-regression and documented behavior.

### How to test the changes in this Pull Request

1. Spin up a site running this branch (block theme such as Twenty Twenty-Five is fine).
2. Add a simple product with a featured image and at least one gallery image.
3. Drop the following snippet into a mu-plugin or `functions.php`:
   ```php
   add_action( 'after_setup_theme', function () {
       remove_theme_support( 'wc-product-gallery-zoom' );
       remove_theme_support( 'wc-product-gallery-slider' );
   }, 99 );
   ```
4. Visit the product page on the frontend and inspect the gallery container.
   - Expected: no hover zoom; clicking a thumbnail does not slide it into the main slot via flexslider; lightbox still opens because `wc-product-gallery-lightbox` was not removed.
   - Without this fix, all three features remain active regardless of the `remove_theme_support` calls.
5. Repeat with `remove_theme_support( 'wc-product-gallery-lightbox' )` and confirm the lightbox no longer activates.

### Testing that has already taken place

- New PHPUnit coverage in `plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImageGallery.php` covering: theme-supported defaults remain forced-on, `remove_theme_support` for zoom/slider is honored while lightbox stays on, and a full opt-out leaves every filter resolving to `false`.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `vendor/bin/phpstan analyse` on the two modified production files — `No errors`.

<!-- ### Changelog entry -->

- [x] This Pull Request does not require a changelog entry. (Changelog file `plugins/woocommerce/changelog/fix-rsmapgj-265` has been added manually.)

### Milestone

- [x] Auto-assign to the first available milestone (recommended).

---

_Submitted via the RSMAPGJ AI Coder pipeline._