### PR TITLE
Fix coupon restrictions not clearing on repeated save()

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-313
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-313
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WC_Coupon restriction fields (product_ids, product_categories, email_restrictions, etc.) not being cleared when `save()` is called more than once in the same request, e.g. from a callback on `woocommerce_coupon_options_save`.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -179,6 +179,24 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			$this->data_store->read( $this );
 		}
 	}
+
+	/**
+	 * Merge changes with data and clear.
+	 *
+	 * Overrides WC_Data::apply_changes which uses array_replace_recursive. The recursive
+	 * variant fails to replace existing array props (e.g. product_ids, product_categories,
+	 * email_restrictions) with empty arrays, leaving stale values behind. When save() is
+	 * invoked a second time within the same request (e.g. from a callback on
+	 * woocommerce_coupon_options_save) the data store then re-persists those stale values
+	 * because metadata_exists() now reports the meta as missing.
+	 *
+	 * @since 10.9.0
+	 */
+	public function apply_changes(): void {
+		$this->data    = array_replace( $this->data, $this->changes );
+		$this->changes = array();
+	}
+
 	/**
 	 * Checks the coupon type.
 	 *

--- a/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
@@ -231,4 +231,39 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 			'Line items associated with deleted products are not included in the discount calculation.'
 		);
 	}
+
+	/**
+	 * @testdox Calling save() twice persists cleared array restriction props (regression for #24570).
+	 */
+	public function test_save_twice_persists_cleared_array_restrictions(): void {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'rsmapgj313' );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->set_amount( 10 );
+		$coupon->set_product_ids( array( 11, 22 ) );
+		$coupon->set_excluded_product_ids( array( 33 ) );
+		$coupon->set_product_categories( array( 44 ) );
+		$coupon->set_excluded_product_categories( array( 55 ) );
+		$coupon->set_email_restrictions( array( 'a@example.com' ) );
+		$coupon_id = $coupon->save();
+
+		// Simulate the meta box flow: hydrate a fresh coupon, clear the restriction
+		// props, then save twice (mirroring a callback on woocommerce_coupon_options_save
+		// that invokes $coupon->save() a second time).
+		$reloaded = new WC_Coupon( $coupon_id );
+		$reloaded->set_product_ids( array() );
+		$reloaded->set_excluded_product_ids( array() );
+		$reloaded->set_product_categories( array() );
+		$reloaded->set_excluded_product_categories( array() );
+		$reloaded->set_email_restrictions( array() );
+		$reloaded->save();
+		$reloaded->save();
+
+		$fresh = new WC_Coupon( $coupon_id );
+		$this->assertSame( array(), $fresh->get_product_ids(), 'product_ids should be cleared after a double save.' );
+		$this->assertSame( array(), $fresh->get_excluded_product_ids(), 'excluded_product_ids should be cleared after a double save.' );
+		$this->assertSame( array(), $fresh->get_product_categories(), 'product_categories should be cleared after a double save.' );
+		$this->assertSame( array(), $fresh->get_excluded_product_categories(), 'excluded_product_categories should be cleared after a double save.' );
+		$this->assertSame( array(), $fresh->get_email_restrictions(), 'email_restrictions should be cleared after a double save.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Tao of WooCommerce](https://github.com/woocommerce/woocommerce/wiki/The-Tao-of-WooCommerce).

### Changes proposed in this Pull Request:

Closes #24570.

When `WC_Coupon::save()` is invoked more than once within the same request (e.g. from a callback on the `woocommerce_coupon_options_save` action), restriction fields that the merchant cleared on the edit screen are not persisted as empty — the previous values come back.

Root cause: `WC_Data::apply_changes()` uses `array_replace_recursive($this->data, $this->changes)`. For array-valued props (`product_ids`, `excluded_product_ids`, `product_categories`, `excluded_product_categories`, `email_restrictions`) an empty array in `$this->changes` cannot replace the loaded value via the recursive variant — recursion has no keys to descend into, so the stale array remains in `$this->data`. The first `save()` correctly deletes the meta because the data store still sees the change in `get_changes()`. The second `save()` then calls `get_props_to_update()`, which also re-queues any prop whose meta no longer exists (`! metadata_exists(...)`), reads the prop via `$coupon->get_product_ids('edit')`, sees the stale array still sitting in `$this->data`, and re-writes the meta.

The fix overrides `apply_changes()` on `WC_Coupon` to use the non-recursive `array_replace`, mirroring the existing precedent in `WC_Order_Item::apply_changes()` (introduced for analogous "empty array doesn't replace" reasons).

### Screenshots or screen recordings:

N/A — backend CRUD fix, no UI change.

### How to test the changes in this Pull Request:

Using the Tools console (or a quick mu-plugin):

1. Add this snippet:
   ```php
   add_action( 'woocommerce_coupon_options_save', function( $post_id, $coupon ) {
       $coupon->save();
   }, 10, 2 );
   ```
2. Create a coupon, add a product restriction and/or a category restriction, save.
3. Edit the same coupon, clear all restrictions, click Update.
4. Reload — restrictions are gone (before the fix they came back).

The included PHPUnit case `WC_Coupon_Tests::test_save_twice_persists_cleared_array_restrictions` covers the same scenario directly against the data layer.

### Testing that has already taken place:

- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- [x] `composer exec -- vendor/bin/phpstan analyse includes/class-wc-coupon.php --memory-limit=2G` — no errors.
- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- [x] Added a regression PHPUnit test (`test_save_twice_persists_cleared_array_restrictions`) — not executed locally in this run; please verify in CI.

### Changelog entry

> Changelog file `plugins/woocommerce/changelog/fix-rsmapgj-313` is included (patch, fix).

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-313

_RSMAPGJ AI Coder pipeline_