### PR TITLE
Fix: only save product once on update (RSMAPGJ-324)

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-324
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-324
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid calling WC_Product::save() twice when updating a product in the classic editor: the gallery image ids are now persisted as part of the product data meta box save handler, removing the redundant second save from the product images meta box handler.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -339,6 +339,20 @@ class WC_Meta_Box_Product_Data {
 		$attributes   = self::prepare_attributes();
 		$stock        = null;
 
+		// Resolve the product gallery image ids from the form submission so they can
+		// be persisted as part of the single $product->save() call below. This
+		// replaces the redundant save() previously performed by
+		// WC_Meta_Box_Product_Images::save() (see #55882).
+		$gallery_image_ids_raw = isset( $_POST['product_image_gallery'] ) ? wp_unslash( $_POST['product_image_gallery'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( is_string( $gallery_image_ids_raw ) ) {
+			$gallery_image_ids_clean = wc_clean( $gallery_image_ids_raw );
+			$gallery_image_ids       = is_string( $gallery_image_ids_clean )
+				? array_filter( array_map( 'absint', explode( ',', $gallery_image_ids_clean ) ) )
+				: array();
+		} else {
+			$gallery_image_ids = array();
+		}
+
 		// Handle stock changes.
 		if ( isset( $_POST['_stock'] ) ) {
 			if ( isset( $_POST['_original_stock'] ) && wc_stock_amount( $product->get_stock_quantity( 'edit' ) ) !== wc_stock_amount( wp_unslash( $_POST['_original_stock'] ) ) ) {
@@ -413,6 +427,7 @@ class WC_Meta_Box_Product_Data {
 				'reviews_allowed'    => ! empty( $_POST['comment_status'] ) && 'open' === $_POST['comment_status'],
 				'attributes'         => $attributes,
 				'default_attributes' => self::prepare_set_attributes( $attributes, 'default_attribute_' ),
+				'gallery_image_ids'  => $gallery_image_ids,
 			)
 		);
 
@@ -439,6 +454,11 @@ class WC_Meta_Box_Product_Data {
 		 * @since 3.0.0
 		 */
 		do_action( 'woocommerce_admin_process_product_object', $product );
+
+		// The gallery image ids are set above via set_props() so the single save() call below
+		// persists them. Mark the gallery as already handled so WC_Meta_Box_Product_Images::save
+		// can skip its redundant second save() call (see #55882).
+		WC_Meta_Box_Product_Images::$gallery_handled_by_product_data = true;
 
 		$product->save();
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
@@ -22,6 +22,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Meta_Box_Product_Images {
 
 	/**
+	 * Whether the product gallery image ids have already been set and saved by
+	 * WC_Meta_Box_Product_Data::save() during the current `woocommerce_process_product_meta`
+	 * cycle. When true, self::save() skips its own call to $product->save() to avoid
+	 * a redundant second save during the same product update (see #55882).
+	 *
+	 * @var bool
+	 */
+	public static $gallery_handled_by_product_data = false;
+
+	/**
 	 * Output the metabox.
 	 *
 	 * @param WP_Post $post
@@ -95,6 +105,19 @@ class WC_Meta_Box_Product_Images {
 	 * @param WP_Post $post
 	 */
 	public static function save( $post_id, $post ) {
+		// The gallery image ids are already set and persisted as part of
+		// WC_Meta_Box_Product_Data::save(), which runs at priority 10 on the same
+		// `woocommerce_process_product_meta` hook. Skipping this redundant save
+		// avoids triggering save() twice per product update (see #55882).
+		// Reset the flag so subsequent product saves in the same request are still
+		// handled correctly.
+		if ( self::$gallery_handled_by_product_data ) {
+			self::$gallery_handled_by_product_data = false;
+			return;
+		}
+
+		// Fallback path: this runs only if WC_Meta_Box_Product_Data::save was unhooked
+		// by a third party. Keep the original behavior in that case.
 		$product_type   = empty( $_POST['product-type'] ) ? WC_Product_Factory::get_product_type( $post_id ) : sanitize_title( stripslashes( $_POST['product-type'] ) );
 		$classname      = WC_Product_Factory::get_product_classname( $post_id, $product_type ? $product_type : ProductType::SIMPLE );
 		$product        = new $classname( $post_id );

--- a/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-product-save-once-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-product-save-once-test.php
@@ -1,0 +1,157 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests that ensure the product Update action only triggers a single
+ * WC_Product::save() during the `woocommerce_process_product_meta` cycle.
+ *
+ * Regression test for woocommerce/woocommerce#55882: prior to the fix, both
+ * WC_Meta_Box_Product_Data::save() and WC_Meta_Box_Product_Images::save()
+ * independently called $product->save(), causing two saves per update.
+ *
+ * @package WooCommerce\Tests\Admin\MetaBoxes
+ */
+
+// phpcs:disable WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * Class WC_Meta_Box_Product_Save_Once_Test
+ */
+class WC_Meta_Box_Product_Save_Once_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Number of times $product->save() has been observed during the test.
+	 *
+	 * @var int
+	 */
+	private $save_count = 0;
+
+	/**
+	 * Callback used to count product saves.
+	 *
+	 * @var callable|null
+	 */
+	private $save_counter_callback;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		require_once WC_ABSPATH . 'includes/admin/meta-boxes/class-wc-meta-box-product-data.php';
+		require_once WC_ABSPATH . 'includes/admin/meta-boxes/class-wc-meta-box-product-images.php';
+
+		$this->save_count            = 0;
+		$this->save_counter_callback = function ( $product ) {
+			if ( $product instanceof WC_Product ) {
+				++$this->save_count;
+			}
+		};
+
+		add_action( 'woocommerce_before_product_object_save', $this->save_counter_callback );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		if ( null !== $this->save_counter_callback ) {
+			remove_action( 'woocommerce_before_product_object_save', $this->save_counter_callback );
+		}
+		WC_Meta_Box_Product_Images::$gallery_handled_by_product_data = false;
+		$_POST = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should call product save() only once when both meta box save handlers run for a product update.
+	 */
+	public function test_product_save_is_called_once_for_update(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$post_id = $product->get_id();
+		$post    = get_post( $post_id );
+
+		$_POST = array(
+			'product-type'          => 'simple',
+			'post_ID'               => $post_id,
+			'_regular_price'        => '12.34',
+			'product_image_gallery' => '',
+		);
+
+		WC_Meta_Box_Product_Data::save( $post_id, $post );
+		WC_Meta_Box_Product_Images::save( $post_id, $post );
+
+		$this->assertSame(
+			1,
+			$this->save_count,
+			'Product update should trigger WC_Product::save() exactly once across both meta box handlers.'
+		);
+	}
+
+	/**
+	 * @testdox Should persist gallery image ids set via the product data meta box save handler.
+	 */
+	public function test_gallery_image_ids_are_persisted_by_product_data_save(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$post_id = $product->get_id();
+		$post    = get_post( $post_id );
+
+		$_POST = array(
+			'product-type'          => 'simple',
+			'post_ID'               => $post_id,
+			'_regular_price'        => '12.34',
+			'product_image_gallery' => '10,20,30',
+		);
+
+		WC_Meta_Box_Product_Data::save( $post_id, $post );
+		WC_Meta_Box_Product_Images::save( $post_id, $post );
+
+		$reloaded = wc_get_product( $post_id );
+
+		$this->assertSame(
+			array( 10, 20, 30 ),
+			array_values( $reloaded->get_gallery_image_ids( 'edit' ) ),
+			'Gallery image ids submitted via the form should be persisted.'
+		);
+		$this->assertSame(
+			1,
+			$this->save_count,
+			'Saving gallery ids alongside other product data should still only trigger a single save().'
+		);
+	}
+
+	/**
+	 * @testdox Should fall back to saving via the images meta box handler when the product data handler did not run.
+	 */
+	public function test_images_save_runs_when_product_data_save_is_unhooked(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$post_id = $product->get_id();
+		$post    = get_post( $post_id );
+
+		$_POST = array(
+			'product-type'          => 'simple',
+			'post_ID'               => $post_id,
+			'product_image_gallery' => '4,5,6',
+		);
+
+		// Simulate a third party having unhooked WC_Meta_Box_Product_Data::save.
+		WC_Meta_Box_Product_Images::$gallery_handled_by_product_data = false;
+
+		WC_Meta_Box_Product_Images::save( $post_id, $post );
+
+		$reloaded = wc_get_product( $post_id );
+
+		$this->assertSame(
+			array( 4, 5, 6 ),
+			array_values( $reloaded->get_gallery_image_ids( 'edit' ) ),
+			'Images handler should still save the gallery when the product data handler did not run.'
+		);
+		$this->assertSame(
+			1,
+			$this->save_count,
+			'Fallback path in the images handler should still result in a single save().'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Testing Guidelines](https://github.com/woocommerce/woocommerce/wiki/How-to-test-your-Pull-Request).

### Changes proposed in this Pull Request:

Clicking **Update** on the classic product edit screen used to call `WC_Product::save()` twice per request: once from `WC_Meta_Box_Product_Data::save()` and again from `WC_Meta_Box_Product_Images::save()`. Both handlers are registered on the same `woocommerce_process_product_meta` action, so a single product update would trigger two database writes plus two rounds of `woocommerce_before/after_product_object_save` hooks, hook callbacks, and any subscriber side effects.

This PR consolidates the writes into a single save:

- `WC_Meta_Box_Product_Data::save()` now resolves `product_image_gallery` from the request and includes it in the same `set_props()` block as the rest of the product fields, so its existing `$product->save()` call persists the gallery too.
- A static guard (`WC_Meta_Box_Product_Images::$gallery_handled_by_product_data`) is set before that `save()` runs.
- `WC_Meta_Box_Product_Images::save()` checks the guard. In the normal path it returns early without saving again. If a third party has unhooked `WC_Meta_Box_Product_Data::save`, the original behavior (set gallery ids + save) still runs as a fallback so we don't silently drop gallery updates in that scenario.

### Closes

Closes #55882
Linear: https://linear.app/a8c/issue/RSMAPGJ-324

### How to test the changes in this Pull Request:

1. Apply a tiny mu-plugin that counts how many times the product is saved:
   ```php
   <?php
   add_action( 'woocommerce_before_product_object_save', function () {
       $count = (int) get_option( 'qa_product_save_count', 0 );
       update_option( 'qa_product_save_count', $count + 1 );
   } );
   ```
2. Create or open a simple product in `wp-admin` (classic editor).
3. `update_option( 'qa_product_save_count', 0 );` (e.g. via WP-CLI or the Options Tool plugin).
4. Click **Update**.
5. Read `qa_product_save_count`:
   - Before this PR: `2`.
   - With this PR applied: `1`.
6. Confirm the product still saves correctly: change the regular price and the gallery images, click **Update**, reload, verify both persisted.

### Testing that has already taken place:

- Added `WC_Meta_Box_Product_Save_Once_Test` PHPUnit coverage that asserts:
  - A single `$product->save()` per `woocommerce_process_product_meta` cycle when both handlers run.
  - Gallery image ids submitted via the form are persisted through the data meta box save path.
  - The images handler still saves the gallery when the data handler is unhooked (fallback path).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse <changed files> --memory-limit=2G` — clean, no baseline additions.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog entry committed under `plugins/woocommerce/changelog/fix-rsmapgj-324`.)

---

Submitted by the RSMAPGJ AI Coder pipeline.