### PR TITLE
Fix duplicate product entry in admin menu order

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-289
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-289
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent duplicate `edit.php?post_type=product` entry in the admin menu order array when WooCommerce reorders the menu.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -317,7 +317,7 @@ class WC_Admin_Menus {
 				$woocommerce_menu_order[] = 'edit.php?post_type=product';
 				unset( $menu_order[ $woocommerce_separator ] );
 				unset( $menu_order[ $woocommerce_product ] );
-			} elseif ( ! in_array( $item, array( 'separator-woocommerce' ), true ) ) {
+			} elseif ( ! in_array( $item, array( 'separator-woocommerce', 'edit.php?post_type=product' ), true ) ) {
 				$woocommerce_menu_order[] = $item;
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-menus-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-menus-test.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Unit tests for the WC_Admin_Menus class.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+
+/**
+ * Class WC_Admin_Menus_Test
+ */
+class WC_Admin_Menus_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Admin_Menus
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
+		require_once $bootstrap->plugin_dir . '/includes/admin/class-wc-admin-menus.php';
+
+		$this->sut = new WC_Admin_Menus();
+	}
+
+	/**
+	 * @testdox Should not duplicate the product menu item when reordering the admin menu.
+	 */
+	public function test_menu_order_does_not_duplicate_product_entry(): void {
+		$menu_order = array(
+			'index.php',
+			'separator1',
+			'edit.php',
+			'upload.php',
+			'edit.php?post_type=page',
+			'separator-woocommerce',
+			'woocommerce',
+			'edit.php?post_type=product',
+			'separator2',
+			'themes.php',
+		);
+
+		$result = $this->sut->menu_order( $menu_order );
+
+		$product_occurrences = count(
+			array_keys( $result, 'edit.php?post_type=product', true )
+		);
+
+		$this->assertSame(
+			1,
+			$product_occurrences,
+			'The product menu entry should appear exactly once after reordering.'
+		);
+	}
+
+	/**
+	 * @testdox Should place the WooCommerce separator and product menu immediately before the WooCommerce item.
+	 */
+	public function test_menu_order_places_woocommerce_block_in_expected_position(): void {
+		$menu_order = array(
+			'index.php',
+			'edit.php',
+			'separator-woocommerce',
+			'woocommerce',
+			'edit.php?post_type=product',
+			'themes.php',
+		);
+
+		$result = $this->sut->menu_order( $menu_order );
+
+		$woocommerce_index = array_search( 'woocommerce', $result, true );
+		$separator_index   = array_search( 'separator-woocommerce', $result, true );
+		$product_index     = array_search( 'edit.php?post_type=product', $result, true );
+
+		$this->assertNotFalse( $woocommerce_index, 'WooCommerce menu item should be present.' );
+		$this->assertSame(
+			$woocommerce_index - 1,
+			$separator_index,
+			'The WooCommerce separator should appear directly before the WooCommerce menu item.'
+		);
+		$this->assertSame(
+			$woocommerce_index + 1,
+			$product_index,
+			'The product menu item should appear directly after the WooCommerce menu item.'
+		);
+	}
+
+	/**
+	 * @testdox Should still inject the product menu item when the input does not include it.
+	 */
+	public function test_menu_order_injects_product_when_absent(): void {
+		$menu_order = array(
+			'index.php',
+			'separator-woocommerce',
+			'woocommerce',
+			'themes.php',
+		);
+
+		$result = $this->sut->menu_order( $menu_order );
+
+		$product_occurrences = count(
+			array_keys( $result, 'edit.php?post_type=product', true )
+		);
+
+		$this->assertSame(
+			1,
+			$product_occurrences,
+			'The product menu entry should be added exactly once even when not in the input order.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Admin_Menus::menu_order()` inserts `edit.php?post_type=product` adjacent to the `woocommerce` menu item when reordering the admin menu, but the loop's `elseif` branch did not exclude the existing `edit.php?post_type=product` entry when it was encountered separately in the input array. Because PHP's `foreach` iterates over a copy of the array, the `unset()` on the original index had no effect on the iteration, leaving the product menu duplicated in the final array.

This PR adds `edit.php?post_type=product` to the exclusion list in the `elseif` branch so the product menu is emitted exactly once via the WooCommerce block insertion. Coverage added in `tests/php/includes/admin/class-wc-admin-menus-test.php`.

Closes #39599

Linear: https://linear.app/a8c/issue/RSMAPGJ-289

### How to test the changes in this Pull Request:

1. On `trunk` (without this PR), enable WooCommerce and add the following mu-plugin to capture the resulting menu order:

   ```php
   <?php
   add_action( 'admin_init', function () {
       global $menu;
       // Trigger reorder.
       $order = apply_filters( 'menu_order', wp_list_pluck( $menu, 2 ) );
       set_transient( 'wc_menu_order_snapshot', $order, 3600 );
   }, 999 );
   ```

   Visit `wp-admin`, then inspect the transient (`wp transient get wc_menu_order_snapshot --format=json`). Observe that `edit.php?post_type=product` appears twice.

2. Check out this branch, repeat the above. Confirm `edit.php?post_type=product` appears exactly once and the WooCommerce menu / separator / Products items remain in the correct relative order.

3. Run the new unit tests:

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce test:php -- --filter WC_Admin_Menus_Test
   ```

### Testing that has already taken place:

- New PHPUnit cases in `WC_Admin_Menus_Test` covering: no duplicate after reorder, correct relative position of separator / WooCommerce / Products, and injection still works when the input order omits the product entry.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse includes/admin/class-wc-admin-menus.php --memory-limit=2G` — no errors.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry committed manually at `plugins/woocommerce/changelog/fix-rsmapgj-289` (patch / fix).

---

Submitted via the **RSMAPGJ AI Coder pipeline**.