### PR TITLE
Add price range filter spacing

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-rsm-3550-price-range-spacing
+++ b/packages/js/experimental-products-app/changelog/fix-rsm-3550-price-range-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add spacing between product list price range filter fields.

--- a/packages/js/experimental-products-app/src/fields/price/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/price/field.tsx
@@ -144,7 +144,7 @@ export const fieldExtensions: Partial< Field< PriceFilterData > > = {
 
 		if ( operator === 'between' ) {
 			return (
-				<Stack direction="row">
+				<Stack direction="row" gap="sm">
 					<InputControl
 						label={ __( 'From', 'woocommerce' ) }
 						type="number"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Price filter's Between operator rendered the From and To fields too tightly together. This adds the standard small gap between the two controls so the filter fields match nearby spacing patterns.


### How to test the changes in this Pull Request:

1. Enable the experimental products app.
2. Go to the experimental products list.
3. Add the Price filter.
4. Choose the Between operator.
5. Confirm the From and To fields have visible spacing between them.

### Testing that has already taken place:

-   Ran `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/fields/price/field.tsx`.
-   Ran `git diff --check`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was added manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
