### PR TITLE
[Performance] Optimize slow SQL and high CPU usage by DB in product filter utility

### DIFF
--- a/plugins/woocommerce/changelog/performance-product-filterer-slow-sql
+++ b/plugins/woocommerce/changelog/performance-product-filterer-slow-sql
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Optimize slow SQL and high CPU usage by DB in product filter utility.

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -533,6 +533,7 @@ class DataRegenerator {
  is_variation_attribute tinyint(1) NOT NULL,
  in_stock tinyint(1) NOT NULL,
  INDEX is_variation_attribute_term_id (is_variation_attribute, term_id),
+ INDEX taxonomy_term_id_in_stock_product_or_parent_id (taxonomy, term_id, in_stock, product_or_parent_id),
  PRIMARY KEY  ( `product_or_parent_id`, `term_id`, `product_id`, `taxonomy` ),
  KEY product_id (product_id)
 ) $collate;";

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php
@@ -166,8 +166,6 @@ class Filterer {
 	public function get_filtered_term_product_counts( $term_ids, $taxonomy, $query_type ) {
 		global $wpdb;
 
-		$use_lookup_table = $this->filtering_via_lookup_table_is_active();
-
 		$tax_query  = \WC_Query::get_main_tax_query();
 		$meta_query = \WC_Query::get_main_meta_query();
 		if ( 'or' === $query_type ) {
@@ -179,14 +177,22 @@ class Filterer {
 		}
 
 		$meta_query = new \WP_Meta_Query( $meta_query );
-		$tax_query  = new \WP_Tax_Query( $tax_query );
+		$tax_query  = new TaxQuery( $tax_query );
 
-		if ( $use_lookup_table ) {
+		if ( $this->filtering_via_lookup_table_is_active() ) {
 			$query = $this->get_product_counts_query_using_lookup_table( $tax_query, $meta_query, $taxonomy, $term_ids );
 		} else {
 			$query = $this->get_product_counts_query_not_using_lookup_table( $tax_query, $meta_query, $term_ids );
 		}
 
+		/**
+		 * Customizes the SQL query that populates product counts in layered navigation.
+		 *
+		 * @since 10.9.0 the query was optimized to remove the join on term_relationships in favor of a nested select from term_relationships.
+		 * @since 2.6.1
+		 *
+		 * @param array $query Query fragments (the available fragments are: select, from, join, where, group_by).
+		 */
 		$query     = apply_filters( 'woocommerce_get_filtered_term_product_counts_query', $query );
 		$query_sql = implode( ' ', $query );
 
@@ -306,7 +312,6 @@ class Filterer {
 			$query['where'] .= ' AND ' . $search_query_sql;
 		}
 
-		$query['group_by'] = 'GROUP BY terms.term_id';
 		$query['group_by'] = "GROUP BY {$this->lookup_table_name}.term_id";
 
 		return $query;

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/TaxQuery.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/TaxQuery.php
@@ -1,0 +1,44 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\ProductAttributesLookup;
+
+/**
+ * Tax query class introduced to optimize SQL performance in bigger product/category catalogs.
+ */
+class TaxQuery extends \WP_Tax_Query {
+	/**
+	 * Generates SQL JOIN and WHERE clauses for a "first-order" query clause.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param array $clause       Query clause (passed by reference).
+	 * @param array $parent_query Parent query array.
+	 * @return array {
+	 *     Array containing JOIN and WHERE SQL clauses to append to a first-order query.
+	 *
+	 *     @type string[] $join  Array of SQL fragments to append to the main JOIN clause.
+	 *     @type string[] $where Array of SQL fragments to append to the main WHERE clause.
+	 * }
+	 */
+	public function get_sql_for_clause( &$clause, $parent_query ) {
+		global $wpdb;
+
+		// Optimization note: targeting only the 'IN' operator, where the default 'LEFT JOIN' causes performance issues.
+		if ( 'IN' !== $clause['operator'] ) {
+			return parent::get_sql_for_clause( $clause, $parent_query );
+		}
+
+		// Call the parent method so it does necessary cleanup with its private APIs.
+		$fallback = parent::get_sql_for_clause( $clause, $parent_query );
+		if ( array( '' ) === $fallback['join'] && array( '0 = 1' ) === $fallback['where'] ) {
+			return $fallback;
+		}
+
+		// Optimization note: 'fan-out LEFT JOIN' -> 'pre-materialized subquery' transition for better SQL performance.
+		$terms = implode( ',', array_map( 'absint', $clause['terms'] ) );
+		return array(
+			'join'  => array( '' ),
+			'where' => array( "$this->primary_table.$this->primary_id_column IN ( SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id IN ( $terms ) )" ),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/TaxQueryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/TaxQueryTest.php
@@ -1,0 +1,65 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\ProductAttributesLookup;
+
+use Automattic\WooCommerce\Internal\ProductAttributesLookup\TaxQuery;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the TaxQuery class.
+ */
+class TaxQueryTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Data provider.
+	 */
+	public static function provide_get_sql_for_clause_scenarios(): array {
+		global $wpdb;
+
+		$term_id = get_term_by( 'slug', 'featured', 'product_visibility' )->term_taxonomy_id;
+
+		return array(
+			array(
+				'clause'   => array(
+					'taxonomy'         => 'product_visibility',
+					'field'            => 'term_taxonomy_id',
+					'terms'            => array( $term_id ),
+					'operator'         => 'IN',
+					'include_children' => false,
+				),
+				'expected' => array(
+					'join'  => array( '' ),
+					'where' => array( "{$wpdb->posts}.ID IN ( SELECT object_id FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN ( $term_id ) )" ),
+				),
+			),
+			array(
+				'clause'   => array(
+					'taxonomy'         => 'product_visibility',
+					'field'            => 'term_taxonomy_id',
+					'terms'            => array(),
+					'operator'         => 'IN',
+					'include_children' => false,
+				),
+				'expected' => array(
+					'join'  => array( '' ),
+					'where' => array( '0 = 1' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider provide_get_sql_for_clause_scenarios
+	 *
+	 * @param array $clause   Input clause.
+	 * @param array $expected Expected result.
+	 */
+	public function test_get_sql_for_clause( array $clause, array $expected ): void {
+		$query                    = new TaxQuery( array() );
+		$query->primary_table     = 'wp_posts';
+		$query->primary_id_column = 'ID';
+
+		$this->assertSame( $expected, $query->get_sql_for_clause( $clause, array() ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #62008, WOOPLUG-5875.

- Resolves the root cause by overriding IN-condition SQL generation for WP_Tax_Query.
- Adds an additional index to the `wc_product_attributes_lookup` table. This results in approximately 19% increased disk space usage, which is a reasonable tradeoff for improved SQL performance on medium-density curve, as detailed below.

The first change also stabilizes the execution plan regardless of the density curve, ensuring predictable database load.

> I re-evaluated the SQL optimizations proposed in the original ticket. Since the root cause has been resolved, these optimizations are either no longer feasible or are already managed by the database.

Benchmarks:

| density | products | baseline | fixed | ratio |
|---|---:|---:|---:|---:|
| high | 1,000 | 12.8 ms | 5.6 ms | 2.3× |
| high | 5,000 | 66.8 ms | 30.9 ms | 2.2× |
| high | 10,000 | 140.2 ms | 63.1 ms | 2.2× |
| high | 25,000 | 387.9 ms | 167.9 ms | 2.3× |
| high | 50,000 | 832.2 ms | 351.4 ms | 2.4× |
| medium | 1,000 | 14.2 ms | 9.9 ms | 1.4× |
| medium | 5,000 | 75.6 ms | 36.4 ms | 2.1× |
| medium | 10,000 | 126.5 ms | 38.9 ms | 3.3× |
| medium | 25,000 | 338.2 ms | 153.9 ms | 2.2× |
| medium | 50,000 | 705.9 ms | 327.0 ms | 2.2× |
| low | 1,000 | 10.6 ms | 9.6 ms | 1.1× |
| low | 5,000 | 51.9 ms | 25.6 ms | 2.0× |
| low | 10,000 | 54.9 ms | 16.3 ms | 3.4× |
| low | 25,000 | 31.0 ms | 31.5 ms | 1.0× |
| low | 50,000 | 66.7 ms | 252.1 ms | 0.3× |

> 0.3× is regression, but the absolute timing is consistent with other 50K products use cases and acceptable in the overall benchmarks picture. The pre-existing transient-based caching also compensates for this edge case.

Density definitions (fan-out = avg matching categories per product in the 30-cat filter):

| density | total categories | cats/product | fan-out |
|---------|-----------------|--------------|---------|
| high    | 30              | 7            | ≈ 7     |
| medium  | 90              | 9            | ≈ 3     |
| low     | 300             | 3            | ≈ 0.3   |

Execution plan stability:

```
EXPLAIN at 25k products, 2 taxonomies, identical dataset for all comparisons.

#### Before

**High density (fan-out ≈ 7):**

id  select_type  table                            type   key                 rows    Extra
1   SIMPLE       wp_posts                         ref    type_status_author  25599   Using where; Using index; Using temporary; Using filesort
1   SIMPLE       wp_wc_product_attributes_lookup  ref    PRIMARY             14      Using where
1   SIMPLE       wp_term_relationships            ref    PRIMARY             6       Using where

Drives from `wp_posts`, probes lookup via PK, then joins `wp_term_relationships` with 6 rows per lookup row — this is the fan-out. 25k products × 14 lookup rows × 6 term_relationships rows = ~2.1M intermediate rows fed into `COUNT(DISTINCT)`.

**Medium density (fan-out ≈ 3):**

id  select_type  table                            type   key         rows    Extra
1   SIMPLE       wp_wc_product_attributes_lookup  index  product_id  350000  Using where; Using index; Using filesort
1   SIMPLE       wp_posts                         eq_ref PRIMARY     1       Using where
1   SIMPLE       wp_term_relationships            ref    PRIMARY     6       Using where

The optimizer flips the driving table to the full lookup index scan (350k rows). Still joins `wp_term_relationships` with 6 rows per lookup row — fan-out persists, different driving table.

**Low density (fan-out ≈ 0.3):**

id  select_type  table                            type   key              rows   Extra
1   SIMPLE       wp_term_relationships            range  term_taxonomy_id 48750  Using where; Using index; Using temporary; Using filesort
1   SIMPLE       wp_wc_product_attributes_lookup  ref    PRIMARY          11     Using where
1   SIMPLE       wp_posts                         eq_ref PRIMARY          1      Using where

The optimizer flips again — now drives from `wp_term_relationships` range scan (~48k rows), probing the lookup via PK. Fan-out is accidentally eliminated by starting from the narrow side. This is why baseline is fast at low density — but it is optimizer luck, not structural correctness.

#### Structural change

The fan-out `JOIN wp_term_relationships ON product_or_parent_id = object_id` is replaced by a pre-materialized `IN` subquery, forcing the category set to be computed once and probed via a hash key; the optimizer can no longer produce a fan-out plan regardless of density or statistics.

#### After

**High density (fan-out ≈ 7):**

id  select_type  table                            type   key                 rows    Extra
1   PRIMARY      wp_posts                         ref    type_status_author  25599   Using where; Using index; Using temporary; Using filesort
1   PRIMARY      wp_wc_product_attributes_lookup  ref    PRIMARY             10      Using where
1   PRIMARY      <subquery2>                      eq_ref distinct_key        1       Using where
2   MATERIALIZED wp_term_relationships            range  term_taxonomy_id    175000  Using where; Using index

**Medium density (fan-out ≈ 3):**

id  select_type  table                            type   key                 rows    Extra
1   PRIMARY      wp_posts                         ref    type_status_author  25599   Using where; Using index; Using temporary; Using filesort
1   PRIMARY      wp_wc_product_attributes_lookup  ref    PRIMARY             14      Using where
1   PRIMARY      <subquery2>                      eq_ref distinct_key        1       Using where
2   MATERIALIZED wp_term_relationships            range  term_taxonomy_id    131581  Using where; Using index

**Low density (fan-out ≈ 0.3):**

id  select_type  table                            type   key                 rows    Extra
1   PRIMARY      wp_posts                         ref    type_status_author  25599   Using where; Using index; Using temporary; Using filesort
1   PRIMARY      wp_wc_product_attributes_lookup  ref    PRIMARY             13      Using where
1   PRIMARY      <subquery2>                      eq_ref distinct_key        1       Using where
2   MATERIALIZED wp_term_relationships            range  term_taxonomy_id    21253   Using where; Using index

All three densities now use **the same plan shape**: `wp_posts → lookup PK probe → subquery hash key`. The category subquery is materialized once per query execution. The fan-out join is gone at every density level. The baseline had three different driving-table choices depending on optimizer statistics; the fixed query has one, unconditionally.

**Why plan stability matters.** The baseline's performance depends on the optimizer making the right driving-table choice — a decision based on row count estimates and index statistics that vary across stores and can change after `ANALYZE TABLE`. A store that shifts from dense to sparse category structure (or vice versa) can silently cross the optimizer's threshold and flip into the slow plan. The fixed query eliminates fan-out structurally: there is no threshold to cross.
```

CPU impact

```
The high CPU usage reported in the issue is caused by the fan-out JOIN creating an intermediate result set that `COUNT(DISTINCT)` collapses in memory — a pure CPU operation (hash aggregate or sort, no I/O). At 24k products × 8 terms × 7 category matches = ~1.34M intermediate rows processed per attribute query.

The subquery fix caps the intermediate set to lookup rows only (~192k), reducing CPU proportionally to the fan-out multiplier. The benchmark confirms: 264–404 ms → 118–140 ms, i.e. 2–3× less wall-clock time on a query that is entirely CPU-bound. The index adds a further reduction at medium density by eliminating the filesort for GROUP BY.

The fix resolves the reported symptom for realistic catalog sizes and category densities. Both variants still scale linearly with product count — the constant is smaller but the exponent is unchanged. The remaining CPU is close to the theoretical floor for a correct live count: the `COUNT(DISTINCT)` aggregation cannot be avoided without a persistent summary table, which is out of scope for this change.
```

### How to test the changes in this Pull Request:



Pre-requisites:
- 100+ products (simple and variable products mix) organized in 2-3 level categories

Theme configuration:
- Configure the test store to use a classic theme (e.g., Storefront)
- Navigate to `Appearance -> Widgets` page
- Modify block `Sidebar`: click `+`, search and add `product filters`
- Modify the added block: Numeric Size (or other attribute-based filter) - click on it and enable `Product counts` toggle on the popping up right side-bar
- Save the page and navigate to the shop page to verify the filter availability


Verify:
- Using trunk, capture counters values for Numeric Size (or other attribute-based filter)
- Switch to this branch
- Remove the `woocommerce_version` and `woocommerce_db_version` options from the `wp_options` table.
- Access the WordPress admin area to trigger DB delta update.
- Confirm that the new index appeared in the DB.
- Add the following hook as a mu-plugin or directly to `plugins/woocommerce/woocommerce.php` (to enable layered nav code paths execution):
  ```php
  add_filter(
	  'woocommerce_pre_product_filter_data',
	  function ( $result, string $filter_type, array $query_vars, array $extra ) {
		  if ( 'attribute' !== $filter_type || empty( $extra['taxonomy'] ) ) {
			  return $result;
		  }
  
		  $taxonomy = $extra['taxonomy'];
		  delete_transient( 'wc_layered_nav_counts_' . sanitize_title( $taxonomy ) );
  
		  $term_ids = wp_list_pluck( get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => true ) ), 'term_id' );
		  if ( empty( $term_ids ) ) {
			  return array();
		  }
  
		  $attribute_slug = str_starts_with( $taxonomy, 'pa_' ) ? substr( $taxonomy, 3 ) : $taxonomy;
		  return wc_get_container()
			  ->get( \Automattic\WooCommerce\Internal\ProductAttributesLookup\Filterer::class )
			  ->get_filtered_term_product_counts( $term_ids, $taxonomy, $query_vars[ 'query_type_' . $attribute_slug ] ?? 'and' );
	  },
	  10,
	  4
  );
  ```
- Alternating `woocommerce_attribute_lookup_enabled` option between `yes` and `no` for the following step
- Refresh the store page and capture the counters' values for the same filter
- Verify the counters across all 3 data sets are the same


> Note: when enabling `woocommerce_attribute_lookup_enabled`, it is worth navigating to `WooCommerce -> Status -> Tools` and running `Product lookup tables` task


