### PR TITLE
Unify prefixes of context keys in Inner Blocks Protocol

### DIFF
--- a/plugins/woocommerce/changelog/update-inner-blocks-protocol-unify-context-prefix
+++ b/plugins/woocommerce/changelog/update-inner-blocks-protocol-unify-context-prefix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Unify prefixes of context keys in Inner Blocks Protocol
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -95,7 +95,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 	return (
 		<BlockContextProvider
 			value={ {
-				woocommerceSelectableItems: selectableContext,
+				'woocommerce/selectableItems': selectableContext,
 			} }
 		>
 			{ isSelected ? (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/block.json
@@ -13,7 +13,7 @@
 	"supports": {
 		"interactivity": true
 	},
-	"usesContext": [ "woocommerceSelectableItems", "woocommerce/attributeId" ],
+	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {},
 	"viewScriptModule": "woocommerce/dropdown",
 	"style": "file:../woocommerce/dropdown-style.css",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/edit.tsx
@@ -42,7 +42,7 @@ function getOptionLabel( item: {
 
 const Edit = ( props: EditProps ): JSX.Element => {
 	const { context } = props;
-	const selectableItems = context?.woocommerceSelectableItems ?? {};
+	const selectableItems = context?.[ 'woocommerce/selectableItems' ] ?? {};
 	const isLoading = selectableItems.isLoading ?? false;
 	const items = Array.isArray( selectableItems.items )
 		? selectableItems.items

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/edit.tsx
@@ -33,7 +33,7 @@ const Edit = () => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceRemovableItems: {
+						'woocommerce/removableItems': {
 							items: filtersPreview,
 							storeNamespace: 'woocommerce/product-filters',
 						} satisfies RemovableItemsContext,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -211,7 +211,7 @@ const Edit = ( props: EditProps ) => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceSelectableItems: {
+						'woocommerce/selectableItems': {
 							items:
 								attributeOptions.length === 0 && isPreview
 									? attributeOptionsPreview

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"interactivity": true
 	},
-	"usesContext": [ "woocommerceSelectableItems" ],
+	"usesContext": [ "woocommerce/selectableItems" ],
 	"attributes": {
 		"optionElementBorder": {
 			"type": "string",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -49,7 +49,7 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 		customOptionElement,
 		customLabelElement,
 	} = attributes;
-	const selectableItems = context?.woocommerceSelectableItems ?? {};
+	const selectableItems = context?.[ 'woocommerce/selectableItems' ] ?? {};
 	const isLoading = selectableItems.isLoading ?? false;
 	const items = Array.isArray( selectableItems.items )
 		? selectableItems.items

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"interactivity": true
 	},
-	"usesContext": [ "woocommerceSelectableItems", "woocommerce/attributeId" ],
+	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {
 		"chipText": {
 			"type": "string"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -53,7 +53,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 		customSelectedChipBorder,
 	} = attributes;
 	const { isLoading = false, items = [] } =
-		context?.woocommerceSelectableItems ?? {};
+		context?.[ 'woocommerce/selectableItems' ] ?? {};
 
 	const hasColorSwatches = items.some( ( item ) => 'color' in item );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/block.json
@@ -8,7 +8,7 @@
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"ancestor": [ "woocommerce/product-filter-active" ],
-	"usesContext": [ "woocommerceRemovableItems" ],
+	"usesContext": [ "woocommerce/removableItems" ],
 	"supports": {
 		"interactivity": true,
 		"inserter": true

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/edit.tsx
@@ -30,7 +30,7 @@ const Edit = () => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceRangeInput: {
+						'woocommerce/rangeInput': {
 							...getPriceFilterData( data ),
 							isLoading,
 						},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/block.json
@@ -49,7 +49,7 @@
 		}
 	},
 	"ancestor": [ "woocommerce/product-filter-price" ],
-	"usesContext": [ "woocommerceRangeInput" ],
+	"usesContext": [ "woocommerce/rangeInput" ],
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/edit.tsx
@@ -56,7 +56,7 @@ const PriceSliderEdit = ( {
 		customSlider,
 	} = attributes;
 
-	const rangeInput = context.woocommerceRangeInput;
+	const rangeInput = context[ 'woocommerce/rangeInput' ];
 	const { isLoading } = rangeInput ?? {};
 
 	const blockProps = useBlockProps( {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -187,7 +187,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 					>
 						<BlockContextProvider
 							value={ {
-								woocommerceSelectableItems: {
+								'woocommerce/selectableItems': {
 									items: displayedOptions,
 									selectionMode: 'multiple' as const,
 									storeNamespace:

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/block.json
@@ -19,7 +19,7 @@
 		},
 		"interactivity": true
 	},
-	"usesContext": [ "queryId", "woocommerceRemovableItems" ],
+	"usesContext": [ "queryId", "woocommerce/removableItems" ],
 	"attributes": {
 		"chipText": {
 			"type": "string"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/edit.tsx
@@ -44,7 +44,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 	} = props;
 	const { customChipText, customChipBackground, customChipBorder, layout } =
 		attributes;
-	const removableItemsContext = context.woocommerceRemovableItems;
+	const removableItemsContext = context[ 'woocommerce/removableItems' ];
 	const { items } = removableItemsContext ?? {};
 
 	// Extract attributes from block layout

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
@@ -90,7 +90,7 @@ const Edit = ( props: EditProps ) => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceSelectableItems: {
+						'woocommerce/selectableItems': {
 							items,
 							selectionMode: 'multiple' as const,
 							storeNamespace: 'woocommerce/product-filters',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -310,7 +310,7 @@ const Edit = ( props: EditProps ) => {
 			<InitialDisabled>
 				<BlockContextProvider
 					value={ {
-						woocommerceSelectableItems: {
+						'woocommerce/selectableItems': {
 							items:
 								termOptions.length === 0 && isPreview
 									? termOptionsPreview

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/range-input.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/range-input.ts
@@ -14,7 +14,8 @@ export interface RangeInputContext {
 }
 
 export type RangeInputBlockContext = {
-	woocommerceRangeInput: RangeInputContext;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'woocommerce/rangeInput': RangeInputContext;
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/removable-items.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/removable-items.ts
@@ -11,7 +11,8 @@ export interface RemovableItemsContext {
 }
 
 export type RemovableItemsBlockContext = {
-	woocommerceRemovableItems: RemovableItemsContext;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'woocommerce/removableItems': RemovableItemsContext;
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/selectable-items.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/selectable-items.ts
@@ -30,7 +30,8 @@ export interface SelectableItemsContext< T = unknown > {
 }
 
 export type SelectableItemsBlockContext< T = unknown > = {
-	woocommerceSelectableItems: SelectableItemsContext< T >;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'woocommerce/selectableItems': SelectableItemsContext< T >;
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
@@ -8,9 +8,9 @@ This document defines the **context protocol pattern** used by WooCommerce block
 
 | Context Key | Purpose | Inner Blocks |
 | --- | --- | --- |
-| `woocommerceSelectableItems` | Select/deselect items (filters, variation attributes) | checkbox-list, chips, dropdown |
-| `woocommerceRemovableItems` | Remove individual items (active filters) | removable-chips |
-| `woocommerceRangeInput` | Numeric range input (price, slider) | price-slider |
+| `woocommerce/selectableItems` | Select/deselect items (filters, variation attributes) | checkbox-list, chips, dropdown |
+| `woocommerce/removableItems` | Remove individual items (active filters) | removable-chips |
+| `woocommerce/rangeInput` | Numeric range input (price, slider) | price-slider |
 
 Each protocol follows the same pattern — only item shape and action names differ.
 
@@ -45,7 +45,7 @@ Inner blocks become **presentational** — they read a standardized context prot
 
 All three protocols follow these rules:
 
-- **Context key** prefixed with `woocommerce` (e.g. `woocommerceSelectableItems`)
+- **Context key** prefixed with `woocommerce` (e.g. `woocommerce/selectableItems`)
 - **`storeNamespace`** field on every context object — tells inner block which parent store to resolve `actions.*` / `state.*` against
 - **Fixed action & getter names** (not configurable via context fields) — inner blocks hardcode them
 - **TS contract interface** (`*ParentStore`) — parents assert conformance via `satisfies`
@@ -74,7 +74,7 @@ Missing method/getter → compile error. No runtime cost.
 ### Context Key
 
 ```text
-woocommerceSelectableItems
+woocommerce/selectableItems
 ```
 
 Items are dynamic (computed at render time from database queries), so parent blocks do **not** use `providesContext` in block.json. Instead, they pass context directly when rendering inner blocks:
@@ -82,14 +82,14 @@ Items are dynamic (computed at render time from database queries), so parent blo
 ```php
 // Parent block render():
 ( new \WP_Block( $parsed_block, array(
-    'woocommerceSelectableItems' => $context,
+    'woocommerce/selectableItems' => $context,
 ) ) )->render();
 ```
 
 In the editor, parent blocks use `BlockContextProvider` to pass the same data:
 
 ```jsx
-<BlockContextProvider value={ { 'woocommerceSelectableItems': context } }>
+<BlockContextProvider value={ { 'woocommerce/selectableItems': context } }>
     { children }
 </BlockContextProvider>
 ```
@@ -101,7 +101,7 @@ Inner blocks declare the context key they consume via `usesContext`, and which p
 ```json
 {
   "name": "woocommerce/product-filter-checkbox-list",
-  "usesContext": ["woocommerceSelectableItems"],
+  "usesContext": ["woocommerce/selectableItems"],
   "ancestor": [
     "woocommerce/product-filter-attribute",
     "woocommerce/product-filter-status",
@@ -111,7 +111,7 @@ Inner blocks declare the context key they consume via `usesContext`, and which p
 }
 ```
 
-Inner blocks receive the protocol data through `$block->context['woocommerceSelectableItems']` in PHP.
+Inner blocks receive the protocol data through `$block->context['woocommerce/selectableItems']` in PHP.
 
 ### SelectableItemsContext
 
@@ -283,7 +283,7 @@ export interface SelectableItemsContext< T = unknown > {
 }
 
 export type SelectableItemsBlockContext< T = unknown > = {
-	'woocommerceSelectableItems': SelectableItemsContext< T >;
+	'woocommerce/selectableItems': SelectableItemsContext< T >;
 };
 
 export interface SelectableItemsParentStore< T = unknown > {
@@ -339,7 +339,7 @@ class ProductFilterAttribute extends AbstractBlock {
             'groupLabel'     => $attributes['label'] ?? '',
         ];
 
-        $block->context['woocommerceSelectableItems'] = $context;
+        $block->context['woocommerce/selectableItems'] = $context;
 
         return sprintf(
             '<div %s>%s</div>',
@@ -410,7 +410,7 @@ block.json:
 ```json
 {
   "name": "woocommerce/product-filter-checkbox-list",
-  "usesContext": ["woocommerceSelectableItems"],
+  "usesContext": ["woocommerce/selectableItems"],
   "supports": {
     "interactivity": true
   }
@@ -516,11 +516,11 @@ const { state } = store( 'woocommerce/product-filter-checkbox-list', {
 
 ```php
 protected function render( $attributes, $content, $block ) {
-    if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+    if ( empty( $block->context['woocommerce/selectableItems'] ) ) {
         return '';
     }
 
-    $block_context   = $block->context['woocommerceSelectableItems'];
+    $block_context   = $block->context['woocommerce/selectableItems'];
     $items           = $block_context['items'] ?? array();
     $store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
     $display_limit   = 15;
@@ -618,7 +618,7 @@ class ProductFilterAttribute extends AbstractBlock {
         ];
 
         // Provide context to inner blocks
-        $block->context['woocommerceSelectableItems'] = $selectable_context;
+        $block->context['woocommerce/selectableItems'] = $selectable_context;
 
         // Render inner blocks
         return sprintf(
@@ -636,7 +636,7 @@ class ProductFilterAttribute extends AbstractBlock {
 
 ## Protocol: Removable Items
 
-Context key: `woocommerceRemovableItems`
+Context key: `woocommerce/removableItems`
 
 Used for lists of items that can be removed individually (active filter chips) with a "clear all" control.
 
@@ -689,7 +689,7 @@ Reference implementation: `ProductFilterRemovableChips.php`, `ProductFilterClear
 
 ## Protocol: Range Input
 
-Context key: `woocommerceRangeInput`
+Context key: `woocommerce/rangeInput`
 
 Used for two-ended numeric range controls (price slider, generic range).
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -81,10 +81,10 @@ class VariationSelectorAttribute extends AbstractBlock {
 		$attribute_label  = wc_attribute_label( $attribute_name );
 		$attribute_id     = 'wc_product_attribute_' . uniqid();
 		$context          = array(
-			'woocommerce/attributeId'    => $attribute_id,
-			'woocommerce/attributeName'  => $attribute_name,
-			'woocommerce/attributeTerms' => $attribute_terms,
-			'woocommerceSelectableItems' => array(
+			'woocommerce/attributeId'     => $attribute_id,
+			'woocommerce/attributeName'   => $attribute_name,
+			'woocommerce/attributeTerms'  => $attribute_terms,
+			'woocommerce/selectableItems' => array(
 				'items'          => $variation_items,
 				'selectionMode'  => 'single',
 				'storeNamespace' => 'woocommerce/add-to-cart-with-options',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Dropdown.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Dropdown.php
@@ -42,11 +42,11 @@ final class Dropdown extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+		if ( empty( $block->context['woocommerce/selectableItems'] ) ) {
 			return '';
 		}
 
-		$selectable_items = $block->context['woocommerceSelectableItems'];
+		$selectable_items = $block->context['woocommerce/selectableItems'];
 		$items            = is_array( $selectable_items['items'] ?? null ) ? $selectable_items['items'] : array();
 		$store_namespace  = is_string( $selectable_items['storeNamespace'] ?? null ) ? $selectable_items['storeNamespace'] : 'woocommerce/add-to-cart-with-options';
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
@@ -100,7 +100,7 @@ final class ProductFilterActive extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceRemovableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/removableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -298,7 +298,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceSelectableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/selectableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -33,11 +33,11 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+		if ( empty( $block->context['woocommerce/selectableItems'] ) ) {
 			return '';
 		}
 
-		$block_context   = $block->context['woocommerceSelectableItems'];
+		$block_context   = $block->context['woocommerce/selectableItems'];
 		$items           = is_array( $block_context['items'] ?? null ) ? $block_context['items'] : array();
 		$store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
 		$filter_type     = $block_context['filterType'] ?? '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -26,11 +26,11 @@ final class ProductFilterChips extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( empty( $block->context['woocommerceSelectableItems'] ) ) {
+		if ( empty( $block->context['woocommerce/selectableItems'] ) ) {
 			return '';
 		}
 
-		$block_context   = $block->context['woocommerceSelectableItems'];
+		$block_context   = $block->context['woocommerce/selectableItems'];
 		$items           = is_array( $block_context['items'] ?? null ) ? $block_context['items'] : array();
 		$store_namespace = $block_context['storeNamespace'] ?? 'woocommerce/product-filters';
 		$display_limit   = 'woocommerce/product-filters' === $store_namespace ? 15 : 30;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
@@ -37,7 +37,7 @@ final class ProductFilterClearButton extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 		// don't render if its admin, or ajax in progress.
-		$removable_context = $block->context['woocommerceRemovableItems'] ?? null;
+		$removable_context = $block->context['woocommerce/removableItems'] ?? null;
 		if (
 			is_admin() ||
 			wp_doing_ajax() ||

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -178,7 +178,7 @@ final class ProductFilterPrice extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceRangeInput' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/rangeInput' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPriceSlider.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPriceSlider.php
@@ -32,11 +32,11 @@ class ProductFilterPriceSlider extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( is_admin() || wp_doing_ajax() || empty( $block->context['woocommerceRangeInput'] ) ) {
+		if ( is_admin() || wp_doing_ajax() || empty( $block->context['woocommerce/rangeInput'] ) ) {
 			return '';
 		}
 
-		$range_data = $block->context['woocommerceRangeInput'];
+		$range_data = $block->context['woocommerce/rangeInput'];
 		$min_range  = $range_data['min'] ?? 0;
 		$max_range  = $range_data['max'] ?? 0;
 		$min_price  = $range_data['currentMin'] ?? $min_range;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -162,7 +162,7 @@ final class ProductFilterRating extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceSelectableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/selectableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRemovableChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRemovableChips.php
@@ -73,9 +73,12 @@ final class ProductFilterRemovableChips extends AbstractBlock {
 				</template>
 				<?php foreach ( $filter_items as $item ) : ?>
 					<?php
-					// translators: %s: item label.
+					$remove_label = sprintf(
+						/* translators: %s: item label. */
+						__( 'Remove filter: %s', 'woocommerce' ),
+						$item['label']
+					);
 					?>
-					<?php $remove_label = sprintf( __( 'Remove filter: %s', 'woocommerce' ), $item['label'] ); ?>
 					<li class="wc-block-product-filter-removable-chips__item" data-wp-each-child
 						<?php echo wp_interactivity_data_wp_context( array( 'item' => $item ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRemovableChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRemovableChips.php
@@ -27,12 +27,12 @@ final class ProductFilterRemovableChips extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 		if (
-			empty( $block->context['woocommerceRemovableItems'] )
+			empty( $block->context['woocommerce/removableItems'] )
 		) {
 			return '';
 		}
 
-		$filter_items = $block->context['woocommerceRemovableItems']['items'] ?? array();
+		$filter_items = $block->context['woocommerce/removableItems']['items'] ?? array();
 
 		$style = '';
 
@@ -72,7 +72,9 @@ final class ProductFilterRemovableChips extends AbstractBlock {
 					</li>
 				</template>
 				<?php foreach ( $filter_items as $item ) : ?>
-					<?php // translators: %s: item label. ?>
+					<?php
+					// translators: %s: item label.
+					?>
 					<?php $remove_label = sprintf( __( 'Remove filter: %s', 'woocommerce' ), $item['label'] ); ?>
 					<li class="wc-block-product-filter-removable-chips__item" data-wp-each-child
 						<?php echo wp_interactivity_data_wp_context( array( 'item' => $item ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -164,7 +164,7 @@ final class ProductFilterStatus extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceSelectableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/selectableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -301,7 +301,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerceSelectableItems' => $filter_context ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'woocommerce/selectableItems' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Built on top of https://github.com/woocommerce/woocommerce/pull/65144.

This PR updates several context keys to use the format `woocommerce/xyz` instead of `woocommerceXyz`, to keep consistency with other existing context keys we had in _Add to Cart + Options_.

### How to test the changes in this Pull Request:

1. Simply smoke test Add to Cart + Options and Product Filter blocks a bit.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->