### PR TITLE
Fix woocommerce_wp_text_input not populating value under HPOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-283
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-283
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `woocommerce_wp_text_input` (and sibling field helpers) not auto-populating their value from order meta when HPOS is enabled and no explicit `value` is passed.

--- a/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
@@ -14,6 +14,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+if ( ! function_exists( 'wc_meta_box_field_resolve_data_object' ) ) {
+	/**
+	 * Resolves the data object used to look up a meta value for a meta box field.
+	 *
+	 * When the legacy edit-order screen is used, the global `$post` is populated and the meta
+	 * value is read via `get_post_meta()`. When HPOS is enabled, the order edit screen is rendered
+	 * outside of the post context, so `$post` is empty but the global `$theorder` is set to the
+	 * current WC_Order. In that case the data object should be used so the value can be read via
+	 * `WC_Data::get_meta()`. This helper centralizes that fallback so all `woocommerce_wp_*`
+	 * field helpers behave consistently.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Data|null $data WC_Data object explicitly passed by the caller, if any.
+	 * @return WC_Data|null The data object to use for meta lookup, or null to fall back to $post.
+	 */
+	function wc_meta_box_field_resolve_data_object( ?WC_Data $data ): ?WC_Data {
+		if ( null !== $data ) {
+			return $data;
+		}
+
+		global $post, $theorder;
+
+		// Only fall back to $theorder when the post context is unavailable (e.g. HPOS edit order screen).
+		if ( empty( $post ) && $theorder instanceof WC_Data ) {
+			return $theorder;
+		}
+
+		return null;
+	}
+}
+
 /**
  * Output a text input box.
  *
@@ -23,6 +55,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function woocommerce_wp_text_input( $field, ?WC_Data $data = null ) {
 	global $post;
 
+	$data                   = wc_meta_box_field_resolve_data_object( $data );
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
@@ -105,6 +138,7 @@ function woocommerce_wp_text_input( $field, ?WC_Data $data = null ) {
 function woocommerce_wp_hidden_input( $field, ?WC_Data $data = null ) {
 	global $post;
 
+	$data           = wc_meta_box_field_resolve_data_object( $data );
 	$field['value'] = isset( $field['value'] ) ? $field['value'] : OrderUtil::get_post_or_object_meta( $post, $data, $field['id'], true );
 	$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
 
@@ -120,6 +154,7 @@ function woocommerce_wp_hidden_input( $field, ?WC_Data $data = null ) {
 function woocommerce_wp_textarea_input( $field, ?WC_Data $data = null ) {
 	global $post;
 
+	$data                   = wc_meta_box_field_resolve_data_object( $data );
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
@@ -165,6 +200,7 @@ function woocommerce_wp_textarea_input( $field, ?WC_Data $data = null ) {
 function woocommerce_wp_checkbox( $field, ?WC_Data $data = null ) {
 	global $post;
 
+	$data                   = wc_meta_box_field_resolve_data_object( $data );
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'checkbox';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
@@ -235,6 +271,7 @@ function woocommerce_wp_checkbox( $field, ?WC_Data $data = null ) {
 function woocommerce_wp_select( $field, ?WC_Data $data = null ) {
 	global $post;
 
+	$data  = wc_meta_box_field_resolve_data_object( $data );
 	$field = wp_parse_args(
 		$field,
 		array(
@@ -293,6 +330,7 @@ function woocommerce_wp_select( $field, ?WC_Data $data = null ) {
 function woocommerce_wp_radio( $field, ?WC_Data $data = null ) {
 	global $post;
 
+	$data                   = wc_meta_box_field_resolve_data_object( $data );
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-meta-box-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-meta-box-functions-test.php
@@ -1,0 +1,204 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the woocommerce_wp_* meta box helper functions in wc-meta-box-functions.php.
+ *
+ * Regression coverage for the HPOS issue where `woocommerce_wp_text_input` (and siblings) would
+ * fail to auto-populate their value from order meta when no explicit `value` was passed and the
+ * order edit screen was rendered without a global `$post` (the HPOS edit-order screen).
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/48454
+ */
+class WC_Meta_Box_Functions_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Ensure the wc-meta-box-functions.php file is loaded so the helpers are available in tests.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		require_once WC_ABSPATH . 'includes/admin/wc-meta-box-functions.php';
+	}
+
+	/**
+	 * Reset globals touched by these tests between cases.
+	 */
+	public function tear_down() {
+		global $post, $theorder;
+		$post     = null;
+		$theorder = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Render a field helper and return its captured output.
+	 *
+	 * @param callable $callable Helper function to invoke.
+	 * @param array    $args     Arguments to pass.
+	 * @return string Captured HTML output.
+	 */
+	private function capture( callable $callable, array $args ): string {
+		ob_start();
+		$callable( ...$args );
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @testdox woocommerce_wp_text_input reads meta from $theorder when $post is empty (HPOS edit order screen).
+	 */
+	public function test_text_input_falls_back_to_theorder_when_post_is_empty() {
+		global $post, $theorder;
+
+		$order = new WC_Order();
+		$order->update_meta_data( 'example_meta', 'hello_example' );
+		$order->save();
+
+		$post     = null;
+		$theorder = $order;
+
+		$output = $this->capture(
+			'woocommerce_wp_text_input',
+			array(
+				array(
+					'id'    => 'example_meta',
+					'label' => 'Example meta',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'value="hello_example"', $output );
+		$this->assertStringContainsString( 'id="example_meta"', $output );
+	}
+
+	/**
+	 * @testdox woocommerce_wp_text_input prefers an explicitly passed WC_Data object over the global $theorder.
+	 */
+	public function test_text_input_prefers_explicit_data_argument() {
+		global $post, $theorder;
+
+		$order_a = new WC_Order();
+		$order_a->update_meta_data( 'example_meta', 'from_theorder' );
+		$order_a->save();
+
+		$order_b = new WC_Order();
+		$order_b->update_meta_data( 'example_meta', 'from_argument' );
+		$order_b->save();
+
+		$post     = null;
+		$theorder = $order_a;
+
+		$output = $this->capture(
+			'woocommerce_wp_text_input',
+			array(
+				array(
+					'id'    => 'example_meta',
+					'label' => 'Example meta',
+				),
+				$order_b,
+			)
+		);
+
+		$this->assertStringContainsString( 'value="from_argument"', $output );
+	}
+
+	/**
+	 * @testdox woocommerce_wp_text_input respects an explicit `value` in the field array.
+	 */
+	public function test_text_input_respects_explicit_value() {
+		global $post, $theorder;
+
+		$order = new WC_Order();
+		$order->update_meta_data( 'example_meta', 'meta_value' );
+		$order->save();
+
+		$post     = null;
+		$theorder = $order;
+
+		$output = $this->capture(
+			'woocommerce_wp_text_input',
+			array(
+				array(
+					'id'    => 'example_meta',
+					'label' => 'Example meta',
+					'value' => 'explicit_value',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'value="explicit_value"', $output );
+		$this->assertStringNotContainsString( 'value="meta_value"', $output );
+	}
+
+	/**
+	 * @testdox woocommerce_wp_textarea_input falls back to $theorder when $post is empty.
+	 */
+	public function test_textarea_input_falls_back_to_theorder() {
+		global $post, $theorder;
+
+		$order = new WC_Order();
+		$order->update_meta_data( 'textarea_meta', 'multiline body' );
+		$order->save();
+
+		$post     = null;
+		$theorder = $order;
+
+		$output = $this->capture(
+			'woocommerce_wp_textarea_input',
+			array(
+				array(
+					'id'    => 'textarea_meta',
+					'label' => 'Textarea meta',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( '>multiline body</textarea>', $output );
+	}
+
+	/**
+	 * @testdox woocommerce_wp_hidden_input falls back to $theorder when $post is empty.
+	 */
+	public function test_hidden_input_falls_back_to_theorder() {
+		global $post, $theorder;
+
+		$order = new WC_Order();
+		$order->update_meta_data( 'hidden_meta', 'hidden_value' );
+		$order->save();
+
+		$post     = null;
+		$theorder = $order;
+
+		$output = $this->capture(
+			'woocommerce_wp_hidden_input',
+			array(
+				array(
+					'id' => 'hidden_meta',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'value="hidden_value"', $output );
+	}
+
+	/**
+	 * @testdox When neither $post nor $theorder is set, the field renders with an empty value (no warnings).
+	 */
+	public function test_text_input_with_no_context_renders_empty_value() {
+		global $post, $theorder;
+
+		$post     = null;
+		$theorder = null;
+
+		$output = $this->capture(
+			'woocommerce_wp_text_input',
+			array(
+				array(
+					'id'    => 'unknown_meta',
+					'label' => 'Unknown meta',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'value=""', $output );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

With HPOS enabled, the edit-order screen is rendered outside the post context, so the global `$post` is empty while the global `$theorder` holds the current `WC_Order`. The `woocommerce_wp_*` meta-box field helpers in `wc-meta-box-functions.php` (`text_input`, `textarea_input`, `hidden_input`, `checkbox`, `select`, `radio`) only consulted `$post` / `get_post_meta()` for the fallback value lookup. As a result, custom fields declared via `woocommerce_admin_order_data_after_billing_address` without an explicit `value` rendered blank on HPOS even when matching order meta existed — a regression from the legacy CPT-based edit screen.

This PR introduces a small helper, `wc_meta_box_field_resolve_data_object()`, that returns:
- the explicitly passed `WC_Data` argument when present;
- otherwise the global `$theorder` when `$post` is empty and `$theorder` is a `WC_Data`;
- otherwise `null`, which preserves the legacy post-meta path.

Each `woocommerce_wp_*` helper now resolves the data object up-front via this helper before calling `OrderUtil::get_post_or_object_meta()`. The legacy post-based edit screen is unaffected because `$post` remains populated there. The helper precedence (explicit argument over `$theorder`) is preserved.

Closes #48454

Linear: https://linear.app/a8c/issue/RSMAPGJ-283

### How to test the changes in this Pull Request:

1. Enable HPOS (WooCommerce → Settings → Advanced → Features → High-performance order storage).
2. Add this snippet to a mu-plugin or theme `functions.php`:
   ```php
   add_action(
       'woocommerce_admin_order_data_after_billing_address',
       function ( $order ) {
           woocommerce_wp_text_input( [ 'id' => 'example_meta', 'label' => 'Example meta' ] );
           woocommerce_wp_text_input( [ 'id' => 'another_meta', 'label' => 'Another meta', 'value' => $order->get_meta( 'another_meta', true ) ] );
       },
       5
   );
   add_action(
       'woocommerce_process_shop_order_meta',
       function ( $order_id ) {
           $order = wc_get_order( $order_id );
           foreach ( [ 'example_meta', 'another_meta' ] as $key ) {
               if ( isset( $_POST[ $key ] ) ) {
                   $order->update_meta_data( $key, wc_clean( wp_unslash( $_POST[ $key ] ) ) );
               }
           }
           $order->save();
       },
       20,
       2
   );
   ```
3. Create an order, edit it, set both fields to non-empty values, and save.
4. Re-open the order. Both "Example meta" and "Another meta" should display their saved values (before this fix, the `example_meta` field rendered blank under HPOS).
5. Disable HPOS, re-open the same order, and confirm both fields still populate (legacy CPT path unchanged).

### Testing that has already taken place:

- New PHPUnit coverage in `class-wc-meta-box-functions-test.php` exercises the HPOS fallback for `text_input`, `textarea_input`, and `hidden_input`, the explicit-argument precedence, the explicit-`value` override, and the no-context (empty value, no warnings) case.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `composer exec -- phpstan analyse includes/admin/wc-meta-box-functions.php` clean (no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog file (`plugins/woocommerce/changelog/fix-rsmapgj-283`) was created manually with `Significance: patch` / `Type: fix`.

- [ ] Automatically create a changelog entry from the details below.

---

_Submitted via the RSMAPGJ AI Coder pipeline._