### PR TITLE
Resync stock status when the out-of-stock threshold changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-274
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-274
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Re-evaluate the stock status of managed-stock products in the background when the site-wide "Out of stock threshold" setting changes, so products are no longer purchasable below the new threshold until their next manual save or order.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -312,7 +312,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 
 				array(
 					'title'             => __( 'Out of stock threshold', 'woocommerce' ),
-					'desc'              => __( 'When product stock reaches this amount the stock status will change to "out of stock" and you will be notified via email. This setting does not affect existing "in stock" products.', 'woocommerce' ),
+					'desc'              => __( 'When product stock reaches this amount the stock status will change to "out of stock" and you will be notified via email. Changing this value re-evaluates the stock status of existing managed-stock products in the background.', 'woocommerce' ),
 					'id'                => 'woocommerce_notify_no_stock_amount',
 					'css'               => 'width:50px;',
 					'type'              => 'number',

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -26,6 +26,7 @@ use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Registe
 use Automattic\WooCommerce\Internal\ProductImage\MatchImageBySKU;
 use Automattic\WooCommerce\Internal\RestockRefundedItemsAdjuster;
 use Automattic\WooCommerce\Internal\Settings\OptionSanitizer;
+use Automattic\WooCommerce\Internal\StockThresholdResync;
 use Automattic\WooCommerce\Internal\Utilities\LegacyRestApiStub;
 use Automattic\WooCommerce\Internal\Utilities\WebhookUtil;
 use Automattic\WooCommerce\Internal\Admin\EmailImprovements\EmailImprovements;
@@ -357,6 +358,7 @@ final class WooCommerce {
 		$container->get( LookupDataStore::class );
 		$container->get( MatchImageBySKU::class );
 		$container->get( RestockRefundedItemsAdjuster::class );
+		$container->get( StockThresholdResync::class );
 		$container->get( CustomOrdersTableController::class );
 		$container->get( ProductCacheController::class );
 		$container->get( OptionSanitizer::class );

--- a/plugins/woocommerce/src/Internal/StockThresholdResync.php
+++ b/plugins/woocommerce/src/Internal/StockThresholdResync.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * StockThresholdResync class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal;
+
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Recomputes the stock status of stock-managed products when the site-wide
+ * out-of-stock threshold (`woocommerce_notify_no_stock_amount`) changes.
+ *
+ * Without this, raising the threshold above a product's current stock quantity
+ * would leave the product flagged as in stock until the next product save or
+ * order, allowing it to remain purchasable below the new threshold. See
+ * https://github.com/woocommerce/woocommerce/issues/55422.
+ *
+ * The recompute work is scheduled through Action Scheduler in small batches so
+ * that large catalogs are processed asynchronously without blocking the
+ * settings save request.
+ *
+ * @since 10.9.0
+ */
+class StockThresholdResync {
+
+	/**
+	 * Action Scheduler hook used to process a single batch of affected products.
+	 *
+	 * @var string
+	 */
+	public const RESYNC_BATCH_HOOK = 'woocommerce_resync_stock_status_after_threshold_change';
+
+	/**
+	 * Action Scheduler group used for the scheduled batches.
+	 *
+	 * @var string
+	 */
+	private const RESYNC_GROUP = 'woocommerce-stock-threshold';
+
+	/**
+	 * Maximum number of product IDs handled in a single scheduled batch.
+	 *
+	 * @var int
+	 */
+	private const BATCH_SIZE = 50;
+
+	/**
+	 * Class initialization, to be executed when the class is resolved by the container.
+	 *
+	 * @internal
+	 */
+	final public function init(): void {
+		add_action( 'add_option_woocommerce_notify_no_stock_amount', array( $this, 'handle_option_added' ), 10, 2 );
+		add_action( 'update_option_woocommerce_notify_no_stock_amount', array( $this, 'handle_option_updated' ), 10, 2 );
+		add_action( self::RESYNC_BATCH_HOOK, array( $this, 'process_batch' ), 10, 1 );
+	}
+
+	/**
+	 * Handle the option being added for the first time.
+	 *
+	 * @param string $option    Option name.
+	 * @param mixed  $new_value The new option value.
+	 */
+	public function handle_option_added( $option, $new_value ): void {
+		$this->maybe_schedule_resync( 0, (int) $new_value );
+	}
+
+	/**
+	 * Handle the option being updated.
+	 *
+	 * @param mixed $old_value The previous option value.
+	 * @param mixed $new_value The new option value.
+	 */
+	public function handle_option_updated( $old_value, $new_value ): void {
+		$this->maybe_schedule_resync( (int) $old_value, (int) $new_value );
+	}
+
+	/**
+	 * Schedule one or more Action Scheduler batches to re-save the products
+	 * whose stock status would change under the new threshold.
+	 *
+	 * @param int $old_threshold The previous threshold value.
+	 * @param int $new_threshold The new threshold value.
+	 */
+	private function maybe_schedule_resync( int $old_threshold, int $new_threshold ): void {
+		if ( $old_threshold === $new_threshold ) {
+			return;
+		}
+
+		// Stock management must be enabled site-wide for the threshold to take effect.
+		if ( 'yes' !== get_option( 'woocommerce_manage_stock' ) ) {
+			return;
+		}
+
+		$product_ids = $this->get_affected_product_ids( $new_threshold );
+		if ( empty( $product_ids ) ) {
+			return;
+		}
+
+		$batches = array_chunk( $product_ids, self::BATCH_SIZE );
+		$delay   = 1;
+		foreach ( $batches as $batch ) {
+			WC()->call_function(
+				'as_schedule_single_action',
+				WC()->call_function( 'time' ) + $delay,
+				self::RESYNC_BATCH_HOOK,
+				array( array_values( array_map( 'intval', $batch ) ) ),
+				self::RESYNC_GROUP
+			);
+			// Stagger batches slightly so they don't all execute on the same queue tick.
+			++$delay;
+		}
+	}
+
+	/**
+	 * Build the list of product IDs whose recorded stock status disagrees with
+	 * the new threshold and therefore needs to be re-evaluated.
+	 *
+	 * Two transitions are possible:
+	 *   - Currently `instock` with quantity at or below the new threshold (must become out of stock,
+	 *     or `onbackorder` if backorders are allowed).
+	 *   - Currently `outofstock` with quantity above the new threshold (may become in stock when the
+	 *     previous status was driven solely by the threshold).
+	 *
+	 * @param int $new_threshold The new threshold value.
+	 *
+	 * @return int[] Product IDs requiring re-save.
+	 */
+	private function get_affected_product_ids( int $new_threshold ): array {
+		global $wpdb;
+
+		$lookup_table = $wpdb->prefix . 'wc_product_meta_lookup';
+
+		// Raising the threshold: in-stock products whose quantity now sits at or below it.
+		// Lowering the threshold: out-of-stock products whose quantity now sits above it.
+		// Querying both cases covers either direction and avoids missing edge cases where
+		// the threshold both rises and falls between option reads.
+		$instock     = ProductStockStatus::IN_STOCK;
+		$outofstock  = ProductStockStatus::OUT_OF_STOCK;
+		$onbackorder = ProductStockStatus::ON_BACKORDER;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT product_id FROM {$lookup_table}
+				 WHERE manage_stock = 1
+				 AND stock_quantity IS NOT NULL
+				 AND (
+					( stock_status = %s AND stock_quantity <= %d )
+					OR ( stock_status IN ( %s, %s ) AND stock_quantity > %d )
+				 )",
+				$instock,
+				$new_threshold,
+				$outofstock,
+				$onbackorder,
+				$new_threshold
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array_map( 'intval', (array) $results );
+	}
+
+	/**
+	 * Action Scheduler callback: re-save each product in the batch so that
+	 * `WC_Product::validate_props()` re-evaluates stock status against the
+	 * current threshold value.
+	 *
+	 * Products that have changed in the meantime (e.g. were deleted, had their
+	 * manage_stock flag turned off, or already crossed the threshold via
+	 * another path) are silently skipped.
+	 *
+	 * @param int[] $product_ids List of product IDs to re-save.
+	 */
+	public function process_batch( $product_ids ): void {
+		if ( ! is_array( $product_ids ) || empty( $product_ids ) ) {
+			return;
+		}
+
+		foreach ( $product_ids as $product_id ) {
+			$product_id = (int) $product_id;
+			if ( $product_id <= 0 ) {
+				continue;
+			}
+
+			$product = wc_get_product( $product_id );
+			if ( ! $product || ! $product->managing_stock() ) {
+				continue;
+			}
+
+			// Saving runs WC_Product::validate_props(), which re-derives the stock status
+			// from the current quantity and threshold and persists any change.
+			$product->save();
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockThresholdResyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockThresholdResyncTest.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * StockThresholdResyncTest class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal;
+
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Internal\StockThresholdResync;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the StockThresholdResync class.
+ */
+class StockThresholdResyncTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var StockThresholdResync
+	 */
+	private $sut;
+
+	/**
+	 * Captured Action Scheduler payloads from the mocked legacy proxy.
+	 *
+	 * @var array<int, array{timestamp:int,hook:string,args:array,group:string}>
+	 */
+	private array $scheduled_actions = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->scheduled_actions = array();
+		$this->sut               = new StockThresholdResync();
+		$this->sut->init();
+
+		// Stock management must be enabled site-wide.
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Capture scheduled Action Scheduler invocations without enqueuing them.
+		$scheduled_actions = &$this->scheduled_actions;
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'as_schedule_single_action' => function ( $timestamp, $hook, $args = array(), $group = '' ) use ( &$scheduled_actions ) {
+					$scheduled_actions[] = array(
+						'timestamp' => $timestamp,
+						'hook'      => $hook,
+						'args'      => $args,
+						'group'     => $group,
+					);
+					return 1;
+				},
+				'time'                      => function () {
+					return 1700000000;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		// Remove our hooks so we don't leak state into other tests in the same process.
+		remove_action( 'add_option_woocommerce_notify_no_stock_amount', array( $this->sut, 'handle_option_added' ), 10 );
+		remove_action( 'update_option_woocommerce_notify_no_stock_amount', array( $this->sut, 'handle_option_updated' ), 10 );
+		remove_action( StockThresholdResync::RESYNC_BATCH_HOOK, array( $this->sut, 'process_batch' ), 10 );
+
+		delete_option( 'woocommerce_notify_no_stock_amount' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should not schedule any work when the threshold value is unchanged.
+	 */
+	public function test_no_schedule_when_threshold_unchanged(): void {
+		$this->sut->handle_option_updated( 5, 5 );
+
+		$this->assertSame( array(), $this->scheduled_actions, 'No actions should be scheduled when the threshold value did not change.' );
+	}
+
+	/**
+	 * @testdox Should not schedule any work when site-wide stock management is disabled.
+	 */
+	public function test_no_schedule_when_stock_management_disabled(): void {
+		update_option( 'woocommerce_manage_stock', 'no' );
+
+		$product = ProductHelper::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->set_stock_status( ProductStockStatus::IN_STOCK );
+		$product->save();
+
+		$this->sut->handle_option_updated( 0, 15 );
+
+		$this->assertSame( array(), $this->scheduled_actions, 'No actions should be scheduled when stock management is disabled.' );
+	}
+
+	/**
+	 * @testdox Should schedule a batch when raising the threshold catches an in-stock product.
+	 */
+	public function test_schedules_batch_when_raising_threshold_traps_instock_product(): void {
+		$product = ProductHelper::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->set_stock_status( ProductStockStatus::IN_STOCK );
+		$product->save();
+
+		$this->sut->handle_option_updated( 0, 15 );
+
+		$this->assertCount( 1, $this->scheduled_actions, 'Exactly one batch should be scheduled for the affected product.' );
+
+		$action = $this->scheduled_actions[0];
+		$this->assertSame( StockThresholdResync::RESYNC_BATCH_HOOK, $action['hook'] );
+		$this->assertIsArray( $action['args'] );
+		$this->assertCount( 1, $action['args'], 'The handler receives a single positional argument: the batch.' );
+		$this->assertContains( $product->get_id(), $action['args'][0], 'The affected product ID should be included in the scheduled batch.' );
+	}
+
+	/**
+	 * @testdox Should not schedule any work when no products would change status.
+	 */
+	public function test_no_schedule_when_no_products_affected(): void {
+		$product = ProductHelper::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 100 );
+		$product->set_stock_status( ProductStockStatus::IN_STOCK );
+		$product->save();
+
+		// Raising the threshold from 0 to 5 leaves a quantity-100 product comfortably in stock.
+		$this->sut->handle_option_updated( 0, 5 );
+
+		$this->assertSame( array(), $this->scheduled_actions, 'No actions should be scheduled when nothing crosses the new threshold.' );
+	}
+
+	/**
+	 * @testdox Should schedule a batch when lowering the threshold frees an out-of-stock product.
+	 */
+	public function test_schedules_batch_when_lowering_threshold_frees_outofstock_product(): void {
+		// Create a stock-managed product currently flagged out-of-stock with quantity above the new threshold.
+		$product = ProductHelper::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		// Force out-of-stock without altering quantity, simulating a state where a previous high threshold parked it out.
+		$product->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
+		$product->save();
+
+		$this->sut->handle_option_updated( 20, 5 );
+
+		$this->assertCount( 1, $this->scheduled_actions );
+		$this->assertContains( $product->get_id(), $this->scheduled_actions[0]['args'][0] );
+	}
+
+	/**
+	 * @testdox Should re-save products in a batch so validate_props re-derives stock status.
+	 */
+	public function test_process_batch_resaves_product_and_updates_stock_status(): void {
+		$product = ProductHelper::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->set_stock_status( ProductStockStatus::IN_STOCK );
+		$product->save();
+
+		// Raise the threshold so a fresh load through validate_props() must flip the status.
+		update_option( 'woocommerce_notify_no_stock_amount', 15 );
+
+		$this->sut->process_batch( array( $product->get_id() ) );
+
+		$reloaded = wc_get_product( $product->get_id() );
+		$this->assertSame(
+			ProductStockStatus::OUT_OF_STOCK,
+			$reloaded->get_stock_status(),
+			'The product should be flipped to out-of-stock after the batch runs.'
+		);
+	}
+
+	/**
+	 * @testdox Should split large affected sets into batches of at most 50 products.
+	 */
+	public function test_schedules_multiple_batches_for_large_affected_sets(): void {
+		$created_ids = array();
+		for ( $i = 0; $i < 60; $i++ ) {
+			$product = ProductHelper::create_simple_product();
+			$product->set_manage_stock( true );
+			$product->set_stock_quantity( 1 );
+			$product->set_stock_status( ProductStockStatus::IN_STOCK );
+			$product->save();
+			$created_ids[] = $product->get_id();
+		}
+
+		$this->sut->handle_option_updated( 0, 5 );
+
+		$this->assertGreaterThanOrEqual( 2, count( $this->scheduled_actions ), 'A 60-product affected set should split into at least 2 batches.' );
+
+		$batched_ids = array();
+		foreach ( $this->scheduled_actions as $action ) {
+			$batched_ids = array_merge( $batched_ids, $action['args'][0] );
+			$this->assertLessThanOrEqual( 50, count( $action['args'][0] ), 'No batch may exceed the configured batch size.' );
+		}
+
+		foreach ( $created_ids as $created_id ) {
+			$this->assertContains( $created_id, $batched_ids, "Product {$created_id} should appear in one of the scheduled batches." );
+		}
+	}
+
+	/**
+	 * @testdox Should silently skip products that no longer manage stock when processing a batch.
+	 */
+	public function test_process_batch_skips_products_no_longer_managing_stock(): void {
+		$product = ProductHelper::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->set_stock_status( ProductStockStatus::IN_STOCK );
+		$product->save();
+
+		// Simulate the merchant turning off stock management between scheduling and processing.
+		$product->set_manage_stock( false );
+		$product->save();
+
+		update_option( 'woocommerce_notify_no_stock_amount', 100 );
+
+		// Should not raise even though the product cannot be flipped via the threshold path.
+		$this->sut->process_batch( array( $product->get_id() ) );
+
+		$reloaded = wc_get_product( $product->get_id() );
+		$this->assertSame(
+			ProductStockStatus::IN_STOCK,
+			$reloaded->get_stock_status(),
+			'Stock status should be untouched for products that no longer manage stock.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #55422.

When the site-wide "Out of stock threshold" setting (`woocommerce_notify_no_stock_amount`) was changed, stock-managed products whose quantity now crossed the new threshold kept their previous `_stock_status` until the next product save or order. That left products purchasable below the new threshold (the three add-to-cart guards — `is_in_stock`, `has_enough_stock`, in-cart-quantity — all consult `_stock_status`, not the live threshold).

This PR adds a new internal class `Automattic\WooCommerce\Internal\StockThresholdResync` that:

1. Hooks `add_option_woocommerce_notify_no_stock_amount` and `update_option_woocommerce_notify_no_stock_amount`.
2. Skips when site-wide stock management is off, or the value did not change.
3. Issues one SELECT against `wc_product_meta_lookup` to enumerate the products whose recorded `stock_status` disagrees with the new threshold — covering both directions (raise: `instock` with qty ≤ threshold; lower: `outofstock`/`onbackorder` with qty > threshold).
4. Dispatches the affected IDs to Action Scheduler in batches of 50 under the `woocommerce-stock-threshold` group, hook `woocommerce_resync_stock_status_after_threshold_change`.
5. The batch handler reloads each product and calls `save()`, letting `WC_Product::validate_props()` re-derive the right status and update the product, the `wc_product_meta_lookup` mirror, and the `outofstock` `product_visibility` term in one consistent path.

Also updates the inventory setting description, which previously claimed the change did not affect existing in-stock products.

The recompute is deliberately async so the settings save returns immediately and large catalogs are processed in the background.

### Screenshots or screen recordings:

Backend only; no UI changes other than the setting description text.

### How to test the changes in this Pull Request:

1. Enable Manage Stock site-wide (**WooCommerce → Settings → Products → Inventory**, "Manage stock?" checked).
2. Set the **Out of stock threshold** to 0 and save.
3. Create a simple product with quantity 10 and stock status In stock. Confirm the shop page shows it as purchasable.
4. Go back to **Inventory** settings, change the threshold to 15, save.
5. Wait for Action Scheduler to process (or run `wp action-scheduler run --group=woocommerce-stock-threshold`). Reload the product / shop page.
6. Expected: the product is now **out of stock** and the Add to cart button is gone. The Out of stock taxonomy term is attached. `wc_product_meta_lookup.stock_status` is `outofstock`.
7. Lower the threshold back to 0, save. After Action Scheduler runs, the product should return to **in stock**.
8. Repeat with a managed-stock product that allows backorders — it should land on `onbackorder` instead of `outofstock` when caught by a raised threshold.
9. Repeat with a product that does **not** manage stock — its status should remain untouched after the threshold changes.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- `composer exec -- phpstan analyse src/Internal/StockThresholdResync.php includes/class-woocommerce.php includes/admin/settings/class-wc-settings-products.php --memory-limit=2G` — no errors, baseline untouched.
- New PHPUnit coverage in `tests/php/src/Internal/StockThresholdResyncTest.php` (7 cases) covers: unchanged value short-circuit, manage-stock-off short-circuit, raising threshold flips in-stock products, lowering threshold frees out-of-stock products, batch chunking at 50, no scheduling when nothing is affected, and skipping products that have since stopped managing stock.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

A changelog entry is already committed at `plugins/woocommerce/changelog/fix-rsmapgj-274`, so the automated entry is not needed.

---

Linear: https://linear.app/a8c/issue/RSMAPGJ-274

RSMAPGJ AI Coder pipeline.