### PR TITLE
Fix wc_format_decimal trimming trailing zeros below price decimals

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-330
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-330
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve trailing zeros within the configured price decimals when wc_format_decimal() formats a float, so a custom woocommerce_internal_rounding_precision no longer renders 3.70 as 3.7.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -280,6 +280,11 @@ function wc_format_refund_total( $amount ) {
  *
  * This function does not remove thousands - this should be done before passing a value to the function.
  *
+ * When $dp is false and a float is supplied, the result is sprintf'd at the internal rounding precision
+ * and trailing zeros are trimmed. Since 10.9.0, the trim no longer reduces a float to fewer decimals than
+ * `wc_get_price_decimals()` unless the caller explicitly requests `$trim_zeros = true`. This avoids `3.70`
+ * being stored as `3.7` once `woocommerce_internal_rounding_precision` is lowered to match the price decimals.
+ *
  * @param  float|string $number     Expects either a float or a string with a decimal separator only (no thousands).
  * @param  mixed        $dp number  Number of decimal points to use, blank to use woocommerce_price_num_decimals, or false to avoid all rounding.
  * @param  bool         $trim_zeros From end of string.
@@ -303,18 +308,40 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 		$number = preg_replace( '/\.(?![^.]+$)|[^0-9.-]/', '', wc_clean( $number ) );
 	}
 
+	// Track whether the caller explicitly requested an aggressive trim. When the trim
+	// is enabled implicitly below (float without an explicit $dp), trailing zeros are
+	// only trimmed down to `wc_get_price_decimals()` so values such as `3.70` are not
+	// reduced to `3.7` once the internal rounding precision is lowered via the
+	// `woocommerce_internal_rounding_precision` filter.
+	$caller_requested_trim = $trim_zeros;
+	$min_decimals          = null;
+
 	if ( false !== $dp ) {
 		$dp     = intval( '' === $dp ? wc_get_price_decimals() : $dp );
 		$number = number_format( floatval( $number ), $dp, '.', '' );
 	} elseif ( is_float( $number ) ) {
 		// DP is false - don't use number format, just return a string using whatever is given. Remove scientific notation using sprintf.
 		$number = str_replace( $decimals, '.', sprintf( '%.' . wc_get_rounding_precision() . 'f', $number ) );
-		// We already had a float, so trailing zeros are not needed.
+		// We already had a float, so excess trailing zeros are not needed.
 		$trim_zeros = true;
+		if ( ! $caller_requested_trim ) {
+			$min_decimals = wc_get_price_decimals();
+		}
 	}
 
-	if ( $trim_zeros && strstr( $number, '.' ) ) {
-		$number = rtrim( rtrim( $number, '0' ), '.' );
+	if ( $trim_zeros && is_string( $number ) && strstr( $number, '.' ) ) {
+		if ( null !== $min_decimals && $min_decimals > 0 ) {
+			list( $integer_part, $decimal_part ) = explode( '.', $number, 2 );
+			$decimal_part                        = rtrim( $decimal_part, '0' );
+
+			if ( strlen( $decimal_part ) < $min_decimals ) {
+				$decimal_part = str_pad( $decimal_part, $min_decimals, '0' );
+			}
+
+			$number = '' === $decimal_part ? $integer_part : $integer_part . '.' . $decimal_part;
+		} else {
+			$number = rtrim( rtrim( $number, '0' ), '.' );
+		}
 	}
 
 	return $number;

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -385,13 +385,38 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 		update_option( 'woocommerce_price_num_decimals', '8' );
 
-		// Floats.
-		$this->assertEquals( '0.00001', wc_format_decimal( 0.00001 ) );
+		// Floats. Trailing zeros are preserved down to woocommerce_price_num_decimals so
+		// formatted values are never displayed with fewer decimals than the configured price precision.
+		$this->assertEquals( '0.00001000', wc_format_decimal( 0.00001 ) );
 		$this->assertEquals( '0.22222222', wc_format_decimal( 0.22222222 ) );
 
 		update_option( 'woocommerce_price_num_decimals', '2' );
 		update_option( 'woocommerce_price_decimal_sep', '.' );
 		update_option( 'woocommerce_price_thousand_sep', ',' );
+	}
+
+	/**
+	 * Trailing zeros that fall within the configured price decimals should be kept.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/46475 — when the
+	 * `woocommerce_internal_rounding_precision` filter narrows the internal precision (e.g. to 2),
+	 * a rounded float such as `3.70` should still format as `3.70` rather than `3.7`.
+	 */
+	public function test_wc_format_decimal_keeps_trailing_zeros_within_price_decimals() {
+		$filter = static function () {
+			return 2;
+		};
+
+		add_filter( 'woocommerce_internal_rounding_precision', $filter );
+
+		try {
+			$this->assertEquals( '3.70', wc_format_decimal( 3.7 ) );
+			$this->assertEquals( '108.40', wc_format_decimal( 108.4 ) );
+			// Explicit trim_zeros = true still trims aggressively (back-compat).
+			$this->assertEquals( '3.7', wc_format_decimal( 3.7, false, true ) );
+		} finally {
+			remove_filter( 'woocommerce_internal_rounding_precision', $filter );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request

Closes #46475
Linear: https://linear.app/a8c/issue/RSMAPGJ-330

`wc_format_decimal()` formats a float through `sprintf( '%.<rounding precision>f', ... )` and then strips all trailing zeros. That works while `wc_get_rounding_precision()` is comfortably wider than `wc_get_price_decimals()`, but the `woocommerce_internal_rounding_precision` filter (introduced in WC 8.8 via #45743) lets stores reduce the internal precision down to the price decimals. Once the two match, a value such as `3.70` is sprintf'd as `"3.70"` and then trimmed back to `"3.7"`, which is what ends up in order-item tax storage. The order edit drawer then renders that as `3.7` instead of `3.70`.

This PR keeps the implicit-trim path (float input, no explicit `$dp`) from reducing a value below `wc_get_price_decimals()` decimal digits. Callers that pass `$trim_zeros = true` explicitly are unaffected so `wc_format_decimal( 9.00, false, true ) === '9'` is preserved.

Bug introduced in PR #45743.

### How to test the changes in this Pull Request

1. Activate this code snippet on a test site:

   ```php
   add_filter( 'woocommerce_internal_rounding_precision', static function () { return 2; }, 10, 1 );
   ```

2. Enable taxes under WooCommerce > Settings > Tax, choose "Yes, I will enter prices inclusive of tax".
3. Add a 21% Standard tax rate.
4. Create a product priced so the tax has a trailing-zero decimal (e.g. `$21.30` or `$108.40`).
5. Place an order with that product.
6. Open the order, click *Edit item*, and inspect the tax input on the line item:
   - Before this PR: shows `3.7`.
   - After this PR: shows `3.70`.

You can also run the formatting unit test:

```sh
pnpm --filter=@woocommerce/plugin-woocommerce test:php --filter test_wc_format_decimal_keeps_trailing_zeros_within_price_decimals
```

### Testing that has already taken place

- Updated and re-ran the existing `WC_Tests_Formatting_Functions::test_wc_format_decimal()` assertions (one expectation around the `0.00001` Bitcoin-precision case was tightened to match the new "preserve down to price decimals" semantics).
- Added a regression test `test_wc_format_decimal_keeps_trailing_zeros_within_price_decimals` covering the filter scenario from the bug report.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `composer exec -- phpstan analyse includes/wc-formatting-functions.php --memory-limit=2G` clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

> Generated as part of the RSMAPGJ AI Coder pipeline.

<!-- changelog -->