### PR TITLE
Fix product CSV import losing 'Used for variations' on edited attributes

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-334
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-334
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product CSV importer/exporter: add an "Attribute X used for variations" column so the "Used for variations" flag survives a round-trip and is honored when the attribute name or values are edited in the CSV.

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -685,6 +685,8 @@ class WC_Product_CSV_Importer_Controller {
 						/* translators: %d: Attribute number */
 						__( 'Attribute %d global', 'woocommerce' ) => 'attributes:taxonomy',
 						/* translators: %d: Attribute number */
+						__( 'Attribute %d used for variations', 'woocommerce' ) => 'attributes:in_variation',
+						/* translators: %d: Attribute number */
 						__( 'Attribute %d default', 'woocommerce' ) => 'attributes:default',
 						/* translators: %d: Download number */
 						__( 'Download %d ID', 'woocommerce' ) => 'downloads:id',
@@ -855,11 +857,12 @@ class WC_Product_CSV_Importer_Controller {
 			'attributes'         => array(
 				'name'    => __( 'Attributes', 'woocommerce' ),
 				'options' => array(
-					'attributes:name' . $index     => __( 'Attribute name', 'woocommerce' ),
-					'attributes:value' . $index    => __( 'Attribute value(s)', 'woocommerce' ),
-					'attributes:taxonomy' . $index => __( 'Is a global attribute?', 'woocommerce' ),
-					'attributes:visible' . $index  => __( 'Attribute visibility', 'woocommerce' ),
-					'attributes:default' . $index  => __( 'Default attribute', 'woocommerce' ),
+					'attributes:name' . $index         => __( 'Attribute name', 'woocommerce' ),
+					'attributes:value' . $index        => __( 'Attribute value(s)', 'woocommerce' ),
+					'attributes:taxonomy' . $index     => __( 'Is a global attribute?', 'woocommerce' ),
+					'attributes:visible' . $index      => __( 'Attribute visibility', 'woocommerce' ),
+					'attributes:in_variation' . $index => __( 'Used for variations', 'woocommerce' ),
+					'attributes:default' . $index      => __( 'Default attribute', 'woocommerce' ),
 				),
 			),
 			'reviews_allowed'    => __( 'Allow customer reviews?', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/importers/mappings/default.php
+++ b/plugins/woocommerce/includes/admin/importers/mappings/default.php
@@ -103,15 +103,16 @@ function wc_importer_default_special_english_mappings( $mappings ) {
 	}
 
 	$new_mappings = array(
-		'Attribute %d name'     => 'attributes:name',
-		'Attribute %d value(s)' => 'attributes:value',
-		'Attribute %d visible'  => 'attributes:visible',
-		'Attribute %d global'   => 'attributes:taxonomy',
-		'Attribute %d default'  => 'attributes:default',
-		'Download %d ID'        => 'downloads:id',
-		'Download %d name'      => 'downloads:name',
-		'Download %d URL'       => 'downloads:url',
-		'Meta: %s'              => 'meta:',
+		'Attribute %d name'                => 'attributes:name',
+		'Attribute %d value(s)'            => 'attributes:value',
+		'Attribute %d visible'             => 'attributes:visible',
+		'Attribute %d global'              => 'attributes:taxonomy',
+		'Attribute %d used for variations' => 'attributes:in_variation',
+		'Attribute %d default'             => 'attributes:default',
+		'Download %d ID'                   => 'downloads:id',
+		'Download %d name'                 => 'downloads:name',
+		'Download %d URL'                  => 'downloads:url',
+		'Meta: %s'                         => 'meta:',
 	);
 
 	return array_merge( $mappings, $new_mappings );

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -706,6 +706,8 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 					$this->column_names[ 'attributes:visible' . $i ] = sprintf( __( 'Attribute %d visible', 'woocommerce' ), $i );
 					/* translators: %s: attribute number */
 					$this->column_names[ 'attributes:taxonomy' . $i ] = sprintf( __( 'Attribute %d global', 'woocommerce' ), $i );
+					/* translators: %s: attribute number */
+					$this->column_names[ 'attributes:in_variation' . $i ] = sprintf( __( 'Attribute %d used for variations', 'woocommerce' ), $i );
 
 					if ( is_a( $attribute, 'WC_Product_Attribute' ) ) {
 						$row[ 'attributes:name' . $i ] = html_entity_decode( wc_attribute_label( $attribute->get_name(), $product ), ENT_QUOTES );
@@ -725,7 +727,8 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 							$row[ 'attributes:taxonomy' . $i ] = 0;
 						}
 
-						$row[ 'attributes:visible' . $i ] = $attribute->get_visible();
+						$row[ 'attributes:visible' . $i ]      = $attribute->get_visible();
+						$row[ 'attributes:in_variation' . $i ] = $attribute->get_variation() ? 1 : 0;
 					} else {
 						$row[ 'attributes:name' . $i ] = html_entity_decode( wc_attribute_label( $attribute_name, $product ), ENT_QUOTES );
 
@@ -738,7 +741,8 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 							$row[ 'attributes:taxonomy' . $i ] = 0;
 						}
 
-						$row[ 'attributes:visible' . $i ] = '';
+						$row[ 'attributes:visible' . $i ]      = '';
+						$row[ 'attributes:in_variation' . $i ] = '';
 					}
 
 					if ( $product->is_type( ProductType::VARIABLE ) && isset( $default_attributes[ sanitize_title( $attribute_name ) ] ) ) {

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -372,14 +372,20 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 				// Get name.
 				$attribute_name = $attribute_id ? wc_attribute_taxonomy_name_by_id( $attribute_id ) : $attribute['name'];
 
-				// Set if is a variation attribute based on existing attributes if possible so updates via CSV do not change this.
-				$is_variation = 0;
+				// Set if is a variation attribute.
+				// Priority: explicit CSV column ("Attribute X used for variations") wins; otherwise
+				// fall back to the existing attribute on the product so updates via CSV do not change this.
+				if ( isset( $attribute['in_variation'] ) ) {
+					$is_variation = $attribute['in_variation'] ? 1 : 0;
+				} else {
+					$is_variation = 0;
 
-				if ( $existing_attributes ) {
-					foreach ( $existing_attributes as $existing_attribute ) {
-						if ( $existing_attribute->get_name() === $attribute_name ) {
-							$is_variation = $existing_attribute->get_variation();
-							break;
+					if ( $existing_attributes ) {
+						foreach ( $existing_attributes as $existing_attribute ) {
+							if ( $existing_attribute->get_name() === $attribute_name ) {
+								$is_variation = $existing_attribute->get_variation();
+								break;
+							}
 						}
 					}
 				}

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -825,11 +825,13 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		 * Match special column names.
 		 */
 		$regex_match_data_formatting = array(
-			'/attributes:value*/'    => array( $this, 'parse_comma_field' ),
-			'/attributes:visible*/'  => array( $this, 'parse_bool_field' ),
-			'/attributes:taxonomy*/' => array( $this, 'parse_bool_field' ),
-			'/downloads:url*/'       => array( $this, 'parse_download_file_field' ),
-			'/meta:*/'               => 'wp_kses_post', // Allow some HTML in meta fields.
+			'/attributes:value*/'        => array( $this, 'parse_comma_field' ),
+			'/attributes:visible*/'      => array( $this, 'parse_bool_field' ),
+			'/attributes:taxonomy*/'     => array( $this, 'parse_bool_field' ),
+			'/attributes:in_variation*/' => array( $this, 'parse_bool_field' ),
+			'/downloads:url*/'           => array( $this, 'parse_download_file_field' ),
+			// Allow some HTML in meta fields.
+			'/meta:*/'                   => 'wp_kses_post',
 		);
 
 		$callbacks = array();
@@ -980,6 +982,13 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 			} elseif ( $this->starts_with( $key, 'attributes:visible' ) ) {
 				$attributes[ str_replace( 'attributes:visible', '', $key ) ]['visible'] = wc_string_to_bool( $value );
+				unset( $data[ $key ] );
+
+			} elseif ( $this->starts_with( $key, 'attributes:in_variation' ) ) {
+				// Only record an explicit value (true/false) so blank cells preserve the existing flag.
+				if ( is_bool( $value ) ) {
+					$attributes[ str_replace( 'attributes:in_variation', '', $key ) ]['in_variation'] = $value;
+				}
 				unset( $data[ $key ] );
 
 			} elseif ( $this->starts_with( $key, 'attributes:default' ) ) {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -224,4 +224,149 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		wc_delete_attribute( $color_attr_id );
 		wc_delete_attribute( $size_attr_id );
 	}
+
+	/**
+	 * @testdox expand_data should collect the "attributes:in_variation" column into the raw_attributes array.
+	 */
+	public function test_expand_data_collects_in_variation_column() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$expand_data = ( new ReflectionClass( WC_Product_CSV_Importer::class ) )->getMethod( 'expand_data' );
+		$expand_data->setAccessible( true );
+
+		$expanded = $expand_data->invoke(
+			$importer,
+			array(
+				'attributes:name1'         => 'Color',
+				'attributes:value1'        => array( 'Red', 'Blue' ),
+				'attributes:taxonomy1'     => true,
+				'attributes:visible1'      => true,
+				'attributes:in_variation1' => true,
+			)
+		);
+
+		$this->assertArrayHasKey( 'raw_attributes', $expanded );
+		$this->assertCount( 1, $expanded['raw_attributes'] );
+		$this->assertTrue( $expanded['raw_attributes'][0]['in_variation'], 'in_variation flag should be carried through to raw_attributes.' );
+	}
+
+	/**
+	 * @testdox The "Attribute X used for variations" CSV column makes the imported attribute respect the flag even when the attribute name/values were edited in the CSV (bug 43190 / RSMAPGJ-334).
+	 */
+	public function test_attribute_in_variation_column_is_respected_on_import() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$attr_id  = wc_create_attribute(
+			array(
+				'name'         => 'Color',
+				'slug'         => 'color',
+				'type'         => 'select',
+				'order_by'     => 'menu_order',
+				'has_archives' => false,
+			)
+		);
+		$taxonomy = wc_attribute_taxonomy_name_by_id( $attr_id );
+		register_taxonomy( $taxonomy, 'product' );
+		wp_insert_term( 'Rouge', $taxonomy );
+		wp_insert_term( 'Bleu', $taxonomy );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Variable Product 43190' );
+		$product->set_sku( 'rsmapgj-334-sku' );
+		$product->save();
+
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$set_product_data = ( new ReflectionClass( $importer ) )->getMethod( 'set_product_data' );
+		$set_product_data->setAccessible( true );
+
+		// Simulate an imported row where the user changed the attribute value labels
+		// and explicitly set "Used for variations" = 1 in the CSV.
+		$data = array(
+			'raw_attributes' => array(
+				array(
+					'name'         => 'Color',
+					'value'        => array( 'Rouge', 'Bleu' ),
+					'taxonomy'     => true,
+					'visible'      => true,
+					'in_variation' => true,
+				),
+			),
+		);
+
+		$set_product_data->invokeArgs( $importer, array( &$product, $data ) );
+
+		$attributes = $product->get_attributes();
+		$this->assertNotEmpty( $attributes, 'Imported product should have attributes.' );
+		$attribute = reset( $attributes );
+		$this->assertTrue( $attribute->get_variation(), '"Used for variations" should be true when the CSV column is set to 1.' );
+		$this->assertTrue( $attribute->get_visible(), '"Visible on the product page" should be true when the CSV column is set to 1.' );
+
+		// Cleanup.
+		WC_Helper_Product::delete_product( $product->get_id() );
+		wc_delete_attribute( $attr_id );
+	}
+
+	/**
+	 * @testdox When the "Attribute X used for variations" CSV column is omitted, the existing variation flag is preserved (back-compat).
+	 */
+	public function test_attribute_in_variation_falls_back_to_existing_attribute_when_column_omitted() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$attr_id  = wc_create_attribute(
+			array(
+				'name'         => 'Size',
+				'slug'         => 'size',
+				'type'         => 'select',
+				'order_by'     => 'menu_order',
+				'has_archives' => false,
+			)
+		);
+		$taxonomy = wc_attribute_taxonomy_name_by_id( $attr_id );
+		register_taxonomy( $taxonomy, 'product' );
+		wp_insert_term( 'Small', $taxonomy );
+		wp_insert_term( 'Large', $taxonomy );
+
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Variable Product No In_Variation Column' );
+		$product->set_sku( 'rsmapgj-334-fallback-sku' );
+
+		$existing = new WC_Product_Attribute();
+		$existing->set_id( $attr_id );
+		$existing->set_name( $taxonomy );
+		$existing->set_options( array( 'Small', 'Large' ) );
+		$existing->set_visible( true );
+		$existing->set_variation( true );
+		$product->set_attributes( array( $existing ) );
+		$product->save();
+
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$set_product_data = ( new ReflectionClass( $importer ) )->getMethod( 'set_product_data' );
+		$set_product_data->setAccessible( true );
+
+		$data = array(
+			'raw_attributes' => array(
+				array(
+					'name'     => 'Size',
+					'value'    => array( 'Small', 'Large' ),
+					'taxonomy' => true,
+					'visible'  => true,
+				),
+			),
+		);
+
+		$set_product_data->invokeArgs( $importer, array( &$product, $data ) );
+
+		$attributes = $product->get_attributes();
+		$this->assertNotEmpty( $attributes );
+		$attribute = reset( $attributes );
+		$this->assertTrue( $attribute->get_variation(), 'Existing "Used for variations" flag should be preserved when CSV does not specify it.' );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+		wc_delete_attribute( $attr_id );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #43190
Linear: https://linear.app/a8c/issue/RSMAPGJ-334

The WooCommerce product CSV format has no column for the per-attribute "Used for variations" flag. The exporter only writes `Attribute X name / value(s) / visible / global / default`. On import, `abstract-wc-product-importer::set_product_data()` therefore falls back to matching each row against the existing attributes on the product by name and copying their `variation` flag.

When the user edits the attribute name or values in the CSV (the common translation/relabel workflow described in the issue), the name match fails and `is_variation` is forced to `0`, regardless of what the user put into `Attribute X visible` / `Attribute X global`. The result is the bug in the issue: variable product attributes lose their "Used for variations" tick after the import.

This PR adds a first-class `Attribute X used for variations` column:

- **Exporter** (`class-wc-product-csv-exporter.php`): writes `attributes:in_variation{N}` for each attribute on the product (1 / 0), so a round-trip preserves the flag.
- **Importer** (`class-wc-product-csv-importer.php`): registers `attributes:in_variation*` as a bool field, parses it into the `raw_attributes` array.
- **Apply layer** (`abstract-wc-product-importer.php::set_product_data`): when the column is explicitly set in CSV, use it as the source of truth for `is_variation`; when the column is absent (older CSVs), keep the existing fallback that copies from the matching existing attribute. Back-compat preserved.
- **Mapping** (`class-wc-product-csv-importer-controller.php` and `mappings/default.php`): expose the new column in the import-mapping UI and special-column auto-mapping.

### Screenshots or screen recordings of the changes:

N/A — CSV column / mapping change.

### How to test the changes in this Pull Request:

Using the steps from the original bug report:

1. Create a variable product with a global attribute (e.g. `Color: Red, Blue`), assign at least one variation, tick "Used for variations" on the attribute.
2. Export the products as CSV from **Products → All Products → Export**. The new column **Attribute 1 used for variations** is present and set to `1`.
3. Edit the CSV: change `Attribute 1 value(s)` (e.g. `Rouge, Bleu`) and confirm `Attribute 1 used for variations` is `1`.
4. Import the modified CSV via **Products → All Products → Import**. The mapping UI shows the new column.
5. Open the product → Attributes. **"Visible on the product page"** and **"Used for variations"** stay ticked.
6. Repeat with the column set to `0` and confirm the flag is unticked.
7. Test back-compat: import a CSV without the new column. The existing attribute's variation flag is preserved (no regression).

### Testing that has already taken place:

- Added two PHPUnit tests in `class-wc-product-csv-importer-test.php`:
  - `test_expand_data_collects_in_variation_column` — verifies the new column is parsed into `raw_attributes`.
  - `test_attribute_in_variation_column_is_respected_on_import` — end-to-end via `set_product_data`, with the user-edited attribute values (`Rouge`, `Bleu`); both `get_variation()` and `get_visible()` are now true.
  - `test_attribute_in_variation_falls_back_to_existing_attribute_when_column_omitted` — back-compat: when the new column is absent, the existing attribute's flag is preserved.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — passes.
- `composer exec -- phpstan analyse <modified files> --memory-limit=2G` — no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

> Significance: patch
> Type: fix
>
> Product CSV importer/exporter: add an "Attribute X used for variations" column so the "Used for variations" flag survives a round-trip and is honored when the attribute name or values are edited in the CSV.

- [x] Automatically create a changelog entry from the details above.

---

_Generated by the RSMAPGJ AI Coder pipeline._