### PR TITLE
Fix tooltip overlap with country/state autocomplete on tax rate entry

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-311
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-311
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent the column header tooltip on the Tax > Standard Rates page from overlapping the country and state autocomplete dropdowns.

--- a/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
@@ -152,17 +152,25 @@
 						this.el.innerHTML = rowTemplateEmpty();
 					}
 
+					// Hide any lingering tipTip tooltip so it cannot overlap the
+					// autocomplete suggestions for the country/state inputs.
+					var hideTipTip = function() {
+						$( '#tiptip_holder' ).hide();
+					};
+
 					// Initialize autocomplete for countries.
 					this.$el.find( 'td.country input' ).autocomplete({
 						source: data.countries,
-						minLength: 2
-					});
+						minLength: 2,
+						open: hideTipTip
+					}).on( 'focus', hideTipTip );
 
 					// Initialize autocomplete for states.
 					this.$el.find( 'td.state input' ).autocomplete({
 						source: data.states,
-						minLength: 3
-					});
+						minLength: 3,
+						open: hideTipTip
+					}).on( 'focus', hideTipTip );
 
 					// Postcode and city don't have `name` values by default.
 					// They're only created if the contents changes, to save on database queries (I think)


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WooCommerce Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

On the Tax > Standard Rates settings screen, the column header help tooltips are rendered with the global `tipTip` plugin, which uses `z-index: 8675309` on `#tiptip_holder`. The jQuery UI autocomplete dropdown used by the country and state inputs inherits the much lower `.ui-front { z-index: 100 }`, so a tooltip that the user has already triggered by hovering the help icon lingers on top of the dropdown and prevents the user from selecting any country whose option falls under it.

This PR dismisses any lingering tipTip tooltip when the country/state autocomplete inputs are focused or when the dropdown opens, so the suggestion list is always usable.

Closes #26139

### How to test the changes in this Pull Request

1. Enable taxes (`WooCommerce > Settings > General > Enable tax rates and calculations`).
2. Navigate to `WooCommerce > Settings > Tax > Standard rates`.
3. Hover the `?` help-tip next to the **Country code** column header so the tooltip becomes visible.
4. Click **Insert row**, focus the new row's **Country code** input, and type `IN`.
5. Verify the autocomplete dropdown (e.g. `IN — India`, `IO — British Indian Ocean Territory`) is fully visible and selectable, with the help-tip tooltip dismissed.
6. Repeat with the **State code** column (e.g. country `US`, type `CA` to see California suggestions).

### Testing that has already taken place

- [x] Manual reasoning and code review of the tipTip / jQuery UI autocomplete interaction.
- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` (PHP: no changes, JS: passes).
- [ ] Manual verification in a local environment.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

Patch / Fix: Prevent the column header tooltip on the Tax > Standard Rates page from overlapping the country and state autocomplete dropdowns.

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-311

_Submitted via the RSMAPGJ AI Coder pipeline._