### PR TITLE
Fix broken product gallery markup when attachment is missing (woo#31646)

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-301
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-301
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip rendering gallery image markup when the referenced attachment cannot be resolved, preventing broken `<img src="">` output on product pages after imports of dummy data.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1829,8 +1829,24 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_
 	$thumbnail_srcset  = wp_get_attachment_image_srcset( $attachment_id, $thumbnail_size );
 	$thumbnail_sizes   = wp_get_attachment_image_sizes( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
-	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-	$alt_text          = ( empty( $alt_text ) && ( $product instanceof WC_Product ) ) ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index ) : $alt_text;
+
+	// If the attachment cannot be resolved (e.g. dummy/imported data referencing a missing image),
+	// short-circuit to avoid emitting broken markup such as `<img src="" />` wrapped in an empty link.
+	if ( false === $full_src && false === $thumbnail_src ) {
+		/**
+		 * Filters the markup returned when a gallery attachment cannot be resolved.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param string $html          Markup to return. Defaults to an empty string.
+		 * @param int    $attachment_id Attachment ID that could not be resolved.
+		 * @param bool   $main_image    Whether this is the main image or a thumbnail.
+		 */
+		return apply_filters( 'woocommerce_gallery_image_html_missing_attachment', '', $attachment_id, $main_image );
+	}
+
+	$alt_text = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
+	$alt_text = ( empty( $alt_text ) && ( $product instanceof WC_Product ) ) ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index ) : $alt_text;
 
 	/**
 	 * Filters the attributes for the image markup.

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -1,0 +1,51 @@
+<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
+/**
+ * Tests for wc-template-functions.php.
+ *
+ * @package WooCommerce\Tests\Functions
+ */
+
+/**
+ * Class WC_Template_Functions_Test
+ */
+class WC_Template_Functions_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * `wc_get_gallery_image_html` should return an empty string when the attachment
+	 * cannot be resolved (e.g. dummy/imported data referencing a missing image), so
+	 * that no broken `<img src="" />` markup is rendered on the product page.
+	 *
+	 * Regression test for woo#31646 / RSMAPGJ-301.
+	 */
+	public function test_wc_get_gallery_image_html_returns_empty_for_missing_attachment() {
+		// An attachment ID that definitely does not exist in the test DB.
+		$missing_attachment_id = 999999;
+
+		$html = wc_get_gallery_image_html( $missing_attachment_id );
+
+		$this->assertSame( '', $html );
+	}
+
+	/**
+	 * The new `woocommerce_gallery_image_html_missing_attachment` filter should let
+	 * themes/plugins substitute a placeholder when the attachment cannot be resolved.
+	 */
+	public function test_wc_get_gallery_image_html_missing_attachment_filter() {
+		$missing_attachment_id = 999998;
+
+		$callback = function ( $html, $attachment_id, $main_image ) use ( $missing_attachment_id ) {
+			$this->assertSame( '', $html );
+			$this->assertSame( $missing_attachment_id, $attachment_id );
+			$this->assertTrue( $main_image );
+			return '<div class="custom-fallback"></div>';
+		};
+
+		add_filter( 'woocommerce_gallery_image_html_missing_attachment', $callback, 10, 3 );
+
+		$html = wc_get_gallery_image_html( $missing_attachment_id, true );
+
+		remove_filter( 'woocommerce_gallery_image_html_missing_attachment', $callback, 10 );
+
+		$this->assertSame( '<div class="custom-fallback"></div>', $html );
+	}
+}


### PR DESCRIPTION
## Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Tools and Configuration](https://github.com/woocommerce/woocommerce/wiki/Recommended-Tools-and-Configuration).
- [x] I have checked if this Pull Request needs [release notes](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions#release-notes).

## Changes proposed in this Pull Request

`wc_get_gallery_image_html()` is called once per gallery image. If the
referenced attachment ID no longer points to a real attachment (a
common state right after a `WordPress Importer` run of dummy data),
`wp_get_attachment_image_src()` returns `false` for every size. The
current code guards against the historical PHP notices via `isset()`,
but `wp_get_attachment_image()` still emits a broken `<img src="" />`,
wrapped in an empty `<a href="">`.

This PR short-circuits the function when neither the thumbnail nor the
full-size source can be resolved, returning an empty string so the
gallery wrapper simply omits the broken slide. A new
`woocommerce_gallery_image_html_missing_attachment` filter lets a
theme/plugin substitute a placeholder instead, if it prefers.

Reported in #31646.

Closes #31646.

Linear issue: https://linear.app/a8c/issue/RSMAPGJ-301

## How to test the changes in this Pull Request

1. On a fresh WooCommerce install, create a variable product.
2. Set its gallery image IDs to attachment IDs that do not exist:
   ```php
   $product = wc_get_product( <id> );
   $product->set_gallery_image_ids( array( 99991, 99992, 99993 ) );
   $product->save();
   ```
3. With `WP_DEBUG`, `WP_DEBUG_LOG`, and `WP_DEBUG_DISPLAY` enabled,
   visit the product page on the storefront.
4. **Before this PR:** the page renders `<img src="" draggable="false">`
   thumbnails with broken `<a href="">` wrappers in the gallery.
5. **After this PR:** the gallery wrapper renders without those broken
   slides — `<a href="">` and `<img src="">` no longer appear.
6. Run the new regression test:
   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce test:php -- --filter WC_Template_Functions_Test
   ```

## Testing that has already taken place

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/wc-template-functions.php --memory-limit=2G` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- Unit tests added in `tests/php/includes/wc-template-functions-test.php` (run in CI).

## Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog was created manually at `plugins/woocommerce/changelog/fix-rsmapgj-301`.)

---

_Authored via the RSMAPGJ AI Coder pipeline._