### PR TITLE
[Payments NOX] Re-add Mercado Pago as a recommended payment partner extension

### DIFF
--- a/plugins/woocommerce/changelog/update-WOOPRD-3539-readd-mercadopago-to-nox
+++ b/plugins/woocommerce/changelog/update-WOOPRD-3539-readd-mercadopago-to-nox
@@ -1,0 +1,3 @@
+Significance: patch
+Type: update
+Comment: Re-add Mercado Pago as a recommended payment partner across 7 LATAM markets in the NOX onboarding flow.

--- a/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php
+++ b/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php
@@ -1330,12 +1330,26 @@ class PaymentsExtensionSuggestions {
 			self::HELIOPAY,
 		),
 		'AR' => array(
-			self::VISA => array(
-				'_append' => array(
+			self::MERCADO_PAGO => array(
+				'_append'        => array(
 					'tags' => array( self::TAG_PREFERRED ),
+				),
+				'_merge_on_type' => array(
+					'links' => array(
+						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+							'url'   => 'https://www.mercadopago.com.ar/costs-section',
+						),
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+							'url'   => 'https://www.mercadopago.com.ar/ayuda/terminos-y-politicas_194',
+						),
+					),
 				),
 			),
 			self::PAYPAL_FULL_STACK,
+			self::VISA,
 			self::PAYPAL_WALLET,
 			self::HELIOPAY,
 		),
@@ -1386,9 +1400,24 @@ class PaymentsExtensionSuggestions {
 			self::HELIOPAY,
 		),
 		'BR' => array(
-			self::STRIPE => array(
+			self::STRIPE       => array(
 				'_append' => array(
 					'tags' => array( self::TAG_PREFERRED ),
+				),
+			),
+			self::MERCADO_PAGO => array(
+				'_merge_on_type' => array(
+					'links' => array(
+						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+							'url'   => 'https://www.mercadopago.com.br/costs-section',
+						),
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+							'url'   => 'https://www.mercadopago.com.br/ajuda/termos-e-politicas_194',
+						),
+					),
 				),
 			),
 			self::PAYPAL_FULL_STACK,
@@ -1409,22 +1438,50 @@ class PaymentsExtensionSuggestions {
 			self::HELIOPAY,
 		),
 		'CL' => array(
-			self::VISA => array(
-				'_append' => array(
+			self::MERCADO_PAGO => array(
+				'_append'        => array(
 					'tags' => array( self::TAG_PREFERRED ),
+				),
+				'_merge_on_type' => array(
+					'links' => array(
+						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+							'url'   => 'https://www.mercadopago.cl/costs-section',
+						),
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+							'url'   => 'https://www.mercadopago.cl/ayuda/terminos-y-politicas_194',
+						),
+					),
 				),
 			),
 			self::PAYPAL_FULL_STACK,
+			self::VISA,
 			self::PAYPAL_WALLET,
 			self::HELIOPAY,
 		),
 		'CO' => array(
-			self::VISA => array(
-				'_append' => array(
+			self::MERCADO_PAGO => array(
+				'_append'        => array(
 					'tags' => array( self::TAG_PREFERRED ),
+				),
+				'_merge_on_type' => array(
+					'links' => array(
+						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+							'url'   => 'https://www.mercadopago.com.co/costs-section',
+						),
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+							'url'   => 'https://www.mercadopago.com.co/ayuda/terminos-y-politicas_194',
+						),
+					),
 				),
 			),
 			self::PAYPAL_FULL_STACK,
+			self::VISA,
 			self::PAYPAL_WALLET,
 			self::HELIOPAY,
 		),
@@ -1557,15 +1614,30 @@ class PaymentsExtensionSuggestions {
 			self::HELIOPAY,
 		),
 		'MX' => array(
-			self::STRIPE => array(
+			self::STRIPE       => array(
 				'_append' => array(
 					'tags' => array( self::TAG_PREFERRED ),
+				),
+			),
+			self::MERCADO_PAGO => array(
+				'_merge_on_type' => array(
+					'links' => array(
+						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+							'url'   => 'https://www.mercadopago.com.mx/costs-section',
+						),
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+							'url'   => 'https://www.mercadopago.com.mx/ayuda/terminos-y-politicas_194',
+						),
+					),
 				),
 			),
 			self::PAYPAL_FULL_STACK,
 			self::VISA,
 			self::PAYPAL_WALLET,
-			self::KLARNA => array(
+			self::KLARNA       => array(
 				'_merge_on_type' => array(
 					'links' => array(
 						array(
@@ -1611,12 +1683,26 @@ class PaymentsExtensionSuggestions {
 			self::HELIOPAY,
 		),
 		'PE' => array(
-			self::VISA => array(
-				'_append' => array(
+			self::MERCADO_PAGO => array(
+				'_append'        => array(
 					'tags' => array( self::TAG_PREFERRED ),
+				),
+				'_merge_on_type' => array(
+					'links' => array(
+						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+							'url'   => 'https://www.mercadopago.com.pe/costs-section',
+						),
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+							'url'   => 'https://www.mercadopago.com.pe/ayuda/terminos-y-politicas_194',
+						),
+					),
 				),
 			),
 			self::PAYPAL_FULL_STACK,
+			self::VISA,
 			self::PAYPAL_WALLET,
 			self::HELIOPAY,
 		),
@@ -1694,12 +1780,26 @@ class PaymentsExtensionSuggestions {
 			self::HELIOPAY,
 		),
 		'UY' => array(
-			self::VISA => array(
-				'_append' => array(
+			self::MERCADO_PAGO => array(
+				'_append'        => array(
 					'tags' => array( self::TAG_PREFERRED ),
+				),
+				'_merge_on_type' => array(
+					'links' => array(
+						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+							'url'   => 'https://www.mercadopago.com.uy/costs-section',
+						),
+						array(
+							'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+							'url'   => 'https://www.mercadopago.com.uy/ayuda/terminos-y-politicas_194',
+						),
+					),
 				),
 			),
 			self::PAYPAL_FULL_STACK,
+			self::VISA,
 			self::PAYPAL_WALLET,
 			self::HELIOPAY,
 		),

--- a/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php
+++ b/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php
@@ -1335,8 +1335,8 @@ class PaymentsExtensionSuggestions {
 					'tags' => array( self::TAG_PREFERRED ),
 				),
 				'_merge_on_type' => array(
+					// These URLs come from the Mercado Pago for WooCommerce extension — see `\MercadoPago\Woocommerce\Helpers\Links`.
 					'links' => array(
-						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
 						array(
 							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
 							'url'   => 'https://www.mercadopago.com.ar/costs-section',
@@ -1407,8 +1407,8 @@ class PaymentsExtensionSuggestions {
 			),
 			self::MERCADO_PAGO => array(
 				'_merge_on_type' => array(
+					// These URLs come from the Mercado Pago for WooCommerce extension — see `\MercadoPago\Woocommerce\Helpers\Links`.
 					'links' => array(
-						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
 						array(
 							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
 							'url'   => 'https://www.mercadopago.com.br/costs-section',
@@ -1443,8 +1443,8 @@ class PaymentsExtensionSuggestions {
 					'tags' => array( self::TAG_PREFERRED ),
 				),
 				'_merge_on_type' => array(
+					// These URLs come from the Mercado Pago for WooCommerce extension — see `\MercadoPago\Woocommerce\Helpers\Links`.
 					'links' => array(
-						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
 						array(
 							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
 							'url'   => 'https://www.mercadopago.cl/costs-section',
@@ -1467,8 +1467,8 @@ class PaymentsExtensionSuggestions {
 					'tags' => array( self::TAG_PREFERRED ),
 				),
 				'_merge_on_type' => array(
+					// These URLs come from the Mercado Pago for WooCommerce extension — see `\MercadoPago\Woocommerce\Helpers\Links`.
 					'links' => array(
-						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
 						array(
 							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
 							'url'   => 'https://www.mercadopago.com.co/costs-section',
@@ -1621,8 +1621,8 @@ class PaymentsExtensionSuggestions {
 			),
 			self::MERCADO_PAGO => array(
 				'_merge_on_type' => array(
+					// These URLs come from the Mercado Pago for WooCommerce extension — see `\MercadoPago\Woocommerce\Helpers\Links`.
 					'links' => array(
-						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
 						array(
 							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
 							'url'   => 'https://www.mercadopago.com.mx/costs-section',
@@ -1688,8 +1688,8 @@ class PaymentsExtensionSuggestions {
 					'tags' => array( self::TAG_PREFERRED ),
 				),
 				'_merge_on_type' => array(
+					// These URLs come from the Mercado Pago for WooCommerce extension — see `\MercadoPago\Woocommerce\Helpers\Links`.
 					'links' => array(
-						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
 						array(
 							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
 							'url'   => 'https://www.mercadopago.com.pe/costs-section',
@@ -1785,8 +1785,8 @@ class PaymentsExtensionSuggestions {
 					'tags' => array( self::TAG_PREFERRED ),
 				),
 				'_merge_on_type' => array(
+					// These URLs come from the Mercado Pago for WooCommerce extension — see `\MercadoPago\Woocommerce\Helpers\Links`.
 					'links' => array(
-						// See the extension code -> \MercadoPago\Woocommerce\Helpers\Links class.
 						array(
 							'_type' => PaymentsProviders::LINK_TYPE_PRICING,
 							'url'   => 'https://www.mercadopago.com.uy/costs-section',

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php
@@ -781,6 +781,149 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that Mercado Pago is the preferred provider, Visa is demoted, and the country-localized links are merged
+	 * across the 5 LATAM markets where Mercado Pago has primary placement (AR, CL, CO, PE, UY).
+	 *
+	 * @dataProvider data_provider_mercado_pago_preferred_markets
+	 *
+	 * @param string $country_code    ISO 3166-1 alpha-2 country code.
+	 * @param string $mercadopago_tld TLD path for the country (e.g. `com.ar`, `cl`).
+	 */
+	public function test_get_country_extensions_with_mercado_pago_as_preferred_provider( string $country_code, string $mercadopago_tld ) {
+		// Act.
+		$extensions = $this->sut->get_country_extensions( $country_code );
+
+		// Assert ordering: Mercado Pago first, Visa demoted into the "other payment options" group.
+		$this->assertSame(
+			array(
+				PaymentsExtensionSuggestions::MERCADO_PAGO,
+				PaymentsExtensionSuggestions::PAYPAL_FULL_STACK,
+				PaymentsExtensionSuggestions::VISA,
+				PaymentsExtensionSuggestions::PAYPAL_WALLET,
+				PaymentsExtensionSuggestions::HELIOPAY,
+			),
+			array_column( $extensions, 'id' ),
+			"Mercado Pago should be the first suggestion in {$country_code}, with Visa demoted."
+		);
+
+		$mercado_pago = $extensions[0];
+		$this->assertContains(
+			PaymentsExtensionSuggestions::TAG_PREFERRED,
+			$mercado_pago['tags'],
+			"Mercado Pago should carry the preferred tag in {$country_code}."
+		);
+
+		$visa = $extensions[2];
+		$this->assertNotContains(
+			PaymentsExtensionSuggestions::TAG_PREFERRED,
+			$visa['tags'],
+			"Visa should not carry the preferred tag in {$country_code}."
+		);
+
+		// The country-localized PRICING/TERMS links should be merged on top of the base ABOUT/DOCS/SUPPORT links.
+		$this->assertEqualsCanonicalizing(
+			array(
+				// These are coming from the per-country details.
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+					'url'   => "https://www.mercadopago.{$mercadopago_tld}/costs-section",
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+					'url'   => "https://www.mercadopago.{$mercadopago_tld}/ayuda/terminos-y-politicas_194",
+				),
+				// These are base details for the suggestion.
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_ABOUT,
+					'url'   => 'https://woocommerce.com/products/mercado-pago-checkout/',
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_DOCS,
+					'url'   => 'https://woocommerce.com/document/mercado-pago/',
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_SUPPORT,
+					'url'   => 'https://woocommerce.com/my-account/contact-support/?select=mercado-pago-checkout',
+				),
+			),
+			$mercado_pago['links']
+		);
+	}
+
+	/**
+	 * Data provider for the markets where Mercado Pago is the preferred provider.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function data_provider_mercado_pago_preferred_markets(): array {
+		return array(
+			'Argentina' => array( 'AR', 'com.ar' ),
+			'Chile'     => array( 'CL', 'cl' ),
+			'Colombia'  => array( 'CO', 'com.co' ),
+			'Peru'      => array( 'PE', 'com.pe' ),
+			'Uruguay'   => array( 'UY', 'com.uy' ),
+		);
+	}
+
+	/**
+	 * Test that in Brazil, Stripe stays preferred and Mercado Pago is the first entry in "other payment options"
+	 * with its Portuguese-localized links merged on top of the base details.
+	 */
+	public function test_get_country_extensions_with_mercado_pago_in_other_options_for_br() {
+		// Act.
+		$extensions = $this->sut->get_country_extensions( 'BR' );
+
+		// Assert ordering: Stripe preferred, Mercado Pago at index 1.
+		$this->assertSame(
+			array(
+				PaymentsExtensionSuggestions::STRIPE,
+				PaymentsExtensionSuggestions::MERCADO_PAGO,
+				PaymentsExtensionSuggestions::PAYPAL_FULL_STACK,
+				PaymentsExtensionSuggestions::VISA,
+				PaymentsExtensionSuggestions::PAYPAL_WALLET,
+				PaymentsExtensionSuggestions::HELIOPAY,
+			),
+			array_column( $extensions, 'id' )
+		);
+
+		$stripe = $extensions[0];
+		$this->assertContains( PaymentsExtensionSuggestions::TAG_PREFERRED, $stripe['tags'] );
+
+		// Mercado Pago should NOT carry the preferred tag in Brazil — Stripe stays primary per the 10.8 fallback.
+		$mercado_pago = $extensions[1];
+		$this->assertNotContains( PaymentsExtensionSuggestions::TAG_PREFERRED, $mercado_pago['tags'] );
+
+		// BR uses Portuguese paths (`ajuda/termos-e-politicas`) vs. Spanish (`ayuda/terminos-y-politicas`) in the other markets.
+		$this->assertEqualsCanonicalizing(
+			array(
+				// These are coming from the per-country details.
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+					'url'   => 'https://www.mercadopago.com.br/costs-section',
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+					'url'   => 'https://www.mercadopago.com.br/ajuda/termos-e-politicas_194',
+				),
+				// These are base details for the suggestion.
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_ABOUT,
+					'url'   => 'https://woocommerce.com/products/mercado-pago-checkout/',
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_DOCS,
+					'url'   => 'https://woocommerce.com/document/mercado-pago/',
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_SUPPORT,
+					'url'   => 'https://woocommerce.com/my-account/contact-support/?select=mercado-pago-checkout',
+				),
+			),
+			$mercado_pago['links']
+		);
+	}
+
+	/**
 	 * Test getting payment extension suggestions by ID.
 	 */
 	public function test_get_extension_by_id() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php
@@ -165,7 +165,7 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 			'CH' => 8,
 			'AG' => 5,
 			'AI' => 3,
-			'AR' => 4,
+			'AR' => 5,
 			'AW' => 3,
 			'BS' => 5,
 			'BB' => 5,
@@ -173,11 +173,11 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 			'BM' => 5,
 			'BO' => 2,
 			'BQ' => 3,
-			'BR' => 5,
+			'BR' => 6,
 			'VG' => 3,
 			'KY' => 5,
-			'CL' => 4,
-			'CO' => 4,
+			'CL' => 5,
+			'CO' => 5,
 			'CR' => 5,
 			'CW' => 3,
 			'DM' => 5,
@@ -193,11 +193,11 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 			'HN' => 5,
 			'JM' => 5,
 			'MQ' => 4,
-			'MX' => 6,
+			'MX' => 7,
 			'NI' => 5,
 			'PA' => 5,
 			'PY' => 2,
-			'PE' => 4,
+			'PE' => 5,
 			'KN' => 5,
 			'LC' => 5,
 			'SX' => 3,
@@ -205,7 +205,7 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 			'SR' => 3,
 			'TT' => 5,
 			'TC' => 5,
-			'UY' => 4,
+			'UY' => 5,
 			'VI' => 3,
 			'VE' => 3,
 			'AU' => 12,
@@ -476,7 +476,7 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 			'CH' => 8,
 			'AG' => 5,
 			'AI' => 3,
-			'AR' => 4,
+			'AR' => 5,
 			'AW' => 3,
 			'BS' => 5,
 			'BB' => 5,
@@ -484,11 +484,11 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 			'BM' => 5,
 			'BO' => 2,
 			'BQ' => 3,
-			'BR' => 5,
+			'BR' => 6,
 			'VG' => 3,
 			'KY' => 5,
-			'CL' => 4,
-			'CO' => 4,
+			'CL' => 5,
+			'CO' => 5,
 			'CR' => 5,
 			'CW' => 3,
 			'DM' => 5,
@@ -504,11 +504,11 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 			'HN' => 5,
 			'JM' => 5,
 			'MQ' => 4,
-			'MX' => 6,
+			'MX' => 7,
 			'NI' => 5,
 			'PA' => 5,
 			'PY' => 2,
-			'PE' => 4,
+			'PE' => 5,
 			'KN' => 5,
 			'LC' => 5,
 			'SX' => 3,
@@ -516,7 +516,7 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 			'SR' => 3,
 			'TT' => 5,
 			'TC' => 5,
-			'UY' => 4,
+			'UY' => 5,
 			'VI' => 3,
 			'VE' => 3,
 			'AU' => 12,
@@ -701,10 +701,11 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 		$extensions = $this->sut->get_country_extensions( 'MX' );
 
 		// Assert.
-		$this->assertCount( 6, $extensions );
+		$this->assertCount( 7, $extensions );
 		$this->assertSame(
 			array(
 				PaymentsExtensionSuggestions::STRIPE,
+				PaymentsExtensionSuggestions::MERCADO_PAGO,
 				PaymentsExtensionSuggestions::PAYPAL_FULL_STACK,
 				PaymentsExtensionSuggestions::VISA,
 				PaymentsExtensionSuggestions::PAYPAL_WALLET,
@@ -718,7 +719,37 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 		// It should have the preferred tag.
 		$this->assertContains( PaymentsExtensionSuggestions::TAG_PREFERRED, $stripe['tags'] );
 
-		$klarna = $extensions[4];
+		$mercado_pago = $extensions[1];
+		// The links should include the country-specific Mercado Pago URLs merged with the base details.
+		$this->assertEqualsCanonicalizing(
+			array(
+				// These are coming from the per-country details.
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_PRICING,
+					'url'   => 'https://www.mercadopago.com.mx/costs-section',
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_TERMS,
+					'url'   => 'https://www.mercadopago.com.mx/ayuda/terminos-y-politicas_194',
+				),
+				// These are base details for the suggestion.
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_ABOUT,
+					'url'   => 'https://woocommerce.com/products/mercado-pago-checkout/',
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_DOCS,
+					'url'   => 'https://woocommerce.com/document/mercado-pago/',
+				),
+				array(
+					'_type' => PaymentsProviders::LINK_TYPE_SUPPORT,
+					'url'   => 'https://woocommerce.com/my-account/contact-support/?select=mercado-pago-checkout',
+				),
+			),
+			$mercado_pago['links']
+		);
+
+		$klarna = $extensions[5];
 		// The links should be the expected ones.
 		$this->assertEqualsCanonicalizing(
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes WOOPRD-3539.

Re-adds Mercado Pago as a recommended payment partner extension in the NOX (Settings → Payments) onboarding flow across its 7 supported LATAM markets, reversing the removal in WOOPRD-920 (PR #61235, shipped in WC 10.3).

**Per-country placement:**

| Country | Mercado Pago placement | Effect |
|---|---|---|
| Argentina | **Preferred (primary)** | Visa Acceptance Solutions moves to "Other payment options" |
| Chile | **Preferred (primary)** | Visa Acceptance Solutions moves to "Other payment options" |
| Colombia | **Preferred (primary)** | Visa Acceptance Solutions moves to "Other payment options" |
| Peru | **Preferred (primary)** | Visa Acceptance Solutions moves to "Other payment options" |
| Uruguay | **Preferred (primary)** | Visa Acceptance Solutions moves to "Other payment options" |
| Brazil | First entry in "Other payment options" | Stripe stays primary |
| Mexico | First entry in "Other payment options" | Stripe stays primary (Klarna keeps its BNPL slot) |

For Brazil and Mexico, Stripe stays as the preferred PSP per the agreed fallback for the 10.8 release.

Each Mercado Pago entry uses `_merge_on_type` to apply country-localized Pricing and Terms URLs (`mercadopago.com.ar`, `.cl`, `.com.co`, `.com.pe`, `.com.uy`, `.com.br`, `.com.mx`), matching the pre-WOOPRD-920 pattern. The Mercado Pago base extension entry in `get_all_extensions_base_details()` is unchanged.

### Screenshots or screen recordings:

To be attached after PR creation.

### How to test the changes in this Pull Request:

1. Spin up a Jurassic Ninja store with WC on this branch and WC Beta Tester ([direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-beta-tester&branches.woocommerce=update/WOOPRD-3539-readd-mercadopago-to-nox)).
2. Go to **WooCommerce → Settings → Payments**.
3. Change the **Business location** to each of the countries below and confirm the main list and "More payment options" section match:

   | Country | Expected primary (main list) | Expected first in "More payment options" |
   | --- | --- | --- |
   | `Argentina` | Mercado Pago | Visa Acceptance Solutions |
   | `Chile` | Mercado Pago | Visa Acceptance Solutions |
   | `Colombia` | Mercado Pago | Visa Acceptance Solutions |
   | `Peru` | Mercado Pago | Visa Acceptance Solutions |
   | `Uruguay` | Mercado Pago | Visa Acceptance Solutions |
   | `Brazil` | Stripe | **Mercado Pago** (before Visa) |
   | `Mexico` | Stripe | **Mercado Pago** (before Visa; Klarna stays in BNPL slot) |

4. Open the Mercado Pago suggestion details for each country and confirm the **Pricing** and **Terms** links resolve to the country-localized URLs:
    - AR → `mercadopago.com.ar/costs-section`, `…/ayuda/terminos-y-politicas_194`
    - CL → `mercadopago.cl/...`
    - CO → `mercadopago.com.co/...`
    - PE → `mercadopago.com.pe/...`
    - UY → `mercadopago.com.uy/...`
    - BR → `mercadopago.com.br/costs-section`, `…/ajuda/termos-e-politicas_194`
    - MX → `mercadopago.com.mx/...`

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- `composer exec -- phpstan analyse` on the changed source file — no errors.
- `pnpm test:php:env -- --filter PaymentsExtensionSuggestionsTest` — **499 tests, 1247 assertions, all pass**, including a new assertion that the MX Mercado Pago entry merges its country-localized URLs.
- Manual smoke in local `wp-env` for Argentina and Mexico via WooCommerce → Settings → Payments: MP appears in the correct slot, Visa is demoted as expected in AR, and MP is the first entry in "Other payment options" before Visa in MX.
- Data-layer verification via `wp eval-file` for all 7 countries: `get_country_extensions()` and the NOX `preferred`/`other` split match the spec, with the expected `TAG_PREFERRED` placement and country-localized links.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually at `plugins/woocommerce/changelog/update-WOOPRD-3539-readd-mercadopago-to-nox` (significance: patch, type: update).

---

🤖 Generated with [Claude Code](https://claude.ai/code)
