### PR TITLE
Fix: clean additional WooCommerce data on WC_REMOVE_ALL_DATA uninstall

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-318
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-318
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Uninstall: when WC_REMOVE_ALL_DATA is enabled, also remove the WooCommerce placeholder attachment, product_visibility taxonomy terms, and WooCommerce-owned _woocommerce_ / wc_ prefixed user meta.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2334,6 +2334,77 @@ $stock_notifications_table_schema;
 	}
 
 	/**
+	 * Delete the placeholder attachment created by WooCommerce during install.
+	 *
+	 * The attachment is referenced by the `woocommerce_placeholder_image` option and
+	 * is removed surgically by ID so that other plugins' attachments are not affected.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return void
+	 */
+	public static function remove_placeholder_attachment() {
+		$placeholder_image_id = (int) get_option( 'woocommerce_placeholder_image', 0 );
+
+		if ( $placeholder_image_id <= 0 ) {
+			return;
+		}
+
+		$post = get_post( $placeholder_image_id );
+
+		if ( $post instanceof WP_Post && 'attachment' === $post->post_type ) {
+			wp_delete_attachment( $placeholder_image_id, true );
+		}
+	}
+
+	/**
+	 * Delete usermeta rows created by WooCommerce core.
+	 *
+	 * Targets the explicit keys WooCommerce core writes to `wp_usermeta` (including
+	 * keys with a leading-underscore prefix and the `wc_` prefixed customer aggregates)
+	 * so they are cleaned up when uninstalling with the `WC_REMOVE_ALL_DATA` constant.
+	 *
+	 * Patterns kept conservative to avoid touching rows that may be owned by other
+	 * plugins/extensions.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return void
+	 */
+	public static function remove_user_meta() {
+		global $wpdb;
+
+		// Keys prefixed with `_woocommerce_` (e.g. `_woocommerce_persistent_cart_<blog_id>`,
+		// `_woocommerce_tracks_anon_id`, `_woocommerce_load_saved_cart_after_login`).
+		$wpdb->query( "DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE '\\_woocommerce\\_%'" );
+
+		// Explicit `wc_` prefixed keys owned by WooCommerce core: `wc_last_active`,
+		// `wc_order_count_*`, `wc_money_spent_*`.
+		$wpdb->query(
+			"DELETE FROM {$wpdb->usermeta} WHERE meta_key = 'wc_last_active'
+			OR meta_key LIKE 'wc\\_order\\_count\\_%'
+			OR meta_key LIKE 'wc\\_money\\_spent\\_%'"
+		);
+	}
+
+	/**
+	 * Taxonomies owned by WooCommerce that should be cleared on uninstall.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return string[]
+	 */
+	public static function get_taxonomies_to_remove() {
+		return array(
+			'product_cat',
+			'product_tag',
+			'product_shipping_class',
+			'product_type',
+			'product_visibility',
+		);
+	}
+
+	/**
 	 * Create files/directories.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -483,4 +483,128 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		remove_filter( 'woocommerce_get_shop_page_id', $supply_shop_id );
 		remove_filter( 'pre_option_' . \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore::OPTION_ORDER_STATS_TABLE_HAS_COLUMN_ORDER_FULFILLMENT_STATUS, $supply_column_status );
 	}
+
+	/**
+	 * Test that the WC-owned taxonomies list used by uninstall includes product_visibility.
+	 *
+	 * Regression for the issue where `product_visibility` terms remained in
+	 * `wp_term_taxonomy` after uninstalling with `WC_REMOVE_ALL_DATA` enabled.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_get_taxonomies_to_remove_includes_product_visibility(): void {
+		$taxonomies = WC_Install::get_taxonomies_to_remove();
+
+		$this->assertContains( 'product_visibility', $taxonomies );
+		$this->assertContains( 'product_cat', $taxonomies );
+		$this->assertContains( 'product_tag', $taxonomies );
+		$this->assertContains( 'product_shipping_class', $taxonomies );
+		$this->assertContains( 'product_type', $taxonomies );
+	}
+
+	/**
+	 * Test that remove_user_meta deletes _woocommerce_ and wc_ prefixed keys
+	 * owned by WooCommerce core, while leaving unrelated rows intact.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_remove_user_meta_cleans_wc_owned_keys(): void {
+		$user_id = self::factory()->user->create();
+
+		// WC-owned rows that must be removed.
+		update_user_meta( $user_id, '_woocommerce_persistent_cart_1', array( 'cart' => true ) );
+		update_user_meta( $user_id, '_woocommerce_tracks_anon_id', 'anon-id-123' );
+		update_user_meta( $user_id, '_woocommerce_load_saved_cart_after_login', 1 );
+		update_user_meta( $user_id, 'wc_last_active', '1700000000' );
+		update_user_meta( $user_id, 'wc_order_count_test_key', 5 );
+		update_user_meta( $user_id, 'wc_money_spent_test_key', 100 );
+
+		// Rows owned by other plugins / WP core that must NOT be removed.
+		update_user_meta( $user_id, 'other_plugin_wc_setting', 'preserve-me' );
+		update_user_meta( $user_id, 'session_tokens', 'preserve-me' );
+
+		WC_Install::remove_user_meta();
+
+		$this->assertSame( '', (string) get_user_meta( $user_id, '_woocommerce_persistent_cart_1', true ) );
+		$this->assertSame( '', (string) get_user_meta( $user_id, '_woocommerce_tracks_anon_id', true ) );
+		$this->assertSame( '', (string) get_user_meta( $user_id, '_woocommerce_load_saved_cart_after_login', true ) );
+		$this->assertSame( '', (string) get_user_meta( $user_id, 'wc_last_active', true ) );
+		$this->assertSame( '', (string) get_user_meta( $user_id, 'wc_order_count_test_key', true ) );
+		$this->assertSame( '', (string) get_user_meta( $user_id, 'wc_money_spent_test_key', true ) );
+
+		$this->assertSame( 'preserve-me', get_user_meta( $user_id, 'other_plugin_wc_setting', true ) );
+		$this->assertSame( 'preserve-me', get_user_meta( $user_id, 'session_tokens', true ) );
+	}
+
+	/**
+	 * Test that remove_placeholder_attachment deletes only the attachment whose ID
+	 * is stored in the `woocommerce_placeholder_image` option.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_remove_placeholder_attachment_deletes_only_the_referenced_attachment(): void {
+		$placeholder_id = self::factory()->post->create(
+			array(
+				'post_type'      => 'attachment',
+				'post_title'     => 'woocommerce-placeholder',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/webp',
+			)
+		);
+
+		$other_attachment_id = self::factory()->post->create(
+			array(
+				'post_type'      => 'attachment',
+				'post_title'     => 'some-other-image',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		$original_option_value = get_option( 'woocommerce_placeholder_image', 0 );
+		update_option( 'woocommerce_placeholder_image', $placeholder_id );
+
+		WC_Install::remove_placeholder_attachment();
+
+		$this->assertNull( get_post( $placeholder_id ), 'Placeholder attachment should be deleted.' );
+		$this->assertNotNull( get_post( $other_attachment_id ), 'Unrelated attachments must be preserved.' );
+
+		// Restore the original option value so we do not leak state.
+		update_option( 'woocommerce_placeholder_image', $original_option_value );
+
+		// Cleanup the surviving fixture.
+		wp_delete_post( $other_attachment_id, true );
+	}
+
+	/**
+	 * Test that remove_placeholder_attachment is a no-op when the option is unset
+	 * or does not point to an attachment.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_remove_placeholder_attachment_is_noop_when_option_missing_or_invalid(): void {
+		$original_option_value = get_option( 'woocommerce_placeholder_image', 0 );
+
+		// Case 1: option is 0 / missing. Should not throw / error.
+		update_option( 'woocommerce_placeholder_image', 0 );
+		WC_Install::remove_placeholder_attachment();
+		$this->assertTrue( true, 'No-op when the option is not set.' );
+
+		// Case 2: option points to a non-attachment post.
+		$non_attachment_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+		update_option( 'woocommerce_placeholder_image', $non_attachment_id );
+
+		WC_Install::remove_placeholder_attachment();
+
+		$this->assertNotNull( get_post( $non_attachment_id ), 'Non-attachment posts must not be deleted.' );
+
+		// Cleanup.
+		update_option( 'woocommerce_placeholder_image', $original_option_value );
+		wp_delete_post( $non_attachment_id, true );
+	}
 }

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -5,7 +5,7 @@
  * Uninstalling WooCommerce deletes user roles, pages, tables, and options.
  *
  * @package WooCommerce\Uninstaller
- * @version 2.3.0
+ * @version 10.9.0
  */
 
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
@@ -67,6 +67,9 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Roles + caps.
 	WC_Install::remove_roles();
 
+	// Delete the placeholder attachment created during install.
+	WC_Install::remove_placeholder_attachment();
+
 	// Pages.
 	wp_trash_post( get_option( 'woocommerce_shop_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_cart_page_id' ) );
@@ -90,8 +93,10 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'woocommerce\_%';" );
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'widget\_woocommerce\_%';" );
 
-	// Delete usermeta.
+	// Delete usermeta written by WooCommerce core, including keys with the
+	// `woocommerce_`, `_woocommerce_`, and well-known `wc_` prefixes.
 	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key LIKE 'woocommerce\_%';" );
+	WC_Install::remove_user_meta();
 
 	// Delete our data from the post and post meta tables, and remove any additional tables we created.
 	$wpdb->query( "DELETE FROM {$wpdb->posts} WHERE post_type IN ( 'product', 'product_variation', 'shop_coupon', 'shop_order', 'shop_order_refund' );" );
@@ -103,7 +108,7 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Delete terms if > WP 4.2 (term splitting was added in 4.2).
 	if ( version_compare( $wp_version, '4.2', '>=' ) ) {
 		// Delete term taxonomies.
-		foreach ( array( 'product_cat', 'product_tag', 'product_shipping_class', 'product_type' ) as $_taxonomy ) {
+		foreach ( WC_Install::get_taxonomies_to_remove() as $_taxonomy ) {
 			$wpdb->delete(
 				$wpdb->term_taxonomy,
 				array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When uninstalling WooCommerce with `WC_REMOVE_ALL_DATA` set to `true`, several pieces of data WooCommerce itself creates were left behind in the database. This PR extends the uninstall routine to clean them up while staying conservative about anything WooCommerce does not own.

Specifically:

- Delete the placeholder attachment (`woocommerce-placeholder.webp`) that `WC_Install` creates during install. The attachment ID is read from the `woocommerce_placeholder_image` option and deleted by ID via `wp_delete_attachment()`, so other plugins' attachments are not affected.
- Include `product_visibility` in the list of WC-owned taxonomies whose `wp_term_taxonomy` rows are cleared. This taxonomy is registered by WC in `class-wc-post-types.php`.
- Delete WC-owned `wp_usermeta` rows that the existing `woocommerce_%` LIKE missed:
  - `_woocommerce_*` (e.g. `_woocommerce_persistent_cart_<blog_id>`, `_woocommerce_tracks_anon_id`, `_woocommerce_load_saved_cart_after_login`).
  - The explicit `wc_` customer aggregates: `wc_last_active`, `wc_order_count_*`, `wc_money_spent_*`.

The new cleanup paths are factored into three static methods on `WC_Install` (`remove_placeholder_attachment`, `remove_user_meta`, `get_taxonomies_to_remove`) so they are unit-testable and callable from `uninstall.php`.

#### Out of scope

The Action Scheduler tables (`wp_actionscheduler_*`) are intentionally left in place. Per the triage verdict on this issue, Action Scheduler is a standalone library shared across the WP plugin ecosystem and whether WC core should drop those tables is a cross-ecosystem ownership decision rather than a localizable bug fix.

Closes #63780

Linear: [RSMAPGJ-318](https://linear.app/a8c/issue/RSMAPGJ-318)

### How to test the changes in this Pull Request:

1. Install WooCommerce on a fresh site and complete the install (so the placeholder attachment, options, user meta, and `product_visibility` terms are created).
2. Add `define( 'WC_REMOVE_ALL_DATA', true );` to `wp-config.php`.
3. Browse some products as a logged-in user (creates `wc_last_active`, etc.) and let the order count / money spent aggregates populate (`wc_order_count_*`, `wc_money_spent_*`). Optionally tick the persistent cart cookie path.
4. Deactivate and delete WooCommerce from `wp-admin/plugins.php`.
5. Inspect the database:
   - `SELECT * FROM wp_postmeta WHERE meta_value LIKE '%woocommerce-placeholder%'` should return 0 rows.
   - `SELECT * FROM wp_posts WHERE post_title = 'woocommerce-placeholder'` should return 0 rows.
   - `SELECT * FROM wp_term_taxonomy WHERE taxonomy = 'product_visibility'` should return 0 rows.
   - `SELECT * FROM wp_usermeta WHERE meta_key LIKE '\_woocommerce\_%' OR meta_key = 'wc_last_active' OR meta_key LIKE 'wc\_order\_count\_%' OR meta_key LIKE 'wc\_money\_spent\_%'` should return 0 rows.
6. Confirm that unrelated rows (e.g. `session_tokens`, attachments owned by other plugins, taxonomy rows for non-WC taxonomies) are untouched.

### Testing that has already taken place:

- New PHPUnit coverage in `class-wc-install-test.php`:
  - `test_get_taxonomies_to_remove_includes_product_visibility` — verifies the list returned by the helper.
  - `test_remove_user_meta_cleans_wc_owned_keys` — seeds WC-owned + unrelated user meta rows, asserts the WC ones are gone and the unrelated ones survive.
  - `test_remove_placeholder_attachment_deletes_only_the_referenced_attachment` — seeds two attachments, points the option at one, confirms only that one is deleted.
  - `test_remove_placeholder_attachment_is_noop_when_option_missing_or_invalid` — confirms the helper is a safe no-op when the option is unset or points at a non-attachment.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse includes/class-wc-install.php --memory-limit=2G` — no errors; `uninstall.php` is not part of the configured PHPStan paths so was not analysed (no baseline change).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually at `plugins/woocommerce/changelog/fix-rsmapgj-318` (significance: patch, type: fix).

---

Submitted by the RSMAPGJ AI Coder pipeline.