### PR TITLE
Preserve 0% tax rates on refund orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-310
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-310
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Preserve 0% tax rates on refund orders so they are recorded alongside non-zero rates for accurate accounting and reporting.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2446,7 +2446,9 @@ class WC_AJAX {
 				$line_items[ $item_id ]['refund_total'] = wc_format_decimal( $total );
 			}
 			foreach ( $line_item_tax_totals as $item_id => $tax_totals ) {
-				$line_items[ $item_id ]['refund_tax'] = array_filter( array_map( 'wc_format_decimal', $tax_totals ) );
+				// Keep numeric entries (including a literal "0") so 0% tax rates are preserved on the refund.
+				// See https://github.com/woocommerce/woocommerce/issues/27118.
+				$line_items[ $item_id ]['refund_tax'] = array_filter( array_map( 'wc_format_decimal', $tax_totals ), 'is_numeric' );
 			}
 
 			// Create the refund object.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -606,7 +606,16 @@ function wc_create_refund( $args = array() ) {
 
 				$qty          = isset( $args['line_items'][ $item_id ]['qty'] ) ? $args['line_items'][ $item_id ]['qty'] : 0;
 				$refund_total = $args['line_items'][ $item_id ]['refund_total'];
-				$refund_tax   = isset( $args['line_items'][ $item_id ]['refund_tax'] ) ? array_filter( (array) $args['line_items'][ $item_id ]['refund_tax'] ) : array();
+				// Keep numeric entries (including a literal 0) so 0% tax rates are preserved on the refund.
+				// See https://github.com/woocommerce/woocommerce/issues/27118.
+				$refund_tax = array();
+				if ( isset( $args['line_items'][ $item_id ]['refund_tax'] ) ) {
+					foreach ( (array) $args['line_items'][ $item_id ]['refund_tax'] as $rate_id => $tax_amount ) {
+						if ( is_numeric( $tax_amount ) ) {
+							$refund_tax[ $rate_id ] = (float) $tax_amount;
+						}
+					}
+				}
 
 				if ( empty( $qty ) && empty( $refund_total ) && empty( $args['line_items'][ $item_id ]['refund_tax'] ) ) {
 					continue;

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1450,6 +1450,97 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that 0% tax rates are preserved on refund orders.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/27118
+	 */
+	public function test_wc_create_refund_preserves_zero_percent_tax_27118() {
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$tax_rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '0.0000',
+				'tax_rate_name'     => 'Zero Rate',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '0',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_tax_status( ProductTaxStatus::TAXABLE );
+		$product->set_regular_price( 20 );
+		$product->save();
+
+		$order = new WC_Order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 1,
+				'subtotal' => 20,
+				'total'    => 20,
+				'taxes'    => array(
+					'total'    => array( $tax_rate_id => '0' ),
+					'subtotal' => array( $tax_rate_id => '0' ),
+				),
+			)
+		);
+		$order->add_item( $item );
+
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate( $tax_rate_id );
+		$tax_item->set_tax_total( 0 );
+		$tax_item->set_shipping_tax_total( 0 );
+		$order->add_item( $tax_item );
+
+		$order->set_total( 20 );
+		$order->save();
+
+		// Sanity check: the parent order should record the 0% tax line.
+		$order_taxes = $order->get_items( 'tax' );
+		$this->assertCount( 1, $order_taxes, 'Parent order should have a 0% tax line item.' );
+
+		$line_items = $order->get_items( 'line_item' );
+		$item_id    = array_keys( $line_items )[0];
+
+		$refund = wc_create_refund(
+			array(
+				'amount'     => 20,
+				'order_id'   => $order->get_id(),
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 1,
+						'refund_total' => 20,
+						'refund_tax'   => array( $tax_rate_id => 0 ),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund );
+
+		// The 0% tax line should be present on the refund order.
+		$refund_taxes = $refund->get_items( 'tax' );
+		$this->assertCount( 1, $refund_taxes, '0% tax line should be carried over to the refund order.' );
+
+		$refund_tax_item = array_values( $refund_taxes )[0];
+		$this->assertEquals( $tax_rate_id, $refund_tax_item->get_rate_id() );
+		$this->assertEquals( 0.0, (float) $refund_tax_item->get_tax_total() );
+
+		// The refunded line item should also retain its 0% tax entry.
+		$refunded_line_items = $refund->get_items( 'line_item' );
+		$this->assertCount( 1, $refunded_line_items );
+		$refunded_line_item = array_values( $refunded_line_items )[0];
+		$refunded_taxes     = $refunded_line_item->get_taxes();
+		$this->assertArrayHasKey( $tax_rate_id, $refunded_taxes['total'], 'Refunded item taxes should include the 0% rate.' );
+	}
+
+	/**
 	 * Test wc_sanitize_order_id().
 	 */
 	public function test_wc_sanitize_order_id() {


### PR DESCRIPTION
**Submitted by the RSMAPGJ AI Coder pipeline.**

Linear: [RSMAPGJ-310](https://linear.app/a8c/issue/RSMAPGJ-310)

### Submission Review Guidelines

- [x] I have followed the [contribution guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] I have added unit / integration tests where appropriate.

### Changes proposed in this Pull Request

When refunding an order that contains items taxed at a 0% rate, the 0% tax lines were silently dropped from the resulting refund order. 0% is **not** the same as "no tax" — it is a legitimate rate (zero-rated VAT, tax-exempt classes, etc.) that should be preserved on refund orders alongside non-zero rates for accurate accounting and reporting.

The bug had two cooperating culprits, both calling `array_filter()` with no callback on the per-line `refund_tax` map. The default `array_filter` strips all falsy values, including the literal `0` / `'0'` / `'0.00'` we care about, so the refund logic ended up with an empty taxes array, `update_taxes()` saw no tax entries, and no `WC_Order_Item_Tax` was attached to the refund:

* **`wc_create_refund()`** in `includes/wc-order-functions.php` — now walks the supplied `refund_tax` map and keeps every numeric entry (including 0), casting to `float` so downstream consumers see a stable type.
* **`WC_AJAX::refund_line_items()`** in `includes/class-wc-ajax.php` — uses `is_numeric` as the `array_filter` callback so `'0.00'` survives the AJAX round-trip into `wc_create_refund()`.

The REST API path (`WC_REST_Order_Refunds_*_Controller`) feeds `wc_create_refund()` directly with raw arrays, so it inherits the fix without further changes.

Closes #27118

### How to test the changes in this Pull Request

1. Enable taxes (**WooCommerce → Settings → General → Enable tax rates and calculations**).
2. Add a tax rate with a rate of `0.0000` and name `Zero Rate` under any tax class.
3. Create a product priced at e.g. `$20` and assign it the zero-rated tax class.
4. Place an order containing that product so the order has a `Zero Rate` tax line of `$0.00`.
5. From the order edit screen, click **Refund**, refund the single line item in full, and click **Refund $20.00 manually**.
6. From WP-CLI or an eval snippet, inspect the refund order:
   ```php
   $refund = current( wc_get_orders( [ 'parent' => <ORDER_ID>, 'type' => 'shop_order_refund' ] ) );
   var_dump( $refund->get_items( 'tax' ) );
   ```
   * **Before this PR:** `array(0) {}` — the 0% tax line is missing.
   * **After this PR:** one `WC_Order_Item_Tax` with `rate_id` matching the Zero Rate and `tax_total` `0`.
7. Repeat with a non-zero rate to confirm no regression for normal tax rates.

### Testing that has already taken place

* New PHPUnit regression test `WC_Tests_Order_Functions::test_wc_create_refund_preserves_zero_percent_tax_27118` — asserts the 0% tax line is carried over to the refund order and to the refunded line item's tax map. The test **fails on trunk** and passes with this PR's fix applied.
* `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_wc_create_refund` — all 3 refund tests pass.
* `WC_Tests_Order_Functions::` — 46 tests, 170 assertions, all pass (1 unrelated pre-existing skip).
* `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
* `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
* PHPStan on both modified files — `[OK] No errors`. No baseline entries added.

### Changelog entry

- [x] Automatically create a changelog entry from the details below. → `plugins/woocommerce/changelog/fix-rsmapgj-310` (patch / fix).

> Signed off by the **RSMAPGJ AI Coder pipeline**.