### PR TITLE
Floating header: Tracks instrumentation for Screen Options and Help icon clicks

### DIFF
--- a/plugins/woocommerce/changelog/sprinkle-floating-header-meta-icon-tracks
+++ b/plugins/woocommerce/changelog/sprinkle-floating-header-meta-icon-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Tracks instrumentation to the floating header's Screen Options (gear) and Help (?) icon buttons. Fires `wcadmin_header_meta_icon_click` with `icon` and `action` (open/close) so engagement with these two icons can be measured.

--- a/plugins/woocommerce/client/admin/client/header/embed.tsx
+++ b/plugins/woocommerce/client/admin/client/header/embed.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
 import { cog, help } from '@wordpress/icons';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -55,12 +56,23 @@ export const EmbedHeader = ( {
 					label={ __( 'Screen options', 'woocommerce' ) }
 					aria-expanded={ activeMetaIcon === 'screen-options' }
 					showTooltip
-					onClick={ () =>
+					onClick={ () => {
+						// Capture the pre-click state so we can tell `open`
+						// from `close` clicks. wp-admin's screen-meta.js flips
+						// aria-expanded synchronously inside triggerMetaIcon(),
+						// so reading it after would lose the original signal.
+						recordEvent( 'header_meta_icon_click', {
+							icon: 'screen-options',
+							action:
+								activeMetaIcon === 'screen-options'
+									? 'close'
+									: 'open',
+						} );
 						triggerMetaIcon(
 							'screen-options',
 							'#show-settings-link'
-						)
-					}
+						);
+					} }
 				>
 					<Icon icon={ cog } size={ 18 } />
 				</Button>
@@ -73,9 +85,14 @@ export const EmbedHeader = ( {
 					label={ __( 'Help', 'woocommerce' ) }
 					aria-expanded={ activeMetaIcon === 'help' }
 					showTooltip
-					onClick={ () =>
-						triggerMetaIcon( 'help', '#contextual-help-link' )
-					}
+					onClick={ () => {
+						recordEvent( 'header_meta_icon_click', {
+							icon: 'help',
+							action:
+								activeMetaIcon === 'help' ? 'close' : 'open',
+						} );
+						triggerMetaIcon( 'help', '#contextual-help-link' );
+					} }
 				>
 					<Icon icon={ help } size={ 18 } />
 				</Button>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Follow-up to #64643 (floating header) and the watch-list item in Linear RSM-3463.

Adds `wcadmin_header_meta_icon_click` Tracks instrumentation to the two icon buttons in the embedded wp-admin header chrome — the gear (Screen Options) and the ? (Help). Without this, RSM-3463's impact check has no signal for these icons.

**Event shape:**
```
wcadmin_header_meta_icon_click
  icon:   'screen-options' | 'help'
  action: 'open' | 'close'
```

**Why `action` is read before `triggerMetaIcon()`:** wp-admin's `screen-meta.js` flips `aria-expanded` synchronously inside the trigger call. Reading it after would always report the post-click state, making open and close indistinguishable.

### How to test:

1. Navigate to any WC Admin page that shows the floating header (e.g. WooCommerce → Home).
2. Open your browser console → Network tab, filter for `tracks`.
3. Click the gear icon (⚙). Verify a `wcadmin_header_meta_icon_click` event fires with `{ icon: 'screen-options', action: 'open' }`.
4. Click it again to close. Verify `action: 'close'`.
5. Repeat for the ? icon with `icon: 'help'`.

### Changelog

- Adds `wcadmin_header_meta_icon_click` Tracks event (patch, type: add)