### PR TITLE
Apply default locale to block checkout before a country is chosen

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-268
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-268
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply block checkout core field customizations from `woocommerce_get_country_locale_default` and the order of additional checkout fields on first render, before the customer selects a country.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -96,10 +96,26 @@ const prepareFormFields = (
 	// Address country code. If unknown, locale fields will not be merged.
 	addressCountry = ''
 ): KeyedFormFields => {
-	const localeConfigs =
+	// When a country is selected, use that country's locale overrides.
+	// When no country is selected (or the selected country has no specific locale),
+	// fall back to the default locale so customizations registered via
+	// `woocommerce_get_country_locale_default` (and the ordering/visibility of
+	// additional checkout fields injected into the default locale) are applied
+	// on first render. Without this fallback, customers landing on the block
+	// checkout in a fresh session would see the unfiltered defaults until they
+	// selected a country.
+	const defaultLocaleConfigs =
+		countryAddressFields.default !== undefined
+			? countryAddressFields.default
+			: {};
+	const countryLocaleConfigs =
 		addressCountry && countryAddressFields[ addressCountry ] !== undefined
 			? countryAddressFields[ addressCountry ]
 			: {};
+	const localeConfigs = {
+		...defaultLocaleConfigs,
+		...countryLocaleConfigs,
+	};
 
 	return fieldKeys
 		.map( ( field ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/test/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/test/prepare-form-fields.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression test for woocommerce#60542.
+ *
+ * Block checkout core field customizations applied via the
+ * `woocommerce_get_country_locale_default` filter (and the ordering/visibility
+ * of additional checkout fields injected into the default locale) must be
+ * applied on first render — before the customer chooses a country.
+ *
+ * The fix exposes a `default` entry in COUNTRY_LOCALE and uses it as a fallback
+ * in prepareFormFields when no country has been selected yet.
+ */
+
+jest.mock( '@woocommerce/block-settings', () => ( {
+	COUNTRY_LOCALE: {
+		default: {
+			last_name: { hidden: true, required: false },
+			first_name: { label: 'Full name', index: 5 },
+			'my-plugin/hello': { index: 11 },
+		},
+		US: {
+			postcode: { label: 'ZIP Code' },
+		},
+	},
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import prepareFormFields from '../prepare-form-fields';
+
+const defaultFields = {
+	first_name: {
+		label: 'First name',
+		required: true,
+		hidden: false,
+		index: 10,
+	},
+	last_name: {
+		label: 'Last name',
+		required: true,
+		hidden: false,
+		index: 20,
+	},
+	postcode: {
+		label: 'Postal code',
+		required: true,
+		hidden: false,
+		index: 90,
+	},
+	'my-plugin/hello': {
+		label: "Hey, I'm the first field!",
+		required: false,
+		hidden: false,
+		index: 25,
+	},
+} as never;
+
+const ADDRESS_KEYS = [
+	'first_name',
+	'last_name',
+	'postcode',
+	'my-plugin/hello',
+] as never;
+
+describe( 'prepareFormFields', () => {
+	it( 'applies the default locale when no country is selected', () => {
+		const fields = prepareFormFields( ADDRESS_KEYS, defaultFields, '' );
+
+		const byKey = Object.fromEntries(
+			fields.map( ( f ) => [ f.key, f ] )
+		);
+
+		// last_name hidden by woocommerce_get_country_locale_default.
+		expect( byKey.last_name.hidden ).toBe( true );
+		expect( byKey.last_name.required ).toBe( false );
+
+		// first_name relabelled and its index pulled forward via the default
+		// locale's `priority` value.
+		expect( byKey.first_name.label ).toBe( 'Full name' );
+		expect( byKey.first_name.index ).toBe( 5 );
+
+		// Additional field ordering applied via the default locale.
+		expect( byKey[ 'my-plugin/hello' ].index ).toBe( 11 );
+	} );
+
+	it( 'lets a selected country locale override the default locale', () => {
+		const fields = prepareFormFields( ADDRESS_KEYS, defaultFields, 'US' );
+		const byKey = Object.fromEntries(
+			fields.map( ( f ) => [ f.key, f ] )
+		);
+
+		// Default-locale customizations still apply where the country locale
+		// is silent.
+		expect( byKey.last_name.hidden ).toBe( true );
+		expect( byKey.first_name.label ).toBe( 'Full name' );
+
+		// Country-specific override wins for postcode.
+		expect( byKey.postcode.label ).toBe( 'ZIP Code' );
+	} );
+
+	it( 'returns fields ordered by the resolved index', () => {
+		const fields = prepareFormFields( ADDRESS_KEYS, defaultFields, '' );
+		const keysInOrder = fields.map( ( f ) => f.key );
+
+		// first_name index 5, my-plugin/hello index 11, last_name index 20, postcode index 90.
+		expect( keysInOrder ).toEqual( [
+			'first_name',
+			'my-plugin/hello',
+			'last_name',
+			'postcode',
+		] );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
@@ -116,6 +116,13 @@ export const COUNTRY_LOCALE = Object.fromEntries(
 	} )
 );
 
+// Include the default locale (filtered via `woocommerce_get_country_locale_default`
+// and augmented with additional checkout field overrides) so locale-driven
+// customizations apply before the customer has chosen a country.
+if ( countryData.default?.locale ) {
+	COUNTRY_LOCALE.default = countryData.default.locale;
+}
+
 const defaultFieldsLocations: FieldsLocations = {
 	address: [
 		'first_name',

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -380,6 +380,21 @@ class CartCheckoutUtils {
 			);
 		}
 
+		// Expose the default locale so the client can apply locale-driven core
+		// field customizations (e.g. `woocommerce_get_country_locale_default`
+		// and ordering of additional checkout fields) before the customer has
+		// chosen a country. Without this entry, the block checkout falls back
+		// to the unfiltered defaults on first render and only applies the
+		// filter after a country is selected.
+		if ( isset( $country_locales['default'] ) ) {
+			$country_data['default'] = array(
+				'allowBilling'  => false,
+				'allowShipping' => false,
+				'states'        => array(),
+				'locale'        => $country_locales['default'],
+			);
+		}
+
 		return $country_data;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
@@ -328,4 +328,50 @@ class CartCheckoutUtilsTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	/**
+	 * Ensure get_country_data() exposes a `default` locale entry so block
+	 * checkout customizations applied via `woocommerce_get_country_locale_default`
+	 * are available to the client before the customer selects a country.
+	 *
+	 * Regression test for woocommerce#60542.
+	 */
+	public function test_get_country_data_exposes_default_locale() {
+		$filter = function ( $locale ) {
+			$locale['last_name']['hidden']   = true;
+			$locale['last_name']['required'] = false;
+			$locale['first_name']['label']   = 'Full name';
+			return $locale;
+		};
+
+		add_filter( 'woocommerce_get_country_locale_default', $filter );
+
+		// Reset the cached locale so the filter is applied on the next read.
+		WC()->countries->locale = array();
+
+		$data = CartCheckoutUtils::get_country_data();
+
+		remove_filter( 'woocommerce_get_country_locale_default', $filter );
+		WC()->countries->locale = array();
+
+		$this->assertArrayHasKey( 'default', $data, 'Default locale entry should be exposed.' );
+		$this->assertArrayHasKey( 'locale', $data['default'] );
+		$this->assertTrue(
+			! empty( $data['default']['locale']['last_name']['hidden'] ),
+			'Default locale should reflect the woocommerce_get_country_locale_default filter (hidden last_name).'
+		);
+		$this->assertSame(
+			'Full name',
+			$data['default']['locale']['first_name']['label'] ?? null,
+			'Default locale should reflect the woocommerce_get_country_locale_default filter (relabelled first_name).'
+		);
+		$this->assertFalse(
+			$data['default']['allowBilling'],
+			'Default locale entry must not be treated as an allowed billing country.'
+		);
+		$this->assertFalse(
+			$data['default']['allowShipping'],
+			'Default locale entry must not be treated as an allowed shipping country.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

When a customer lands on the block checkout in a fresh session (no country selected yet), customizations applied via `woocommerce_get_country_locale_default` and the ordering of additional checkout fields registered with `woocommerce_register_additional_checkout_field` were not reflected in the rendered form. The customizations only took effect after the customer explicitly selected a country.

Two related gaps caused this:

1. `CartCheckoutUtils::get_country_data()` only walked the keys of allowed/shipping countries when building the `countryData` payload sent to the client, so the filtered `default` locale entry from `WC_Countries::get_country_locale()` was dropped on the server before reaching the block.
2. The client-side `prepareFormFields` short-circuited locale resolution to `{}` whenever `addressCountry` was empty, so even with the default locale data available it would fall back to the raw `defaultFields`.

This PR:

- Exposes the filtered default locale through `countryData.default.locale` (with `allowBilling`/`allowShipping` set to `false`, so it never participates in country selection), and surfaces it as `COUNTRY_LOCALE.default` on the client.
- Uses `COUNTRY_LOCALE.default` as the locale fallback in `prepareFormFields`. Country-specific locale entries still win when a country is selected.

Closes #60542.
Linear: https://linear.app/a8c/issue/RSMAPGJ-268

### How to test the changes in this Pull Request:

Drop the following mu-plugin into a test site running this branch:

```php
<?php
add_filter( 'woocommerce_get_country_locale_default', function ( $locale ) {
    $locale['last_name']['hidden']   = true;
    $locale['last_name']['required'] = false;
    $locale['first_name']['label']   = 'Full name';
    return $locale;
} );

add_action( 'woocommerce_blocks_loaded', function () {
    woocommerce_register_additional_checkout_field( array(
        'id'       => 'rsm-test/first-field',
        'label'    => "Hey, I'm the first field!",
        'location' => 'address',
        'type'     => 'text',
        'required' => false,
    ) );
} );

add_filter( 'woocommerce_get_country_locale_default', function ( $locale ) {
    if ( isset( $locale['rsm-test/first-field'] ) ) {
        $locale['rsm-test/first-field']['index'] = 5;
    }
    return $locale;
}, 20 );
```

1. Add any product to the cart.
2. Open the block checkout in an incognito window (no prior country selection).
3. Confirm on first render — without selecting a country — that:
   - The "Last name" field is hidden.
   - The "First name" field is labelled "Full name".
   - The "Hey, I'm the first field!" custom field renders before the name fields (ordered by the locale-supplied index).
4. Select a country and confirm the customizations still apply (country-specific locale entries can still override).

### Testing that has already taken place:

- Unit test in `tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php` exercising `get_country_data()` with a `woocommerce_get_country_locale_default` filter and asserting the new `default` locale entry surfaces the filtered values.
- Jest test in `assets/js/base/components/cart-checkout/form/test/prepare-form-fields.ts` confirming the default locale is applied when no country is selected, that country-specific overrides still win, and that fields are sorted by the resolved index.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `lint:changes:branch` pass.
- `phpstan analyse src/Blocks/Utils/CartCheckoutUtils.php` reports no errors.

### Changelog entry

- [x] This Pull Request does not require a changelog entry.

Changelog entry already added at `plugins/woocommerce/changelog/fix-rsmapgj-268`.

---

Submitted via the RSMAPGJ AI Coder pipeline.