### PR TITLE
Remove products shipping class filter

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-remove-shipping-class-filter
+++ b/packages/js/experimental-products-app/changelog/update-remove-shipping-class-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove the Shipping Class filter from the experimental products app product list.

--- a/packages/js/experimental-products-app/src/fields/shipping_class/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/shipping_class/field.tsx
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { resolveSelect, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { decodeEntities } from '@wordpress/html-entities';
+import { useSelect } from '@wordpress/data';
 import { SelectControl } from '@wordpress/ui';
 import type { Field } from '@wordpress/dataviews';
 
@@ -27,9 +25,7 @@ const fieldDefinition = {
 	label: __( 'Shipping Class', 'woocommerce' ),
 	enableSorting: false,
 	enableHiding: false,
-	filterBy: {
-		operators: [ 'isAny', 'isNone' ],
-	},
+	filterBy: false,
 } satisfies Partial< Field< ProductEntityRecord > >;
 
 export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
@@ -41,17 +37,6 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 	getValue: ( { item } ) =>
 		item.shipping_class_id ? item.shipping_class_id.toString() : '',
 	render: ( { item } ) => item.shipping_class ?? '',
-	getElements: async () => {
-		const records = ( await resolveSelect( coreStore ).getEntityRecords(
-			'taxonomy',
-			'product_shipping_class',
-			{ per_page: -1 }
-		) ) as Array< { id: number; name: string } > | null;
-		return ( records ?? [] ).map( ( { id, name } ) => ( {
-			value: id.toString(),
-			label: decodeEntities( name ),
-		} ) );
-	},
 	isVisible: ( item ) => ! item.virtual,
 	Edit: ( { data, onChange, field } ) => {
 		const { shippingClasses } = useSelect( ( select ) => {

--- a/packages/js/experimental-products-app/src/product-list/query.test.ts
+++ b/packages/js/experimental-products-app/src/product-list/query.test.ts
@@ -203,7 +203,8 @@ describe( 'buildProductListQuery', () => {
 
 		expect( query.brand ).toEqual( '8,9' );
 	} );
-	it( 'maps the shipping_class isAny filter to the shipping_class query param', () => {
+
+	it( 'ignores shipping_class filters', () => {
 		const query = buildProductListQuery( {
 			...baseView,
 			filters: [
@@ -215,23 +216,9 @@ describe( 'buildProductListQuery', () => {
 			],
 		} as View );
 
-		expect( query.shipping_class ).toEqual( '3,4' );
+		expect( query.shipping_class ).toBeUndefined();
 	} );
 
-	it( 'maps the shipping_class isNone filter to exclude_shipping_class', () => {
-		const query = buildProductListQuery( {
-			...baseView,
-			filters: [
-				{
-					field: 'shipping_class',
-					operator: 'isNone',
-					value: [ '3', 4 ],
-				},
-			],
-		} as View );
-
-		expect( query.exclude_shipping_class ).toEqual( [ 3, 4 ] );
-	} );
 	it( 'maps the stock_quantity is filter to both min and max', () => {
 		const query = buildProductListQuery( {
 			...baseView,

--- a/packages/js/experimental-products-app/src/product-list/query.ts
+++ b/packages/js/experimental-products-app/src/product-list/query.ts
@@ -16,7 +16,6 @@ export type ProductListQuery = Omit< ProductQuery, 'status' > & {
 	include_types?: ProductType[];
 	exclude_types?: ProductType[];
 	exclude_category?: number[];
-	exclude_shipping_class?: number[];
 	exclude_tag?: number[];
 	min_stock_quantity?: string;
 	max_stock_quantity?: string;
@@ -139,21 +138,6 @@ function applyBrandFilter( query: ProductListQuery, filter: Filter ) {
 	query.brand = values.join( ',' );
 }
 
-function applyShippingClassFilter( query: ProductListQuery, filter: Filter ) {
-	const values = getNumericValues( filter.value );
-
-	if ( values.length === 0 ) {
-		return;
-	}
-
-	if ( filter.operator === 'isNone' ) {
-		query.exclude_shipping_class = values;
-		return;
-	}
-
-	query.shipping_class = values.join( ',' );
-}
-
 function applyStockFilter( query: ProductListQuery, filter: Filter ) {
 	const [ stockStatus ] = getStringValues( filter.value );
 
@@ -261,9 +245,6 @@ export function buildProductListQuery( view: View ): ProductListQuery {
 				break;
 			case 'categories':
 				applyCategoryFilter( query, filter );
-				break;
-			case 'shipping_class':
-				applyShippingClassFilter( query, filter );
 				break;
 			case 'tags':
 				applyTagFilter( query, filter );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental products app should no longer offer Shipping Class as a DataViews list filter. This removes the field-level filter configuration and stops stale `shipping_class` filters from being translated into product list query params.

### Screenshots or screen recordings:

Not included. This removes an option from the DataViews filter menu.

### How to test the changes in this Pull Request:

1. Open the experimental products app product list.
2. Open the DataViews filters menu.
3. Confirm that Shipping Class is not available as a filter.
4. Add a saved/stale `shipping_class` filter to the view state, then reload the product list.
5. Confirm that the product list request does not include `shipping_class` or `exclude_shipping_class` query params.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/product-list/query.test.ts`
- `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/fields/shipping_class/field.tsx src/product-list/query.ts src/product-list/query.test.ts`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was added manually in `packages/js/experimental-products-app/changelog/update-remove-shipping-class-filter`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
