### PR TITLE
Product Editor: show variation options as attributes for product types that don't support variations

### DIFF
--- a/packages/js/product-editor/changelog/fix-rsmapgj-281
+++ b/packages/js/product-editor/changelog/fix-rsmapgj-281
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Display previously generated variation options as regular attributes (with the variation flag preserved) when the product type does not support variations, instead of showing them as disabled entries.

--- a/packages/js/product-editor/src/blocks/product-fields/attributes/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/attributes/edit.tsx
@@ -34,6 +34,13 @@ export function AttributesBlockEdit( {
 		handleChange,
 	} = useProductAttributes( {
 		allAttributes: entityAttributes,
+		// Product types that surface this block (e.g. grouped) do not
+		// support variations. Surface any attribute marked for variations
+		// here so previously generated variation options aren't hidden as
+		// disabled entries; the `variation` flag is preserved in the data
+		// so switching back to a variation-capable product type restores
+		// them as variation options.
+		includeVariationAttributes: true,
 		onChange: setEntityAttributes,
 		productId,
 	} );
@@ -48,9 +55,6 @@ export function AttributesBlockEdit( {
 		<div { ...blockProps }>
 			<AttributeControl
 				value={ attributeList }
-				disabledAttributeIds={ entityAttributes
-					.filter( ( attr ) => !! attr.variation )
-					.map( ( attr ) => attr.id ) }
 				uiStrings={ {
 					disabledAttributeMessage: __(
 						'Already used in Variations',

--- a/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
+++ b/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
@@ -479,6 +479,69 @@ describe( 'useProductAttributes', () => {
 			);
 		} );
 
+		it( 'should include variation attributes when includeVariationAttributes is true', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 0 ] },
+				{ ...testAttributes[ 1 ], variation: true },
+				{ ...testAttributes[ 2 ] },
+			];
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange: jest.fn(),
+						isVariationAttributes: false,
+						includeVariationAttributes: true,
+						productId: 123,
+					},
+				}
+			);
+			result.current.fetchAttributes();
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			expect( result.current.attributes.length ).toBe( 3 );
+			const variationAttr = result.current.attributes.find(
+				( a ) => a.name === allAttributes[ 1 ].name
+			);
+			expect( variationAttr ).toBeDefined();
+			expect( variationAttr?.variation ).toBe( true );
+		} );
+
+		it( 'should preserve the variation flag in handleChange when includeVariationAttributes is true', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 1 ], variation: true },
+				{ ...testAttributes[ 2 ], variation: false },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: false,
+						includeVariationAttributes: true,
+						productId: 123,
+					},
+				}
+			);
+			result.current.fetchAttributes();
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			result.current.handleChange( [
+				{ ...allAttributes[ 0 ], isDefault: false },
+				{ ...allAttributes[ 1 ], isDefault: false },
+			] );
+			expect( onChange ).toHaveBeenCalledWith(
+				[
+					{ ...allAttributes[ 0 ], position: 0, variation: true },
+					{ ...allAttributes[ 1 ], position: 1, variation: false },
+				],
+				[]
+			);
+		} );
+
 		it( 'sets terms for any global attributes and leaves options the same', async () => {
 			const allAttributes = [
 				{ ...testAttributes[ 0 ] },

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -25,6 +25,15 @@ export type EnhancedProductAttribute = ProductProductAttribute & {
 type useProductAttributesProps = {
 	allAttributes: ProductProductAttribute[];
 	isVariationAttributes?: boolean;
+	/**
+	 * When true and `isVariationAttributes` is false, attributes flagged for
+	 * variations (`variation: true`) are also returned so they can be displayed
+	 * as regular attributes for product types that do not support variations
+	 * (e.g. grouped products). The underlying `variation` flag is preserved on
+	 * the attribute data so switching back to a variation-capable product type
+	 * keeps them as variation options.
+	 */
+	includeVariationAttributes?: boolean;
 	onChange: (
 		attributes: ProductProductAttribute[],
 		defaultAttributes: ProductDefaultAttribute[]
@@ -34,11 +43,16 @@ type useProductAttributesProps = {
 
 const getFilteredAttributes = (
 	attr: ProductProductAttribute[],
-	isVariationAttributes: boolean
+	isVariationAttributes: boolean,
+	includeVariationAttributes = false
 ) => {
-	return isVariationAttributes
-		? attr.filter( ( attribute ) => !! attribute.variation )
-		: attr.filter( ( attribute ) => ! attribute.variation );
+	if ( isVariationAttributes ) {
+		return attr.filter( ( attribute ) => !! attribute.variation );
+	}
+	if ( includeVariationAttributes ) {
+		return attr;
+	}
+	return attr.filter( ( attribute ) => ! attribute.variation );
 };
 
 function manageDefaultAttributes( values: EnhancedProductAttribute[] ) {
@@ -67,12 +81,19 @@ function manageDefaultAttributes( values: EnhancedProductAttribute[] ) {
 export function useProductAttributes( {
 	allAttributes = [],
 	isVariationAttributes = false,
+	includeVariationAttributes = false,
 	onChange,
 	productId,
 }: useProductAttributesProps ) {
 	const [ attributes, setAttributes ] = useState<
 		EnhancedProductAttribute[]
-	>( getFilteredAttributes( allAttributes, isVariationAttributes ) );
+	>(
+		getFilteredAttributes(
+			allAttributes,
+			isVariationAttributes,
+			includeVariationAttributes
+		)
+	);
 
 	const fetchTerms = useCallback(
 		( attributeId: number ) => {
@@ -107,20 +128,40 @@ export function useProductAttributes( {
 	const getAugmentedAttributes = (
 		atts: EnhancedProductAttribute[],
 		variation: boolean,
-		startPosition: number
+		startPosition: number,
+		preserveVariation = false
 	): ProductProductAttribute[] => {
 		return atts.map( ( { isDefault, terms, ...attribute }, index ) => ( {
 			...attribute,
-			variation,
+			variation: preserveVariation ? !! attribute.variation : variation,
 			position: startPosition + index,
 		} ) );
 	};
 
 	const handleChange = ( newAttributes: EnhancedProductAttribute[] ) => {
 		const defaultAttributes = manageDefaultAttributes( newAttributes );
-		let otherAttributes = isVariationAttributes
-			? allAttributes.filter( ( attribute ) => ! attribute.variation )
-			: allAttributes.filter( ( attribute ) => !! attribute.variation );
+
+		// When the non-variation block is rendering variation attributes
+		// (e.g. grouped products) we keep each attribute's existing
+		// `variation` flag instead of forcing it to false. This way the
+		// underlying data is preserved across product-type switches.
+		const preserveVariationFlag =
+			! isVariationAttributes && includeVariationAttributes;
+
+		let otherAttributes: ProductProductAttribute[];
+		if ( isVariationAttributes ) {
+			otherAttributes = allAttributes.filter(
+				( attribute ) => ! attribute.variation
+			);
+		} else if ( includeVariationAttributes ) {
+			// We're already rendering both variation and non-variation
+			// attributes, so there are no "other" attributes to preserve.
+			otherAttributes = [];
+		} else {
+			otherAttributes = allAttributes.filter(
+				( attribute ) => !! attribute.variation
+			);
+		}
 
 		// Remove duplicate global attributes.
 		otherAttributes = otherAttributes.filter( ( attr ) => {
@@ -144,7 +185,8 @@ export function useProductAttributes( {
 		const newAugmentedAttributes = getAugmentedAttributes(
 			newAttributes,
 			isVariationAttributes,
-			isVariationAttributes ? otherAttributes.length : 0
+			isVariationAttributes ? otherAttributes.length : 0,
+			preserveVariationFlag
 		);
 		const otherAugmentedAttributes = getAugmentedAttributes(
 			otherAttributes,
@@ -170,7 +212,11 @@ export function useProductAttributes( {
 			localAttributes,
 			globalAttributes,
 		]: ProductProductAttribute[][] = sift(
-			getFilteredAttributes( allAttributes, isVariationAttributes ),
+			getFilteredAttributes(
+				allAttributes,
+				isVariationAttributes,
+				includeVariationAttributes
+			),
 			( attr: ProductProductAttribute ) => attr.id === 0
 		);
 
@@ -185,7 +231,12 @@ export function useProductAttributes( {
 				...localAttributes,
 			] );
 		} );
-	}, [ allAttributes, isVariationAttributes, fetchTerms ] );
+	}, [
+		allAttributes,
+		isVariationAttributes,
+		includeVariationAttributes,
+		fetchTerms,
+	] );
 
 	return {
 		attributes,

--- a/plugins/woocommerce/changelog/fix-rsmapgj-281
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-281
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor: display previously generated variation options as attributes (with the variation flag preserved) when the current product type does not support variations.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a user generated variations on a variable product and then switched the product type to one that doesn't support variations (e.g. Grouped), the Attributes section still showed the previously generated variation options as disabled entries instead of as regular attributes.

This PR teaches the non-variation Attributes block to display attributes that were previously flagged for variations as regular attributes, while preserving the `variation: true` flag in the underlying data. Switching back to a variation-capable product type therefore restores them as variation options.

- Adds an `includeVariationAttributes` option to `useProductAttributes`. When the consuming block is the non-variation block (`isVariationAttributes: false`) and this option is `true`, attributes with `variation: true` are surfaced in the list rather than filtered out.
- `handleChange` preserves each attribute's existing `variation` flag in that mode instead of forcing it to `false`, so the boolean is not lost on save.
- The non-variation attributes block (`packages/js/product-editor/src/blocks/product-fields/attributes/edit.tsx`) opts in to the new option and no longer marks the variation-flagged attribute ids as disabled — they're now shown in the list itself.

Closes #49701

Linear: https://linear.app/a8c/issue/RSMAPGJ-281

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the new Product Editor (`Settings → Advanced → Features → New product editor`).
2. Create a global attribute (e.g. Color with terms Red and Blue).
3. Create a Variable product, add the Color attribute as a variation option, and generate variations.
4. Save and reopen the product, then switch the product type to Grouped.
5. Open the Attributes section.
    - Expected: Color appears in the attributes list (as a regular attribute), not as a disabled entry. Save the product.
6. Switch the product type back to a variation-capable product type (e.g. simple → toggle variations, or revert via the product type selector).
    - Expected: Color is still listed as a variation option (the `variation` flag was preserved).
7. Jest: `pnpm --filter=@woocommerce/product-editor test:js -- src/hooks/test/use-product-attributes.test.ts` — all tests pass, including the two new cases covering `includeVariationAttributes`.

<!-- End testing instructions -->

### Testing that has already taken place:

- Added unit tests covering both the rendering inclusion and the preservation of the `variation` flag through `handleChange`. All 13 tests in the `useProductAttributes` suite pass locally.
- Ran `pnpm --filter=@woocommerce/product-editor lint`; only pre-existing warnings remain (no new errors).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entries were added manually under `packages/js/product-editor/changelog/fix-rsmapgj-281` and `plugins/woocommerce/changelog/fix-rsmapgj-281`.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

---

Submitted via the RSMAPGJ AI Coder pipeline.