### PR TITLE
Fix experimental products table polish

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-table-polish
+++ b/packages/js/experimental-products-app/changelog/fix-products-table-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product table row refresh, price spacing, and stock badge display.

--- a/packages/js/experimental-products-app/src/fields/price/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/price/field.tsx
@@ -100,7 +100,7 @@ export const fieldExtensions: Partial< Field< PriceFilterData > > = {
 		// since partially saved products may send empty or NaN-like values here.
 		if ( item.on_sale && Number.isFinite( regularPrice ) ) {
 			return (
-				<Stack direction="row">
+				<Stack direction="row" gap="xs">
 					<s>{ formatCurrency( regularPrice, currency.code ) }</s>
 					<span>{ formatCurrency( price, currency.code ) }</span>
 				</Stack>

--- a/packages/js/experimental-products-app/src/fields/stock/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/stock/field.tsx
@@ -56,16 +56,16 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 			return item.stock_status;
 		}
 
+		const stockLabel =
+			item.stock_quantity && item.stock_quantity > 0
+				? `${ match.label } (${ item.stock_quantity })`
+				: match.label;
+
 		return (
 			<div className="woocommerce-fields-field__stock">
 				<Badge intent={ stockStatusBadgeIntent[ match.value ] }>
-					{ match.label }
+					{ stockLabel }
 				</Badge>
-				{ item.stock_quantity && item.stock_quantity > 0 && (
-					<span className="woocommerce-fields-field__stock-quantity">
-						({ item.stock_quantity })
-					</span>
-				) }
 			</div>
 		);
 	},

--- a/packages/js/experimental-products-app/src/product-list/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/index.tsx
@@ -352,7 +352,7 @@ export default function ProductList( {
 				paginationInfo={ paginationInfo }
 				fields={ productFields }
 				data={ data }
-				isLoading={ isLoading && ! hasResolved }
+				isLoading={ isLoading || ! hasResolved }
 				view={ view }
 				actions={ actions }
 				onChangeView={ setView }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Polishes the experimental products table to avoid a temporary empty state while product rows refresh after moving items to trash. It also adds spacing between sale and regular prices, and keeps stock availability and quantity together inside the stock badge.



### How to test the changes in this Pull Request:

1. Enable the experimental products app and open the products table.
2. Move a product to trash and confirm the table keeps showing products while the refresh completes.
3. View a product with both regular and sale prices and confirm there is spacing between the two prices.
4. View a product with stock quantity and confirm the stock quantity appears inside the stock badge.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app lint:lang:js`
-   `pnpm --filter=@woocommerce/experimental-products-app exec jest --config ./jest.config.json --runTestsByPath src/dataviews-actions/actions.test.tsx src/product-list/query.test.ts`

The lint command passed with existing warnings outside the files changed in this PR.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually in `packages/js/experimental-products-app/changelog/fix-products-table-polish`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
