### PR TITLE
Shopper Collection: add an editable heading inner block

### DIFF
--- a/plugins/woocommerce/changelog/add-shopper-collection-heading
+++ b/plugins/woocommerce/changelog/add-shopper-collection-heading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Shopper Collection: add a built-in heading inner block (defaults to "Saved for later" at H2). Editable in the block editor.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/block.json
@@ -18,6 +18,7 @@
 			"default": 5
 		}
 	},
+	"allowedBlocks": [ "core/heading" ],
 	"supports": {
 		 "align": [ "wide", "full" ],
 		"interactivity": true,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+} from '@wordpress/block-editor';
 import { PanelBody, RangeControl, SelectControl } from '@wordpress/components';
 import { Icon, trash } from '@wordpress/icons';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
@@ -19,6 +23,16 @@ interface EditProps {
 
 const MIN_COLUMNS = 2;
 const MAX_COLUMNS = 6;
+
+// Lives in JS because `__()` is needed for the heading copy. `block.json`
+// strings aren't run through translation, so keeping the template here
+// is the only way to ship a localized default.
+const TEMPLATE: [ string, Record< string, unknown > ][] = [
+	[
+		'core/heading',
+		{ content: __( 'Saved for later', 'woocommerce' ), level: 2 },
+	],
+];
 
 const PREVIEW_ITEMS = [
 	{
@@ -69,8 +83,13 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 	const { listName, columnCount } = attributes;
 
 	const blockProps = useBlockProps( {
-		className: `wc-block-shopper-collection columns-${ columnCount }`,
+		className: 'wc-block-shopper-collection',
 	} );
+
+	// `allowedBlocks` is read from block.json automatically — passing it
+	// here would just duplicate the declaration. `templateLock: false`
+	// is the default so we omit that too.
+	const innerBlocksProps = useInnerBlocksProps( {}, { template: TEMPLATE } );
 
 	return (
 		<>
@@ -109,68 +128,73 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<ul { ...blockProps }>
-				{ PREVIEW_ITEMS.map( ( item ) => (
-					<li
-						key={ item.key }
-						className="wc-block-shopper-collection-item"
-					>
-						<div className="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
-							<a
-								href="#preview"
-								onClick={ ( e ) => e.preventDefault() }
-							>
-								<img src={ PLACEHOLDER_IMG_SRC } alt="" />
-							</a>
-							<button
-								type="button"
-								className="wc-block-shopper-collection-item__remove"
-								aria-label={ sprintf(
-									/* translators: %s: product name. */
-									__(
-										'Remove %s from Saved for later list',
-										'woocommerce'
-									),
-									item.name
+			<section { ...blockProps }>
+				<div { ...innerBlocksProps } />
+				<ul
+					className={ `wc-block-shopper-collection__list columns-${ columnCount }` }
+				>
+					{ PREVIEW_ITEMS.map( ( item ) => (
+						<li
+							key={ item.key }
+							className="wc-block-shopper-collection-item"
+						>
+							<div className="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+								<a
+									href="#preview"
+									onClick={ ( e ) => e.preventDefault() }
+								>
+									<img src={ PLACEHOLDER_IMG_SRC } alt="" />
+								</a>
+								<button
+									type="button"
+									className="wc-block-shopper-collection-item__remove"
+									aria-label={ sprintf(
+										/* translators: %s: product name. */
+										__(
+											'Remove %s from Saved for later list',
+											'woocommerce'
+										),
+										item.name
+									) }
+									disabled
+								>
+									<Icon icon={ trash } size={ 24 } />
+								</button>
+								{ item.variation && (
+									<span className="wc-block-shopper-collection-item__variation">
+										{ item.variation }
+									</span>
 								) }
-								disabled
-							>
-								<Icon icon={ trash } size={ 24 } />
-							</button>
-							{ item.variation && (
-								<span className="wc-block-shopper-collection-item__variation">
-									{ item.variation }
+							</div>
+							<h2 className="wp-block-post-title has-text-align-center has-medium-font-size">
+								<a
+									href="#preview"
+									onClick={ ( e ) => e.preventDefault() }
+								>
+									{ item.name }
+								</a>
+							</h2>
+							<div className="price wc-block-components-product-price has-text-align-center has-small-font-size">
+								<span className="wc-block-components-product-price__value">
+									{ item.price }
 								</span>
-							) }
-						</div>
-						<h2 className="wp-block-post-title has-text-align-center has-medium-font-size">
-							<a
-								href="#preview"
-								onClick={ ( e ) => e.preventDefault() }
-							>
-								{ item.name }
-							</a>
-						</h2>
-						<div className="price wc-block-components-product-price has-text-align-center has-small-font-size">
-							<span className="wc-block-components-product-price__value">
-								{ item.price }
+							</div>
+							<span className="wc-block-shopper-collection-item__quantity">
+								{ item.quantity }
 							</span>
-						</div>
-						<span className="wc-block-shopper-collection-item__quantity">
-							{ item.quantity }
-						</span>
-						<div className="wp-block-button wc-block-components-product-button">
-							<button
-								type="button"
-								className="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
-								disabled
-							>
-								{ __( 'Move to cart', 'woocommerce' ) }
-							</button>
-						</div>
-					</li>
-				) ) }
-			</ul>
+							<div className="wp-block-button wc-block-components-product-button">
+								<button
+									type="button"
+									className="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+									disabled
+								>
+									{ __( 'Move to cart', 'woocommerce' ) }
+								</button>
+							</div>
+						</li>
+					) ) }
+				</ul>
+			</section>
 		</>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/edit.tsx
@@ -88,8 +88,13 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 
 	// `allowedBlocks` is read from block.json automatically — passing it
 	// here would just duplicate the declaration. `templateLock: false`
-	// is the default so we omit that too.
-	const innerBlocksProps = useInnerBlocksProps( {}, { template: TEMPLATE } );
+	// is the default so we omit that too. The className matches the
+	// `<div>` PHP wraps `$content` in on the frontend, so any CSS keyed
+	// off `__header` applies in both contexts.
+	const innerBlocksProps = useInnerBlocksProps(
+		{ className: 'wc-block-shopper-collection__header' },
+		{ template: TEMPLATE }
+	);
 
 	return (
 		<>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/save.tsx
@@ -1,7 +1,14 @@
 /**
- * The block is rendered server-side. The save callback returns null so the
- * Block Editor stores no static markup.
+ * External dependencies
  */
-const Save = (): null => null;
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * The block is rendered server-side, but the inner blocks (default
+ * `core/heading`) must be serialized to `post_content` so user edits
+ * persist — returning `null` would drop them. `<InnerBlocks.Content />`
+ * emits only the inner blocks' static markup.
+ */
+const Save = (): JSX.Element => <InnerBlocks.Content />;
 
 export default Save;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/style.scss
@@ -5,13 +5,16 @@
 // which we declare as style dependencies in `block.json` so WordPress
 // enqueues them whenever this block renders. Don't duplicate those rules here.
 
+// The outer `<section>` is a plain wrapper — no layout of its own. The
+// grid lives on the inner `<ul class="wc-block-shopper-collection__list">`
+// so it doesn't try to grid-place the seeded heading inner block.
 // One concrete `.columns-N` class per supported column count so narrow
 // viewports reflow to fewer columns instead of shrinking items uniformly.
 // Mirrors Product Collection's `__responsive` formula.
 $min-item-width: 150px;
 $grid-gap: var(--wp--style--block-gap, 1.5em);
 
-.wc-block-shopper-collection {
+.wc-block-shopper-collection__list {
 	display: grid;
 	gap: $grid-gap;
 	list-style: none;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -80,6 +80,34 @@ final class ShopperCollection extends AbstractBlock {
 			return $parsed_hooked_block;
 		}
 		$parsed_hooked_block['attrs']['listName'] = 'saved-for-later';
+
+		// Seed a `core/heading` inner block so freshly-injected SC instances
+		// ship with the same heading the editor template seeds. Only do this
+		// when nothing else has already populated `innerBlocks` (e.g. another
+		// hook running first) — we don't want to clobber a customisation.
+		//
+		// `core/heading` is a static block, so the serialised markup must
+		// match what the editor would have saved (`<h2 class="wp-block-heading">…</h2>`)
+		// or it'll fail block validation when the cart page is opened in the
+		// editor. The matching `null` push onto `innerContent` is what makes
+		// `WP_Block::render()` walk into the heading when building `$content`.
+		if ( empty( $parsed_hooked_block['innerBlocks'] ) ) {
+			$region_label = $this->get_variation_config()['regionLabel'];
+			$heading_html = '<h2 class="wp-block-heading">' . esc_html( $region_label ) . '</h2>';
+
+			$parsed_hooked_block['innerBlocks'][] = array(
+				'blockName'    => 'core/heading',
+				'attrs'        => array( 'level' => 2 ),
+				'innerBlocks'  => array(),
+				'innerHTML'    => $heading_html,
+				'innerContent' => array( $heading_html ),
+			);
+			if ( ! isset( $parsed_hooked_block['innerContent'] ) || ! is_array( $parsed_hooked_block['innerContent'] ) ) {
+				$parsed_hooked_block['innerContent'] = array();
+			}
+			$parsed_hooked_block['innerContent'][] = null;
+		}
+
 		return $parsed_hooked_block;
 	}
 
@@ -184,9 +212,8 @@ final class ShopperCollection extends AbstractBlock {
 		);
 
 		$wrapper_class = sprintf(
-			'wc-block-shopper-collection wc-block-shopper-collection--%s columns-%d',
-			$variation['modifierSlug'],
-			$column_count
+			'wc-block-shopper-collection wc-block-shopper-collection--%s',
+			$variation['modifierSlug']
 		);
 
 		$wrapper_attributes = array(
@@ -200,13 +227,20 @@ final class ShopperCollection extends AbstractBlock {
 
 		$is_empty = empty( $items );
 
+		$list_class = sprintf( 'wc-block-shopper-collection__list columns-%d', $column_count );
+
+		// `$content` is the rendered output of the heading inner block (and
+		// any future siblings). It sits above the inner `<ul>` so the
+		// heading reads first in source order.
 		return sprintf(
-			'<ul %1$s>%2$s%3$s%4$s%5$s</ul>',
+			'<section %1$s>%6$s<ul class="%7$s">%2$s%3$s%4$s%5$s</ul></section>',
 			get_block_wrapper_attributes( $wrapper_attributes ),
 			$this->render_template_markup( $variation ),
 			$this->render_items_markup( $items, $variation ),
 			$this->render_empty_markup( $is_empty, $variation ),
-			$this->render_error_markup()
+			$this->render_error_markup(),
+			$content,
+			esc_attr( $list_class )
 		);
 	}
 
@@ -227,6 +261,9 @@ final class ShopperCollection extends AbstractBlock {
 	private function get_variation_config(): array {
 		return array(
 			'modifierSlug'          => 'saved-for-later',
+			// Content for the seeded `core/heading` inner block on
+			// auto-injected SC instances (via `set_hooked_block_attributes`).
+			'regionLabel'           => __( 'Saved for later', 'woocommerce' ),
 			'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
 			/* translators: %s: product name. */
 			'removeLabelTemplate'   => __( 'Remove %s from Saved for later list', 'woocommerce' ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -252,9 +252,13 @@ final class ShopperCollection extends AbstractBlock {
 
 		$list_class = sprintf( 'wc-block-shopper-collection__list columns-%d', $column_count );
 
-		// `$content` is the rendered output of the heading inner block (and
-		// any future siblings). It sits above the inner `<ul>` so the
-		// heading reads first in source order.
+		// The heading inner block (and any future siblings rendered into
+		// `$content`) is wrapped so its visibility matches the empty-state
+		// gating: hidden on first paint for shoppers who have never had
+		// items in this session, revealed once the iAPI watcher flips
+		// `context.hasShownItems` to `true`. Without this wrapper a heading
+		// would be visible even on a fresh empty page, with no list under
+		// it — visually disconnected from anything.
 		return sprintf(
 			'<section %1$s>%6$s<ul class="%7$s">%2$s%3$s%4$s%5$s</ul></section>',
 			get_block_wrapper_attributes( $wrapper_attributes ),
@@ -262,7 +266,7 @@ final class ShopperCollection extends AbstractBlock {
 			$this->render_items_markup( $items, $variation ),
 			$this->render_empty_markup( $variation ),
 			$this->render_error_markup(),
-			$content,
+			$this->render_header_markup( $content, empty( $items ) ),
 			esc_attr( $list_class )
 		);
 	}
@@ -560,6 +564,30 @@ final class ShopperCollection extends AbstractBlock {
 		</li>
 		<?php
 		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Wrap the inner-block content (heading + any future siblings) in an
+	 * element whose visibility mirrors the empty-state gating: hidden when
+	 * the shopper has never seen items in this session, revealed once
+	 * `context.hasShownItems` flips to `true`. Returns an empty string when
+	 * there's no content to wrap (e.g. merchant deleted the heading and
+	 * saved), so we don't emit an empty `<div>`.
+	 *
+	 * @param string $content  Rendered inner-block content (typically the heading HTML).
+	 * @param bool   $is_empty Whether the SC list is empty on initial paint.
+	 * @return string
+	 */
+	private function render_header_markup( string $content, bool $is_empty ): string {
+		if ( '' === $content ) {
+			return '';
+		}
+		$hidden_attr = $is_empty ? ' hidden' : '';
+		return sprintf(
+			'<div class="wc-block-shopper-collection__header" data-wp-bind--hidden="!context.hasShownItems"%s>%s</div>',
+			$hidden_attr,
+			$content
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -89,15 +89,23 @@ final class ShopperCollection extends AbstractBlock {
 		// `core/heading` is a static block, so the serialised markup must
 		// match what the editor would have saved (`<h2 class="wp-block-heading">…</h2>`)
 		// or it'll fail block validation when the cart page is opened in the
-		// editor. The matching `null` push onto `innerContent` is what makes
-		// `WP_Block::render()` walk into the heading when building `$content`.
+		// editor. `attrs.content` mirrors what the editor's template seeds
+		// (`{ content, level }`) so the parsed shape round-trips identically;
+		// the value is the raw string because attrs are JSON-encoded into the
+		// block comment and `esc_html()` would corrupt translations whose text
+		// contains `&`, `<`, etc. The matching `null` push onto `innerContent`
+		// is what makes `WP_Block::render()` walk into the heading when
+		// building `$content`.
 		if ( empty( $parsed_hooked_block['innerBlocks'] ) ) {
 			$region_label = $this->get_variation_config()['regionLabel'];
 			$heading_html = '<h2 class="wp-block-heading">' . esc_html( $region_label ) . '</h2>';
 
 			$parsed_hooked_block['innerBlocks'][] = array(
 				'blockName'    => 'core/heading',
-				'attrs'        => array( 'level' => 2 ),
+				'attrs'        => array(
+					'level'   => 2,
+					'content' => $region_label,
+				),
 				'innerBlocks'  => array(),
 				'innerHTML'    => $heading_html,
 				'innerContent' => array( $heading_html ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -98,8 +98,8 @@ final class ShopperCollection extends AbstractBlock {
 		// contains `&`, `<`, etc. The matching `null` push onto `innerContent`
 		// is what makes `WP_Block::render()` walk into the heading when
 		// building `$content`.
-		$region_label = $this->get_variation_config()['regionLabel'];
-		$heading_html = '<h2 class="wp-block-heading">' . esc_html( $region_label ) . '</h2>';
+		$list_heading = $this->get_variation_config()['listHeading'];
+		$heading_html = '<h2 class="wp-block-heading">' . esc_html( $list_heading ) . '</h2>';
 
 		if ( ! isset( $parsed_hooked_block['innerBlocks'] ) || ! is_array( $parsed_hooked_block['innerBlocks'] ) ) {
 			$parsed_hooked_block['innerBlocks'] = array();
@@ -108,7 +108,7 @@ final class ShopperCollection extends AbstractBlock {
 			'blockName'    => 'core/heading',
 			'attrs'        => array(
 				'level'   => 2,
-				'content' => $region_label,
+				'content' => $list_heading,
 			),
 			'innerBlocks'  => array(),
 			'innerHTML'    => $heading_html,
@@ -272,9 +272,7 @@ final class ShopperCollection extends AbstractBlock {
 	private function get_variation_config(): array {
 		return array(
 			'modifierSlug'          => 'saved-for-later',
-			// Content for the seeded `core/heading` inner block on
-			// auto-injected SC instances (via `set_hooked_block_attributes`).
-			'regionLabel'           => __( 'Saved for later', 'woocommerce' ),
+			'listHeading'           => __( 'Saved for later', 'woocommerce' ),
 			'emptyMessage'          => __( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
 			/* translators: %s: product name. */
 			'removeLabelTemplate'   => __( 'Remove %s from Saved for later list', 'woocommerce' ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ShopperCollection.php
@@ -82,9 +82,11 @@ final class ShopperCollection extends AbstractBlock {
 		$parsed_hooked_block['attrs']['listName'] = 'saved-for-later';
 
 		// Seed a `core/heading` inner block so freshly-injected SC instances
-		// ship with the same heading the editor template seeds. Only do this
-		// when nothing else has already populated `innerBlocks` (e.g. another
-		// hook running first) — we don't want to clobber a customisation.
+		// ship with the same heading the editor template seeds. We append
+		// unconditionally — extensions are free to hook
+		// `hooked_block_woocommerce/shopper-collection` to add their own
+		// inner blocks, and gating on `empty( innerBlocks )` would silently
+		// suppress our heading whenever any other extension ran first.
 		//
 		// `core/heading` is a static block, so the serialised markup must
 		// match what the editor would have saved (`<h2 class="wp-block-heading">…</h2>`)
@@ -96,25 +98,26 @@ final class ShopperCollection extends AbstractBlock {
 		// contains `&`, `<`, etc. The matching `null` push onto `innerContent`
 		// is what makes `WP_Block::render()` walk into the heading when
 		// building `$content`.
-		if ( empty( $parsed_hooked_block['innerBlocks'] ) ) {
-			$region_label = $this->get_variation_config()['regionLabel'];
-			$heading_html = '<h2 class="wp-block-heading">' . esc_html( $region_label ) . '</h2>';
+		$region_label = $this->get_variation_config()['regionLabel'];
+		$heading_html = '<h2 class="wp-block-heading">' . esc_html( $region_label ) . '</h2>';
 
-			$parsed_hooked_block['innerBlocks'][] = array(
-				'blockName'    => 'core/heading',
-				'attrs'        => array(
-					'level'   => 2,
-					'content' => $region_label,
-				),
-				'innerBlocks'  => array(),
-				'innerHTML'    => $heading_html,
-				'innerContent' => array( $heading_html ),
-			);
-			if ( ! isset( $parsed_hooked_block['innerContent'] ) || ! is_array( $parsed_hooked_block['innerContent'] ) ) {
-				$parsed_hooked_block['innerContent'] = array();
-			}
-			$parsed_hooked_block['innerContent'][] = null;
+		if ( ! isset( $parsed_hooked_block['innerBlocks'] ) || ! is_array( $parsed_hooked_block['innerBlocks'] ) ) {
+			$parsed_hooked_block['innerBlocks'] = array();
 		}
+		$parsed_hooked_block['innerBlocks'][] = array(
+			'blockName'    => 'core/heading',
+			'attrs'        => array(
+				'level'   => 2,
+				'content' => $region_label,
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => $heading_html,
+			'innerContent' => array( $heading_html ),
+		);
+		if ( ! isset( $parsed_hooked_block['innerContent'] ) || ! is_array( $parsed_hooked_block['innerContent'] ) ) {
+			$parsed_hooked_block['innerContent'] = array();
+		}
+		$parsed_hooked_block['innerContent'][] = null;
 
 		return $parsed_hooked_block;
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -169,25 +169,22 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * If something else has already populated `innerBlocks` (e.g. another hook
-	 * running first, or a saved customisation), the seeding logic must not
-	 * clobber it.
+	 * Extensions are free to hook `hooked_block_woocommerce/shopper-collection`
+	 * to add their own inner blocks at a different priority. Our heading must
+	 * still be seeded alongside, not in place of, what they added.
 	 */
-	public function test_hooked_block_attributes_preserves_existing_inner_blocks(): void {
-		$existing_heading    = array(
-			'blockName'    => 'core/heading',
-			'attrs'        => array(
-				'level'   => 3,
-				'content' => 'My custom heading',
-			),
+	public function test_hooked_block_attributes_appends_heading_alongside_existing_inner_blocks(): void {
+		$existing_block      = array(
+			'blockName'    => 'core/paragraph',
+			'attrs'        => array(),
 			'innerBlocks'  => array(),
-			'innerHTML'    => '<h3 class="wp-block-heading">My custom heading</h3>',
-			'innerContent' => array( '<h3 class="wp-block-heading">My custom heading</h3>' ),
+			'innerHTML'    => '<p>From another extension</p>',
+			'innerContent' => array( '<p>From another extension</p>' ),
 		);
 		$parsed_hooked_block = array(
 			'blockName'    => 'woocommerce/shopper-collection',
 			'attrs'        => array(),
-			'innerBlocks'  => array( $existing_heading ),
+			'innerBlocks'  => array( $existing_block ),
 			'innerContent' => array( null ),
 		);
 		$parsed_anchor_block = array( 'blockName' => 'woocommerce/cart' );
@@ -199,8 +196,15 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 			$parsed_anchor_block
 		);
 
-		$this->assertCount( 1, $result['innerBlocks'] );
-		$this->assertSame( $existing_heading, $result['innerBlocks'][0] );
+		$this->assertCount( 2, $result['innerBlocks'] );
+		// The other-extension block is preserved at its original index.
+		$this->assertSame( $existing_block, $result['innerBlocks'][0] );
+		// Our heading is appended after it.
+		$this->assertSame( 'core/heading', $result['innerBlocks'][1]['blockName'] );
+		$this->assertSame( 'Saved for later', $result['innerBlocks'][1]['attrs']['content'] );
+		// Parent innerContent gains a `null` placeholder for each inner block,
+		// so `WP_Block::render()` walks into both when building `$content`.
+		$this->assertCount( 2, $result['innerContent'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -157,7 +157,10 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 		$this->assertSame( 'core/heading', $heading['blockName'] );
 		$this->assertSame( 2, $heading['attrs']['level'] );
 		$this->assertArrayHasKey( 'content', $heading['attrs'] );
-		$this->assertNotEmpty( $heading['attrs']['content'] );
+		// `attrs.content` is the raw translated string (no `esc_html`) —
+		// JSON encoding handles escaping at serialization time. Asserts
+		// the en_US source string the test bootstrap runs under.
+		$this->assertSame( 'Saved for later', $heading['attrs']['content'] );
 		$this->assertStringContainsString( '<h2 class="wp-block-heading">', $heading['innerHTML'] );
 		$this->assertSame( array( $heading['innerHTML'] ), $heading['innerContent'] );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -281,4 +281,43 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 			'Wrapper must wire the trackShownItems watcher so hasShownItems can flip to true the first time items appear in-session.'
 		);
 	}
+
+	/**
+	 * The seeded heading (and any future sibling inner blocks rendered via
+	 * `$content`) must share the empty-state visibility gating: hidden on
+	 * first paint for new shoppers / empty refreshes, revealed once the
+	 * iAPI watcher flips `context.hasShownItems`. Without this, a saved
+	 * cart page rendered with no items would show an orphaned heading
+	 * sitting above nothing.
+	 */
+	public function test_render_wraps_header_with_hidden_visibility_gate_when_empty(): void {
+		$customer_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $customer_id );
+
+		$attributes = array( 'listName' => 'saved-for-later' );
+
+		$previous_block_to_render            = \WP_Block_Supports::$block_to_render;
+		\WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'woocommerce/shopper-collection',
+			'attrs'     => $attributes,
+		);
+
+		try {
+			$render = new ReflectionMethod( ShopperCollection::class, 'render' );
+			$render->setAccessible( true );
+
+			$content = '<h2 class="wp-block-heading">Saved for later</h2>';
+			$markup  = (string) $render->invoke( $this->sut, $attributes, $content, null );
+		} finally {
+			\WP_Block_Supports::$block_to_render = $previous_block_to_render;
+		}
+
+		// The header wrapper exists, contains the heading, has the iAPI
+		// visibility bind, and is initially hidden because items is empty.
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*class="wc-block-shopper-collection__header"[^>]*data-wp-bind--hidden="!context\.hasShownItems"[^>]*\bhidden\b[^>]*>.*Saved for later/s',
+			$markup,
+			'Header wrapper must be initially hidden for an empty list so a fresh-load empty SC does not show an orphaned heading.'
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -156,6 +156,8 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 		$heading = $result['innerBlocks'][0];
 		$this->assertSame( 'core/heading', $heading['blockName'] );
 		$this->assertSame( 2, $heading['attrs']['level'] );
+		$this->assertArrayHasKey( 'content', $heading['attrs'] );
+		$this->assertNotEmpty( $heading['attrs']['content'] );
 		$this->assertStringContainsString( '<h2 class="wp-block-heading">', $heading['innerHTML'] );
 		$this->assertSame( array( $heading['innerHTML'] ), $heading['innerContent'] );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ShopperCollectionTests.php
@@ -131,6 +131,74 @@ class ShopperCollectionTests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The auto-injected block ships with a seeded `core/heading` inner block so
+	 * fresh cart pages render the heading on the frontend out of the box. The
+	 * matching `null` push onto `innerContent` is what makes `WP_Block::render()`
+	 * walk into the heading when building `$content`.
+	 */
+	public function test_hooked_block_attributes_seed_heading_inner_block(): void {
+		$parsed_hooked_block = array(
+			'blockName' => 'woocommerce/shopper-collection',
+			'attrs'     => array(),
+		);
+		$parsed_anchor_block = array( 'blockName' => 'woocommerce/cart' );
+
+		$result = $this->sut->set_hooked_block_attributes(
+			$parsed_hooked_block,
+			'woocommerce/shopper-collection',
+			'after',
+			$parsed_anchor_block
+		);
+
+		$this->assertArrayHasKey( 'innerBlocks', $result );
+		$this->assertCount( 1, $result['innerBlocks'] );
+
+		$heading = $result['innerBlocks'][0];
+		$this->assertSame( 'core/heading', $heading['blockName'] );
+		$this->assertSame( 2, $heading['attrs']['level'] );
+		$this->assertStringContainsString( '<h2 class="wp-block-heading">', $heading['innerHTML'] );
+		$this->assertSame( array( $heading['innerHTML'] ), $heading['innerContent'] );
+
+		$this->assertArrayHasKey( 'innerContent', $result );
+		$this->assertContains( null, $result['innerContent'] );
+	}
+
+	/**
+	 * If something else has already populated `innerBlocks` (e.g. another hook
+	 * running first, or a saved customisation), the seeding logic must not
+	 * clobber it.
+	 */
+	public function test_hooked_block_attributes_preserves_existing_inner_blocks(): void {
+		$existing_heading    = array(
+			'blockName'    => 'core/heading',
+			'attrs'        => array(
+				'level'   => 3,
+				'content' => 'My custom heading',
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '<h3 class="wp-block-heading">My custom heading</h3>',
+			'innerContent' => array( '<h3 class="wp-block-heading">My custom heading</h3>' ),
+		);
+		$parsed_hooked_block = array(
+			'blockName'    => 'woocommerce/shopper-collection',
+			'attrs'        => array(),
+			'innerBlocks'  => array( $existing_heading ),
+			'innerContent' => array( null ),
+		);
+		$parsed_anchor_block = array( 'blockName' => 'woocommerce/cart' );
+
+		$result = $this->sut->set_hooked_block_attributes(
+			$parsed_hooked_block,
+			'woocommerce/shopper-collection',
+			'after',
+			$parsed_anchor_block
+		);
+
+		$this->assertCount( 1, $result['innerBlocks'] );
+		$this->assertSame( $existing_heading, $result['innerBlocks'][0] );
+	}
+
+	/**
 	 * `render()` returns an empty string for logged-out shoppers.
 	 */
 	public function test_render_returns_empty_for_logged_out_user(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds an editable `core/heading` as an inner block of Shopper Collection so merchants can rename the section without code. Defaults to "Saved for later" at H2, restructures the wrapper to a `<section>` with an inner `<ul class="wc-block-shopper-collection__list">`, and seeds the same heading on the auto-injected cart-page instance via `set_hooked_block_attributes()` so fresh installs ship with it out of the box.

The heading's visibility on the frontend mirrors the empty-state gating — hidden on first paint for shoppers who have never had items in this session, revealed once `context.hasShownItems` flips to `true`. Otherwise a fresh empty SC would show an orphaned heading sitting above nothing.

<img width="687" height="511" alt="Screenshot 2026-05-15 at 17 28 04" src="https://github.com/user-attachments/assets/8756d5f9-aa1e-49c1-80d9-3349800b9e61" />

<img width="754" height="543" alt="Screenshot 2026-05-15 at 17 27 46" src="https://github.com/user-attachments/assets/16926976-11da-4be0-a340-e107b29b89e7" />

### How to test the changes in this Pull Request:

1. Trash the cart page and recreate it from the WooCommerce → Pages action. Visit the cart on the frontend with a logged-in shopper that has at least one saved item — the "Saved for later" H2 should render above the list.
2. In the inspector controls, change the column count between 2 and 6 — the list should reflow accordingly (cells re-arrange, not just shrink).
3. Edit the cart page in the block editor, click the heading inside Shopper Collection, change its text (e.g. to "My wishlist"), update the page. Reload the frontend — the new text should render above the list.
4. Edit the cart page again, delete the heading, update the page. Reload the frontend — the list renders without the heading.
5. With the heading deleted, click the inserter inside Shopper Collection — only `core/heading` should be offered.
6. **Empty-state heading gating.** Save the cart page in the editor with the heading present. As a logged-in shopper who has no saved items, visit the cart on the frontend — the heading should be hidden (no orphaned title above nothing). Save an item via the cart's "Save for later" link — the heading should appear. Remove the item — the heading should remain visible alongside the empty-state message. Refresh the page — the heading should be hidden again, because the session-scoped `hasShownItems` flag resets on every full page load.

### Testing that has already taken place:

PHP unit tests pass (`pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter ShopperCollection`, 11/11). PHPCS, PHPStan, the JS build, CSS lint, TypeScript check (for changed code) and ESLint (for changed files) all clean.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually in `plugins/woocommerce/changelog/add-shopper-collection-heading`.

</details>