### PR TITLE
Fix CSV product export leaking variations when type and category filters are combined

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-339
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-339
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CSV product export: stop leaking variations into the export when a category filter is combined with a type filter that does not include "variation".

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -229,10 +229,19 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		$this->row_data    = array();
 		$variable_products = array();
 
+		// When a category filter is applied, variations are not returned by the query because they do not
+		// carry their parent's category terms. We therefore append variations of any variable products that
+		// matched the category filter, but only when the user has not excluded the "variation" type from
+		// their selection (otherwise, picking only "Variable" alongside a category would leak variations
+		// into the export). For the include-by-ID path the type filter is ignored upstream, so we preserve
+		// the prior behavior of always appending variations of selected variable parents.
+		$include_variations = ! empty( $args['include'] )
+			|| ( ! empty( $args['category'] ) && in_array( ProductType::VARIATION, $this->product_types_to_export, true ) );
+
 		foreach ( $products->products as $product ) {
 			// Check if the product is variable and if either the include or category filter is active.
 			// This is to ensure that product variations are only included if they are being selectively exported or if they are part of a category.
-			if ( ( ! empty( $args['include'] ) || ! empty( $args['category'] ) ) &&
+			if ( $include_variations &&
 				$product->is_type( ProductType::VARIABLE ) &&
 				! in_array( $product->get_id(), $variable_products, true ) ) {
 				$variable_products[] = $product->get_id();

--- a/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
+++ b/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Enums\ProductStatus;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * Class WC_Product_CSV_Exporter_Test
@@ -67,5 +68,89 @@ class WC_Product_CSV_Exporter_Test extends \WC_Unit_Test_Case {
 			$this->assertEquals( -1, $row['published'] );
 		}
 		remove_filter( 'woocommerce_product_export_product_query_args', array( $this, 'set_export_product_query_args' ) );
+	}
+
+	/**
+	 * Helper: build a variable product with two variations assigned to a category.
+	 *
+	 * @param string $category_slug Category slug.
+	 * @return WC_Product_Variable
+	 */
+	private function create_variable_product_in_category( $category_slug ) {
+		$term    = wp_insert_term( $category_slug, 'product_cat' );
+		$cat_id  = is_wp_error( $term ) ? $term->error_data['term_exists'] : $term['term_id'];
+		$product = WC_Helper_Product::create_variation_product();
+		$product->set_category_ids( array( $cat_id ) );
+		$product->save();
+		return $product;
+	}
+
+	/**
+	 * @testdox category filter combined with the variable type filter must not leak variations into the export
+	 */
+	public function test_category_with_variable_type_filter_excludes_variations() {
+		$product = $this->create_variable_product_in_category( 'csv-export-variable-only' );
+
+		WC_Brands::init_taxonomy();
+
+		$exporter = new WC_Product_CSV_Exporter();
+		$exporter->set_product_types_to_export( array( ProductType::VARIABLE ) );
+		$exporter->set_product_category_to_export( array( 'csv-export-variable-only' ) );
+		$exporter->prepare_data_to_export();
+
+		$reflected_exporter = new ReflectionClass( WC_Product_CSV_Exporter::class );
+		$get_data_to_export = $reflected_exporter->getMethod( 'get_data_to_export' );
+		$get_data_to_export->setAccessible( true );
+		$data = $get_data_to_export->invoke( $exporter );
+
+		$types = wp_list_pluck( $data, 'type' );
+		$this->assertContains( ProductType::VARIABLE, $types, 'The variable parent should be exported.' );
+		$this->assertNotContains( ProductType::VARIATION, $types, 'Variations must not be exported when the user filters by variable type only.' );
+	}
+
+	/**
+	 * @testdox category filter without a type filter still includes variations of matching variable products
+	 */
+	public function test_category_filter_with_default_types_still_includes_variations() {
+		$product = $this->create_variable_product_in_category( 'csv-export-default-types' );
+
+		WC_Brands::init_taxonomy();
+
+		// Default types: constructor seeds all known product types including 'variation'.
+		$exporter = new WC_Product_CSV_Exporter();
+		$exporter->set_product_category_to_export( array( 'csv-export-default-types' ) );
+		$exporter->prepare_data_to_export();
+
+		$reflected_exporter = new ReflectionClass( WC_Product_CSV_Exporter::class );
+		$get_data_to_export = $reflected_exporter->getMethod( 'get_data_to_export' );
+		$get_data_to_export->setAccessible( true );
+		$data = $get_data_to_export->invoke( $exporter );
+
+		$types = wp_list_pluck( $data, 'type' );
+		$this->assertContains( ProductType::VARIABLE, $types, 'The variable parent should be exported.' );
+		$this->assertContains( ProductType::VARIATION, $types, 'Variations should still be exported when the variation type is part of the type filter.' );
+	}
+
+	/**
+	 * @testdox category filter combined with explicit variation type still includes variations
+	 */
+	public function test_category_filter_with_variation_type_includes_variations() {
+		$product = $this->create_variable_product_in_category( 'csv-export-variation-type' );
+
+		WC_Brands::init_taxonomy();
+
+		$exporter = new WC_Product_CSV_Exporter();
+		$exporter->set_product_types_to_export( array( ProductType::VARIABLE, ProductType::VARIATION ) );
+		$exporter->set_product_category_to_export( array( 'csv-export-variation-type' ) );
+		$exporter->prepare_data_to_export();
+
+		$reflected_exporter = new ReflectionClass( WC_Product_CSV_Exporter::class );
+		$get_data_to_export = $reflected_exporter->getMethod( 'get_data_to_export' );
+		$get_data_to_export->setAccessible( true );
+		$data = $get_data_to_export->invoke( $exporter );
+
+		$types = wp_list_pluck( $data, 'type' );
+		$this->assertContains( ProductType::VARIABLE, $types );
+		$this->assertContains( ProductType::VARIATION, $types );
 	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)?
- [x] Does your code pass all tests?
- [x] Have you tested for security vulnerabilities and added the relevant test coverage?

### Changes proposed in this Pull Request:

When the product CSV exporter ran with a category filter and a product type filter that did not include `variation` (for example only `Variable Product`), variations of any matching variable parents were appended to the export anyway, so the resulting CSV contained both `variable` and `variation` rows even though the user only selected `Variable Product`.

The fix gates the auto-append of variations on whether the user actually included `variation` in their type filter. Behavior is preserved when:

- Specific product IDs are exported (the type filter is ignored on that path), or
- A category filter is set and the user has not removed `variation` from the type selection (the default state of the form keeps all types selected).

Bug introduced before 8.1.1; first reported in woocommerce/woocommerce#40563.

### Screenshots or screen recordings:

N/A - server-side fix, no UI change.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment):

1. Create a product category, for example "Hoodies-QA".
2. Create a variable product, assign it to the new category, and add two variations.
3. Go to **Products -> All Products** and click **Export**.
4. In the export dialog:
   - Select product type **Variable Product**.
   - Select product category **Hoodies-QA**.
   - Click **Generate CSV**.
5. Open the generated CSV.

**Before the fix:** the CSV contains both the `variable` parent row and `variation` rows.

**After the fix:** the CSV only contains the `variable` parent row. Variations are still included when:

- The type filter is empty (default state - "Export all products").
- `Product variations` is explicitly added to the type selection alongside `Variable Product`.
- Specific product IDs are exported via the "Selected products" flow.

### Testing that has already taken place:

- Added PHPUnit coverage in `tests/php/includes/exporter/class-wc-product-csv-exporter-test.php` for three scenarios:
  - Variable type + category filter excludes variations.
  - Default (all types) + category filter still includes variations.
  - Variable + variation types + category filter still includes variations.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` - clean.
- Ran `composer exec -- phpstan analyse includes/export/class-wc-product-csv-exporter.php --memory-limit=2G` - clean.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` - clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Enhancement
- [x] Fix
- [ ] Tweak
- [ ] Performance
- [ ] Compatibility
- [ ] Other

#### Message

CSV product export: stop leaking variations into the export when a category filter is combined with a type filter that does not include "variation".

</details>

<details>

<summary>Significance: patch</summary>

Type: fix

</details>

Closes #40563
Linear: https://linear.app/a8c/issue/RSMAPGJ-339

_Submitted via the RSMAPGJ AI Coder pipeline._