### PR TITLE
Fix Filter Products by Rating widget: add visible chosen-state indicator

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-308
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-308
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Filter Products by Rating widget: provide clearer visual indication of the selected rating by bolding the chosen item and exposing an accessible "Remove filter" label.

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -1583,6 +1583,10 @@ p.demo_store,
 			}
 		}
 
+		li.chosen > a {
+			font-weight: 700;
+		}
+
 		li.chosen a::before {
 			@include iconbefore("\e013");
 			color: var(--wc-red);

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-rating-filter.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-rating-filter.php
@@ -110,16 +110,17 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			if ( empty( $count ) ) {
 				continue;
 			}
-			$found = true;
-			$link  = $base_link;
+			$found     = true;
+			$link      = $base_link;
+			$is_chosen = in_array( $rating, $rating_filter, true );
 
-			if ( in_array( $rating, $rating_filter, true ) ) {
+			if ( $is_chosen ) {
 				$link_ratings = implode( ',', array_diff( $rating_filter, array( $rating ) ) );
 			} else {
 				$link_ratings = implode( ',', array_merge( $rating_filter, array( $rating ) ) );
 			}
 
-			$class       = in_array( $rating, $rating_filter, true ) ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating';
+			$class       = $is_chosen ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating';
 			$link        = apply_filters( 'woocommerce_rating_filter_link', $link_ratings ? add_query_arg( 'rating_filter', $link_ratings, $link ) : remove_query_arg( 'rating_filter' ) );
 			$rating_html = wc_get_star_rating_html( $rating );
 			$count_html  = wp_kses(
@@ -131,7 +132,15 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 				)
 			);
 
-			printf( '<li class="%s"><a href="%s"><span class="star-rating">%s</span> %s</a></li>', esc_attr( $class ), esc_url( $link ), $rating_html, $count_html ); // WPCS: XSS ok.
+			$link_attrs = '';
+			if ( $is_chosen ) {
+				/* translators: %d: rating number from 1 to 5 */
+				$aria_label = sprintf( __( 'Remove filter for rated %d out of 5', 'woocommerce' ), $rating );
+				$link_attrs = ' rel="nofollow" aria-current="true" aria-label="' . esc_attr( $aria_label ) . '"';
+			}
+
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $link_attrs is built from escaped values, $rating_html and $count_html are escaped above.
+			printf( '<li class="%s"><a%s href="%s"><span class="star-rating">%s</span> %s</a></li>', esc_attr( $class ), $link_attrs, esc_url( $link ), $rating_html, $count_html );
 		}
 
 		echo '</ul>';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a customer selected a rating in the "Filter Products by Rating" widget, the only feedback was the appended `?rating_filter=X` in the URL — the widget itself looked unchanged on themes that strip the WooCommerce icon font. The list item already received a `chosen` class, but the visual treatment was rendered solely via the icon-font glyph `\e013`, which is not visible on themes like Twenty Seventeen.

This PR adds a robust, theme-resilient indicator for the chosen rating:

- Bold the `<a>` inside `.widget_rating_filter li.chosen` in the legacy WooCommerce stylesheet so the selected state is visible without depending on the icon font.
- Render `rel="nofollow"`, `aria-current="true"` and a translated `"Remove filter for rated N out of 5"` aria-label on the chosen link, mirroring the Layered Nav Filters widget and conveying the "click to remove" action to assistive technology.

Closes #28283
Linear: https://linear.app/a8c/issue/RSMAPGJ-308

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Selecting a rating only changes the URL; no list item in the widget appears bold or marked. | The chosen rating row is bold, prefixed with the existing red "x" glyph, exposes `aria-current="true"` and an accessible "Remove filter" label, and clicking it removes the rating filter. |

### How to test the changes in this Pull Request:

1. Activate WooCommerce and a classic theme such as Storefront or Twenty Seventeen.
2. Create at least three products and add product reviews so each gets a different average star rating (e.g. 3, 4 and 5 stars).
3. From WP Admin -> Appearance -> Widgets, add the "Filter Products by Rating" widget to the Shop sidebar.
4. Visit `/shop/`.
5. Click any rating in the widget.
6. Verify the URL gains `?rating_filter=N` AND the clicked row is now visibly distinct: bold text, leading red "x", `aria-current="true"` on the link.
7. Open DevTools -> Inspect the chosen list item: it should be `<li class="wc-layered-nav-rating chosen">` with the `<a>` exposing `rel="nofollow" aria-current="true" aria-label="Remove filter for rated N out of 5"`.
8. Click the same row again -> the rating filter is removed from the URL and the bold/active styling is gone.
9. Run a screen reader on the chosen row and confirm it announces "Remove filter for rated N out of 5".

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` -> clean.
- `composer exec -- phpstan analyse includes/widgets/class-wc-widget-rating-filter.php --memory-limit=2G` -> No errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` -> clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was added manually at `plugins/woocommerce/changelog/fix-rsmapgj-308` (patch / fix).

---

_Generated via the RSMAPGJ AI Coder pipeline._