### PR TITLE
Fix incorrect heading order on admin orders page

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-266
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-266
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Admin order screen: demote the duplicate `Order #N details` heading and its `General`/`Billing`/`Shipping` sub-headings so the heading hierarchy no longer skips levels.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1928,7 +1928,7 @@ ul.wc_coupon_list_block {
 		padding: 0 2% 0 0;
 		float: left;
 
-		> h3 span {
+		> h4 span {
 			display: block;
 		}
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -216,7 +216,7 @@ class WC_Meta_Box_Order_Data {
 			<div id="order_data" class="panel woocommerce-order-data">
 				<div class="order_data_header">
 					<div class="order_data_header_column">
-						<h2 class="woocommerce-order-data__heading">
+						<h3 class="woocommerce-order-data__heading">
 							<?php
 
 							printf(
@@ -227,7 +227,7 @@ class WC_Meta_Box_Order_Data {
 							);
 
 							?>
-						</h2>
+						</h3>
 						<p class="woocommerce-order-data__meta order_number">
 							<?php
 
@@ -311,7 +311,7 @@ class WC_Meta_Box_Order_Data {
 				?>
 				<div class="order_data_column_container">
 					<div class="order_data_column">
-						<h3><?php esc_html_e( 'General', 'woocommerce' ); ?></h3>
+						<h4><?php esc_html_e( 'General', 'woocommerce' ); ?></h4>
 
 						<p class="form-field form-field-wide">
 							<?php
@@ -415,13 +415,13 @@ class WC_Meta_Box_Order_Data {
 						<?php do_action( 'woocommerce_admin_order_data_after_order_details', $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment ?>
 					</div>
 					<div class="order_data_column">
-						<h3>
+						<h4>
 							<?php esc_html_e( 'Billing', 'woocommerce' ); ?>
 							<a href="#" class="edit_address"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
 							<span>
 								<a href="#" class="load_customer_billing" style="display:none;"><?php esc_html_e( 'Load billing address', 'woocommerce' ); ?></a>
 							</span>
-						</h3>
+						</h4>
 						<div class="address">
 							<?php
 							// Display values.
@@ -553,14 +553,14 @@ class WC_Meta_Box_Order_Data {
 						<?php do_action( 'woocommerce_admin_order_data_after_billing_address', $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment ?>
 					</div>
 					<div class="order_data_column">
-						<h3>
+						<h4>
 							<?php esc_html_e( 'Shipping', 'woocommerce' ); ?>
 							<a href="#" class="edit_address"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
 							<span>
 								<a href="#" class="load_customer_shipping" style="display:none;"><?php esc_html_e( 'Load shipping address', 'woocommerce' ); ?></a>
 								<a href="#" class="billing-same-as-shipping" style="display:none;"><?php esc_html_e( 'Copy billing address', 'woocommerce' ); ?></a>
 							</span>
-						</h3>
+						</h4>
 						<div class="address">
 							<?php
 							// Display values.

--- a/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.ts
@@ -47,7 +47,7 @@ const taxTotals = [ '10.00', '20.00', '240.00' ];
 async function getOrderIdFromPage( page: Page ) {
 	// get order ID from the page
 	const orderText = await page
-		.locator( 'h2.woocommerce-order-data__heading' )
+		.locator( '.woocommerce-order-data__heading' )
 		.textContent();
 	const parts = orderText.match( /([0-9])\w+/ );
 	return parts[ 0 ];

--- a/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-heading-hierarchy-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-heading-hierarchy-test.php
@@ -1,0 +1,115 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Heading hierarchy tests for the order data meta box.
+ *
+ * @package WooCommerce\Tests\Admin\MetaBoxes
+ */
+
+/**
+ * Class WC_Meta_Box_Order_Data_Heading_Hierarchy_Test
+ *
+ * Regression coverage for RSMAPGJ-266 / woo#60963 (incorrect heading order on the admin
+ * single-order screen). The WordPress meta-box chrome wraps the box body in an `<h2 class="hndle">`
+ * title, so any headings rendered inside the box body must use `<h3>` or smaller to avoid skipping
+ * heading levels for assistive technology.
+ */
+class WC_Meta_Box_Order_Data_Heading_Hierarchy_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Render the order data meta box for a freshly created order and return the markup.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render_meta_box_output(): string {
+		// Ensure the meta-box class is loaded.
+		if ( ! class_exists( 'WC_Meta_Box_Order_Data' ) ) {
+			require_once WC_ABSPATH . 'includes/admin/meta-boxes/class-wc-meta-box-order-data.php';
+		}
+
+		$order = wc_create_order();
+
+		ob_start();
+		WC_Meta_Box_Order_Data::output( $order );
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @testdox Inner order details heading should be h3 (one level below the meta-box h2 hndle).
+	 */
+	public function test_order_details_heading_is_h3(): void {
+		$markup = $this->render_meta_box_output();
+
+		$this->assertMatchesRegularExpression(
+			'#<h3[^>]*class="[^"]*woocommerce-order-data__heading[^"]*"#',
+			$markup,
+			'The "Order #N details" heading inside the order data meta box must render as <h3> so it nests below the meta-box <h2 class="hndle"> title without skipping heading levels.'
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'#<h2[^>]*class="[^"]*woocommerce-order-data__heading[^"]*"#',
+			$markup,
+			'The legacy <h2 class="woocommerce-order-data__heading"> must not be re-introduced; it duplicated the meta-box title heading level.'
+		);
+	}
+
+	/**
+	 * @testdox Section sub-headings (General, Billing, Shipping) should be h4.
+	 */
+	public function test_section_sub_headings_are_h4(): void {
+		$markup = $this->render_meta_box_output();
+
+		$this->assertStringContainsString(
+			'<h4>General</h4>',
+			$markup,
+			'The "General" section heading inside the order data meta box must render as <h4>.'
+		);
+
+		// Billing and Shipping h4 elements contain inline action links, so match the opening tag and label.
+		$this->assertMatchesRegularExpression(
+			'#<h4>\s*Billing#',
+			$markup,
+			'The "Billing" section heading inside the order data meta box must render as <h4>.'
+		);
+		$this->assertMatchesRegularExpression(
+			'#<h4>\s*Shipping#',
+			$markup,
+			'The "Shipping" section heading inside the order data meta box must render as <h4>.'
+		);
+	}
+
+	/**
+	 * @testdox Order data meta box markup must not skip heading levels.
+	 *
+	 * Assistive technology relies on monotonically increasing heading levels; jumping from h3 to h5
+	 * (or similar) inside this meta-box body would be a regression.
+	 */
+	public function test_no_heading_level_skips_in_meta_box(): void {
+		$markup = $this->render_meta_box_output();
+
+		preg_match_all( '#<h([1-6])\b#i', $markup, $matches );
+		$levels = array_map( 'intval', $matches[1] );
+
+		$this->assertNotEmpty( $levels, 'Expected at least one heading inside the order data meta box body.' );
+
+		// Every heading inside the meta-box body must be h3 or deeper (h2 is owned by the WordPress meta-box chrome).
+		foreach ( $levels as $level ) {
+			$this->assertGreaterThanOrEqual( 3, $level, 'Headings inside the order data meta box body must be h3 or deeper.' );
+		}
+
+		// Walk the headings in document order and confirm no jump greater than +1.
+		$previous = $levels[0];
+		foreach ( $levels as $level ) {
+			$this->assertLessThanOrEqual(
+				$previous + 1,
+				$level,
+				sprintf( 'Heading level jumped from h%d to h%d, which skips a level.', $previous, $level )
+			);
+			if ( $level > $previous ) {
+				$previous = $level;
+			} elseif ( $level < $previous ) {
+				$previous = $level;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The single-order admin screen rendered headings that skipped levels: WordPress wraps each meta-box body in an `<h2 class="hndle">` title, but the "Order data" meta-box body re-declared the same level with `<h2 class="woocommerce-order-data__heading">` and then jumped directly to `<h3>` for the General / Billing / Shipping sub-sections. The duplicate `<h2>` was redundant with the surrounding meta-box title, and the resulting outline made screen-reader navigation harder.

- Demote the "Order #N details" heading inside the order data meta-box body from `<h2>` to `<h3>` so it nests properly under the WordPress meta-box `<h2 class="hndle">` title.
- Demote the General / Billing / Shipping sub-section headings from `<h3>` to `<h4>` so the hierarchy walks h2 → h3 → h4 without skipping.
- Update the matching CSS selector in `admin.scss` (`> h3 span` → `> h4 span`) so the existing visual layout for the sub-section headings is preserved.
- Loosen the heading selector in the existing order create e2e test so it does not couple to a specific tag name.
- Add a PHPUnit regression test (`tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-heading-hierarchy-test.php`) that renders the meta-box and asserts the heading tags and that no heading level is skipped inside the meta-box body.

This PR is intentionally narrow — it does not rewrite the full page heading outline proposed in the original report (that piece is design-review territory), it only removes the duplicate-and-skip issue inside the order data meta box.

Closes #60963.

Linear: https://linear.app/a8c/issue/RSMAPGJ-266

### Screenshots or screen recordings:

UI styling for the affected headings is unchanged (CSS selectors updated to keep the same rules). No visual regression expected.

| Before | After |
| ------ | ----- |
| h2 (hndle) → h2 (order details) → h3 (General/Billing/Shipping) | h2 (hndle) → h3 (order details) → h4 (General/Billing/Shipping) |

### How to test the changes in this Pull Request:

1. Apply the branch and load the admin order edit screen (`/wp-admin/post.php?post=<order_id>&action=edit` or the HPOS equivalent).
2. Open dev tools and run `Array.from(document.querySelectorAll('#order_data h2, #order_data h3, #order_data h4')).map(h => h.tagName + ': ' + h.textContent.trim())`.
3. Confirm the order data box now reports `H3: Order #N details`, `H4: General`, `H4: Billing …`, `H4: Shipping …` — no longer `H2 → H3`.
4. Optional: install a HeadingsMap or accessibility browser extension and confirm headings inside the order data box no longer skip a level.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — PHP clean; only pre-existing, unrelated JS warning surfaces.
- PHPStan analyse on `includes/admin/meta-boxes/class-wc-meta-box-order-data.php` — no errors.
- Added PHPUnit coverage at `tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-heading-hierarchy-test.php` that asserts the heading tags and that no level is skipped.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog created manually at `plugins/woocommerce/changelog/fix-rsmapgj-266` (patch / fix).

---

Generated by the RSMAPGJ AI Coder pipeline.