### PR TITLE
Fix products app bulk editing action label

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-app-bulk-editing-label
+++ b/packages/js/experimental-products-app/changelog/fix-products-app-bulk-editing-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Rename quick edit to bulk editing when multiple products are selected.

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.test.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.test.tsx
@@ -12,6 +12,7 @@ import { renderHook } from '@testing-library/react';
 import {
 	duplicateProductAction,
 	moveToTrashAction,
+	quickEditAction,
 	selectAllVariationsAction,
 	useProductActions,
 } from './actions';
@@ -80,6 +81,15 @@ function getCallbackAction( action: Action< ProductEntityRecord > ) {
 			}
 		) => Promise< void >;
 	};
+}
+
+function getActionLabel(
+	action: Action< ProductEntityRecord >,
+	items: ProductEntityRecord[]
+) {
+	return typeof action.label === 'string'
+		? action.label
+		: action.label( items );
 }
 
 describe( 'product list actions', () => {
@@ -186,6 +196,17 @@ describe( 'product list actions', () => {
 		);
 
 		expect( quickEditProductAction?.supportsBulk ).toBe( true );
+	} );
+
+	it( 'renames Quick edit to Bulk editing when multiple products are selected', () => {
+		const action = quickEditAction( {
+			navigate,
+		} );
+
+		expect( getActionLabel( action, [ product ] ) ).toBe( 'Quick edit' );
+		expect( getActionLabel( action, [ product, hoodie ] ) ).toBe(
+			'Bulk editing'
+		);
 	} );
 
 	it( 'opens quick edit panel with all selected products when triggered as a bulk action', () => {

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
@@ -148,7 +148,10 @@ export const quickEditAction = ( {
 	query = {},
 }: EditActionOptions ): Action< ProductEntityRecord > => ( {
 	id: 'quick-edit-product',
-	label: __( 'Quick edit', 'woocommerce' ),
+	label: ( items ) =>
+		items.length > 1
+			? __( 'Bulk editing', 'woocommerce' )
+			: __( 'Quick edit', 'woocommerce' ),
 	isPrimary: true,
 	supportsBulk: true,
 	icon: edit,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When multiple products are selected in the experimental Products app, the primary quick edit action still uses the single-product "Quick edit" label. This updates the label to "Bulk editing" for multi-product selections while keeping "Quick edit" for a single product, and adds test coverage for both cases.

### Screenshots or screen recordings:

Screenshots should be added before moving this PR out of draft.

### How to test the changes in this Pull Request:

1. Go to the experimental Products app in WooCommerce admin.
2. Select one product.
3. Confirm the primary action label is "Quick edit".
4. Select multiple products.
5. Confirm the primary action label changes to "Bulk editing".
6. Trigger the action and confirm the quick edit panel opens for the selected products.

### Testing that has already taken place:

Ran `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/dataviews-actions/actions.test.tsx`.

The focused Jest suite passed with 11 tests.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Manual changelog entry added in `packages/js/experimental-products-app/changelog/fix-products-app-bulk-editing-label`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
