### PR TITLE
Fix: do not auto-create account during shortcode checkout when signup is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-272
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-272
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Align shortcode checkout account creation with the Store API: do not auto-create a customer account when checkout signup is disabled in the store settings, even if `woocommerce_checkout_registration_required` is filtered to true.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1160,6 +1160,47 @@ class WC_Checkout {
 	}
 
 	/**
+	 * Decide whether a new customer account should be created during checkout.
+	 *
+	 * Mirrors the Store API logic in
+	 * `Automattic\WooCommerce\StoreApi\Routes\V1\Checkout::should_create_customer_account()`
+	 * so that shortcode and block-based checkouts behave consistently:
+	 *
+	 *  - Never create an account when the shopper is already logged in.
+	 *  - Never create an account when checkout signup is disabled in the
+	 *    store settings (`woocommerce_enable_signup_and_login_from_checkout`).
+	 *  - Force account creation when registration is required (i.e. guest
+	 *    checkout is disabled).
+	 *  - Otherwise create the account only when the shopper explicitly
+	 *    opted-in via the "Create an account?" checkbox.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param array $data Posted data.
+	 * @return bool True if a new customer account should be created.
+	 */
+	protected function should_create_customer_account( $data ) {
+		if ( is_user_logged_in() ) {
+			return false;
+		}
+
+		// If checkout signup is disabled, never auto-create an account, even
+		// if `woocommerce_checkout_registration_required` is filtered to true
+		// without a corresponding way to opt-in.
+		if ( ! $this->is_registration_enabled() ) {
+			return false;
+		}
+
+		// Guest checkout is disabled, so an account is required to complete checkout.
+		if ( $this->is_registration_required() ) {
+			return true;
+		}
+
+		// Shopper explicitly ticked the "Create an account?" checkbox.
+		return ! empty( $data['createaccount'] );
+	}
+
+	/**
 	 * Create a new customer account if needed.
 	 *
 	 * @throws Exception When not able to create customer.
@@ -1173,7 +1214,7 @@ class WC_Checkout {
 		 */
 		$customer_id = apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() );
 
-		if ( ! is_user_logged_in() && ( $this->is_registration_required() || ! empty( $data['createaccount'] ) ) ) {
+		if ( $this->should_create_customer_account( $data ) ) {
 			$username    = ! empty( $data['account_username'] ) ? $data['account_username'] : '';
 			$password    = ! empty( $data['account_password'] ) ? $data['account_password'] : '';
 			$customer_id = wc_create_new_customer(

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -30,6 +30,10 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			public function validate_checkout( &$data, &$errors ) {
 				return parent::validate_checkout( $data, $errors );
 			}
+
+			public function should_create_customer_account( $data ) {
+				return parent::should_create_customer_account( $data );
+			}
 		};
 		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
 
@@ -247,6 +251,74 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->assertNull( $sut->get_value( 'billing_country' ) );
 
 		WC()->customer = $orig_customer;
+	}
+
+	/**
+	 * @testdox `should_create_customer_account` returns false when the shopper is already logged in.
+	 */
+	public function test_should_create_customer_account_returns_false_when_logged_in() {
+		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( $this->sut->should_create_customer_account( array( 'createaccount' => 1 ) ) );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * @testdox `should_create_customer_account` returns false when checkout signup is disabled, even if `createaccount` is present.
+	 */
+	public function test_should_create_customer_account_returns_false_when_registration_disabled() {
+		wp_set_current_user( 0 );
+
+		// Override the global setUp filter that forces registration enabled.
+		remove_filter( 'woocommerce_checkout_registration_enabled', '__return_true' );
+		add_filter( 'woocommerce_checkout_registration_enabled', '__return_false' );
+
+		$this->assertFalse( $this->sut->should_create_customer_account( array( 'createaccount' => 1 ) ) );
+
+		remove_filter( 'woocommerce_checkout_registration_enabled', '__return_false' );
+		add_filter( 'woocommerce_checkout_registration_enabled', '__return_true' );
+	}
+
+	/**
+	 * @testdox `should_create_customer_account` returns true when registration is required (guest checkout disabled).
+	 */
+	public function test_should_create_customer_account_returns_true_when_registration_required() {
+		wp_set_current_user( 0 );
+
+		add_filter( 'woocommerce_checkout_registration_required', '__return_true' );
+
+		$this->assertTrue( $this->sut->should_create_customer_account( array( 'createaccount' => 0 ) ) );
+
+		remove_filter( 'woocommerce_checkout_registration_required', '__return_true' );
+	}
+
+	/**
+	 * @testdox `should_create_customer_account` returns false for guests who did not tick the create-account checkbox.
+	 */
+	public function test_should_create_customer_account_returns_false_when_checkbox_not_ticked() {
+		wp_set_current_user( 0 );
+
+		add_filter( 'woocommerce_checkout_registration_required', '__return_false' );
+
+		$this->assertFalse( $this->sut->should_create_customer_account( array( 'createaccount' => 0 ) ) );
+		$this->assertFalse( $this->sut->should_create_customer_account( array() ) );
+
+		remove_filter( 'woocommerce_checkout_registration_required', '__return_false' );
+	}
+
+	/**
+	 * @testdox `should_create_customer_account` returns true for guests who ticked the create-account checkbox.
+	 */
+	public function test_should_create_customer_account_returns_true_when_checkbox_ticked() {
+		wp_set_current_user( 0 );
+
+		add_filter( 'woocommerce_checkout_registration_required', '__return_false' );
+
+		$this->assertTrue( $this->sut->should_create_customer_account( array( 'createaccount' => 1 ) ) );
+
+		remove_filter( 'woocommerce_checkout_registration_required', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The shortcode checkout (`WC_Checkout::process_customer()`) and the Store API checkout (`Automattic\WooCommerce\StoreApi\Routes\V1\Checkout::should_create_customer_account()`) used different rules to decide whether a customer account should be created at checkout. The Store API correctly refuses to auto-create an account when `is_registration_enabled()` is `false` (i.e. the **Account creation during checkout** setting is off). The shortcode path did not check that setting at all and only consulted `is_registration_required()` (the **Allow guest checkout** setting). The result is that an extension or custom filter that sets `woocommerce_checkout_registration_required` to `true` while signup-during-checkout is disabled in the store admin can still cause silent account creation on the shortcode checkout — there is no checkbox shown, no opt-in, and no consistency with the Store API.

This PR introduces a `WC_Checkout::should_create_customer_account()` helper that mirrors the Store API logic and routes `process_customer()` through it:

- Never create an account when the shopper is already logged in.
- Never create an account when `is_registration_enabled()` is `false`, even if `is_registration_required()` is filtered to `true`.
- Force account creation when `is_registration_required()` is `true` (guest checkout disabled) and signup is enabled.
- Otherwise honour the explicit "Create an account?" checkbox.

A new test case in `WC_Checkout_Test` exercises each branch of the helper.

Closes #56632.

Linear: https://linear.app/a8c/issue/RSMAPGJ-272

### How to test the changes in this Pull Request:

1. In **WooCommerce -> Settings -> Accounts & Privacy**, uncheck **Allow customers to create an account during checkout** and uncheck **Account creation: During checkout**. Keep **Allow guest checkout** enabled.
2. In a snippet, force-require registration:
   ```php
   add_filter( 'woocommerce_checkout_registration_required', '__return_true' );
   ```
3. Add a product to the cart, go to the **shortcode** (classic) checkout, fill in billing details with a brand-new email, and place the order.
4. Before the fix: `wp user list --search=<email>` returns a customer. After the fix: no customer is created.
5. Remove the filter, enable both **Allow guest checkout** and **Account creation: During checkout**, tick the "Create an account?" checkbox at checkout, and verify a customer account IS created (no regression in the normal path).
6. With guest checkout disabled and signup-during-checkout enabled, place a guest order via the shortcode checkout and verify an account is still force-created (no regression).

### Testing that has already taken place:

- New PHPUnit cases in `plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php` cover: logged-in shopper, signup disabled, registration required, checkbox unticked, and checkbox ticked.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch` pass.
- `composer exec -- phpstan analyse includes/class-wc-checkout.php --memory-limit=2G` passes with no new errors.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] Changelog entry created manually (`plugins/woocommerce/changelog/fix-rsmapgj-272`).

---

_Submitted via the RSMAPGJ AI Coder pipeline._