### PR TITLE
[RSM] Shopper Collections: add wishlists feature flag and My Account support

### DIFF
--- a/plugins/woocommerce/changelog/add-shopper-collections-wishlists-base
+++ b/plugins/woocommerce/changelog/add-shopper-collections-wishlists-base
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Shopper Collections: add experimental wishlist support.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -399,6 +399,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\ProductFeed\ProductFeed::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
 use Automattic\WooCommerce\Blocks\BlockTypes\Checkout;
 use Automattic\WooCommerce\Blocks\BlockTypes\MiniCartContents;
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController;
 
 /**
  * BlockTypesController class.
@@ -554,7 +554,7 @@ final class BlockTypesController {
 			MiniCartContents::get_mini_cart_block_types()
 		);
 
-		if ( FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
+		if ( wc_get_container()->get( ShopperListsController::class )->is_enabled( 'saved-for-later' ) ) {
 			$block_types[] = 'SavedForLater';
 		}
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -615,6 +615,17 @@ class FeaturesController {
 				'option_key'                   => 'woocommerce_cart_save_for_later_enabled',
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
+			'product_wishlist'                   => array(
+				'name'                         => __( 'Wishlists', 'woocommerce' ),
+				'description'                  => __(
+					'Let shoppers save products to a wishlist from product pages.',
+					'woocommerce'
+				),
+				'is_experimental'              => true,
+				'enabled_by_default'           => false,
+				'option_key'                   => 'woocommerce_product_wishlist_enabled',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+			),
 			ProductCacheController::FEATURE_NAME => array(
 				'name'                         => __( 'Cache Product Objects', 'woocommerce' ),
 				'description'                  => __(

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -81,11 +81,12 @@ class ShopperList {
 			return self::from_array( $stored, $user_id );
 		}
 
-		// In-memory saved-for-later; persisted lazily on the first save().
-		if ( 'saved-for-later' === $slug ) {
+		// In-memory list; saved on the first save(). Disabled or unknown
+		// slugs return false (the Store API returns a 404 for them).
+		if ( wc_get_container()->get( ShopperListsController::class )->is_enabled( $slug ) ) {
 			return new self(
 				$user_id,
-				'saved-for-later',
+				$slug,
 				current_time( 'mysql', true ),
 				array()
 			);
@@ -101,14 +102,14 @@ class ShopperList {
 	 * @return array<string, self>
 	 */
 	public static function get_all_for_user( ?int $user_id = null ): array {
-		// Only `saved-for-later` is registered today. Additional list types
-		// (e.g. wishlist) will be added here behind their own feature flag
-		// once the corresponding block ships.
-		return array_filter(
-			array(
-				'saved-for-later' => self::get_by_slug( 'saved-for-later', $user_id ),
-			)
-		);
+		$result = array();
+		foreach ( wc_get_container()->get( ShopperListsController::class )->get_enabled_slugs() as $slug ) {
+			$list = self::get_by_slug( $slug, $user_id );
+			if ( $list ) {
+				$result[ $slug ] = $list;
+			}
+		}
+		return $result;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperList.php
@@ -70,6 +70,12 @@ class ShopperList {
 	 * @return self|false
 	 */
 	public static function get_by_slug( string $slug, ?int $user_id = null ) {
+		// Gate disabled or unknown slugs upfront so previously-persisted lists
+		// don't bypass the feature flag (the Store API surfaces this as 404).
+		if ( ! wc_get_container()->get( ShopperListsController::class )->is_enabled( $slug ) ) {
+			return false;
+		}
+
 		$user_id = absint( $user_id ? $user_id : get_current_user_id() );
 		if ( ! $user_id ) {
 			return false;
@@ -81,18 +87,13 @@ class ShopperList {
 			return self::from_array( $stored, $user_id );
 		}
 
-		// In-memory list; saved on the first save(). Disabled or unknown
-		// slugs return false (the Store API returns a 404 for them).
-		if ( wc_get_container()->get( ShopperListsController::class )->is_enabled( $slug ) ) {
-			return new self(
-				$user_id,
-				$slug,
-				current_time( 'mysql', true ),
-				array()
-			);
-		}
-
-		return false;
+		// In-memory list; saved on the first save().
+		return new self(
+			$user_id,
+			$slug,
+			current_time( 'mysql', true ),
+			array()
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListsController.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListsController.php
@@ -1,0 +1,157 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+/**
+ * Tracks which shopper-list types are turned on and registers the
+ * user-facing pieces that depend on each.
+ *
+ * @internal Just for internal use.
+ */
+final class ShopperListsController implements RegisterHooksInterface {
+
+	/**
+	 * Known list slugs and the feature flag that controls each.
+	 */
+	private const SUPPORTED_LISTS = array(
+		'saved-for-later' => 'cart_save_for_later',
+		'wishlist'        => 'product_wishlist',
+	);
+
+	/**
+	 * Wishlist My Account endpoint slug. Wrapped in a method (rather than
+	 * a constant) so a future filter or settings hook can override it
+	 * without touching every call site.
+	 */
+	public function get_wishlist_endpoint(): string {
+		return 'wishlist';
+	}
+
+	/**
+	 * Whether a given list type is on, or whether any list type is on
+	 * when no slug is passed.
+	 *
+	 * @param string|null $list_slug List slug, or null to ask about any type.
+	 */
+	public function is_enabled( ?string $list_slug = null ): bool {
+		if ( null === $list_slug ) {
+			foreach ( self::SUPPORTED_LISTS as $feature ) {
+				if ( FeaturesUtil::feature_is_enabled( $feature ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
+		$feature = self::SUPPORTED_LISTS[ $list_slug ] ?? null;
+		return null !== $feature && FeaturesUtil::feature_is_enabled( $feature );
+	}
+
+	/**
+	 * Slugs of all currently-enabled lists, in declaration order.
+	 *
+	 * @return string[]
+	 */
+	public function get_enabled_slugs(): array {
+		return array_keys(
+			array_filter(
+				self::SUPPORTED_LISTS,
+				static fn( string $feature ): bool => FeaturesUtil::feature_is_enabled( $feature )
+			)
+		);
+	}
+
+	/**
+	 * Register hooks.
+	 */
+	public function register(): void {
+		add_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'maybe_flush_rewrite_rules' ), 10, 1 );
+		add_action( 'init', array( $this, 'maybe_register_wishlist_endpoint' ), 5 );
+	}
+
+	/**
+	 * Register the wishlist endpoint.
+	 */
+	public function maybe_register_wishlist_endpoint(): void {
+		if ( ! $this->is_enabled( 'wishlist' ) ) {
+			return;
+		}
+
+		$endpoint = $this->get_wishlist_endpoint();
+		add_filter( 'woocommerce_get_query_vars', array( $this, 'add_wishlist_query_var' ) );
+		add_filter( 'woocommerce_account_menu_items', array( $this, 'add_wishlist_menu_item' ) );
+		add_filter( 'woocommerce_endpoint_' . $endpoint . '_title', array( $this, 'wishlist_endpoint_title' ) );
+		add_action( 'woocommerce_account_' . $endpoint . '_endpoint', array( $this, 'render_wishlist_endpoint' ) );
+	}
+
+	/**
+	 * Flush rewrite rules when the wishlist feature is turned on or off.
+	 *
+	 * @param string $feature_id The feature that changed.
+	 */
+	public function maybe_flush_rewrite_rules( string $feature_id ): void {
+		if ( 'product_wishlist' === $feature_id ) {
+			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+		}
+	}
+
+	/**
+	 * Register the `wishlist` query var.
+	 *
+	 * @param array $vars Existing query vars keyed by slug.
+	 */
+	public function add_wishlist_query_var( $vars ): array {
+		if ( ! is_array( $vars ) ) {
+			return array();
+		}
+
+		$endpoint          = $this->get_wishlist_endpoint();
+		$vars[ $endpoint ] = $endpoint;
+		return $vars;
+	}
+
+	/**
+	 * Insert the Wishlist link just before the logout link.
+	 *
+	 * @param array $items Existing menu items keyed by slug.
+	 */
+	public function add_wishlist_menu_item( $items ): array {
+		if ( ! is_array( $items ) ) {
+			return array();
+		}
+
+		$wishlist_endpoint = $this->get_wishlist_endpoint();
+		$wishlist_label    = __( 'Wishlist', 'woocommerce' );
+
+		// Insert the wishlist item before the logout item, or at the end if not present.
+		$logout_pos = array_search( 'customer-logout', array_keys( $items ), true );
+		if ( false === $logout_pos ) {
+			$items[ $wishlist_endpoint ] = $wishlist_label;
+		} else {
+			$items = array_slice( $items, 0, $logout_pos, true )
+				+ array( $wishlist_endpoint => $wishlist_label )
+				+ array_slice( $items, $logout_pos, null, true );
+		}
+		return $items;
+	}
+
+	/**
+	 * Wishlist endpoint page title.
+	 *
+	 * @param string $title Default title.
+	 */
+	public function wishlist_endpoint_title( $title ): string {
+		return __( 'Wishlist', 'woocommerce' );
+	}
+
+	/**
+	 * Placeholder rendered until the wishlist block variation lands.
+	 */
+	public function render_wishlist_endpoint(): void {
+		echo '<p>' . esc_html__( 'Your wishlist is empty.', 'woocommerce' ) . '</p>';
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -77,7 +77,7 @@ class RoutesController {
 				Routes\V1\Patterns::IDENTIFIER => Routes\V1\Patterns::class,
 			],
 			'shopper_lists' => [
-				// Gated behind the `cart_save_for_later` feature flag.
+				// Gated by ShopperListsController — registered only when at least one shopper-list feature is enabled.
 				Routes\V1\ShopperLists::IDENTIFIER       => Routes\V1\ShopperLists::class,
 				Routes\V1\ShopperListsBySlug::IDENTIFIER => Routes\V1\ShopperListsBySlug::class,
 				Routes\V1\ShopperListItems::IDENTIFIER   => Routes\V1\ShopperListItems::class,

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\StoreApi;
 
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController;
 use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractRoute;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
@@ -99,7 +100,7 @@ class RoutesController {
 		$this->register_routes( 'v1', self::$api_namespace . '/v1' );
 		$this->register_routes( 'private', 'wc/private' );
 
-		if ( FeaturesUtil::feature_is_enabled( 'cart_save_for_later' ) ) {
+		if ( wc_get_container()->get( ShopperListsController::class )->is_enabled() ) {
 			$this->register_routes( 'shopper_lists', self::$api_namespace . '/v1' );
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/ShopperListSchemaTest.php
@@ -36,6 +36,11 @@ class ShopperListSchemaTest extends WC_Unit_Test_Case {
 	 * Set up.
 	 */
 	public function setUp(): void {
+		// `saved-for-later` depends on the `cart_save_for_later` feature
+		// flag. Filter the option read so `ShopperList::get_by_slug()`
+		// returns a list without writing the option to the database.
+		add_filter( 'pre_option_woocommerce_cart_save_for_later_enabled', array( $this, 'filter_save_for_later_enabled' ) );
+
 		parent::setUp();
 
 		$formatters = new Formatters();
@@ -55,7 +60,15 @@ class ShopperListSchemaTest extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		wp_delete_user( $this->user_id );
 		$this->sut = null;
+		remove_filter( 'pre_option_woocommerce_cart_save_for_later_enabled', array( $this, 'filter_save_for_later_enabled' ) );
 		parent::tearDown();
+	}
+
+	/**
+	 * Filter callback that forces the SFL option to `yes` for the lifetime of the test.
+	 */
+	public function filter_save_for_later_enabled(): string {
+		return 'yes';
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -15,6 +15,14 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	private const SAVED_FOR_LATER_SLUG = 'saved-for-later';
 
 	/**
+	 * Map of shopper-list slug => feature option key.
+	 */
+	private const LIST_OPTIONS = array(
+		'saved-for-later' => 'woocommerce_cart_save_for_later_enabled',
+		'wishlist'        => 'woocommerce_product_wishlist_enabled',
+	);
+
+	/**
 	 * @var int
 	 */
 	private $user_id;
@@ -33,12 +41,9 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	 * Set up.
 	 */
 	public function setUp(): void {
-		// `saved-for-later` depends on the `cart_save_for_later` feature
-		// flag. Filter the option read so `ShopperList::get_by_slug()`
-		// returns a list without writing the option to the database.
-		add_filter( 'pre_option_woocommerce_cart_save_for_later_enabled', array( $this, 'filter_save_for_later_enabled' ) );
-
 		parent::setUp();
+		$this->enable_list( self::SAVED_FOR_LATER_SLUG );
+
 		$this->user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
 		$this->product = \WC_Helper_Product::create_simple_product(
 			true,
@@ -57,15 +62,29 @@ class ShopperListTests extends WC_Unit_Test_Case {
 		if ( $this->product ) {
 			$this->product->delete( true );
 		}
-		remove_filter( 'pre_option_woocommerce_cart_save_for_later_enabled', array( $this, 'filter_save_for_later_enabled' ) );
+		foreach ( array_keys( self::LIST_OPTIONS ) as $slug ) {
+			$this->disable_list( $slug );
+		}
+		delete_option( 'woocommerce_queue_flush_rewrite_rules' );
 		parent::tearDown();
 	}
 
 	/**
-	 * Filter callback that forces the SFL option to `yes` for the lifetime of the test.
+	 * Enable the feature backing the given shopper-list slug.
+	 *
+	 * @param string $slug List slug.
 	 */
-	public function filter_save_for_later_enabled(): string {
-		return 'yes';
+	private function enable_list( string $slug ): void {
+		update_option( self::LIST_OPTIONS[ $slug ], 'yes' );
+	}
+
+	/**
+	 * Disable the feature backing the given shopper-list slug.
+	 *
+	 * @param string $slug List slug.
+	 */
+	private function disable_list( string $slug ): void {
+		update_option( self::LIST_OPTIONS[ $slug ], 'no' );
 	}
 
 	/**
@@ -95,6 +114,22 @@ class ShopperListTests extends WC_Unit_Test_Case {
 		$this->assertFalse( ShopperList::get_by_slug( 'wishlist', $this->user_id ) );
 		$this->assertFalse( ShopperList::get_by_slug( 'INVALID', $this->user_id ) );
 		$this->assertFalse( ShopperList::get_by_slug( '', $this->user_id ) );
+	}
+
+	/**
+	 * @testdox get_by_slug should return false when the feature is disabled, even when the list has persisted items.
+	 */
+	public function test_load_returns_false_when_feature_disabled_for_persisted_list(): void {
+		// Persist a list while the feature is on.
+		$list = ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id );
+		$list->add_item( $this->item );
+		$list->save();
+		$meta_key = ShopperList::META_KEY_PREFIX . self::SAVED_FOR_LATER_SLUG;
+		$this->assertIsArray( Users::get_site_user_meta( $this->user_id, $meta_key ) );
+
+		// Disable the feature; the persisted list must no longer be returned.
+		$this->disable_list( self::SAVED_FOR_LATER_SLUG );
+		$this->assertFalse( ShopperList::get_by_slug( self::SAVED_FOR_LATER_SLUG, $this->user_id ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListTests.php
@@ -33,6 +33,11 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	 * Set up.
 	 */
 	public function setUp(): void {
+		// `saved-for-later` depends on the `cart_save_for_later` feature
+		// flag. Filter the option read so `ShopperList::get_by_slug()`
+		// returns a list without writing the option to the database.
+		add_filter( 'pre_option_woocommerce_cart_save_for_later_enabled', array( $this, 'filter_save_for_later_enabled' ) );
+
 		parent::setUp();
 		$this->user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
 		$this->product = \WC_Helper_Product::create_simple_product(
@@ -52,7 +57,15 @@ class ShopperListTests extends WC_Unit_Test_Case {
 		if ( $this->product ) {
 			$this->product->delete( true );
 		}
+		remove_filter( 'pre_option_woocommerce_cart_save_for_later_enabled', array( $this, 'filter_save_for_later_enabled' ) );
 		parent::tearDown();
+	}
+
+	/**
+	 * Filter callback that forces the SFL option to `yes` for the lifetime of the test.
+	 */
+	public function filter_save_for_later_enabled(): string {
+		return 'yes';
 	}
 
 	/**
@@ -75,9 +88,10 @@ class ShopperListTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_by_slug should return false for any list slug other than saved-for-later.
+	 * @testdox get_by_slug should return false for any disabled or unknown list slug.
 	 */
 	public function test_load_returns_false_for_unsupported_list_slug(): void {
+		// `wishlist` is a known slug but its feature is off in this test class.
 		$this->assertFalse( ShopperList::get_by_slug( 'wishlist', $this->user_id ) );
 		$this->assertFalse( ShopperList::get_by_slug( 'INVALID', $this->user_id ) );
 		$this->assertFalse( ShopperList::get_by_slug( '', $this->user_id ) );

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListsControllerTests.php
@@ -1,0 +1,296 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\ShopperLists;
+
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController;
+use WC_Unit_Test_Case;
+
+/**
+ * Unit tests for ShopperListsController.
+ */
+class ShopperListsControllerTests extends WC_Unit_Test_Case {
+
+	private const SFL_OPTION_FILTER      = 'pre_option_woocommerce_cart_save_for_later_enabled';
+	private const WISHLIST_OPTION_FILTER = 'pre_option_woocommerce_product_wishlist_enabled';
+	private const FLUSH_QUEUE_OPTION     = 'woocommerce_queue_flush_rewrite_rules';
+
+	/**
+	 * System under test.
+	 *
+	 * @var ShopperListsController|null
+	 */
+	private $sut;
+
+	/**
+	 * Whether the SFL feature should report enabled for the current test.
+	 *
+	 * @var bool
+	 */
+	private $sfl_enabled = false;
+
+	/**
+	 * Whether the wishlist feature should report enabled for the current test.
+	 *
+	 * @var bool
+	 */
+	private $wishlist_enabled = false;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// Direct construction (not via container) keeps each test isolated:
+		// the controller has no constructor deps, and hooks attached by one
+		// test don't leak into the shared container instance.
+		$this->sut = new ShopperListsController();
+		add_filter( self::SFL_OPTION_FILTER, array( $this, 'filter_save_for_later_option' ) );
+		add_filter( self::WISHLIST_OPTION_FILTER, array( $this, 'filter_wishlist_option' ) );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		remove_filter( self::SFL_OPTION_FILTER, array( $this, 'filter_save_for_later_option' ) );
+		remove_filter( self::WISHLIST_OPTION_FILTER, array( $this, 'filter_wishlist_option' ) );
+
+		if ( null !== $this->sut ) {
+			$endpoint = $this->sut->get_wishlist_endpoint();
+			remove_filter( 'woocommerce_get_query_vars', array( $this->sut, 'add_wishlist_query_var' ) );
+			remove_filter( 'woocommerce_account_menu_items', array( $this->sut, 'add_wishlist_menu_item' ) );
+			remove_filter( 'woocommerce_endpoint_' . $endpoint . '_title', array( $this->sut, 'wishlist_endpoint_title' ) );
+			remove_action( 'woocommerce_account_' . $endpoint . '_endpoint', array( $this->sut, 'render_wishlist_endpoint' ) );
+		}
+
+		delete_option( self::FLUSH_QUEUE_OPTION );
+
+		$this->sfl_enabled      = false;
+		$this->wishlist_enabled = false;
+		$this->sut              = null;
+		parent::tearDown();
+	}
+
+	/**
+	 * Filter callback returning the SFL option value for the current test.
+	 */
+	public function filter_save_for_later_option(): string {
+		return $this->sfl_enabled ? 'yes' : 'no';
+	}
+
+	/**
+	 * Filter callback returning the wishlist option value for the current test.
+	 */
+	public function filter_wishlist_option(): string {
+		return $this->wishlist_enabled ? 'yes' : 'no';
+	}
+
+	/**
+	 * Set the feature state pair for this test.
+	 *
+	 * @param bool $sfl      Whether to report cart_save_for_later as enabled.
+	 * @param bool $wishlist Whether to report product_wishlist as enabled.
+	 */
+	private function set_features( bool $sfl, bool $wishlist ): void {
+		$this->sfl_enabled      = $sfl;
+		$this->wishlist_enabled = $wishlist;
+	}
+
+	/**
+	 * @testdox is_enabled reflects the underlying feature state, with null asking about any list type.
+	 * @dataProvider provide_is_enabled_cases
+	 *
+	 * @param bool        $sfl      Whether SFL is enabled in this case.
+	 * @param bool        $wishlist Whether wishlist is enabled in this case.
+	 * @param string|null $slug     Slug argument to pass to is_enabled().
+	 * @param bool        $expected Expected return value.
+	 */
+	public function test_is_enabled( bool $sfl, bool $wishlist, ?string $slug, bool $expected ): void {
+		$this->set_features( $sfl, $wishlist );
+		$this->assertSame( $expected, $this->sut->is_enabled( $slug ) );
+	}
+
+	/**
+	 * Data provider for {@see test_is_enabled()}.
+	 *
+	 * @return array<string, array{0:bool, 1:bool, 2:?string, 3:bool}>
+	 */
+	public function provide_is_enabled_cases(): array {
+		return array(
+			'no slug: both off'            => array( false, false, null, false ),
+			'no slug: sfl on'              => array( true, false, null, true ),
+			'no slug: wishlist on'         => array( false, true, null, true ),
+			'no slug: both on'             => array( true, true, null, true ),
+			'saved-for-later: on'          => array( true, false, 'saved-for-later', true ),
+			'saved-for-later: off'         => array( false, false, 'saved-for-later', false ),
+			'wishlist: on'                 => array( false, true, 'wishlist', true ),
+			'wishlist: off'                => array( false, false, 'wishlist', false ),
+			'unknown slug never qualifies' => array( true, true, 'unknown-list', false ),
+		);
+	}
+
+	/**
+	 * @testdox get_enabled_slugs returns the slugs of currently enabled list types in declaration order.
+	 * @dataProvider provide_enabled_slug_cases
+	 *
+	 * @param bool               $sfl      Whether SFL is enabled in this case.
+	 * @param bool               $wishlist Whether wishlist is enabled in this case.
+	 * @param array<int, string> $expected Expected slugs.
+	 */
+	public function test_get_enabled_slugs( bool $sfl, bool $wishlist, array $expected ): void {
+		$this->set_features( $sfl, $wishlist );
+		$this->assertSame( $expected, $this->sut->get_enabled_slugs() );
+	}
+
+	/**
+	 * Data provider for {@see test_get_enabled_slugs()}.
+	 *
+	 * @return array<string, array{0:bool, 1:bool, 2:array<int, string>}>
+	 */
+	public function provide_enabled_slug_cases(): array {
+		return array(
+			'none'          => array( false, false, array() ),
+			'sfl only'      => array( true, false, array( 'saved-for-later' ) ),
+			'wishlist only' => array( false, true, array( 'wishlist' ) ),
+			'both'          => array( true, true, array( 'saved-for-later', 'wishlist' ) ),
+		);
+	}
+
+	/**
+	 * @testdox maybe_flush_rewrite_rules queues a flush only for the product_wishlist feature.
+	 * @dataProvider provide_maybe_flush_cases
+	 *
+	 * @param string $feature_id     The feature id passed to the callback.
+	 * @param bool   $expect_queued  Whether the queue option should end up set to 'yes'.
+	 */
+	public function test_maybe_flush_rewrite_rules( string $feature_id, bool $expect_queued ): void {
+		delete_option( self::FLUSH_QUEUE_OPTION );
+		$this->sut->maybe_flush_rewrite_rules( $feature_id );
+		$this->assertSame(
+			$expect_queued ? 'yes' : false,
+			get_option( self::FLUSH_QUEUE_OPTION, false )
+		);
+	}
+
+	/**
+	 * Data provider for {@see test_maybe_flush_rewrite_rules()}.
+	 *
+	 * @return array<string, array{0:string, 1:bool}>
+	 */
+	public function provide_maybe_flush_cases(): array {
+		return array(
+			'wishlist toggles flush'    => array( 'product_wishlist', true ),
+			'sfl change ignored'        => array( 'cart_save_for_later', false ),
+			'unrelated feature ignored' => array( 'agentic_checkout', false ),
+		);
+	}
+
+	/**
+	 * @testdox add_wishlist_query_var injects the wishlist entry and returns an array for non-array input.
+	 * @dataProvider provide_query_var_cases
+	 *
+	 * @param mixed                $input    Filter input.
+	 * @param array<string, mixed> $expected Expected return value.
+	 */
+	public function test_add_wishlist_query_var( $input, array $expected ): void {
+		$this->assertSame( $expected, $this->sut->add_wishlist_query_var( $input ) );
+	}
+
+	/**
+	 * Data provider for {@see test_add_wishlist_query_var()}.
+	 *
+	 * @return array<string, array{0:mixed, 1:array<string, mixed>}>
+	 */
+	public function provide_query_var_cases(): array {
+		return array(
+			'empty'           => array( array(), array( 'wishlist' => 'wishlist' ) ),
+			'with other vars' => array(
+				array( 'orders' => 'orders' ),
+				array(
+					'orders'   => 'orders',
+					'wishlist' => 'wishlist',
+				),
+			),
+			'non-array input' => array( 'not-an-array', array() ),
+		);
+	}
+
+	/**
+	 * @testdox add_wishlist_menu_item inserts the wishlist link before customer-logout when present, or at the end otherwise.
+	 * @dataProvider provide_menu_item_cases
+	 *
+	 * @param mixed              $input         Filter input.
+	 * @param array<int, string> $expected_keys Expected ordered keys.
+	 */
+	public function test_add_wishlist_menu_item( $input, array $expected_keys ): void {
+		$result = $this->sut->add_wishlist_menu_item( $input );
+		$this->assertSame( $expected_keys, array_keys( $result ) );
+	}
+
+	/**
+	 * Data provider for {@see test_add_wishlist_menu_item()}.
+	 *
+	 * @return array<string, array{0:mixed, 1:array<int, string>}>
+	 */
+	public function provide_menu_item_cases(): array {
+		return array(
+			'logout present'  => array(
+				array(
+					'dashboard'       => 'Dashboard',
+					'orders'          => 'Orders',
+					'customer-logout' => 'Log out',
+				),
+				array( 'dashboard', 'orders', 'wishlist', 'customer-logout' ),
+			),
+			'logout absent'   => array(
+				array(
+					'dashboard' => 'Dashboard',
+					'orders'    => 'Orders',
+				),
+				array( 'dashboard', 'orders', 'wishlist' ),
+			),
+			'empty'           => array( array(), array( 'wishlist' ) ),
+			'non-array input' => array( 'not-an-array', array() ),
+		);
+	}
+
+	/**
+	 * @testdox maybe_register_wishlist_endpoint attaches the endpoint hooks only when wishlist is enabled.
+	 * @dataProvider provide_register_endpoint_cases
+	 *
+	 * @param bool $wishlist_on    Whether wishlist is enabled in this case.
+	 * @param bool $hooks_expected Whether all four endpoint hooks should be present.
+	 */
+	public function test_maybe_register_wishlist_endpoint( bool $wishlist_on, bool $hooks_expected ): void {
+		$this->set_features( false, $wishlist_on );
+		$this->sut->maybe_register_wishlist_endpoint();
+
+		$endpoint = $this->sut->get_wishlist_endpoint();
+		$hooks    = array(
+			array( 'woocommerce_get_query_vars', 'add_wishlist_query_var' ),
+			array( 'woocommerce_account_menu_items', 'add_wishlist_menu_item' ),
+			array( 'woocommerce_endpoint_' . $endpoint . '_title', 'wishlist_endpoint_title' ),
+			array( 'woocommerce_account_' . $endpoint . '_endpoint', 'render_wishlist_endpoint' ),
+		);
+		foreach ( $hooks as $hook ) {
+			$this->assertSame(
+				$hooks_expected,
+				(bool) has_filter( $hook[0], array( $this->sut, $hook[1] ) ),
+				"Hook {$hook[0]}::{$hook[1]} state mismatch."
+			);
+		}
+	}
+
+	/**
+	 * Data provider for {@see test_maybe_register_wishlist_endpoint()}.
+	 *
+	 * @return array<string, array{0:bool, 1:bool}>
+	 */
+	public function provide_register_endpoint_cases(): array {
+		return array(
+			'wishlist on attaches hooks'   => array( true, true ),
+			'wishlist off leaves no hooks' => array( false, false ),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListsControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListsControllerTests.php
@@ -11,9 +11,15 @@ use WC_Unit_Test_Case;
  */
 class ShopperListsControllerTests extends WC_Unit_Test_Case {
 
-	private const SFL_OPTION_FILTER      = 'pre_option_woocommerce_cart_save_for_later_enabled';
-	private const WISHLIST_OPTION_FILTER = 'pre_option_woocommerce_product_wishlist_enabled';
-	private const FLUSH_QUEUE_OPTION     = 'woocommerce_queue_flush_rewrite_rules';
+	private const FLUSH_QUEUE_OPTION = 'woocommerce_queue_flush_rewrite_rules';
+
+	/**
+	 * Map of shopper-list slug => feature option key.
+	 */
+	private const LIST_OPTIONS = array(
+		'saved-for-later' => 'woocommerce_cart_save_for_later_enabled',
+		'wishlist'        => 'woocommerce_product_wishlist_enabled',
+	);
 
 	/**
 	 * System under test.
@@ -21,20 +27,6 @@ class ShopperListsControllerTests extends WC_Unit_Test_Case {
 	 * @var ShopperListsController|null
 	 */
 	private $sut;
-
-	/**
-	 * Whether the SFL feature should report enabled for the current test.
-	 *
-	 * @var bool
-	 */
-	private $sfl_enabled = false;
-
-	/**
-	 * Whether the wishlist feature should report enabled for the current test.
-	 *
-	 * @var bool
-	 */
-	private $wishlist_enabled = false;
 
 	/**
 	 * Set up.
@@ -45,17 +37,16 @@ class ShopperListsControllerTests extends WC_Unit_Test_Case {
 		// the controller has no constructor deps, and hooks attached by one
 		// test don't leak into the shared container instance.
 		$this->sut = new ShopperListsController();
-		add_filter( self::SFL_OPTION_FILTER, array( $this, 'filter_save_for_later_option' ) );
-		add_filter( self::WISHLIST_OPTION_FILTER, array( $this, 'filter_wishlist_option' ) );
+		// Start every test with all features off; individual tests opt in.
+		foreach ( array_keys( self::LIST_OPTIONS ) as $slug ) {
+			$this->disable_list( $slug );
+		}
 	}
 
 	/**
 	 * Tear down.
 	 */
 	public function tearDown(): void {
-		remove_filter( self::SFL_OPTION_FILTER, array( $this, 'filter_save_for_later_option' ) );
-		remove_filter( self::WISHLIST_OPTION_FILTER, array( $this, 'filter_wishlist_option' ) );
-
 		if ( null !== $this->sut ) {
 			$endpoint = $this->sut->get_wishlist_endpoint();
 			remove_filter( 'woocommerce_get_query_vars', array( $this->sut, 'add_wishlist_query_var' ) );
@@ -64,37 +55,42 @@ class ShopperListsControllerTests extends WC_Unit_Test_Case {
 			remove_action( 'woocommerce_account_' . $endpoint . '_endpoint', array( $this->sut, 'render_wishlist_endpoint' ) );
 		}
 
+		foreach ( array_keys( self::LIST_OPTIONS ) as $slug ) {
+			$this->disable_list( $slug );
+		}
 		delete_option( self::FLUSH_QUEUE_OPTION );
 
-		$this->sfl_enabled      = false;
-		$this->wishlist_enabled = false;
-		$this->sut              = null;
+		$this->sut = null;
 		parent::tearDown();
 	}
 
 	/**
-	 * Filter callback returning the SFL option value for the current test.
-	 */
-	public function filter_save_for_later_option(): string {
-		return $this->sfl_enabled ? 'yes' : 'no';
-	}
-
-	/**
-	 * Filter callback returning the wishlist option value for the current test.
-	 */
-	public function filter_wishlist_option(): string {
-		return $this->wishlist_enabled ? 'yes' : 'no';
-	}
-
-	/**
-	 * Set the feature state pair for this test.
+	 * Enable the feature backing the given shopper-list slug.
 	 *
-	 * @param bool $sfl      Whether to report cart_save_for_later as enabled.
-	 * @param bool $wishlist Whether to report product_wishlist as enabled.
+	 * @param string $slug List slug.
+	 */
+	private function enable_list( string $slug ): void {
+		update_option( self::LIST_OPTIONS[ $slug ], 'yes' );
+	}
+
+	/**
+	 * Disable the feature backing the given shopper-list slug.
+	 *
+	 * @param string $slug List slug.
+	 */
+	private function disable_list( string $slug ): void {
+		update_option( self::LIST_OPTIONS[ $slug ], 'no' );
+	}
+
+	/**
+	 * Convenience for the (sfl, wishlist) combinations used by the providers.
+	 *
+	 * @param bool $sfl      Whether to enable cart_save_for_later.
+	 * @param bool $wishlist Whether to enable product_wishlist.
 	 */
 	private function set_features( bool $sfl, bool $wishlist ): void {
-		$this->sfl_enabled      = $sfl;
-		$this->wishlist_enabled = $wishlist;
+		$sfl ? $this->enable_list( 'saved-for-later' ) : $this->disable_list( 'saved-for-later' );
+		$wishlist ? $this->enable_list( 'wishlist' ) : $this->disable_list( 'wishlist' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds basic support for wishlists, pending split of the shopper collection block into dedicated saved for later and wishlists blocks. In particular:

- Adds support for wishlists to the programmatic shopper collections API.
- Registers a wishlist endpoint under My Account (`/my-account/wishlist`).
- Ensures the shopper collection block as well as StoreApi routes are only registered when at least one shopper collection is enabled.

closes https://linear.app/a8c/issue/WOOPRD-3514/create-a-wishlist-page-inside-my-account
closes https://linear.app/a8c/issue/WOOPRD-3512/support-for-wishlists-storeapi-backend

### How to test the changes in this Pull Request:

Make sure you're logged in as a customer for all steps, since the Store API routes require an authenticated user.

1. Visit **WooCommerce → Settings → Advanced → Features** and confirm that a new **Wishlists** experimental feature appears alongside **Save for Later in Cart**.
2. With both features off, confirm you get a 404 when you hit any of `GET /wp-json/wc/store/v1/shopper-lists`, `GET /wp-json/wc/store/v1/shopper-lists/saved-for-later` or `GET /wp-json/wc/store/v1/shopper-lists/wishlist`.
3. Enable **Wishlists** only.
   - `GET /shopper-lists` should now return a 200 with a single entry whose slug is `wishlist`.
   - `GET /shopper-lists/saved-for-later` should still 404.
   - `GET /shopper-lists/wishlist` should return 200 with an empty list.
4. `POST /shopper-lists/wishlist/items` with body `{"product_id": <id>}` for any purchasable product, and you should get a 201 along with the saved item.
5. Hit `GET /shopper-lists/wishlist` once more and confirm `item_count` is now 1 and the product appears under `items`.
6. Enable **Save for Later** as well, so both features are now on:
   - `GET /shopper-lists` should return 200 with two entries (`saved-for-later` and `wishlist`). Both `GET /shopper-lists/saved-for-later` and `GET /shopper-lists/wishlist` should return 200, and the wishlist should still contain the item you added in the previous step.
7. Navigate to the Cart page and confirm that the **saved for later** block still works normally and allows products to move from the cart and back to the cart, as well as removing items.
8. Navigate to `/my-account/`. Confirm that there's a "Wishlist" item before the logout link. Clicking it takes you to a page showing a placeholder message: "Your wishlist is empty.").
9. Turn **Wishlists** off in settings and reload: `/my-account/wishlist/` should now 404 and the nav link should be gone.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->