### PR TITLE
Widen wc_product_download_directories.url column to VARCHAR(2048)

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-325
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-325
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Widen the `url` column on `wc_product_download_directories` from VARCHAR(256) to VARCHAR(2048) so URLs whose domain is at the RFC 1035 255-character limit (plus scheme) can be stored without truncation or insert failure.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -329,6 +329,9 @@ class WC_Install {
 			'wc_update_1080_slim_orders_meta_key_index',
 			'wc_update_1080_backfill_email_template_sync_meta',
 		),
+		'10.9.0' => array(
+			'wc_update_1090_widen_product_download_directories_url_column',
+		),
 	);
 
 	/**
@@ -1967,7 +1970,7 @@ CREATE TABLE {$wpdb->prefix}wc_rate_limits (
 $product_attributes_lookup_table_creation_sql
 CREATE TABLE {$wpdb->prefix}wc_product_download_directories (
 	url_id bigint(20) unsigned NOT NULL auto_increment,
-	url varchar(256) NOT NULL,
+	url varchar(2048) NOT NULL,
 	enabled tinyint(1) NOT NULL DEFAULT 0,
 	PRIMARY KEY (url_id),
 	KEY url (url($max_index_length))

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3511,3 +3511,36 @@ function wc_update_1080_slim_orders_meta_key_index(): void {
 function wc_update_1080_backfill_email_template_sync_meta(): bool {
 	return WCEmailTemplateSyncBackfill::run();
 }
+
+/**
+ * Widen the `url` column on `wc_product_download_directories` from VARCHAR(256) to VARCHAR(2048).
+ *
+ * RFC 1035 permits domain names up to 255 characters, so a URL that includes the scheme
+ * (e.g. `https://`) can easily exceed the previous 256-character limit and trigger a
+ * `Data too long for column 'url'` error on insert. Widening the column to 2048 brings
+ * the schema in line with the practical upper bound for URLs while keeping the indexed
+ * key prefix unchanged (which already uses `$max_index_length`).
+ *
+ * @since 10.9.0
+ *
+ * @return void
+ */
+function wc_update_1090_widen_product_download_directories_url_column(): void {
+	global $wpdb;
+
+	$table_name = $wpdb->prefix . 'wc_product_download_directories';
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$column_type = $wpdb->get_var( "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '{$table_name}' AND COLUMN_NAME = 'url'" );
+
+	if ( null === $column_type ) {
+		return;
+	}
+
+	if ( 0 === stripos( (string) $column_type, 'varchar(2048)' ) ) {
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$wpdb->query( "ALTER TABLE `{$table_name}` MODIFY COLUMN `url` VARCHAR(2048) NOT NULL" );
+}

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
@@ -296,8 +296,9 @@ class Register {
 	private function prepare_url_for_upsert( string $url ): string {
 		$url = trailingslashit( $this->normalize_url( $url ) );
 
-		if ( mb_strlen( $url ) > 256 ) {
-			throw new ApprovedDirectoriesException( __( 'Approved directory URLs cannot be longer than 256 characters.', 'woocommerce' ), ApprovedDirectoriesException::INVALID_URL );
+		if ( mb_strlen( $url ) > 2048 ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The message is localized and safe; this exception is caught and handled by the caller, not echoed.
+			throw new ApprovedDirectoriesException( __( 'Approved directory URLs cannot be longer than 2048 characters.', 'woocommerce' ), ApprovedDirectoriesException::INVALID_URL );
 		}
 
 		return $url;

--- a/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/RegisterTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/RegisterTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\ProductDownloads\ApprovedDirectories;
 
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\ApprovedDirectoriesException;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register;
 use WC_Unit_Test_Case;
 
@@ -138,5 +139,53 @@ class RegisterTest extends WC_Unit_Test_Case {
 
 		static::$sut->enable_by_id( $approved_directory_id );
 		$this->assertTrue( static::$sut->get_by_url( 'https://foo.bar/assets/' )->is_enabled() );
+	}
+
+	/**
+	 * @testdox URLs longer than the legacy 256-character limit but within the 2048-character maximum can be added.
+	 *
+	 * Regression test for RSMAPGJ-325 / woo#53964: RFC 1035 allows domain names up to
+	 * 255 characters, so a fully-qualified URL with scheme can exceed 256 chars and used
+	 * to fail to insert into `wc_product_download_directories` because the `url` column
+	 * was VARCHAR(256). The column is now VARCHAR(2048).
+	 */
+	public function test_long_url_within_extended_limit_is_accepted() {
+		// Build a URL whose length is well above the legacy 256-char ceiling but below
+		// the new 2048-char ceiling. 8 (scheme) + 248 + 5 (".com/") = 261 characters.
+		$long_url = 'https://' . str_repeat( 'a', 248 ) . '.com/';
+		$this->assertGreaterThan( 256, strlen( $long_url ) );
+
+		$register = new Register();
+
+		try {
+			$rule_id = $register->add_approved_directory( $long_url );
+			$this->assertIsInt( $rule_id );
+			$this->assertGreaterThan( 0, $rule_id );
+
+			$stored = $register->get_by_url( $long_url );
+			$this->assertNotNull( $stored, 'The long URL should be retrievable after insertion.' );
+			$this->assertGreaterThan(
+				256,
+				strlen( $stored->get_url() ),
+				'The stored URL must not be silently truncated down to the legacy 256-character ceiling.'
+			);
+		} finally {
+			if ( isset( $rule_id ) ) {
+				$register->delete_by_id( $rule_id );
+			}
+		}
+	}
+
+	/**
+	 * @testdox URLs longer than the 2048-character maximum are rejected with a descriptive exception.
+	 */
+	public function test_url_longer_than_2048_is_rejected() {
+		$too_long_url = 'https://' . str_repeat( 'a', 2048 ) . '.com/';
+		$register     = new Register();
+
+		$this->expectException( ApprovedDirectoriesException::class );
+		$this->expectExceptionCode( ApprovedDirectoriesException::INVALID_URL );
+
+		$register->add_approved_directory( $too_long_url );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Particular Guidelines for this Repository](https://github.com/woocommerce/woocommerce/blob/trunk/.github/contributing/CORE.md).
- [x] I have checked that the [linked issue](#53964) is assigned to me.

### Changes proposed in this Pull Request

The `url` column on the `wc_product_download_directories` table was previously defined as `VARCHAR(256)`. RFC 1035 permits domain names up to 255 characters, so a fully-qualified URL with scheme (`https://...`) routinely exceeds 256 characters, causing inserts to fail with `Data too long for column 'url'`.

This PR:

- Updates the schema returned by `WC_Install::get_schema()` so fresh installs get `VARCHAR(2048)`.
- Adds a `10.9.0` db update entry (`wc_update_1090_widen_product_download_directories_url_column`) that issues an explicit `ALTER TABLE ... MODIFY COLUMN` on upgrade, idempotently (it bails out if the column is already `varchar(2048)`).
- Lifts the matching PHP-level length check in `Register::prepare_url_for_upsert()` from 256 to 2048 so the runtime validation aligns with the new column width.
- Adds unit test coverage for both the long-URL-accepted and over-2048-URL-rejected paths in `RegisterTest`.

Closes #53964
Linear: https://linear.app/a8c/issue/RSMAPGJ-325

### How to test the changes in this Pull Request

1. Upgrade an existing site (with the table already created at `VARCHAR(256)`) to this branch and confirm the upgrade routine runs (e.g. observe schema with `SHOW COLUMNS FROM wp_wc_product_download_directories LIKE 'url'`; column should now report `varchar(2048)`).
2. From WP admin, add an Approved Download Directory whose URL is ~260 characters (well past the legacy 256-char ceiling but under 2048) and confirm it saves successfully and round-trips through `get_by_url()` without truncation.
3. Attempt to save a URL longer than 2048 characters and confirm the request is rejected with the matching `ApprovedDirectoriesException` ("Approved directory URLs cannot be longer than 2048 characters").
4. On a fresh install, verify the new column type is `varchar(2048)` (no upgrade routine needed because `get_schema()` already produces the wider definition).

### Testing that has already taken place

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` -- clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` -- clean.
- `composer exec -- phpstan analyse <touched production files> --memory-limit=2G` -- no errors, no new baseline entries.
- Unit tests added in `RegisterTest`; not executed locally per pipeline policy (see signoff below).

### Changelog entry

`plugins/woocommerce/changelog/fix-rsmapgj-325` -- patch / fix.

---

Submitted via the **RSMAPGJ AI Coder pipeline**.