### PR TITLE
Fix HPOS: $order->get_taxes() returns empty after save with out-of-band items

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-322
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-322
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix HPOS regression where $order->get_taxes() (and other item accessors) could return stale empty results on the same order instance after $order->save() when order item rows were also persisted out-of-band via wc_add_order_item(). Aligns behaviour with the legacy post-based storage.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -236,6 +236,19 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			 */
 			do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
 
+			/*
+			 * Invalidate the per-instance order items cache so that any rows persisted directly
+			 * to the order items tables outside of $this->add_item()/save_items() (e.g. via the
+			 * legacy wc_add_order_item() helper) become visible on subsequent reads against the
+			 * same order instance.
+			 *
+			 * Without this, get_items()/get_taxes()/get_fees()/etc. can return a stale snapshot
+			 * captured before the external write, despite the underlying object cache having
+			 * already been invalidated by the data store. See https://github.com/woocommerce/woocommerce/issues/57204.
+			 */
+			$this->items           = array();
+			$this->items_to_delete = array();
+
 		} catch ( Exception $e ) {
 			$message_id = $this->get_id() ? $this->get_id() : __( '(no ID)', 'woocommerce' );
 			$this->handle_exception(

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -635,4 +635,89 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		};
 		// phpcs:enable Squiz.Commenting
 	}
+
+	/**
+	 * @testDox After calling $order->save(), tax rows persisted out-of-band via wc_add_order_item()
+	 *          must be visible to $order->get_taxes() on the same instance, matching the behaviour
+	 *          previously observed under post-based storage. Regression test for woocommerce/woocommerce#57204.
+	 */
+	public function test_get_taxes_returns_externally_added_tax_rows_after_save() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 9.75 );
+		$product->set_tax_status( 'taxable' );
+		$product->save();
+
+		$tax_rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country' => 'GB',
+				'tax_rate'         => '20.0000',
+				'tax_rate_name'    => 'VAT',
+				'tax_rate_order'   => 1,
+			)
+		);
+
+		$order = new WC_Order();
+		$order->set_currency( 'GBP' );
+		$order->set_prices_include_tax( false );
+		$order->set_billing_country( 'GB' );
+		$order->set_cart_tax( 1.95 );
+		$order->set_shipping_tax( 0 );
+		$order->set_total( 11.70 );
+
+		$item = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 1,
+				'subtotal' => 9.75,
+				'total'    => 9.75,
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+
+		$order_id = $order->save();
+		$item_id  = $item->get_id();
+
+		// Add line item meta the legacy way, as in the bug report.
+		wc_add_order_item_meta( $item_id, '_qty', 1 );
+		wc_add_order_item_meta( $item_id, '_tax_class', '' );
+		wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( 9.75 ) );
+		wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( 9.75 ) );
+		wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( 1.95 ) );
+		wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( 1.95 ) );
+
+		// Add a tax line directly via the legacy global helper, bypassing $order->add_item().
+		$tax_item_id = wc_add_order_item(
+			$order_id,
+			array(
+				'order_item_name' => 'VAT',
+				'order_item_type' => 'tax',
+			)
+		);
+		$this->assertGreaterThan( 0, $tax_item_id, 'wc_add_order_item() should return a positive item ID.' );
+		wc_add_order_item_meta( $tax_item_id, 'rate_id', $tax_rate_id );
+		wc_add_order_item_meta( $tax_item_id, 'label', 'VAT (20%)' );
+		wc_add_order_item_meta( $tax_item_id, 'compound', 0 );
+		wc_add_order_item_meta( $tax_item_id, 'tax_amount', wc_format_decimal( 1.95, 4 ) );
+		wc_add_order_item_meta( $tax_item_id, 'shipping_tax_amount', wc_format_decimal( 0, 4 ) );
+
+		// Save the order a second time, mirroring the reporter's flow.
+		$order->save();
+
+		// On the SAME instance, the tax row must now be visible.
+		$taxes_same_instance = $order->get_taxes();
+		$this->assertNotEmpty(
+			$taxes_same_instance,
+			'After $order->save(), get_taxes() must reflect tax rows persisted out-of-band on the same instance.'
+		);
+
+		// Re-instantiating the order should return the same tax rows.
+		$taxes_fresh = wc_get_order( $order_id )->get_taxes();
+		$this->assertCount(
+			count( $taxes_fresh ),
+			$taxes_same_instance,
+			'get_taxes() on the same instance should match wc_get_order( $id )->get_taxes() after save.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Rules](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?

### Changes proposed in this Pull Request:

Closes #57204.

Linear: https://linear.app/a8c/issue/RSMAPGJ-322

Programmatically created orders that persist order-item rows via the legacy `wc_add_order_item()` global helper after the first `$order->save()` could end up with `$order->get_taxes()` returning an empty array under HPOS — despite the rows existing in `wp_woocommerce_order_items`. Re-instantiating via `wc_get_order( $id )` returned the expected taxes. The same code worked correctly under the legacy post-based storage.

The cause is the per-instance `$this->items` cache on `WC_Abstract_Order`. Hooks that fire during a subsequent `$order->save()` (for example `OrdersVersionStringInvalidator::handle_before_order_save` calling `$order->get_data()` on `woocommerce_before_order_object_save`) can prime `$this->items[$group]` from the data store before all DB changes are reflected, leaving the per-instance cache stale even after the data store has cleared its own `wp_cache` entries.

This PR invalidates `$this->items` (and `$this->items_to_delete`) after a successful save so that subsequent `get_items()` / `get_taxes()` / `get_fees()` / etc. re-read from the data store on the same instance, matching the behaviour previously observed under post-based storage.

### How to test the changes in this Pull Request:

Manual:

1. Enable HPOS in **WooCommerce -> Settings -> Advanced -> Features**.
2. Create a tax rate (e.g. GB / 20% / VAT).
3. From WP-CLI or a small mu-plugin, run a script that mirrors the reporter's flow: create a `WC_Order`, add a `WC_Order_Item_Product` via `$order->add_item()`, call `$order->save()`, then call `wc_add_order_item( $order_id, [ 'order_item_type' => 'tax', ... ] )` plus `wc_add_order_item_meta()` for `rate_id`, `tax_amount`, etc., then call `$order->save()` a second time.
4. Confirm `$order->get_taxes()` on the same instance now returns the tax line (previously empty under HPOS) and matches `wc_get_order( $order_id )->get_taxes()`.

Automated:

```sh
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_get_taxes_returns_externally_added_tax_rows_after_save
```

The test (in `tests/php/includes/abstracts/class-wc-abstract-order-test.php`) fails on trunk under HPOS and passes with this fix.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

### Changelog entry

Added via `plugins/woocommerce/changelog/fix-rsmapgj-322` (Significance: patch, Type: fix).

---

Submitted via the RSMAPGJ AI Coder pipeline.