### PR TITLE
internal-style-build: alias WordPress-defaults SCSS vars to @wordpress/base-styles

### DIFF
--- a/packages/js/internal-style-build/abstracts/_variables.scss
+++ b/packages/js/internal-style-build/abstracts/_variables.scss
@@ -53,11 +53,12 @@ $alert-red: $error-red;
 $alert-yellow: $notice-yellow;
 $alert-green: $valid-green;
 
-// WordPress defaults
-$adminbar-height: 32px;
-$adminbar-height-mobile: 46px;
-$admin-menu-width: 160px;
-$admin-menu-width-collapsed: 36px;
+// WordPress defaults — aliased from @wordpress/base-styles/variables (already
+// imported above) so these track Core automatically if the upstream values change.
+$adminbar-height: $admin-bar-height;
+$adminbar-height-mobile: $admin-bar-height-big;
+$admin-menu-width: $admin-sidebar-width;
+$admin-menu-width-collapsed: $admin-sidebar-width-collapsed;
 
 // wp-admin colors. Hardcoded because WordPress doesn't expose them as CSS
 // custom properties on `:root` (verified via the `wp-token-check` skill).

--- a/packages/js/internal-style-build/changelog/sprinkle-adminbar-height-from-base-styles
+++ b/packages/js/internal-style-build/changelog/sprinkle-adminbar-height-from-base-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Alias the four WordPress-defaults SCSS variables ($adminbar-height, $adminbar-height-mobile, $admin-menu-width, $admin-menu-width-collapsed) to their @wordpress/base-styles equivalents instead of hardcoding raw px values, so they track Core automatically.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

A small follow-up to #64885, spotted while writing a P2 about the floating-header token-alignment work.

`packages/js/internal-style-build/abstracts/_variables.scss` already imports `@wordpress/base-styles/variables.scss` on line 5. That file exports four variables that match the values in Woo's own "WordPress defaults" section — but under slightly different names. The Woo-local definitions were hardcoding raw `px` values instead of referencing Core directly.

**Before:**
```scss
// WordPress defaults
$adminbar-height: 32px;
$adminbar-height-mobile: 46px;
$admin-menu-width: 160px;
$admin-menu-width-collapsed: 36px;
```

**After:**
```scss
// WordPress defaults — aliased from @wordpress/base-styles/variables
$adminbar-height: $admin-bar-height;
$adminbar-height-mobile: $admin-bar-height-big;
$admin-menu-width: $admin-sidebar-width;
$admin-menu-width-collapsed: $admin-sidebar-width-collapsed;
```

No callsite changes — Woo's variable names are preserved. No new imports — base-styles is already in scope. If Core ever adjusts these values, Woo follows automatically.

### How to test:

Build the admin client (`pnpm build` in `plugins/woocommerce/client/admin`) and verify the compiled CSS is unchanged — the four aliased values resolve to the same px values as before.

### Changelog

- `packages/js/internal-style-build`: patch tweak, alias WordPress-defaults vars to `@wordpress/base-styles` equivalents