### PR TITLE
Split variation edit drawer into a dedicated VariationEditForm

### DIFF
--- a/packages/js/experimental-products-app/changelog/split-variation-edit-form
+++ b/packages/js/experimental-products-app/changelog/split-variation-edit-form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Split the variation edit drawer into a dedicated VariationEditForm component, alongside the existing ProductEditForm. Shared field registry and DataForm pipeline are unchanged.

--- a/packages/js/experimental-products-app/src/product-edit/index.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/index.tsx
@@ -4,7 +4,6 @@
 import { Button, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { select as wpSelect, useDispatch, useSelect } from '@wordpress/data';
-import { DataForm } from '@wordpress/dataviews';
 import { useCallback, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -22,24 +21,17 @@ import {
 import type { ProductEntityRecord } from '../fields/types';
 import { unlock } from '../lock-unlock';
 import {
-	buildMergedProductEditData,
 	findProductInList,
 	getProductEditRecord,
 	getProductWithUpdatedVariation,
 	getProductEditFields,
-	getProductTypeFormFields,
-	getVisibleProductEditFields,
 	isProductVariation,
 } from './utils';
+import { ProductEditForm } from './product-edit-form';
+import { VariationEditForm } from './variation-edit-form';
 import { saveSelectedProducts } from './save';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
-
-type ProductEditFormProps = {
-	editableFields: ReturnType< typeof getProductEditFields >;
-	onChange: ( changes: Partial< ProductEntityRecord > ) => void;
-	selectedProducts: ProductEntityRecord[];
-};
 
 type ProductEditProps = {
 	products: ProductEntityRecord[];
@@ -79,35 +71,6 @@ function getSaveNoticeMessage( successCount: number, failedCount: number ) {
 		),
 		successCount,
 		failedCount
-	);
-}
-
-function ProductEditForm( {
-	editableFields,
-	onChange,
-	selectedProducts,
-}: ProductEditFormProps ) {
-	const mergedData = buildMergedProductEditData( selectedProducts );
-	const visibleFields = getVisibleProductEditFields(
-		editableFields,
-		selectedProducts
-	);
-
-	const form = {
-		type: 'regular' as const,
-		labelPosition: 'top' as const,
-		fields: getProductTypeFormFields( selectedProducts, visibleFields ),
-	};
-
-	return (
-		<div className="woocommerce-product-edit__form">
-			<DataForm
-				data={ mergedData }
-				fields={ visibleFields }
-				form={ form }
-				onChange={ onChange }
-			/>
-		</div>
 	);
 }
 
@@ -438,13 +401,20 @@ export default function ProductEdit( { products, isOpen }: ProductEditProps ) {
 							</div>
 						) }
 
-					{ isReady && (
-						<ProductEditForm
-							editableFields={ editableFields }
-							onChange={ onChange }
-							selectedProducts={ selectedProducts }
-						/>
-					) }
+					{ isReady &&
+						( selectedProducts.every( isProductVariation ) ? (
+							<VariationEditForm
+								editableFields={ editableFields }
+								onChange={ onChange }
+								selectedVariations={ selectedProducts }
+							/>
+						) : (
+							<ProductEditForm
+								editableFields={ editableFields }
+								onChange={ onChange }
+								selectedProducts={ selectedProducts }
+							/>
+						) ) }
 				</Drawer.Content>
 
 				{ isReady && (

--- a/packages/js/experimental-products-app/src/product-edit/product-edit-form.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/product-edit-form.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { DataForm } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { ProductEntityRecord } from '../fields/types';
+import {
+	buildMergedProductEditData,
+	getProductEditFields,
+	getProductTypeFormFields,
+	getVisibleProductEditFields,
+} from './utils';
+
+type ProductEditFormProps = {
+	editableFields: ReturnType< typeof getProductEditFields >;
+	onChange: ( changes: Partial< ProductEntityRecord > ) => void;
+	selectedProducts: ProductEntityRecord[];
+};
+
+export function ProductEditForm( {
+	editableFields,
+	onChange,
+	selectedProducts,
+}: ProductEditFormProps ) {
+	const mergedData = buildMergedProductEditData( selectedProducts );
+	const visibleFields = getVisibleProductEditFields(
+		editableFields,
+		selectedProducts
+	);
+
+	const form = {
+		type: 'regular' as const,
+		labelPosition: 'top' as const,
+		fields: getProductTypeFormFields( selectedProducts, visibleFields ),
+	};
+
+	return (
+		<div className="woocommerce-product-edit__form">
+			<DataForm
+				data={ mergedData }
+				fields={ visibleFields }
+				form={ form }
+				onChange={ onChange }
+			/>
+		</div>
+	);
+}

--- a/packages/js/experimental-products-app/src/product-edit/variation-edit-form.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/variation-edit-form.tsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { DataForm } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { ProductEntityRecord } from '../fields/types';
+import {
+	buildMergedProductEditData,
+	getProductEditFields,
+	getProductTypeFormFields,
+	getVisibleProductEditFields,
+} from './utils';
+
+type VariationEditFormProps = {
+	editableFields: ReturnType< typeof getProductEditFields >;
+	onChange: ( changes: Partial< ProductEntityRecord > ) => void;
+	selectedVariations: ProductEntityRecord[];
+};
+
+// Dedicated form for editing variations. Mirrors ProductEditForm today but
+// lives in its own component so variation-specific UX (parent inheritance
+// affordances, custom groupings, etc.) can evolve independently from the
+// regular product edit form. Shared field components from the productFields
+// registry are still re-used via the standard DataForm pipeline.
+export function VariationEditForm( {
+	editableFields,
+	onChange,
+	selectedVariations,
+}: VariationEditFormProps ) {
+	const mergedData = buildMergedProductEditData( selectedVariations );
+	const visibleFields = getVisibleProductEditFields(
+		editableFields,
+		selectedVariations
+	);
+
+	const form = {
+		type: 'regular' as const,
+		labelPosition: 'top' as const,
+		fields: getProductTypeFormFields( selectedVariations, visibleFields ),
+	};
+
+	return (
+		<div className="woocommerce-variation-edit__form">
+			<DataForm
+				data={ mergedData }
+				fields={ visibleFields }
+				form={ form }
+				onChange={ onChange }
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Splits the variation edit drawer body into a dedicated `VariationEditForm` component, alongside the existing `ProductEditForm`. The drawer (`ProductEdit`) now picks which form to render based on whether every selected product is a variation.

What's shared between the two forms:
- The drawer chrome (`Drawer.Root`, header, footer, save handling).
- The `productFields` registry — one source of truth for field definitions.
- The merging/visibility/form-config helpers in [utils.ts](packages/js/experimental-products-app/src/product-edit/utils.ts).
- The `<DataForm>` pipeline itself, including field-component implementations like weight, sku, taxonomy edit, etc.

What's now isolated:
- The wrapping component identity (`woocommerce-product-edit__form` vs `woocommerce-variation-edit__form`).
- The body of the variation drawer can now diverge from the regular product drawer without touching shared code.

**No user-visible change in this PR.** It's a structural refactor that unblocks variation-specific UX work (parent inheritance affordances, dedicated field groupings, possibly future variation-only drawer chrome).

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

(No visual change — only the wrapping component class differs.)

### How to test the changes in this Pull Request:

1. Enable feature flags in `plugins/woocommerce/client/admin/config/development.json`:
   - `product-data-views: true`
   - `product-variations-classic-redesign: true`
2. Regenerate feature config: `cd plugins/woocommerce/client/admin && WC_ADMIN_PHASE=development php ../../bin/generate-feature-config.php`.
3. Build: `pnpm --filter=@woocommerce/experimental-products-app build && pnpm --filter=@woocommerce/admin-library build && rsync -a plugins/woocommerce/client/admin/build/ plugins/woocommerce/assets/client/admin/`.
4. In the new All Products view, click a non-variation product. Inspect — the form wrapper has class `woocommerce-product-edit__form`. Confirm the drawer renders identically to before.
5. Open a variable product's variation drawer (e.g. drill into Costume Plushie, then click a variation). Inspect — the form wrapper now has class `woocommerce-variation-edit__form`. Confirm the drawer renders identically to before.
6. Confirm shared field changes still flow into both views (e.g. editing a field's component file affects both forms).

### Testing that has already taken place:

- Local wp-env, dev flags enabled.
- Verified both forms render with the expected wrapper class (DOM inspected).
- TypeScript check + ESLint clean on the modified files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog entry included for `@woocommerce/experimental-products-app`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)