### PR TITLE
Add backwards compatibility to new Variation Selector inner blocks

### DIFF
--- a/plugins/woocommerce/changelog/update-add-to-cart-with-options-filter-inner-blocks-backwards-compatibility
+++ b/plugins/woocommerce/changelog/update-add-to-cart-with-options-filter-inner-blocks-backwards-compatibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Add backwards compatibility to new Variation Selector inner blocks
+
+

--- a/plugins/woocommerce/changelog/update-inner-blocks-protocol-unify-context-prefix
+++ b/plugins/woocommerce/changelog/update-inner-blocks-protocol-unify-context-prefix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Unify prefixes of context keys in Inner Blocks Protocol
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/deprecated.tsx
@@ -48,7 +48,19 @@ function migrateInnerBlocks(
 			block.name === 'core/missing' &&
 			block.attributes.originalName === LEGACY_ATTRIBUTE_OPTIONS_BLOCK
 		) {
-			if ( block.originalContent?.includes( 'dropdown' ) ) {
+			if ( block.originalContent?.includes( '"autoselect":true' ) ) {
+				settings.autoselect = true;
+			}
+			if (
+				block.originalContent?.includes(
+					'"disabledAttributesAction":"hide"'
+				)
+			) {
+				settings.disabledAttributesAction = 'hide';
+			}
+			if (
+				block.originalContent?.includes( '"optionStyle":"dropdown"' )
+			) {
 				settings.displayStyle = INNER_DROPDOWN;
 				return [ createBlock( INNER_DROPDOWN ) ];
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/deprecated.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { BlockInstance, createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import save from './save';
+
+const LEGACY_ATTRIBUTE_OPTIONS_BLOCK =
+	'woocommerce/add-to-cart-with-options-variation-selector-attribute-options';
+const INNER_CHIPS = 'woocommerce/product-filter-chips';
+const INNER_DROPDOWN = 'woocommerce/dropdown';
+
+interface MigratedAttributeSettings {
+	displayStyle: string;
+	autoselect: boolean;
+	disabledAttributesAction: 'disable' | 'hide';
+}
+
+function containsLegacyAttributeOptionsBlock(
+	blocks: BlockInstance[]
+): boolean {
+	return blocks.some( ( block ) => {
+		if (
+			block.name === 'core/missing' &&
+			block.attributes.originalName === LEGACY_ATTRIBUTE_OPTIONS_BLOCK
+		) {
+			return true;
+		}
+
+		if ( block.innerBlocks?.length ) {
+			return containsLegacyAttributeOptionsBlock( block.innerBlocks );
+		}
+
+		return false;
+	} );
+}
+
+function migrateInnerBlocks(
+	innerBlocks: BlockInstance[],
+	settings: MigratedAttributeSettings
+): BlockInstance[] {
+	return innerBlocks.flatMap( ( block ) => {
+		if (
+			block.name === 'core/missing' &&
+			block.attributes.originalName === LEGACY_ATTRIBUTE_OPTIONS_BLOCK
+		) {
+			if ( block.originalContent?.includes( 'dropdown' ) ) {
+				settings.displayStyle = INNER_DROPDOWN;
+				return [ createBlock( INNER_DROPDOWN ) ];
+			}
+			settings.displayStyle = INNER_CHIPS;
+			return [ createBlock( INNER_CHIPS ) ];
+		}
+
+		if ( block.innerBlocks?.length ) {
+			return migrateInnerBlocks( block.innerBlocks, settings );
+		}
+
+		return [ block ];
+	} );
+}
+
+const deprecated = [
+	{
+		save,
+		isEligible(
+			_attributes: Record< string, unknown >,
+			innerBlocks: BlockInstance[]
+		) {
+			return containsLegacyAttributeOptionsBlock( innerBlocks );
+		},
+		migrate(
+			attributes: Record< string, unknown >,
+			innerBlocks: BlockInstance[]
+		) {
+			const settings: MigratedAttributeSettings = {
+				displayStyle: metadata.attributes.displayStyle.default,
+				autoselect: metadata.attributes.autoselect.default,
+				disabledAttributesAction: metadata.attributes
+					.disabledAttributesAction.default as 'disable' | 'hide',
+			};
+
+			const migratedInnerBlocks = migrateInnerBlocks(
+				innerBlocks,
+				settings
+			);
+
+			return [
+				{
+					...attributes,
+					displayStyle: settings.displayStyle,
+					autoselect: settings.autoselect,
+					disabledAttributesAction: settings.disabledAttributesAction,
+				},
+				migratedInnerBlocks,
+			];
+		},
+	},
+];
+
+export default deprecated;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/deprecated.tsx
@@ -57,7 +57,15 @@ function migrateInnerBlocks(
 		}
 
 		if ( block.innerBlocks?.length ) {
-			return migrateInnerBlocks( block.innerBlocks, settings );
+			return [
+				{
+					...block,
+					innerBlocks: migrateInnerBlocks(
+						block.innerBlocks,
+						settings
+					),
+				},
+			];
 		}
 
 		return [ block ];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -95,7 +95,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 	return (
 		<BlockContextProvider
 			value={ {
-				woocommerceSelectableItems: selectableContext,
+				'woocommerce/selectableItems': selectableContext,
 			} }
 		>
 			{ isSelected ? (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/index.tsx
@@ -10,6 +10,7 @@ import { Icon, button } from '@wordpress/icons';
 import metadata from './block.json';
 import AttributeItemTemplateEdit from './edit';
 import AttributeItemTemplateSave from './save';
+import deprecated from './deprecated';
 import './style.scss';
 
 registerBlockType( metadata, {
@@ -23,4 +24,5 @@ registerBlockType( metadata, {
 		),
 	},
 	save: AttributeItemTemplateSave,
+	deprecated,
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/test/deprecated.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/test/deprecated.ts
@@ -158,7 +158,7 @@ describe( 'Variation Selector Attribute block deprecation', () => {
 			};
 			const innerBlocks = [
 				createLegacyMissingBlock(
-					'<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options {"optionStyle":"chips"} /-->'
+					'<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options {"optionStyle":"pills"} /-->'
 				),
 			];
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/test/deprecated.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/test/deprecated.ts
@@ -213,11 +213,15 @@ describe( 'Variation Selector Attribute block deprecation', () => {
 			);
 
 			expect( migratedAttributes.displayStyle ).toBe( INNER_DROPDOWN );
-			expect( migratedInnerBlocks ).toHaveLength( 2 );
-			expect( migratedInnerBlocks[ 0 ].name ).toBe(
+			expect( migratedInnerBlocks ).toHaveLength( 1 );
+			expect( migratedInnerBlocks[ 0 ].name ).toBe( 'core/group' );
+			expect( migratedInnerBlocks[ 0 ].innerBlocks ).toHaveLength( 2 );
+			expect( migratedInnerBlocks[ 0 ].innerBlocks[ 0 ].name ).toBe(
 				'woocommerce/add-to-cart-with-options-variation-selector-attribute-name'
 			);
-			expect( migratedInnerBlocks[ 1 ].name ).toBe( INNER_DROPDOWN );
+			expect( migratedInnerBlocks[ 0 ].innerBlocks[ 1 ].name ).toBe(
+				INNER_DROPDOWN
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/test/deprecated.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/test/deprecated.ts
@@ -1,0 +1,223 @@
+/**
+ * External dependencies
+ */
+import type { BlockInstance } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from '../block.json';
+import deprecated from '../deprecated';
+
+function createTestBlock( block: {
+	clientId: string;
+	name: string;
+	attributes?: Record< string, unknown >;
+	innerBlocks?: BlockInstance[];
+	originalContent?: string;
+} ): BlockInstance {
+	return {
+		isValid: true,
+		attributes: {},
+		innerBlocks: [],
+		...block,
+	};
+}
+
+jest.mock( '@wordpress/blocks', () => {
+	const actual = jest.requireActual( '@wordpress/blocks' );
+
+	return {
+		...actual,
+		createBlock: jest.fn(
+			(
+				name: string,
+				attributes = {},
+				innerBlocks: BlockInstance[] = []
+			) => ( {
+				clientId: `mock-${ name }`,
+				name,
+				attributes,
+				innerBlocks,
+				isValid: true,
+			} )
+		),
+	};
+} );
+
+const LEGACY_ATTRIBUTE_OPTIONS_BLOCK =
+	'woocommerce/add-to-cart-with-options-variation-selector-attribute-options';
+const INNER_CHIPS = 'woocommerce/product-filter-chips';
+const INNER_DROPDOWN = 'woocommerce/dropdown';
+
+const { isEligible, migrate } = deprecated[ 0 ];
+
+type MigrateResult = [ Record< string, unknown >, BlockInstance[] ];
+
+function runMigrate(
+	attributes: Record< string, unknown >,
+	innerBlocks: BlockInstance[]
+): MigrateResult {
+	return migrate( attributes, innerBlocks ) as MigrateResult;
+}
+
+function createLegacyMissingBlock( originalContent = '' ): BlockInstance {
+	return createTestBlock( {
+		clientId: 'legacy-options',
+		name: 'core/missing',
+		attributes: {
+			originalName: LEGACY_ATTRIBUTE_OPTIONS_BLOCK,
+		},
+		originalContent,
+	} );
+}
+
+function createAttributeNameBlock(): BlockInstance {
+	return createTestBlock( {
+		clientId: 'attribute-name',
+		name: 'woocommerce/add-to-cart-with-options-variation-selector-attribute-name',
+	} );
+}
+
+function createGroupWithInnerBlocks(
+	innerBlocks: BlockInstance[]
+): BlockInstance {
+	return createTestBlock( {
+		clientId: 'group',
+		name: 'core/group',
+		innerBlocks,
+	} );
+}
+
+describe( 'Variation Selector Attribute block deprecation', () => {
+	describe( 'isEligible', () => {
+		it( 'returns false when there is no legacy attribute options block', () => {
+			const innerBlocks = [ createAttributeNameBlock() ];
+
+			expect( isEligible( {}, innerBlocks ) ).toBe( false );
+		} );
+
+		it( 'returns true when a legacy attribute options block is a direct inner block', () => {
+			const innerBlocks = [
+				createAttributeNameBlock(),
+				createLegacyMissingBlock(),
+			];
+
+			expect( isEligible( {}, innerBlocks ) ).toBe( true );
+		} );
+
+		it( 'returns true when a legacy attribute options block is nested in inner blocks', () => {
+			const innerBlocks = [
+				createGroupWithInnerBlocks( [
+					createAttributeNameBlock(),
+					createLegacyMissingBlock(),
+				] ),
+			];
+
+			expect( isEligible( {}, innerBlocks ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'migrate', () => {
+		it( 'replaces a legacy dropdown options block and sets displayStyle to dropdown', () => {
+			const attributes = {
+				displayStyle: INNER_CHIPS,
+				autoselect: true,
+				disabledAttributesAction: 'hide' as const,
+				customAttribute: 'preserved',
+			};
+			const innerBlocks = [
+				createAttributeNameBlock(),
+				createLegacyMissingBlock(
+					'<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options {"optionStyle":"dropdown"} /-->'
+				),
+			];
+
+			const [ migratedAttributes, migratedInnerBlocks ] = runMigrate(
+				attributes,
+				innerBlocks
+			);
+
+			expect( migratedAttributes ).toEqual( {
+				...attributes,
+				displayStyle: INNER_DROPDOWN,
+				autoselect: metadata.attributes.autoselect.default,
+				disabledAttributesAction:
+					metadata.attributes.disabledAttributesAction.default,
+			} );
+			expect( migratedInnerBlocks ).toHaveLength( 2 );
+			expect( migratedInnerBlocks[ 0 ].name ).toBe(
+				'woocommerce/add-to-cart-with-options-variation-selector-attribute-name'
+			);
+			expect( migratedInnerBlocks[ 1 ].name ).toBe( INNER_DROPDOWN );
+		} );
+
+		it( 'replaces a legacy chips options block and sets displayStyle to chips', () => {
+			const attributes = {
+				displayStyle: INNER_DROPDOWN,
+			};
+			const innerBlocks = [
+				createLegacyMissingBlock(
+					'<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options {"optionStyle":"chips"} /-->'
+				),
+			];
+
+			const [ migratedAttributes, migratedInnerBlocks ] = runMigrate(
+				attributes,
+				innerBlocks
+			);
+
+			expect( migratedAttributes.displayStyle ).toBe( INNER_CHIPS );
+			expect( migratedInnerBlocks ).toHaveLength( 1 );
+			expect( migratedInnerBlocks[ 0 ].name ).toBe( INNER_CHIPS );
+		} );
+
+		it( 'defaults to chips when legacy block content does not indicate dropdown', () => {
+			const innerBlocks = [ createLegacyMissingBlock() ];
+
+			const [ migratedAttributes, migratedInnerBlocks ] = runMigrate(
+				{},
+				innerBlocks
+			);
+
+			expect( migratedAttributes.displayStyle ).toBe( INNER_CHIPS );
+			expect( migratedInnerBlocks[ 0 ].name ).toBe( INNER_CHIPS );
+		} );
+
+		it( 'uses block.json defaults for autoselect and disabledAttributesAction', () => {
+			const innerBlocks = [ createLegacyMissingBlock() ];
+
+			const [ migratedAttributes ] = runMigrate( {}, innerBlocks );
+
+			expect( migratedAttributes.autoselect ).toBe(
+				metadata.attributes.autoselect.default
+			);
+			expect( migratedAttributes.disabledAttributesAction ).toBe(
+				metadata.attributes.disabledAttributesAction.default
+			);
+		} );
+
+		it( 'replaces a nested legacy attribute options block', () => {
+			const innerBlocks = [
+				createGroupWithInnerBlocks( [
+					createAttributeNameBlock(),
+					createLegacyMissingBlock(
+						'<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options {"optionStyle":"dropdown"} /-->'
+					),
+				] ),
+			];
+
+			const [ migratedAttributes, migratedInnerBlocks ] = runMigrate(
+				{},
+				innerBlocks
+			);
+
+			expect( migratedAttributes.displayStyle ).toBe( INNER_DROPDOWN );
+			expect( migratedInnerBlocks ).toHaveLength( 2 );
+			expect( migratedInnerBlocks[ 0 ].name ).toBe(
+				'woocommerce/add-to-cart-with-options-variation-selector-attribute-name'
+			);
+			expect( migratedInnerBlocks[ 1 ].name ).toBe( INNER_DROPDOWN );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/block.json
@@ -13,7 +13,7 @@
 	"supports": {
 		"interactivity": true
 	},
-	"usesContext": [ "woocommerceSelectableItems", "woocommerce/attributeId" ],
+	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {},
 	"viewScriptModule": "woocommerce/dropdown",
 	"style": "file:../woocommerce/dropdown-style.css",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/edit.tsx
@@ -42,7 +42,7 @@ function getOptionLabel( item: {
 
 const Edit = ( props: EditProps ): JSX.Element => {
 	const { context } = props;
-	const selectableItems = context?.woocommerceSelectableItems ?? {};
+	const selectableItems = context?.[ 'woocommerce/selectableItems' ] ?? {};
 	const isLoading = selectableItems.isLoading ?? false;
 	const items = Array.isArray( selectableItems.items )
 		? selectableItems.items

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/edit.tsx
@@ -33,7 +33,7 @@ const Edit = () => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceRemovableItems: {
+						'woocommerce/removableItems': {
 							items: filtersPreview,
 							storeNamespace: 'woocommerce/product-filters',
 						} satisfies RemovableItemsContext,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -211,7 +211,7 @@ const Edit = ( props: EditProps ) => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceSelectableItems: {
+						'woocommerce/selectableItems': {
 							items:
 								attributeOptions.length === 0 && isPreview
 									? attributeOptionsPreview

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"interactivity": true
 	},
-	"usesContext": [ "woocommerceSelectableItems" ],
+	"usesContext": [ "woocommerce/selectableItems" ],
 	"attributes": {
 		"optionElementBorder": {
 			"type": "string",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -49,7 +49,7 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 		customOptionElement,
 		customLabelElement,
 	} = attributes;
-	const selectableItems = context?.woocommerceSelectableItems ?? {};
+	const selectableItems = context?.[ 'woocommerce/selectableItems' ] ?? {};
 	const isLoading = selectableItems.isLoading ?? false;
 	const items = Array.isArray( selectableItems.items )
 		? selectableItems.items

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"interactivity": true
 	},
-	"usesContext": [ "woocommerceSelectableItems", "woocommerce/attributeId" ],
+	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {
 		"chipText": {
 			"type": "string"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -53,7 +53,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 		customSelectedChipBorder,
 	} = attributes;
 	const { isLoading = false, items = [] } =
-		context?.woocommerceSelectableItems ?? {};
+		context?.[ 'woocommerce/selectableItems' ] ?? {};
 
 	const hasColorSwatches = items.some( ( item ) => 'color' in item );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/block.json
@@ -8,7 +8,7 @@
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"ancestor": [ "woocommerce/product-filter-active" ],
-	"usesContext": [ "woocommerceRemovableItems" ],
+	"usesContext": [ "woocommerce/removableItems" ],
 	"supports": {
 		"interactivity": true,
 		"inserter": true

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/edit.tsx
@@ -30,7 +30,7 @@ const Edit = () => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceRangeInput: {
+						'woocommerce/rangeInput': {
 							...getPriceFilterData( data ),
 							isLoading,
 						},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/block.json
@@ -49,7 +49,7 @@
 		}
 	},
 	"ancestor": [ "woocommerce/product-filter-price" ],
-	"usesContext": [ "woocommerceRangeInput" ],
+	"usesContext": [ "woocommerce/rangeInput" ],
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/edit.tsx
@@ -56,7 +56,7 @@ const PriceSliderEdit = ( {
 		customSlider,
 	} = attributes;
 
-	const rangeInput = context.woocommerceRangeInput;
+	const rangeInput = context[ 'woocommerce/rangeInput' ];
 	const { isLoading } = rangeInput ?? {};
 
 	const blockProps = useBlockProps( {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -187,7 +187,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 					>
 						<BlockContextProvider
 							value={ {
-								woocommerceSelectableItems: {
+								'woocommerce/selectableItems': {
 									items: displayedOptions,
 									selectionMode: 'multiple' as const,
 									storeNamespace:

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/block.json
@@ -19,7 +19,7 @@
 		},
 		"interactivity": true
 	},
-	"usesContext": [ "queryId", "woocommerceRemovableItems" ],
+	"usesContext": [ "queryId", "woocommerce/removableItems" ],
 	"attributes": {
 		"chipText": {
 			"type": "string"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/edit.tsx
@@ -44,7 +44,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 	} = props;
 	const { customChipText, customChipBackground, customChipBorder, layout } =
 		attributes;
-	const removableItemsContext = context.woocommerceRemovableItems;
+	const removableItemsContext = context[ 'woocommerce/removableItems' ];
 	const { items } = removableItemsContext ?? {};
 
 	// Extract attributes from block layout

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
@@ -90,7 +90,7 @@ const Edit = ( props: EditProps ) => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceSelectableItems: {
+						'woocommerce/selectableItems': {
 							items,
 							selectionMode: 'multiple' as const,
 							storeNamespace: 'woocommerce/product-filters',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -310,7 +310,7 @@ const Edit = ( props: EditProps ) => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceSelectableItems: {
+						'woocommerce/selectableItems': {
 							items:
 								termOptions.length === 0 && isPreview
 									? termOptionsPreview

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/range-input.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/range-input.ts
@@ -14,7 +14,8 @@ export interface RangeInputContext {
 }
 
 export type RangeInputBlockContext = {
-	woocommerceRangeInput: RangeInputContext;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'woocommerce/rangeInput': RangeInputContext;
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/removable-items.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/removable-items.ts
@@ -11,7 +11,8 @@ export interface RemovableItemsContext {
 }
 
 export type RemovableItemsBlockContext = {
-	woocommerceRemovableItems: RemovableItemsContext;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'woocommerce/removableItems': RemovableItemsContext;
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/selectable-items.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/selectable-items.ts
@@ -30,7 +30,8 @@ export interface SelectableItemsContext< T = unknown > {
 }
 
 export type SelectableItemsBlockContext< T = unknown > = {
-	woocommerceSelectableItems: SelectableItemsContext< T >;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'woocommerce/selectableItems': SelectableItemsContext< T >;
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
@@ -8,9 +8,9 @@ This document defines the **context protocol pattern** used by WooCommerce block
 
 | Context Key | Purpose | Inner Blocks |
 | --- | --- | --- |
-| `woocommerceSelectableItems` | Select/deselect items (filters, variation attributes) | checkbox-list, chips, dropdown |
-| `woocommerceRemovableItems` | Remove individual items (active filters) | removable-chips |
-| `woocommerceRangeInput` | Numeric range input (price, slider) | price-slider |
+| `woocommerce/selectableItems` | Select/deselect items (filters, variation attributes) | checkbox-list, chips, dropdown |
+| `woocommerce/removableItems` | Remove individual items (active filters) | removable-chips |
+| `woocommerce/rangeInput` | Numeric range input (price, slider) | price-slider |
 
 Each protocol follows the same pattern — only item shape and action names differ.
 
@@ -45,7 +45,7 @@ Inner blocks become **presentational** — they read a standardized context prot
 
 All three protocols follow these rules:
 
-- **Context key** prefixed with `woocommerce` (e.g. `woocommerceSelectableItems`)
+- **Context key** prefixed with `woocommerce` (e.g. `woocommerce/selectableItems`)
 - **`storeNamespace`** field on every context object — tells inner block which parent store to resolve `actions.*` / `state.*` against
 - **Fixed action & getter names** (not configurable via context fields) — inner blocks hardcode them
 - **TS contract interface** (`*ParentStore`) — parents assert conformance via `satisfies`
@@ -74,7 +74,7 @@ Missing method/getter → compile error. No runtime cost.
 ### Context Key
 
 ```text
-woocommerceSelectableItems
+woocommerce/selectableItems
 ```
 
 Items are dynamic (computed at render time from database queries), so parent blocks do **not** use `providesContext` in block.json. Instead, they pass context directly when rendering inner blocks:
@@ -82,14 +82,14 @@ Items are dynamic (computed at render time from database queries), so parent blo
 ```php
 // Parent block render():
 ( new \WP_Block( $parsed_block, array(
-    'woocommerceSelectableItems' => $context,
+    'woocommerce/selectableItems' => $context,
 ) ) )->render();
 ```
 
 In the editor, parent blocks use `BlockContextProvider` to pass the same data:
 
 ```jsx
-<BlockContextProvider value={ { 'woocommerceSelectableItems': context } }>
+<BlockContextProvider value={ { 'woocommerce/selectableItems': context } }>
     { children }
 </BlockContextProvider>
 ```
@@ -101,7 +101,7 @@ Inner blocks declare the context key they consume via `usesContext`, and which p
 ```json
 {
   "name": "woocommerce/product-filter-checkbox-list",
-  "usesContext": ["woocommerceSelectableItems"],
+  "usesContext": ["woocommerce/selectableItems"],
   "ancestor": [
     "woocommerce/product-filter-attribute",
     "woocommerce/product-filter-status",
@@ -111,7 +111,7 @@ Inner blocks declare the context key they consume via `usesContext`, and which p
 }
 ```
 
-Inner blocks receive the protocol data through `$block->context['woocommerceSelectableItems']` in PHP.
+Inner blocks receive the protocol data through `$block->context['woocommerce/selectableItems']` in PHP.
 
 ### SelectableItemsContext
 
@@ -283,7 +283,7 @@ export interface SelectableItemsContext< T = unknown > {
 }
 
 export type SelectableItemsBlockContext< T = unknown > = {
-	'woocommerceSelectableItems': SelectableItemsContext< T >;
+	'woocommerce/selectableItems': SelectableItemsContext< T >;
 };
 
 export interface SelectableItemsParentStore< T = unknown > {
@@ -339,7 +339,7 @@ class ProductFilterAttribute extends AbstractBlock {
             'groupLabel'     => $attributes['label'] ?? '',
         ];
 
-        $block->context['woocommerceSelectableItems'] = $context;
+        $block->context['woocommerce/selectableItems'] = $context;
 
         return sprintf(
             '<div %s>%s</div>',
@@ -410,7 +410,7 @@ block.json:
 ```json
 {
   "name": "woocommerce/product-filter-checkbox-list",
-  "usesContext": ["woocommerceSelectableItems"],
+  "usesContext": ["woocommerce/selectableItems"],
   "supports": {
     "interactivity": true
   }
@@ -516,11 +516,11 @@ const { state } = store( 'woocommerce/product-filter-checkbox-list', {
 
 ```php
 protected function render( $attributes, $content, $block ) {
-    if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+    if ( empty( $block->context['woocommerce/selectableItems'] ) ) {
         return '';
     }
 
-    $block_context   = $block->context['woocommerceSelectableItems'];
+    $block_context   = $block->context['woocommerce/selectableItems'];
     $items           = $block_context['items'] ?? array();
     $store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
     $display_limit   = 15;
@@ -618,7 +618,7 @@ class ProductFilterAttribute extends AbstractBlock {
         ];
 
         // Provide context to inner blocks
-        $block->context['woocommerceSelectableItems'] = $selectable_context;
+        $block->context['woocommerce/selectableItems'] = $selectable_context;
 
         // Render inner blocks
         return sprintf(
@@ -636,7 +636,7 @@ class ProductFilterAttribute extends AbstractBlock {
 
 ## Protocol: Removable Items
 
-Context key: `woocommerceRemovableItems`
+Context key: `woocommerce/removableItems`
 
 Used for lists of items that can be removed individually (active filter chips) with a "clear all" control.
 
@@ -689,7 +689,7 @@ Reference implementation: `ProductFilterRemovableChips.php`, `ProductFilterClear
 
 ## Protocol: Range Input
 
-Context key: `woocommerceRangeInput`
+Context key: `woocommerce/rangeInput`
 
 Used for two-ended numeric range controls (price slider, generic range).
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -81,10 +81,10 @@ class VariationSelectorAttribute extends AbstractBlock {
 		$attribute_label  = wc_attribute_label( $attribute_name );
 		$attribute_id     = 'wc_product_attribute_' . uniqid();
 		$context          = array(
-			'woocommerce/attributeId'    => $attribute_id,
-			'woocommerce/attributeName'  => $attribute_name,
-			'woocommerce/attributeTerms' => $attribute_terms,
-			'woocommerceSelectableItems' => array(
+			'woocommerce/attributeId'     => $attribute_id,
+			'woocommerce/attributeName'   => $attribute_name,
+			'woocommerce/attributeTerms'  => $attribute_terms,
+			'woocommerce/selectableItems' => array(
 				'items'          => $variation_items,
 				'selectionMode'  => 'single',
 				'storeNamespace' => 'woocommerce/add-to-cart-with-options',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -106,7 +106,9 @@ class VariationSelectorAttribute extends AbstractBlock {
 		);
 
 		$inner_html = '';
+
 		foreach ( $inner_blocks as $inner_block ) {
+			$inner_block = $this->replace_legacy_attribute_options_block( $inner_block );
 			$inner_html .= ( new WP_Block( $inner_block, $context ) )->render();
 		}
 
@@ -116,6 +118,30 @@ class VariationSelectorAttribute extends AbstractBlock {
 			wp_interactivity_data_wp_context( $interactive_context ),
 			$inner_html
 		);
+	}
+
+	/**
+	 * Replace the legacy attribute options block with the new dropdown or chips block.
+	 *
+	 * @param array $inner_block The inner block to replace.
+	 * @return array The replaced inner block.
+	 */
+	private function replace_legacy_attribute_options_block( array $inner_block ): array {
+		if ( 'woocommerce/add-to-cart-with-options-variation-selector-attribute-options' === $inner_block['blockName'] ) {
+			$option_style = $inner_block['attrs']['optionStyle'] ?? 'chips';
+			$inner_block  = array(
+				'blockName'    => 'dropdown' === $option_style ? 'woocommerce/dropdown' : 'woocommerce/product-filter-chips',
+				'attrs'        => array(),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			);
+		} elseif ( isset( $inner_block['innerBlocks'] ) && is_array( $inner_block['innerBlocks'] ) && ! empty( $inner_block['innerBlocks'] ) ) {
+			foreach ( $inner_block['innerBlocks'] as $key => $child_inner_block ) {
+				$inner_block['innerBlocks'][ $key ] = $this->replace_legacy_attribute_options_block( $child_inner_block );
+			}
+		}
+		return $inner_block;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -92,6 +92,13 @@ class VariationSelectorAttribute extends AbstractBlock {
 			),
 		);
 
+		$inner_html = '';
+
+		foreach ( $inner_blocks as $inner_block ) {
+			$inner_block = $this->replace_legacy_attribute_options_block( $inner_block, $attributes );
+			$inner_html .= ( new WP_Block( $inner_block, $context ) )->render();
+		}
+
 		$interactive_context = array(
 			'name'                      => $attribute_label,
 			'variationAttributeOptions' => $variation_items,
@@ -105,13 +112,6 @@ class VariationSelectorAttribute extends AbstractBlock {
 			'data-wp-init'        => 'callbacks.setDefaultSelectedAttribute',
 		);
 
-		$inner_html = '';
-
-		foreach ( $inner_blocks as $inner_block ) {
-			$inner_block = $this->replace_legacy_attribute_options_block( $inner_block );
-			$inner_html .= ( new WP_Block( $inner_block, $context ) )->render();
-		}
-
 		return sprintf(
 			'<div %s %s>%s</div>',
 			get_block_wrapper_attributes( $interactive_attributes ),
@@ -121,16 +121,30 @@ class VariationSelectorAttribute extends AbstractBlock {
 	}
 
 	/**
-	 * Replace the legacy attribute options block with the new dropdown or chips block.
+	 * Replace legacy Attribute Options block and apply its settings to the parent attributes.
 	 *
-	 * @param array $inner_block The inner block to replace.
+	 * @param array $inner_block  The inner block to replace.
+	 * @param array $attributes   Parent block attributes, updated when attributes in the legacy Attribute Options block are found.
 	 * @return array The replaced inner block.
 	 */
-	private function replace_legacy_attribute_options_block( array $inner_block ): array {
+	private function replace_legacy_attribute_options_block( array $inner_block, array &$attributes ): array {
 		if ( 'woocommerce/add-to-cart-with-options-variation-selector-attribute-options' === $inner_block['blockName'] ) {
-			$option_style = $inner_block['attrs']['optionStyle'] ?? 'chips';
-			$inner_block  = array(
-				'blockName'    => 'dropdown' === $option_style ? 'woocommerce/dropdown' : 'woocommerce/product-filter-chips',
+			$legacy_attrs = $inner_block['attrs'] ?? array();
+
+			if ( array_key_exists( 'autoselect', $legacy_attrs ) && true === $legacy_attrs['autoselect'] ) {
+				$attributes['autoselect'] = true;
+			}
+
+			if ( array_key_exists( 'disabledAttributesAction', $legacy_attrs ) && 'hide' === $legacy_attrs['disabledAttributesAction'] ) {
+				$attributes['disabledAttributesAction'] = 'hide';
+			}
+
+			if ( array_key_exists( 'optionStyle', $legacy_attrs ) && 'dropdown' === $legacy_attrs['optionStyle'] ) {
+				$attributes['displayStyle'] = 'woocommerce/dropdown';
+			}
+
+			return array(
+				'blockName'    => 'woocommerce/dropdown' === $attributes['displayStyle'] ? 'woocommerce/dropdown' : 'woocommerce/product-filter-chips',
 				'attrs'        => array(),
 				'innerBlocks'  => array(),
 				'innerHTML'    => '',
@@ -138,9 +152,10 @@ class VariationSelectorAttribute extends AbstractBlock {
 			);
 		} elseif ( isset( $inner_block['innerBlocks'] ) && is_array( $inner_block['innerBlocks'] ) && ! empty( $inner_block['innerBlocks'] ) ) {
 			foreach ( $inner_block['innerBlocks'] as $key => $child_inner_block ) {
-				$inner_block['innerBlocks'][ $key ] = $this->replace_legacy_attribute_options_block( $child_inner_block );
+				$inner_block['innerBlocks'][ $key ] = $this->replace_legacy_attribute_options_block( $child_inner_block, $attributes );
 			}
 		}
+
 		return $inner_block;
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Dropdown.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Dropdown.php
@@ -42,11 +42,11 @@ final class Dropdown extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+		if ( empty( $block->context['woocommerce/selectableItems'] ) ) {
 			return '';
 		}
 
-		$selectable_items = $block->context['woocommerceSelectableItems'];
+		$selectable_items = $block->context['woocommerce/selectableItems'];
 		$items            = is_array( $selectable_items['items'] ?? null ) ? $selectable_items['items'] : array();
 		$store_namespace  = is_string( $selectable_items['storeNamespace'] ?? null ) ? $selectable_items['storeNamespace'] : 'woocommerce/add-to-cart-with-options';
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
@@ -100,7 +100,7 @@ final class ProductFilterActive extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceRemovableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/removableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -298,7 +298,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceSelectableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/selectableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -33,11 +33,11 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+		if ( empty( $block->context['woocommerce/selectableItems'] ) ) {
 			return '';
 		}
 
-		$block_context   = $block->context['woocommerceSelectableItems'];
+		$block_context   = $block->context['woocommerce/selectableItems'];
 		$items           = is_array( $block_context['items'] ?? null ) ? $block_context['items'] : array();
 		$store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
 		$filter_type     = $block_context['filterType'] ?? '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -26,11 +26,11 @@ final class ProductFilterChips extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+		if ( empty( $block->context['woocommerce/selectableItems'] ) ) {
 			return '';
 		}
 
-		$block_context   = $block->context['woocommerceSelectableItems'];
+		$block_context   = $block->context['woocommerce/selectableItems'];
 		$items           = is_array( $block_context['items'] ?? null ) ? $block_context['items'] : array();
 		$store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
 		$display_limit   = 'woocommerce/product-filters' === $store_namespace ? 15 : 30;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
@@ -37,7 +37,7 @@ final class ProductFilterClearButton extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 		// don't render if its admin, or ajax in progress.
-		$removable_context = $block->context['woocommerceRemovableItems'] ?? null;
+		$removable_context = $block->context['woocommerce/removableItems'] ?? null;
 		if (
 			is_admin() ||
 			wp_doing_ajax() ||

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -178,7 +178,7 @@ final class ProductFilterPrice extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceRangeInput' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/rangeInput' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPriceSlider.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPriceSlider.php
@@ -32,11 +32,11 @@ class ProductFilterPriceSlider extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( is_admin() || wp_doing_ajax() || empty( $block->context['woocommerceRangeInput'] ) ) {
+		if ( is_admin() || wp_doing_ajax() || empty( $block->context['woocommerce/rangeInput'] ) ) {
 			return '';
 		}
 
-		$range_data = $block->context['woocommerceRangeInput'];
+		$range_data = $block->context['woocommerce/rangeInput'];
 		$min_range  = $range_data['min'] ?? 0;
 		$max_range  = $range_data['max'] ?? 0;
 		$min_price  = $range_data['currentMin'] ?? $min_range;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -162,7 +162,7 @@ final class ProductFilterRating extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceSelectableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/selectableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRemovableChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRemovableChips.php
@@ -27,12 +27,12 @@ final class ProductFilterRemovableChips extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 		if (
-			empty( $block->context['woocommerceRemovableItems'] )
+			empty( $block->context['woocommerce/removableItems'] )
 		) {
 			return '';
 		}
 
-		$filter_items = $block->context['woocommerceRemovableItems']['items'] ?? array();
+		$filter_items = $block->context['woocommerce/removableItems']['items'] ?? array();
 
 		$style = '';
 
@@ -72,8 +72,13 @@ final class ProductFilterRemovableChips extends AbstractBlock {
 					</li>
 				</template>
 				<?php foreach ( $filter_items as $item ) : ?>
-					<?php // translators: %s: item label. ?>
-					<?php $remove_label = sprintf( __( 'Remove filter: %s', 'woocommerce' ), $item['label'] ); ?>
+					<?php
+					$remove_label = sprintf(
+						/* translators: %s: item label. */
+						__( 'Remove filter: %s', 'woocommerce' ),
+						$item['label']
+					);
+					?>
 					<li class="wc-block-product-filter-removable-chips__item" data-wp-each-child
 						<?php echo wp_interactivity_data_wp_context( array( 'item' => $item ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -164,7 +164,7 @@ final class ProductFilterStatus extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceSelectableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/selectableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -301,7 +301,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceSelectableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/selectableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -470,54 +470,6 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the VariationSelectorAttribute block returns empty string
-	 * for non-variable products (simple, grouped, external) to prevent
-	 * a fatal error from calling get_variation_attributes() on unsupported
-	 * product types.
-	 *
-	 * @covers VariationSelectorAttribute::render
-	 */
-	public function test_variation_selector_attribute_returns_empty_for_non_variable_products() {
-		global $product;
-		$original_product = $product;
-
-		$block_markup = '<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute /-->';
-
-		try {
-			// Test with a missing/invalid product context.
-			$product = null;
-			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string when the global product is null.' );
-
-			$product = false;
-			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string when the global product is false.' );
-
-			// Test with a simple product.
-			$simple_product = new \WC_Product_Simple();
-			$simple_product->set_regular_price( 10 );
-			$simple_product->save();
-
-			$product = $simple_product;
-			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string for simple products.' );
-
-			// Test with a grouped product.
-			$grouped_product = new \WC_Product_Grouped();
-			$grouped_product->save();
-
-			$product = $grouped_product;
-			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string for grouped products.' );
-
-			// Test with an external product.
-			$external_product = new \WC_Product_External();
-			$external_product->save();
-
-			$product = $external_product;
-			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string for external products.' );
-		} finally {
-			$product = $original_product;
-		}//end try
-	}
-
-	/**
 	 * Tests that the quantity selector and its steppers are hidden when
 	 * a filter sets min and max quantity to the same value for a product.
 	 */

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
@@ -48,8 +48,8 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 				'wc-block-dropdown',
 				'wc-block-product-filter-chips',
 			),
-			'chips'    => array(
-				array( 'optionStyle' => 'chips' ),
+			'pills'    => array(
+				array( 'optionStyle' => 'pills' ),
 				'wc-block-product-filter-chips',
 				'wc-block-dropdown',
 			),

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
@@ -1,0 +1,244 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeNameMock;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the VariationSelectorAttribute block type.
+ */
+class VariationSelectorAttribute extends WC_Unit_Test_Case {
+
+	/**
+	 * Tracks whether blocks have been registered.
+	 *
+	 * @var bool
+	 */
+	protected static $are_blocks_registered = false;
+
+	/**
+	 * Register blocks required for do_blocks tests.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! self::$are_blocks_registered ) {
+			new AddToCartWithOptionsVariationSelectorAttributeMock();
+			new AddToCartWithOptionsVariationSelectorAttributeNameMock();
+
+			self::$are_blocks_registered = true;
+		}
+	}
+
+	/**
+	 * Data provider for legacy attribute options block replacement styles.
+	 *
+	 * @return array<string, array{0: array<string, string>, 1: string, 2: string}>
+	 */
+	public function legacy_attribute_options_block_styles_provider(): array {
+		return array(
+			'dropdown' => array(
+				array( 'optionStyle' => 'dropdown' ),
+				'wc-block-dropdown',
+				'wc-block-product-filter-chips',
+			),
+			'chips'    => array(
+				array( 'optionStyle' => 'chips' ),
+				'wc-block-product-filter-chips',
+				'wc-block-dropdown',
+			),
+			'default'  => array(
+				array(),
+				'wc-block-product-filter-chips',
+				'wc-block-dropdown',
+			),
+		);
+	}
+
+	/**
+	 * Tests that the block returns empty string for non-variable products.
+	 *
+	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::render
+	 */
+	public function test_returns_empty_for_non_variable_products(): void {
+		global $product;
+		$original_product = $product;
+
+		$block_markup = '<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute /-->';
+
+		try {
+			$product = null;
+			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string when the global product is null.' );
+
+			$product = false;
+			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string when the global product is false.' );
+
+			$simple_product = new \WC_Product_Simple();
+			$simple_product->set_regular_price( 10 );
+			$simple_product->save();
+
+			$product = $simple_product;
+			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string for simple products.' );
+
+			$grouped_product = new \WC_Product_Grouped();
+			$grouped_product->save();
+
+			$product = $grouped_product;
+			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string for grouped products.' );
+
+			$external_product = new \WC_Product_External();
+			$external_product->save();
+
+			$product = $external_product;
+			$this->assertSame( '', do_blocks( $block_markup ), 'VariationSelectorAttribute should return empty string for external products.' );
+		} finally {
+			$product = $original_product;
+		}
+	}
+
+	/**
+	 * Tests that legacy attribute options blocks are replaced with dropdown or chips blocks when rendered.
+	 *
+	 * @dataProvider legacy_attribute_options_block_styles_provider
+	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::replace_legacy_attribute_options_block
+	 *
+	 * @param array  $options_attrs          Legacy options block attributes.
+	 * @param string $expected_output_class  CSS class expected in rendered output.
+	 * @param string $unexpected_output_class CSS class that should not appear in rendered output.
+	 */
+	public function test_replaces_legacy_attribute_options_block_when_rendered( array $options_attrs, string $expected_output_class, string $unexpected_output_class ): void {
+		$variable_product = $this->create_variable_product_with_variations();
+		$inner_blocks     = $this->get_attribute_name_block_markup() . $this->get_legacy_options_block_markup( $options_attrs );
+
+		$markup = $this->render_variation_selector_attribute( $variable_product, $inner_blocks );
+
+		$this->assertStringContainsString( 'variation-selector-attribute-name', $markup, 'Attribute name block should render.' );
+		$this->assertStringContainsString( $expected_output_class, $markup, 'Legacy attribute options block should render as the replacement block.' );
+		$this->assertStringNotContainsString( $unexpected_output_class, $markup, 'Legacy attribute options block should not render as the other option style.' );
+	}
+
+	/**
+	 * Tests that legacy attribute options blocks nested in a group are replaced when rendered.
+	 *
+	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::replace_legacy_attribute_options_block
+	 */
+	public function test_replaces_nested_legacy_attribute_options_block_when_rendered(): void {
+		$variable_product = $this->create_variable_product_with_variations();
+		$inner_blocks     = sprintf(
+			'<!-- wp:group -->%s%s<!-- /wp:group -->',
+			$this->get_attribute_name_block_markup(),
+			$this->get_legacy_options_block_markup( array( 'optionStyle' => 'dropdown' ) )
+		);
+
+		$markup = $this->render_variation_selector_attribute( $variable_product, $inner_blocks );
+
+		$this->assertStringContainsString( 'variation-selector-attribute-name', $markup, 'Attribute name block should render.' );
+		$this->assertStringContainsString( 'wc-block-dropdown', $markup, 'Nested legacy attribute options block should render as a dropdown.' );
+		$this->assertStringNotContainsString( 'wc-block-product-filter-chips', $markup, 'Nested legacy attribute options block should not render as chips.' );
+	}
+
+	/**
+	 * Create a variable product with color variations for rendering tests.
+	 *
+	 * @return \WC_Product_Variable
+	 */
+	private function create_variable_product_with_variations(): \WC_Product_Variable {
+		$fixtures = new FixtureData();
+
+		$product = $fixtures->get_variable_product(
+			array(),
+			array(
+				$fixtures->get_product_attribute( 'color', array( 'red', 'blue' ) ),
+			)
+		);
+
+		$product_id = $product->get_id();
+
+		$fixtures->get_variation_product(
+			$product_id,
+			array(
+				'pa_color' => 'red-slug',
+			),
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		$fixtures->get_variation_product(
+			$product_id,
+			array(
+				'pa_color' => 'blue-slug',
+			),
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		\WC_Product_Variable::sync( $product_id );
+
+		$variable_product = wc_get_product( $product_id );
+
+		$this->assertInstanceOf( \WC_Product_Variable::class, $variable_product );
+
+		return $variable_product;
+	}
+
+	/**
+	 * Render the variation selector attribute block with the given inner block markup.
+	 *
+	 * @param \WC_Product_Variable $variable_product  Variable product to use as context.
+	 * @param string               $inner_blocks_markup Inner blocks markup.
+	 * @return string Rendered block output.
+	 */
+	private function render_variation_selector_attribute( \WC_Product_Variable $variable_product, string $inner_blocks_markup ): string {
+		global $product;
+
+		$original_product = $product;
+		$product          = $variable_product;
+
+		$block_markup = sprintf(
+			'<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->%s<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->',
+			$inner_blocks_markup
+		);
+
+		try {
+			return do_blocks( $block_markup );
+		} finally {
+			$product = $original_product;
+		}
+	}
+
+	/**
+	 * Get block markup for the attribute name inner block.
+	 *
+	 * @return string
+	 */
+	private function get_attribute_name_block_markup(): string {
+		return '<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-name /-->';
+	}
+
+	/**
+	 * Get block markup for the legacy attribute options inner block.
+	 *
+	 * @param array $attrs Legacy options block attributes.
+	 * @return string
+	 */
+	private function get_legacy_options_block_markup( array $attrs ): string {
+		if ( empty( $attrs ) ) {
+			return '<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options /-->';
+		}
+
+		return sprintf(
+			'<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options %s /-->',
+			wp_json_encode( $attrs )
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
@@ -37,7 +37,7 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Data provider for legacy attribute options block replacement styles.
+	 * Data provider for legacy Attribute Options block replacement styles.
 	 *
 	 * @return array<string, array{0: array<string, string>, 1: string, 2: string}>
 	 */
@@ -64,6 +64,7 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 	/**
 	 * Tests that the block returns empty string for non-variable products.
 	 *
+	 * @testdox VariationSelectorAttribute returns an empty string for non-variable products.
 	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::render
 	 */
 	public function test_returns_empty_for_non_variable_products(): void {
@@ -103,8 +104,9 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests that legacy attribute options blocks are replaced with dropdown or chips blocks when rendered.
+	 * Tests that legacy Attribute Options blocks are replaced with dropdown or chips blocks when rendered.
 	 *
+	 * @testdox Legacy Attribute Options block renders with %2$s and not %3$s.
 	 * @dataProvider legacy_attribute_options_block_styles_provider
 	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::replace_legacy_attribute_options_block
 	 *
@@ -119,13 +121,14 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 		$markup = $this->render_variation_selector_attribute( $variable_product, $inner_blocks );
 
 		$this->assertStringContainsString( 'variation-selector-attribute-name', $markup, 'Attribute name block should render.' );
-		$this->assertStringContainsString( $expected_output_class, $markup, 'Legacy attribute options block should render as the replacement block.' );
-		$this->assertStringNotContainsString( $unexpected_output_class, $markup, 'Legacy attribute options block should not render as the other option style.' );
+		$this->assertStringContainsString( $expected_output_class, $markup, 'Legacy Attribute Options block should render as the replacement block.' );
+		$this->assertStringNotContainsString( $unexpected_output_class, $markup, 'Legacy Attribute Options block should not render as the other option style.' );
 	}
 
 	/**
-	 * Tests that autoselect and disabledAttributesAction are migrated from legacy attribute options blocks.
+	 * Tests that autoselect and disabledAttributesAction are migrated from legacy Attribute Options blocks.
 	 *
+	 * @testdox autoselect and disabledAttributesAction are migrated from legacy Attribute Options block.
 	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::replace_legacy_attribute_options_block
 	 */
 	public function test_migrates_legacy_attribute_options_settings_when_rendered(): void {
@@ -144,8 +147,9 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests that legacy attribute options blocks nested in a group are replaced when rendered.
+	 * Tests that legacy Attribute Options blocks nested in a group are replaced when rendered.
 	 *
+	 * @testdox Legacy Attribute Options block nested in a group is replaced with a dropdown when rendered.
 	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::replace_legacy_attribute_options_block
 	 */
 	public function test_replaces_nested_legacy_attribute_options_block_when_rendered(): void {
@@ -159,8 +163,8 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 		$markup = $this->render_variation_selector_attribute( $variable_product, $inner_blocks );
 
 		$this->assertStringContainsString( 'variation-selector-attribute-name', $markup, 'Attribute name block should render.' );
-		$this->assertStringContainsString( 'wc-block-dropdown', $markup, 'Nested legacy attribute options block should render as a dropdown.' );
-		$this->assertStringNotContainsString( 'wc-block-product-filter-chips', $markup, 'Nested legacy attribute options block should not render as chips.' );
+		$this->assertStringContainsString( 'wc-block-dropdown', $markup, 'Nested legacy Attribute Options block should render as a dropdown.' );
+		$this->assertStringNotContainsString( 'wc-block-product-filter-chips', $markup, 'Nested legacy Attribute Options block should not render as chips.' );
 	}
 
 	/**
@@ -246,7 +250,7 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Get block markup for the legacy attribute options inner block.
+	 * Get block markup for the legacy Attribute Options inner block.
 	 *
 	 * @param array $attrs Legacy options block attributes.
 	 * @return string

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
@@ -124,6 +124,26 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that autoselect and disabledAttributesAction are migrated from legacy attribute options blocks.
+	 *
+	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::replace_legacy_attribute_options_block
+	 */
+	public function test_migrates_legacy_attribute_options_settings_when_rendered(): void {
+		$variable_product = $this->create_variable_product_with_variations();
+		$inner_blocks     = $this->get_attribute_name_block_markup() . $this->get_legacy_options_block_markup(
+			array(
+				'autoselect'               => true,
+				'disabledAttributesAction' => 'hide',
+			)
+		);
+
+		$markup = $this->render_variation_selector_attribute( $variable_product, $inner_blocks );
+
+		$this->assertStringContainsString( '"autoselect":true', $markup, 'Legacy autoselect should be applied to the interactivity context.' );
+		$this->assertStringContainsString( '"disabledAttributesAction":"hide"', $markup, 'Legacy disabledAttributesAction should be applied to the interactivity context.' );
+	}
+
+	/**
 	 * Tests that legacy attribute options blocks nested in a group are replaced when rendered.
 	 *
 	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::replace_legacy_attribute_options_block


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/64887.

This PR adds backwards compatibility to the refactor of the Add to Cart + Options Variation Selector by:

* In the frontend, we replace the Variation Selector: Attribute Option block by the new Chips or Dropdown blocks at render time.
* In the editor, we have a deprecation at the Variation Selector: Template level that runs through the inner blocks and if it detects a Variation Selector: Attribute Option, it replaces it by the Chips or Dropdown blocks.

### How to test the changes in this Pull Request:

1. In `trunk` or WC 10.8. Make some edits to the Variable products template part of the Add to Cart + Options block. Ie, by moving some blocks around or changing some styles.
2. Update to this branch.
3. Go to the frontend. Verify the block still shows up correctly.
4. Go to the editor. Verify the block shows the Chips or Dropdown blocks appropriately.
5. Repeat the process by doing different edits at step 1: changing the option style from chips to dropdown, moving the Variation Selector: Attribute Option block at the root of the template part or inside other blocks, etc...
6. Try also adding a `parts/variable-product-add-to-cart-with-options.html` theme file with the old blocks (you can copy [the current template part from WC core `trunk`](https://github.com/woocommerce/woocommerce/blob/56e40f76a11d4107db08aac34893a5f40ec40440/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html)). And repeat steps 2-4.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->