### PR TITLE
Fix 404 for products with numeric slug in a sub-category

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-329
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-329
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 404 when accessing a product with a purely numeric slug placed in a sub-category and using the `%product_cat%` product permalink tag.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1083,6 +1083,63 @@ function wc_fix_rewrite_rules( $rules ) {
 add_filter( 'rewrite_rules_array', 'wc_fix_rewrite_rules' );
 
 /**
+ * Fix request query vars for products with a purely numeric slug when the product
+ * permalink uses the `%product_cat%` tag.
+ *
+ * When the permalink structure contains `%product_cat%` (e.g. `/shop/%product_cat%/`),
+ * WordPress generates a single-post rewrite rule that allows an optional trailing
+ * numeric segment to be interpreted as a `page` (pagination) value. For a URL like
+ * `/shop/parent-cat/child-cat/12345/`, this causes the regex to match
+ * `product=child-cat` and `page=12345`, returning a 404 instead of the product whose
+ * slug is `12345`. This filter detects that scenario and reassigns the numeric value
+ * back to the `product` query var when an actual product with that slug exists.
+ *
+ * @since 10.9.0
+ *
+ * @param array $query_vars Parsed query vars from the request.
+ * @return array
+ */
+function wc_fix_numeric_product_slug_request( $query_vars ) {
+	// Only run when the product permalink uses the %product_cat% rewrite tag.
+	$permalinks = wc_get_permalink_structure();
+	if ( false === strpos( $permalinks['product_rewrite_slug'], '%product_cat%' ) ) {
+		return $query_vars;
+	}
+
+	// Require a product slug and a numeric page value to be present.
+	if ( empty( $query_vars['product'] ) || empty( $query_vars['page'] ) ) {
+		return $query_vars;
+	}
+
+	$page_value = is_array( $query_vars['page'] ) ? '' : (string) $query_vars['page'];
+	if ( '' === $page_value || ! ctype_digit( ltrim( $page_value, '/' ) ) ) {
+		return $query_vars;
+	}
+
+	$numeric_slug = ltrim( $page_value, '/' );
+
+	// If the existing product slug already resolves to a published product, leave
+	// things alone (this is a legitimate paged request).
+	$existing = get_page_by_path( $query_vars['product'], OBJECT, 'product' );
+	if ( $existing instanceof WP_Post ) {
+		return $query_vars;
+	}
+
+	// Look for a product whose slug matches the numeric trailing segment.
+	$numeric_product = get_page_by_path( $numeric_slug, OBJECT, 'product' );
+	if ( ! $numeric_product instanceof WP_Post ) {
+		return $query_vars;
+	}
+
+	$query_vars['product'] = $numeric_slug;
+	$query_vars['name']    = $numeric_slug;
+	unset( $query_vars['page'] );
+
+	return $query_vars;
+}
+add_filter( 'request', 'wc_fix_numeric_product_slug_request' );
+
+/**
  * Prevent product attachment links from breaking when using complex rewrite structures.
  *
  * @param  string $link    Link.

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -275,4 +275,141 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertFalse( _wc_delete_transients( true ) );
 		$this->assertFalse( _wc_delete_transients( new stdClass() ) );
 	}
+
+	/**
+	 * Helper to set the product permalink structure for a test.
+	 *
+	 * @param string $product_base The product_base value to use.
+	 */
+	private function set_product_permalink_base( $product_base ) {
+		update_option(
+			'woocommerce_permalinks',
+			array(
+				'product_base'  => $product_base,
+				'category_base' => 'product-category',
+				'tag_base'      => 'product-tag',
+			)
+		);
+	}
+
+	/**
+	 * @testdox Should reassign the product query var when the numeric slug is misinterpreted as a page.
+	 */
+	public function test_wc_fix_numeric_product_slug_request_reassigns_numeric_slug() {
+		$original = get_option( 'woocommerce_permalinks' );
+		$this->set_product_permalink_base( '/shop/%product_cat%' );
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Numeric Slug Product' );
+		$product->set_slug( '12345' );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		$query_vars = wc_fix_numeric_product_slug_request(
+			array(
+				'product' => 'qa-child-cat',
+				'page'    => '12345',
+			)
+		);
+
+		$this->assertSame( '12345', $query_vars['product'], 'Numeric slug should become the product query var.' );
+		$this->assertSame( '12345', $query_vars['name'], 'Numeric slug should also populate the name query var.' );
+		$this->assertArrayNotHasKey( 'page', $query_vars, 'Page query var should be cleared once consumed.' );
+
+		$product->delete( true );
+		update_option( 'woocommerce_permalinks', is_array( $original ) ? $original : array() );
+	}
+
+	/**
+	 * @testdox Should leave query vars untouched when product permalink does not use %product_cat%.
+	 */
+	public function test_wc_fix_numeric_product_slug_request_skips_without_product_cat_placeholder() {
+		$original = get_option( 'woocommerce_permalinks' );
+		$this->set_product_permalink_base( '/shop' );
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Numeric Slug Product Skip' );
+		$product->set_slug( '67890' );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		$input      = array(
+			'product' => 'qa-child-cat',
+			'page'    => '67890',
+		);
+		$query_vars = wc_fix_numeric_product_slug_request( $input );
+
+		$this->assertSame( $input, $query_vars, 'Query vars should be untouched without %product_cat%.' );
+
+		$product->delete( true );
+		update_option( 'woocommerce_permalinks', is_array( $original ) ? $original : array() );
+	}
+
+	/**
+	 * @testdox Should leave query vars untouched when the existing product slug already resolves.
+	 */
+	public function test_wc_fix_numeric_product_slug_request_skips_when_existing_product_resolves() {
+		$original = get_option( 'woocommerce_permalinks' );
+		$this->set_product_permalink_base( '/shop/%product_cat%' );
+
+		$existing = new WC_Product_Simple();
+		$existing->set_name( 'Existing Product' );
+		$existing->set_slug( 'existing-product' );
+		$existing->set_status( 'publish' );
+		$existing->save();
+
+		$numeric = new WC_Product_Simple();
+		$numeric->set_name( 'Numeric Page' );
+		$numeric->set_slug( '42' );
+		$numeric->set_status( 'publish' );
+		$numeric->save();
+
+		$input      = array(
+			'product' => 'existing-product',
+			'page'    => '42',
+		);
+		$query_vars = wc_fix_numeric_product_slug_request( $input );
+
+		$this->assertSame( $input, $query_vars, 'Legitimate paged product requests should be preserved.' );
+
+		$existing->delete( true );
+		$numeric->delete( true );
+		update_option( 'woocommerce_permalinks', is_array( $original ) ? $original : array() );
+	}
+
+	/**
+	 * @testdox Should leave query vars untouched when no product matches the numeric slug.
+	 */
+	public function test_wc_fix_numeric_product_slug_request_skips_when_no_numeric_match() {
+		$original = get_option( 'woocommerce_permalinks' );
+		$this->set_product_permalink_base( '/shop/%product_cat%' );
+
+		$input      = array(
+			'product' => 'qa-child-cat',
+			'page'    => '99999',
+		);
+		$query_vars = wc_fix_numeric_product_slug_request( $input );
+
+		$this->assertSame( $input, $query_vars, 'Without a matching numeric product, query vars should be unchanged.' );
+
+		update_option( 'woocommerce_permalinks', is_array( $original ) ? $original : array() );
+	}
+
+	/**
+	 * @testdox Should leave query vars untouched when the page value is not purely numeric.
+	 */
+	public function test_wc_fix_numeric_product_slug_request_skips_non_numeric_page() {
+		$original = get_option( 'woocommerce_permalinks' );
+		$this->set_product_permalink_base( '/shop/%product_cat%' );
+
+		$input      = array(
+			'product' => 'qa-child-cat',
+			'page'    => 'not-a-number',
+		);
+		$query_vars = wc_fix_numeric_product_slug_request( $input );
+
+		$this->assertSame( $input, $query_vars, 'Non-numeric page values must be ignored.' );
+
+		update_option( 'woocommerce_permalinks', is_array( $original ) ? $original : array() );
+	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #46670
Linear: https://linear.app/a8c/issue/RSMAPGJ-329

When a WooCommerce product has a purely numeric slug and is placed in a hierarchical sub-category, and the product permalink uses the `%product_cat%` rewrite tag (e.g. `/shop/%product_cat%/`), visiting the product URL `/shop/parent-cat/child-cat/12345/` returns a 404 instead of the single-product page.

**Root cause**

WordPress generates a single-post rewrite rule for the product post type whose slug expands to `^shop/(.+?)/([^/]+)(?:/([0-9]+))?/?\$ → index.php?product=\$matches[2]&page=\$matches[3]`. The optional trailing `([0-9]+)` segment is meant for in-post pagination (`<!--nextpage-->`), but it greedily captures a numeric trailing slug. For `/shop/parent-cat/child-cat/12345/` this resolves to `product=child-cat` and `page=12345`. Because `child-cat` is a category slug rather than a product slug, the request 404s.

**Fix**

Adds a `request` filter, `wc_fix_numeric_product_slug_request`, in `wc-core-functions.php`. When the product permalink contains `%product_cat%` and an incoming request has both a `product` query var and a numeric `page` query var, the filter:

1. Looks up the existing `product` slug — if it resolves to a published product, the request is left alone (legitimate paged product page).
2. Otherwise looks up a product whose slug matches the numeric `page` value — if one exists, swaps it into the `product`/`name` query vars and unsets `page`.

This is a narrow, behaviour-preserving fix: it only kicks in for the exact pattern where the bug occurs and never overrides a request that already resolves to a valid product.

### Screenshots or screen recordings (if applicable):

N/A — back-end routing fix.

### How to test the changes in this Pull Request:

Using a local WordPress site with this branch active:

1. WooCommerce → Settings → Permalinks → set the Product permalink base to `Custom Base` and use `/shop/%product_cat%`. Save (this flushes rewrite rules).
2. Create a parent product category, e.g. `qa-parent-cat`.
3. Create a child product category, e.g. `qa-child-cat`, with `qa-parent-cat` as its parent.
4. Create a Simple product, set its slug to `12345`, assign it to `qa-child-cat`, and publish it.
5. Visit `/shop/qa-parent-cat/qa-child-cat/12345/`.
6. Confirm the product page renders (no 404).
7. Re-test with a non-numeric slug (e.g. `regular-product`) to confirm normal product URLs still work.
8. Re-test paged content: a product with `<!--nextpage-->` and a numeric page suffix should still paginate.

### Testing that has already taken place:

- New PHPUnit cases in `WC_Core_Functions_Test` cover: the swap, the no-op when permalink lacks `%product_cat%`, the no-op when the original product slug already resolves, the no-op when no product matches the numeric segment, and the no-op for non-numeric `page` values.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/wc-core-functions.php --memory-limit=2G` — clean, no baseline additions.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

> [!NOTE]
> A changelog entry was added manually at `plugins/woocommerce/changelog/fix-rsmapgj-329`.

---

_Generated by the RSMAPGJ AI Coder pipeline._