### PR TITLE
Update PayPal IPN verification URLs to ipnpb endpoints

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-307
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-307
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update PayPal IPN verification endpoints to ipnpb.paypal.com and ipnpb.sandbox.paypal.com to match PayPal's current developer documentation.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -99,7 +99,7 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 		);
 
 		// Post back to get a response.
-		$response = wp_safe_remote_post( $this->sandbox ? 'https://www.sandbox.paypal.com/cgi-bin/webscr' : 'https://www.paypal.com/cgi-bin/webscr', $params );
+		$response = wp_safe_remote_post( $this->sandbox ? 'https://ipnpb.sandbox.paypal.com/cgi-bin/webscr' : 'https://ipnpb.paypal.com/cgi-bin/webscr', $params );
 
 		WC_Gateway_Paypal::log( 'IPN Response: ' . wc_print_r( $response, true ) );
 

--- a/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-test.php
+++ b/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-test.php
@@ -174,6 +174,63 @@ class WC_Gateway_Paypal_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that the live IPN verification request is sent to the ipnpb.paypal.com endpoint.
+	 *
+	 * see @link https://github.com/woocommerce/woocommerce/issues/28513
+	 */
+	public function test_ipn_validate_uses_ipnpb_live_endpoint() {
+		$captured_url = $this->capture_ipn_validate_url( false );
+
+		$this->assertEquals( 'https://ipnpb.paypal.com/cgi-bin/webscr', $captured_url );
+	}
+
+	/**
+	 * Test that the sandbox IPN verification request is sent to the ipnpb.sandbox.paypal.com endpoint.
+	 *
+	 * see @link https://github.com/woocommerce/woocommerce/issues/28513
+	 */
+	public function test_ipn_validate_uses_ipnpb_sandbox_endpoint() {
+		$captured_url = $this->capture_ipn_validate_url( true );
+
+		$this->assertEquals( 'https://ipnpb.sandbox.paypal.com/cgi-bin/webscr', $captured_url );
+	}
+
+	/**
+	 * Run validate_ipn() against an HTTP short-circuit and capture the URL it posts to.
+	 *
+	 * @param bool $sandbox Whether to instantiate the handler in sandbox mode.
+	 * @return string The URL that validate_ipn() attempted to POST to.
+	 */
+	private function capture_ipn_validate_url( $sandbox ) {
+		$captured_url = '';
+
+		$capture = function ( $preempt, $args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => 'VERIFIED',
+			);
+		};
+
+		add_filter( 'pre_http_request', $capture, 10, 3 );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Simulating an inbound IPN POST for the unit test.
+		$previous_post = $_POST;
+		$_POST         = array( 'foo' => 'bar' );
+
+		$handler  = new WC_Gateway_Paypal_IPN_Handler( $sandbox );
+		$is_valid = $handler->validate_ipn();
+
+		$_POST = $previous_post;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		remove_filter( 'pre_http_request', $capture, 10 );
+
+		$this->assertTrue( $is_valid );
+
+		return $captured_url;
+	}
+
+	/**
 	 * Test that correct settings are displayed when Orders v2 is enabled.
 	 */
 	public function test_correct_settings_is_displayed_when_orders_v2_is_enabled() {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Testing Guidelines](https://github.com/woocommerce/woocommerce/wiki/How-to-test-WooCommerce).

### Changes proposed in this Pull Request

The PayPal IPN handler hardcodes the verification endpoint URLs that WooCommerce uses to call back PayPal during IPN validation. The two URLs in `validate_ipn()` still point at `www.paypal.com` / `www.sandbox.paypal.com`, but PayPal's [IPN documentation](https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNImplementation/#ipn-listener-request-response-flow) now specifies `ipnpb.paypal.com` and `ipnpb.sandbox.paypal.com` as the listener endpoints. Continuing to call the old hosts can cause IPN verification to fail silently and leave order status updates stuck.

This PR:

- Updates the live and sandbox IPN verification URLs in `WC_Gateway_Paypal_IPN_Handler::validate_ipn()`.
- Adds unit tests that intercept `pre_http_request` and assert the handler posts to the new `ipnpb.*` endpoints in both live and sandbox modes.

Closes #28513

Linear: https://linear.app/a8c/issue/RSMAPGJ-307

### How to test the changes in this Pull Request

1. Configure a store with the legacy WooCommerce PayPal Standard gateway, in both production and sandbox modes.
2. Enable PayPal debug logging.
3. Trigger an IPN (or simulate one with curl POST to `/?wc-api=WC_Gateway_Paypal`).
4. In the PayPal log, confirm the verification POST is sent to `https://ipnpb.paypal.com/cgi-bin/webscr` (live) or `https://ipnpb.sandbox.paypal.com/cgi-bin/webscr` (sandbox).
5. Run the unit tests: `pnpm --filter=@woocommerce/plugin-woocommerce test:php -- --filter WC_Gateway_Paypal_Test`.

### Testing that has already taken place

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php --memory-limit=2G` — no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- Added two unit tests asserting the captured URL via `pre_http_request` matches the new endpoints for both live and sandbox modes.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<!-- Changelog entry committed: plugins/woocommerce/changelog/fix-rsmapgj-307 -->

- Significance: patch
- Type: fix
- Message: Update PayPal IPN verification endpoints to ipnpb.paypal.com and ipnpb.sandbox.paypal.com to match PayPal's current developer documentation.

---

Submitted via the RSMAPGJ AI Coder pipeline.