### PR TITLE
Fix WooCommerce Status warning when PHP memory_limit is -1

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-299
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-299
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Treat a PHP `memory_limit` of `-1` (unlimited) as valid on the Status page and in the system status REST response, mirroring WordPress core and suppressing the spurious low-memory warning.

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -175,7 +175,11 @@ if ( file_exists( $plugin_path ) ) {
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The maximum amount of memory (RAM) that your site can use at one time.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
-				if ( $environment['wp_memory_limit'] < 67108864 ) {
+				if ( -1 === (int) $environment['wp_memory_limit'] ) {
+					// `-1` means "no limit" per the PHP manual and WordPress core;
+					// don't raise a low-memory warning in that case.
+					echo '<mark class="yes">' . esc_html__( 'Unlimited', 'woocommerce' ) . '</mark>';
+				} elseif ( $environment['wp_memory_limit'] < 67108864 ) {
 					/* Translators: %1$s: Memory limit, %2$s: Docs link. */
 					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend setting memory to at least 64MB. See: %2$s', 'woocommerce' ), esc_html( size_format( $environment['wp_memory_limit'] ) ), '<a href="https://wordpress.org/support/article/editing-wp-config-php/#increasing-memory-allocated-to-php" target="_blank">' . esc_html__( 'Increasing memory allocated to PHP', 'woocommerce' ) . '</a>' ) . '</mark>';
 				} else {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -939,9 +939,24 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		}
 
 		// WP memory limit.
-		$wp_memory_limit = wc_let_to_num( WP_MEMORY_LIMIT );
+		// Match WordPress core's Site Health behavior: prefer WP_MAX_MEMORY_LIMIT
+		// (the admin-context limit) when available, fall back to WP_MEMORY_LIMIT,
+		// and consider the PHP ini value. Any of these may be `-1`, which means
+		// "no limit" per the PHP manual and WordPress core; in that case we
+		// surface `-1` so consumers/views can render it as unlimited rather than
+		// raising a spurious low-memory warning (see GH #32961).
+		$memory_limit_candidates = array( wc_let_to_num( WP_MEMORY_LIMIT ) );
+		if ( defined( 'WP_MAX_MEMORY_LIMIT' ) ) {
+			$memory_limit_candidates[] = wc_let_to_num( WP_MAX_MEMORY_LIMIT );
+		}
 		if ( function_exists( 'memory_get_usage' ) ) {
-			$wp_memory_limit = max( $wp_memory_limit, wc_let_to_num( @ini_get( 'memory_limit' ) ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$memory_limit_candidates[] = wc_let_to_num( @ini_get( 'memory_limit' ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+
+		if ( in_array( -1, $memory_limit_candidates, true ) ) {
+			$wp_memory_limit = -1;
+		} else {
+			$wp_memory_limit = max( $memory_limit_candidates );
 		}
 
 		// Test POST requests.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -672,11 +672,21 @@ function wc_price( $price, $args = array() ) {
  *
  * This function transforms the php.ini notation for numbers (like '2M') to an integer.
  *
- * @param  string $size Size value.
+ * The special value `-1` (used by PHP's `memory_limit` and WordPress' memory
+ * limit constants to mean "no limit") is preserved and returned as `-1` so
+ * callers can detect the unlimited case rather than receiving a misleading `0`.
+ *
+ * @param  string|int|false|null $size Size value.
  * @return int
  */
 function wc_let_to_num( $size ) {
-	$size = $size ?? '';
+	$size = (string) ( $size ?? '' );
+
+	// PHP/WordPress use `-1` to signal "no limit". Preserve that semantic
+	// instead of letting the legacy parsing turn it into `0`.
+	if ( '-1' === $size ) {
+		return -1;
+	}
 
 	$l   = substr( $size, -1 );
 	$ret = (int) substr( $size, 0, -1 );

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -16183,12 +16183,6 @@ parameters:
 			path: includes/class-wc-tracker.php
 
 		-
-			message: '#^Parameter \#1 \$size of function wc_let_to_num expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-tracker.php
-
-		-
 			message: '#^Parameter \#1 \$str of function trim expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -28202,12 +28196,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$keys of function array_fill_keys expects an array of values castable to string, array\<stromg\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
-
-		-
-			message: '#^Parameter \#1 \$size of function wc_let_to_num expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -666,6 +666,22 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that wc_let_to_num() preserves the PHP/WordPress "no limit" sentinel.
+	 *
+	 * PHP's `memory_limit` and WordPress' memory limit constants use `-1` to
+	 * indicate that no limit should be applied. wc_let_to_num() must surface
+	 * that as `-1` instead of folding it into `0`, so that downstream checks
+	 * (e.g. the WooCommerce Status page) don't raise spurious low-memory
+	 * warnings. Regression test for GH #32961.
+	 *
+	 * @since 10.9.0
+	 */
+	public function test_wc_let_to_num_preserves_unlimited_sentinel() {
+		$this->assertSame( -1, wc_let_to_num( '-1' ) );
+		$this->assertSame( -1, wc_let_to_num( -1 ) );
+	}
+
+	/**
 	 * Test wc_date_format().
 	 *
 	 * @since 2.2

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller-test.php
@@ -34,6 +34,35 @@ class WC_REST_System_Status_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox WP memory limit should be reported as `-1` (unlimited) when the PHP ini value is `-1`.
+	 *
+	 * Regression test for GH #32961: WooCommerce used to coerce `-1` to `0`
+	 * via wc_let_to_num(), which then made the Status page display the small
+	 * WP_MEMORY_LIMIT value and raise a spurious low-memory warning. PHP and
+	 * WordPress core both treat `-1` as "no limit"; we now mirror that.
+	 */
+	public function test_get_environment_info_treats_ini_memory_limit_minus_one_as_unlimited(): void {
+		if ( ! function_exists( 'memory_get_usage' ) ) {
+			$this->markTestSkipped( 'memory_get_usage() not available; controller path under test is skipped.' );
+		}
+
+		$original = @ini_get( 'memory_limit' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		// phpcs:ignore WordPress.PHP.IniSet.memory_limit_Disallowed,WordPress.PHP.NoSilencedErrors.Discouraged -- Test fixture, restored in finally.
+		$set = @ini_set( 'memory_limit', '-1' );
+		if ( false === $set ) {
+			$this->markTestSkipped( 'Unable to set memory_limit ini at runtime; cannot exercise the -1 path here.' );
+		}
+
+		try {
+			$env = $this->sut->get_environment_info_per_fields( array( 'environment' ) );
+			$this->assertSame( -1, $env['wp_memory_limit'], 'A `-1` PHP memory limit must surface as `-1`, not a coerced small value.' );
+		} finally {
+			// phpcs:ignore WordPress.PHP.IniSet.memory_limit_Disallowed,WordPress.PHP.NoSilencedErrors.Discouraged -- Restoring original value.
+			@ini_set( 'memory_limit', (string) $original );
+		}
+	}
+
+	/**
 	 * @testdox Should detect template override via wc_get_template filter.
 	 */
 	public function test_get_theme_info_detects_wc_get_template_filter_override(): void {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Workflow For Contributions](https://github.com/woocommerce/woocommerce/wiki/Recommended-Workflow-For-Contributions).
- [x] I have checked that the changes work as expected on the latest version of WordPress and supported (PHP, MySQL, ...) software.
- [x] If applicable, I have added tests to cover my changes.

### Changes proposed in this Pull Request

When PHP's `memory_limit` (or `WP_MAX_MEMORY_LIMIT`) is set to `-1`, the WooCommerce Status page incorrectly fell back to `WP_MEMORY_LIMIT` (typically `40M`) and raised a spurious "We recommend setting memory to at least 64MB" warning. WordPress core's Site Health page treats `-1` as "no limit" per the [PHP manual](https://www.php.net/manual/en/ini.core.php#ini.memory-limit) and does not warn.

Root cause: `wc_let_to_num()` parsed `'-1'` as `(int) substr('-1', 0, -1)` → `(int) '-'` → `0`, so the controller computed `max(40MB, 0) = 40MB < 64MB`, triggering the warning.

This PR:

- Updates `wc_let_to_num()` to preserve the `-1` "no limit" sentinel instead of returning `0`.
- Updates `WC_REST_System_Status_V2_Controller::get_environment_info_per_fields()` to also consider `WP_MAX_MEMORY_LIMIT` (matching WordPress core's admin-context behavior via `wp_raise_memory_limit('admin')`) and to surface `-1` when any candidate value is unlimited.
- Updates the Status report view to render `-1` as `Unlimited` (green check) instead of running the `< 67108864` warning branch.
- Removes two PHPStan baseline entries that are no longer needed now that `wc_let_to_num()` accepts a broader input type.

Closes #32961
Linear issue: https://linear.app/a8c/issue/RSMAPGJ-299

### Screenshots or screen recordings

_Not applicable — text content of the Status row changes from "40 MB - We recommend..." to "Unlimited"._

### How to test the changes in this Pull Request

1. In the local WordPress install, add a `mu-plugin` that pins the PHP memory limit to `-1` at runtime:
   ```php
   <?php
   // wp-content/mu-plugins/set-memory-limit.php
   ini_set( 'memory_limit', '-1' );
   ```
2. Visit `wp-admin/admin.php?page=wc-status` → "Get system report" / WooCommerce → Status.
3. **Before this PR:** The "WordPress memory limit" row shows `40 MB - We recommend setting memory to at least 64MB...`
4. **After this PR:** The row shows `Unlimited` with a green check mark and no warning.
5. Also verify the REST endpoint returns `wp_memory_limit: -1`:
   ```sh
   curl -u <user>:<app_pwd> 'http://localhost:<port>/wp-json/wc/v3/system_status?_fields=environment.wp_memory_limit'
   ```
6. Confirm the existing "normal" path still works: remove the mu-plugin, set `memory_limit = 256M`, reload Status — value should display as `256 MB` (green) with no warning.

### Testing that has already taken place

- New PHPUnit coverage: `WC_REST_System_Status_V2_Controller_Test::test_get_environment_info_treats_ini_memory_limit_minus_one_as_unlimited` and `test_wc_let_to_num_preserves_unlimited_sentinel`.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` ✓
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` ✓
- `composer exec -- phpstan analyse` on all touched files ✓ (baseline shrunk, not grown)

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

Patch

#### Type

Fix

#### Message

Treat a PHP `memory_limit` of `-1` (unlimited) as valid on the Status page and in the system status REST response, mirroring WordPress core and suppressing the spurious low-memory warning.

</details>

---

_Submitted via the RSMAPGJ AI Coder pipeline._