### PR TITLE
Fix Mini Cart toggle missing from Navigation hooked-blocks panel

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-275
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-275
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the Mini Cart toggle alongside the Customer Account toggle in the Navigation block's hooked blocks settings panel by exposing both blocks' hook placements on their registered block types.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -52,6 +52,8 @@ class CustomerAccount extends AbstractBlock {
 		if ( version_compare( get_bloginfo( 'version' ), '6.5', '>=' ) ) {
 			add_filter( 'hooked_block_woocommerce/customer-account', array( $this, 'modify_hooked_block_attributes' ), 10, 5 );
 			add_filter( 'hooked_block_types', array( $this, 'register_hooked_block' ), 9, 4 );
+			// Run after block registration (priority 10) so the block type is available.
+			add_action( 'init', array( $this, 'register_block_hooks_metadata' ), 11 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -118,6 +118,8 @@ class MiniCart extends AbstractBlock {
 		add_action( 'wp_print_footer_scripts', array( $this, 'print_lazy_load_scripts' ), 2 );
 		add_filter( 'hooked_block_woocommerce/mini-cart', array( $this, 'modify_hooked_block_attributes' ), 10, 5 );
 		add_filter( 'hooked_block_types', array( $this, 'register_hooked_block' ), 9, 4 );
+		// Run after block registration (priority 10) so the block type is available.
+		add_action( 'init', array( $this, 'register_block_hooks_metadata' ), 11 );
 
 		// Priority 20 ensures this runs after WooCommerce block registration (priority 10)
 		// allowing us to modify the block supports in the registry after registration is complete.

--- a/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
@@ -8,6 +8,54 @@ namespace Automattic\WooCommerce\Blocks\Utils;
  */
 trait BlockHooksTrait {
 	/**
+	 * Expose this block's hook placements on its registered `WP_Block_Type` so the
+	 * block editor can render a toggle for it in the anchor block's inspector
+	 * (e.g. the Navigation block's hooked block toggles).
+	 *
+	 * Without this, blocks that are hooked exclusively via the `hooked_block_types`
+	 * PHP filter (as opposed to the `blockHooks` field in `block.json`) are invisible
+	 * to the editor's hooked block UI until the user has saved the template at least
+	 * once, because the metadata that drives the toggle is only populated after that.
+	 *
+	 * Setting the `block_hooks` property on the `WP_Block_Type` instance makes it
+	 * available via the block types REST endpoint and therefore to the editor.
+	 * Actual auto-insertion is still gated by `register_hooked_block` below, so
+	 * existing version-based opt-out behaviour is preserved.
+	 *
+	 * @return void
+	 */
+	public function register_block_hooks_metadata() {
+		if ( empty( $this->hooked_block_placements ) ) {
+			return;
+		}
+
+		$block_name = $this->namespace . '/' . $this->block_name;
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+
+		if ( ! $block_type instanceof \WP_Block_Type ) {
+			return;
+		}
+
+		$block_hooks = is_array( $block_type->block_hooks ) ? $block_type->block_hooks : array();
+
+		foreach ( $this->hooked_block_placements as $placement ) {
+			if ( ! isset( $placement['anchor'], $placement['position'] ) ) {
+				continue;
+			}
+
+			// Only `before`, `after`, `first_child` and `last_child` are valid positions
+			// for the `block_hooks` property on `WP_Block_Type`.
+			if ( ! in_array( $placement['position'], array( 'before', 'after', 'first_child', 'last_child' ), true ) ) {
+				continue;
+			}
+
+			$block_hooks[ $placement['anchor'] ] = $placement['position'];
+		}
+
+		$block_type->block_hooks = $block_hooks;
+	}
+
+	/**
 	 * Callback for `hooked_block_types` to auto-inject the mini-cart block into headers after navigation.
 	 *
 	 * @param array                             $hooked_blocks An array of block slugs hooked into a given context.
@@ -23,6 +71,8 @@ trait BlockHooksTrait {
 			return $hooked_blocks;
 		}
 
+		$block_name = $this->namespace . '/' . $this->block_name;
+
 		// Cache the block hooks version.
 		static $block_hooks_version = null;
 		if ( defined( 'WP_RUN_CORE_TESTS' ) || is_null( $block_hooks_version ) ) {
@@ -30,8 +80,10 @@ trait BlockHooksTrait {
 		}
 
 		// If block hooks are disabled or the version is not set, return early.
+		// Also remove the block from the hooked list if it was added via the `block_hooks`
+		// metadata on the registered block type (which is exposed for editor toggles).
 		if ( 'no' === $block_hooks_version || false === $block_hooks_version ) {
-			return $hooked_blocks;
+			return $this->remove_self_from_hooked_blocks( $hooked_blocks );
 		}
 
 		// Valid placements are those that have no version specified,
@@ -44,6 +96,24 @@ trait BlockHooksTrait {
 			}
 		);
 
+		// If no placement applies to this anchor/position pair, the block must not be
+		// auto-inserted here even if `block_hooks` metadata on the registered block type
+		// listed it. Strip any stale entry that core may have added.
+		$placement_matches_anchor = false;
+		foreach ( $valid_placements as $placement ) {
+			if ( isset( $placement['position'], $placement['anchor'] )
+				&& $placement['position'] === $position
+				&& $placement['anchor'] === $anchor_block
+			) {
+				$placement_matches_anchor = true;
+				break;
+			}
+		}
+		if ( ! $placement_matches_anchor ) {
+			return $this->remove_self_from_hooked_blocks( $hooked_blocks );
+		}
+
+		$should_hook = false;
 		if ( $context && ! empty( $valid_placements ) ) {
 			foreach ( $valid_placements as $placement ) {
 
@@ -54,14 +124,20 @@ trait BlockHooksTrait {
 						! $this->has_block_in_content( $context )
 						&& $this->is_target_area( $context, $placement['area'] )
 					) {
-						$hooked_blocks[] = $this->namespace . '/' . $this->block_name;
+						$should_hook = true;
+						if ( ! in_array( $block_name, $hooked_blocks, true ) ) {
+							$hooked_blocks[] = $block_name;
+						}
 					}
 
 					// If no area has been specified for this placement just insert the block.
 					// This is likely to be the case when we're inserting into the navigation block
 					// where we don't have a specific area to target.
 					if ( ! isset( $placement['area'] ) ) {
-						$hooked_blocks[] = $this->namespace . '/' . $this->block_name;
+						$should_hook = true;
+						if ( ! in_array( $block_name, $hooked_blocks, true ) ) {
+							$hooked_blocks[] = $block_name;
+						}
 					}
 
 					// If a callback has been specified for this placement, call it. This allows for custom block-specific logic to be run.
@@ -76,6 +152,30 @@ trait BlockHooksTrait {
 			}
 		}
 
+		if ( ! $should_hook ) {
+			$hooked_blocks = $this->remove_self_from_hooked_blocks( $hooked_blocks );
+		}
+
+		return $hooked_blocks;
+	}
+
+	/**
+	 * Remove this block from a list of hooked block names.
+	 *
+	 * Used to clear entries that core may have added because we declare the placement
+	 * via `block_hooks` metadata on the registered block type (so editor toggles work),
+	 * even when our placement rules say the block should not be auto-inserted.
+	 *
+	 * @param array $hooked_blocks An array of block slugs hooked into a given context.
+	 * @return array
+	 */
+	protected function remove_self_from_hooked_blocks( $hooked_blocks ) {
+		$block_name = $this->namespace . '/' . $this->block_name;
+		$key        = array_search( $block_name, $hooked_blocks, true );
+		if ( false !== $key ) {
+			unset( $hooked_blocks[ $key ] );
+			$hooked_blocks = array_values( $hooked_blocks );
+		}
 		return $hooked_blocks;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
@@ -82,4 +82,62 @@ class BlockHooksTests extends WP_UnitTestCase {
 		);
 		delete_option( self::$option_name );
 	}
+
+	/**
+	 * Test that `register_block_hooks_metadata` exposes the block's hook placement
+	 * via the `block_hooks` property on the registered `WP_Block_Type`. This is what
+	 * lets the block editor render a toggle for the block in the anchor block's
+	 * inspector even when the block is hooked exclusively via a PHP filter.
+	 *
+	 * @return void
+	 */
+	public function test_register_block_hooks_metadata_sets_block_hooks_on_registered_type() {
+		$registry   = \WP_Block_Type_Registry::get_instance();
+		$block_name = 'woocommerce/test-block';
+
+		$was_registered = $registry->is_registered( $block_name );
+		if ( ! $was_registered ) {
+			register_block_type( $block_name );
+		}
+
+		try {
+			self::$block_instance->register_block_hooks_metadata();
+
+			$block_type = $registry->get_registered( $block_name );
+			$this->assertInstanceOf( \WP_Block_Type::class, $block_type );
+			$this->assertIsArray( $block_type->block_hooks );
+			$this->assertArrayHasKey( 'core/navigation', $block_type->block_hooks );
+			$this->assertSame( 'after', $block_type->block_hooks['core/navigation'] );
+		} finally {
+			if ( ! $was_registered ) {
+				$registry->unregister( $block_name );
+			}
+		}
+	}
+
+	/**
+	 * Test that the hooked block list does not contain the block when no placement
+	 * matches the requested anchor/position pair — even when something else (e.g.
+	 * the `block_hooks` metadata registered via `register_block_hooks_metadata`)
+	 * already added it.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooked_block_strips_block_when_anchor_does_not_match() {
+		update_option( self::$option_name, '8.4.0', false );
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
+		$hooked_block_types = apply_filters(
+			'hooked_block_types',
+			array( 'woocommerce/test-block' ),
+			'after',
+			'core/paragraph',
+			array( 'mock-context' )
+		);
+		$this->assertNotContains(
+			'woocommerce/test-block',
+			$hooked_block_types,
+			'Test block should be removed when the anchor does not match any placement'
+		);
+		delete_option( self::$option_name );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Navigation block's hooked-blocks inspector renders a toggle for every block whose registered `WP_Block_Type::block_hooks` property references the navigation anchor (or whose name shows up in the navigation's `metadata.ignoredHookedBlocks`). The Customer Account and Mini Cart blocks were hooked exclusively via the `hooked_block_types` PHP filter, so neither had `block_hooks` set on its registered type. The Customer Account toggle still appeared in established stores because that block name happened to be persisted in `ignoredHookedBlocks` on a prior save, but the Mini Cart toggle was not exposed at all — matching the report in #54568.

This PR teaches `BlockHooksTrait` to set the `block_hooks` property on the registered `WP_Block_Type` for each declared placement (after `register_block_type` has run). The Customer Account and Mini Cart classes now call this on `init` at priority 11. To preserve the existing version-gated auto-insertion behaviour, `register_hooked_block` is updated so it strips the block from the hooked list when no placement matches the current anchor/position or when the store's `woocommerce_hooked_blocks_version` doesn't permit insertion. The block now opts back in to inserting only when the trait's existing placement/version checks all pass.

Net effect:
- Both toggles now appear consistently in the Navigation block inspector.
- Existing stores below the configured `woocommerce_hooked_blocks_version` still do not auto-insert these blocks.
- Toggling either block off persists via `ignoredHookedBlocks` exactly the way the Customer Account toggle already does today.

Closes #54568.

### How to test the changes in this Pull Request:

1. On a new store (`woocommerce_hooked_blocks_version` not yet set, or set to a recent version), open the Site Editor and edit the **Header** template part.
2. Make sure both the Customer Account and Mini Cart blocks appear after the Navigation block.
3. Select the Navigation block, open its **Settings** panel.
4. Verify a toggle is shown for **both** Customer Account **and** Mini Cart under the hooked block controls.
5. Toggle Mini Cart off and save; reload — the Mini Cart block should remain removed.
6. Toggle Mini Cart back on; the block should reappear.
7. Run the new PHP unit tests:
   ```
   pnpm --filter=@woocommerce/plugin-woocommerce test:php -- --filter BlockHooksTests
   ```

### Testing that has already taken place:

- New PHPUnit cases added to `BlockHooksTests` exercising `register_block_hooks_metadata` and the stripping branch of `register_hooked_block`.
- PHPStan run against the three modified PHP files — no errors, no baseline additions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix

#### Message

Show the Mini Cart toggle alongside the Customer Account toggle in the Navigation block's hooked blocks settings panel.

</details>

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-275

_Generated via the RSMAPGJ AI Coder pipeline._