### PR TITLE
Respect block alignment on Cart/Checkout pages with Twenty Twenty-Three theme

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-335
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-335
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect block alignment on Cart and Checkout pages with the Twenty Twenty-Three theme by not constraining `<main>` width when it contains a wide or full-aligned child block.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -18,9 +18,15 @@
 
 	main {
 		// This is to allow .woocommerce div to have width of 1000px on styles with full width layout (such as Pitch).
-		max-width: calc(1000px + var(--wp--style--root--padding-right) + var(--wp--style--root--padding-left));
-		margin-left: auto;
-		margin-right: auto;
+		// Skip the constraint when the page contains a wide/full-aligned block (e.g. the Cart or
+		// Checkout block with alignment set to "Wide" or "Full") so the user's block alignment
+		// setting is respected on the frontend, matching the site editor preview.
+		// See https://github.com/woocommerce/woocommerce/issues/42238.
+		&:not(:has(> .alignwide, > .alignfull)) {
+			max-width: calc(1000px + var(--wp--style--root--padding-right) + var(--wp--style--root--padding-left));
+			margin-left: auto;
+			margin-right: auto;
+		}
 
 		.woocommerce {
 			@include clearfix();


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #42238.

Linear: https://linear.app/a8c/issue/RSMAPGJ-335

The Twenty Twenty-Three theme styles shipped in WooCommerce (`client/legacy/css/twenty-twenty-three.scss`) apply a hardcoded `max-width: calc(1000px + ...)` to `.woocommerce-page main`. That rule overrides the block alignment ("Wide" or "Full") the user sets on the Cart or Checkout block in the site editor, so the frontend renders constrained at ~1000px while the site editor preview correctly honours the user's alignment.

This PR scopes the `max-width`/auto-margin block with `:not(:has(> .alignwide, > .alignfull))`, so the cap is skipped whenever `main` contains a wide- or full-aligned child block. Shop, account, and other unaligned WooCommerce pages keep the existing 1000px constraint; pages whose block content explicitly opts into a wider layout now render at that wider width on the frontend, matching the editor preview.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| `<main>` clamped to ~1000px even when the Checkout block has `alignfull`. | `<main>` is unconstrained when an `alignwide`/`alignfull` child is present, matching the site editor preview. |

### How to test the changes in this Pull Request:

1. Activate the Twenty Twenty-Three theme.
2. Make sure the Cart and Checkout pages use the Cart/Checkout blocks (the default block-based ones).
3. Edit the Checkout page in the site editor and set the Checkout block's alignment to "Full width" (or "Wide width"). Save.
4. Add a product to the cart and visit `/checkout/`.
5. Inspect the `<main>` element under `.woocommerce-page`: its computed `max-width` should now be `none` (instead of `calc(1000px + ...)`).
6. The Checkout block should visibly fill the page width, matching the site editor preview.
7. Visit a Shop or My Account page (no aligned blocks): `<main>` should still be capped at ~1000px (existing behaviour preserved).

### Testing that has already taken place:

- Verified the SCSS compiles cleanly with `sass` (Dart Sass 1.99) and the compiled output contains `.woocommerce-page main:not(:has(> .alignwide, > .alignfull)) { max-width: ...; margin-left: auto; margin-right: auto; }`.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — no warnings.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually at `plugins/woocommerce/changelog/fix-rsmapgj-335` (patch / fix).

- [ ] This Pull Request does not require a changelog entry.

---

_Submitted via the RSMAPGJ AI Coder pipeline._