### PR TITLE
[VA] PHP groundwork: tab rename + form-POST preservation

### DIFF
--- a/plugins/woocommerce/changelog/rsm-3467-variations-tab-php-groundwork
+++ b/plugins/woocommerce/changelog/rsm-3467-variations-tab-php-groundwork
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Rename the Attributes tab to "Product attributes", filter variation=true attributes out of it, and add a form-POST preservation handler to prevent inline-saved variation attributes from being wiped on legacy form saves (all gated on the product-variations-classic-redesign feature flag).

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1157,23 +1157,30 @@ jQuery( function ( $ ) {
 						newSelectedAttributes
 					);
 
-					// Reload variations panel.
-					var this_page = window.location.toString();
-					this_page = this_page.replace(
-						'post-new.php?',
-						'post.php?post=' +
-							woocommerce_admin_meta_boxes.post_id +
-							'&action=edit&'
+					// Reload variations panel — skipped when the product-variations-classic-redesign
+					// feature owns the variations tab (the new editor manages its own state).
+					var skipVariationsReload = document.body.classList.contains(
+						'woocommerce-feature-enabled-product-variations-classic-redesign'
 					);
 
-					$( '#variable_product_options' ).load(
-						this_page + ' #variable_product_options_inner',
-						function () {
-							$( '#variable_product_options' ).trigger(
-								'reload'
-							);
-						}
-					);
+					if ( ! skipVariationsReload ) {
+						var this_page = window.location.toString();
+						this_page = this_page.replace(
+							'post-new.php?',
+							'post.php?post=' +
+								woocommerce_admin_meta_boxes.post_id +
+								'&action=edit&'
+						);
+
+						$( '#variable_product_options' ).load(
+							this_page + ' #variable_product_options_inner',
+							function () {
+								$( '#variable_product_options' ).trigger(
+									'reload'
+								);
+							}
+						);
+					}
 
 					$( document.body ).trigger(
 						'woocommerce_attributes_saved'

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1162,13 +1162,15 @@ jQuery( function ( $ ) {
 						newSelectedAttributes
 					);
 
-					// Reload variations panel — skipped when the product-variations-classic-redesign
-					// feature owns the variations tab (the new editor manages its own state).
-					var skipVariationsReload = document.body.classList.contains(
-						'woocommerce-feature-enabled-product-variations-classic-redesign'
+					// Reload variations panel — skipped when the variations classic redesign
+					// editor owns the panel. The mount point's presence is the durable signal:
+					// it exists whenever the new editor is active, independent of how the
+					// feature is gated (flag today, default in the future).
+					var hasClassicRedesignEditor = !! document.getElementById(
+						'woocommerce-variations-classic-root'
 					);
 
-					if ( ! skipVariationsReload ) {
+					if ( ! hasClassicRedesignEditor ) {
 						var this_page = window.location.toString();
 						this_page = this_page.replace(
 							'post-new.php?',

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1123,6 +1123,11 @@ jQuery( function ( $ ) {
 					$( '.product_attributes' ).html( response.data.html );
 					$( '.product_attributes' ).unblock();
 
+					// Re-enhance the replaced selects (term pickers, taxonomy
+					// dropdowns) so they render as select2 rather than native
+					// multi-selects.
+					init_select_controls();
+
 					// Hide the 'Used for variations' checkbox if not viewing a variable product
 					show_and_hide_panels();
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -153,20 +153,24 @@ class WC_Meta_Box_Product_Data {
 	/**
 	 * Filter callback for finding variation attributes.
 	 *
+	 * @internal
+	 * @since 10.9.0
 	 * @param  WC_Product_Attribute $attribute Product attribute.
 	 * @return bool
 	 */
-	private static function filter_variation_attributes( $attribute ) {
+	public static function filter_variation_attributes( $attribute ) {
 		return true === $attribute->get_variation();
 	}
 
 	/**
 	 * Filter callback for finding non-variation attributes.
 	 *
+	 * @internal
+	 * @since 10.9.0
 	 * @param  WC_Product_Attribute $attribute Product attribute.
 	 * @return bool
 	 */
-	private static function filter_non_variation_attributes( $attribute ) {
+	public static function filter_non_variation_attributes( $attribute ) {
 		return false === $attribute->get_variation();
 	}
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -100,6 +100,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<label><input type="checkbox" class="woocommerce_attribute_visible_on_product_page checkbox" <?php checked( $attribute->get_visible(), true ); ?> name="attribute_visibility[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Visible on the product page', 'woocommerce' ); ?></label>
 		</td>
 	</tr>
+	<?php if ( ! \Automattic\WooCommerce\Admin\Features\Features::exists( \Automattic\WooCommerce\Admin\Features\ProductVariationsClassicRedesign\Init::FEATURE_ID ) ) : ?>
 	<tr>
 		<td>
 			<div class="enable_variation show_if_variable">
@@ -107,6 +108,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</div>
 		</td>
 	</tr>
+	<?php endif; ?>
 	<?php
 	/**
 	 * Hook to display custom attribute terms.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -62,9 +62,7 @@ if ( \Automattic\WooCommerce\Admin\Features\Features::exists( \Automattic\WooCom
 		<span class="expand-close">
 			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
 		</span>
-		<?php if ( ! \Automattic\WooCommerce\Admin\Features\Features::exists( \Automattic\WooCommerce\Admin\Features\ProductVariationsClassicRedesign\Init::FEATURE_ID ) ) : ?>
 		<button type="button" aria-disabled="true" class="button save_attributes button-primary disabled"><?php esc_html_e( 'Save attributes', 'woocommerce' ); ?></button>
-		<?php endif; ?>
 	</div>
 	<?php do_action( 'woocommerce_product_options_attributes' ); ?>
 </div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -62,7 +62,9 @@ if ( \Automattic\WooCommerce\Admin\Features\Features::exists( \Automattic\WooCom
 		<span class="expand-close">
 			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
 		</span>
+		<?php if ( ! \Automattic\WooCommerce\Admin\Features\Features::exists( \Automattic\WooCommerce\Admin\Features\ProductVariationsClassicRedesign\Init::FEATURE_ID ) ) : ?>
 		<button type="button" aria-disabled="true" class="button save_attributes button-primary disabled"><?php esc_html_e( 'Save attributes', 'woocommerce' ); ?></button>
+		<?php endif; ?>
 	</div>
 	<?php do_action( 'woocommerce_product_options_attributes' ); ?>
 </div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -14,6 +14,10 @@ global $wc_product_attributes;
 $attribute_taxonomies = wc_get_attribute_taxonomies();
 // Product attributes - taxonomies and custom, ordered, with visibility and variation attributes set.
 $product_attributes = $product_object->get_attributes( 'edit' );
+
+if ( \Automattic\WooCommerce\Admin\Features\Features::exists( \Automattic\WooCommerce\Admin\Features\ProductVariationsClassicRedesign\Init::FEATURE_ID ) ) {
+	$product_attributes = array_filter( $product_attributes, array( 'WC_Meta_Box_Product_Data', 'filter_non_variation_attributes' ) );
+}
 ?>
 <div id="product_attributes" class="panel wc-metaboxes-wrapper hidden">
 	<div class="toolbar toolbar-top">

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -5719,12 +5719,6 @@ parameters:
 			path: includes/admin/meta-boxes/class-wc-meta-box-product-data.php
 
 		-
-			message: '#^Static method WC_Meta_Box_Product_Data\:\:filter_non_variation_attributes\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: includes/admin/meta-boxes/class-wc-meta-box-product-data.php
-
-		-
 			message: '#^Static method WC_Meta_Box_Product_Data\:\:get_product_data_tabs\(\) is unused\.$#'
 			identifier: method.unused
 			count: 1

--- a/plugins/woocommerce/src/Admin/Features/ProductVariationsClassicRedesign/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductVariationsClassicRedesign/Init.php
@@ -7,6 +7,10 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Admin\Features\ProductVariationsClassicRedesign;
 
+use Automattic\WooCommerce\Internal\Caches\ProductCache;
+use WC_Meta_Box_Product_Data;
+use WC_Product;
+
 /**
  * Loads assets for the product variations classic redesign feature.
  */
@@ -26,6 +30,7 @@ class Init {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 20 );
 		add_filter( 'woocommerce_product_data_tabs', array( $this, 'handle_woocommerce_product_data_tabs' ), 5 );
+		add_action( 'woocommerce_admin_process_product_object', array( $this, 'preserve_variation_attributes' ), 10, 1 );
 	}
 
 	/**
@@ -48,6 +53,10 @@ class Init {
 	/**
 	 * Handle the woocommerce_product_data_tabs filter.
 	 *
+	 * Reorders Variations and Linked Products to bracket the Product attributes tab, and
+	 * renames "Attributes" to "Product attributes" so the legacy meta-box reflects its new
+	 * scope (non-variation attributes only).
+	 *
 	 * @internal
 	 *
 	 * @param array $tabs Product data tabs.
@@ -62,7 +71,51 @@ class Init {
 			$tabs['linked_product']['priority'] = 60;
 		}
 
+		if ( isset( $tabs['attribute'] ) && is_array( $tabs['attribute'] ) ) {
+			$tabs['attribute']['label'] = __( 'Product attributes', 'woocommerce' );
+		}
+
 		return $tabs;
+	}
+
+	/**
+	 * Preserves variation attributes saved by the inline editor when the legacy form-POST save handler runs.
+	 *
+	 * The legacy save handler calls prepare_attributes() which rebuilds the product attributes array
+	 * from $_POST form fields. Because the Product attributes tab filters out variation=true attributes,
+	 * those rows have no form fields and would otherwise be wiped on every WordPress "Update" click.
+	 * This handler re-merges the persisted variation attributes back into the in-flight product so
+	 * the inline REST save and the legacy form save are properly decoupled.
+	 *
+	 * @since 10.9.0
+	 * @param WC_Product $product The product being saved.
+	 */
+	public function preserve_variation_attributes( WC_Product $product ): void {
+		if ( ! $product->is_type( 'variable' ) ) {
+			return;
+		}
+
+		wc_get_container()
+			->get( ProductCache::class )
+			->remove( $product->get_id() );
+
+		$existing = wc_get_product( $product->get_id() );
+
+		if ( ! $existing ) {
+			return;
+		}
+
+		$existing_variation = array_filter(
+			array_filter( $existing->get_attributes() ),
+			array( WC_Meta_Box_Product_Data::class, 'filter_variation_attributes' )
+		);
+
+		$non_variation = array_filter(
+			array_filter( $product->get_attributes() ),
+			array( WC_Meta_Box_Product_Data::class, 'filter_non_variation_attributes' )
+		);
+
+		$product->set_attributes( array_merge( $non_variation, $existing_variation ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductVariationsClassicRedesign/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductVariationsClassicRedesign/Init.php
@@ -31,6 +31,7 @@ class Init {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 20 );
 		add_filter( 'woocommerce_product_data_tabs', array( $this, 'handle_woocommerce_product_data_tabs' ), 5 );
 		add_action( 'woocommerce_admin_process_product_object', array( $this, 'preserve_variation_attributes' ), 10, 1 );
+		add_action( 'woocommerce_before_product_object_save', array( $this, 'preserve_variation_attributes_on_legacy_ajax_save' ), 10, 1 );
 	}
 
 	/**
@@ -116,6 +117,36 @@ class Init {
 		);
 
 		$product->set_attributes( array_merge( $non_variation, $existing_variation ) );
+	}
+
+	/**
+	 * Variation-attribute preservation companion for the legacy `woocommerce_save_attributes` AJAX flow.
+	 *
+	 * The legacy "Save attributes" button on the Product attributes tab triggers an AJAX handler
+	 * (`WC_AJAX::save_attributes()`) that bypasses `woocommerce_admin_process_product_object`.
+	 * That handler rebuilds the attributes array from POST data (which contains no variation rows,
+	 * since the renamed tab filters them out) and overwrites the product, wiping any persisted
+	 * variation attributes. This hook re-merges them in before `WC_Product::save()` persists.
+	 *
+	 * The guard restricts the merge to the legacy AJAX endpoint only — inline REST saves from the
+	 * new editor, programmatic `WC_Product::save()` calls, and the WordPress "Update" form-POST flow
+	 * (already covered by `preserve_variation_attributes` above) all proceed unmodified.
+	 *
+	 * @since 10.9.0
+	 * @param WC_Product $product The product being saved.
+	 */
+	public function preserve_variation_attributes_on_legacy_ajax_save( WC_Product $product ): void {
+		if ( ! wp_doing_ajax() ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified by WC_AJAX::save_attributes() before this hook fires.
+		$action = isset( $_POST['action'] ) ? sanitize_text_field( wp_unslash( $_POST['action'] ) ) : '';
+		if ( 'woocommerce_save_attributes' !== $action ) {
+			return;
+		}
+
+		$this->preserve_variation_attributes( $product );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductVariationsClassicRedesign/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductVariationsClassicRedesign/Init.php
@@ -32,6 +32,23 @@ class Init {
 		add_filter( 'woocommerce_product_data_tabs', array( $this, 'handle_woocommerce_product_data_tabs' ), 5 );
 		add_action( 'woocommerce_admin_process_product_object', array( $this, 'preserve_variation_attributes' ), 10, 1 );
 		add_action( 'woocommerce_before_product_object_save', array( $this, 'preserve_variation_attributes_on_legacy_ajax_save' ), 10, 1 );
+		add_filter( 'admin_body_class', array( $this, 'add_feature_body_class' ) );
+	}
+
+	/**
+	 * Appends the feature-enabled body class on product edit screens so client-side legacy code
+	 * (e.g. `meta-boxes-product.js`) can detect the redesign and skip behaviours the new editor owns.
+	 *
+	 * @since 10.9.0
+	 * @param string $classes Space-separated body class string.
+	 * @return string
+	 */
+	public function add_feature_body_class( $classes ): string {
+		if ( ! self::is_product_edit_page() ) {
+			return $classes;
+		}
+		$feature_class = sanitize_html_class( 'woocommerce-feature-enabled-' . self::FEATURE_ID );
+		return trim( $classes . ' ' . $feature_class );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductVariationsClassicRedesign/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductVariationsClassicRedesign/Init.php
@@ -32,23 +32,6 @@ class Init {
 		add_filter( 'woocommerce_product_data_tabs', array( $this, 'handle_woocommerce_product_data_tabs' ), 5 );
 		add_action( 'woocommerce_admin_process_product_object', array( $this, 'preserve_variation_attributes' ), 10, 1 );
 		add_action( 'woocommerce_before_product_object_save', array( $this, 'preserve_variation_attributes_on_legacy_ajax_save' ), 10, 1 );
-		add_filter( 'admin_body_class', array( $this, 'add_feature_body_class' ) );
-	}
-
-	/**
-	 * Appends the feature-enabled body class on product edit screens so client-side legacy code
-	 * (e.g. `meta-boxes-product.js`) can detect the redesign and skip behaviours the new editor owns.
-	 *
-	 * @since 10.9.0
-	 * @param string $classes Space-separated body class string.
-	 * @return string
-	 */
-	public function add_feature_body_class( $classes ): string {
-		if ( ! self::is_product_edit_page() ) {
-			return $classes;
-		}
-		$feature_class = sanitize_html_class( 'woocommerce-feature-enabled-' . self::FEATURE_ID );
-		return trim( $classes . ' ' . $feature_class );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/Features/ProductVariationsClassicRedesign/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/ProductVariationsClassicRedesign/InitTest.php
@@ -139,7 +139,7 @@ class InitTest extends WC_Unit_Test_Case {
 		$product->set_attributes( $existing_attributes );
 		$product->save();
 
-		$variation_attrs = array_filter(
+		$variation_attrs     = array_filter(
 			$product->get_attributes(),
 			array( 'WC_Meta_Box_Product_Data', 'filter_variation_attributes' )
 		);

--- a/plugins/woocommerce/tests/php/src/Admin/Features/ProductVariationsClassicRedesign/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/ProductVariationsClassicRedesign/InitTest.php
@@ -1,0 +1,168 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\Features\ProductVariationsClassicRedesign;
+
+use Automattic\WooCommerce\Admin\Features\ProductVariationsClassicRedesign\Init;
+use WC_Helper_Product;
+use WC_Product_Attribute;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Init class's preserve_variation_attributes handler.
+ */
+class InitTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var Init
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new Init();
+	}
+
+	/**
+	 * @testdox Should merge DB variation attributes back into the in-flight product when form POST save runs.
+	 */
+	public function test_preserve_variation_attributes_merges_db_variation_attributes(): void {
+		$product = WC_Helper_Product::create_variation_product();
+
+		$variation_attrs = array_filter(
+			$product->get_attributes(),
+			array( 'WC_Meta_Box_Product_Data', 'filter_variation_attributes' )
+		);
+		$this->assertNotEmpty( $variation_attrs, 'Test requires a product with variation attributes.' );
+
+		// Simulate form POST: product in-flight has only non-variation attributes.
+		// set_attributes fills existing keys with null (WC "to be deleted" marker) before
+		// setting provided values, so the in-flight product retains null entries for every
+		// variation attribute that was filtered out of the rendered tab.
+		$non_variation_attrs = array_filter(
+			$product->get_attributes(),
+			array( 'WC_Meta_Box_Product_Data', 'filter_non_variation_attributes' )
+		);
+		$product->set_attributes( $non_variation_attrs );
+
+		// The DB was NOT modified — the handler must read variation attrs from there.
+		$this->sut->preserve_variation_attributes( $product );
+
+		$result_attributes = $product->get_attributes();
+
+		foreach ( array_keys( $variation_attrs ) as $key ) {
+			$this->assertArrayHasKey(
+				$key,
+				$result_attributes,
+				"Variation attribute '{$key}' should be preserved after form POST save."
+			);
+			$this->assertInstanceOf(
+				WC_Product_Attribute::class,
+				$result_attributes[ $key ],
+				"Preserved attribute '{$key}' should be a WC_Product_Attribute instance."
+			);
+			$this->assertTrue(
+				$result_attributes[ $key ]->get_variation(),
+				"Preserved attribute '{$key}' should still have variation=true."
+			);
+		}
+	}
+
+	/**
+	 * @testdox Should not modify a simple product (non-variable) when handler runs.
+	 */
+	public function test_preserve_variation_attributes_is_no_op_for_simple_product(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$before_attributes = $product->get_attributes();
+
+		$this->sut->preserve_variation_attributes( $product );
+
+		$this->assertSame(
+			$before_attributes,
+			$product->get_attributes(),
+			'Simple product attributes should be unchanged after handler runs.'
+		);
+	}
+
+	/**
+	 * @testdox Should preserve variation attributes when product has only variation attributes (empty form POST).
+	 */
+	public function test_preserve_variation_attributes_handles_variation_only_product(): void {
+		$product = WC_Helper_Product::create_variation_product();
+
+		$variation_attrs = array_filter(
+			$product->get_attributes(),
+			array( 'WC_Meta_Box_Product_Data', 'filter_variation_attributes' )
+		);
+		$this->assertNotEmpty( $variation_attrs, 'Test requires a product with at least one variation attribute.' );
+
+		// Simulate form POST with no attributes at all (all were variation=true, filtered from the tab).
+		$product->set_attributes( array() );
+
+		// The DB was NOT modified — variation attributes are still in the database.
+		$this->sut->preserve_variation_attributes( $product );
+
+		$result_attributes = $product->get_attributes();
+
+		foreach ( array_keys( $variation_attrs ) as $key ) {
+			$this->assertArrayHasKey(
+				$key,
+				$result_attributes,
+				"Variation-only product: attribute '{$key}' should be re-merged after preservation handler runs."
+			);
+		}
+	}
+
+	/**
+	 * @testdox Should preserve both variation and non-variation attributes when a mixed product is updated.
+	 */
+	public function test_preserve_variation_attributes_keeps_non_variation_attributes(): void {
+		$product = WC_Helper_Product::create_variation_product();
+
+		// Add a non-variation attribute so we have a mixed set to work with.
+		$custom_attr = new WC_Product_Attribute();
+		$custom_attr->set_id( 0 );
+		$custom_attr->set_name( 'Material' );
+		$custom_attr->set_options( array( 'Cotton', 'Polyester' ) );
+		$custom_attr->set_position( 10 );
+		$custom_attr->set_visible( true );
+		$custom_attr->set_variation( false );
+
+		$existing_attributes             = $product->get_attributes();
+		$existing_attributes['material'] = $custom_attr;
+		$product->set_attributes( $existing_attributes );
+		$product->save();
+
+		$variation_attrs = array_filter(
+			$product->get_attributes(),
+			array( 'WC_Meta_Box_Product_Data', 'filter_variation_attributes' )
+		);
+		$non_variation_attrs = array_filter(
+			array_filter( $product->get_attributes() ),
+			array( 'WC_Meta_Box_Product_Data', 'filter_non_variation_attributes' )
+		);
+
+		$this->assertNotEmpty( $non_variation_attrs, 'Test requires at least one non-variation attribute.' );
+
+		// Simulate form POST: only the non-variation attributes are in the submitted form.
+		$product->set_attributes( $non_variation_attrs );
+
+		// The DB was NOT modified after the last save — variation attributes are still persisted.
+		$this->sut->preserve_variation_attributes( $product );
+
+		$result_attributes = $product->get_attributes();
+
+		foreach ( array_keys( $variation_attrs ) as $key ) {
+			$this->assertArrayHasKey( $key, $result_attributes, "Variation attribute '{$key}' should be present after preservation." );
+		}
+		foreach ( array_keys( $non_variation_attrs ) as $key ) {
+			$this->assertArrayHasKey( $key, $result_attributes, "Non-variation attribute '{$key}' should still be present after preservation." );
+		}
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

PR1 of 3 for the variation attributes refactor (Linear: [RSM-3467](https://linear.app/a8c/issue/RSM-3467), epic [RSM-2615](https://linear.app/a8c/issue/RSM-2615)). PHP-only groundwork the upcoming JS editor depends on. All changes are gated on the existing \`product-variations-classic-redesign\` feature flag.

The Product attributes tab is reshaped to manage **only** non-variation attributes; variation attributes are exclusively managed by the new editor (PR2/PR3). Server-side guards ensure both legacy save paths can't silently wipe variation attributes when their UI is hidden, while leaving non-variation save flows untouched.

**Tab + render changes (UX):**
1. Rename the "Attributes" product data tab to "Product attributes" via the \`woocommerce_product_data_tabs\` filter.
2. Filter \`variation=true\` attributes out of the renamed tab.
3. Hide the "Used for variations" checkbox on attribute rows in the renamed tab.

**Server-side guards (correctness):**
4. Register a \`woocommerce_admin_process_product_object\` action handler that re-merges persisted variation attributes from the database into the in-flight product before the WordPress "Update" form-POST save runs. Without this, every Update click would wipe variation attributes (they're now filtered out of the rendered form).
5. Register a \`woocommerce_before_product_object_save\` handler — gated to the legacy \`woocommerce_save_attributes\` AJAX action only — that performs the same re-merge. This protects the "Save attributes" button on the Product attributes tab, which still works for non-variation attributes but would otherwise wipe variation attributes (the AJAX path bypasses \`woocommerce_admin_process_product_object\`).

Together, items 4 and 5 decouple the inline REST save (PR2/PR3) from both legacy save paths.

Closes RSM-3467.

See \`docs/plans/2026-05-17-001-feat-variation-attributes-in-variations-tab-plan.md\` (Unit U6) for the full design.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|<img width="1696" height="1418" alt="CleanShot 2026-05-19 at 11 48 42@2x" src="https://github.com/user-attachments/assets/d1c064d5-c87e-4369-aa13-7f0c74be849e" />|<img width="1700" height="1244" alt="CleanShot 2026-05-19 at 11 47 34@2x" src="https://github.com/user-attachments/assets/45da9332-f774-40ee-a5fc-4c9f79fcaa9b" />|

### How to test the changes in this Pull Request:

1. Enable the \`product-variations-classic-redesign\` feature flag (via the WooCommerce Beta Tester plugin or by enabling it directly in \`wc_admin_get_feature_config()\`).
2. Edit a variable product in wp-admin. Verify the "Attributes" tab is labeled **Product attributes** and the "Used for variations" checkbox is gone from each attribute row.
3. With the flag **off**, set up a variable product with a mix of variation (\`Used for variations\` checked) and non-variation attributes; save. Turn the flag **on** and reload. Confirm the Product attributes tab shows only the non-variation rows.
4. Click the WordPress **Update** button on that product without touching the variation attributes UI. Reload. Confirm the variation attributes are still persisted (not wiped).
5. On the Product attributes tab, add a new non-variation attribute and click **Save attributes** (the AJAX button). Reload. Confirm: (a) the new non-variation attribute is saved, and (b) the existing variation attributes are still there.
6. Disable the feature flag. Edit the same product. Confirm the tab label reverts to "Attributes", all attributes (variation + non-variation) are visible again, and the "Used for variations" checkbox is back.
7. Edit a simple product and a grouped product. Confirm their Attributes tab is unaffected.

### Testing that has already taken place:

- PHPUnit coverage for \`Init::preserve_variation_attributes\` (mixed-product merge, simple-product no-op, variation-only product, non-variation-preservation scenarios) in \`InitTest.php\`. The new dispatcher (\`preserve_variation_attributes_on_legacy_ajax_save\`) is thin context-routing on top of the same logic.
- PHPStan baseline regenerated; only the previously-baselined \`filter_non_variation_attributes\` "unused method" entry was removed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry already added manually: \`plugins/woocommerce/changelog/rsm-3467-variations-tab-php-groundwork\`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)