### PR TITLE
Fix misleading out-of-stock message on variable products with no priced variations

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-309
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-309
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Stop showing a misleading "out of stock and unavailable" message on the product page of a variable product whose variations have no prices set. The add-to-cart area is now suppressed entirely in that case, mirroring how simple products with no price behave.

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
@@ -12,12 +12,20 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.6.0
+ * @version 10.9.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 global $product;
+
+// If the variable product has no purchasable variations (e.g. no variations have a price set),
+// suppress the add-to-cart form entirely. This mirrors the behaviour of simple products with no
+// price and avoids showing a misleading "out of stock and unavailable" message when the cause is
+// missing prices rather than stock status.
+if ( empty( $available_variations ) && false !== $available_variations && ! $product->is_purchasable() ) {
+	return;
+}
 
 $attribute_keys  = array_keys( $attributes );
 $variations_json = wp_json_encode( $available_variations );

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -162,4 +162,134 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$this->assertIsBool( $has_purchasable_variations );
 		$this->assertFalse( $has_purchasable_variations );
 	}
+
+	/**
+	 * @testdox The variable add-to-cart template should not show the "out of stock and unavailable" message when no variations have a price (mirrors simple product behaviour).
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/27192
+	 */
+	public function test_variable_add_to_cart_template_suppresses_out_of_stock_message_when_no_variations_have_a_price() {
+		$product = new WC_Product_Variable();
+		$product->set_props(
+			array(
+				'name' => 'Dummy Variable Product No Price',
+				'sku'  => 'DUMMY VARIABLE NO PRICE ' . microtime(),
+			)
+		);
+
+		$attributes   = array();
+		$attributes[] = WC_Helper_Product::create_product_attribute_object( 'size', array( 'small', 'large' ) );
+		$product->set_attributes( $attributes );
+		$product->save();
+
+		// Create two variations with no price set, so the parent is not purchasable.
+		$variations    = array();
+		$variations[]  = WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'DUMMY SKU VARIABLE NO PRICE SMALL',
+			'',
+			array( 'pa_size' => 'small' )
+		);
+		$variations[]  = WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'DUMMY SKU VARIABLE NO PRICE LARGE',
+			'',
+			array( 'pa_size' => 'large' )
+		);
+		$variation_ids = array_map(
+			function ( $variation ) {
+				return $variation->get_id();
+			},
+			$variations
+		);
+		$product->set_children( $variation_ids );
+		WC_Product_Variable::sync( $product->get_id() );
+
+		// Sanity: parent is not purchasable when no variation has a price.
+		$reloaded = wc_get_product( $product->get_id() );
+		$this->assertFalse( $reloaded->is_purchasable(), 'Variable product with no priced variations should not be purchasable.' );
+		$this->assertEmpty( $reloaded->get_available_variations(), 'No variations should be available when none have a price.' );
+
+		// Render the variable add-to-cart template.
+		$GLOBALS['product'] = $reloaded;
+		ob_start();
+		wc_get_template(
+			'single-product/add-to-cart/variable.php',
+			array(
+				'available_variations' => $reloaded->get_available_variations(),
+				'attributes'           => $reloaded->get_variation_attributes(),
+				'selected_attributes'  => $reloaded->get_default_attributes(),
+			)
+		);
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'This product is currently out of stock and unavailable.',
+			$output,
+			'Variable products with no priced variations should not show the misleading out-of-stock message.'
+		);
+		$this->assertStringNotContainsString(
+			'<form',
+			$output,
+			'No add-to-cart form should be rendered when the variable product has no priced variations.'
+		);
+	}
+
+	/**
+	 * @testdox The variable add-to-cart template should still show the out-of-stock message when variations are priced but none are available (e.g. all hidden out-of-stock).
+	 */
+	public function test_variable_add_to_cart_template_shows_out_of_stock_message_when_priced_variations_are_unavailable() {
+		$product = new WC_Product_Variable();
+		$product->set_props(
+			array(
+				'name' => 'Dummy Variable Product Priced Hidden',
+				'sku'  => 'DUMMY VARIABLE PRICED HIDDEN ' . microtime(),
+			)
+		);
+
+		$attributes   = array();
+		$attributes[] = WC_Helper_Product::create_product_attribute_object( 'size', array( 'small' ) );
+		$product->set_attributes( $attributes );
+		$product->save();
+
+		$variations    = array();
+		$variations[]  = WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'DUMMY SKU VARIABLE PRICED SMALL',
+			10,
+			array( 'pa_size' => 'small' )
+		);
+		$variation_ids = array_map(
+			function ( $variation ) {
+				return $variation->get_id();
+			},
+			$variations
+		);
+		$product->set_children( $variation_ids );
+		WC_Product_Variable::sync( $product->get_id() );
+
+		$reloaded = wc_get_product( $product->get_id() );
+		$this->assertTrue( $reloaded->is_purchasable(), 'Variable product with at least one priced variation should be purchasable.' );
+
+		// Force the available variations to be empty to simulate the "all unavailable" case
+		// (e.g. all variations out of stock with hide-out-of-stock enabled) while the parent is still
+		// purchasable. This is the scenario where the out-of-stock message is appropriate.
+		$GLOBALS['product'] = $reloaded;
+		ob_start();
+		wc_get_template(
+			'single-product/add-to-cart/variable.php',
+			array(
+				'available_variations' => array(),
+				'attributes'           => $reloaded->get_variation_attributes(),
+				'selected_attributes'  => $reloaded->get_default_attributes(),
+			)
+		);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			'This product is currently out of stock and unavailable.',
+			$output,
+			'Variable products with priced but unavailable variations should still show the out-of-stock message.'
+		);
+	}
 }


### PR DESCRIPTION
## Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Best Practices](https://github.com/woocommerce/woocommerce/wiki/Best-practices) for my contributions.
- [x] I have made my code easy for a reviewer to understand and have used the same code style as the rest of the project.

## Changes proposed in this Pull Request

Closes #27192
Linear: https://linear.app/a8c/issue/RSMAPGJ-309

When a variable product has variations but none of them have a price set, the product page was showing **"This product is currently out of stock and unavailable."** That message is misleading — the product is not out of stock, it simply has no purchasable variations because no prices are configured.

The reporter suggested the expected behaviour is to mirror how a simple product with no price is displayed: just the thumbnail/title/description, with no add-to-cart area and no stock message.

This PR updates `templates/single-product/add-to-cart/variable.php` to return early when:

1. `$available_variations` is an empty array (i.e. the data layer found no purchasable variations), **and**
2. the parent product is not purchasable (`! $product->is_purchasable()`), which means no variation has a price.

Both conditions must hold. The existing "out of stock and unavailable" message is preserved for the legitimate case where the parent **is** purchasable (at least one variation has a price) but no variations are currently available — e.g. all priced variations are out of stock with "Hide out of stock items from the catalog" enabled.

## Screenshots or screen recordings

_n/a — text-only change, removes a misleading sentence from the product page._

## How to test the changes in this Pull Request

1. In WP admin, create a new **Variable product**.
2. Add an attribute (e.g. `Color: red | blue`), check "Used for variations".
3. Generate the two variations, but do **not** set a price for either of them.
4. Publish the product.
5. Visit the public product page.

**Before this PR:** The page shows "This product is currently out of stock and unavailable."
**After this PR:** The page shows only the title / image / description with no add-to-cart form and no misleading stock message — matching the appearance of a simple product with no price.

### Regression check (out-of-stock should still display)

1. Edit the product above and set a price for both variations.
2. Mark both variations as **Out of stock**.
3. Under WooCommerce -> Settings -> Products -> Inventory, enable "Hide out of stock items from the catalog".
4. Visit the product page — the "out of stock and unavailable" message should still appear, because the parent product is now purchasable (it has prices) but all variations are hidden.

## Testing that has already taken place

- Added two regression unit tests in `WC_Product_Variable_Test`:
  - `test_variable_add_to_cart_template_suppresses_out_of_stock_message_when_no_variations_have_a_price`
  - `test_variable_add_to_cart_template_shows_out_of_stock_message_when_priced_variations_are_unavailable`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- Template `@version` bumped to `10.9.0` per AGENTS.md conventions.

## Changelog entry

Added: `plugins/woocommerce/changelog/fix-rsmapgj-309` (Significance: patch, Type: fix).

---

_Generated by the RSMAPGJ AI Coder pipeline._