### PR TITLE
Avoid wp_count_posts() on every admin page load in WC_Install::is_new_install()

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-303
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-303
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip the per-status product count in WC_Install::is_new_install(); use a lightweight existence check so admin page loads are not slowed down on stores with large product catalogs.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -825,11 +825,31 @@ class WC_Install {
 	 * @return boolean
 	 */
 	public static function is_new_install() {
-		return is_null( get_option( 'woocommerce_version', null ) )
-			|| (
-				-1 === wc_get_page_id( 'shop' )
-				&& 0 === array_sum( (array) wp_count_posts( 'product' ) )
-			);
+		if ( is_null( get_option( 'woocommerce_version', null ) ) ) {
+			return true;
+		}
+
+		if ( -1 !== wc_get_page_id( 'shop' ) ) {
+			return false;
+		}
+
+		// Only check whether any products exist; we do not need a full count grouped
+		// by post status. On stores with very large catalogs, wp_count_posts() can be
+		// expensive and would otherwise run on every admin page load via the callers
+		// of this method (e.g. WC_Admin_Notices::init()).
+		$product_ids = get_posts(
+			array(
+				'post_type'        => 'product',
+				'post_status'      => 'any',
+				'posts_per_page'   => 1,
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'cache_results'    => false,
+				'suppress_filters' => false,
+			)
+		);
+
+		return empty( $product_ids );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -192,10 +192,10 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	 */
 	public function test_is_new_install(): void {
 		// Determining if we are in a new install is based on the following three factors.
-		$version       = null;
-		$shop_id       = null;
-		$post_count    = 0;
-		$counted_posts = false;
+		$version        = null;
+		$shop_id        = null;
+		$product_exists = false;
+		$queried_posts  = false;
 
 		$supply_version = function () use ( &$version ) {
 			return $version;
@@ -205,22 +205,39 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 			return $shop_id;
 		};
 
-		$supply_post_count = function () use ( &$post_count ) {
-			$counted_posts = true;
-			return $post_count;
+		// Short-circuit the products existence check used by is_new_install().
+		// is_new_install() runs get_posts( array( 'post_type' => 'product', ... ) ).
+		// Returning an array from posts_pre_query bypasses the actual query while
+		// letting us simulate the "no products" and "one or more products" states.
+		$supply_product_existence = function ( $posts, $query ) use ( &$product_exists, &$queried_posts ) {
+			if ( ! isset( $query->query_vars['post_type'] ) || 'product' !== $query->query_vars['post_type'] ) {
+				return $posts;
+			}
+			$queried_posts = true;
+			return $product_exists ? array( 1 ) : array();
+		};
+
+		// Fail loudly if anything attempts the heavyweight wp_count_posts() path
+		// for products from within is_new_install().
+		$forbid_wp_count_posts = function ( $counts, $type ) {
+			if ( 'product' === $type ) {
+				$this->fail( 'is_new_install() must not call wp_count_posts() for the product post type.' );
+			}
+			return $counts;
 		};
 
 		// Make it straightforward to test different values for our key variables.
 		add_filter( 'option_woocommerce_version', $supply_version );
 		add_filter( 'woocommerce_get_shop_page_id', $supply_shop_id );
-		add_filter( 'wp_count_posts', $supply_post_count );
+		add_filter( 'posts_pre_query', $supply_product_existence, 10, 2 );
+		add_filter( 'wp_count_posts', $forbid_wp_count_posts, 10, 2 );
 
 		$this->assertTrue( WC_Install::is_new_install(), 'We are in a new install if the WC version is null.' );
 
 		$shop_id = 1;
 		$this->assertTrue( WC_Install::is_new_install(), 'We are in a new install if the WC version is null (even if the shop ID is set).' );
 
-		$post_count = 1;
+		$product_exists = true;
 		$this->assertTrue( WC_Install::is_new_install(), 'We are in a new install if the WC version is null (even if the shop ID is set and we have one or more products).' );
 
 		$version = '9.0.0';
@@ -229,19 +246,20 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		$shop_id = null;
 		$this->assertFalse( WC_Install::is_new_install(), 'We are not in a new install if the WC version is set and we have one or more products (even if the shop ID is not set).' );
 
-		$post_count = 0;
+		$product_exists = false;
 		$this->assertTrue( WC_Install::is_new_install(), 'We are in a new install if the WC version is set but the shop ID is not set and we do not have any products.' );
 
-		$counted_posts = false;
+		$queried_posts = false;
 		$version       = '9.0.0';
 		$shop_id       = 10;
 		WC_Install::is_new_install();
-		$this->assertFalse( $counted_posts, 'For established stores (version and shop ID both set), we do not need to count the number of existing products.' );
+		$this->assertFalse( $queried_posts, 'For established stores (version and shop ID both set), we do not need to query for existing products.' );
 
 		// Cleanup.
-		remove_filter( 'option_woocommerce_db_version', $supply_version );
+		remove_filter( 'option_woocommerce_version', $supply_version );
 		remove_filter( 'woocommerce_get_shop_page_id', $supply_shop_id );
-		remove_filter( 'wp_count_posts', $supply_post_count );
+		remove_filter( 'posts_pre_query', $supply_product_existence, 10 );
+		remove_filter( 'wp_count_posts', $forbid_wp_count_posts, 10 );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Admin_Notices::init()` runs on every WP Admin page load and calls `WC_Install::is_new_install()`, which until now invoked `wp_count_posts( 'product' )`. That query aggregates products by status across the entire catalog. On large stores (100k+ products) the reporter measured ~2s added to every admin page load via Query Monitor.

The method only needs to know whether *any* product exists. This PR replaces the per-status count with a tightly scoped `get_posts()` call:

- `posts_per_page=1` so the database does at most one row of work.
- `fields=ids` so we never hydrate post objects.
- `no_found_rows=true` to skip the `SQL_CALC_FOUND_ROWS` pass.
- `cache_results=false` so we don't pollute the post cache for one-off existence checks.

The behaviour of `is_new_install()` is preserved: it returns `true` when no `woocommerce_version` option exists, or when the WC version is known but neither the Shop page nor any product is present.

Note on scope: the bug report also flagged `WC_Tracker::get_product_counts()`, but in current code that method runs only via the weekly `woocommerce_tracker_send_event` Action Scheduler cron, not on every admin page load. It is therefore out of scope here.

Closes #31029
Linear: https://linear.app/a8c/issue/RSMAPGJ-303

### How to test the changes in this Pull Request:

1. On a development site, install a few hundred or more products (the more, the easier the regression shows in Query Monitor).
2. With Query Monitor active, load any WP Admin page (e.g. **Dashboard**) and inspect the slow queries / duplicate queries panel.
3. Confirm there is no longer a `SELECT post_status, COUNT( * ) AS num_posts FROM ... WHERE post_type = 'product' ... GROUP BY post_status` query fired from `WC_Admin_Notices::init()` / `WC_Install::is_new_install()`.
4. Confirm `is_new_install()` still behaves correctly:
    - Fresh install (no `woocommerce_version` option, no Shop page, no products) -> returns `true`.
    - Established install (version + Shop page set) -> returns `false` without running the product existence query.
    - Set `woocommerce_version`, delete the Shop page, add at least one product -> returns `false`.
    - Set `woocommerce_version`, delete the Shop page, remove all products -> returns `true`.
5. Run the PHPUnit coverage:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Install_Test::test_is_new_install
    ```

### Testing that has already taken place:

- Updated PHPUnit case `WC_Install_Test::test_is_new_install` to exercise the new code path via `posts_pre_query` and to assert (via a filter that calls `$this->fail()`) that the heavyweight `wp_count_posts()` is no longer used for the `product` post type.
- Lint: ran `phpcs` directly against the touched files; no new warnings on the changed lines (only pre-existing repo-wide issues).
- PHPStan: `composer exec -- phpstan analyse includes/class-wc-install.php --memory-limit=2G` -> No errors.
- `lint:php:changes` / `lint:changes:branch` cannot complete in the local sandbox due to a pre-existing `phpcs-changed` ↔ PHPCS environment mismatch unrelated to this PR.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry committed manually as `plugins/woocommerce/changelog/fix-rsmapgj-303` (significance: patch, type: fix).

---

Submitted via the RSMAPGJ AI Coder pipeline.