### PR TITLE
Fix wcSettings hard dependency in Search Variations autocompleter

### DIFF
--- a/packages/js/components/changelog/fix-rsmapgj-341
+++ b/packages/js/components/changelog/fix-rsmapgj-341
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Guard wcSettings access in Search Variations autocompleter so importing @woocommerce/components no longer errors in third-party plugins.

--- a/packages/js/components/src/phone-number-input/utils.ts
+++ b/packages/js/components/src/phone-number-input/utils.ts
@@ -72,7 +72,7 @@ const countryNames: Record< string, string > = mapValues(
 	{
 		AC: 'Ascension Island',
 		XK: 'Kosovo',
-		...( window.wcSettings?.countries || [] ),
+		...( window.wcSettings?.countries || {} ),
 	},
 	( name ) => decodeHtmlEntities( name )
 );

--- a/packages/js/components/src/search/autocompleters/test/variations.test.tsx
+++ b/packages/js/components/src/search/autocompleters/test/variations.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Internal dependencies
+ */
+import variations from '../variations';
+
+describe( 'variations autocompleter', () => {
+	const originalWcSettings = window.wcSettings;
+
+	afterEach( () => {
+		window.wcSettings = originalWcSettings;
+	} );
+
+	it( 'does not throw when wcSettings is undefined (third-party context)', () => {
+		// Simulate a third-party plugin context where wcSettings is not set.
+		delete ( window as { wcSettings?: unknown } ).wcSettings;
+
+		expect( () =>
+			variations.getOptionKeywords( {
+				id: 1,
+				name: 'My Variation',
+				attributes: [ { option: 'Red' }, { option: 'Large' } ],
+				sku: 'SKU-1',
+			} )
+		).not.toThrow();
+	} );
+
+	it( 'uses the default separator when wcSettings is undefined', () => {
+		delete ( window as { wcSettings?: unknown } ).wcSettings;
+
+		const keywords = variations.getOptionKeywords( {
+			id: 1,
+			name: 'My Variation',
+			attributes: [ { option: 'Red' }, { option: 'Large' } ],
+			sku: 'SKU-1',
+		} );
+
+		// First keyword is the formatted variation name using default separator " - ".
+		expect( keywords[ 0 ] ).toBe( 'My Variation - Red, Large' );
+		expect( keywords[ 1 ] ).toBe( 'SKU-1' );
+	} );
+
+	it( 'uses the configured separator when wcSettings provides one', () => {
+		window.wcSettings = {
+			variationTitleAttributesSeparator: ' | ',
+			countries: {},
+		};
+
+		const keywords = variations.getOptionKeywords( {
+			id: 1,
+			name: 'My Variation',
+			attributes: [ { option: 'Red' } ],
+			sku: 'SKU-1',
+		} );
+
+		expect( keywords[ 0 ] ).toBe( 'My Variation | Red' );
+	} );
+} );

--- a/packages/js/components/src/search/autocompleters/variations.tsx
+++ b/packages/js/components/src/search/autocompleters/variations.tsx
@@ -30,7 +30,7 @@ function getVariationName( {
 	name: string;
 } ) {
 	const separator =
-		window.wcSettings.variationTitleAttributesSeparator || ' - ';
+		window.wcSettings?.variationTitleAttributesSeparator || ' - ';
 
 	if ( name.indexOf( separator ) > -1 ) {
 		return name;

--- a/packages/js/components/typings/global.d.ts
+++ b/packages/js/components/typings/global.d.ts
@@ -1,6 +1,6 @@
 declare global {
 	interface Window {
-		wcSettings: {
+		wcSettings?: {
 			variationTitleAttributesSeparator?: string;
 			countries: Record< string, string >;
 		};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `Search` component's Variations autocompleter (`packages/js/components/src/search/autocompleters/variations.tsx`) accessed `window.wcSettings.variationTitleAttributesSeparator` without guarding for a missing `wcSettings`. Third-party plugins that consume `@woocommerce/components` through `WooCommerceDependencyExtractionWebpackPlugin` do not always have `wcSettings` defined, so any code path that exercised the variations autocompleter logged the console error `Cannot read properties of undefined (reading 'variationTitleAttributesSeparator')`.

This PR:

- Guards the `wcSettings` access with optional chaining (`window.wcSettings?.variationTitleAttributesSeparator`), preserving the existing default-separator fallback.
- Updates the package's `Window` typing in `typings/global.d.ts` so `wcSettings` is optional, matching real-world third-party usage.
- Adjusts the existing `phone-number-input/utils.ts` fallback from `|| []` to `|| {}` so the (now optional) `countries` spread continues to type-check under the relaxed `wcSettings` typing.
- Adds a Jest test covering the third-party-context case (no `wcSettings`), the default-separator path, and a custom separator.

Closes #39772.

Linear: https://linear.app/a8c/issue/RSMAPGJ-341

### Screenshots or screen recordings:

N/A (no UI changes).

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm --filter=@woocommerce/components test:js variations` — the new `variations` autocompleter tests should pass.
2. In a sandbox third-party WP plugin, `npm i @woocommerce/components` and import anything from it with `WooCommerceDependencyExtractionWebpackPlugin` configured. Load any WP admin page where the plugin script enqueues. Before this fix the console showed `Cannot read properties of undefined (reading 'variationTitleAttributesSeparator')`; after this fix the import is silent.
3. Inside the WooCommerce admin, exercise any view that uses the Variations search autocompleter (e.g. the analytics filters that allow variation lookup) and confirm the separator behavior is unchanged when `wcSettings.variationTitleAttributesSeparator` is set.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/components test:js variations` → 3 passed.
- `pnpm --filter=@woocommerce/components test:js search` → 25 passed.
- `pnpm --filter=@woocommerce/components test:js phone-number` → 20 passed.
- `pnpm --filter=@woocommerce/components build` → clean.
- `pnpm --filter=@woocommerce/components lint` → 0 errors (only pre-existing warnings).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry already created manually at `packages/js/components/changelog/fix-rsmapgj-341` (significance: patch, type: fix).

---

_This PR was produced by the RSMAPGJ AI Coder pipeline._