### PR TITLE
Migrate Checkout block family to block.json-declared styles and EnableBlockJsonAssetsTrait

### DIFF
--- a/plugins/woocommerce/changelog/feat-issue-64253
+++ b/plugins/woocommerce/changelog/feat-issue-64253
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrate the Checkout block and its 23 inner blocks to declare styles in `block.json` and use `EnableBlockJsonAssetsTrait`, removing the legacy PHP-side style registration path.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/block.json
@@ -27,6 +27,8 @@
 			"default": false
 		}
 	},
+	"style": [ "wc-blocks-style", "wc-blocks-style-checkout", "wc-blocks-packages-style" ],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.json
@@ -38,6 +38,7 @@
 		}
 	},
 	"parent": [ "woocommerce/checkout-fields-block" ],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.json
@@ -26,6 +26,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.json
@@ -24,6 +24,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.json
@@ -24,6 +24,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/block.json
@@ -40,6 +40,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/block.json
@@ -28,6 +28,7 @@
 	"parent": [
 		"woocommerce/checkout"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/block.json
@@ -26,6 +26,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/block.json
@@ -23,6 +23,7 @@
 	"parent": [
 		"woocommerce/checkout-totals-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/block.json
@@ -29,6 +29,7 @@
 		}
 	},
 	"parent": [ "woocommerce/checkout-order-summary-block" ],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-coupon-form/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-coupon-form/block.json
@@ -26,6 +26,7 @@
 	"parent": [
 		"woocommerce/checkout-order-summary-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/block.json
@@ -27,6 +27,7 @@
 	"parent": [
 		"woocommerce/checkout-order-summary-totals-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-fee/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-fee/block.json
@@ -27,6 +27,7 @@
 	"parent": [
 		"woocommerce/checkout-order-summary-totals-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.json
@@ -23,6 +23,7 @@
 	"parent": [
 		"woocommerce/checkout-order-summary-totals-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-subtotal/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-subtotal/block.json
@@ -27,6 +27,7 @@
 	"parent": [
 		"woocommerce/checkout-order-summary-totals-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/block.json
@@ -27,6 +27,7 @@
 	"parent": [
 		"woocommerce/checkout-order-summary-totals-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-totals/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-totals/block.json
@@ -27,6 +27,7 @@
 	"parent": [
 		"woocommerce/checkout-order-summary-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/block.json
@@ -24,6 +24,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.json
@@ -24,6 +24,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.json
@@ -24,6 +24,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.json
@@ -24,6 +24,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.json
@@ -24,6 +24,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/block.json
@@ -31,6 +31,7 @@
 	"parent": [
 		"woocommerce/checkout-fields-block"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/block.json
@@ -29,6 +29,7 @@
 	"parent": [
 		"woocommerce/checkout"
 	],
+	"editorStyle": "wc-blocks-editor-style",
 	"textdomain": "woocommerce",
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -51003,7 +51003,6 @@ parameters:
 			count: 1
 			path: src/Blocks/BlockTypes/AbstractInnerBlock.php
 
-
 		-
 			message: '#^@param Automattic\\WooCommerce\\Blocks\\BlockTypes\\WC_Product \$product does not accept actual type of parameter\: WC_Product\.$#'
 			identifier: parameter.phpDocType

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -51003,11 +51003,6 @@ parameters:
 			count: 1
 			path: src/Blocks/BlockTypes/AbstractInnerBlock.php
 
-		-
-			message: '#^Parameter \#2 \$args of function register_block_type_from_metadata expects array\{api_version\?\: string, title\?\: string, category\?\: string\|null, parent\?\: array\<string\>\|null, ancestor\?\: array\<string\>\|null, allowed_blocks\?\: array\<string\>\|null, icon\?\: string\|null, description\?\: string, \.\.\.\}, array\{render_callback\: mixed, editor_style\: string\|null, style\: null, api_version\?\: int\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/BlockTypes/AbstractInnerBlock.php
 
 		-
 			message: '#^@param Automattic\\WooCommerce\\Blocks\\BlockTypes\\WC_Product \$product does not accept actual type of parameter\: WC_Product\.$#'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractInnerBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractInnerBlock.php
@@ -22,12 +22,11 @@ abstract class AbstractInnerBlock extends AbstractBlock {
 	protected function register_block_type() {
 		$block_settings = [
 			'render_callback' => $this->get_block_type_render_callback(),
-			'editor_style'    => $this->get_block_type_editor_style(),
-			'style'           => $this->get_block_type_style(),
 		];
 
-		if ( isset( $this->api_version ) ) {
-			$block_settings['api_version'] = intval( $this->api_version );
+		$block_type_editor_style = $this->get_block_type_editor_style();
+		if ( $block_type_editor_style ) {
+			$block_settings['editor_style'] = $block_type_editor_style;
 		}
 
 		$metadata_path = $this->asset_api->get_block_metadata_path( $this->block_name, 'inner-blocks/' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -17,6 +17,8 @@ use Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController;
  * @internal
  */
 class Checkout extends AbstractBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *
@@ -38,6 +40,7 @@ class Checkout extends AbstractBlock {
 	 * - Register the block with WordPress.
 	 */
 	protected function initialize() {
+		$this->asset_api->register_style( 'wc-blocks-style-checkout', $this->asset_api->get_block_asset_build_path( 'checkout', 'css' ), [], 'all', true );
 		parent::initialize();
 		add_action( 'rest_api_init', array( $this, 'register_settings' ) );
 		add_action( 'wp_loaded', array( $this, 'register_patterns' ) );
@@ -200,15 +203,6 @@ class Checkout extends AbstractBlock {
 			'dependencies' => $dependencies,
 		];
 		return $key ? $script[ $key ] : $script;
-	}
-
-	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @return string[]
-	 */
-	protected function get_block_type_style() {
-		return array_merge( parent::get_block_type_style(), [ 'wc-blocks-packages-style' ] );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutActionsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutActionsBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutActionsBlock class.
  */
 class CheckoutActionsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutAdditionalInformationBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutAdditionalInformationBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutAdditionalInformationBlock class.
  */
 class CheckoutAdditionalInformationBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutBillingAddressBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutBillingAddressBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutBillingAddressBlock class.
  */
 class CheckoutBillingAddressBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutContactInformationBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutContactInformationBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutContactInformationBlock class.
  */
 class CheckoutContactInformationBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutExpressPaymentBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutExpressPaymentBlock.php
@@ -8,6 +8,8 @@ use Exception;
  * CheckoutExpressPaymentBlock class.
  */
 class CheckoutExpressPaymentBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutFieldsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutFieldsBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutFieldsBlock class.
  */
 class CheckoutFieldsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderNoteBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderNoteBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderNoteBlock class.
  */
 class CheckoutOrderNoteBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummaryBlock class.
  */
 class CheckoutOrderSummaryBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryCartItemsBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummaryCartItemsBlock class.
  */
 class CheckoutOrderSummaryCartItemsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryCouponFormBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryCouponFormBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummaryCouponFormBlock class.
  */
 class CheckoutOrderSummaryCouponFormBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryDiscountBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryDiscountBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummaryDiscountBlock class.
  */
 class CheckoutOrderSummaryDiscountBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryFeeBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryFeeBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummaryFeeBlock class.
  */
 class CheckoutOrderSummaryFeeBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryShippingBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryShippingBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummaryShippingBlock class.
  */
 class CheckoutOrderSummaryShippingBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummarySubtotalBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummarySubtotalBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummarySubtotalBlock class.
  */
 class CheckoutOrderSummarySubtotalBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryTaxesBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryTaxesBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummaryTaxesBlock class.
  */
 class CheckoutOrderSummaryTaxesBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryTotalsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutOrderSummaryTotalsBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutOrderSummaryTotalsBlock class.
  */
 class CheckoutOrderSummaryTotalsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutPaymentBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutPaymentBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutPaymentBlock class.
  */
 class CheckoutPaymentBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutPickupOptionsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutPickupOptionsBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutPickupOptionsBlock class.
  */
 class CheckoutPickupOptionsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutShippingAddressBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutShippingAddressBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutShippingAddressBlock class.
  */
 class CheckoutShippingAddressBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutShippingMethodBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutShippingMethodBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutShippingMethodBlock class.
  */
 class CheckoutShippingMethodBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutShippingMethodsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutShippingMethodsBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutShippingMethodsBlock class.
  */
 class CheckoutShippingMethodsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutTermsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutTermsBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutTermsBlock class.
  */
 class CheckoutTermsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutTotalsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutTotalsBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * CheckoutTotalsBlock class.
  */
 class CheckoutTotalsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Follows the established migration pattern (already applied to `AddToCartForm`, `SingleProduct`, `ProductGallery`, and others) to move the Checkout block family off the legacy PHP-side style registration path and onto `block.json`-declared assets.

**`AbstractInnerBlock`** (`src/Blocks/BlockTypes/AbstractInnerBlock.php`):
- Rewrote `register_block_type()` to conditionally include `editor_style` only when non-null, matching `AbstractBlock`'s existing pattern. Previously it unconditionally passed both `style` and `editor_style` as explicit args, meaning a `null` value would override any `style` declared in block.json.
- Removed the dead `style` conditional — inner blocks never provide a PHP-side style handle (`get_block_type_style()` always returns `null`) so the branch was unreachable dead code.
- Removed the dead `api_version` conditional — no inner block subclass sets `$api_version` (block.json already declares `"apiVersion": 3`).
- Removed the now-resolved PHPStan baseline entry that covered the old array shape `{style: null, api_version?: int}`.

**`Checkout.php`** (`src/Blocks/BlockTypes/Checkout.php`):
- Added `use EnableBlockJsonAssetsTrait;` so `get_block_type_style()` and `get_block_type_editor_style()` return `null`, letting block.json take effect.
- Moved the `register_style('wc-blocks-style-checkout', ...)` call into `initialize()` — previously this was a side-effect of `get_block_type_style()`. The handle must still be registered before WordPress attempts to enqueue it from block.json.
- Removed the `get_block_type_style()` override.
- `get_block_type_script()` is preserved — class methods take precedence over trait methods in PHP, so the conditional dependency logic for `zxcvbn-async` and `wc-schema-parser` is unaffected.

**`client/blocks/assets/js/blocks/checkout/block.json`** (source):
- Declared `"style": ["wc-blocks-style", "wc-blocks-style-checkout", "wc-blocks-packages-style"]` and `"editorStyle": "wc-blocks-editor-style"`, replicating the three handles previously returned from PHP.

Note: the checkout block's CSS architecture differs from other migrated blocks (`add-to-cart-form`, etc.) which use `file:` references to per-block CSS files. Checkout depends on two shared bundles (`wc-blocks-style`, `wc-blocks-packages-style`) that have no per-block file path, so named handle strings are used instead — as the issue description explicitly specifies ("handles").

**23 Checkout inner block PHP classes** (`CheckoutActionsBlock` → `CheckoutTotalsBlock`):
- Added `use EnableBlockJsonAssetsTrait;` to each class. This makes `get_block_type_editor_style()` return `null` (previously inherited `'wc-blocks-editor-style'` from `AbstractBlock`), so the fixed `AbstractInnerBlock::register_block_type()` no longer passes it as a PHP override and block.json's `editorStyle` takes effect.

**23 Checkout inner block `block.json` source files** (`client/blocks/assets/js/blocks/checkout/inner-blocks/*/block.json`):
- Added `"editorStyle": "wc-blocks-editor-style"` to each. No `style` field is needed — inner blocks have no frontend CSS of their own; their styles come from the parent checkout block's stylesheet.

Closes #64253 

### Screenshots or screen recordings:

| checkout-editor | checkout-frontend |
| --- | --- |
| <img width="1200" height="663" alt="checkout-editor" src="https://github.com/user-attachments/assets/ea8a310d-0831-4c66-8739-c120ba4a0d38" /> | <img width="1200" height="1024" alt="checkout-frontend" src="https://github.com/user-attachments/assets/e5dbd89a-8420-42c1-812b-d8a4ef1c40a6" /> |


### How to test the changes in this Pull Request:

1. Set up a WooCommerce store with the block-based Checkout page (default in recent WooCommerce).
2. Add at least one product to the cart and navigate to `/checkout`.
3. Open DevTools → Network tab, filter by `.css`. Confirm all three frontend handles are present in the loaded stylesheets:
   - `wc-blocks-style`
   - `wc-blocks-style-checkout`
   - `wc-blocks-packages-style`
4. Confirm the checkout page renders correctly — form fields, express payments, order summary, shipping methods, and the place-order button all display with correct styling and layout.
5. Check the browser console for any CSS 404 errors or stylesheet warnings.
6. Navigate to **WP Admin → Pages**, open the Checkout page in the block editor. Confirm the checkout block and all inner blocks render with correct styles in the editor (no broken or unstyled sections).
7. Confirm `wc-blocks-editor-style` appears in the editor's loaded stylesheets (DevTools → Network, filter CSS).

### Testing that has already taken place:

- PHP linting (`phpcs-changed` via `lint:php:changes`) passes with no errors.
- Branch-level PHP and JS lint (`lint:changes:branch`) passes clean.
- PHPStan analysis on all modified PHP files reports no errors. A previously baselined PHPStan error for `AbstractInnerBlock` covering the old array shape (`{style: null, api_version?: int}`) has been removed from the baseline since that code path no longer exists.
- The migration follows the identical pattern already in production for `AddToCartForm`, `SingleProduct`, `CatalogSorting`, `ProductGallery`, and ~13 other blocks.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
