### PR TITLE
Preserve commas inside quoted attribute values on CSV import

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-326
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-326
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve commas inside double-quoted product attribute values when importing a CSV (e.g. `"New, no box. Multiple quantity, minor shelf wear."` now imports as one value).

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -791,7 +791,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 	/**
 	 * Explode CSV cell values using commas by default, and handling escaped
-	 * separators.
+	 * separators as well as double-quoted substrings that may themselves
+	 * contain the separator (per RFC 4180-style quoting).
 	 *
 	 * @since  3.2.0
 	 * @param  string $value     Value to explode.
@@ -799,8 +800,25 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 * @return array
 	 */
 	protected function explode_values( $value, $separator = ',' ) {
-		$value  = str_replace( '\\,', '::separator::', $value );
-		$values = explode( $separator, $value );
+		$value = str_replace( '\\,', '::separator::', $value );
+
+		// When the field contains double quotes, honour them so values
+		// like `foo, "bar, baz", qux` are split into [foo, bar, baz, qux]
+		// rather than being broken on the inner commas. str_getcsv handles
+		// RFC 4180-style quoting and also strips the surrounding quotes.
+		if ( false !== strpos( $value, '"' ) ) {
+			$values = str_getcsv( $value, $separator, '"', "\0" );
+			// str_getcsv can yield null entries for empty fields; coerce to string.
+			$values = array_map(
+				static function ( $part ) {
+					return null === $part ? '' : $part;
+				},
+				$values
+			);
+		} else {
+			$values = explode( $separator, $value );
+		}
+
 		$values = array_map( array( $this, 'explode_values_formatter' ), $values );
 
 		return $values;

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -224,4 +224,41 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		wc_delete_attribute( $color_attr_id );
 		wc_delete_attribute( $size_attr_id );
 	}
+
+	/**
+	 * @testdox parse_comma_field preserves commas inside double-quoted attribute values.
+	 *
+	 * Regression test for woocommerce/woocommerce#53617 — quoted commas in a
+	 * product attribute value (e.g. `"New, no box. Multiple quantity, minor shelf wear."`)
+	 * were being split into multiple attribute values instead of being treated
+	 * as a single value.
+	 */
+	public function test_parse_comma_field_preserves_commas_inside_double_quotes() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		// Single quoted value containing commas should stay as one value.
+		$this->assertSame(
+			array( 'New, no box. Multiple quantity, minor shelf wear.' ),
+			$importer->parse_comma_field( '"New, no box. Multiple quantity, minor shelf wear."' )
+		);
+
+		// Mixed unquoted and quoted values: only the quoted commas are preserved.
+		$this->assertSame(
+			array( 'Red', 'Blue, navy', 'Green' ),
+			$importer->parse_comma_field( 'Red, "Blue, navy", Green' )
+		);
+
+		// Backslash-escaped commas (the legacy escape syntax) continue to work.
+		$this->assertSame(
+			array( 'Red, navy', 'Green' ),
+			$importer->parse_comma_field( 'Red\\, navy, Green' )
+		);
+
+		// Values without quotes still split on commas as before.
+		$this->assertSame(
+			array( 'Red', 'Green', 'Blue' ),
+			$importer->parse_comma_field( 'Red, Green, Blue' )
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a CSV-importer parsing bug where product attribute values wrapped in double quotes that contain commas (e.g. `"New, no box. Multiple quantity, minor shelf wear."`) were split on the inner commas, producing multiple attribute values instead of one.

`WC_Product_Importer::explode_values` previously only honoured backslash-escaped commas (`\,`). It now also honours RFC 4180-style double-quoted substrings via `str_getcsv`, so `Red, "Blue, navy", Green` exploder into `[Red, Blue, navy, Green]`. Unquoted input is unaffected — the fast path remains a plain `explode`.

Closes #53617
Linear: https://linear.app/a8c/issue/RSMAPGJ-326

### How to test the changes in this Pull Request:

1. Create a CSV with the standard product columns plus `Attribute 1 name` and `Attribute 1 value(s)`. For the value, use `"New, no box. Multiple quantity, minor shelf wear."` (a single field, double quoted, with literal commas inside).
2. Import the CSV via **Products → Import**.
3. Open the imported product and check the **Attributes** tab.

Expected: a single attribute value `New, no box. Multiple quantity, minor shelf wear.`. Before this fix: three separate values (`"New`, `no box. Multiple quantity`, `minor shelf wear."`).

Additional smoke cases:

- `Red, "Blue, navy", Green` -> three values, the middle one preserves the comma.
- `Red\, navy, Green` -> two values (legacy backslash escape still works).
- `Red, Green, Blue` -> three values (unquoted behaviour unchanged).

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance**: Patch
**Type**: Fix

**Message**: Preserve commas inside double-quoted product attribute values when importing a CSV.

</details>

---

_Generated by the RSMAPGJ AI Coder pipeline._