### PR TITLE
Fix variation dropdown collapsing to pinned out-of-stock value (#44830)

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-331
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-331
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix variation dropdown showing only the out-of-stock value when sibling variations use the "any" wildcard for that attribute on the front-end product page.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -250,25 +250,37 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 				}
 
 				// Get possible values for this attribute, for only visible variations.
+				$has_any_wildcard = false;
 				if ( ! empty( $child_ids ) ) {
 					$format     = array_fill( 0, count( $child_ids ), '%d' );
 					$query_in   = '(' . implode( ',', $format ) . ')';
 					$query_args = array( 'attribute_name' => wc_variation_attribute_name( $attribute['name'] ) ) + $child_ids;
-					$values     = array_unique(
-						$wpdb->get_col(
-							$wpdb->prepare(
-								// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-								"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN {$query_in}", // @codingStandardsIgnoreLine.
-								$query_args
-							)
+					$raw_values = $wpdb->get_col(
+						$wpdb->prepare(
+							// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+							"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN {$query_in}",
+							$query_args
 						)
 					);
+
+					/*
+					 * A missing meta row for a variation must be treated as the "any" wildcard,
+					 * the same as a row whose value is null/empty. Without this guard, a variation
+					 * that only pins one attribute (e.g. an out-of-stock placeholder for "blue")
+					 * would shadow sibling variations that use the wildcard, collapsing the
+					 * front-end dropdown to just the pinned value. See woo#44830.
+					 */
+					if ( count( $raw_values ) < count( $child_ids ) ) {
+						$has_any_wildcard = true;
+					}
+
+					$values = array_unique( $raw_values );
 				} else {
 					$values = array();
 				}
 
 				// Empty value indicates that all options for given attribute are available.
-				if ( in_array( null, $values, true ) || in_array( '', $values, true ) || empty( $values ) ) {
+				if ( $has_any_wildcard || in_array( null, $values, true ) || in_array( '', $values, true ) || empty( $values ) ) {
 					$values = $attribute['is_taxonomy'] ? wc_get_object_terms( $product->get_id(), $attribute['name'], 'slug' ) : wc_get_text_attributes( $attribute['value'] );
 					// Get custom attributes (non taxonomy) as defined.
 				} elseif ( ! $attribute['is_taxonomy'] ) {

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -393,6 +393,94 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Regression test for woo#44830 / RSMAPGJ-331.
+	 *
+	 * When a variable product has variations that use the wildcard "any" value
+	 * (empty string) for an attribute alongside a variation that pins that
+	 * attribute to a specific term (e.g. an out-of-stock placeholder), all
+	 * parent-assigned terms must still appear in the variation attributes
+	 * map. Otherwise the front-end dropdown collapses to only the pinned
+	 * value and the rest of the terms become unselectable.
+	 *
+	 * @since 10.4.0
+	 */
+	public function test_variation_attributes_with_any_value_and_specific_value() {
+		// Create a variable product with a color attribute that has 3 terms.
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Variable product with any + specific variations' );
+
+		$color_attribute    = WC_Helper_Product::create_product_attribute_object( 'rsmapgj331_color', array( 'blue', 'red', 'green' ) );
+		$material_attribute = WC_Helper_Product::create_product_attribute_object( 'rsmapgj331_material', array( 'cotton', 'silk' ) );
+
+		$product->set_attributes( array( $color_attribute, $material_attribute ) );
+		$product->save();
+
+		$product_id = $product->get_id();
+
+		// Variation 1: any color, material cotton (in stock).
+		$variation_1 = new WC_Product_Variation();
+		$variation_1->set_parent_id( $product_id );
+		$variation_1->set_regular_price( 10 );
+		$variation_1->set_stock_status( ProductStockStatus::IN_STOCK );
+		$variation_1->set_attributes(
+			array(
+				'pa_rsmapgj331_color'    => '',
+				'pa_rsmapgj331_material' => 'cotton',
+			)
+		);
+		$variation_1->save();
+
+		// Variation 2: any color, material silk (in stock).
+		$variation_2 = new WC_Product_Variation();
+		$variation_2->set_parent_id( $product_id );
+		$variation_2->set_regular_price( 15 );
+		$variation_2->set_stock_status( ProductStockStatus::IN_STOCK );
+		$variation_2->set_attributes(
+			array(
+				'pa_rsmapgj331_color'    => '',
+				'pa_rsmapgj331_material' => 'silk',
+			)
+		);
+		$variation_2->save();
+
+		// Variation 3: color = blue, any material (OUT OF STOCK placeholder).
+		$variation_3 = new WC_Product_Variation();
+		$variation_3->set_parent_id( $product_id );
+		$variation_3->set_regular_price( 12 );
+		$variation_3->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
+		$variation_3->set_manage_stock( false );
+		$variation_3->set_attributes(
+			array(
+				'pa_rsmapgj331_color'    => 'blue',
+				'pa_rsmapgj331_material' => '',
+			)
+		);
+		$variation_3->save();
+
+		WC_Product_Variable::sync( $product_id );
+
+		// Re-read product to discard any in-memory state.
+		$product            = wc_get_product( $product_id );
+		$variation_attrs    = $product->get_variation_attributes();
+		$resolved_colors    = $variation_attrs['pa_rsmapgj331_color'] ?? array();
+		$resolved_materials = $variation_attrs['pa_rsmapgj331_material'] ?? array();
+
+		sort( $resolved_colors );
+		sort( $resolved_materials );
+
+		$this->assertSame(
+			array( 'blue', 'green', 'red' ),
+			$resolved_colors,
+			'When any variation uses the "any" wildcard for an attribute, the dropdown must list every term assigned to the parent product, not just the pinned values.'
+		);
+		$this->assertSame(
+			array( 'cotton', 'silk' ),
+			$resolved_materials,
+			'Specifying a value on every variation must continue to limit the dropdown to those values.'
+		);
+	}
+
+	/**
 	 * Tests saving variation attribute via set_attribute.
 	 */
 	public function test_variation_save_attributes() {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #44830.

When a variable product has variations that use the "any" wildcard (empty string) for an attribute alongside another variation that pins that attribute to a specific term, the front-end attribute dropdown is supposed to expose every term assigned to the parent product. Today, when sibling "any" variations are missing the per-variation meta row entirely (no `attribute_pa_xxx` postmeta is written for them — for example, variations created before the attribute was added to the parent, imported from CSV, or only created to flag an out-of-stock placeholder), `WC_Product_Variable_Data_Store_CPT::read_variation_attributes` treats the remaining specific value as the exhaustive list. The dropdown then collapses to that one option (e.g. only "Blue") and customers cannot choose the other terms.

This fix treats a missing variation meta row the same as a null/empty value: when the count of returned `meta_value` rows is less than the number of variations queried, at least one variation is implicitly using the wildcard, so we fall back to every term assigned to the parent product.

### How to test the changes in this Pull Request:

1. Create a variable product with attributes Size, Color (with at least three terms: Blue, Red, Green), and Material (with three terms: Cotton, Polyester, Silk).
2. Add three variations, one per material, leaving Size and Color set to "Any …".
3. Add a fourth variation with Color = Blue and the other attributes set to "Any …". Mark it as Out of stock.
4. Visit the product page on the front-end.
5. Expected with this fix: the Color dropdown lists Blue, Red, and Green.
6. Without the fix (e.g. on trunk, with the failure mode described in #44830), the Color dropdown only shows Blue.

You can also run the new PHPUnit regression test:

```
pnpm test:php:env -- --filter test_variation_attributes_with_any_value_and_specific_value
```

### Testing that has already taken place:

- Added a focused PHPUnit regression test (`WC_Tests_Product_Data_Store::test_variation_attributes_with_any_value_and_specific_value`) that creates the exact scenario from the bug report and asserts that all three colors are returned by `WC_Product_Variable::get_variation_attributes()`.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`: clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`: clean.
- `composer exec -- phpstan analyse includes/data-stores/class-wc-product-variable-data-store-cpt.php --memory-limit=2G`: no errors, no baseline additions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix

#### Message

Fix variation dropdown showing only the out-of-stock value when sibling variations use the "any" wildcard for that attribute on the front-end product page.

</details>

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-331

_Submitted via the RSMAPGJ AI Coder pipeline._