### PR TITLE
Fix duplicate/missing rows in Analytics Products CSV export

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-287
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-287
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix duplicate and missing rows in Analytics > Products CSV export by adding a deterministic `product_id` tie-breaker to the report query's ORDER BY, so paginated export batches no longer overlap or skip products when the primary sort column contains ties.

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
@@ -414,11 +414,21 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$this->subquery->clear_sql_clause( 'select' );
 			$this->subquery->add_sql_clause( 'select', $selections );
-			if ( in_array( $query_args['orderby'], array( 'items_sold', 'net_revenue', 'orders_count', 'variations' ), true ) ) {
-				$this->subquery->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) . ', product_id' );
-			} else {
-				$this->subquery->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
+			$order_by_clause = $this->get_sql_clause( 'order_by' );
+
+			/*
+			 * Always append `product_id` as a deterministic tie-breaker so that
+			 * paginated CSV exports do not duplicate or skip products when the
+			 * primary sort column contains ties (e.g. two products with the same
+			 * title, SKU, items_sold count, or `date_created` after GROUP BY).
+			 * Without this, MySQL is free to return rows in any order for tied
+			 * values, which means consecutive export batches can return
+			 * overlapping or missing product rows.
+			 */
+			if ( false === strpos( $order_by_clause, 'product_id' ) ) {
+				$order_by_clause .= ', product_id';
 			}
+			$this->subquery->add_sql_clause( 'order_by', $order_by_clause );
 			$this->subquery->add_sql_clause( 'limit', $this->get_sql_clause( 'limit' ) );
 			$products_query = $this->subquery->get_query_statement();
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -212,6 +212,96 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Paginated queries must be deterministic even when the primary sort
+	 * column contains ties (same product title, SKU, date, etc.). Without
+	 * a stable secondary sort key, MySQL is free to return ordered rows
+	 * differently across consecutive paginated queries, which causes CSV
+	 * exports to duplicate some products and skip others.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/41574.
+	 */
+	public function test_pagination_is_stable_with_tied_sort_columns() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create several products that all share the same title so the
+		// `product_name` ORDER BY column has nothing but ties.
+		$products = array();
+		for ( $i = 0; $i < 6; $i++ ) {
+			$product = new WC_Product_Simple();
+			$product->set_name( 'Duplicate Title Product' );
+			$product->set_regular_price( 10 );
+			$product->save();
+			$products[] = $product;
+		}
+
+		$date_created = time();
+		foreach ( $products as $idx => $product ) {
+			$order = WC_Helper_Order::create_order( 1, $product );
+			$order->set_status( OrderStatus::COMPLETED );
+			$order->set_total( 40 );
+			$order->set_date_created( $date_created + $idx );
+			$order->save();
+		}
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$data_store = new ProductsDataStore();
+		$start_time = gmdate( 'Y-m-d H:00:00', $date_created - HOUR_IN_SECONDS );
+		$end_time   = gmdate( 'Y-m-d H:00:00', $date_created + ( count( $products ) + 1 ) * HOUR_IN_SECONDS );
+
+		$base_args = array(
+			'after'    => $start_time,
+			'before'   => $end_time,
+			'order_by' => 'product_name',
+			'order'    => 'asc',
+			'per_page' => 2,
+		);
+
+		// Walk all pages and collect the product_ids returned. Each product
+		// must appear exactly once across the full result set, regardless of
+		// the fact that every row has the same product title.
+		$seen_ids = array();
+		for ( $page = 1; $page <= 3; $page++ ) {
+			$args     = array_merge( $base_args, array( 'page' => $page ) );
+			$data     = $data_store->get_data( $args );
+			$seen_ids = array_merge( $seen_ids, wp_list_pluck( $data->data, 'product_id' ) );
+			$this->assertEquals( 6, $data->total );
+			$this->assertEquals( 3, $data->pages );
+		}
+
+		$expected_ids = array_map(
+			static function ( $product ) {
+				return $product->get_id();
+			},
+			$products
+		);
+		sort( $expected_ids );
+		sort( $seen_ids );
+
+		$this->assertSame(
+			$expected_ids,
+			$seen_ids,
+			'Paginated product report results must include each product exactly once, even when the sort column has ties.'
+		);
+
+		// Same assertion when sorting by date, which is also non-unique after
+		// GROUP BY product_id.
+		$base_args['order_by'] = 'date';
+		$seen_ids              = array();
+		for ( $page = 1; $page <= 3; $page++ ) {
+			$args     = array_merge( $base_args, array( 'page' => $page ) );
+			$data     = $data_store->get_data( $args );
+			$seen_ids = array_merge( $seen_ids, wp_list_pluck( $data->data, 'product_id' ) );
+		}
+		sort( $seen_ids );
+		$this->assertSame(
+			$expected_ids,
+			$seen_ids,
+			'Paginated product report results sorted by date must not skip or duplicate rows.'
+		);
+	}
+
+	/**
 	 * Test the extended info.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Coding Standards for the Frontend Platform](https://github.com/woocommerce/woocommerce/blob/trunk/docs/contribution/coding-standards.md).
- [x] I have enabled this PR to be edited by maintainers.

#### Changes proposed in this Pull Request

The Analytics > Products CSV export iterates the report endpoint in pages (one Action Scheduler job per batch). The Products report's ORDER BY only added a `product_id` tie-breaker when sorting by `items_sold`, `net_revenue`, `orders_count`, or `variations`. When the user sorted by `date`, `product_name`, or `sku` — or when the export ran with the default `date` orderby — MySQL was free to return tied rows in any order, so consecutive pages could include the same product twice while skipping others. The exported CSV ended up with duplicate product rows and missing entries.

This PR always appends `product_id` as a deterministic tie-breaker to the report query's `ORDER BY` clause (only when it is not already part of the clause), so pagination is stable for every sort column the CSV export can use.

Closes #41574.
Linear: [RSMAPGJ-287](https://linear.app/a8c/issue/RSMAPGJ-287).

#### Screenshots or screen recordings

Not applicable — this is a SQL/ordering fix with no UI changes.

#### How to test the changes in this Pull Request

1. Create at least 6 simple products that all share the **same title** (e.g. all named `Duplicate Title Product`) and place one completed order per product.
2. Wait for Action Scheduler to sync the analytics product lookup tables (or trigger `woocommerce_analytics_update_product_lookup_tables`).
3. Visit `WP Admin > Analytics > Products`, sort by `Product title`, and trigger a CSV export. Wait for the emailed download link.
4. Open the CSV and confirm every product appears exactly once and no rows are missing or duplicated.
5. Repeat with `Date` and `SKU` as the active sort column.

#### Testing that has already taken place

- Added a PHPUnit regression test (`WC_Admin_Tests_Reports_Products::test_pagination_is_stable_with_tied_sort_columns`) that creates 6 products with identical titles, paginates the report at `per_page=2`, and asserts that the union of all pages contains every product exactly once (both for `product_name` and `date` sort columns).
- Re-ran existing tests in `WC_Admin_Tests_Reports_Products` to confirm no behavioral change for distinct-title fixtures.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse src/Admin/API/Reports/Products/DataStore.php --memory-limit=2G` — no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

---

#### Milestone

- [x] Use the first available milestone that is not in the past.

#### Changelog entry

> Added manually as `plugins/woocommerce/changelog/fix-rsmapgj-287` (type: fix, significance: patch).

---

_Submitted via the RSMAPGJ AI Coder pipeline._