### PR TITLE
Match state-filtered shipping zones when optional state is blank

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-333
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-333
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Match state-filtered shipping zones for countries where the state field is optional (e.g. New Zealand) even when the destination state is blank, so customers using express payment methods or checkouts that omit the optional state still see the correct shipping rates.

--- a/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -313,7 +313,23 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 		// Work out criteria for our zone search.
 		$criteria   = array();
 		$criteria[] = $wpdb->prepare( "( ( location_type = 'country' AND location_code = %s )", $country );
-		$criteria[] = $wpdb->prepare( "OR ( location_type = 'state' AND location_code = %s )", $country . ':' . $state );
+
+		/*
+		 * For countries where the state field is optional at checkout (e.g. New Zealand),
+		 * the destination state can legitimately be blank — including for express payment
+		 * methods such as Apple Pay / Google Pay that do not provide a state value. In that
+		 * situation, matching `location_code = 'NZ:'` excludes every state-filtered zone
+		 * the merchant has configured, leaving customers stranded on broader fallback zones
+		 * (or no zone at all). Treat the blank state as a wildcard within the country so
+		 * state-filtered zones remain reachable; the existing `zone_order` ordering and
+		 * postcode-rule filtering below continue to pick the most specific matching zone.
+		 */
+		if ( '' === $state && $country && $this->country_has_optional_state( $country ) ) {
+			$criteria[] = $wpdb->prepare( "OR ( location_type = 'state' AND location_code LIKE %s )", $country . ':%' );
+		} else {
+			$criteria[] = $wpdb->prepare( "OR ( location_type = 'state' AND location_code = %s )", $country . ':' . $state );
+		}
+
 		$criteria[] = $wpdb->prepare( "OR ( location_type = 'continent' AND location_code = %s )", $continent );
 		$criteria[] = 'OR ( location_type IS NULL ) )';
 
@@ -347,6 +363,37 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 			WHERE " . implode( ' ', $criteria ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			. ' ORDER BY zone_order ASC, zones.zone_id ASC LIMIT 1'
 		);
+	}
+
+	/**
+	 * Determine whether a country marks the address state field as optional.
+	 *
+	 * Some countries (for example New Zealand) treat the state/region/province field as
+	 * optional at checkout, which means a destination address can arrive at zone matching
+	 * with a blank state even though the merchant configured a state-filtered shipping
+	 * zone. This helper centralises the locale lookup used to decide whether to treat a
+	 * blank state as a country-wide wildcard during zone matching.
+	 *
+	 * @since 10.9.0
+	 * @param string $country Country code (uppercase ISO 3166-1 alpha-2).
+	 * @return bool True when the state field is explicitly marked as not required for the country.
+	 */
+	protected function country_has_optional_state( $country ) {
+		if ( ! function_exists( 'WC' ) || ! WC()->countries ) {
+			return false;
+		}
+
+		$locale = WC()->countries->get_country_locale();
+
+		if ( ! isset( $locale[ $country ]['state'] ) ) {
+			return false;
+		}
+
+		$state_locale = $locale[ $country ]['state'];
+
+		// `required` only counts as "optional" when the locale explicitly sets it to false.
+		// Treating an unset value as optional would change behaviour for every country.
+		return isset( $state_locale['required'] ) && false === $state_locale['required'];
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-shipping-zone-data-store-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-shipping-zone-data-store-test.php
@@ -98,6 +98,85 @@ class WC_Shipping_Zone_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_zone_id_from_package() returns a state-filtered zone for an optional-state country when the destination state is blank.
+	 */
+	public function test_get_zone_id_from_package_matches_state_zone_when_optional_state_is_blank() {
+		// Auckland-specific state-filtered zone, lower zone_order so it wins ordering ties.
+		$state_zone = new WC_Shipping_Zone();
+		$state_zone->set_zone_name( 'NZ Auckland' );
+		$state_zone->set_zone_order( 1 );
+		$state_zone->add_location( 'NZ:NZ-AUK', 'state' );
+		$state_zone->save();
+
+		// Country-wide NZ fallback zone, higher zone_order.
+		$country_zone = new WC_Shipping_Zone();
+		$country_zone->set_zone_name( 'NZ Fallback' );
+		$country_zone->set_zone_order( 2 );
+		$country_zone->add_location( 'NZ', 'country' );
+		$country_zone->save();
+
+		$package = array(
+			'destination' => array(
+				// Optional in NZ — left blank, as Apple/Google Pay would.
+				'country'  => 'NZ',
+				'state'    => '',
+				'postcode' => '1021',
+			),
+		);
+
+		$datastore = new WC_Shipping_Zone_Data_Store();
+		$matched   = (int) $datastore->get_zone_id_from_package( $package );
+
+		$this->assertSame(
+			$state_zone->get_id(),
+			$matched,
+			'Optional-state countries with a blank state should still match more specific state-filtered zones.'
+		);
+
+		$state_zone->delete();
+		$country_zone->delete();
+	}
+
+	/**
+	 * @testdox get_zone_id_from_package() still requires an exact state match for countries where the state field is required.
+	 */
+	public function test_get_zone_id_from_package_requires_state_for_required_state_country() {
+		// California-specific zone — US states are required, so a blank state must NOT match.
+		$state_zone = new WC_Shipping_Zone();
+		$state_zone->set_zone_name( 'US California' );
+		$state_zone->set_zone_order( 1 );
+		$state_zone->add_location( 'US:CA', 'state' );
+		$state_zone->save();
+
+		// US country fallback.
+		$country_zone = new WC_Shipping_Zone();
+		$country_zone->set_zone_name( 'US Fallback' );
+		$country_zone->set_zone_order( 2 );
+		$country_zone->add_location( 'US', 'country' );
+		$country_zone->save();
+
+		$package = array(
+			'destination' => array(
+				'country'  => 'US',
+				'state'    => '',
+				'postcode' => '94016',
+			),
+		);
+
+		$datastore = new WC_Shipping_Zone_Data_Store();
+		$matched   = (int) $datastore->get_zone_id_from_package( $package );
+
+		$this->assertSame(
+			$country_zone->get_id(),
+			$matched,
+			'Required-state countries should not wildcard-match state-filtered zones when the state is blank.'
+		);
+
+		$state_zone->delete();
+		$country_zone->delete();
+	}
+
+	/**
 	 * @testdox add_meta() returns 0 as shipping zones do not support meta storage.
 	 */
 	public function test_add_meta_returns_zero() {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Countries such as New Zealand mark the state/region field as **optional** at checkout. When such a destination reaches shipping zone matching with a blank state — for example from Apple Pay or Google Pay, which do not supply a state for those countries, or from a customer who simply skipped the optional field — the existing exact-match comparison `location_code = 'NZ:'` excluded every state-filtered zone the merchant had configured. Customers ended up on broader fallback zones (or no zone at all) even with a postcode that clearly belonged to the state-filtered zone, and merchants saw their state-filtered zones silently bypassed.

This PR teaches `WC_Shipping_Zone_Data_Store::get_zone_id_from_package()` to treat a blank state as a country-wide wildcard when, and only when, the country's locale explicitly marks the state field as `'required' => false`. The existing `zone_order` ordering and postcode-rule narrowing continue to select the most specific applicable zone, so:

- For optional-state countries (NZ, NO, and similar): state-filtered zones become reachable for blank-state destinations.
- For required-state countries (US, CA, etc.): behaviour is unchanged — a blank state still falls through to country/continent/everywhere zones, never to state-filtered zones.

A new protected helper `country_has_optional_state()` centralises the locale lookup so the call site stays readable and the rule is easy to override in subclasses.

Closes #43711

Linear: https://linear.app/a8c/issue/RSMAPGJ-333

### How to test the changes in this Pull Request:

1. In a fresh store, set the base/selling country to include New Zealand and the currency to NZD.
2. Under **WooCommerce > Settings > Shipping**, create a zone named "NZ Auckland" with `Auckland` (NZ:NZ-AUK) as the region and a flat rate of $5; set its order to 1.
3. Create a second zone named "NZ Fallback" with `New Zealand` as the region and a flat rate of $15; set its order to 2.
4. Add a shippable product to the cart and go to the checkout.
5. Select **New Zealand** as the country, enter postcode `1021`, leave the **Region** field blank.
6. Verify: the **Auckland Flat Rate** ($5) is offered — not the fallback ($15).
7. Now switch the country to the **United States**, leave the state field blank, and confirm that any US:CA-style state-filtered zone is **not** matched (the US-wide fallback or "Rest of the world" is used). This confirms the wildcard only applies to optional-state countries.
8. Repeat step 5 via the Cart/Checkout Blocks and via Store API `wc/store/v1/cart/update-customer` for parity.

### Testing that has already taken place:

- Added PHPUnit coverage in `WC_Shipping_Zone_Data_Store_CPT_Test` for two scenarios: optional-state country (NZ) with a blank state matches the state-filtered zone, and required-state country (US) with a blank state continues to match only the country-level zone.
- Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`, branch-level `lint:changes:branch`, and `phpstan` on the modified data store: all clean, no baseline additions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Added manually as `plugins/woocommerce/changelog/fix-rsmapgj-333` (patch / fix).

---

Submitted via the RSMAPGJ AI Coder pipeline.