### PR TITLE
Fix country dropdown dropping the order's saved country on order edit screen

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-337
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-337
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the order's saved billing and shipping country remains selectable in the order edit screen dropdown when the store no longer sells/ships to that country, preventing silent country changes on save.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -52,7 +52,7 @@ class WC_Meta_Box_Order_Data {
 		 * @param WC_Order|false $order Order object.
 		 * @param string $context Context of fields (view or edit).
 		 */
-		return apply_filters(
+		$fields = apply_filters(
 			'woocommerce_admin_billing_fields',
 			array(
 				'first_name' => array(
@@ -105,6 +105,8 @@ class WC_Meta_Box_Order_Data {
 			$order,
 			$context
 		);
+
+		return self::ensure_order_country_in_options( $fields, $order, 'billing' );
 	}
 
 	/**
@@ -124,7 +126,7 @@ class WC_Meta_Box_Order_Data {
 		 * @param WC_Order|false $order Order object.
 		 * @param string $context Context of fields (view or edit).
 		 */
-		return apply_filters(
+		$fields = apply_filters(
 			'woocommerce_admin_shipping_fields',
 			array(
 				'first_name' => array(
@@ -174,6 +176,64 @@ class WC_Meta_Box_Order_Data {
 			$order,
 			$context
 		);
+
+		return self::ensure_order_country_in_options( $fields, $order, 'shipping' );
+	}
+
+	/**
+	 * Ensures the order's currently saved country is present in the country field's options.
+	 *
+	 * When a country is removed from the store's allowed sell/ship-to countries (or a
+	 * plugin filters the country list), the order edit screen would otherwise omit the
+	 * order's saved country from the dropdown. The first option would then be silently
+	 * selected on save, mutating historical order data. This guard merges the saved
+	 * country back into the options so it always remains selectable.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param mixed             $fields Address fields array (or whatever a filter returned).
+	 * @param \WC_Order|boolean $order  Order object, or false when no order context.
+	 * @param string            $group  Field group: 'billing' or 'shipping'.
+	 * @return mixed Fields with the saved country merged into options when missing.
+	 */
+	protected static function ensure_order_country_in_options( $fields, $order, $group ) {
+		if ( ! is_array( $fields ) ) {
+			return $fields;
+		}
+
+		if ( ! $order instanceof WC_Order ) {
+			return $fields;
+		}
+
+		if ( ! isset( $fields['country'] ) || ! is_array( $fields['country'] ) ) {
+			return $fields;
+		}
+
+		$getter = 'billing' === $group ? 'get_billing_country' : 'get_shipping_country';
+		if ( ! is_callable( array( $order, $getter ) ) ) {
+			return $fields;
+		}
+
+		$order_country = $order->{$getter}( 'edit' );
+		if ( empty( $order_country ) ) {
+			return $fields;
+		}
+
+		$options = isset( $fields['country']['options'] ) && is_array( $fields['country']['options'] )
+			? $fields['country']['options']
+			: array();
+
+		if ( array_key_exists( $order_country, $options ) ) {
+			return $fields;
+		}
+
+		$all_countries = WC()->countries->get_countries();
+		$country_label = isset( $all_countries[ $order_country ] ) ? $all_countries[ $order_country ] : $order_country;
+
+		$options[ $order_country ]    = $country_label;
+		$fields['country']['options'] = $options;
+
+		return $fields;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-test.php
@@ -1,0 +1,213 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the WC_Meta_Box_Order_Data class.
+ *
+ * @package WooCommerce\Tests\Admin\MetaBoxes
+ */
+
+/**
+ * Class WC_Meta_Box_Order_Data_Test
+ *
+ * Covers regression guards added for RSMAPGJ-337 / woo#41777: ensuring the
+ * order's saved billing/shipping country is always present in the order
+ * edit screen country dropdown, even when the store has restricted its
+ * sell/ship-to countries or a filter removed the option.
+ */
+class WC_Meta_Box_Order_Data_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Helper for invoking a protected static method on WC_Meta_Box_Order_Data.
+	 *
+	 * @param string $method_name Method name.
+	 * @param array  $args        Positional arguments.
+	 * @return mixed
+	 */
+	private function call_protected_static( string $method_name, array $args ) {
+		$reflection = new ReflectionMethod( 'WC_Meta_Box_Order_Data', $method_name );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( null, $args );
+	}
+
+	/**
+	 * Tear down filters that tests may register.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_admin_billing_fields' );
+		remove_all_filters( 'woocommerce_admin_shipping_fields' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Build an order with a billing/shipping country set.
+	 *
+	 * @param string $billing_country  Billing country code.
+	 * @param string $shipping_country Shipping country code.
+	 * @return WC_Order
+	 */
+	private function create_order_with_country( string $billing_country, string $shipping_country ): WC_Order {
+		$order = WC_Helper_Order::create_order();
+		$order->set_billing_country( $billing_country );
+		$order->set_shipping_country( $shipping_country );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * The order's billing country must be present in the dropdown even when
+	 * a filter restricts the country options.
+	 */
+	public function test_billing_country_is_included_when_filter_restricts_options(): void {
+		$order = $this->create_order_with_country( 'ST', 'ST' );
+
+		add_filter(
+			'woocommerce_admin_billing_fields',
+			function ( $fields ) {
+				$fields['country']['options'] = array(
+					''   => 'Select a country',
+					'PT' => 'Portugal',
+					'ES' => 'Spain',
+				);
+				return $fields;
+			}
+		);
+
+		$fields = $this->call_protected_static( 'get_billing_fields', array( $order, 'edit' ) );
+
+		$this->assertArrayHasKey( 'country', $fields );
+		$this->assertArrayHasKey(
+			'ST',
+			$fields['country']['options'],
+			"The order's saved billing country (ST) must remain selectable on the order edit screen."
+		);
+		// Existing options are preserved.
+		$this->assertArrayHasKey( 'PT', $fields['country']['options'] );
+		$this->assertArrayHasKey( 'ES', $fields['country']['options'] );
+	}
+
+	/**
+	 * Same regression guard for the shipping country dropdown.
+	 */
+	public function test_shipping_country_is_included_when_filter_restricts_options(): void {
+		$order = $this->create_order_with_country( 'PT', 'ST' );
+
+		add_filter(
+			'woocommerce_admin_shipping_fields',
+			function ( $fields ) {
+				$fields['country']['options'] = array(
+					''   => 'Select a country',
+					'PT' => 'Portugal',
+					'ES' => 'Spain',
+				);
+				return $fields;
+			}
+		);
+
+		$fields = $this->call_protected_static( 'get_shipping_fields', array( $order, 'edit' ) );
+
+		$this->assertArrayHasKey( 'country', $fields );
+		$this->assertArrayHasKey(
+			'ST',
+			$fields['country']['options'],
+			"The order's saved shipping country (ST) must remain selectable on the order edit screen."
+		);
+	}
+
+	/**
+	 * The injected country must use the human-readable label from WC()->countries.
+	 */
+	public function test_injected_country_uses_label_from_countries_class(): void {
+		$order = $this->create_order_with_country( 'ST', 'ST' );
+
+		add_filter(
+			'woocommerce_admin_billing_fields',
+			function ( $fields ) {
+				$fields['country']['options'] = array( '' => 'Select a country', 'PT' => 'Portugal' );
+				return $fields;
+			}
+		);
+
+		$fields    = $this->call_protected_static( 'get_billing_fields', array( $order, 'edit' ) );
+		$countries = WC()->countries->get_countries();
+
+		$this->assertSame(
+			$countries['ST'],
+			$fields['country']['options']['ST'],
+			'The injected country label should come from the canonical country list.'
+		);
+	}
+
+	/**
+	 * If the order's country is already present, the options must not change.
+	 */
+	public function test_country_already_present_is_not_duplicated(): void {
+		$order = $this->create_order_with_country( 'PT', 'PT' );
+
+		add_filter(
+			'woocommerce_admin_billing_fields',
+			function ( $fields ) {
+				$fields['country']['options'] = array(
+					''   => 'Select a country',
+					'PT' => 'Portugal',
+					'ES' => 'Spain',
+				);
+				return $fields;
+			}
+		);
+
+		$fields = $this->call_protected_static( 'get_billing_fields', array( $order, 'edit' ) );
+
+		$this->assertSame(
+			array( '', 'PT', 'ES' ),
+			array_keys( $fields['country']['options'] ),
+			'Options should remain unchanged when the order country is already present.'
+		);
+	}
+
+	/**
+	 * An empty saved country must not inject an empty key beyond the placeholder.
+	 */
+	public function test_empty_order_country_does_not_inject_option(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_billing_country( '' );
+		$order->save();
+
+		add_filter(
+			'woocommerce_admin_billing_fields',
+			function ( $fields ) {
+				$fields['country']['options'] = array( '' => 'Select', 'PT' => 'Portugal' );
+				return $fields;
+			}
+		);
+
+		$fields = $this->call_protected_static( 'get_billing_fields', array( $order, 'edit' ) );
+
+		$this->assertSame(
+			array( '', 'PT' ),
+			array_keys( $fields['country']['options'] ),
+			'No extra option should be injected when the order has no billing country.'
+		);
+	}
+
+	/**
+	 * When no order is supplied (early calls), the helper must be a no-op.
+	 */
+	public function test_no_order_context_returns_fields_unchanged(): void {
+		add_filter(
+			'woocommerce_admin_billing_fields',
+			function ( $fields ) {
+				$fields['country']['options'] = array( '' => 'Select', 'PT' => 'Portugal' );
+				return $fields;
+			}
+		);
+
+		$fields = $this->call_protected_static( 'get_billing_fields', array( false, 'edit' ) );
+
+		$this->assertSame(
+			array( '', 'PT' ),
+			array_keys( $fields['country']['options'] ),
+			'Fields must be returned unchanged when no order context is available.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Coding Guidelines](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines).

### Changes proposed in this Pull Request

Closes #41777.

Linear: https://linear.app/a8c/issue/RSMAPGJ-337

When a country is removed from the store's allowed sell/ship-to countries (or a plugin filters `woocommerce_admin_billing_fields` / `woocommerce_admin_shipping_fields` to restrict the dropdown), the order edit screen would render the country `<select>` without the order's saved country. Saving the order without touching the form would then silently mutate the saved country to the first option in the dropdown — corrupting historical order data.

This PR adds a defensive guard inside `WC_Meta_Box_Order_Data::get_billing_fields()` and `get_shipping_fields()` that, after the public filter runs, re-injects the order's currently saved country into the field's `options` array if it is missing. The label is sourced from `WC()->countries->get_countries()`, falling back to the country code if it is not in the canonical list.

### Screenshots or screen recordings

UI change is a single dropdown option restored. No new visual chrome.

### How to test the changes in this Pull Request

1. Settings → General: allow specific countries; pick e.g. Portugal (PT) and Spain (ES) only.
2. Create an order with billing country set to São Tomé e Príncipe (`ST`) — for example via `wc_create_order()` from `wp shell` or a manual order, then `update_post_meta` / `$order->set_billing_country( 'ST' )` to bypass the allowed-countries restriction.
3. Visit the order edit screen.
4. Without the fix, the country dropdown only lists PT/ES and "first one selected" is shown; clicking **Update** silently changes the country.
5. With the fix, the dropdown includes São Tomé e Príncipe alongside PT/ES, the saved country stays selected, and clicking **Update** preserves it.
6. Repeat for shipping country.

### Testing that has already taken place

- New PHPUnit coverage in `tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-test.php` exercising:
  - billing & shipping country re-injected when a filter restricts options;
  - injected label sourced from `WC()->countries`;
  - no-op when the order country is already present;
  - no-op when the order has no country or no order context is available.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.
- `composer exec -- phpstan analyse` on the modified file clean (no new baseline entries).
- `composer exec -- changelogger validate` clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance:** Patch
**Type:** Fix
**Message:** Ensure the order's saved billing and shipping country remains selectable in the order edit screen dropdown when the store no longer sells/ships to that country, preventing silent country changes on save.

</details>

---

Submitted by the RSMAPGJ AI Coder pipeline.