### PR TITLE
TypeError in wc_modify_map_meta_cap() on PHP 8+ when \$args[0] is not…

### DIFF
--- a/plugins/woocommerce/changelog/wc-modify-map-meta-cap-php8-type-error-changelog
+++ b/plugins/woocommerce/changelog/wc-modify-map-meta-cap-php8-type-error-changelog
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent fatal TypeError in `wc_modify_map_meta_cap()` on PHP 8+
+Prevent fatal TypeError in wc_modify_map_meta_cap() on PHP 8+ when a capability check is passed an invalid user ID.

--- a/plugins/woocommerce/changelog/wc-modify-map-meta-cap-php8-type-error-changelog
+++ b/plugins/woocommerce/changelog/wc-modify-map-meta-cap-php8-type-error-changelog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal TypeError in `wc_modify_map_meta_cap()` on PHP 8+

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -747,7 +747,7 @@ function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
 					// Shop managers can only edit customer info.
 					$userdata                    = get_userdata( $args[0] );
 					$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					if ( $userdata instanceof WP_User && property_exists( $userdata, 'roles' ) && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {
+					if ( $userdata instanceof WP_User && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {
 						$caps[] = 'do_not_allow';
 					}
 				}

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -747,7 +747,7 @@ function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
 					// Shop managers can only edit customer info.
 					$userdata                    = get_userdata( $args[0] );
 					$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					if ( property_exists( $userdata, 'roles' ) && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {
+					if ( $userdata instanceof WP_User && property_exists( $userdata, 'roles' ) && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {
 						$caps[] = 'do_not_allow';
 					}
 				}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -36682,12 +36682,6 @@ parameters:
 			path: includes/wc-user-functions.php
 
 		-
-			message: '#^Parameter \#1 \$object_or_class of function property_exists expects object\|string, WP_User\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/wc-user-functions.php
-
-		-
 			message: '#^Parameter \#1 \$user of function user_can expects int\|WP_User, WP_User\|false given\.$#'
 			identifier: argument.type
 			count: 2

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-user-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-user-functions.php
@@ -130,6 +130,41 @@ class WC_Tests_User_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that wc_modify_map_meta_cap handles invalid user IDs without fataling.
+	 *
+	 * Regression test: on PHP 8+, get_userdata( 0 ) returns false and the
+	 * subsequent property_exists() call would fatal with a TypeError. The
+	 * function should silently no-op when the target user is invalid rather
+	 * than appending do_not_allow.
+	 */
+	public function test_wc_modify_map_meta_cap_invalid_user_id() {
+		$password = wp_generate_password();
+
+		$manager_id = wp_insert_user(
+			array(
+				'user_login' => 'test_manager_invalid',
+				'user_pass'  => $password,
+				'user_email' => 'manager_invalid@example.com',
+				'role'       => 'shop_manager',
+			)
+		);
+
+		wp_set_current_user( $manager_id );
+
+		// User ID 0 — get_userdata( 0 ) returns false.
+		$caps = map_meta_cap( 'edit_user', $manager_id, 0 );
+		$this->assertNotContains( 'do_not_allow', $caps );
+
+		// Non-existent user ID — get_userdata() also returns false.
+		$caps = map_meta_cap( 'edit_user', $manager_id, PHP_INT_MAX );
+		$this->assertNotContains( 'do_not_allow', $caps );
+
+		// Repeat with delete_user for switch-case breadth.
+		$caps = map_meta_cap( 'delete_user', $manager_id, 0 );
+		$this->assertNotContains( 'do_not_allow', $caps );
+	}
+
+	/**
 	 * Test wc_shop_manager_has_capability function.
 	 *
 	 * @since 3.5.4


### PR DESCRIPTION
## What is the problem?

```wc_modify_map_meta_cap()``` calls ```property_exists( $userdata, 'roles' )``` 
where ```$userdata``` can be ```false``` — returned by ```get_userdata()``` when 
```$args[0]``` is not a valid user ID. On PHP 8+, this is a fatal TypeError.

```property_exists()``` throws a fatal TypeError on PHP 8+ when passed false, which happens when ```wc_modify_map_meta_cap()``` handles edit_user / remove_user / promote_user / delete_user capability checks for a shop_manager user with an invalid \$args[0] - for example, when Yoast SEO's First_Time_Configuration_Integration calls ```current_user_can('edit_user', \$person_id)``` and ```\$person_id``` is 0 (the default for sites configured as Organization) or a stale ID for a deleted user.

Related upstream issue: https://github.com/Yoast/wordpress-seo/issues/20201 and https://github.com/woocommerce/woocommerce/issues/65170

## What is the fix?

Add an `instanceof WP_User` check before `property_exists()`:

```php
if ( $userdata instanceof WP_User && property_exists( $userdata, 'roles' ) && ...
```

## Why is this safe?

- The shop_manager role restriction is **fully preserved** — the guard only 
  skips the check when no valid user is being edited, which is correct behaviour
- `instanceof WP_User` is the idiomatic WordPress way to validate user objects
- Zero behaviour change for any valid `edit_user`, `remove_user`, 
  `promote_user`, or `delete_user` capability check
- One line change, no new dependencies

## Testing

1. Install WooCommerce and Yoast SEO on PHP 8+
2. Set Yoast's Site Representation to "Organization" (or leave the default), which leaves wpseo_titles['company_or_person_user_id'] at 0
3. Using a role manager plugin (e.g. User Role Editor), assign any of these capabilities to the shop_manager role (this is needed only so the shop_manager can access the page — it isn't itself the trigger):
- wpseo_manage_options
- wpseo_bulk_edit
- wpseo_edit_advanced_metadata
4. Log in as a Shop Manager
5. Navigate to wp-admin/admin.php?page=wpseo_dashboard

Closes #65170 