### PR TITLE
Fix Mini-Cart Fill variant button style inconsistency

### DIFF
--- a/plugins/woocommerce/changelog/fix-rsmapgj-360
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-360
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Mini-Cart: Make the "Fill" variant of the View Cart and Checkout buttons inherit Mini-Cart Contents text/background colors symmetrically.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -52426,7 +52426,7 @@ parameters:
 			path: src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
 
 		-
-			message: '#^Call to function is_array\(\) with array\{''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…''\} will always evaluate to true\.$#'
+			message: '#^Call to function is_array\(\) with array\{''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…'', ''\.wc\-block\-mini\-cart…''\} will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Blocks/BlockTypes/MiniCartContents.php

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
@@ -130,6 +130,7 @@ class MiniCartContents extends AbstractBlock {
 					'.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-checkout',
 					'.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-checkout:hover',
 					'.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-checkout:focus',
+					'.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-cart.wc-block-components-button',
 					'.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-cart.wc-block-components-button:hover',
 					'.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-cart.wc-block-components-button:focus',
 					'.wc-block-mini-cart__shopping-button a:hover',


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have read the [WooCommerce contributing guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).

### Changes proposed in this Pull Request

In the Mini-Cart Contents block, the "Fill" variant of the View Cart and Checkout buttons did not behave symmetrically: the Checkout button correctly inherited the Mini-Cart Contents block's text and background colors, but the View Cart button did not, leaving the two sibling buttons visually inconsistent on the frontend.

Looking at `MiniCartContents::enqueue_assets()` (`plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php`), the inline-style ruleset included three states for the checkout button (`base`, `:hover`, `:focus`) but only `:hover` and `:focus` for the cart button. This PR adds the missing base-state selector `.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-cart.wc-block-components-button` so both buttons inherit parent text/background colors uniformly in the default Fill state.

Closes #59614
Linear: https://linear.app/a8c/issue/RSMAPGJ-360

### Screenshots or screen recordings

Not applicable for this asymmetric-CSS fix; the change is a single missing selector to align two sibling buttons.

### How to test the changes in this Pull Request

1. Go to **Site Editor → Patterns → Mini-Cart**.
2. Select the **Mini-Cart Contents** block and apply some background and text colors.
3. Select the **Mini-Cart View Cart Button** and apply the "Fill" variant.
4. Select the **Mini-Cart Checkout Button** and apply the "Fill" variant.
5. Save the template part and open the Mini-Cart on the storefront (with at least one product in the cart).
6. Verify that **both** buttons inherit the Mini-Cart Contents block's text/background colors. Before this fix, only the Checkout button inherited them; the View Cart button kept its own defaults.

### Testing that has already taken place

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — passes.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — passes.
- `composer exec -- phpstan analyse src/Blocks/BlockTypes/MiniCartContents.php` — no new errors. (The pre-existing baselined `is_array()` already-narrowed warning has been re-anchored to reflect the additional selector; the baseline did not grow.)
- Manual reasoning verified the selector parallels the existing checkout-button selector and writes the same three CSS properties.

### Changelog entry

- [x] Changelog entry added manually (`plugins/woocommerce/changelog/fix-rsmapgj-360`, patch / fix).

---

Generated by the RSMAPGJ AI Coder pipeline.