### PR TITLE
Add a nightly channel and version to the WooCommerce Beta Tester

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/add-beta-tester-nightly-channel
+++ b/plugins/woocommerce-beta-tester/changelog/add-beta-tester-nightly-channel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add nightly channel option to install WooCommerce trunk builds from GitHub via settings and version picker

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-admin-menus.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-admin-menus.php
@@ -270,6 +270,9 @@ Copy and paste the system status report from **WooCommerce > System Status** in 
 
 		$settings = WC_Beta_Tester::get_settings();
 		switch ( $settings->channel ) {
+			case 'nightly':
+				$current_channel = __( 'Nightly', 'woocommerce-beta-tester' );
+				break;
 			case 'beta':
 				$current_channel = __( 'Beta', 'woocommerce-beta-tester' );
 				break;

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-channel.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-channel.php
@@ -75,15 +75,19 @@ class WC_Beta_Tester_Channel {
 	public function version_select_html( $args ) {
 		$settings = WC_Beta_Tester::get_settings();
 		$channels = array(
-			'beta'   => array(
+			'nightly' => array(
+				'name'        => __( 'Nightly Releases', 'woocommerce-beta-tester' ),
+				'description' => __( 'Nightly builds are generated daily from the development trunk and may be unstable. Use for testing the latest changes only.', 'woocommerce-beta-tester' ),
+			),
+			'beta'    => array(
 				'name'        => __( 'Beta Releases', 'woocommerce-beta-tester' ),
 				'description' => __( 'Beta releases contain experimental functionality for testing purposes only. This channel will also include RC and stable releases if more current.', 'woocommerce-beta-tester' ),
 			),
-			'rc'     => array(
+			'rc'      => array(
 				'name'        => __( 'Release Candidates', 'woocommerce-beta-tester' ),
 				'description' => __( 'Release candidates are released to ensure any critical problems have not gone undetected. This channel will also include stable releases if more current.', 'woocommerce-beta-tester' ),
 			),
-			'stable' => array(
+			'stable'  => array(
 				'name'        => __( 'Stable Releases', 'woocommerce-beta-tester' ),
 				'description' => __( 'This is the default behavior in WordPress.', 'woocommerce-beta-tester' ),
 			),

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-plugin-upgrader.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-plugin-upgrader.php
@@ -40,6 +40,10 @@ class WC_Beta_Tester_Plugin_Upgrader extends Plugin_Upgrader {
 
 		$download_url = WC_Beta_Tester::instance()->get_download_url( $plugin_version );
 
+		if ( empty( $download_url ) ) {
+			return new WP_Error( 'no_download_url', __( 'Could not find download URL for version: ', 'woocommerce-beta-tester' ) . $plugin_version );
+		}
+
 		add_filter( 'upgrader_pre_install', array( $this, 'deactivate_plugin_before_upgrade' ), 10, 2 );
 		add_filter( 'upgrader_clear_destination', array( $this, 'delete_old_plugin' ), 10, 4 );
 
@@ -70,5 +74,4 @@ class WC_Beta_Tester_Plugin_Upgrader extends Plugin_Upgrader {
 
 		return true;
 	}
-
 }

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-version-picker.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-version-picker.php
@@ -69,10 +69,20 @@ class WC_Beta_Tester_Version_Picker {
 			// Try to reactivate.
 			activate_plugin( $plugin, '', is_network_admin(), true );
 
-			if ( is_wp_error( $skin->result ) ) {
+			if ( is_wp_error( $result ) ) {
+				throw new Exception( $result->get_error_message() );
+			} elseif ( is_wp_error( $skin->result ) ) {
 				throw new Exception( $skin->result->get_error_message() );
 			} elseif ( false === $result ) {
 				throw new Exception( __( 'Update failed', 'woocommerce-beta-tester' ) );
+			}
+
+			// Store the nightly asset timestamp so we can detect future updates.
+			if ( 'nightly' === $version ) {
+				$nightly_timestamp = WC_Beta_Tester::instance()->get_nightly_asset_timestamp();
+				if ( $nightly_timestamp ) {
+					WC_Beta_Tester::instance()->set_nightly_installed_timestamp( $nightly_timestamp );
+				}
 			}
 
 			wp_safe_redirect( admin_url( 'plugins.php?page=wc-beta-tester-version-picker&switched=' . rawurlencode( $version ) ) );
@@ -139,6 +149,20 @@ class WC_Beta_Tester_Version_Picker {
 		$versions_html        .= '<ul class="wcbt-version-list">';
 		$plugin_data           = WC_Beta_Tester::instance()->get_plugin_data();
 		$this->current_version = $plugin_data['Version'];
+
+		// Add nightly option at the top.
+		// Nightly builds have version strings ending in '-dev' (e.g., '10.9.0-dev').
+		$is_nightly     = strpos( $this->current_version, '-dev' ) !== false;
+		$versions_html .= '<li class="wcbt-version-li">';
+		$versions_html .= '<label><input type="radio" ' . checked( $is_nightly, true, false ) . ' value="nightly" name="wcbt_switch_to_version">nightly';
+		$versions_html .= ' <em>(' . esc_html__( 'Unstable - latest trunk build from GitHub', 'woocommerce-beta-tester' ) . ')</em>';
+
+		if ( $is_nightly ) {
+			$versions_html .= '<span class="wcbt-current-version"><strong>' . esc_html__( '&nbsp;Installed Version', 'woocommerce-beta-tester' ) . '</strong></span>';
+		}
+
+		$versions_html .= '</label>';
+		$versions_html .= '</li>';
 
 		// Loop through versions and output in a radio list.
 		foreach ( $tags as $tag_version ) {

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
@@ -620,16 +620,32 @@ class WC_Beta_Tester {
 			return;
 		}
 
-		// Check if WooCommerce was updated.
-		$wc_updated = false;
+		// Check if WooCommerce was in the update list.
+		$wc_in_update = false;
+		$is_bulk      = false;
 		if ( isset( $options['plugins'] ) && is_array( $options['plugins'] ) ) {
-			$wc_updated = in_array( 'woocommerce/woocommerce.php', $options['plugins'], true );
+			$wc_in_update = in_array( 'woocommerce/woocommerce.php', $options['plugins'], true );
+			$is_bulk      = true;
 		} elseif ( isset( $options['plugin'] ) ) {
-			$wc_updated = 'woocommerce/woocommerce.php' === $options['plugin'];
+			$wc_in_update = 'woocommerce/woocommerce.php' === $options['plugin'];
 		}
 
-		if ( ! $wc_updated ) {
+		if ( ! $wc_in_update ) {
 			return;
+		}
+
+		// Verify the upgrade actually succeeded.
+		$result = $upgrader->result;
+		if ( is_wp_error( $result ) ) {
+			return;
+		}
+
+		// For bulk updates, check the specific result for WooCommerce.
+		if ( $is_bulk && is_array( $result ) ) {
+			$wc_result = isset( $result['woocommerce/woocommerce.php'] ) ? $result['woocommerce/woocommerce.php'] : null;
+			if ( ! $wc_result || is_wp_error( $wc_result ) ) {
+				return;
+			}
 		}
 
 		// If we're on nightly channel, store the asset timestamp.

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
@@ -13,6 +13,16 @@ defined( 'ABSPATH' ) || exit;
 class WC_Beta_Tester {
 
 	/**
+	 * URL to download the nightly build zip from GitHub.
+	 */
+	const NIGHTLY_DOWNLOAD_URL = 'https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip';
+
+	/**
+	 * URL to fetch nightly release info from GitHub API.
+	 */
+	const NIGHTLY_VERSION_URL = 'https://api.github.com/repos/woocommerce/woocommerce/releases/tags/nightly';
+
+	/**
 	 * Config
 	 *
 	 * @var array
@@ -41,6 +51,13 @@ class WC_Beta_Tester {
 	private $wporg_data;
 
 	/**
+	 * GitHub nightly data
+	 *
+	 * @var object
+	 */
+	private $nightly_data;
+
+	/**
 	 * Main Instance.
 	 */
 	public static function instance() {
@@ -55,6 +72,7 @@ class WC_Beta_Tester {
 	public static function activate() {
 		delete_site_transient( 'update_plugins' );
 		delete_site_transient( 'woocommerce_latest_tag' );
+		delete_site_transient( 'wc_beta_tester_nightly_data' );
 	}
 
 	/**
@@ -71,7 +89,6 @@ class WC_Beta_Tester {
 			)
 		);
 
-		$settings->channel     = $settings->channel;
 		$settings->auto_update = (bool) $settings->auto_update;
 
 		return $settings;
@@ -102,11 +119,18 @@ class WC_Beta_Tester {
 		add_filter( "plugin_action_links_{$this->plugin_name}", array( $this, 'plugin_action_links' ), 10, 1 );
 		add_filter( 'auto_update_plugin', array( $this, 'auto_update_woocommerce' ), 100, 2 );
 
+		// Always add source selection filter for folder renaming (needed for nightly/GitHub downloads).
+		add_filter( 'upgrader_source_selection', array( $this, 'upgrader_source_selection' ), 10, 3 );
+
 		if ( 'stable' !== $this->get_settings()->channel ) {
-			add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'api_check' ) );
+			// Priority 99 to run after WC_Helper_Updater (priority 21) which may
+			// otherwise overwrite our changes to the update transient.
+			add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'api_check' ), 99 );
 			add_filter( 'plugins_api_result', array( $this, 'plugins_api_result' ), 10, 3 );
-			add_filter( 'upgrader_source_selection', array( $this, 'upgrader_source_selection' ), 10, 3 );
 		}
+
+		// Track when WooCommerce is updated so we can detect new nightly builds.
+		add_action( 'upgrader_process_complete', array( $this, 'on_upgrade_complete' ), 10, 2 );
 
 		$this->includes();
 	}
@@ -139,21 +163,36 @@ class WC_Beta_Tester {
 	}
 
 	/**
-	 * Get New Version from WPorg
+	 * Get New Version from WPorg or GitHub (for nightly)
 	 *
 	 * @since 1.0
-	 * @return int $version the version number
+	 * @return string|false $version the version number or false on failure.
 	 */
 	public function get_latest_channel_release() {
 		$tagged_version = get_site_transient( md5( $this->plugin_config['slug'] ) . '_latest_tag' );
+		$channel        = $this->get_settings()->channel;
 
 		if ( $this->overrule_transients() || empty( $tagged_version ) ) {
 
+			// Handle nightly channel separately - it doesn't come from WP.org.
+			// Use date-based version (YYYY.MM.DD-nightly) showing when the build was created.
+			// This format satisfies WooCommerce's requirement for X.Y.Z version format.
+			if ( 'nightly' === $channel ) {
+				$asset_timestamp = $this->get_nightly_asset_timestamp();
+				$nightly_date    = $asset_timestamp ? gmdate( 'Y.m.d', strtotime( $asset_timestamp ) ) : gmdate( 'Y.m.d' );
+				$tagged_version  = $nightly_date . '-nightly';
+				set_site_transient( md5( $this->plugin_config['slug'] ) . '_latest_tag', $tagged_version, HOUR_IN_SECONDS );
+				return $tagged_version;
+			}
+
+			// Existing WP.org logic for beta/rc/stable channels.
 			$data = $this->get_wporg_data();
 
-			$latest_version = $data->version;
-			$versions       = (array) $data->versions;
-			$channel        = $this->get_settings()->channel;
+			if ( ! $data ) {
+				return false;
+			}
+
+			$versions = (array) $data->versions;
 
 			foreach ( $versions as $version => $download_url ) {
 				if ( 'trunk' === $version ) {
@@ -220,6 +259,49 @@ class WC_Beta_Tester {
 	}
 
 	/**
+	 * Get nightly release data from GitHub API.
+	 *
+	 * @since 3.1.0
+	 * @return object|false The nightly data or false on failure.
+	 */
+	public function get_nightly_data() {
+		if ( ! empty( $this->nightly_data ) ) {
+			return $this->nightly_data;
+		}
+
+		$nightly_data = get_site_transient( 'wc_beta_tester_nightly_data' );
+
+		if ( $this->overrule_transients() || empty( $nightly_data ) ) {
+			$response = wp_remote_get(
+				self::NIGHTLY_VERSION_URL,
+				array(
+					'headers' => array(
+						'Accept' => 'application/vnd.github.v3+json',
+					),
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				return false;
+			}
+
+			$nightly_data = json_decode( wp_remote_retrieve_body( $response ) );
+
+			if ( empty( $nightly_data ) || isset( $nightly_data->message ) ) {
+				return false;
+			}
+
+			// Cache for 1 hour (nightlies update daily, but we check more frequently).
+			set_site_transient( 'wc_beta_tester_nightly_data', $nightly_data, HOUR_IN_SECONDS );
+		}
+
+		// Store the data in this class instance for future calls.
+		$this->nightly_data = $nightly_data;
+
+		return $nightly_data;
+	}
+
+	/**
 	 * Get plugin download URL.
 	 *
 	 * @since 1.0
@@ -227,6 +309,12 @@ class WC_Beta_Tester {
 	 * @return string
 	 */
 	public function get_download_url( $version ) {
+		// Handle nightly builds from GitHub.
+		if ( self::is_nightly_version( $version ) ) {
+			return self::NIGHTLY_DOWNLOAD_URL;
+		}
+
+		// Handle WP.org versions.
 		$data = $this->get_wporg_data();
 
 		if ( empty( $data->versions->$version ) ) {
@@ -258,15 +346,32 @@ class WC_Beta_Tester {
 		delete_site_transient( md5( $this->plugin_config['slug'] ) . '_latest_tag' );
 
 		// Get version data.
-		$plugin_data = $this->get_plugin_data();
-		$version     = $plugin_data['Version'];
-		$new_version = $this->get_latest_channel_release();
+		$plugin_data    = $this->get_plugin_data();
+		$current_version = $plugin_data['Version'];
+		$new_version    = $this->get_latest_channel_release();
 
-		// check the version and decide if it's new.
-		$update = version_compare( $new_version, $version, '>' );
+		if ( ! $new_version ) {
+			return $transient;
+		}
+
+		// Check if an update is available.
+		if ( 'nightly' === $this->get_settings()->channel ) {
+			// For nightly channel, check if the nightly release has been updated
+			// since we last installed it (using the asset's updated_at timestamp).
+			$update = $this->is_nightly_update_available();
+		} else {
+			// Standard version comparison for other channels.
+			$update = version_compare( $new_version, $current_version, '>' );
+		}
 
 		if ( ! $update ) {
 			return $transient;
+		}
+
+		// Remove from no_update if present (WordPress may have put it there
+		// because the .org version is lower than our installed dev version).
+		if ( isset( $transient->no_update['woocommerce/woocommerce.php'] ) ) {
+			unset( $transient->no_update['woocommerce/woocommerce.php'] );
 		}
 
 		// Populate response data.
@@ -303,6 +408,10 @@ class WC_Beta_Tester {
 
 		$warning = '';
 
+		if ( self::is_nightly_version( $new_version ) ) {
+			$warning = __( '<h1><span>&#9888;</span>This is a nightly development build<span>&#9888;</span></h1>', 'woocommerce-beta-tester' );
+		}
+
 		if ( $this->is_beta_version( $new_version ) ) {
 			$warning = __( '<h1><span>&#9888;</span>This is a beta release<span>&#9888;</span></h1>', 'woocommerce-beta-tester' );
 		}
@@ -315,9 +424,16 @@ class WC_Beta_Tester {
 		$response->version       = $new_version;
 		$response->download_link = $this->get_download_url( $new_version );
 
+		// Set the changelog URL based on version type.
+		if ( self::is_nightly_version( $new_version ) ) {
+			$changelog_url = 'https://github.com/woocommerce/woocommerce/releases/tag/nightly';
+		} else {
+			$changelog_url = 'https://github.com/woocommerce/woocommerce/blob/' . $response->version . '/readme.txt';
+		}
+
 		$response->sections['changelog'] = sprintf(
 			'<p><a target="_blank" href="%s">' . __( 'Read the changelog and find out more about the release on GitHub.', 'woocommerce-beta-tester' ) . '</a></p>',
-			'https://github.com/woocommerce/woocommerce/blob/' . $response->version . '/readme.txt'
+			$changelog_url
 		);
 
 		foreach ( $response->sections as $key => $section ) {
@@ -338,13 +454,20 @@ class WC_Beta_Tester {
 	public function upgrader_source_selection( $source, $remote_source, $upgrader ) {
 		global $wp_filesystem;
 
-		if ( strstr( $source, '/woocommerce-woocommerce-' ) ) {
+		// Get the folder name of the extracted plugin (e.g., 'woocommerce' or 'woocommerce-woocommerce-abc123').
+		$source_folder_name = basename( untrailingslashit( $source ) );
+
+		// Handle GitHub downloads that extract to non-standard folder names.
+		// Other GitHub downloads extract to 'woocommerce-woocommerce-{hash}/'.
+		// Only rename if the extracted folder name itself needs correction.
+		// Nightly builds already extract to 'woocommerce/' so no rename needed.
+		if ( strpos( $source_folder_name, 'woocommerce-woocommerce-' ) === 0 ) {
 			$corrected_source = trailingslashit( $remote_source ) . trailingslashit( $this->plugin_config['proper_folder_name'] );
 
 			if ( $wp_filesystem->move( $source, $corrected_source, true ) ) {
 				return $corrected_source;
 			} else {
-				return new WP_Error();
+				return new WP_Error( 'move_failed', 'Could not move ' . $source . ' to ' . $corrected_source );
 			}
 		}
 
@@ -393,7 +516,129 @@ class WC_Beta_Tester {
 	 * @return bool
 	 */
 	protected static function is_stable_version( $version_str ) {
-		return ! self::is_beta_version( $version_str ) && ! self::is_rc_version( $version_str );
+		return ! self::is_beta_version( $version_str ) && ! self::is_rc_version( $version_str ) && ! self::is_nightly_version( $version_str );
+	}
+
+	/**
+	 * Return true if version string is a nightly version.
+	 *
+	 * @since 3.1.0
+	 * @param string $version_str Version string.
+	 * @return bool
+	 */
+	protected static function is_nightly_version( $version_str ) {
+		// Nightly versions are either:
+		// - Contains '-nightly' (e.g., '2026.05.15-nightly' used in the update system)
+		// - Version strings containing '-dev' (e.g., '10.9.0-dev' from installed builds)
+		return strpos( $version_str, '-nightly' ) !== false || strpos( $version_str, '-dev' ) !== false;
+	}
+
+	/**
+	 * Check if a nightly update is available by comparing the GitHub release
+	 * asset's updated_at timestamp to when we last installed a nightly.
+	 *
+	 * @since 3.1.0
+	 * @return bool True if a newer nightly is available.
+	 */
+	protected function is_nightly_update_available() {
+		$nightly_data = $this->get_nightly_data();
+
+		if ( ! $nightly_data || empty( $nightly_data->assets ) ) {
+			return false;
+		}
+
+		// Find the zip asset's updated_at timestamp.
+		$asset_updated_at = null;
+		foreach ( $nightly_data->assets as $asset ) {
+			if ( isset( $asset->name ) && 'woocommerce-trunk-nightly.zip' === $asset->name ) {
+				$asset_updated_at = isset( $asset->updated_at ) ? $asset->updated_at : null;
+				break;
+			}
+		}
+
+		if ( ! $asset_updated_at ) {
+			// Can't determine, offer update to be safe.
+			return true;
+		}
+
+		// Get the timestamp of when we last installed a nightly.
+		$last_installed = get_option( 'wc_beta_tester_nightly_installed_at' );
+
+		if ( ! $last_installed ) {
+			// Never installed a nightly via this plugin, offer update.
+			return true;
+		}
+
+		// Compare timestamps - offer update if asset is newer.
+		return strtotime( $asset_updated_at ) > strtotime( $last_installed );
+	}
+
+	/**
+	 * Store the timestamp when a nightly build was installed.
+	 * Called after successful nightly installation.
+	 *
+	 * @since 3.1.0
+	 * @param string $timestamp ISO 8601 timestamp of the installed nightly asset.
+	 */
+	public function set_nightly_installed_timestamp( $timestamp ) {
+		update_option( 'wc_beta_tester_nightly_installed_at', $timestamp );
+	}
+
+	/**
+	 * Get the current nightly asset's updated_at timestamp from GitHub.
+	 *
+	 * @since 3.1.0
+	 * @return string|null ISO 8601 timestamp or null if not available.
+	 */
+	public function get_nightly_asset_timestamp() {
+		$nightly_data = $this->get_nightly_data();
+
+		if ( ! $nightly_data || empty( $nightly_data->assets ) ) {
+			return null;
+		}
+
+		foreach ( $nightly_data->assets as $asset ) {
+			if ( isset( $asset->name ) && 'woocommerce-trunk-nightly.zip' === $asset->name ) {
+				return isset( $asset->updated_at ) ? $asset->updated_at : null;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Callback for upgrader_process_complete action.
+	 * Stores the nightly timestamp when WooCommerce is updated via standard updater.
+	 *
+	 * @since 3.1.0
+	 * @param WP_Upgrader $upgrader WP_Upgrader instance.
+	 * @param array       $options  Array of update data.
+	 */
+	public function on_upgrade_complete( $upgrader, $options ) {
+		// Only handle plugin updates.
+		if ( 'update' !== $options['action'] || 'plugin' !== $options['type'] ) {
+			return;
+		}
+
+		// Check if WooCommerce was updated.
+		$wc_updated = false;
+		if ( isset( $options['plugins'] ) && is_array( $options['plugins'] ) ) {
+			$wc_updated = in_array( 'woocommerce/woocommerce.php', $options['plugins'], true );
+		} elseif ( isset( $options['plugin'] ) ) {
+			$wc_updated = 'woocommerce/woocommerce.php' === $options['plugin'];
+		}
+
+		if ( ! $wc_updated ) {
+			return;
+		}
+
+		// If we're on nightly channel, store the asset timestamp.
+		if ( 'nightly' === $this->get_settings()->channel ) {
+			$nightly_timestamp = $this->get_nightly_asset_timestamp();
+			if ( $nightly_timestamp ) {
+				$this->set_nightly_installed_timestamp( $nightly_timestamp );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -68,7 +68,8 @@ function _wc_beta_tester_bootstrap() {
 
 		register_activation_hook( __FILE__, array( 'WC_Beta_Tester', 'activate' ) );
 
-		add_action( 'admin_init', array( 'WC_Beta_Tester', 'instance' ) );
+		// Initialize immediately so update filters are registered for cron/CLI.
+		WC_Beta_Tester::instance();
 	}
 
 	// Load admin.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a "Nightly" channel to the WooCommerce Beta Tester plugin that allows users to install WooCommerce trunk builds directly from GitHub.

Key changes:
 - New "Nightly Releases" channel option in Beta Tester settings
 - Downloads nightly builds from https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip
 - Version displayed as YYYY.MM.DD-nightly based on the GitHub asset's build date
 - Auto-update detection compares installed nightly timestamp to GitHub asset timestamp
 - Nightly option in version picker is pre-selected when running a nightly build (detected by -dev in version string)

#### Implementation note

The WC_Beta_Tester::instance() is now initialized immediately within the plugins_loaded bootstrap rather than being deferred. This ensures the update-related filters (pre_set_site_transient_update_plugins, auto_update_plugin, etc.) are registered early enough for WordPress cron jobs and WP-CLI commands to detect updates. Without this, automatic update checks running via cron would not see the nightly channel updates because the filters wouldn't be registered yet.

If there's a better approach, let me know.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #41818 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

  How to test the changes in this Pull Request

  Test 1: Install nightly via channel setting

  1. Go to Plugins > WC Beta Tester
  2. Select Nightly Releases channel
  3. Save settings
  4. Go to Dashboard > Updates or Plugins page
  5. Verify WooCommerce shows an update available with version like 2026.05.15-nightly
  6. Click update and verify it downloads and installs successfully
  7. Verify WooCommerce activates and the site works

  Test 2: Install nightly via version picker

  1. Go to Plugins > WooCommerce Version Switch
  2. Verify "nightly" option appears at the top of the list with description "(Unstable - latest trunk build from GitHub)"
  3. Select "nightly" and click Switch version
  4. Verify the switch completes successfully
  5. Refresh the page and verify "nightly" is now checked with "Installed
  Version" label

  Test 3: Auto-update detection

  1. Install a nightly build using either method above
  2. Wait for the next day's nightly to be published on GitHub (or manually clear the wc_beta_tester_nightly_installed_at option to simulate)
  3. Verify the plugins page shows an update available when a newer nightly exists

  Test 4: Switch back to stable

  1. While running a nightly build, go to Plugins > WC Beta Tester
  2. Change channel to Stable Releases or Beta Releases
  3. Go to Dashboard > Updates
  4. Verify the stable/beta version is offered as an update
  5. Update and verify the site works correctly

  ---
  Testing that has already taken place

  - Verified nightly download URL works
  - Verified version picker correctly shows nightly option
  - Verified nightly is pre-selected when running -dev version
  - Verified auto-update timestamp tracking works
  - Verified switching between channels works

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
