### PR TITLE
Replace deprecated `width` attribute on `<td>` with inline CSS

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-273
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-273
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace deprecated HTML `width` attribute on `<td>` elements in admin shipping zone settings and the payments promotion row with inline CSS.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -209,11 +209,17 @@ export const PaymentPromotionRow = ( {
 						</td>
 					);
 				}
+				// Use inline CSS for column width instead of the deprecated
+				// HTML `width` attribute on <td>.
+				const style =
+					column.width !== undefined
+						? { width: column.width }
+						: undefined;
 				return (
 					<td
 						key={ column.className }
 						className={ column.className }
-						width={ column.width }
+						style={ style }
 						dangerouslySetInnerHTML={
 							column.className.includes( 'sort' ) ||
 							column.className.includes( 'renewals' )

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -114,11 +114,11 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 
 <script type="text/html" id="tmpl-wc-shipping-zone-method-row">
 	<tr data-id="{{ data.instance_id }}" data-enabled="{{ data.enabled }}">
-		<td width="1%" class="wc-shipping-zone-method-sort"></td>
+		<td style="width:1%" class="wc-shipping-zone-method-sort"></td>
 		<td class="wc-shipping-zone-method-title">
 			{{{ data.title }}}
 		</td>
-		<td width="1%" class="wc-shipping-zone-method-enabled"><a href="#">{{{ data.enabled_icon }}}</a></td>
+		<td style="width:1%" class="wc-shipping-zone-method-enabled"><a href="#">{{{ data.enabled_icon }}}</a></td>
 		<td class="wc-shipping-zone-method-description">
 			{{{ data.method_description }}}
 		</td>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
@@ -50,7 +50,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<tbody class="wc-shipping-zone-rows wc-shipping-tables-tbody"></tbody>
 
 	<tfoot data-id="0" class="wc-shipping-zone-worldwide wc-shipping-zone-rows-tfoot">
-		<td width="1%" class="wc-shipping-zone-worldwide"></td>
+		<td style="width:1%" class="wc-shipping-zone-worldwide"></td>
 		<td class="wc-shipping-zone-name">
 			<?php esc_html_e( 'Rest of the world', 'woocommerce' ); ?>
 		</td>
@@ -99,7 +99,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <script type="text/html" id="tmpl-wc-shipping-zone-row">
 	<tr data-id="{{ data.zone_id }}">
-		<td width="1%" class="wc-shipping-zone-sort"></td>
+		<td style="width:1%" class="wc-shipping-zone-sort"></td>
 		<td class="wc-shipping-zone-name">
 			{{ data.zone_name }}
 		</td>


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Pull Request Guidelines](https://github.com/woocommerce/woocommerce/wiki/Recommended-Pull-Request-Guidelines).

### Changes proposed in this Pull Request

The HTML [`width` attribute on `<td>` is deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#width). The reporter flagged it on the WooCommerce Settings → Payments tab; the legacy `table.wc_gateways` markup referenced there was removed when the Payments NOX UI was reactified (#58153), but the same deprecated attribute still appeared in a few admin tables that share the WC settings page chrome and in the React `PaymentPromotionRow` component used to wrap legacy payment-method promotion rows.

This PR swaps `width="…"` for inline `style="width:…"` in:

- `includes/admin/settings/views/html-admin-page-shipping-zones.php` (`<td>` in the Rest-of-the-world tfoot and in the JS template row)
- `includes/admin/settings/views/html-admin-page-shipping-zone-methods.php` (sort and enabled `<td>` cells in the JS template row)
- `client/admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx` (renders `<td>` cells for payment-method promotion rows, with the column width propagated from legacy DOM markup)

The deprecated tax-page `<th width="8%">` cells were left untouched to keep this PR narrowly scoped; the surrounding lines use `_e()` rather than `esc_html_e()`, so changing them trips pre-existing escape lint warnings that are out of scope for this hygiene fix.

Closes #55477.

Linear: https://linear.app/a8c/issue/RSMAPGJ-273

### Screenshots or screen recordings

No visual change is expected — the inline CSS resolves to the same column width as the deprecated attribute.

### How to test the changes in this Pull Request

1. Go to **WooCommerce → Settings → Shipping** and confirm the shipping zones table renders normally (sort handle column is still ~1% wide on the "Rest of the world" row and in any custom zones).
2. Open a zone and confirm the shipping methods table renders normally (sort handle and enabled columns remain narrow).
3. Inspect the rendered HTML and confirm there is no `width=""` or `width="1%"` attribute on any of the touched `<td>` elements; they should use `style="width:1%"` instead.

### Testing that has already taken place

- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — passes
- [x] `composer exec -- phpstan analyse …` on the two touched PHP files — `No errors`
- [x] `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — PHP branch lint clean; JS file is ignored by ESLint config (existing pattern, not introduced here)

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

  Significance: patch
  Type: fix
  Message: Replace deprecated HTML `width` attribute on `<td>` elements in admin shipping zone settings and the payments promotion row with inline CSS.

---

_Filed by the RSMAPGJ AI Coder pipeline._