### PR TITLE
Fix unreadable delta badge in Analytics Summary (RSMAPGJ-291)

### DIFF
--- a/packages/js/components/changelog/fix-rsmapgj-291
+++ b/packages/js/components/changelog/fix-rsmapgj-291
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unreadable delta badge text in the Analytics Summary component by ensuring the badge's text color is inherited by nested Text elements, restoring the intended white-on-red and white-on-green contrast.

--- a/packages/js/components/src/summary/style.scss
+++ b/packages/js/components/src/summary/style.scss
@@ -343,6 +343,14 @@ $border: $gray-200;
 		height: min-content;
 		background-color: $gray-100;
 		color: $gray-900;
+
+		// The delta value is rendered inside a `Text` component from
+		// `@wordpress/components`, which applies its own `color`. Force
+		// the inner text to inherit the badge color so good/bad trend
+		// colors are not overridden — see RSMAPGJ-291 / woo#37987.
+		* {
+			color: inherit;
+		}
 	}
 
 	&.is-selected {

--- a/packages/js/components/src/summary/test/number.js
+++ b/packages/js/components/src/summary/test/number.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import SummaryNumber from '../number';
+
+describe( 'SummaryNumber', () => {
+	test( 'applies the is-bad-trend class for a negative delta so the badge gets the high-contrast accessible color (RSMAPGJ-291 / woo#37987)', () => {
+		const { container } = render(
+			<SummaryNumber
+				label="Total sales"
+				value="$100"
+				prevValue="$200"
+				delta={ -50 }
+			/>
+		);
+
+		const item = container.querySelector( '.woocommerce-summary__item' );
+		expect( item ).not.toBeNull();
+		expect( item.classList.contains( 'is-bad-trend' ) ).toBe( true );
+		expect( item.classList.contains( 'is-good-trend' ) ).toBe( false );
+
+		// The delta badge must be rendered — the CSS rule that gives it the
+		// accessible white text depends on this element + the is-bad-trend
+		// class on its ancestor.
+		const delta = container.querySelector(
+			'.woocommerce-summary__item-delta'
+		);
+		expect( delta ).not.toBeNull();
+	} );
+
+	test( 'applies the is-good-trend class for a positive delta', () => {
+		const { container } = render(
+			<SummaryNumber
+				label="Total sales"
+				value="$300"
+				prevValue="$200"
+				delta={ 50 }
+			/>
+		);
+
+		const item = container.querySelector( '.woocommerce-summary__item' );
+		expect( item.classList.contains( 'is-good-trend' ) ).toBe( true );
+		expect( item.classList.contains( 'is-bad-trend' ) ).toBe( false );
+	} );
+
+	test( 'inverts good/bad trend classes when reverseTrend is set', () => {
+		const { container } = render(
+			<SummaryNumber
+				label="Refunds"
+				value="$50"
+				prevValue="$10"
+				delta={ 50 }
+				reverseTrend
+			/>
+		);
+
+		const item = container.querySelector( '.woocommerce-summary__item' );
+		expect( item.classList.contains( 'is-bad-trend' ) ).toBe( true );
+		expect( item.classList.contains( 'is-good-trend' ) ).toBe( false );
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-rsmapgj-291
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-291
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unreadable delta badge text in the Analytics Summary component so the percentage change renders in high-contrast white on the red/green background.


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Tooling for WooCommerce Development](https://github.com/woocommerce/woocommerce/wiki/Recommended-Tooling-for-WooCommerce-Development).

### Changes proposed in this Pull Request

The delta percentage in the WooCommerce Analytics Summary component is rendered inside a `Text` element from `@wordpress/components`. That element applies its own `color`, which overrode the badge's intended `$white` foreground on `.is-good-trend` and `.is-bad-trend`. As a result, the badge showed dark text on a red/green background and failed WCAG contrast requirements.

This PR forces the inner Text element to inherit the badge color so the existing white-on-red / white-on-green styling from `summary/style.scss` is actually applied at the leaf node. It also adds a Jest regression test that asserts the `is-bad-trend` / `is-good-trend` classes are wired onto the badge container for negative / positive deltas (and inverted via `reverseTrend`), so future refactors of `SummaryNumber` won't silently regress the trend styling that the contrast fix depends on.

Closes #37987
Linear: https://linear.app/a8c/issue/RSMAPGJ-291

### Screenshots or screen recordings

The screenshots and Figma reference from the original issue (#37987) show the bug: black text on the red `is-bad-trend` badge. After this change the badge renders the percentage in white.

### How to test the changes in this Pull Request

1. Check out this branch and run `pnpm --filter=@woocommerce/components build`.
2. Boot a WooCommerce dev environment with the package built in.
3. Create at least one completed order for the current period and one for the previous period so the Analytics Summary has a non-zero delta (or use the blueprint script in the Linear issue's reproduction plan).
4. Visit `wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`.
5. Wait for `.woocommerce-summary` to render and inspect a Summary card whose delta is negative (red `is-bad-trend` badge) or positive (green `is-good-trend` badge).
6. Confirm the percentage text inside the badge is white (`rgb(255, 255, 255)`) instead of near-black, and that the badge now meets contrast requirements visually.

You can also run the regression tests directly:

```sh
pnpm --filter=@woocommerce/components test:js -- --testPathPattern=summary
```

### Testing that has already taken place

- Added Jest tests in `packages/js/components/src/summary/test/number.js` covering the `is-bad-trend`, `is-good-trend`, and `reverseTrend` branches; all three pass locally.
- Manually walked through the SCSS cascade to confirm that `* { color: inherit; }` inside `.woocommerce-summary__item-delta` lets the trend colors (`$white`) defined on `.is-good-trend .woocommerce-summary__item-delta` / `.is-bad-trend .woocommerce-summary__item-delta` reach the `Text` element produced by `@wordpress/components`.

### Changelog entries

- [x] Automatically create a changelog entry from the details below.

<!--
Reviewer: If a Changelog entry is required, the author should provide a Changelog entry in the following format. If the Changelog entry is not required (this is a developer-only change), please mark the PR with the `team: Developer Advocacy` label.
-->

#### Changelog significance
- [ ] **Patch:** Backwards-compatible bug fixes.
- [x] **Minor:** Adds functionality in a backwards-compatible manner.
- [ ] **Major:** Breaking changes.

#### Changelog type
- [x] **Fix:** Fixes an existing bug.

#### Message
Fix unreadable delta badge text in the Analytics Summary component so the percentage change renders in high-contrast white on the red/green background.

#### Comment (optional)
Both `plugins/woocommerce/changelog/fix-rsmapgj-291` and `packages/js/components/changelog/fix-rsmapgj-291` were added manually.

---

Submitted via the **RSMAPGJ AI Coder pipeline**.