### PR TITLE
Allow multiple stock status filters

### DIFF
--- a/packages/js/data/changelog/fix-rsm-3550-stock-status-query-type
+++ b/packages/js/data/changelog/fix-rsm-3550-stock-status-query-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow product queries to type multiple stock statuses.

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -206,7 +206,11 @@ export type ProductQuery<
 	on_sale?: boolean;
 	min_price?: string;
 	max_price?: string;
-	stock_status?: 'instock' | 'outofstock' | 'onbackorder';
+	stock_status?:
+		| 'instock'
+		| 'outofstock'
+		| 'onbackorder'
+		| Array< 'instock' | 'outofstock' | 'onbackorder' >;
 };
 
 export type SuggestedProductOptionsKey = string;

--- a/packages/js/experimental-products-app/changelog/fix-rsm-3550-stock-multiselect
+++ b/packages/js/experimental-products-app/changelog/fix-rsm-3550-stock-multiselect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow selecting multiple stock statuses in product list filters.

--- a/packages/js/experimental-products-app/src/fields/stock/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/stock/field.tsx
@@ -32,7 +32,7 @@ const fieldDefinition = {
 	enableSorting: false,
 	enableHiding: false,
 	filterBy: {
-		operators: [ 'is' ],
+		operators: [ 'isAny' ],
 	},
 	elements: [
 		{ label: __( 'In stock', 'woocommerce' ), value: 'instock' },

--- a/packages/js/experimental-products-app/src/product-list/query.test.ts
+++ b/packages/js/experimental-products-app/src/product-list/query.test.ts
@@ -159,6 +159,36 @@ describe( 'buildProductListQuery', () => {
 		expect( query.stock_status ).toBe( 'onbackorder' );
 	} );
 
+	it( 'maps stock filters from multiple selected stock statuses', () => {
+		const query = buildProductListQuery( {
+			...baseView,
+			filters: [
+				{
+					field: 'stock',
+					operator: 'isAny',
+					value: [ 'instock', 'onbackorder' ],
+				},
+			],
+		} as View );
+
+		expect( query.stock_status ).toEqual( [ 'instock', 'onbackorder' ] );
+	} );
+
+	it( 'ignores empty stock filters until a value is selected', () => {
+		const query = buildProductListQuery( {
+			...baseView,
+			filters: [
+				{
+					field: 'stock',
+					operator: 'isAny',
+					value: [],
+				},
+			],
+		} as View );
+
+		expect( query.stock_status ).toBeUndefined();
+	} );
+
 	it( 'maps the tags isAny filter to the tag query param', () => {
 		const query = buildProductListQuery( {
 			...baseView,

--- a/packages/js/experimental-products-app/src/product-list/query.ts
+++ b/packages/js/experimental-products-app/src/product-list/query.ts
@@ -8,8 +8,14 @@ import type {
 	ProductType,
 } from '@woocommerce/data';
 
-export type ProductListQuery = Omit< ProductQuery, 'status' > & {
+type ProductStockStatus = 'instock' | 'outofstock' | 'onbackorder';
+
+export type ProductListQuery = Omit<
+	ProductQuery,
+	'status' | 'stock_status'
+> & {
 	status?: ProductStatus | ProductStatus[];
+	stock_status?: ProductStockStatus | ProductStockStatus[];
 	_embed?: number;
 	search_name_or_sku?: string;
 	exclude_status?: ProductStatus[];
@@ -139,10 +145,13 @@ function applyBrandFilter( query: ProductListQuery, filter: Filter ) {
 }
 
 function applyStockFilter( query: ProductListQuery, filter: Filter ) {
-	const [ stockStatus ] = getStringValues( filter.value );
+	const stockStatuses = getStringValues(
+		filter.value
+	) as ProductStockStatus[];
 
-	if ( stockStatus ) {
-		query.stock_status = stockStatus as ProductListQuery[ 'stock_status' ];
+	if ( stockStatuses.length > 0 ) {
+		query.stock_status =
+			stockStatuses.length === 1 ? stockStatuses[ 0 ] : stockStatuses;
 	}
 }
 

--- a/plugins/woocommerce/changelog/fix-rsm-3550-stock-status-filter
+++ b/plugins/woocommerce/changelog/fix-rsm-3550-stock-status-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow the v4 products endpoint to filter by multiple stock statuses.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -535,8 +535,9 @@ class Controller extends WC_REST_Products_V2_Controller {
 			$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				$args,
 				array(
-					'key'   => '_stock_status',
-					'value' => $request['stock_status'],
+					'key'     => '_stock_status',
+					'value'   => $request['stock_status'],
+					'compare' => 'IN',
 				)
 			);
 		}
@@ -2083,10 +2084,13 @@ class Controller extends WC_REST_Products_V2_Controller {
 
 		unset( $params['in_stock'] );
 		$params['stock_status'] = array(
-			'description'       => __( 'Limit result set to products with specified stock status.', 'woocommerce' ),
-			'type'              => 'string',
-			'enum'              => array_keys( wc_get_product_stock_status_options() ),
-			'sanitize_callback' => 'sanitize_text_field',
+			'description'       => __( 'Limit result set to products with any of the specified stock statuses.', 'woocommerce' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'string',
+				'enum' => array_keys( wc_get_product_stock_status_options() ),
+			),
+			'sanitize_callback' => 'wp_parse_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -2085,7 +2085,7 @@ class Controller extends WC_REST_Products_V2_Controller {
 		unset( $params['in_stock'] );
 		$params['stock_status'] = array(
 			'description'       => __( 'Limit result set to products with any of the specified stock statuses.', 'woocommerce' ),
-			'type'              => 'array',
+			'type'              => array( 'string', 'array' ),
 			'items'             => array(
 				'type' => 'string',
 				'enum' => array_keys( wc_get_product_stock_status_options() ),

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/README.md
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/README.md
@@ -28,7 +28,7 @@ As discussed in the team conversation:
 
 **Summary**: Updated the collection `stock_status` query parameter to accept an array of stock statuses, enabling clients to request products matching any selected stock status. The endpoint now validates each value against WooCommerce stock status options, sanitizes the parameter with `wp_parse_list`, and applies the filter with an `_stock_status IN (...)` meta query. Single stock status values remain supported through list parsing.
 
-**PR**: TBD
+**PR**: [65155](https://github.com/woocommerce/woocommerce/pull/65155)
 
 **Breaking Changes**: None
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/README.md
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/README.md
@@ -24,6 +24,14 @@ As discussed in the team conversation:
 
 ## Change Log
 
+### 2026-05-19 - Support multiple stock status filters
+
+**Summary**: Updated the collection `stock_status` query parameter to accept an array of stock statuses, enabling clients to request products matching any selected stock status. The endpoint now validates each value against WooCommerce stock status options, sanitizes the parameter with `wp_parse_list`, and applies the filter with an `_stock_status IN (...)` meta query. Single stock status values remain supported through list parsing.
+
+**PR**: TBD
+
+**Breaking Changes**: None
+
 ### 2026-05-05 - Add embedded variation links
 
 **Summary**: Added embeddable `variations` links to variable product responses so child variations can be embedded when requesting products with `_embed=1`. The product schema now exposes the `embed` context for fields that are already available in `view` context, while sensitive fields such as downloads, metadata, purchase notes, and cost of goods sold remain excluded from embedded variation responses.

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
@@ -1191,9 +1191,23 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the `stock_status` parameter filters products by multiple stock statuses.
+	 * @testdox Should accept scalar and array stock status collection filters.
+	 *
+	 * @dataProvider stock_status_filter_query_provider
+	 *
+	 * @param string|array $stock_status_query Query value for the stock_status parameter.
+	 * @param array        $expected_stock_statuses Expected normalized stock status values.
 	 */
-	public function test_collection_filter_with_multiple_stock_statuses() {
+	public function test_collection_filter_with_stock_statuses( $stock_status_query, array $expected_stock_statuses ): void {
+		$normalized_stock_status = null;
+		$capture_stock_status    = static function ( $response, $handler, $request ) use ( &$normalized_stock_status ) {
+			if ( '/wc/v4/products' === $request->get_route() ) {
+				$normalized_stock_status = $request->get_param( 'stock_status' );
+			}
+
+			return $response;
+		};
+
 		$in_stock_product     = WC_Helper_Product::create_simple_product(
 			true,
 			array(
@@ -1216,33 +1230,66 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		);
 
+		$in_stock_product->set_stock_status( ProductStockStatus::IN_STOCK );
+		$in_stock_product->save();
 		$out_of_stock_product->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
 		$out_of_stock_product->save();
 		$backorder_product->set_stock_status( ProductStockStatus::ON_BACKORDER );
 		$backorder_product->save();
 
 		try {
+			add_filter( 'rest_request_before_callbacks', $capture_stock_status, 10, 3 );
+
 			$request = new WP_REST_Request( 'GET', '/wc/v4/products' );
 			$request->set_query_params(
 				array(
 					'search_name_or_sku' => 'stock-filter-target',
-					'stock_status'       => array( ProductStockStatus::OUT_OF_STOCK, ProductStockStatus::ON_BACKORDER ),
+					'stock_status'       => $stock_status_query,
 				)
 			);
 
 			$response = $this->server->dispatch( $request );
 			$this->assertEquals( 200, $response->get_status() );
+			$this->assertEquals( $expected_stock_statuses, $normalized_stock_status, 'Stock status should be normalized to a list.' );
 
 			$product_ids = wp_list_pluck( $response->get_data(), 'id' );
+			$products    = array(
+				ProductStockStatus::IN_STOCK     => $in_stock_product,
+				ProductStockStatus::OUT_OF_STOCK => $out_of_stock_product,
+				ProductStockStatus::ON_BACKORDER => $backorder_product,
+			);
 
-			$this->assertContains( $out_of_stock_product->get_id(), $product_ids );
-			$this->assertContains( $backorder_product->get_id(), $product_ids );
-			$this->assertNotContains( $in_stock_product->get_id(), $product_ids );
+			foreach ( $products as $stock_status => $product ) {
+				if ( in_array( $stock_status, $expected_stock_statuses, true ) ) {
+					$this->assertContains( $product->get_id(), $product_ids );
+				} else {
+					$this->assertNotContains( $product->get_id(), $product_ids );
+				}
+			}
 		} finally {
+			remove_filter( 'rest_request_before_callbacks', $capture_stock_status, 10 );
 			WC_Helper_Product::delete_product( $in_stock_product->get_id() );
 			WC_Helper_Product::delete_product( $out_of_stock_product->get_id() );
 			WC_Helper_Product::delete_product( $backorder_product->get_id() );
 		}
+	}
+
+	/**
+	 * Data provider for stock status collection filters.
+	 *
+	 * @return array
+	 */
+	public function stock_status_filter_query_provider() {
+		return array(
+			'scalar stock status'  => array(
+				ProductStockStatus::IN_STOCK,
+				array( ProductStockStatus::IN_STOCK ),
+			),
+			'array stock statuses' => array(
+				array( ProductStockStatus::OUT_OF_STOCK, ProductStockStatus::ON_BACKORDER ),
+				array( ProductStockStatus::OUT_OF_STOCK, ProductStockStatus::ON_BACKORDER ),
+			),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Tests\Internal\RestApi\Routes\V4\Products;
 
 use Automattic\WooCommerce\Enums\ProductStatus;
+use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Products\Controller as ProductsController;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareUnitTestSuiteTrait;
@@ -1187,6 +1188,61 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 
 		$product_types = wp_list_pluck( $response_products, 'type' );
 		$this->assertEqualsCanonicalizing( array( ProductType::EXTERNAL, ProductType::GROUPED, ProductType::GROUPED ), $product_types );
+	}
+
+	/**
+	 * Test that the `stock_status` parameter filters products by multiple stock statuses.
+	 */
+	public function test_collection_filter_with_multiple_stock_statuses() {
+		$in_stock_product     = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Stock Filter Target In Stock',
+				'sku'  => 'stock-filter-target-in-stock',
+			)
+		);
+		$out_of_stock_product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Stock Filter Target Out Of Stock',
+				'sku'  => 'stock-filter-target-out-of-stock',
+			)
+		);
+		$backorder_product    = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Stock Filter Target Backorder',
+				'sku'  => 'stock-filter-target-backorder',
+			)
+		);
+
+		$out_of_stock_product->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
+		$out_of_stock_product->save();
+		$backorder_product->set_stock_status( ProductStockStatus::ON_BACKORDER );
+		$backorder_product->save();
+
+		try {
+			$request = new WP_REST_Request( 'GET', '/wc/v4/products' );
+			$request->set_query_params(
+				array(
+					'search_name_or_sku' => 'stock-filter-target',
+					'stock_status'       => array( ProductStockStatus::OUT_OF_STOCK, ProductStockStatus::ON_BACKORDER ),
+				)
+			);
+
+			$response = $this->server->dispatch( $request );
+			$this->assertEquals( 200, $response->get_status() );
+
+			$product_ids = wp_list_pluck( $response->get_data(), 'id' );
+
+			$this->assertContains( $out_of_stock_product->get_id(), $product_ids );
+			$this->assertContains( $backorder_product->get_id(), $product_ids );
+			$this->assertNotContains( $in_stock_product->get_id(), $product_ids );
+		} finally {
+			WC_Helper_Product::delete_product( $in_stock_product->get_id() );
+			WC_Helper_Product::delete_product( $out_of_stock_product->get_id() );
+			WC_Helper_Product::delete_product( $backorder_product->get_id() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental products app stock filter needs to support selecting more than one stock status at a time. This changes the app filter to `isAny`, sends multiple stock statuses in product list queries, and updates the v4 Products endpoint so `stock_status` accepts an array and filters with an `_stock_status IN (...)` meta query.



### How to test the changes in this Pull Request:

1. Enable the experimental products app and the REST API v4 feature flag.
2. Create or identify products across at least two stock statuses, such as In stock and On backorder.
3. Go to the experimental products list and add the Stock filter.
4. Select multiple stock statuses.
5. Confirm products matching any selected stock status are shown.
6. Confirm `/wp-json/wc/v4/products?stock_status[]=instock&stock_status[]=onbackorder` returns products from both statuses.

### Testing that has already taken place:

-   Ran `pnpm --filter=@woocommerce/experimental-products-app test:js -- --runTestsByPath src/product-list/query.test.ts`.
-   Ran `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/product-list/query.ts src/fields/stock/field.tsx`.
-   Ran `pnpm --filter=@woocommerce/data exec eslint src/products/types.ts`.
-   Ran `php -l plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php`.
-   Ran `php -l plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php`.
-   Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`.
-   Ran `composer exec -- phpstan analyse src/Internal/RestApi/Routes/V4/Products/Controller.php --memory-limit=2G`.
-   Could not run the focused PHP unit test locally because Docker/OrbStack is not running.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entries were added manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
