### PR TITLE
Fix Leaderboards analytics for users with view_woocommerce_reports cap

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-290
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-290
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow users with the `view_woocommerce_reports` capability to access the Analytics Leaderboards REST endpoint and view leaderboard data.

--- a/plugins/woocommerce/src/Admin/API/Leaderboards.php
+++ b/plugins/woocommerce/src/Admin/API/Leaderboards.php
@@ -88,6 +88,25 @@ class Leaderboards extends \WC_REST_Data_Controller {
 	}
 
 	/**
+	 * Check whether a given request has permission to read leaderboards.
+	 *
+	 * Leaderboards expose analytics report data, so the capability check should
+	 * match other Analytics report endpoints and use `view_woocommerce_reports`
+	 * rather than the broader `manage_woocommerce` capability inherited from the
+	 * parent data controller.
+	 *
+	 * @param  \WP_REST_Request<array<string, mixed>> $request Full details about the request.
+	 * @return \WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'reports', 'read' ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get the data for the coupons leaderboard.
 	 *
 	 * @param int    $per_page Number of rows.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/leaderboards.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/leaderboards.php
@@ -162,6 +162,44 @@ class WC_Admin_Tests_API_Leaderboards extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that a user with only the `view_woocommerce_reports` capability can
+	 * read the leaderboards endpoint.
+	 *
+	 * Regression test for woocommerce/woocommerce#39366.
+	 */
+	public function test_get_leaderboards_with_view_woocommerce_reports_cap() {
+		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$user    = new WP_User( $user_id );
+		$user->add_cap( 'view_woocommerce_reports' );
+		wp_set_current_user( $user_id );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/allowed' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/products' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test that a user without report-viewing capabilities is denied access to
+	 * the leaderboards endpoint.
+	 */
+	public function test_get_leaderboards_without_capabilities_is_denied() {
+		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
 	 * Test that leaderboards response changes based on applied filters.
 	 */
 	public function test_filter_leaderboards() {


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [Contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Coding Standards](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines-and-Best-Practices).

### Changes proposed in this Pull Request

The Analytics > Overview "Leaderboards" section calls the `wc-analytics/leaderboards` REST endpoint to populate Top Customers / Coupons / Categories / Products tables. The endpoint inherits its permission check from `WC_REST_Data_Controller::get_items_permissions_check()`, which requires the `manage_woocommerce` capability via `wc_rest_check_manager_permissions( 'settings', 'read' )`.

A Shop Manager (or any user) granted only the documented read-only `view_woocommerce_reports` capability therefore receives a 403 from the endpoint and sees only the Leaderboards section title with no data, while the rest of the Analytics pages render correctly.

This PR overrides `get_items_permissions_check` in `Automattic\WooCommerce\Admin\API\Leaderboards` so it uses `wc_rest_check_manager_permissions( 'reports', 'read' )` — the same check used by the legacy v1 reports controllers and the mapping that resolves to `view_woocommerce_reports`. Behavior for `manage_woocommerce`-only users is unchanged because that capability already includes report-viewing.

Bug introduced in PR — N/A (long-standing, since the controller was added).

Closes #39366
Linear: https://linear.app/a8c/issue/RSMAPGJ-290

### How to test the changes in this Pull Request

1. Install a capability-editing plugin (e.g. User Role Editor) on a fresh WooCommerce site.
2. Create / edit a user so they have the `view_woocommerce_reports` capability but **not** `manage_woocommerce`.
3. Seed at least one completed order so the leaderboards have data to display.
4. Log in as that user and navigate to **Analytics > Overview**.
5. Scroll to the Leaderboards section and confirm the tables (Top Customers, Coupons, Categories, Products) render with data instead of being empty.
6. Confirm `GET /wp-json/wc-analytics/leaderboards` returns `200` with the expected payload; before this fix it returned `403`.

PHPUnit covers both the positive case (request with only `view_woocommerce_reports` returns 200) and the negative case (no capability returns 401) in `WC_Admin_Tests_API_Leaderboards`.

### Testing that has already taken place

- [x] PHP linting (`pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`) — clean.
- [x] Branch-level lint (`pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`) — clean.
- [x] PHPStan on `src/Admin/API/Leaderboards.php` — no errors, no baseline additions.
- [x] Added regression tests `test_get_leaderboards_with_view_woocommerce_reports_cap` and `test_get_leaderboards_without_capabilities_is_denied`.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

> **Significance:** patch
> **Type:** fix
>
> Allow users with the `view_woocommerce_reports` capability to access the Analytics Leaderboards REST endpoint and view leaderboard data.

---

_Submitted via the RSMAPGJ AI Coder pipeline._