### PR TITLE
Fix variation matching and pre-selection for non-ASCII attribute slugs

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-269
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-269
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix variation matching, pre-selection and permalink generation when product attribute taxonomies or term slugs use non-ASCII characters such as Greek

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -511,6 +511,13 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * Set attributes. Unlike the parent product which uses terms, variations are assigned
 	 * specific attributes using name value pairs.
 	 *
+	 * Attribute keys are normalised with `sanitize_title()` so they line up with the
+	 * keys stored in the parent product's `_product_attributes` meta (which also
+	 * uses the sanitised form). Without this, non-ASCII attribute taxonomy names
+	 * (e.g. Greek `pa_χρώμα`) would be stored as raw meta keys while the rest of
+	 * the codebase looks them up in percent-encoded form, breaking variation
+	 * matching and pre-selection. See woo#59199.
+	 *
 	 * @param array $raw_attributes array of raw attributes.
 	 */
 	public function set_attributes( $raw_attributes ) {
@@ -522,7 +529,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 			if ( 0 === strpos( $key, 'attribute_' ) ) {
 				$key = substr( $key, 10 );
 			}
-			$attributes[ $key ] = $value;
+			$attributes[ sanitize_title( $key ) ] = $value;
 		}
 		$this->set_prop( 'attributes', $attributes );
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1462,17 +1462,48 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			return 0;
 		}
 
+		// Normalise incoming attribute keys to the sanitised form used internally so
+		// that callers passing raw (un-percent-encoded) keys for non-ASCII attribute
+		// taxonomy names also match. See woo#59199.
+		if ( ! empty( $match_attributes ) ) {
+			$normalised_match_attributes = array();
+			foreach ( $match_attributes as $key => $value ) {
+				if ( is_string( $key ) && 0 === strpos( $key, 'attribute_' ) ) {
+					$normalised_key = 'attribute_' . sanitize_title( substr( $key, 10 ) );
+				} else {
+					$normalised_key = $key;
+				}
+				// First occurrence wins; this preserves explicit sanitised keys when callers pass both.
+				if ( ! array_key_exists( $normalised_key, $normalised_match_attributes ) ) {
+					$normalised_match_attributes[ $normalised_key ] = $value;
+				}
+			}
+			$match_attributes = $normalised_match_attributes;
+		}
+
 		global $wpdb;
 
 		$meta_attribute_names = array();
+		// Map of raw attribute meta key -> sanitised meta key. Used to normalise legacy
+		// variation meta where keys for non-ASCII attribute taxonomy names (e.g. Greek
+		// `pa_χρώμα`) were stored in raw rather than percent-encoded form. See woo#59199.
+		$meta_key_alias_map = array();
 
 		// Get attributes to match in meta.
 		foreach ( $product->get_attributes() as $attribute ) {
 			if ( ! $attribute->get_variation() ) {
 				continue;
 			}
-			$meta_attribute_names[] = 'attribute_' . sanitize_title( $attribute->get_name() );
+			$sanitized_meta_key     = 'attribute_' . sanitize_title( $attribute->get_name() );
+			$raw_meta_key           = 'attribute_' . $attribute->get_name();
+			$meta_attribute_names[] = $sanitized_meta_key;
+			if ( $raw_meta_key !== $sanitized_meta_key ) {
+				$meta_attribute_names[]              = $raw_meta_key;
+				$meta_key_alias_map[ $raw_meta_key ] = $sanitized_meta_key;
+			}
 		}
+
+		$meta_attribute_names = array_values( array_unique( $meta_attribute_names ) );
 
 		// Get the attributes of the variations.
 		$query = $wpdb->prepare(
@@ -1502,7 +1533,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$sorted_meta = array();
 
 		foreach ( $attributes as $m ) {
-			$sorted_meta[ $m->post_id ][ $m->meta_key ] = $m->meta_value; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$meta_key = isset( $meta_key_alias_map[ $m->meta_key ] ) ? $meta_key_alias_map[ $m->meta_key ] : $m->meta_key;
+			// If both a raw and a sanitised version exist for the same variation, prefer the sanitised one.
+			if ( isset( $sorted_meta[ $m->post_id ][ $meta_key ] ) && $meta_key !== $m->meta_key ) {
+				continue;
+			}
+			$sorted_meta[ $m->post_id ][ $meta_key ] = $m->meta_value; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		}
 
 		/**

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1178,10 +1178,25 @@ function wc_get_product_variation_attributes( $variation_id ) {
 
 	// Get the variation attributes from meta.
 	foreach ( $all_meta as $name => $value ) {
-		// Only look at valid attribute meta, and also compare variation level attributes and remove any which do not exist at parent level.
-		if ( 0 !== strpos( $name, 'attribute_' ) || ! in_array( $name, $found_parent_attributes, true ) ) {
+		// Only look at valid attribute meta.
+		if ( 0 !== strpos( $name, 'attribute_' ) ) {
 			unset( $variation_attributes[ $name ] );
 			continue;
+		}
+
+		// Backward compatibility: historically, variation meta keys for taxonomy attributes
+		// with non-ASCII names (e.g. Greek `pa_χρώμα`) could be stored in raw form while
+		// the rest of the codebase looks them up in percent-encoded (sanitize_title) form,
+		// causing the variation to look "empty". Normalise the key so existing data still
+		// reads correctly. See woo#59199.
+		if ( ! in_array( $name, $found_parent_attributes, true ) ) {
+			$sanitized_name = 'attribute_' . sanitize_title( substr( $name, 10 ) );
+			if ( $sanitized_name !== $name && in_array( $sanitized_name, $found_parent_attributes, true ) ) {
+				$name = $sanitized_name;
+			} else {
+				unset( $variation_attributes[ $name ] );
+				continue;
+			}
 		}
 		/**
 		 * Pre 2.4 handling where 'slugs' were saved instead of the full text attribute.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3571,8 +3571,20 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 		// Get selected value.
 		if ( false === $args['selected'] && $args['attribute'] && $args['product'] instanceof WC_Product ) {
 			$selected_key = 'attribute_' . sanitize_title( $args['attribute'] );
+			// Direct URLs may pass the attribute key in raw (un-percent-encoded) form for
+			// non-ASCII taxonomy slugs (e.g. `?attribute_pa_χρώμα=κόκκινο`), which PHP
+			// surfaces in `$_REQUEST` as the raw key rather than the percent-encoded one.
+			// Fall back to that form so pre-selection works regardless of how the URL was
+			// constructed. See woo#59199.
+			$raw_selected_key = 'attribute_' . $args['attribute'];
 			// phpcs:disable WordPress.Security.NonceVerification.Recommended
-			$args['selected'] = isset( $_REQUEST[ $selected_key ] ) ? wc_clean( wp_unslash( $_REQUEST[ $selected_key ] ) ) : $args['product']->get_variation_default_attribute( $args['attribute'] );
+			if ( isset( $_REQUEST[ $selected_key ] ) ) {
+				$args['selected'] = wc_clean( wp_unslash( $_REQUEST[ $selected_key ] ) );
+			} elseif ( $raw_selected_key !== $selected_key && isset( $_REQUEST[ $raw_selected_key ] ) ) {
+				$args['selected'] = wc_clean( wp_unslash( $_REQUEST[ $raw_selected_key ] ) );
+			} else {
+				$args['selected'] = $args['product']->get_variation_default_attribute( $args['attribute'] );
+			}
 			// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -430,6 +430,138 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that a variation with a non-ASCII (Greek) attribute taxonomy slug stores
+	 * its attribute meta in the percent-encoded (sanitize_title) form so the rest of
+	 * the codebase can read it back. Regression test for woo#59199.
+	 */
+	public function test_variation_save_attributes_with_non_ascii_taxonomy_slug() {
+		$taxonomy_slug = 'χρώμα';
+		$taxonomy      = 'pa_' . $taxonomy_slug;
+		$term_slug     = 'κόκκινο';
+
+		$attribute_id = wc_create_attribute(
+			array(
+				'name'         => 'Χρώμα',
+				'slug'         => $taxonomy_slug,
+				'type'         => 'select',
+				'order_by'     => 'menu_order',
+				'has_archives' => false,
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			register_taxonomy( $taxonomy, 'product' );
+		}
+
+		$red_term = wp_insert_term( 'Κόκκινο', $taxonomy, array( 'slug' => $term_slug ) );
+		$this->assertIsArray( $red_term );
+
+		$product   = new WC_Product_Variable();
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( $attribute_id );
+		$attribute->set_name( $taxonomy );
+		$attribute->set_options( array( $red_term['term_id'] ) );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_attributes( array( $taxonomy => $term_slug ) );
+		$variation->set_regular_price( '20' );
+		$variation->set_status( ProductStatus::PUBLISH );
+		$variation->save();
+
+		// Meta should be stored under the sanitised key (same form the parent uses).
+		$sanitized_meta_key = 'attribute_' . sanitize_title( $taxonomy );
+		$meta_value         = get_post_meta( $variation->get_id(), $sanitized_meta_key, true );
+		$this->assertSame( $term_slug, $meta_value );
+
+		// The legacy raw-key meta should not be set for freshly saved variations.
+		$raw_meta_key = 'attribute_' . $taxonomy;
+		$this->assertSame( '', get_post_meta( $variation->get_id(), $raw_meta_key, true ) );
+
+		// Reloading the variation should expose the value (not an empty "any").
+		$reloaded   = wc_get_product( $variation->get_id() );
+		$attributes = $reloaded->get_attributes( 'edit' );
+		$this->assertSame( $term_slug, $attributes[ sanitize_title( $taxonomy ) ] );
+
+		// find_matching_product_variation should locate the variation when given
+		// either the raw URL form or the sanitised form of the attribute key.
+		$data_store = $product->get_data_store();
+		$this->assertSame(
+			$variation->get_id(),
+			$data_store->find_matching_product_variation( $product, array( $raw_meta_key => $term_slug ) )
+		);
+		$this->assertSame(
+			$variation->get_id(),
+			$data_store->find_matching_product_variation( $product, array( $sanitized_meta_key => $term_slug ) )
+		);
+
+		// Permalink should carry the attribute query arg (cart -> product link path).
+		$permalink = $reloaded->get_permalink();
+		$this->assertNotFalse( strpos( $permalink, 'attribute_pa_' ) );
+		$this->assertNotFalse( strpos( $permalink, rawurlencode( $term_slug ) ) );
+	}
+
+	/**
+	 * Tests find_matching_product_variation against legacy raw-key meta written by
+	 * older WooCommerce versions for non-ASCII attribute taxonomy names. Regression
+	 * test for woo#59199.
+	 */
+	public function test_find_matching_product_variation_with_legacy_raw_key_meta() {
+		$taxonomy_slug = 'χρώμα2';
+		$taxonomy      = 'pa_' . $taxonomy_slug;
+		$term_slug     = 'κόκκινο';
+
+		$attribute_id = wc_create_attribute(
+			array(
+				'name'         => 'Χρώμα 2',
+				'slug'         => $taxonomy_slug,
+				'type'         => 'select',
+				'order_by'     => 'menu_order',
+				'has_archives' => false,
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			register_taxonomy( $taxonomy, 'product' );
+		}
+
+		$red_term = wp_insert_term( 'Κόκκινο 2', $taxonomy, array( 'slug' => $term_slug ) );
+		$this->assertIsArray( $red_term );
+
+		$product   = new WC_Product_Variable();
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( $attribute_id );
+		$attribute->set_name( $taxonomy );
+		$attribute->set_options( array( $red_term['term_id'] ) );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_regular_price( '20' );
+		$variation->set_status( ProductStatus::PUBLISH );
+		$variation->save();
+
+		// Simulate legacy data: write the variation attribute meta in raw form.
+		$raw_meta_key = 'attribute_' . $taxonomy;
+		update_post_meta( $variation->get_id(), $raw_meta_key, $term_slug );
+
+		$data_store = $product->get_data_store();
+		$this->assertSame(
+			$variation->get_id(),
+			$data_store->find_matching_product_variation( $product, array( $raw_meta_key => $term_slug ) )
+		);
+	}
+
+	/**
 	 * Tests for set_default_attributes and get_default_attributes.
 	 */
 	public function test_save_default_attributes() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -119,6 +119,63 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that direct URLs using the raw (un-percent-encoded) form of a non-ASCII
+	 * attribute key (e.g. `?attribute_pa_χρώμα=...`) still pre-select the option in
+	 * the dropdown. Regression test for woo#59199.
+	 */
+	public function test_wc_dropdown_variation_attribute_options_preselects_non_ascii_raw_url_param() {
+		$taxonomy_slug = 'χρώμα3';
+		$taxonomy      = 'pa_' . $taxonomy_slug;
+		$term_slug     = 'κόκκινο';
+
+		$attribute_id = wc_create_attribute(
+			array(
+				'name'         => 'Χρώμα 3',
+				'slug'         => $taxonomy_slug,
+				'type'         => 'select',
+				'order_by'     => 'menu_order',
+				'has_archives' => false,
+			)
+		);
+		$this->assertIsInt( $attribute_id );
+
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			register_taxonomy( $taxonomy, 'product' );
+		}
+
+		$term = wp_insert_term( 'Κόκκινο 3', $taxonomy, array( 'slug' => $term_slug ) );
+		$this->assertIsArray( $term );
+
+		$product   = new WC_Product_Variable();
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( $attribute_id );
+		$attribute->set_name( $taxonomy );
+		$attribute->set_options( array( $term['term_id'] ) );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		// Simulate `?attribute_pa_χρώμα3=κόκκινο` — PHP exposes the key in raw form here.
+		$_REQUEST[ 'attribute_' . $taxonomy ] = $term_slug;
+
+		ob_start();
+		wc_dropdown_variation_attribute_options(
+			array(
+				'product'   => $product,
+				'attribute' => $taxonomy,
+			)
+		);
+		$output = ob_get_clean();
+
+		unset( $_REQUEST[ 'attribute_' . $taxonomy ] );
+
+		// The matching option should be marked as selected.
+		$this->assertStringContainsString( "selected='selected'", $output );
+		$this->assertStringContainsString( 'value="' . esc_attr( sanitize_title( $term_slug ) ) . '"', $output );
+	}
+
+	/**
 	 * Test: test_wc_dropdown_variation_attribute_options_displays_aria_label_when_defined.
 	 */
 	public function test_wc_dropdown_variation_attribute_options_displays_aria_label_when_defined() {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open or closed [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Variation products did not pre-select, did not match via `find_matching_product_variation`, and could not be created via the REST API when their attribute taxonomy or term slugs used non-ASCII characters (e.g. Greek `pa_χρώμα` / `κόκκινο`).

Root cause: `WC_Product_Variation::set_attributes()` stored the attribute key in raw form (e.g. `attribute_pa_χρώμα`) while the variable parent and the rest of the codebase look the same key up in `sanitize_title()` (percent-encoded) form (e.g. `attribute_pa_%cf%87%cf%81%cf%8e%ce%bc%ce%b1`). The mismatch caused:

- Variations to look empty in the admin ("Any Χρώμα") and via REST.
- `find_matching_product_variation()` to return 0 for every chosen variation, breaking the cart-link / direct-URL pre-selection paths.
- Variation permalinks to be generated without the `?attribute_pa_*=*` query args (the `array_intersect_key()` in `get_permalink()` produced an empty intersection).

Fixes in this PR:

- `WC_Product_Variation::set_attributes()` now `sanitize_title()`s each attribute key so new variations store the canonical key form.
- `wc_get_product_variation_attributes()` falls back to the sanitised form when matching raw-key meta written by older versions, so existing installs read correctly without forcing a re-save.
- `find_matching_product_variation()` accepts both the raw and sanitised meta key forms and normalises incoming `\$match_attributes` keys, matching variations regardless of which form is stored or posted.
- `wc_dropdown_variation_attribute_options()` also checks the raw form of the URL parameter so direct URLs such as `?attribute_pa_χρώμα=κόκκινο` pre-select the option.

Closes #59199. Linear issue: https://linear.app/a8c/issue/RSMAPGJ-269

### Screenshots or screen recordings:

N/A — backend / data-handling fix.

### How to test the changes in this Pull Request:

Using WooCommerce Beta Tester, [test this PR](https://docker.baopinshidai.com/woocommerce/woocommerce/pull/new) — or apply the branch locally — then:

1. Create a global attribute named ``Χρώμα`` with slug ``χρώμα``.
2. Add terms ``Κόκκινο`` (``κόκκινο``) and ``Πράσινο`` (``πράσινο``) to that attribute.
3. Create a variable product, attach the attribute (mark it as ``Used for variations``), then create variations for both terms.
4. Open the product page with `?attribute_pa_χρώμα=κόκκινο` appended to the URL — the ``Κόκκινο`` option should be pre-selected.
5. Add a variation to the cart, then click the product link from the cart page — the variation's attributes should be pre-selected when you land back on the product page.
6. Create a variation via the REST API (``POST /wp-json/wc/v3/products/<id>/variations`` with ``attributes: [{ id: <attr_id>, option: 'Κόκκινο' }]``) and confirm the new variation shows the correct attribute value in the admin variations tab.
7. Confirm that nothing regressed for variations with Latin-only attribute / term slugs.

### Testing that has already taken place:

- Reproduced the bug on a clean install and confirmed the fix locally end-to-end (variation meta, ``find_matching_product_variation``, permalink, dropdown pre-select).
- Added unit tests in ``tests/legacy/unit-tests/product/data-store.php`` and ``tests/legacy/unit-tests/templates/functions.php`` covering save/read, legacy raw-key meta, and direct-URL pre-selection for Greek slugs.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` clean.
- `composer exec -- phpstan analyse <changed files> --memory-limit=2G` clean (no baseline additions).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

Changelog entry committed as ``plugins/woocommerce/changelog/fix-rsmapgj-269`` (significance: patch, type: fix).

---

_Generated by the RSMAPGJ AI Coder pipeline._