### PR TITLE
Fix product attribute terms not ordering by Term ID

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-305
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-305
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Order attribute terms by term_id on the frontend when the attribute is configured with the "Term ID" sort order.

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -42,6 +42,11 @@ function wc_change_get_terms_defaults( $defaults, $taxonomies ) {
 		case 'parent':
 			$defaults['orderby'] = $orderby;
 			break;
+		case 'id':
+			// Map the attribute "Term ID" option (stored as `id`) to the
+			// `term_id` orderby value understood by `get_terms()`.
+			$defaults['orderby'] = 'term_id';
+			break;
 	}
 
 	return $defaults;

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/taxonomies.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/taxonomies.php
@@ -196,4 +196,63 @@ class WC_Test_Taxonomies extends WC_Unit_Test_Case {
 			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		);
 	}
+
+	/**
+	 * Test that an attribute taxonomy configured with `Order by Term ID` (stored as `id`)
+	 * causes attribute terms to be returned ordered by term_id, not name.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/30052
+	 */
+	public function test_get_terms_orderby_attribute_term_id() {
+		// Create an attribute taxonomy ordered by Term ID.
+		$attribute_id = wc_create_attribute(
+			array(
+				'name'         => 'Size 30052',
+				'slug'         => 'size30052',
+				'type'         => 'select',
+				'order_by'     => 'id',
+				'has_archives' => false,
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		$taxonomy = wc_attribute_taxonomy_name( 'size30052' );
+		register_taxonomy(
+			$taxonomy,
+			array( 'product' ),
+			array(
+				'hierarchical' => false,
+				'public'       => false,
+			)
+		);
+
+		// Bust the cached attribute taxonomies so wc_attribute_orderby() sees the new one.
+		wp_cache_delete( 'attribute_taxonomies', 'woocommerce-attributes' );
+
+		// Insert terms in non-alphabetical order so name vs. term_id ordering differ.
+		$t1 = wp_insert_term( 'Zebra', $taxonomy ); // lowest term_id.
+		$t2 = wp_insert_term( 'Apple', $taxonomy );
+		$t3 = wp_insert_term( 'Mango', $taxonomy ); // highest term_id.
+
+		$expected_term_ids = array( $t1['term_id'], $t2['term_id'], $t3['term_id'] );
+
+		// get_terms without an explicit orderby should fall back to the attribute's configured order_by.
+		$terms = get_terms(
+			array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => false,
+			)
+		);
+
+		$actual_term_ids = array_values( wp_list_pluck( $terms, 'term_id' ) );
+
+		$this->assertEquals(
+			$expected_term_ids,
+			$actual_term_ids,
+			'Attribute terms should be returned ordered by term_id when attribute order_by is "id".'
+		);
+
+		// Tidy up registered taxonomy.
+		unregister_taxonomy( $taxonomy );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Contributor Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have checked to ensure there aren't other open [pull requests](https://github.com/woocommerce/woocommerce/pulls) for the same issue.

### Changes proposed in this Pull Request

When a product attribute is configured with the "Term ID" sort order (stored internally as `id`), the frontend variation dropdown still displayed terms ordered by name. The root cause is in `wc_change_get_terms_defaults()` (`plugins/woocommerce/includes/wc-term-functions.php`): the switch maps `menu_order`, `name_num`, and `parent` through to `get_terms()` but silently dropped `id`, so the WordPress default `orderby = name` took over.

This PR maps the attribute's `id` order setting to `term_id`, which is a first-class `orderby` value for `WP_Term_Query`. No new field, no new API — just routing the existing admin choice through to the underlying query.

Closes #30052
Linear: https://linear.app/a8c/issue/RSMAPGJ-305

### Screenshots or screen recordings

N/A — fix is in the query layer; behaviour is verified by the new unit test.

### How to test the changes in this Pull Request

1. In `wp-admin`, go to **Products → Attributes** and create an attribute (e.g. `Size`) with **Default sort order = Term ID**.
2. Add a few terms in non-alphabetical order, e.g. `Zebra`, `Apple`, `Mango` (so `Zebra` has the lowest `term_id`).
3. Create a variable product, attach the attribute, mark it used for variations, set all options, generate one variation per term, and publish.
4. View the product on the frontend.
5. Expected: the attribute dropdown lists `Zebra`, `Apple`, `Mango` (term_id ascending). Without the fix it would list them alphabetically (`Apple`, `Mango`, `Zebra`).

Automated coverage: `plugins/woocommerce/tests/legacy/unit-tests/core/taxonomies.php::test_get_terms_orderby_attribute_term_id` exercises the path end-to-end against a registered attribute taxonomy.

### Testing that has already taken place

- Added a focused PHPUnit test (`test_get_terms_orderby_attribute_term_id`) that creates an attribute with `order_by = id`, inserts three terms whose term_id and name orderings disagree, and asserts `get_terms()` returns them ordered by term_id.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- PHPStan on the modified production file (`includes/wc-term-functions.php`) — clean, no new baseline entries.
- Branch-level `phpcs-changed` against `origin/trunk` — clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance:** Patch
**Type:** Fix

Order attribute terms by term_id on the frontend when the attribute is configured with the "Term ID" sort order.

</details>

---

Submitted by the RSMAPGJ AI Coder pipeline.