### PR TITLE
Avoid resending emails when restoring HPOS orders

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6670-untrash-customer-emails
+++ b/plugins/woocommerce/changelog/wooplug-6670-untrash-customer-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop re-sending customer order email notifications when restoring orders from the trash.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -252,7 +252,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			} else {
 				wp_update_post( array_merge( array( 'ID' => $order->get_id() ), $post_data ) );
 			}
-			$order->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
+			$order->read_meta_data( true );
+			// Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
 		}
 		$this->update_post_meta( $order );
 		$order->apply_changes();
@@ -1172,6 +1173,117 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		}
 		foreach ( $non_cached_ids as $order_id ) {
 			wp_cache_set( $tax_keys[ $order_id ], $tax_by_order[ $order_id ] ?? 0.0, 'orders' );
+		}
+	}
+
+	/**
+	 * Temporarily neutralizes the WC_Emails transactional dispatch listeners
+	 * (send_transactional_email and queue_transactional_email) so that restoring an order
+	 * from the trash does not re-notify the customer about an order they were already
+	 * emailed about.
+	 *
+	 * The listeners are left in their original WP_Hook slots: the action, priority,
+	 * accepted-args count and position are all kept, and only the callback function is
+	 * wrapped to suppress dispatches for the restored order. This preserves the relative
+	 * ordering of every other listener on those actions, so third-party integrations are
+	 * unaffected. Pass the returned snapshot to {@see restore_transactional_email_dispatch()}
+	 * to undo this.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $restored_order_id The ID of the order being restored.
+	 * @return list<array{0: string, 1: int, 2: string, 3: callable}> Snapshot of neutralized listeners.
+	 */
+	protected function suspend_transactional_email_dispatch( int $restored_order_id ): array {
+		global $wp_filter;
+
+		$suspended           = array();
+		$dispatch_method_set = array( 'send_transactional_email', 'queue_transactional_email' );
+
+		foreach ( $wp_filter as $action => $hook ) {
+			if ( ! is_string( $action ) || ! $hook instanceof WP_Hook ) {
+				continue;
+			}
+			foreach ( $hook->callbacks as $priority => $callbacks ) {
+				foreach ( $callbacks as $key => $cb ) {
+					$function = $cb['function'] ?? null;
+					if ( ! is_array( $function ) || ! isset( $function[0], $function[1] ) ) {
+						continue;
+					}
+					if ( ! is_callable( $function ) ) {
+						continue;
+					}
+					$class  = is_object( $function[0] ) ? get_class( $function[0] ) : $function[0];
+					$method = $function[1];
+					if ( ! is_string( $class ) || ! is_string( $method ) ) {
+						continue;
+					}
+					if ( 'WC_Emails' !== $class || ! in_array( $method, $dispatch_method_set, true ) ) {
+						continue;
+					}
+					$suspended[]                                      = array( $action, (int) $priority, (string) $key, $function );
+					$hook->callbacks[ $priority ][ $key ]['function'] = function ( ...$args ) use ( $action, $function, $restored_order_id ) {
+						if ( $this->should_suppress_transactional_email_dispatch( $action, $restored_order_id, $args ) ) {
+							return null;
+						}
+
+						return call_user_func_array( $function, $args );
+					};
+				}
+			}
+		}
+
+		return $suspended;
+	}
+
+	/**
+	 * Checks whether a transactional email dispatch belongs to the restored order.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param string $action            The action being dispatched.
+	 * @param int    $restored_order_id The ID of the order being restored.
+	 * @param array  $args              The runtime action arguments.
+	 * @return bool
+	 */
+	private function should_suppress_transactional_email_dispatch( string $action, int $restored_order_id, array $args ): bool {
+		if ( 0 !== strpos( $action, 'woocommerce_order_status_' ) ) {
+			return false;
+		}
+
+		$order = $args[1] ?? null;
+		if ( $order instanceof WC_Order ) {
+			return $restored_order_id === $order->get_id();
+		}
+
+		$order_id = $args[0] ?? null;
+		return is_numeric( $order_id ) && $restored_order_id === (int) $order_id;
+	}
+
+	/**
+	 * Restores the transactional email dispatch listeners previously neutralized by
+	 * {@see suspend_transactional_email_dispatch()} to their original callbacks.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param list<array{0: string, 1: int, 2: string, 3: callable}> $suspended Snapshot returned by suspend_transactional_email_dispatch().
+	 *
+	 * @return void
+	 */
+	protected function restore_transactional_email_dispatch( array $suspended ): void {
+		global $wp_filter;
+
+		foreach ( $suspended as $entry ) {
+			list( $action, $priority, $key, $function ) = $entry;
+			if ( ! isset( $wp_filter[ $action ] ) || ! $wp_filter[ $action ] instanceof WP_Hook ) {
+				continue;
+			}
+			// Only restore the slot if it still exists; if it was removed during the
+			// suspended window we must not resurrect it.
+			if ( ! isset( $wp_filter[ $action ]->callbacks[ $priority ][ $key ] ) ) {
+				continue;
+			}
+			$wp_filter[ $action ]->callbacks[ $priority ][ $key ]['function'] = $function;
 		}
 	}
 }

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -252,8 +252,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			} else {
 				wp_update_post( array_merge( array( 'ID' => $order->get_id() ), $post_data ) );
 			}
-			$order->read_meta_data( true );
-			// Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
+			$order->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
 		}
 		$this->update_post_meta( $order );
 		$order->apply_changes();

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1244,8 +1244,21 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			return false;
 		}
 
-		$order->set_status( get_post_field( 'post_status', $order->get_id() ) );
-		return (bool) $order->save();
+		// Restoring the order triggers a status transition (from 'trash' back to its previous
+		// status). WC_Emails dispatches customer notifications on those transitions, so suppress
+		// email dispatch for this order while we restore to avoid re-notifying the customer
+		// about an order they were already emailed about. The status transition actions
+		// themselves still fire, so any 3rd-party code hooked into them keeps working.
+		$suspended_email_dispatch = $this->suspend_transactional_email_dispatch( $order->get_id() );
+
+		try {
+			$order->set_status( get_post_field( 'post_status', $order->get_id() ) );
+			$saved = (bool) $order->save();
+		} finally {
+			$this->restore_transactional_email_dispatch( $suspended_email_dispatch );
+		}
+
+		return $saved;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2771,8 +2771,19 @@ FROM $order_meta_table
 		 */
 		do_action( 'woocommerce_untrash_order', $order->get_id(), $previous_status );
 
-		$order->set_status( $previous_status );
-		$order->save();
+		// Customer order emails (and other transactional emails) are dispatched via WC_Emails
+		// listeners on the woocommerce_order_status_* actions. Suppress dispatch for this order
+		// while we restore it so customers aren't re-notified about an order they
+		// already received emails for. The status transition actions themselves still fire,
+		// so any 3rd-party code hooked into them keeps working.
+		$suspended_email_dispatch = $this->suspend_transactional_email_dispatch( $order->get_id() );
+
+		try {
+			$order->set_status( $previous_status );
+			$order->save();
+		} finally {
+			$this->restore_transactional_email_dispatch( $suspended_email_dispatch );
+		}
 
 		// Was the status successfully restored? Let's clean up the meta and indicate success...
 		if ( 'wc-' . $order->get_status() === $previous_status ) {
@@ -2795,7 +2806,6 @@ FROM $order_meta_table
 
 		return false;
 	}
-
 
 	/**
 	 * Deletes order data from custom order tables.

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -304,6 +304,161 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Restoring a CPT order from trash does not re-fire transactional email dispatch, but still fires the status transition actions.
+	 */
+	public function test_untrash_suspends_email_dispatch_but_keeps_status_actions(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+		$order_id = $order->get_id();
+
+		$order->delete();
+		$this->assertEquals( OrderStatus::TRASH, $order->get_status(), 'The order was successfully trashed.' );
+
+		$status_action_count       = 0;
+		$status_notification_count = 0;
+		$status_action             = function ( $id ) use ( $order_id, &$status_action_count ) {
+			if ( $order_id === $id ) {
+				++$status_action_count;
+			}
+		};
+		$notification_action       = function ( $id ) use ( $order_id, &$status_notification_count ) {
+			if ( $order_id === $id ) {
+				++$status_notification_count;
+			}
+		};
+
+		add_action( 'woocommerce_order_status_completed', $status_action );
+		add_action( 'woocommerce_order_status_completed_notification', $notification_action );
+
+		try {
+			$order = wc_get_order( $order_id );
+			$this->assertTrue( $order->untrash(), 'The order was restored from the trash.' );
+		} finally {
+			remove_action( 'woocommerce_order_status_completed', $status_action );
+			remove_action( 'woocommerce_order_status_completed_notification', $notification_action );
+		}
+
+		$this->assertEquals( OrderStatus::COMPLETED, $order->get_status() );
+		// The status transition action still fires so 3rd-party integrations keep working.
+		$this->assertSame( 1, $status_action_count );
+		// The _notification action (which transactional emails listen to) must NOT fire on restore.
+		$this->assertSame( 0, $status_notification_count );
+	}
+
+	/**
+	 * @testdox Restoring an order only suppresses transactional email dispatch for the restored order.
+	 */
+	public function test_untrash_does_not_suppress_email_dispatch_for_other_orders(): void {
+		$restored_order = WC_Helper_Order::create_order();
+		$restored_order->set_status( OrderStatus::COMPLETED );
+		$restored_order->save();
+		$restored_order_id = $restored_order->get_id();
+
+		$other_order = WC_Helper_Order::create_order();
+		$other_order->set_status( OrderStatus::PENDING );
+		$other_order->save();
+		$other_order_id = $other_order->get_id();
+
+		$restored_order->delete();
+		$this->assertEquals( OrderStatus::TRASH, $restored_order->get_status(), 'The restored order was successfully trashed.' );
+
+		$restored_order_notification_count = 0;
+		$other_order_notification_count    = 0;
+		$other_order_status_change_count   = 0;
+		$status_action                     = function ( $order_id ) use ( $restored_order_id, $other_order, &$other_order_status_change_count ) {
+			if ( $restored_order_id !== $order_id ) {
+				return;
+			}
+
+			$other_order->set_status( OrderStatus::COMPLETED );
+			$other_order->save();
+			++$other_order_status_change_count;
+		};
+		$notification_action               = function ( $order_id ) use ( $restored_order_id, $other_order_id, &$restored_order_notification_count, &$other_order_notification_count ) {
+			if ( $restored_order_id === $order_id ) {
+				++$restored_order_notification_count;
+			}
+			if ( $other_order_id === $order_id ) {
+				++$other_order_notification_count;
+			}
+		};
+
+		add_action( 'woocommerce_order_status_completed', $status_action );
+		add_action( 'woocommerce_order_status_completed_notification', $notification_action );
+
+		try {
+			$restored_order = wc_get_order( $restored_order_id );
+			$this->assertTrue( $restored_order->untrash(), 'The order was restored from the trash.' );
+		} finally {
+			remove_action( 'woocommerce_order_status_completed', $status_action );
+			remove_action( 'woocommerce_order_status_completed_notification', $notification_action );
+		}
+
+		$this->assertSame( 1, $other_order_status_change_count );
+		$this->assertSame( 0, $restored_order_notification_count );
+		$this->assertSame( 1, $other_order_notification_count );
+	}
+
+	/**
+	 * No-op listener used as a stable, uniquely-identified probe by
+	 * {@see test_untrash_preserves_email_hook_callback_order()}.
+	 *
+	 * @return void
+	 */
+	public static function untrash_email_hook_order_probe(): void {}
+
+	/**
+	 * @testdox Restoring an order keeps the WC_Emails dispatch listener in its original hook slot rather than removing and re-adding it.
+	 */
+	public function test_untrash_preserves_email_hook_callback_order(): void {
+		global $wp_filter;
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+		$order_id = $order->get_id();
+		$order->delete();
+
+		// Register a 3rd-party listener after WC_Emails dispatch, at the same priority. A
+		// uniquely-named static method is used so its hook ID is a stable string that nothing
+		// else collides with.
+		$probe = array( self::class, 'untrash_email_hook_order_probe' );
+		add_action( 'woocommerce_order_status_completed', $probe, 10 );
+
+		// Capture the priority 10 listener order at the moment the restore transition fires.
+		// A remove/re-add suspension would leave WC_Emails dispatch absent here (it would be
+		// removed before save() and only re-added afterwards); the in-place wrapper keeps
+		// it registered in its original slot, ahead of the 3rd-party listener.
+		$keys_during = array();
+		$recorder    = function () use ( &$wp_filter, &$keys_during ) {
+			$keys_during = array_keys( $wp_filter['woocommerce_order_status_completed']->callbacks[10] );
+		};
+		add_action( 'woocommerce_order_status_completed', $recorder, 99 );
+
+		try {
+			$order = wc_get_order( $order_id );
+			$this->assertTrue( $order->untrash(), 'The order was restored from the trash.' );
+		} finally {
+			remove_action( 'woocommerce_order_status_completed', $probe, 10 );
+			remove_action( 'woocommerce_order_status_completed', $recorder, 99 );
+		}
+
+		$pos_dispatch = false;
+		foreach ( array( 'WC_Emails::send_transactional_email', 'WC_Emails::queue_transactional_email' ) as $dispatch_key ) {
+			$pos_dispatch = array_search( $dispatch_key, $keys_during, true );
+			if ( false !== $pos_dispatch ) {
+				break;
+			}
+		}
+		$pos_listener = array_search( self::class . '::untrash_email_hook_order_probe', $keys_during, true );
+
+		$this->assertNotFalse( $pos_dispatch, 'WC_Emails dispatch callback stays registered during the restore transition.' );
+		$this->assertNotFalse( $pos_listener, 'The 3rd-party listener stays registered during the restore transition.' );
+		$this->assertLessThan( $pos_listener, $pos_dispatch, 'WC_Emails dispatch keeps its original position ahead of a later listener.' );
+	}
+
+	/**
 	 * @testDox A 'suppress_filters' argument can be passed to 'delete', if true no 'woocommerce_(before_)trash/delete_order' actions will be fired.
 	 *
 	 * @testWith [null, true]

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -596,6 +596,77 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 	}
 
 	/**
+	 * @testdox Restoring an HPOS order from trash does not re-fire transactional email dispatch, but still fires the status transition actions.
+	 */
+	public function test_cot_datastore_untrash_suspends_email_dispatch_but_keeps_status_actions() {
+		$this->toggle_cot_feature_and_usage( true );
+
+		$order = $this->create_complex_cot_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$this->sut->trash_order( $order );
+		$this->sut->read( $order );
+
+		$status_action_count       = 0;
+		$status_notification_count = 0;
+		$status_action             = function ( $order_id ) use ( $order, &$status_action_count ) {
+			if ( $order->get_id() === $order_id ) {
+				++$status_action_count;
+			}
+		};
+		$notification_action       = function ( $order_id ) use ( $order, &$status_notification_count ) {
+			if ( $order->get_id() === $order_id ) {
+				++$status_notification_count;
+			}
+		};
+
+		add_action( 'woocommerce_order_status_completed', $status_action );
+		add_action( 'woocommerce_order_status_completed_notification', $notification_action );
+
+		try {
+			$this->assertTrue( $this->sut->untrash_order( $order ) );
+		} finally {
+			remove_action( 'woocommerce_order_status_completed', $status_action );
+			remove_action( 'woocommerce_order_status_completed_notification', $notification_action );
+		}
+
+		$this->assertSame( OrderStatus::COMPLETED, $order->get_status() );
+		// The status transition action still fires so 3rd-party integrations keep working.
+		$this->assertSame( 1, $status_action_count );
+		// The _notification action (which transactional emails listen to) must NOT fire on restore.
+		$this->assertSame( 0, $status_notification_count );
+	}
+
+	/**
+	 * @testdox After untrash, the WC_Emails transactional dispatch listeners are reinstated.
+	 */
+	public function test_cot_datastore_untrash_restores_email_dispatch_after_save() {
+		$this->toggle_cot_feature_and_usage( true );
+
+		$order = $this->create_complex_cot_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$this->sut->trash_order( $order );
+		$this->sut->read( $order );
+
+		$dispatch_callbacks_before = array(
+			has_action( 'woocommerce_order_status_completed', array( 'WC_Emails', 'send_transactional_email' ) ),
+			has_action( 'woocommerce_order_status_completed', array( 'WC_Emails', 'queue_transactional_email' ) ),
+		);
+
+		$this->assertTrue( $this->sut->untrash_order( $order ) );
+
+		$dispatch_callbacks_after = array(
+			has_action( 'woocommerce_order_status_completed', array( 'WC_Emails', 'send_transactional_email' ) ),
+			has_action( 'woocommerce_order_status_completed', array( 'WC_Emails', 'queue_transactional_email' ) ),
+		);
+
+		$this->assertSame( $dispatch_callbacks_before, $dispatch_callbacks_after );
+	}
+
+	/**
 	 * @testDox Tests the `delete()` method on the COT datastore -- full deletes.
 	 *
 	 * @return void


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #64739, closes WOOPLUG-6670

Don't send emails when restoring order from trash. 

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Enable HPOS.
2. Trash a completed order.
3. Restore the order and confirm customer order emails are not resent.

### Testing that has already taken place:

Syntax checks passed. Focused PHPUnit could not run locally because the WordPress test library is missing in this checkout.

<!-- milestone-target-selection -->
### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Avoid resending customer order emails when HPOS orders are restored from trash.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)


