### PR TITLE
Fix a11y: render product attribute Remove control as a button

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-316
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-316
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render the "Remove" control in the Product data > Attributes panel as a `<button>` element instead of an `<a>` link so it is announced as a button by screen readers and activates with the Space key (WCAG 2.2 SC 4.1.2, 2.1.1).

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -6512,7 +6512,16 @@ img.help_tip {
 				margin-right: 12px;
 			}
 
-			a.delete {
+			button.delete,
+			button.edit {
+				background: none;
+				border: 0;
+				padding: 0;
+				cursor: pointer;
+			}
+
+			a.delete,
+			button.delete {
 				color: red;
 				font-weight: normal;
 				line-height: 26px;
@@ -6520,7 +6529,8 @@ img.help_tip {
 				position: relative;
 			}
 
-			a.edit {
+			a.edit,
+			button.edit {
 				font-weight: normal;
 				line-height: 26px;
 				text-decoration: none;
@@ -6561,6 +6571,8 @@ img.help_tip {
 
 			a.delete,
 			a.edit,
+			button.delete,
+			button.edit,
 			.sort {
 				margin-top: 0.25em;
 			}
@@ -6568,6 +6580,8 @@ img.help_tip {
 		&.woocommerce_variation h3 {
 			a.delete,
 			a.edit,
+			button.delete,
+			button.edit,
 			.sort {
 				margin-top: 0.45em;
 			}

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<h3>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop to set admin attribute order', 'woocommerce' ); ?>"></div>
-		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
+		<button type="button" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></button>
 		<strong class="attribute_name<?php echo esc_attr( $attribute->get_name() === '' ? ' placeholder' : '' ); ?>"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'New attribute', 'woocommerce' ) ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content hidden">


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Development Workflow](https://github.com/woocommerce/woocommerce/wiki/Recommended-Development-Workflow).

### Changes proposed in this Pull Request

The "Remove" control in the Product data > Attributes panel was rendered as an `<a href="#">` element. Because it triggers an action rather than navigation, this violated WCAG 2.2 SC 4.1.2 (Name, Role, Value) and SC 2.1.1 (Keyboard):

- Screen readers announced it as a link.
- Pressing Space did not trigger the action — it scrolled the page.

This PR replaces the anchor with a native `<button type="button">`, preserving the existing `remove_row delete` classes (so the delegated jQuery handler in `meta-boxes-product.js` keeps working) and updating `admin.scss` to extend the matching `a.delete` / `a.edit` rules to also target `button.delete` / `button.edit` with a button reset, so the visual appearance is unchanged.

Closes #63831
Linear: https://linear.app/a8c/issue/RSMAPGJ-316

### Screenshots or screen recordings

N/A — visual appearance is unchanged. See linked Linear issue for the original repro screenshot.

### How to test the changes in this Pull Request

1. Go to **WooCommerce → Products → Add new product**.
2. Open the **Attributes** tab inside the Product data panel.
3. Click **Add new** to add a custom attribute row.
4. Inspect the **Remove** control with DevTools — confirm the rendered tag is `<button type="button" class="remove_row delete">…</button>` (was `<a>` before).
5. Tab focus to the **Remove** control, press **Space** — confirm the attribute row is removed (was: page scrolled, nothing happened).
6. Press **Enter** with focus on **Remove** on another row — confirm the attribute row is also removed.
7. Confirm a screen reader (or Firefox Accessibility Inspector) announces the control as a **button** named "Remove" (was: link).
8. Confirm the control still looks the same as before (red, no underline, normal weight, floats right inside the row's `<h3>`).
9. Confirm clicking the rest of the row's `<h3>` still toggles the row open/closed, and clicking the **Remove** button does not also toggle the row.

### Testing that has already taken place

- Static lint: `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- Static lint (branch): `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- PHPStan: `composer exec -- phpstan analyse includes/admin/meta-boxes/views/html-product-attribute.php --memory-limit=2G` — no errors.
- Verified the delegated click handler in `client/legacy/js/admin/meta-boxes-product.js` (`#product_attributes` → `.product_attributes .remove_row`) is selector-based and does not depend on the anchor tag.
- Verified the h3-click row-toggle handler in `client/legacy/js/admin/meta-boxes.js` bails on `:input` targets (which includes `<button>`), so clicking the button does not also toggle the row.

### Changelog entry

- [x] Added manually — `plugins/woocommerce/changelog/fix-rsmapgj-316` (patch / fix).

### Milestone

- [x] Auto-assign milestone.

---

RSMAPGJ AI Coder pipeline