### PR TITLE
Fix insufficient contrast on product attributes placeholder text

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-317
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-317
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace opacity-based dimming on the product attributes placeholder text with an explicit muted color, so the "New attribute" label meets the WCAG 2.2 AA 4.5:1 contrast ratio.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -6643,7 +6643,11 @@ img.help_tip {
 			}
 		}
 		.placeholder {
-			opacity: 0.4;
+			// Use an explicit color instead of opacity: 0.4 to ensure the
+			// placeholder text meets WCAG 2.2 AA contrast ratio (4.5:1) on
+			// the white metabox background. #646970 is WordPress core's
+			// secondary text color and yields a 5.74:1 contrast ratio.
+			color: #646970;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The placeholder text rendered for an unsaved product attribute (the "New attribute" label inside `.wc-metaboxes-wrapper .wc-metabox .placeholder`) used `opacity: 0.4` on top of the inherited `h3` color (`#1d2327`). That produced an effective foreground of approximately `#A5A7A9` on white — a contrast ratio of only **2.41:1**, well below the WCAG 2.2 AA minimum of **4.5:1** required by SC 1.4.3 Contrast (Minimum).

This PR replaces the opacity-based dimming with an explicit muted color, `#646970` (the same secondary text color used widely by WordPress core admin UI), which yields a contrast ratio of **5.74:1** on white and meets WCAG 2.2 AA.

Closes #63792
Linear: https://linear.app/a8c/issue/RSMAPGJ-317

### Screenshots:

_Visual change only: the placeholder text "New attribute" appears in a darker, fully opaque muted gray instead of a faded near-white. No layout, sizing, or behavior changes._

### How to test the changes in this Pull Request:

Using the WooCommerce test environment:

1. Log in to **WP Admin**.
2. Go to **Products → Add new product**.
3. Scroll to the **Product data** panel and click the **Attributes** tab.
4. Click **Add new** (or any control that yields an attribute row without a chosen name) to ensure an attribute row exists whose `<strong class="attribute_name placeholder">` reads "New attribute".
5. Inspect that element in DevTools:
   - Confirm `.wc-metaboxes-wrapper .wc-metabox .placeholder` no longer applies `opacity: 0.4`.
   - Confirm `color: #646970` is applied.
   - Confirm the computed contrast ratio against the white background is ~5.74:1 (passes WCAG 2.2 AA).
6. Visually confirm the placeholder text reads as muted but clearly legible.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance:** Patch
**Type:** Fix

Replace opacity-based dimming on the product attributes placeholder text with an explicit muted color, so the "New attribute" label meets the WCAG 2.2 AA 4.5:1 contrast ratio.

</details>

---

_Submitted via the RSMAPGJ AI Coder pipeline._