### PR TITLE
Fix schedule-sale end date input bleeding past the drawer padding

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-app-schedule-sale-date-row-overflow
+++ b/packages/js/experimental-products-app/changelog/fix-products-app-schedule-sale-date-row-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop the schedule-sale end date input from bleeding past the drawer's right padding in the experimental products app by letting row-layout fields shrink inside their flex container.

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -164,6 +164,15 @@
 	.dataforms-layouts__wrapper + .dataforms-layouts-regular__header {
 		margin-top: 32px;
 	}
+
+	// Allow row layout children (e.g. start/end sale dates) to shrink
+	// inside their flex container. Without this, the inputs' intrinsic
+	// min-width keeps them from fitting two-up in the drawer, and the
+	// second column bleeds past the right padding.
+	.dataforms-layouts-row__field-control {
+		min-width: 0;
+		flex: 1 1 0;
+	}
 }
 
 .woocommerce-product-edit__footer {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When the **Schedule sale** toggle is on in the experimental products app drawer, the **Start sale on** and **End sale on** date pickers are rendered in a DataForm `row` layout. Each child gets `width: 100%`, but the wrapper is a flex row with default `min-width: auto`, so the inputs' intrinsic min-width (from the `datetime-local` placeholder) prevents them from shrinking — the second column extends past the drawer's right padding.

This PR adds two flex hints to the row-layout children inside `.woocommerce-product-edit__form`:

- `min-width: 0` so flex children can shrink below their intrinsic content width.
- `flex: 1 1 0` so the two date inputs share the row equally instead of inheriting an auto basis.

Scoped to the product edit form so other dataform row layouts (if any are added later) aren't affected unless they live in the same drawer.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <!-- end date input bleeds past the drawer's right padding --> | <!-- both date inputs fit within the drawer with equal width --> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open **Products → All Products ( new )**.
2. Open Quick edit on a product with a regular price.
3. Toggle **Schedule sale** on. The **Start sale on** / **End sale on** date pickers appear.
4. Confirm both inputs sit side-by-side within the drawer, sharing the width equally, and neither extends past the drawer's right padding.
5. Resize the drawer narrower (if applicable) and confirm both inputs continue to shrink together without overflow.
6. Toggle the schedule sale off and on a few times — no layout shift on the surrounding fields.

### Testing that has already taken place:

Local visual check at the default drawer width.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under `packages/js/experimental-products-app/changelog/fix-products-app-schedule-sale-date-row-overflow`.

</details>