### PR TITLE
Fix price display suffix on variable products when variations share the same price

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-277
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-277
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the price display suffix on variable products when every variation shares the same price, including when the suffix uses dynamic placeholders such as {price_including_tax}.

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -151,11 +151,11 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Returns the price in html format.
 	 *
-	 * Note: Variable prices do not show suffixes like other product types. This
-	 * is due to some things like tax classes being set at variation level which
-	 * could differ from the parent price. The only way to show accurate prices
-	 * would be to load the variation and get its price, which adds extra
-	 * overhead and still has edge cases where the values would be inaccurate.
+	 * Note: Variable prices do not show suffixes with dynamic placeholders
+	 * (e.g. `{price_including_tax}`) when the variations span a price range,
+	 * because tax classes can differ between variations and the resolved
+	 * placeholder value would be ambiguous. When all variations share the
+	 * same price the suffix can be resolved accurately, so it is shown.
 	 *
 	 * Additionally, ranges of prices no longer show 'striked out' sale prices
 	 * due to the strings being very long and unclear/confusing. A single range
@@ -176,14 +176,25 @@ class WC_Product_Variable extends WC_Product {
 			$max_reg_price = end( $prices['regular_price'] );
 
 			if ( $min_price !== $max_price ) {
-				$price = wc_format_price_range( $min_price, $max_price );
+				$price        = wc_format_price_range( $min_price, $max_price );
+				$suffix_price = '';
 			} elseif ( $this->is_on_sale() && $min_reg_price === $max_reg_price ) {
-				$price = wc_format_sale_price( wc_price( $max_reg_price ), wc_price( $min_price ) );
+				$price        = wc_format_sale_price( wc_price( $max_reg_price ), wc_price( $min_price ) );
+				$suffix_price = $min_price;
 			} else {
-				$price = wc_price( $min_price );
+				$price        = wc_price( $min_price );
+				$suffix_price = $min_price;
 			}
 
-			$price = apply_filters( 'woocommerce_variable_price_html', $price . $this->get_price_suffix(), $this );
+			/**
+			 * Filters the displayed price HTML for a variable product.
+			 *
+			 * @since 2.5.0
+			 *
+			 * @param string              $price   The price HTML (price string plus suffix).
+			 * @param WC_Product_Variable $product The variable product instance.
+			 */
+			$price = apply_filters( 'woocommerce_variable_price_html', $price . $this->get_price_suffix( $suffix_price ), $this );
 		}
 
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );
@@ -192,22 +203,25 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get the suffix to display after prices > 0.
 	 *
-	 * This is skipped if the suffix
-	 * has dynamic values such as {price_excluding_tax} for variable products.
+	 * Dynamic placeholders such as {price_including_tax} are normally skipped for
+	 * variable products because the resolved price would be ambiguous across the
+	 * variation range. When the caller supplies an explicit (non-empty) $price —
+	 * for example when all variations share the same price — the placeholder can
+	 * be resolved accurately, so we defer to the parent implementation.
 	 *
 	 * @see get_price_html for an explanation as to why.
-	 * @param  string  $price Price to calculate, left blank to just use get_price().
-	 * @param  integer $qty   Quantity passed on to get_price_including_tax() or get_price_excluding_tax().
+	 * @param  string|float $price Price to calculate, left blank to just use get_price().
+	 * @param  integer      $qty   Quantity passed on to get_price_including_tax() or get_price_excluding_tax().
 	 * @return string
 	 */
 	public function get_price_suffix( $price = '', $qty = 1 ) {
 		$suffix = get_option( 'woocommerce_price_display_suffix' );
 
-		if ( strstr( $suffix, '{' ) ) {
+		if ( '' === $price && strstr( $suffix, '{' ) ) {
 			return apply_filters( 'woocommerce_get_price_suffix', '', $this, $price, $qty );
-		} else {
-			return parent::get_price_suffix( $price, $qty );
 		}
+
+		return parent::get_price_suffix( (string) $price, $qty );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -162,4 +162,91 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$this->assertIsBool( $has_purchasable_variations );
 		$this->assertFalse( $has_purchasable_variations );
 	}
+
+	/**
+	 * @testdox 'get_price_html' renders a dynamic price display suffix when all variation prices match.
+	 *
+	 * Regression for woocommerce#54016: when every variation shared the same price, the
+	 * `{price_including_tax}` placeholder suffix was suppressed alongside the price range case.
+	 */
+	public function test_get_price_html_renders_dynamic_suffix_when_variation_prices_match() {
+		$original_suffix             = get_option( 'woocommerce_price_display_suffix' );
+		$original_calc_taxes         = get_option( 'woocommerce_calc_taxes' );
+		$original_prices_include_tax = get_option( 'woocommerce_prices_include_tax' );
+		$original_tax_display_shop   = get_option( 'woocommerce_tax_display_shop' );
+
+		update_option( 'woocommerce_price_display_suffix', '{price_including_tax} (inc vat)' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_tax_display_shop', 'excl' );
+
+		$tax_rate    = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '20.0000',
+			'tax_rate_name'     => 'VAT',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$product = new WC_Product_Variable();
+		$product->set_props(
+			array(
+				'name' => 'Same-price variable product',
+				'sku'  => 'SAME-PRICE-VAR-' . microtime( true ),
+			)
+		);
+
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'color', array( 'black', 'white' ) );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'SAME-PRICE-VAR-BLACK',
+			20,
+			array( 'pa_color' => 'black' )
+		);
+		WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'SAME-PRICE-VAR-WHITE',
+			20,
+			array( 'pa_color' => 'white' )
+		);
+
+		// Reload to pick up synced min/max prices.
+		$product = wc_get_product( $product->get_id() );
+
+		$price_html = $product->get_price_html();
+
+		// Suffix label and resolved tax-inclusive price (20 * 1.20 = 24) should both be present.
+		$this->assertStringContainsString( '(inc vat)', $price_html, 'Expected the price display suffix label to appear when variations share a price.' );
+		$this->assertStringContainsString( 'woocommerce-price-suffix', $price_html, 'Expected the suffix wrapper markup to be present.' );
+
+		// Sanity: the placeholder itself should have been replaced.
+		$this->assertStringNotContainsString( '{price_including_tax}', $price_html );
+
+		// Now flip one variation's price so the variations form a range; suffix with dynamic placeholders should be suppressed.
+		$variations = $product->get_children();
+		$variation  = wc_get_product( end( $variations ) );
+		$variation->set_regular_price( 30 );
+		$variation->save();
+
+		$product    = wc_get_product( $product->get_id() );
+		$range_html = $product->get_price_html();
+
+		$this->assertStringNotContainsString( '(inc vat)', $range_html, 'Dynamic placeholder suffix should remain suppressed when variation prices form a range.' );
+
+		// Test clean up.
+		WC_Tax::_delete_tax_rate( $tax_rate_id );
+		WC_Helper_Product::delete_product( $product->get_id() );
+		update_option( 'woocommerce_price_display_suffix', $original_suffix );
+		update_option( 'woocommerce_calc_taxes', $original_calc_taxes );
+		update_option( 'woocommerce_prices_include_tax', $original_prices_include_tax );
+		update_option( 'woocommerce_tax_display_shop', $original_tax_display_shop );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a variable product had every variation set to the same price, the configured price display suffix was suppressed if it contained a dynamic placeholder such as `{price_including_tax}`. The placeholder bail-out in `WC_Product_Variable::get_price_suffix()` was meant for ranged prices (where the resolved value would be ambiguous across the range), but it also kicked in for the single-price case where the resolved value is well-defined and matches the behaviour users expect.

This PR:

- Passes the resolved `$min_price` through to the parent suffix renderer when min/max variation prices match (both the regular and on-sale branches in `get_price_html`).
- Updates `get_price_suffix()` to only short-circuit dynamic placeholders when no price context is supplied (preserving the existing ambiguity-avoidance behaviour for true price ranges).
- Adds a regression test that exercises both the same-price branch (suffix renders, placeholder resolved) and the range-price branch (suffix still suppressed).

Closes #54016.
Linear: https://linear.app/a8c/issue/RSMAPGJ-277

### Screenshots or screen recordings:

N/A — covered by automated test. The user-visible change is that `{price_including_tax} (inc vat)` now renders on the variable product page when both variations are priced at e.g. £20, matching the behaviour already shown for products with differing variation prices.

### How to test the changes in this Pull Request:

1. In **WooCommerce → Settings → Tax**, set:
   - *Prices entered with tax*: **No, I will enter prices exclusive of tax**
   - *Display prices in the shop / cart and checkout*: **Excluding tax**
   - *Price display suffix*: `{price_including_tax} (inc vat)`
2. Add a 20% standard tax rate.
3. Create a variable product with a `Color` attribute (Black, White), then create two variations, both priced at `20`.
4. Visit the product page on the front end.
5. Confirm the price renders as `£20.00 £24.00 (inc vat)` (or your locale equivalent) — the suffix label and the tax-inclusive price are both visible.
6. Edit one of the variations to a different price (e.g. `30`) and reload.
7. Confirm the range still renders without the dynamic suffix (`£20.00 – £30.00`), as before.

### Testing that has already taken place:

- New PHPUnit regression test: `WC_Product_Variable_Test::test_get_price_html_renders_dynamic_suffix_when_variation_prices_match` covers both the same-price (suffix shown, placeholder resolved) and range-price (suffix suppressed) branches.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse includes/class-wc-product-variable.php --memory-limit=2G` — no errors.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry was created manually at `plugins/woocommerce/changelog/fix-rsmapgj-277` (Significance: patch, Type: fix).

---

Submitted via the RSMAPGJ AI Coder pipeline.