### PR TITLE
Fix update_order_review marking success notices as failure

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-288
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-288
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `update_checkout` retriggering field validation when the `update_order_review` AJAX handler outputs a non-error notice (e.g. a success message).

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -477,16 +477,19 @@ class WC_AJAX {
 		// Get messages if reload checkout is not true.
 		$reload_checkout = isset( WC()->session->reload_checkout );
 		if ( ! $reload_checkout ) {
-			$messages = wc_print_notices( true );
+			// Capture the error notice count before printing, because wc_print_notices() clears the queued notices.
+			$has_error_notices = wc_notice_count( 'error' ) > 0;
+			$messages          = wc_print_notices( true );
 		} else {
-			$messages = '';
+			$has_error_notices = false;
+			$messages          = '';
 		}
 
 		unset( WC()->session->refresh_totals, WC()->session->reload_checkout );
 
 		wp_send_json(
 			array(
-				'result'    => empty( $messages ) ? 'success' : 'failure',
+				'result'    => $has_error_notices ? 'failure' : 'success',
 				'messages'  => $messages,
 				'reload'    => $reload_checkout,
 				'fragments' => apply_filters(

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -553,6 +553,83 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Should return success when update_order_review produces only a non-error notice.
+	 */
+	public function test_update_order_review_returns_success_when_only_non_error_notice_is_queued() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$callback = function () {
+			wc_add_notice( 'Coupon applied.', 'success' );
+		};
+		add_action( 'woocommerce_checkout_update_order_review', $callback );
+
+		$_POST['security']  = wp_create_nonce( 'update-order-review' );
+		$_POST['post_data'] = '';
+
+		$response = $this->do_ajax( 'woocommerce_update_order_review' );
+
+		remove_action( 'woocommerce_checkout_update_order_review', $callback );
+		WC()->cart->empty_cart();
+		unset( $_POST['security'], $_POST['post_data'] );
+		$product->delete( true );
+
+		$this->assertIsArray( $response, 'AJAX handler should return a JSON-decoded array' );
+		$this->assertSame( 'success', $response['result'], 'A non-error notice (e.g. a success message) must not flip the result to "failure".' );
+		$this->assertNotEmpty( $response['messages'], 'The success notice should still be sent back in messages.' );
+	}
+
+	/**
+	 * @testdox Should return failure when update_order_review produces an error notice.
+	 */
+	public function test_update_order_review_returns_failure_when_error_notice_is_queued() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$callback = function () {
+			wc_add_notice( 'Something went wrong.', 'error' );
+		};
+		add_action( 'woocommerce_checkout_update_order_review', $callback );
+
+		$_POST['security']  = wp_create_nonce( 'update-order-review' );
+		$_POST['post_data'] = '';
+
+		$response = $this->do_ajax( 'woocommerce_update_order_review' );
+
+		remove_action( 'woocommerce_checkout_update_order_review', $callback );
+		WC()->cart->empty_cart();
+		unset( $_POST['security'], $_POST['post_data'] );
+		$product->delete( true );
+
+		$this->assertIsArray( $response, 'AJAX handler should return a JSON-decoded array' );
+		$this->assertSame( 'failure', $response['result'], 'An error notice should result in a "failure" response.' );
+		$this->assertNotEmpty( $response['messages'], 'The error notice should be sent back in messages.' );
+	}
+
+	/**
+	 * @testdox Should return success when update_order_review produces no notices.
+	 */
+	public function test_update_order_review_returns_success_when_no_notice_is_queued() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$_POST['security']  = wp_create_nonce( 'update-order-review' );
+		$_POST['post_data'] = '';
+
+		$response = $this->do_ajax( 'woocommerce_update_order_review' );
+
+		WC()->cart->empty_cart();
+		unset( $_POST['security'], $_POST['post_data'] );
+		$product->delete( true );
+
+		$this->assertIsArray( $response, 'AJAX handler should return a JSON-decoded array' );
+		$this->assertSame( 'success', $response['result'], 'No notices means the request should be marked as a success.' );
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contribution guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

The `update_order_review` AJAX handler (`WC_AJAX::update_order_review`) returned `result: 'failure'` whenever it produced any response body in `messages`, including success notices. The legacy checkout JS treats `result === 'failure'` as a signal to retrigger field validation, so any code adding a success notice in `woocommerce_checkout_update_order_review` (e.g. apply/remove a coupon when the payment method changes) would cause empty required fields to be highlighted on every `update_checkout` event.

This PR captures `wc_notice_count( 'error' )` before `wc_print_notices()` clears the queue, and only marks the response as `failure` when at least one error notice was queued.

Closes #40443

Linear: https://linear.app/a8c/issue/RSMAPGJ-288

### How to test the changes in this Pull Request

1. Enable two payment methods (e.g. Cash on Delivery + Direct bank transfer) and create a 5%-off coupon named `fiveoff`.
2. Add the following to a mu-plugin so the coupon is applied/removed based on the selected payment method:

   ```php
   add_action( 'woocommerce_checkout_update_order_review', function ( $data ) {
       parse_str( $data, $post_data );
       $method = sanitize_text_field( $post_data['payment_method'] ?? '' );
       if ( 'cod' === $method ) {
           if ( ! WC()->cart->has_discount( 'fiveoff' ) ) {
               WC()->cart->apply_coupon( 'fiveoff' );
           }
       } elseif ( WC()->cart->has_discount( 'fiveoff' ) ) {
           WC()->cart->remove_coupon( 'fiveoff' );
       }
   } );
   ```

3. Add the following snippet from the browser console on the Checkout page so changing the payment method also retriggers `update_checkout`:

   ```js
   jQuery( document.body ).on( 'change', 'input[name=payment_method]', function () {
       jQuery( document.body ).trigger( 'update_checkout' );
   } );
   ```

4. Add a product to the cart, go to the checkout page (with the Storefront theme, which highlights invalid fields), and switch payment method.
5. Without this fix the empty required fields are highlighted as invalid. With this fix the success notice is shown but the form is not flagged as invalid.

### Testing that has already taken place

- Added PHPUnit coverage for `WC_AJAX::update_order_review` covering the three branches:
  - non-error notice queued → `result: success`
  - error notice queued → `result: failure`
  - no notices queued → `result: success`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/class-wc-ajax.php` — clean (no new errors, no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

**Significance:** Patch
**Type:** Fix
**Message:** Fix `update_checkout` retriggering field validation when the `update_order_review` AJAX handler outputs a non-error notice (e.g. a success message).

</details>

---

_Submitted by the RSMAPGJ AI Coder pipeline._