### PR TITLE
Fix order refund items inheriting meta IDs from original line item

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-298
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-298
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order refund creation so that copying a line item's meta to the refunded item no longer carries over the original meta IDs, preventing unique meta saves on the refund from overwriting or deleting the original line item's meta.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -625,6 +625,14 @@ function wc_create_refund( $args = array() ) {
 				$class         = get_class( $item );
 				$refunded_item = new $class( $item );
 				$refunded_item->set_id( 0 );
+
+				// Clear the IDs of any meta carried over from the original item so that saving the refund
+				// line item creates new meta rows instead of overwriting (or deleting, when unique keys are
+				// used) the original item's meta. See https://github.com/woocommerce/woocommerce/issues/33545.
+				foreach ( $refunded_item->get_meta_data() as $refunded_item_meta ) {
+					$refunded_item_meta->id = null;
+				}
+
 				$refunded_item->add_meta_data( '_refunded_item_id', $item_id, true );
 				$refunded_item->set_total( wc_format_refund_total( $refund_total ) );
 				$refunded_item->set_taxes(

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -328,6 +328,73 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that creating a refund does not strip meta data from the original order line item
+	 * when the refunded item is given the same meta key with the unique flag set.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/33545: previously,
+	 * the refunded line item copied the original item's meta together with its meta_id, so saving
+	 * unique meta on the refund would overwrite or delete the original item's meta row instead of
+	 * creating a new one.
+	 */
+	public function test_refund_preserves_original_line_item_meta() {
+		// Create a product and place an order for it.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 20 );
+		$product->save();
+
+		$order = new WC_Order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 1,
+				'total'    => 20,
+			)
+		);
+		$item->add_meta_data( 'foo', 'bar', true );
+		$order->add_item( $item );
+		$order->calculate_totals();
+		$order->save();
+
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Sanity check: the original line item has the 'foo' meta with a real meta_id.
+		$original_item = WC_Order_Factory::get_order_item( $item_id );
+		$this->assertSame( 'bar', $original_item->get_meta( 'foo' ) );
+
+		// Create a refund and add a unique 'foo' meta to the refunded line item. The bug caused
+		// this save to delete the meta row from the original line item.
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 20,
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 1,
+						'refund_total' => 20,
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'Refund should be created successfully' );
+
+		$refund_items   = $refund->get_items();
+		$refunded_item  = reset( $refund_items );
+		$refunded_item->update_meta_data( 'foo', 'baz', true );
+		$refunded_item->save_meta_data();
+
+		// Re-read the original item from the database to ensure the meta is still intact.
+		$reloaded_item = WC_Order_Factory::get_order_item( $item_id );
+		$this->assertSame( 'bar', $reloaded_item->get_meta( 'foo' ), 'Original order line item meta should not be deleted by refund.' );
+
+		// The refunded item should carry the new value as its own row.
+		$reloaded_refund_item = WC_Order_Factory::get_order_item( $refunded_item->get_id() );
+		$this->assertSame( 'baz', $reloaded_refund_item->get_meta( 'foo' ), 'Refunded line item should hold its own meta value.' );
+	}
+
+	/**
 	 * Test that wc_wptexturize_order_note() preserves URLs with double hyphens.
 	 *
 	 * @dataProvider url_protection_test_data


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #33545.

Linear: https://linear.app/a8c/issue/RSMAPGJ-298

`wc_create_refund()` builds the refunded line item with `$refunded_item = new $class( $item );`, which loads the original item's meta from the database, including each row's `meta_id`. The subsequent `set_id( 0 )` clears the refund item's order item ID but leaves the meta_data array referencing the original item's meta rows.

When code (or a third party hook such as the one in `woocommerce_new_order_item`) then writes a meta key with the unique flag set on the refunded item, WooCommerce's `save_meta_data()` follows the inherited `meta_id` and updates / deletes the corresponding row on the original item, silently destroying the original line item's data.

This PR clears the meta IDs on the refunded item right after it is constructed and before `_refunded_item_id` is added. The meta values themselves are retained on the refund (matching the existing behaviour), but each will now be written as a new row instead of mutating the originals.

### How to test the changes in this Pull Request:

1. Add the following snippet (e.g. via Code Snippets or a mu-plugin):
   ```php
   add_action(
       'woocommerce_new_order_item',
       function ( $item_id, $item ) {
           $item->add_meta_data( 'foo', 'bar', true );
           $item->save_meta_data();
       },
       10,
       2
   );
   ```
2. From the admin, create a new order with a single simple product, set status to **Completed**, save.
3. Inspect `wp_woocommerce_order_itemmeta` and confirm the order line item has a `foo = bar` row.
4. From the order edit screen, refund the line item (full quantity).
5. Re-query `wp_woocommerce_order_itemmeta`. Expected:
   - The original line item still has its `foo = bar` row (unchanged `meta_id`).
   - The refunded line item has its own `foo = bar` row with a different `meta_id`.
6. With this PR reverted (or on `trunk` before this fix), step 5 fails: the original item's `foo = bar` row disappears.

PHPUnit regression test: `WC_Order_Functions_Test::test_refund_preserves_original_line_item_meta`.

### Testing that has already taken place:

- Added `test_refund_preserves_original_line_item_meta` to `wc-order-functions-test.php`.
- PHPStan clean on `includes/wc-order-functions.php` (`composer exec -- phpstan analyse includes/wc-order-functions.php`).
- `phpcs` could not be executed in the agent environment due to missing global WP coding standards sniffs; production diff is small and follows surrounding conventions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request includes a changelog entry (`plugins/woocommerce/changelog/fix-rsmapgj-298`, type `fix`, significance `patch`).

---

Filed by the RSMAPGJ AI Coder pipeline.