### PR TITLE
Fix attribute slug length validation for multibyte characters

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-342
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-342
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix attribute slug length validation to count characters instead of bytes so multibyte (e.g. Cyrillic) slugs of 28 characters or fewer are accepted.

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -506,11 +506,11 @@ function wc_create_attribute( $args ) {
 	if ( empty( $args['slug'] ) ) {
 		$slug = wc_sanitize_taxonomy_name( $args['name'] );
 	} else {
-		$slug = preg_replace( '/^pa\_/', '', wc_sanitize_taxonomy_name( $args['slug'] ) );
+		$slug = (string) preg_replace( '/^pa\_/', '', wc_sanitize_taxonomy_name( $args['slug'] ) );
 	}
 
-	// Validate slug.
-	if ( strlen( $slug ) > 28 ) {
+	// Validate slug. Use mb_strlen so multibyte characters (e.g. Cyrillic) are counted as one character each, matching the user-visible character count.
+	if ( mb_strlen( $slug ) > 28 ) {
 		/* translators: %s: attribute slug */
 		return new WP_Error( 'invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), array( 'status' => 400 ) );
 	} elseif ( wc_check_if_attribute_name_is_reserved( $slug ) ) {

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -148,6 +148,21 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			'Attribute slugs should not be allowed to be over 28 characters long.'
 		);
 
+		// Multibyte (Cyrillic) slug of 28 characters should be allowed even though its byte length exceeds 28.
+		$ids[] = wc_create_attribute( array( 'name' => str_repeat( 'я', 28 ) ) );
+		$this->assertIsInt(
+			end( $ids ),
+			'Attribute creation should succeed when its multibyte slug is 28 characters long, even though its byte length exceeds 28.'
+		);
+
+		// Multibyte (Cyrillic) slug of 29 characters should be rejected based on character count, not byte count.
+		$err = wc_create_attribute( array( 'name' => str_repeat( 'я', 29 ) ) );
+		$this->assertEquals(
+			'invalid_product_attribute_slug_too_long',
+			$err->get_error_code(),
+			'Attribute slugs longer than 28 characters should be rejected for multibyte strings as well.'
+		);
+
 		$err = wc_create_attribute( array( 'name' => 'Cat' ) );
 		$this->assertEquals(
 			'invalid_product_attribute_slug_reserved_name',


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The slug length check in `wc_create_attribute()` (in `includes/wc-attribute-functions.php`) used `strlen()`, which counts bytes rather than characters. For multibyte slugs (e.g. Cyrillic) a 21 character string can report 40+ bytes, producing a spurious "Slug is too long (28 characters max)" error and blocking attribute creation even when the user-visible character count is within the limit advertised by the error message itself.

This PR switches the check to `mb_strlen()` so the 28 character limit is enforced consistently with what the UI tells the user. The cast added to the surrounding `preg_replace()` result keeps PHPStan happy under the stricter `mb_strlen()` signature.

Closes #36892
Linear: https://linear.app/a8c/issue/RSMAPGJ-342

### How to test the changes in this Pull Request:

1. Go to **Products → Attributes** in wp-admin.
2. Create an attribute with `Name = Тест Атрибут Кириллица` and `Slug = тестатрибуткирил` (21 Cyrillic characters).
3. Confirm the attribute is created successfully and no "Slug is too long" error is shown.
4. Now try creating another attribute with a 29 Cyrillic character slug (e.g. `str_repeat('я', 29)` worth of characters) and confirm it is rejected with the same "Slug is too long" message — multibyte slugs longer than 28 characters should still fail.
5. ASCII behaviour is unchanged: a 28 character ASCII slug should still succeed and a 29 character ASCII slug should still be rejected.

Automated coverage: `plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php::test_wc_create_attribute` now asserts both the 28 character Cyrillic success case and the 29 character Cyrillic rejection case.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Significance: Patch
Type: Fix

Message: Fix attribute slug length validation to count characters instead of bytes so multibyte (e.g. Cyrillic) slugs of 28 characters or fewer are accepted.

---

Submitted via the RSMAPGJ AI Coder pipeline.