### PR TITLE
Fix variation quantity input not enforcing stock max on product page

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-292
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-292
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the variation quantity input on the product page enforce the variation's stock limit when the parent variable product does not manage stock, so the `max` attribute matches the cart page and prevents over-stock selections.

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -349,8 +349,21 @@
 			$qty_input = form.$singleVariationWrap.find(
 				'.quantity input.qty[name="quantity"]'
 			),
-			$qty = $qty_input.closest( '.quantity' ),
-			purchasable = true,
+			$qty;
+
+		// Fall back to searching the whole form when the quantity input
+		// is rendered outside of `.single_variation_wrap` (custom or
+		// block-based themes), otherwise the variation's stock-derived
+		// `min`/`max` would never be applied and the product page would
+		// allow over-stock quantities that the cart page later rejects.
+		if ( ! $qty_input.length ) {
+			$qty_input = form.$form.find(
+				'.quantity input.qty[name="quantity"]'
+			);
+		}
+
+		$qty = $qty_input.closest( '.quantity' );
+		var purchasable = true,
 			variation_id = '',
 			template = false,
 			$template_html = '';
@@ -401,30 +414,32 @@
 			$qty_input
 				.val( '1' )
 				.attr( 'min', '1' )
-				.attr( 'max', '' )
+				.removeAttr( 'max' )
 				.trigger( 'change' );
 			$qty.hide();
 		} else {
 			var qty_val = parseFloat( $qty_input.val() );
+			var max_qty = parseFloat( variation.max_qty );
+			var min_qty = parseFloat( variation.min_qty );
 
 			if ( isNaN( qty_val ) ) {
-				qty_val = variation.min_qty;
+				qty_val = isNaN( min_qty ) ? 1 : min_qty;
 			} else {
-				qty_val =
-					qty_val > parseFloat( variation.max_qty )
-						? variation.max_qty
-						: qty_val;
-				qty_val =
-					qty_val < parseFloat( variation.min_qty )
-						? variation.min_qty
-						: qty_val;
+				if ( ! isNaN( max_qty ) && qty_val > max_qty ) {
+					qty_val = max_qty;
+				}
+				if ( ! isNaN( min_qty ) && qty_val < min_qty ) {
+					qty_val = min_qty;
+				}
 			}
 
-			$qty_input
-				.attr( 'min', variation.min_qty )
-				.attr( 'max', variation.max_qty )
-				.val( qty_val )
-				.trigger( 'change' );
+			$qty_input.attr( 'min', variation.min_qty );
+			if ( '' === variation.max_qty || isNaN( max_qty ) ) {
+				$qty_input.removeAttr( 'max' );
+			} else {
+				$qty_input.attr( 'max', variation.max_qty );
+			}
+			$qty_input.val( qty_val ).trigger( 'change' );
 			$qty.show();
 		}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -162,4 +162,66 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$this->assertIsBool( $has_purchasable_variations );
 		$this->assertFalse( $has_purchasable_variations );
 	}
+
+	/**
+	 * @testdox 'get_available_variations' exposes the variation's stock-derived max_qty when stock is managed at the variation level only.
+	 *
+	 * Regression: when the parent variable product does not manage stock but a variation does, the product page's
+	 * quantity input must receive the variation's stock quantity as `max_qty` so it matches the cart page behaviour.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/37141
+	 */
+	public function test_get_available_variation_exposes_variation_stock_as_max_qty() {
+		$product = new WC_Product_Variable();
+		$product->set_props(
+			array(
+				'name'         => 'Variation Stock Parent',
+				'sku'          => 'VARSTOCK-PARENT-' . microtime( true ),
+				'manage_stock' => false,
+			)
+		);
+
+		$attributes   = array();
+		$attributes[] = WC_Helper_Product::create_product_attribute_object( 'color', array( 'red' ) );
+		$product->set_attributes( $attributes );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_props(
+			array(
+				'parent_id'      => $product->get_id(),
+				'attributes'     => array( 'pa_color' => 'red' ),
+				'regular_price'  => 20,
+				'manage_stock'   => true,
+				'stock_quantity' => 5,
+				'stock_status'   => 'instock',
+			)
+		);
+		$variation->save();
+
+		$product->set_children( array( $variation->get_id() ) );
+		WC_Product_Variable::sync( $product->get_id() );
+
+		// Refresh from the DB so parent_data is hydrated as it would be for a frontend request.
+		$variation = wc_get_product( $variation->get_id() );
+
+		$this->assertTrue( $variation->managing_stock(), 'Variation should be stock-managed.' );
+		$this->assertSame( 5, $variation->get_max_purchase_quantity(), 'Variation max purchase quantity must equal its stock.' );
+
+		$variable_product = wc_get_product( $product->get_id() );
+		$available        = $variable_product->get_available_variation( $variation );
+
+		$this->assertIsArray( $available );
+		$this->assertArrayHasKey( 'max_qty', $available );
+		$this->assertSame(
+			5,
+			$available['max_qty'],
+			'max_qty in the available-variation payload should match the variation stock so the product page quantity input can enforce it.'
+		);
+		$this->assertNotSame(
+			'',
+			$available['max_qty'],
+			'max_qty should not be empty when the variation manages stock.'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] I have checked the relevant guides for documenting an internal API change.

### Changes proposed in this Pull Request

Fixes the inconsistency where, when a variation managed its own stock but the parent variable product did not, the quantity input on the single product page was rendered without a `max` attribute (the parent reports unlimited max) and the JS that updates the input on `found_variation` could fail to locate it whenever a custom or block-based theme rendered `.quantity` outside of `.single_variation_wrap`. The customer could then enter a quantity above the variation's stock and only learn it was rejected at add-to-cart, while the cart page correctly capped the same input.

This PR:

- Broadens the qty input lookup in `add-to-cart-variation.js` to fall back to the entire form when the input is not inside `.single_variation_wrap`, so the variation's stock-derived `min`/`max` are applied regardless of where the theme places it.
- Tightens the attribute writes so unlimited stock removes the `max` attribute instead of emitting `max=""`, and clamps the seeded quantity value safely when `min`/`max` are NaN.
- Adds a PHPUnit regression test asserting `WC_Product_Variable::get_available_variation()` exposes the variation's stock as `max_qty` when only the variation manages stock — this is the contract the JS depends on.

Closes #37141.
Linear: https://linear.app/a8c/issue/RSMAPGJ-292

### How to test the changes in this Pull Request

1. Create a variable product without parent-level stock management.
2. Add a variation with stock management enabled and stock quantity = 5.
3. Visit the product page on the storefront and pick that variation.
4. Inspect the quantity input — it should have `max="5"`.
5. Try typing/clicking past 5 — the browser should clamp via the input's native validation and add-to-cart should reflect 5 as the ceiling, matching cart-page behaviour.

### Testing that has already taken place

- Added PHPUnit regression test (`test_get_available_variation_exposes_variation_stock_as_max_qty`).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passes for both JS and PHP.
- Node/PHP syntax checks pass on the touched files.

### Milestone

- [x] Use the next available milestone automatically.

### Changelog entry

- [x] Changelog entry added at `plugins/woocommerce/changelog/fix-rsmapgj-292` (significance: patch / type: fix).

---

_Filed by the RSMAPGJ AI Coder pipeline._