### PR TITLE
Shopper Collection: salvage partial-stock on Move to cart

### DIFF
--- a/plugins/woocommerce/changelog/add-cart-mutation-batcher-error-data
+++ b/plugins/woocommerce/changelog/add-cart-mutation-batcher-error-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Cart mutation batcher: propagate the server error `data` field onto rejected request errors so callers can read structured fields like `quantity_remaining`.

--- a/plugins/woocommerce/changelog/add-cart-store-rethrow-errors
+++ b/plugins/woocommerce/changelog/add-cart-store-rethrow-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Cart Interactivity store: add `rethrowErrors` opt-in to `addCartItem` so callers can branch on the underlying failure.

--- a/plugins/woocommerce/changelog/add-shopper-collection-move-to-cart-partial-stock
+++ b/plugins/woocommerce/changelog/add-shopper-collection-move-to-cart-partial-stock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Shopper Collection: when the saved quantity exceeds available stock, move the addable amount into the cart instead of failing the whole action.

--- a/plugins/woocommerce/changelog/add-shopper-collection-partial-stock-quantity-remaining
+++ b/plugins/woocommerce/changelog/add-shopper-collection-partial-stock-quantity-remaining
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Store API: expose remaining stock quantity on partial-stock add-to-cart errors via additional_data.quantity_remaining.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -58,7 +58,14 @@ export type ClientCartItem = Omit<
 	quantityToAdd?: number;
 };
 
-type CartUpdateOptions = { showCartUpdatesNotices?: boolean };
+type CartUpdateOptions = {
+	showCartUpdatesNotices?: boolean;
+	// Opt-in: rethrow the underlying error instead of swallowing it into a
+	// store notice. Lets callers branch on the failure (e.g. retrying with a
+	// smaller quantity on a partial-stock error). Default `false` preserves
+	// the existing "errors become notices" behavior.
+	rethrowErrors?: boolean;
+};
 
 export type Store = {
 	state: {
@@ -339,7 +346,10 @@ const { actions } = store< Store >(
 
 			*addCartItem(
 				{ id, key, quantity, quantityToAdd, variation }: ClientCartItem,
-				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
+				{
+					showCartUpdatesNotices = true,
+					rethrowErrors = false,
+				}: CartUpdateOptions = {}
 			): AsyncAction< void > {
 				if ( quantity !== undefined && quantityToAdd !== undefined ) {
 					throw new Error(
@@ -480,6 +490,9 @@ const { actions } = store< Store >(
 						speak( messages.addedToCartText, 'polite' );
 					}
 				} catch ( error ) {
+					if ( rethrowErrors ) {
+						throw error;
+					}
 					// Show error notice
 					actions.showNoticeError( error as Error );
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/mutation-batcher.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/mutation-batcher.ts
@@ -177,12 +177,16 @@ export function createMutationQueue< TState >(
 				const errorBody = itemResponse.body as {
 					message?: string;
 					code?: string;
+					data?: unknown;
 				};
 				errors.set(
 					requestId,
 					Object.assign(
 						new Error( errorBody?.message || 'Request failed' ),
-						{ code: errorBody?.code || 'unknown_error' }
+						{
+							code: errorBody?.code || 'unknown_error',
+							data: errorBody?.data,
+						}
 					)
 				);
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-collection/frontend.ts
@@ -252,34 +252,82 @@ store< BlockStore >(
 					} )
 				);
 				const isVariation = listItem.variation_id > 0;
-
-				// `cartActions.addCartItem` catches its own errors and
-				// surfaces them as store notices, so the yield resolves
-				// the same way on success and failure. Snapshot the
-				// matching line's quantity, run the add, then only remove
-				// from the saved list if it actually grew.
+				const payload = {
+					id: listItem.id,
+					type: isVariation ? 'variation' : 'simple',
+					...( isVariation && { variation } ),
+				} as const;
 				const lookup = {
 					id: listItem.id,
 					...( isVariation && { variation } ),
 				};
-				const beforeItem = cartState.findItemInCart( lookup );
-				const beforeQuantity = beforeItem?.quantity ?? 0;
 
-				yield cartActions.addCartItem( {
-					id: listItem.id,
-					quantityToAdd: listItem.quantity,
-					type: isVariation ? 'variation' : 'simple',
-					...( isVariation && { variation } ),
-				} );
-
-				const afterItem = cartState.findItemInCart( lookup );
-				const afterQuantity = afterItem?.quantity ?? 0;
-
-				if ( afterQuantity <= beforeQuantity ) {
-					return;
+				// Opt into rethrow so we can branch on the failure: a
+				// partial-stock error means we still want to move what we
+				// can. Any other failure (full out-of-stock, network, etc.)
+				// leaves the saved list entry untouched so the shopper
+				// can try again later.
+				let added = false;
+				try {
+					yield cartActions.addCartItem(
+						{ ...payload, quantityToAdd: listItem.quantity },
+						{ rethrowErrors: true }
+					);
+					added = true;
+				} catch ( err ) {
+					const code = ( err as { code?: string } ).code;
+					if (
+						code ===
+						'woocommerce_rest_product_partially_out_of_stock'
+					) {
+						// `quantity_remaining` is the product's total
+						// remaining stock (matches what the message
+						// shows). Subtract what's already in the cart
+						// to get how much we can still add.
+						const remaining =
+							( err as {
+								data?: { quantity_remaining?: number };
+							} ).data?.quantity_remaining ?? 0;
+						const inCart =
+							cartState.findItemInCart( lookup )?.quantity ?? 0;
+						const addable = Math.max( 0, remaining - inCart );
+						if ( addable > 0 ) {
+							try {
+								yield cartActions.addCartItem(
+									{ ...payload, quantityToAdd: addable },
+									{ rethrowErrors: true }
+								);
+								added = true;
+								// TODO: once block-level notices are
+								// wired up (see
+								// https://github.com/woocommerce/woocommerce/pull/64961),
+								// surface an info notice covering both
+								// outcomes of this branch — the partial
+								// cart add (`addable` of
+								// `listItem.quantity` moved) and the
+								// saved-list removal that follows — so
+								// the shopper isn't left wondering why
+								// the list entry disappeared.
+							} catch {
+								// Stock changed between calls — bail and
+								// leave the saved list entry alone.
+							}
+						}
+					}
 				}
 
-				yield shopperListsActions.removeItem( listSlug, listItem.key );
+				// Once anything was successfully moved into the cart
+				// (whether the full saved quantity or a partial amount),
+				// the saved list entry is no longer useful — mirror the
+				// "Save for later" flow (cart → list removes the source
+				// cart line after the list POST succeeds, see
+				// `useSaveForLater`).
+				if ( added ) {
+					yield shopperListsActions.removeItem(
+						listSlug,
+						listItem.key
+					);
+				}
 			},
 		},
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -309,7 +309,8 @@ class CartController {
 						$product->get_name(),
 						wc_format_stock_quantity_for_display( $qty_remaining, $product )
 					),
-					400
+					400,
+					array( 'quantity_remaining' => $qty_remaining ) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 				);
 			}
 		}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Utilities;
 
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
@@ -162,6 +163,53 @@ class CartControllerTests extends TestCase {
 
 		foreach ( $expected_errors as $expected_error ) {
 			$this->assertContains( $expected_error, $error_codes );
+		}
+	}
+
+	/**
+	 * Partial-stock errors from validate_add_to_cart must expose the
+	 * remaining stock quantity (matching what the user-facing message says)
+	 * under `additional_data` so clients can compute an addable amount and
+	 * retry with a clamped quantity.
+	 */
+	public function test_validate_add_to_cart_partial_stock_exposes_quantity_remaining(): void {
+		$class    = new CartController();
+		$fixtures = new FixtureData();
+
+		$product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product Partial Stock',
+				'regular_price' => 10,
+			)
+		);
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 3 );
+		$product->save();
+
+		// 1 already in cart, request 5 more → 6 > 3 remaining.
+		wc()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$request = array(
+			'id'             => $product->get_id(),
+			'quantity'       => 5,
+			'variation'      => array(),
+			'cart_item_data' => array(),
+		);
+
+		$fresh_product = wc_get_product( $product->get_id() );
+		$this->assertInstanceOf( \WC_Product::class, $fresh_product );
+
+		try {
+			$class->validate_add_to_cart( $fresh_product, $request );
+			$this->fail( 'Expected RouteException was not thrown.' );
+		} catch ( RouteException $e ) {
+			$this->assertSame( 'woocommerce_rest_product_partially_out_of_stock', $e->getErrorCode() );
+			$additional = $e->getAdditionalData();
+			$this->assertArrayHasKey( 'quantity_remaining', $additional );
+			// Matches the value shown in the user-facing message — total
+			// stock remaining for the product, not net of what's already in
+			// the cart.
+			$this->assertSame( 3, $additional['quantity_remaining'] );
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Move to cart on a Shopper Collection row used to fail entirely when the saved quantity exceeded available stock, leaving both the cart and the saved list untouched. This PR salvages the partial: the Store API now exposes `quantity_remaining` on `woocommerce_rest_product_partially_out_of_stock` errors, the cart Interactivity store gained a `rethrowErrors` opt-in so callers can branch on the failure, the mutation batcher now copies the server's `data` field onto rejected request errors, and the block catches the partial-stock error, retries with a clamped quantity, and removes the saved list entry only when something actually moved into the cart.

Commits are kept independent (endpoint, store, batcher plumbing, block) so each layer can be reviewed on its own.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Enable the Save for Later feature flag and add a Shopper Collection (Save for later variation) block to a page.
2. Create a simple product with **Manage stock** enabled and **Stock quantity = 2**.
3. As a logged-in shopper, save that product to the list with **quantity = 5** (use the API or the cart's Save for later link with quantity adjusted).
4. Navigate to the page with the Shopper Collection and click **Move to cart** on that row.
    - Expected: the cart now holds 2 of the product (the addable remainder) and the saved list entry is gone.
5. Repeat with a product set to **Out of stock**.
    - Expected: the saved list entry stays in place and an error notice is shown.
6. Repeat with a normal in-stock product where the saved qty is within stock limits.
    - Expected: the full saved qty moves into the cart and the saved entry is removed.

### Testing that has already taken place:

- PHPUnit: `CartControllerTests::test_validate_add_to_cart_partial_stock_exposes_quantity_remaining` covers the new API field.
- Lint/PHPStan on changed files: clean.
- Manual UI testing: pending.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entries are already committed manually — one per logical layer:

- `add-shopper-collection-partial-stock-quantity-remaining` (minor / add)
- `add-cart-store-rethrow-errors` (patch / add)
- `add-cart-mutation-batcher-error-data` (patch / add)
- `add-shopper-collection-move-to-cart-partial-stock` (patch / fix)

</details>