### PR TITLE
Gate full PR CI behind `run: full ci` label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: 'CI'
 on:
   pull_request:
+    # Include labeled so adding `run: full ci` can trigger full PR CI immediately.
+    types: [opened, synchronize, reopened, labeled]
   push:
     paths:
       - '**'
@@ -47,11 +49,17 @@ jobs:
     if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     outputs:
+      run-full-ci: ${{ steps.ci-mode.outputs.run-full-ci }}
       needs-code-validation: ${{ steps.target-changes.outputs.needs-code-validation }}
       needs-changelog-validation: ${{ steps.target-changes.outputs.needs-changelog-validation }}
       needs-markdown-validation:  ${{ steps.target-changes.outputs.needs-markdown-validation }}
       needs-syncpack-validation:  ${{ steps.target-changes.outputs.needs-syncpack-validation }}
     steps:
+      - name: 'Check CI mode'
+        id: ci-mode
+        run: |
+          echo "run-full-ci=${{ contains( github.event.pull_request.labels.*.name, 'run: full ci' ) }}" >> "$GITHUB_OUTPUT"
+
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: target-changes
         with:
@@ -71,7 +79,7 @@ jobs:
     # which projects have changed and what kind of change occurred. This lets us build the
     # matrices that we can use to run CI tasks only on the projects that need them.
     name: 'Build Project Jobs'
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.run-full-ci == 'true' ) }}
     needs: 'identify-jobs-to-run'
     runs-on: ubuntu-latest
     outputs:
@@ -121,10 +129,11 @@ jobs:
             child_process.execSync( `pnpm utils ci-jobs ${ prNumberFilter } --event ${ githubEvent }` );
 
   project-lint-jobs:
+    # Full PR CI is opt-in. Add `run: full ci` to run these jobs on a PR.
     name: "Lint - ${{ matrix.projectName }} ${{ ( matrix.optional && ' (optional)' ) || '' }}"
     runs-on: ubuntu-latest
     needs: [ 'identify-jobs-to-run', 'project-jobs' ]
-    if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' && needs.project-jobs.outputs.lint-jobs != '[]' }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.identify-jobs-to-run.outputs.run-full-ci == 'true' && needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' && needs.project-jobs.outputs.lint-jobs != '[]' }}
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -151,8 +160,8 @@ jobs:
   project-test-jobs:
     name: '${{ matrix.name }}'
     runs-on: ubuntu-latest
-    needs: 'project-jobs'
-    if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' ) && needs.project-jobs.outputs.test-jobs != '[]' }}
+    needs: [ 'identify-jobs-to-run', 'project-jobs' ]
+    if: ${{ !cancelled() && ( github.event_name != 'pull_request' || ( needs.identify-jobs-to-run.outputs.run-full-ci == 'true' && needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' ) ) && needs.project-jobs.outputs.test-jobs != '[]' }}
     env: ${{ matrix.testEnv.envVars }}
     strategy:
       fail-fast: false
@@ -297,9 +306,9 @@ jobs:
     # on the results of the other jobs in the workflow.
     name: 'Evaluate Project Job Statuses'
     runs-on: ubuntu-latest
-    needs: [ 'project-jobs', 'project-lint-jobs', 'project-test-jobs', 'validate-changelog', 'validate-markdown', 'validate-syncpack' ]
+    needs: [ 'identify-jobs-to-run', 'project-jobs', 'project-lint-jobs', 'project-test-jobs', 'validate-changelog', 'validate-markdown', 'validate-syncpack' ]
     # This job must run for all trigger types (not just PRs) so that alert-on-failure can access its outputs
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.run-full-ci == 'true' ) }}
     outputs:
       non_successful_jobs: ${{ steps.evaluation.outputs.non_successful_jobs }}
     steps:
@@ -325,6 +334,24 @@ jobs:
           fi
 
           node .github/workflows/scripts/evaluate-jobs-conclusions.js
+
+  full-ci-required:
+    name: 'Full CI Required'
+    runs-on: ubuntu-latest
+    needs: [ 'identify-jobs-to-run', 'evaluate-project-jobs' ]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    steps:
+      - name: 'Check full CI status'
+        run: |
+          if [[ "${{ needs.identify-jobs-to-run.outputs.run-full-ci }}" != "true" ]]; then
+            echo "::error::Add the 'run: full ci' label to run full CI before merging."
+            exit 1
+          fi
+
+          if [[ "${{ needs.evaluate-project-jobs.result }}" != "success" ]]; then
+            echo "::error::Full CI has not passed for this commit."
+            exit 1
+          fi
 
   alert-on-failure:
     name: 'Report results on Slack'
@@ -375,8 +402,8 @@ jobs:
 
   test-reports:
     name: 'Test reports - ${{ matrix.report }}'
-    needs: ['project-jobs', 'project-test-jobs', 'evaluate-project-jobs']
-    if: ${{ !cancelled() && github.repository == 'woocommerce/woocommerce' && ( github.event_name != 'pull_request' || ( needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' && ! github.event.pull_request.head.repo.fork ) ) && needs.project-jobs.outputs.report-jobs != '[]' }}
+    needs: ['identify-jobs-to-run', 'project-jobs', 'project-test-jobs', 'evaluate-project-jobs']
+    if: ${{ !cancelled() && github.repository == 'woocommerce/woocommerce' && ( github.event_name != 'pull_request' || ( needs.identify-jobs-to-run.outputs.run-full-ci == 'true' && needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' && ! github.event.pull_request.head.repo.fork ) ) && needs.project-jobs.outputs.report-jobs != '[]' }}
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: 'CI'
 on:
   pull_request:
-    # Include labeled so adding `run: full ci` can trigger full PR CI immediately.
-    types: [opened, synchronize, reopened, labeled]
+    # Include label changes so `run: full ci` updates can refresh required checks immediately.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     paths:
       - '**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: 'CI'
 on:
   pull_request:
-    # Include label changes so `run: full ci` updates can refresh required checks immediately.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     paths:
       - '**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: 'CI'
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     paths:
       - '**'

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ CLAUDE.local.md
 
 # Docusaurus
 .docusaurus
+
+# CI labeled-event unrelated path test marker; safe to remove after measuring workflow jobs.

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -30,6 +30,7 @@ if ( ! \Automattic\WooCommerce\Autoloader::init() ) {
 \Automattic\WooCommerce\Packages::init();
 
 // Include the main WooCommerce class.
+// CI labeled-event path test marker; safe to remove after measuring workflow jobs.
 if ( ! class_exists( 'WooCommerce', false ) ) {
 	include_once dirname( WC_PLUGIN_FILE ) . '/includes/class-woocommerce.php';
 }

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -30,6 +30,7 @@ if ( ! \Automattic\WooCommerce\Autoloader::init() ) {
 \Automattic\WooCommerce\Packages::init();
 
 // Include the main WooCommerce class.
+// CI usage test marker; safe to remove after measuring workflow minutes.
 if ( ! class_exists( 'WooCommerce', false ) ) {
 	include_once dirname( WC_PLUGIN_FILE ) . '/includes/class-woocommerce.php';
 }

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -30,7 +30,6 @@ if ( ! \Automattic\WooCommerce\Autoloader::init() ) {
 \Automattic\WooCommerce\Packages::init();
 
 // Include the main WooCommerce class.
-// CI usage test marker; safe to remove after measuring workflow minutes.
 if ( ! class_exists( 'WooCommerce', false ) ) {
 	include_once dirname( WC_PLUGIN_FILE ) . '/includes/class-woocommerce.php';
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`ci.yml` is the dominant Actions minutes consumer for WooCommerce Core. This PR makes the full PR CI matrix opt-in behind the `run: full ci` label so contributors can iterate without running the expensive matrix on every push, while still providing a required check that can block merging until full CI has run successfully.

Changes:

- Adds `labeled` to the `pull_request` trigger so applying `run: full ci` starts full PR CI immediately.
- Keeps the lightweight PR analysis job running so the workflow can decide whether full CI should run.
- Gates the full PR CI jobs behind the `run: full ci` label.
- Adds a stable `Full CI Required` job that fails until the label is present and full CI has passed for the current PR workflow run.
- Preserves full CI behavior for `push` and `workflow_call` runs.

Rollout note:

To enforce this before merge, repository branch protection or rulesets should require the `Full CI Required` check. The `run: full ci` label also needs to exist in the repository.

### Screenshots or screen recordings:

Not applicable. This PR only changes GitHub Actions workflow behavior.

### How to test the changes in this Pull Request:

1. Open a test PR without the `run: full ci` label.
2. Confirm that `Analyze changes` runs, full PR CI jobs are skipped, and `Full CI Required` fails with instructions to add `run: full ci`.
3. Add the `run: full ci` label to the test PR.
4. Confirm that the workflow is triggered by the label event and the full PR CI jobs run.
5. Confirm that `Full CI Required` passes only after the full CI evaluation succeeds.
6. Push another commit to the labeled PR and confirm full CI runs again for the latest PR commit.

### Testing that has already taken place:

- Parsed `.github/workflows/ci.yml` as YAML.
- Ran `git diff --check -- .github/workflows/ci.yml`.
- Confirmed the branch differs from `origin/trunk` only in `.github/workflows/ci.yml`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI workflow-only change; no user-facing product changelog entry is needed.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)