### PR TITLE
Fix empty product list filters

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-rsm-3550-empty-filters
+++ b/packages/js/experimental-products-app/changelog/fix-rsm-3550-empty-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ignore empty product list filters until a value is selected.

--- a/packages/js/experimental-products-app/src/product-list/query.test.ts
+++ b/packages/js/experimental-products-app/src/product-list/query.test.ts
@@ -159,6 +159,33 @@ describe( 'buildProductListQuery', () => {
 		expect( query.stock_status ).toBe( 'onbackorder' );
 	} );
 
+	it( 'ignores empty taxonomy filters until a value is selected', () => {
+		const query = buildProductListQuery( {
+			...baseView,
+			filters: [
+				{
+					field: 'brands',
+					operator: 'isAny',
+					value: undefined,
+				},
+				{
+					field: 'categories',
+					operator: 'isAny',
+					value: '',
+				},
+				{
+					field: 'tags',
+					operator: 'isAny',
+					value: [],
+				},
+			],
+		} as View );
+
+		expect( query.brand ).toBeUndefined();
+		expect( query.category ).toBeUndefined();
+		expect( query.tag ).toBeUndefined();
+	} );
+
 	it( 'maps the tags isAny filter to the tag query param', () => {
 		const query = buildProductListQuery( {
 			...baseView,

--- a/packages/js/experimental-products-app/src/product-list/query.ts
+++ b/packages/js/experimental-products-app/src/product-list/query.ts
@@ -45,15 +45,17 @@ function getStringValues( value: unknown ): string[] {
 
 function getNumericValues( value: unknown ): number[] {
 	const values = Array.isArray( value ) ? value : [ value ];
-	return values.map( ( item ) => {
-		if ( typeof item === 'number' ) {
-			return item;
-		}
-		if ( typeof item === 'string' ) {
-			return Number( item );
-		}
-		return Number.NaN;
-	} );
+	return values
+		.map( ( item ) => {
+			if ( typeof item === 'number' ) {
+				return item;
+			}
+			if ( typeof item === 'string' && item.trim() !== '' ) {
+				return Number( item );
+			}
+			return Number.NaN;
+		} )
+		.filter( Number.isFinite );
 }
 
 function getPriceValue( value: unknown ): string | undefined {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Selecting an empty taxonomy filter in the experimental products app should keep showing the full product list until the merchant chooses a value. This updates product list query building so empty or non-numeric taxonomy filter values are ignored instead of being sent as invalid IDs such as `NaN`.

### How to test the changes in this Pull Request:

1. Enable the experimental products app.
2. Go to the experimental products list.
3. Add the Brands, Category, or Tags filter without selecting a value.
4. Confirm the product list still shows the unfiltered products.
5. Select a taxonomy value and confirm the product list filters to matching products.

### Testing that has already taken place:

-   Ran `pnpm --filter=@woocommerce/experimental-products-app test:js -- --runTestsByPath src/product-list/query.test.ts`.
-   Ran `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/product-list/query.ts`.
-   Ran `git diff --check`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was added manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
