### PR TITLE
Polish shipping fields in the product edit drawer

### DIFF
--- a/packages/js/experimental-products-app/changelog/reorder-shipping-fields
+++ b/packages/js/experimental-products-app/changelog/reorder-shipping-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Reorder shipping fields in the product edit drawer to Length, Width, Height in a row with Weight below.

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -361,10 +361,10 @@ describe( 'product edit utils', () => {
 				'tags',
 				'featured',
 				'shipping_class',
-				'weight',
 				'length',
 				'width',
 				'height',
+				'weight',
 			] );
 			expectFieldsHidden( fieldIds, [
 				'price',
@@ -1039,9 +1039,9 @@ describe( 'product edit utils', () => {
 						{
 							id: 'dimensions',
 							layout: { type: 'row' },
-							children: [ 'weight', 'length', 'width' ],
+							children: [ 'length', 'width', 'height' ],
 						},
-						'height',
+						'weight',
 					],
 				},
 			] );
@@ -1202,7 +1202,7 @@ describe( 'product edit utils', () => {
 					children: [
 						'shipping_class',
 						{
-							id: 'parent-dimensions',
+							id: 'dimensions',
 							layout: { type: 'row' },
 							children: [ 'length', 'width', 'height' ],
 						},
@@ -1260,9 +1260,9 @@ describe( 'product edit utils', () => {
 						{
 							id: 'dimensions',
 							layout: { type: 'row' },
-							children: [ 'weight', 'length', 'width' ],
+							children: [ 'length', 'width', 'height' ],
 						},
-						'height',
+						'weight',
 					],
 				},
 			] );

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -76,16 +76,8 @@ const PRODUCT_EDIT_FIELD_IDS = [
 	'linked_products_count',
 ] as const;
 
-const DIMENSION_GROUP_FIELD_IDS = [ 'weight', 'length', 'width' ] as const;
-
 const DIMENSIONS_FORM_FIELD: ProductEditFormField = {
 	id: 'dimensions',
-	layout: { type: 'row' as const },
-	children: [ ...DIMENSION_GROUP_FIELD_IDS ],
-};
-
-const PARENT_DIMENSIONS_FORM_FIELD: ProductEditFormField = {
-	id: 'parent-dimensions',
 	layout: { type: 'row' as const },
 	children: [ 'length', 'width', 'height' ],
 };
@@ -129,7 +121,7 @@ const SIMPLE_PRODUCT_EDIT_FORM_FIELDS = [
 	createProductEditFormGroup(
 		'shipping-fields',
 		__( 'Shipping', 'woocommerce' ),
-		[ DIMENSIONS_FORM_FIELD, 'height' ]
+		[ DIMENSIONS_FORM_FIELD, 'weight' ]
 	),
 ] satisfies ProductEditFormField[];
 
@@ -154,7 +146,7 @@ const VARIATION_PRODUCT_EDIT_FORM_FIELDS = [
 	createProductEditFormGroup(
 		'shipping-fields',
 		__( 'Shipping', 'woocommerce' ),
-		[ 'shipping_class', DIMENSIONS_FORM_FIELD, 'height' ]
+		[ 'shipping_class', DIMENSIONS_FORM_FIELD, 'weight' ]
 	),
 ] satisfies ProductEditFormField[];
 
@@ -180,7 +172,7 @@ const VARIABLE_PRODUCT_EDIT_FORM_FIELDS = [
 	createProductEditFormGroup(
 		'shipping-fields',
 		__( 'Shipping', 'woocommerce' ),
-		[ 'shipping_class', PARENT_DIMENSIONS_FORM_FIELD, 'weight' ]
+		[ 'shipping_class', DIMENSIONS_FORM_FIELD, 'weight' ]
 	),
 ] satisfies ProductEditFormField[];
 

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -134,7 +134,7 @@ const SIMPLE_PRODUCT_EDIT_FORM_FIELDS = [
 	createProductEditFormGroup(
 		'shipping-fields',
 		__( 'Shipping', 'woocommerce' ),
-		[ 'shipping_class', DIMENSIONS_FORM_FIELD, 'height' ]
+		[ 'shipping_class', DIMENSIONS_FORM_FIELD, 'weight' ]
 	),
 ] satisfies ProductEditFormField[];
 

--- a/plugins/woocommerce/changelog/register-settings-entity
+++ b/plugins/woocommerce/changelog/register-settings-entity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Register a settings entity in the WooCommerce Blocks entities module so admin clients can read store settings via core-data.

--- a/plugins/woocommerce/client/blocks/assets/js/entities/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/index.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { isExperimentalWcRestApiV4Enabled } from '../settings/blocks/feature-flags';
 import {
 	registerProductEntity,
 	registerSettingsEntity,
@@ -10,4 +11,10 @@ export * from './product';
 export * from './settings';
 
 registerProductEntity();
-registerSettingsEntity();
+
+/**
+ * Register the settings entity only when the experimental v4 REST API is enabled.
+ */
+if (isExperimentalWcRestApiV4Enabled()) {
+	registerSettingsEntity();
+}

--- a/plugins/woocommerce/client/blocks/assets/js/entities/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/index.ts
@@ -15,6 +15,6 @@ registerProductEntity();
 /**
  * Register the settings entity only when the experimental v4 REST API is enabled.
  */
-if (isExperimentalWcRestApiV4Enabled()) {
+if ( isExperimentalWcRestApiV4Enabled() ) {
 	registerSettingsEntity();
 }

--- a/plugins/woocommerce/client/blocks/assets/js/entities/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/index.ts
@@ -1,8 +1,13 @@
 /**
  * Internal dependencies
  */
-import { registerProductEntity } from './register-entities';
+import {
+	registerProductEntity,
+	registerSettingsEntity,
+} from './register-entities';
 
 export * from './product';
+export * from './settings';
 
 registerProductEntity();
+registerSettingsEntity();

--- a/plugins/woocommerce/client/blocks/assets/js/entities/register-entities.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/register-entities.ts
@@ -8,6 +8,7 @@ import { dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { PRODUCT_ENTITY } from './product/constants';
+import { SETTINGS_ENTITY } from './settings/constants';
 
 const registered: string[] = [];
 
@@ -18,4 +19,13 @@ export const registerProductEntity = () => {
 	const { addEntities } = dispatch( coreStore );
 	addEntities( [ PRODUCT_ENTITY ] );
 	registered.push( PRODUCT_ENTITY.name );
+};
+
+export const registerSettingsEntity = () => {
+	if ( registered.includes( SETTINGS_ENTITY.name ) ) {
+		return;
+	}
+	const { addEntities } = dispatch( coreStore );
+	addEntities( [ SETTINGS_ENTITY ] );
+	registered.push( SETTINGS_ENTITY.name );
 };

--- a/plugins/woocommerce/client/blocks/assets/js/entities/settings/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/settings/constants.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Entity } from '../types';
+import { SettingsEntityRecord } from './types';
+
+export const SETTINGS_ENTITY: Entity = {
+	name: 'settings',
+	kind: 'root',
+	baseURL: '/wc/v4/settings',
+	label: __( 'Settings', 'woocommerce' ),
+	getTitle: ( record ) => {
+		const recordData = record as SettingsEntityRecord;
+		return (
+			recordData?.id.charAt( 0 ).toUpperCase() +
+			recordData?.id.slice( 1 ) +
+			' settings'
+		);
+	},
+	key: 'id',
+	supportsPagination: false,
+	plural: __( 'Settings', 'woocommerce' ),
+};

--- a/plugins/woocommerce/client/blocks/assets/js/entities/settings/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/settings/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/plugins/woocommerce/client/blocks/assets/js/entities/settings/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/settings/types.ts
@@ -1,0 +1,15 @@
+export type SettingsEntityValue = string | number | boolean | unknown[];
+
+export interface SettingsEntityRecord {
+	id: string;
+	title?: string;
+	description?: string;
+	values?: Record< string, SettingsEntityValue >;
+	groups?: Record<
+		string,
+		{
+			title?: string;
+			description?: string;
+		}
+	>;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR polishes the shipping fields in the product edit drawer (the React side panel that opens when editing a product, variation, or variable product from the All Products view).

Two changes:

1. **Reorder the shipping fields** so dimensions read Length, Width, Height on one row with Weight on its own row below — matching the design. The previous order had Weight, Length, Width on the row and Height alone. The simple and variation product configs were doing this; variable was already correct. All three product configs now share a single `DIMENSIONS_FORM_FIELD`.

2. **Register a settings entity in the WooCommerce Blocks entities module** so the unit suffixes on the weight/length/width/height inputs actually render. The existing `useEntityRecord( 'root', 'settings', 'products' )` calls in [packages/js/experimental-products-app/src/fields/weight/field.tsx](packages/js/experimental-products-app/src/fields/weight/field.tsx) and [dimension.tsx](packages/js/experimental-products-app/src/fields/components/dimension.tsx) were silently failing because no settings entity was registered. This PR adds one, pointed at `/wc/v4/settings`, mirroring the existing `PRODUCT_ENTITY` pattern in [plugins/woocommerce/client/blocks/assets/js/entities/](plugins/woocommerce/client/blocks/assets/js/entities/). Registration happens in `wc-entities.js`, which gets enqueued on every admin page.

> The settings endpoint is v4-only — there is no v3 fallback, since the v3 settings shape is incompatible. The `rest-api-v4` feature flag must be enabled for the suffix to render.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="224" height="101" alt="image" src="https://github.com/user-attachments/assets/5beae71c-1e88-42c4-a601-c7eb7c94c09c" /> | <img width="224" height="105" alt="image" src="https://github.com/user-attachments/assets/f32f2583-91e4-4247-91db-3cc9e789a881" /> |

### How to test the changes in this Pull Request:

1. Enable the following feature flags in `plugins/woocommerce/client/admin/config/development.json`:
   - `product-data-views: true`
   - `rest-api-v4: true`
2. Regenerate the feature config: `cd plugins/woocommerce/client/admin && WC_ADMIN_PHASE=development php ../../bin/generate-feature-config.php`
3. Build: `pnpm --filter=@woocommerce/experimental-products-app build && pnpm --filter=@woocommerce/admin-library build && pnpm --filter=@woocommerce/block-library build`
4. Sync assets: `rsync -a plugins/woocommerce/client/admin/build/ plugins/woocommerce/assets/client/admin/ && rsync -a plugins/woocommerce/client/blocks/build/ plugins/woocommerce/assets/client/blocks/`
5. Open the new All Products view, click a product to open the edit drawer, scroll to the Shipping section.
6. Confirm the field order: Length, Width, Height (in a row) and Weight (on its own row below).
7. Confirm each input shows a unit suffix (e.g. `cm`, `kg`) sourced from `WooCommerce > Settings > Products`.
8. Change the store's weight/dimension units in WC settings, reload, and confirm the suffixes update.
9. Repeat for a variation (drill into a variable product's variation) and a variable product. Confirm both show the same field order.

### Testing that has already taken place:

- Local wp-env, dev flags `product-data-views`, `product-variations-classic-redesign`, and `rest-api-v4` enabled.
- Verified field order on simple and variation products.
- Verified `/wc/v4/settings/products` returns the expected shape and that the `kg` / `cm` suffixes render.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog entries are included for the two affected packages.)

### Release Communication

<!-- release-communication-section -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)