### PR TITLE
Style bare <button> elements injected via Woo hooks on Twenty Twenty-Two

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-296
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-296
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Apply WooCommerce button styles to bare `<button>` elements injected via WooCommerce hooks on Twenty Twenty-Two, so plugin- or theme-injected unclassed buttons match other Woo CTAs.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -96,7 +96,9 @@ $tt2-gray: #f7f7f7;
 	button[name="add-to-cart"],
 	input[name="submit"],
 	button.single_add_to_cart_button,
-	button[type="submit"]:not(.wp-block-search__button) {
+	button[type="submit"]:not(.wp-block-search__button),
+	button:not([class]),
+	button[class=""] {
 		display: inline-block;
 		text-align: center;
 		word-break: break-word;


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [Recommended Tooling for WooCommerce Development](https://github.com/woocommerce/woocommerce/wiki/Recommended-Tooling-for-WooCommerce-Development).

### Changes proposed in this Pull Request

In WordPress' Twenty Twenty-Two FSE theme, native `<button>` elements rendered inside a WooCommerce template (e.g. injected via `woocommerce_before_single_product_summary`) were left visually unstyled. The existing CTA rule in `twenty-twenty-two.scss` only matched buttons by class or attribute (`a.button`, `button[name="add-to-cart"]`, `button.single_add_to_cart_button`, `button[type="submit"]:not(.wp-block-search__button)`), so a bare `<button>Send Tacos</button>` rendered inside `.woocommerce` fell through to the FSE theme's (lack of) default button styling.

This change extends the existing selector group to also match `button:not([class])` and `button[class=""]`, both still scoped inside `.woocommerce`. That covers the unclassed buttons plugin authors typically inject through Woo hooks, while leaving Woo's own classed buttons (quantity steppers, dismiss buttons, etc.) untouched.

Bug introduced in PR #25358 (initial Twenty Twenty-Two stylesheet).

Closes #35042.

Linear: https://linear.app/a8c/issue/RSMAPGJ-296

### Screenshots or screen recordings

n/a — CSS-only fix matching existing TT2 CTA styling.

### How to test the changes in this Pull Request

1. Activate the Twenty Twenty-Two theme.
2. Add a snippet that hooks into a single product page:
   ```php
   add_action( 'woocommerce_before_single_product_summary', function () {
       echo '<button>Send Tacos</button>';
   } );
   ```
3. View any single product on the front end.
4. Before this patch: the bare `<button>` renders with the browser default (small, unstyled). After this patch: it inherits the TT2 Woo CTA styling (primary background, white text, 1rem/2rem padding).
5. Sanity check: quantity steppers, cart "Remove" links, dismiss buttons, etc. still look the same as before — those have classes and aren't matched by the new selectors.

### Testing that has already taken place

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — no PHP changes, no-op.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.
  - Significance: Patch
  - Type: Fix
  - Message: Apply WooCommerce button styles to bare `<button>` elements injected via WooCommerce hooks on Twenty Twenty-Two, so plugin- or theme-injected unclassed buttons match other Woo CTAs.

A changelog entry is also already committed at `plugins/woocommerce/changelog/fix-rsmapgj-296`.

### Milestone

- [x] Add this PR to the first upcoming release milestone.

---

Submitted via the RSMAPGJ AI Coder pipeline.