### PR TITLE
Fix variation quick edit crashes and save errors in experimental products app

### DIFF
--- a/packages/js/experimental-products-app/src/product-edit/save.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/save.test.ts
@@ -189,6 +189,59 @@ describe( 'saveSelectedProducts', () => {
 		expect( request.data.images ).toBeUndefined();
 	} );
 
+	it( 'omits variation cost of goods when the defined value is null', async () => {
+		const editedVariation = buildVariation( {
+			id: 101,
+			cost_of_goods_sold: {
+				values: [
+					{
+						defined_value: null,
+						effective_value: '5.00',
+					},
+				],
+			},
+		} );
+		const editedParent = buildProduct( {
+			id: 10,
+			type: 'variable',
+			_embedded: {
+				variations: [ editedVariation ],
+			},
+		} );
+		const editEntityRecord = jest.fn(
+			(
+				_kind,
+				_name,
+				_recordId,
+				edits: Partial< ProductEntityRecord >
+			) => {
+				Object.assign( editedParent, edits );
+			}
+		);
+		const saveEditedEntityRecord = jest.fn( async () => editedParent );
+
+		mockGetEditedEntityRecord.mockImplementation( ( _kind, _name, id ) =>
+			id === editedParent.id ? editedParent : undefined
+		);
+		( apiFetch as unknown as jest.Mock ).mockResolvedValueOnce( {
+			id: 101,
+			parent_id: 10,
+			name: 'Blue saved',
+			manage_stock: false,
+		} );
+
+		await saveSelectedProducts( {
+			selectedProducts: [ editedVariation ],
+			editEntityRecord,
+			saveEditedEntityRecord,
+		} );
+
+		const request = ( apiFetch as unknown as jest.Mock ).mock
+			.calls[ 0 ][ 0 ];
+
+		expect( request.data.cost_of_goods_sold ).toBeUndefined();
+	} );
+
 	it( 'keeps edits for selected variations that failed after another variation saved', async () => {
 		const originalSavedVariation = buildVariation( {
 			id: 101,

--- a/packages/js/experimental-products-app/src/product-edit/save.ts
+++ b/packages/js/experimental-products-app/src/product-edit/save.ts
@@ -82,6 +82,21 @@ function getVariationSaveData(
 	};
 }
 
+function sanitizeVariationForSave(
+	variation: ProductEntityRecord
+): ProductEntityRecord {
+	const data = { ...variation } as Record< string, unknown >;
+	// The REST API rejects cost_of_goods_sold when defined_value is null.
+	// Omit the field so the server retains its existing value.
+	const cogs = data.cost_of_goods_sold as
+		| { values?: Array< { defined_value: unknown } > }
+		| undefined;
+	if ( cogs?.values?.some( ( v ) => v.defined_value === null ) ) {
+		delete data.cost_of_goods_sold;
+	}
+	return data as ProductEntityRecord;
+}
+
 async function saveVariation(
 	product: ProductVariationEntityRecord,
 	editEntityRecord: EditProductRecord
@@ -94,7 +109,7 @@ async function saveVariation(
 	const savedVariation = await apiFetch< ProductVariation >( {
 		path: getProductVariationUpdatePath( product ),
 		method: 'PUT',
-		data: getVariationSaveData( editedVariation ),
+		data: getVariationSaveData( sanitizeVariationForSave( editedVariation ) ),
 	} );
 
 	if ( parentProduct ) {

--- a/packages/js/experimental-products-app/src/product-edit/save.ts
+++ b/packages/js/experimental-products-app/src/product-edit/save.ts
@@ -74,27 +74,18 @@ function getVariationImageSaveData(
 function getVariationSaveData(
 	variation: ProductEntityRecord
 ): ProductVariationSaveData {
-	const { images, ...data } = variation;
+	const { images, cost_of_goods_sold: costOfGoodsSold, ...data } = variation;
+	const hasNullCostOfGoodsSoldValue = costOfGoodsSold?.values?.some(
+		( value ) => value.defined_value === null
+	);
 
 	return {
 		...data,
+		...( ! hasNullCostOfGoodsSoldValue && costOfGoodsSold !== undefined
+			? { cost_of_goods_sold: costOfGoodsSold }
+			: {} ),
 		image: getVariationImageSaveData( images?.[ 0 ] ),
 	};
-}
-
-function sanitizeVariationForSave(
-	variation: ProductEntityRecord
-): ProductEntityRecord {
-	const data = { ...variation } as Record< string, unknown >;
-	// The REST API rejects cost_of_goods_sold when defined_value is null.
-	// Omit the field so the server retains its existing value.
-	const cogs = data.cost_of_goods_sold as
-		| { values?: Array< { defined_value: unknown } > }
-		| undefined;
-	if ( cogs?.values?.some( ( v ) => v.defined_value === null ) ) {
-		delete data.cost_of_goods_sold;
-	}
-	return data as ProductEntityRecord;
 }
 
 async function saveVariation(
@@ -109,7 +100,7 @@ async function saveVariation(
 	const savedVariation = await apiFetch< ProductVariation >( {
 		path: getProductVariationUpdatePath( product ),
 		method: 'PUT',
-		data: getVariationSaveData( sanitizeVariationForSave( editedVariation ) ),
+		data: getVariationSaveData( editedVariation ),
 	} );
 
 	if ( parentProduct ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there are not other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes three bugs in the experimental products app variations quick edit:

1. **Shipping-class crash** — blank screen when the shipping-class store is not yet registered; added a safe `store?.getProductShippingClasses?.()` guard.
2. **Save 400 error** — variation save fails with a 400 when `cost_of_goods_sold` has a null `defined_value`; added `sanitizeVariationForSave` to strip the field before the PUT request.
3. **Edit action wrong post ID** — the Edit action for variations was navigating to the variation post ID instead of the parent product; trunk's `getProductEditPostId` helper already handles this correctly.

### Screenshots or screen recordings:

N/A — bug fixes with no visual changes.

### How to test the changes in this Pull Request:

**Prerequisites:**

- Enable the **Product Variations Classic Redesign** beta feature flag (`product-variations-classic-redesign`).

**Bug fix 1 — Shipping-class crash:**

1. Open a variable product in the classic product editor and navigate to the **Variations** tab.
2. Confirm the tab loads without a blank screen error.

**Bug fix 2 — Save 400 error:**

3. Quick-edit a variation on a product that has cost of goods sold enabled.
4. Save — confirm the save completes without a 400 error.

**Bug fix 3 — Edit action post ID:**

5. In the All Products view, expand a variable product row.
6. Click **Edit** on a variation — confirm it navigates to the parent product editor, not an error page.

### Testing that has already taken place:

Manual testing in wp-env with the `product-variations-classic-redesign` flag enabled.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Internal beta feature behind the `product-variations-classic-redesign` flag. No changelog entry needed.

</details>