### PR TITLE
Stabilize useSelect hooks in checkout pickup options and shipping method edit views

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-323
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-323
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stabilize useSelect hooks in the Checkout Pickup Options and Shipping Method block edit views to avoid "Too many re-renders" warnings in the Site Editor.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
@@ -32,12 +32,10 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element | null => {
-	const { prefersCollection } = useSelect( ( select ) => {
-		const checkoutStore = select( checkoutStoreDescriptor );
-		return {
-			prefersCollection: checkoutStore.prefersCollection(),
-		};
-	} );
+	const prefersCollection = useSelect(
+		( select ) => select( checkoutStoreDescriptor ).prefersCollection(),
+		[]
+	);
 	const { className } = attributes;
 
 	if ( ! prefersCollection || ! LOCAL_PICKUP_ENABLED ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -171,12 +171,10 @@ export const Edit = ( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ setAttributes ] );
 	const { setPrefersCollection } = useDispatch( checkoutStoreDescriptor );
-	const { prefersCollection } = useSelect( ( select ) => {
-		const checkoutStore = select( checkoutStoreDescriptor );
-		return {
-			prefersCollection: checkoutStore.prefersCollection(),
-		};
-	} );
+	const prefersCollection = useSelect(
+		( select ) => select( checkoutStoreDescriptor ).prefersCollection(),
+		[]
+	);
 	const { showPrice, showIcon, className, localPickupText, shippingText } =
 		attributes;
 	const {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-on to PR #54408. The Site Editor still reports "Too many re-renders" warnings while editing the Cart and Checkout block templates (#56838). Two of the remaining offenders are the `Edit` components for the Pickup Options and Shipping Method inner blocks:

```ts
const { prefersCollection } = useSelect( ( select ) => {
    const checkoutStore = select( checkoutStoreDescriptor );
    return {
        prefersCollection: checkoutStore.prefersCollection(),
    };
} );
```

Both call `useSelect` without a dependency array and wrap the boolean result in a fresh object literal. The selector is rebuilt on every render and `useSelect` cannot bail out via reference equality.

Fix: return the primitive directly and pin the dependency array, matching the stabilization pattern from PR #54408.

```ts
const prefersCollection = useSelect(
    ( select ) => select( checkoutStoreDescriptor ).prefersCollection(),
    []
);
```

Bug introduced in PR #43475 (Pickup Options) / PR #41768 (Shipping Method) — original implementations of these edit views.

### How to test the changes in this Pull Request:

1. Go to Appearance → Editor → Templates → Cart, open the canvas, open the browser console.
2. Confirm there is no `useSelect` "unstable" warning attributed to the Pickup Options block.
3. Go to Appearance → Editor → Templates → Checkout, open the canvas.
4. Click into the Shipping Method block (the local pickup / shipping toggle row) and confirm the same — no `useSelect` warning attributed to that block in the console.
5. Smoke test on the frontend: the cart and checkout pages still render normally and switching between Shipping/Local Pickup still works.

### Changelog entry

- [x] This Pull Request includes a manually-created changelog entry (`plugins/woocommerce/changelog/fix-rsmapgj-323`).

### Milestone

- [x] Add this PR to the first available milestone.

---

Closes #56838
Linear: https://linear.app/a8c/issue/RSMAPGJ-323

RSMAPGJ AI Coder pipeline