### PR TITLE
Fix wc_get_orders total filter when decimals=0 (regression test)

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-302
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-302
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Add regression coverage for wc_get_orders total filter when 'Number of decimals' is 0 — float (e.g. 12345.00) and integer (12345) representations of the same total must return identical results. Underlying normalization shipped in #60995; this locks in HPOS + CPT data store behavior to prevent regression (woocommerce/woocommerce#31483).
+

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/query.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/query.php
@@ -346,4 +346,43 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 		$results = $query->get_orders();
 		$this->assertEquals( 0, count( $results ) );
 	}
+
+	/**
+	 * Regression test for woocommerce/woocommerce#31483.
+	 *
+	 * With `woocommerce_price_num_decimals` set to 0, querying via `wc_get_orders` with a float
+	 * total (e.g. 12345.00) must return the same result as querying with the equivalent integer
+	 * (12345). Prior to PR #60995 the legacy post-meta query passed the unformatted value through
+	 * to a `meta_value = 12345.00` comparison, which failed to match a `_order_total` stored as
+	 * `'12345'`.
+	 */
+	public function test_order_query_total_zero_decimals_float_and_int_are_equivalent() {
+		$original_decimals = get_option( 'woocommerce_price_num_decimals' );
+		update_option( 'woocommerce_price_num_decimals', '0' );
+
+		try {
+			$order = new WC_Order();
+			$order->set_total( '12345' );
+			$order->save();
+			$order_id = $order->get_id();
+
+			$float_query  = new WC_Order_Query( array( 'total' => 12345.00 ) );
+			$int_query    = new WC_Order_Query( array( 'total' => 12345 ) );
+			$string_query = new WC_Order_Query( array( 'total' => '12345.00' ) );
+
+			$float_results  = $float_query->get_orders();
+			$int_results    = $int_query->get_orders();
+			$string_results = $string_query->get_orders();
+
+			$this->assertEquals( 1, count( $int_results ), 'Integer total should find the order when decimals=0.' );
+			$this->assertEquals( 1, count( $float_results ), 'Float total 12345.00 should find the order when decimals=0.' );
+			$this->assertEquals( 1, count( $string_results ), 'String "12345.00" should find the order when decimals=0.' );
+
+			$this->assertEquals( $order_id, $float_results[0]->get_id() );
+			$this->assertEquals( $order_id, $int_results[0]->get_id() );
+			$this->assertEquals( $order_id, $string_results[0]->get_id() );
+		} finally {
+			update_option( 'woocommerce_price_num_decimals', $original_decimals );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -681,6 +681,41 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox Float and integer representations of the same total match identically when 'Number of decimals' is set to 0.
+	 *
+	 * Regression test for woocommerce/woocommerce#31483: with `woocommerce_price_num_decimals` = 0,
+	 * `wc_get_orders( array( 'total' => 12345.00 ) )` previously returned no orders while
+	 * `wc_get_orders( array( 'total' => 12345 ) )` correctly returned the matching order. Both
+	 * representations of the same numeric value must return identical results regardless of how
+	 * the value is passed (float, int, numeric string).
+	 */
+	public function test_total_filtering_with_zero_decimals_float_and_int_are_equivalent() {
+		$original_decimals = get_option( 'woocommerce_price_num_decimals' );
+		update_option( 'woocommerce_price_num_decimals', '0' );
+
+		try {
+			$order = OrderHelper::create_order();
+			$order->set_total( '12345' );
+			$order->save();
+			$order_id = $order->get_id();
+
+			$orders_float  = wc_get_orders( array( 'total' => 12345.00 ) );
+			$orders_int    = wc_get_orders( array( 'total' => 12345 ) );
+			$orders_string = wc_get_orders( array( 'total' => '12345.00' ) );
+
+			$this->assertCount( 1, $orders_int, 'Integer total should match the order stored with decimals=0.' );
+			$this->assertCount( 1, $orders_float, 'Float total 12345.00 should match the order stored with decimals=0.' );
+			$this->assertCount( 1, $orders_string, 'String total "12345.00" should match the order stored with decimals=0.' );
+
+			$this->assertSame( $order_id, $orders_float[0]->get_id() );
+			$this->assertSame( $order_id, $orders_int[0]->get_id() );
+			$this->assertSame( $order_id, $orders_string[0]->get_id() );
+		} finally {
+			update_option( 'woocommerce_price_num_decimals', $original_decimals );
+		}
+	}
+
+	/**
 	 * @testDox Orderby total functionality works as expected for HPOS storage.
 	 */
 	public function test_orderby_total() {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you written new tests for your changes?

### Changes proposed in this Pull Request:

Adds regression coverage for [woocommerce/woocommerce#31483](https://github.com/woocommerce/woocommerce/issues/31483).

With WooCommerce's "Number of decimals" set to `0`, `wc_get_orders( array( 'total' => 12345.00 ) )` (float) historically returned no orders while `wc_get_orders( array( 'total' => 12345 ) )` (integer) correctly returned the matching order. The reporter expected both representations of the same numeric value to behave identically.

The underlying normalization shipped in [#60995](https://github.com/woocommerce/woocommerce/pull/60995) — the `total` argument is now routed through `wc_format_decimal( $value, wc_get_price_decimals() )` in both `OrdersTableQuery::generate_total_query()` (HPOS) and the legacy CPT data store before being matched against `total_amount` / `_order_total`. This PR locks that behavior in with two regression tests so the bug cannot reappear silently.

No production code change is required.

Closes #31483
Linear: https://linear.app/a8c/issue/RSMAPGJ-302

### Screenshots / screen recordings:

N/A — backend-only regression test.

### How to test the changes in this Pull Request:

Run the new unit tests against trunk:

```bash
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- \
  --filter test_total_filtering_with_zero_decimals_float_and_int_are_equivalent

pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- \
  --filter test_order_query_total_zero_decimals_float_and_int_are_equivalent
```

Both should pass. To manually verify the underlying behavior:

1. In WP admin > WooCommerce > Settings > General, set "Number of decimals" to `0`.
2. Create an order with a unique total (e.g. `12345`) and save.
3. Run from a snippet or mu-plugin:
   ```php
   $float_orders  = wc_get_orders( array( 'total' => 12345.00 ) );
   $int_orders    = wc_get_orders( array( 'total' => 12345 ) );
   $string_orders = wc_get_orders( array( 'total' => '12345.00' ) );
   ```
4. All three queries should return the same single order.

### Testing instructions for users:

N/A — internal regression coverage; no user-facing behavior change.

### Changelog entry:

- [x] Automatically create a changelog entry from the details below.

Significance: patch
Type: fix
Message: Add regression coverage for `wc_get_orders` total filter when "Number of decimals" is 0, ensuring float (`12345.00`) and integer (`12345`) representations of the same total return identical results.

---

_Submitted via the RSMAPGJ AI Coder pipeline._