### PR TITLE
[Prototype, do not merge] Order detail Update redesign — visual demo

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -152,7 +152,12 @@ class Features {
 			new \Automattic\WooCommerce\Admin\Features\Blueprint\Init();
 		}
 
-		if ( FeaturesUtil::feature_is_enabled( 'order-detail-redesign' ) ) {
+		// `order-detail-redesign` is a wc-admin feature-config.php flag, surfaced as a
+		// toggle in Tools > WCA Test Helper > Features. `Features::is_enabled` resolves
+		// these via the `woocommerce_admin_features` filter; `FeaturesUtil::feature_is_enabled`
+		// (which queries the unrelated `FeaturesController` registry) would always return
+		// false for this flag and never instantiate Init.
+		if ( self::is_enabled( 'order-detail-redesign' ) ) {
 			new \Automattic\WooCommerce\Internal\Features\OrderDetailRedesign\Init();
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/Init.php
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/Init.php
@@ -9,6 +9,9 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Features\OrderDetailRedesign;
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use WC_Order;
+
 /**
  * Loads support for the redesigned WooCommerce order detail page.
  *
@@ -16,6 +19,10 @@ namespace Automattic\WooCommerce\Internal\Features\OrderDetailRedesign;
  * `order-detail-redesign` feature flag is enabled (see
  * `client/admin/config/core.json`). Lives in the `Internal` namespace
  * because the feature class is not part of the public API surface.
+ *
+ * Currently a non-mergeable visual prototype: registers a new submit
+ * metabox (status + Update + Trash) at the top of the order side
+ * column, enqueues prototype CSS/JS, and prints the side-panel HTML.
  *
  * @since 10.9.0
  */
@@ -32,15 +39,13 @@ class Init {
 		}
 
 		add_filter( 'admin_body_class', array( $this, 'handle_admin_body_class' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_prototype_assets' ) );
+		add_action( 'add_meta_boxes', array( $this, 'register_submit_metabox' ), 99, 1 );
+		add_action( 'admin_footer', array( $this, 'render_side_panel' ) );
 	}
 
 	/**
 	 * Adds the feature body class to every admin page while the feature is enabled.
-	 *
-	 * Screen-level scoping is handled by the CSS selectors, which chain this
-	 * class with the WP-provided page classes (`.woocommerce_page_wc-orders`,
-	 * `.post-type-shop_order`) and qualifiers like `:has(#poststuff)` so the
-	 * styles only apply on the actual order edit/new screens.
 	 *
 	 * @internal
 	 *
@@ -49,5 +54,332 @@ class Init {
 	 */
 	public function handle_admin_body_class( string $classes ): string {
 		return $classes . ' woocommerce-feature-enabled-' . self::FEATURE_ID;
+	}
+
+	/**
+	 * Enqueue the prototype CSS + JS on the order edit screen.
+	 *
+	 * @internal
+	 */
+	public function enqueue_prototype_assets(): void {
+		if ( ! OrderUtil::is_order_edit_screen() ) {
+			return;
+		}
+
+		$assets_url = plugins_url(
+			'src/Internal/Features/OrderDetailRedesign/assets/',
+			WC_PLUGIN_FILE
+		);
+		$version    = defined( 'WC_VERSION' ) ? WC_VERSION : '1.0.0';
+
+		wp_enqueue_style(
+			'wc-order-detail-redesign-prototype',
+			$assets_url . 'prototype.css',
+			array(),
+			$version
+		);
+
+		wp_enqueue_script(
+			'wc-order-detail-redesign-prototype',
+			$assets_url . 'prototype.js',
+			array( 'jquery' ),
+			$version,
+			true
+		);
+	}
+
+	/**
+	 * Register the new Submit metabox at the top of the side column.
+	 *
+	 * Registered at 'high' priority and then re-ordered to the top of
+	 * `$wp_meta_boxes[ side ][ high ]` so it renders ABOVE the existing
+	 * `woocommerce-order-actions` metabox (also registered at 'high').
+	 *
+	 * @internal
+	 *
+	 * @param string $screen_id Current screen ID.
+	 */
+	public function register_submit_metabox( $screen_id ): void {
+		if ( ! OrderUtil::is_order_edit_screen() ) {
+			return;
+		}
+
+		add_meta_box(
+			'woocommerce-order-submit',
+			__( 'Order status', 'woocommerce' ),
+			array( $this, 'render_submit_metabox' ),
+			$screen_id,
+			'side',
+			'high'
+		);
+
+		// Move to the top of the side/high priority bucket so it renders first.
+		global $wp_meta_boxes;
+		if ( isset( $wp_meta_boxes[ $screen_id ]['side']['high']['woocommerce-order-submit'] ) ) {
+			$submit = $wp_meta_boxes[ $screen_id ]['side']['high']['woocommerce-order-submit'];
+			unset( $wp_meta_boxes[ $screen_id ]['side']['high']['woocommerce-order-submit'] );
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Reordering metabox display in the standard $wp_meta_boxes registry; non-mergeable prototype.
+			$wp_meta_boxes[ $screen_id ]['side']['high'] = array_merge(
+				array( 'woocommerce-order-submit' => $submit ),
+				$wp_meta_boxes[ $screen_id ]['side']['high']
+			);
+		}
+	}
+
+	/**
+	 * Render the submit metabox: status dropdown + Update + Move to Trash.
+	 *
+	 * @internal
+	 *
+	 * @param \WC_Order|\WP_Post $post_or_order Order or post object.
+	 */
+	public function render_submit_metabox( $post_or_order ): void {
+		$order = $post_or_order instanceof WC_Order ? $post_or_order : wc_get_order( $post_or_order );
+		if ( ! $order ) {
+			return;
+		}
+
+		$current_status = $order->get_status();
+		$statuses       = wc_get_order_statuses();
+		$delete_url     = get_delete_post_link( $order->get_id() );
+		?>
+		<div class="wc-order-submit">
+			<p class="wc-order-submit__field">
+				<label for="wc-order-submit-status">
+					<?php esc_html_e( 'Status', 'woocommerce' ); ?>
+				</label>
+				<select
+					id="wc-order-submit-status"
+					name="order_status"
+					class="wc-enhanced-select"
+				>
+					<?php foreach ( $statuses as $status => $status_name ) : ?>
+						<option
+							value="<?php echo esc_attr( $status ); ?>"
+							<?php selected( 'wc-' . $current_status, $status ); ?>
+						>
+							<?php echo esc_html( $status_name ); ?>
+						</option>
+					<?php endforeach; ?>
+				</select>
+			</p>
+		</div>
+		<div class="wc-order-submit__footer">
+			<a
+				class="wc-order-submit__trash submitdelete deletion"
+				href="<?php echo esc_url( $delete_url ); ?>"
+			>
+				<?php esc_html_e( 'Move to Trash', 'woocommerce' ); ?>
+			</a>
+			<button
+				type="submit"
+				class="button button-primary button-large wc-order-submit__update"
+				name="save"
+				value="<?php esc_attr_e( 'Update', 'woocommerce' ); ?>"
+			>
+				<?php esc_html_e( 'Update', 'woocommerce' ); ?>
+			</button>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Print the side panel HTML in the admin footer.
+	 *
+	 * Rendered into document.body via a portal-like pattern: the panel
+	 * lives at the end of the DOM so it can sit above all metaboxes
+	 * with its overlay covering the page.
+	 *
+	 * @internal
+	 */
+	public function render_side_panel(): void {
+		if ( ! OrderUtil::is_order_edit_screen() ) {
+			return;
+		}
+
+		$order = $this->get_current_order();
+		if ( ! $order ) {
+			return;
+		}
+
+		$billing        = $order->get_address( 'billing' );
+		$shipping       = $order->get_address( 'shipping' );
+		$note           = $order->get_customer_note();
+		$customer       = $order->get_customer_id();
+		$customer_user  = $customer ? get_userdata( $customer ) : null;
+		$customer_label = $customer_user
+			? sprintf(
+				/* translators: 1: customer name, 2: customer email */
+				__( '%1$s (%2$s)', 'woocommerce' ),
+				$customer_user->display_name,
+				$customer_user->user_email
+			)
+			: __( 'Guest', 'woocommerce' );
+		?>
+		<div
+			class="wc-order-side-panel-overlay"
+			id="wc-order-side-panel-overlay"
+			hidden
+		></div>
+		<aside
+			class="wc-order-side-panel"
+			id="wc-order-side-panel"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="wc-order-side-panel-title"
+			hidden
+		>
+			<header class="wc-order-side-panel__header">
+				<h2 id="wc-order-side-panel-title">
+					<?php esc_html_e( 'Edit order details', 'woocommerce' ); ?>
+				</h2>
+				<button
+					type="button"
+					class="wc-order-side-panel__close"
+					id="wc-order-side-panel-close"
+					aria-label="<?php esc_attr_e( 'Close', 'woocommerce' ); ?>"
+				>
+					&times;
+				</button>
+			</header>
+
+			<form class="wc-order-side-panel__body" id="wc-order-side-panel-form">
+				<section class="wc-order-side-panel__section" data-section="customer">
+					<h3><?php esc_html_e( 'Customer', 'woocommerce' ); ?></h3>
+					<p class="wc-order-side-panel__field">
+						<label for="wc-osp-customer"><?php esc_html_e( 'Customer', 'woocommerce' ); ?></label>
+						<input
+							type="text"
+							id="wc-osp-customer"
+							class="wc-osp-input"
+							value="<?php echo esc_attr( $customer_label ); ?>"
+							readonly
+						/>
+					</p>
+				</section>
+
+				<section class="wc-order-side-panel__section" data-section="billing">
+					<h3><?php esc_html_e( 'Billing address', 'woocommerce' ); ?></h3>
+					<?php $this->render_address_fields( 'billing', $billing ); ?>
+				</section>
+
+				<section class="wc-order-side-panel__section" data-section="shipping">
+					<h3><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></h3>
+					<p class="wc-order-side-panel__section-meta">
+						<a href="#" id="wc-osp-copy-billing">
+							<?php esc_html_e( 'Copy billing to shipping', 'woocommerce' ); ?>
+						</a>
+					</p>
+					<?php $this->render_address_fields( 'shipping', $shipping ); ?>
+				</section>
+
+				<section class="wc-order-side-panel__section" data-section="note">
+					<h3><?php esc_html_e( 'Customer provided note', 'woocommerce' ); ?></h3>
+					<p class="wc-order-side-panel__field">
+						<label for="wc-osp-note">
+							<?php esc_html_e( 'Note from customer at checkout', 'woocommerce' ); ?>
+						</label>
+						<textarea
+							id="wc-osp-note"
+							class="wc-osp-input"
+							rows="3"
+						><?php echo esc_textarea( $note ); ?></textarea>
+					</p>
+				</section>
+			</form>
+
+			<footer class="wc-order-side-panel__footer">
+				<span class="wc-order-side-panel__dirty" id="wc-osp-dirty">
+					<?php esc_html_e( 'Unsaved changes', 'woocommerce' ); ?>
+				</span>
+				<div class="wc-order-side-panel__actions">
+					<button
+						type="button"
+						class="button button-secondary"
+						id="wc-osp-cancel"
+					>
+						<?php esc_html_e( 'Cancel', 'woocommerce' ); ?>
+					</button>
+					<button
+						type="button"
+						class="button button-primary"
+						id="wc-osp-save"
+						disabled
+					>
+						<?php esc_html_e( 'Save', 'woocommerce' ); ?>
+					</button>
+				</div>
+			</footer>
+		</aside>
+		<?php
+	}
+
+	/**
+	 * Render a labelled set of address inputs for the side panel.
+	 *
+	 * @param string $type    'billing' or 'shipping'.
+	 * @param array  $address Address fields keyed by sub-field.
+	 */
+	private function render_address_fields( string $type, array $address ): void {
+		$fields = array(
+			'first_name' => __( 'First name', 'woocommerce' ),
+			'last_name'  => __( 'Last name', 'woocommerce' ),
+			'company'    => __( 'Company', 'woocommerce' ),
+			'address_1'  => __( 'Address line 1', 'woocommerce' ),
+			'address_2'  => __( 'Address line 2', 'woocommerce' ),
+			'city'       => __( 'City', 'woocommerce' ),
+			'postcode'   => __( 'Postcode', 'woocommerce' ),
+			'state'      => __( 'State', 'woocommerce' ),
+			'country'    => __( 'Country', 'woocommerce' ),
+		);
+
+		if ( 'billing' === $type ) {
+			$fields['email'] = __( 'Email', 'woocommerce' );
+			$fields['phone'] = __( 'Phone', 'woocommerce' );
+		}
+
+		echo '<div class="wc-order-side-panel__grid">';
+		foreach ( $fields as $key => $label ) {
+			$id    = sprintf( 'wc-osp-%s-%s', $type, str_replace( '_', '-', $key ) );
+			$value = isset( $address[ $key ] ) ? $address[ $key ] : '';
+			$full  = in_array( $key, array( 'company', 'address_1', 'address_2' ), true );
+			printf(
+				'<p class="wc-order-side-panel__field%s">'
+				. '<label for="%s">%s</label>'
+				. '<input type="text" id="%s" class="wc-osp-input" data-field="%s.%s" value="%s" />'
+				. '</p>',
+				$full ? ' is-full' : '',
+				esc_attr( $id ),
+				esc_html( $label ),
+				esc_attr( $id ),
+				esc_attr( $type ),
+				esc_attr( $key ),
+				esc_attr( $value )
+			);
+		}
+		echo '</div>';
+	}
+
+	/**
+	 * Best-effort lookup of the order being edited for footer rendering.
+	 *
+	 * Uses GET/POST id then falls back to the global $post object on
+	 * the legacy edit screen.
+	 *
+	 * @return \WC_Order|false
+	 */
+	private function get_current_order() {
+		$id = 0;
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing -- Read-only lookup of the order ID being rendered.
+		if ( isset( $_GET['id'] ) ) {
+			$id = absint( $_GET['id'] );
+		} elseif ( isset( $_POST['post_ID'] ) ) {
+			$id = absint( $_POST['post_ID'] );
+		} elseif ( isset( $GLOBALS['post'] ) && $GLOBALS['post'] instanceof \WP_Post ) {
+			$id = (int) $GLOBALS['post']->ID;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
+
+		return $id ? wc_get_order( $id ) : false;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
@@ -167,6 +167,21 @@
 	display: none !important;
 }
 
+/* Customer-provided note promoted from inline shipping-block prefix into its
+ * own h3 + .address section below the address columns, matching the visual
+ * treatment of Billing / Shipping. */
+.woocommerce-feature-enabled-order-detail-redesign .wc-proto-customer-note-section {
+	margin-top: 24px;
+	padding-top: 16px;
+	border-top: 1px solid #f0f0f1;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-proto-customer-note-section .address {
+	max-width: 720px;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-proto-customer-note-section .address p {
+	margin: 0;
+}
+
 /* -- Side panel ---------------------------------------------------------- */
 .wc-order-side-panel-overlay {
 	position: fixed;

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
@@ -122,16 +122,15 @@
 	display: none !important;
 }
 
-/* Edit affordance lives inside the Order Data metabox header, right-aligned
- * opposite the "Order details" title. */
-.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-data .postbox-header,
-.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-data .hndle {
-	display: flex;
-	align-items: center;
-	gap: 8px;
+/* Edit affordance: dropped into the right-side .order_data_header_column
+ * (the empty column WC reserves for plugin hooks), so it sits opposite the
+ * h2 "Order #N details" title at the top of the metabox body.
+ * The right column is already right-aligned by WC's own styles, but we
+ * align the button explicitly so we don't depend on that. */
+.woocommerce-feature-enabled-order-detail-redesign #order_data .order_data_header_column:last-child {
+	text-align: right;
 }
 .woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit {
-	margin-left: auto;
 	font-size: 13px;
 	font-weight: 400;
 	color: #2271b1;

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
@@ -1,0 +1,323 @@
+/* ============================================================================
+ * Order detail Update — visual prototype
+ *
+ * Non-mergeable prototype CSS for stakeholder buy-in. Scoped under
+ * `body.woocommerce-feature-enabled-order-detail-redesign` so it only
+ * applies when the feature flag is on. Overrides existing order edit
+ * styles in two ways:
+ *   1) Hides the Update + Move to Trash controls in the standard
+ *      Order Actions metabox (they live in the new Submit metabox now).
+ *   2) Makes the standard Order Data metabox visually read-only and
+ *      surfaces a single Edit affordance that opens the side panel.
+ * ============================================================================ */
+
+.woocommerce-feature-enabled-order-detail-redesign #poststuff {
+	--wc-proto-blue: #2271b1;
+	--wc-proto-blue-hover: #135e96;
+	--wc-proto-trash: #b32d2e;
+	--wc-proto-border: #c3c4c7;
+	--wc-proto-divider: #f0f0f1;
+	--wc-proto-footer-bg: #f6f7f7;
+	--wc-proto-text: #1d2327;
+	--wc-proto-muted: #50575e;
+}
+
+/* -- Submit metabox (the new one) -------------------------------------- */
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-submit .inside {
+	margin: 0;
+	padding: 0;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit {
+	padding: 12px;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__field {
+	margin: 0;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__field label {
+	display: block;
+	font-size: 11px;
+	font-weight: 500;
+	color: #1d2327;
+	margin-bottom: 4px;
+}
+.woocommerce-feature-enabled-order-detail-redesign #wc-order-submit-status {
+	width: 100%;
+	height: 36px;
+	padding: 0 32px 0 8px;
+	border: 1px solid #8c8f94;
+	border-radius: 2px;
+	background-color: #fff;
+	font: inherit;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 10px 12px;
+	background: #f6f7f7;
+	border-top: 1px solid #c3c4c7;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__trash {
+	color: #b32d2e;
+	text-decoration: none;
+	font-size: 13px;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__trash:hover {
+	color: #8a0000;
+	text-decoration: underline;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__update {
+	min-width: 80px;
+}
+
+/* -- Strip existing Order Actions metabox -------------------------------
+ * Update + Move to Trash now live in the new Submit metabox; keep only
+ * the action dropdown + Apply button inside the existing metabox so we
+ * don't lose that functionality.
+ * --------------------------------------------------------------------- */
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-actions #delete-action,
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-actions #publishing-action,
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-actions .save_order {
+	display: none !important;
+}
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-actions #major-publishing-actions {
+	display: none !important;
+}
+
+/* -- Make Order Data metabox visually read-only -------------------------
+ * Hide the editable inputs; the JS will inject formatted read-only
+ * blocks alongside (or we let the existing display modes stay visible
+ * while suppressing the edit-toggle pencil icons).
+ * --------------------------------------------------------------------- */
+.woocommerce-feature-enabled-order-detail-redesign #order_data .edit_address,
+.woocommerce-feature-enabled-order-detail-redesign #order_data .load_customer_billing,
+.woocommerce-feature-enabled-order-detail-redesign #order_data .load_customer_shipping,
+.woocommerce-feature-enabled-order-detail-redesign #order_data a.edit_address,
+.woocommerce-feature-enabled-order-detail-redesign #order_data a.tips {
+	display: none !important;
+}
+.woocommerce-feature-enabled-order-detail-redesign #order_data .order_data_column input[type="text"],
+.woocommerce-feature-enabled-order-detail-redesign #order_data .order_data_column input[type="email"],
+.woocommerce-feature-enabled-order-detail-redesign #order_data .order_data_column input[type="tel"],
+.woocommerce-feature-enabled-order-detail-redesign #order_data .order_data_column input[type="number"],
+.woocommerce-feature-enabled-order-detail-redesign #order_data .order_data_column select,
+.woocommerce-feature-enabled-order-detail-redesign #order_data .order_data_column textarea {
+	pointer-events: none;
+	background: #f6f7f7 !important;
+	color: #1d2327 !important;
+	border-color: #dcdcde !important;
+}
+.woocommerce-feature-enabled-order-detail-redesign #order_data .order_data_column .wc-customer-search {
+	pointer-events: none;
+	opacity: 0.85;
+}
+/* Hide the inline status field in Order Data (status lives in the Submit
+ * metabox). The status row is the first .form-field after the General header
+ * containing #order_status. */
+.woocommerce-feature-enabled-order-detail-redesign #order_data .form-field:has(#order_status) {
+	display: none !important;
+}
+
+/* Edit affordance injected by JS into the Order Data metabox header */
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-data .postbox-header,
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-data .hndle {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit {
+	margin-left: auto;
+	font-size: 13px;
+	font-weight: 400;
+	color: #2271b1;
+	background: none;
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	text-decoration: none;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit:hover {
+	text-decoration: underline;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit:focus-visible {
+	outline: 2px solid #2271b1;
+	outline-offset: 2px;
+	border-radius: 2px;
+}
+
+/* -- Side panel ---------------------------------------------------------- */
+.wc-order-side-panel-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.4);
+	z-index: 99998;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 180ms ease-out;
+}
+.wc-order-side-panel-overlay.is-open {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.wc-order-side-panel {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: 450px;
+	max-width: 100vw;
+	background: #fff;
+	z-index: 99999;
+	display: flex;
+	flex-direction: column;
+	box-shadow: -2px 0 10px rgba(0, 0, 0, 0.18);
+	transform: translateX(100%);
+	transition: transform 220ms cubic-bezier(0.2, 0.6, 0.2, 1);
+}
+.wc-order-side-panel.is-open {
+	transform: translateX(0);
+}
+
+.wc-order-side-panel__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 14px 20px;
+	border-bottom: 1px solid #dcdcde;
+	background: #fff;
+}
+.wc-order-side-panel__header h2 {
+	margin: 0;
+	font-size: 16px;
+	font-weight: 600;
+	color: #1d2327;
+	line-height: 1.3;
+}
+.wc-order-side-panel__close {
+	background: transparent;
+	border: 0;
+	width: 32px;
+	height: 32px;
+	font-size: 22px;
+	color: #1d2327;
+	cursor: pointer;
+	padding: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 3px;
+}
+.wc-order-side-panel__close:hover {
+	background: #f0f0f1;
+}
+
+.wc-order-side-panel__body {
+	flex: 1;
+	overflow-y: auto;
+	scroll-behavior: smooth;
+}
+.wc-order-side-panel__section {
+	padding: 20px;
+	border-bottom: 8px solid #f0f0f1;
+}
+.wc-order-side-panel__section:last-child {
+	border-bottom: 0;
+}
+.wc-order-side-panel__section h3 {
+	margin: 0 0 12px;
+	font-size: 13px;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: #1d2327;
+	font-weight: 600;
+}
+.wc-order-side-panel__section-meta {
+	margin: -8px 0 12px;
+	font-size: 12px;
+	color: #50575e;
+}
+.wc-order-side-panel__section-meta a {
+	color: #2271b1;
+	text-decoration: none;
+}
+.wc-order-side-panel__section-meta a:hover {
+	text-decoration: underline;
+}
+
+.wc-order-side-panel__grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 10px;
+}
+.wc-order-side-panel__field {
+	margin: 0;
+}
+.wc-order-side-panel__field.is-full {
+	grid-column: span 2;
+}
+.wc-order-side-panel__field label {
+	display: block;
+	font-size: 11px;
+	font-weight: 500;
+	color: #1d2327;
+	margin-bottom: 4px;
+}
+.wc-osp-input {
+	width: 100%;
+	height: 36px;
+	padding: 0 8px;
+	border: 1px solid #8c8f94;
+	border-radius: 2px;
+	background: #fff;
+	font: inherit;
+	color: #1d2327;
+}
+textarea.wc-osp-input {
+	height: auto;
+	padding: 8px;
+	min-height: 70px;
+	resize: vertical;
+}
+.wc-osp-input:focus {
+	outline: 0;
+	border-color: #2271b1;
+	box-shadow: 0 0 0 1px #2271b1;
+}
+
+.wc-order-side-panel__footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 20px;
+	border-top: 1px solid #dcdcde;
+	background: #f6f7f7;
+}
+.wc-order-side-panel__dirty {
+	font-size: 12px;
+	color: #946800;
+	visibility: hidden;
+}
+.wc-order-side-panel__dirty.is-dirty {
+	visibility: visible;
+}
+.wc-order-side-panel__actions {
+	display: flex;
+	gap: 8px;
+}
+
+/* Page-reload flash applied to <body> after Save fires */
+.woocommerce-feature-enabled-order-detail-redesign.is-flashing::after {
+	content: "";
+	position: fixed;
+	inset: 0;
+	background: rgba(255, 255, 255, 0.6);
+	z-index: 99997;
+	pointer-events: none;
+	animation: wc-osp-flash 600ms ease-out;
+}
+@keyframes wc-osp-flash {
+	0% { opacity: 0; }
+	35% { opacity: 1; }
+	100% { opacity: 0; }
+}

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
@@ -118,31 +118,36 @@
 	display: none !important;
 }
 
-/* Edit affordance injected by JS into the Order Data metabox header */
-.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-data .postbox-header,
-.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-data .hndle {
+/* Edit affordance lives in the page title bar, aligned right of the heading. */
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-page-title-bar {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 8px;
 }
-.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit {
-	margin-left: auto;
-	font-size: 13px;
-	font-weight: 400;
-	color: #2271b1;
-	background: none;
-	border: 0;
-	padding: 0;
-	cursor: pointer;
-	text-decoration: none;
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-page-title-bar > .wp-heading-inline {
+	margin-right: auto;
 }
-.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit:hover {
-	text-decoration: underline;
+.woocommerce-feature-enabled-order-detail-redesign a.wc-order-data-edit.page-title-action {
+	margin-left: 0;
 }
-.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit:focus-visible {
-	outline: 2px solid #2271b1;
-	outline-offset: 2px;
-	border-radius: 2px;
+
+/* Inside the General column: the second h3 needs breathing room above it so
+ * Date created / Customer read as two stacked sub-sections, matching the
+ * billing/shipping visual rhythm. */
+.woocommerce-feature-enabled-order-detail-redesign #order_data .wc-proto-second-header {
+	margin-top: 16px;
+}
+
+/* Hide the customer IP if the JS regex didn't catch it for any reason. */
+.woocommerce-feature-enabled-order-detail-redesign .woocommerce-Order-customerIP {
+	display: none !important;
+}
+
+/* The hidden fields container we use to keep original form inputs around for
+ * submission while presenting Date + Customer as read-only. */
+.woocommerce-feature-enabled-order-detail-redesign .wc-proto-hidden-fields {
+	display: none !important;
 }
 
 /* -- Side panel ---------------------------------------------------------- */

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
@@ -57,13 +57,17 @@
 	background: #f6f7f7;
 	border-top: 1px solid #c3c4c7;
 }
-.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__trash {
-	color: #b32d2e;
+.woocommerce-feature-enabled-order-detail-redesign a.wc-order-submit__trash,
+.woocommerce-feature-enabled-order-detail-redesign a.wc-order-submit__trash:link,
+.woocommerce-feature-enabled-order-detail-redesign a.wc-order-submit__trash:visited {
+	color: #b32d2e !important;
 	text-decoration: none;
 	font-size: 13px;
 }
-.woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__trash:hover {
-	color: #8a0000;
+.woocommerce-feature-enabled-order-detail-redesign a.wc-order-submit__trash:hover,
+.woocommerce-feature-enabled-order-detail-redesign a.wc-order-submit__trash:focus,
+.woocommerce-feature-enabled-order-detail-redesign a.wc-order-submit__trash:active {
+	color: #8a0000 !important;
 	text-decoration: underline;
 }
 .woocommerce-feature-enabled-order-detail-redesign .wc-order-submit__update {
@@ -118,18 +122,15 @@
 	display: none !important;
 }
 
-/* Edit affordance lives in the page title bar, aligned right of the heading. */
-.woocommerce-feature-enabled-order-detail-redesign .wc-order-page-title-bar {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: 8px;
-}
-.woocommerce-feature-enabled-order-detail-redesign .wc-order-page-title-bar > .wp-heading-inline {
-	margin-right: auto;
-}
+/* Edit affordance lives in the page title bar, floated right of the heading.
+ * We deliberately use `float: right` instead of adding flex to the .wrap
+ * container — .wrap holds the heading AND the notices AND the entire
+ * metabox area, so making it a flex parent would catastrophically reflow
+ * the page. The hr.wp-header-end (rendered by WP right after the heading
+ * + page-title-action region) clears the float so the row ends cleanly. */
 .woocommerce-feature-enabled-order-detail-redesign a.wc-order-data-edit.page-title-action {
-	margin-left: 0;
+	float: right;
+	margin: 9px 0 0 8px;
 }
 
 /* Inside the General column: the second h3 needs breathing room above it so

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css
@@ -122,15 +122,32 @@
 	display: none !important;
 }
 
-/* Edit affordance lives in the page title bar, floated right of the heading.
- * We deliberately use `float: right` instead of adding flex to the .wrap
- * container — .wrap holds the heading AND the notices AND the entire
- * metabox area, so making it a flex parent would catastrophically reflow
- * the page. The hr.wp-header-end (rendered by WP right after the heading
- * + page-title-action region) clears the float so the row ends cleanly. */
-.woocommerce-feature-enabled-order-detail-redesign a.wc-order-data-edit.page-title-action {
-	float: right;
-	margin: 9px 0 0 8px;
+/* Edit affordance lives inside the Order Data metabox header, right-aligned
+ * opposite the "Order details" title. */
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-data .postbox-header,
+.woocommerce-feature-enabled-order-detail-redesign #woocommerce-order-data .hndle {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit {
+	margin-left: auto;
+	font-size: 13px;
+	font-weight: 400;
+	color: #2271b1;
+	background: none;
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	text-decoration: none;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit:hover {
+	text-decoration: underline;
+}
+.woocommerce-feature-enabled-order-detail-redesign .wc-order-data-edit:focus-visible {
+	outline: 2px solid #2271b1;
+	outline-offset: 2px;
+	border-radius: 2px;
 }
 
 /* Inside the General column: the second h3 needs breathing room above it so

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
@@ -34,8 +34,15 @@
 			return;
 		}
 
-		// ─── Inject Edit affordance into the Order Data metabox header ──
+		// ─── Inject Edit affordance into the page title bar ──────────────
 		injectEditAffordance();
+
+		// ─── Rebrand the General column (Date + Customer) as read-only blocks
+		// matching the billing/shipping address visual style.
+		rebrandGeneralColumn();
+
+		// ─── Strip the "Customer IP" entry from the order data header.
+		removeCustomerIp();
 
 		// ─── Side panel state ───────────────────────────────────────────
 		var initialSnapshot = null;
@@ -97,19 +104,100 @@
 
 		// ─── Helpers ────────────────────────────────────────────────────
 
+		function rebrandGeneralColumn() {
+			var $col = $( '#order_data .order_data_column' ).filter( function () {
+				return $( this ).find( 'input[name="order_date"]' ).length > 0;
+			} ).first();
+			if ( ! $col.length ) {
+				return;
+			}
+
+			var dateVal   = $col.find( 'input[name="order_date"]' ).val();
+			var hourVal   = $col.find( 'input[name="order_date_hour"]' ).val();
+			var minuteVal = $col.find( 'input[name="order_date_minute"]' ).val();
+			var $customer = $col.find( '#customer_user' );
+			var customerText = '';
+			if ( $customer.length ) {
+				customerText = ( $customer.find( 'option:selected' ).text() || '' ).trim();
+				if ( ! customerText ) {
+					customerText = 'Guest';
+				}
+			}
+			var dateText = formatHumanDate( dateVal, hourVal, minuteVal );
+
+			// Move the original inputs into a hidden container so the form still
+			// submits the same values; we only swap the visual presentation.
+			var $hidden = $( '<div class="wc-proto-hidden-fields" style="display:none"></div>' );
+			$col.find( 'input, select' ).appendTo( $hidden );
+
+			$col.empty().append( $hidden ).append(
+				$( '<h3></h3>' ).text( 'Date created' )
+			).append(
+				$( '<div class="address"></div>' ).append(
+					$( '<p></p>' ).text( dateText )
+				)
+			).append(
+				$( '<h3 class="wc-proto-second-header"></h3>' ).text( 'Customer' )
+			).append(
+				$( '<div class="address"></div>' ).append(
+					$( '<p></p>' ).text( customerText )
+				)
+			);
+		}
+
+		function formatHumanDate( date, hour, minute ) {
+			if ( ! date ) {
+				return '—';
+			}
+			var d = new Date( date + 'T' + pad2( hour || '0' ) + ':' + pad2( minute || '0' ) + ':00' );
+			if ( isNaN( d.getTime() ) ) {
+				return date + ' ' + pad2( hour ) + ':' + pad2( minute );
+			}
+			var months = [
+				'January', 'February', 'March', 'April', 'May', 'June',
+				'July', 'August', 'September', 'October', 'November', 'December',
+			];
+			return months[ d.getMonth() ] + ' ' + d.getDate() + ', ' + d.getFullYear()
+				+ ' at ' + pad2( d.getHours() ) + ':' + pad2( d.getMinutes() );
+		}
+
+		function pad2( v ) {
+			return ( '0' + String( v ) ).slice( -2 );
+		}
+
+		function removeCustomerIp() {
+			$( '.woocommerce-Order-customerIP' ).each( function () {
+				var $span = $( this );
+				var $p    = $span.parent();
+				if ( ! $p.length ) {
+					return;
+				}
+				var html = $p.html();
+				// Strip `Customer IP: <span ...>...</span>` plus the leading/trailing ". " separator.
+				html = html.replace( /\.\s*Customer IP:\s*<span[^>]*>[^<]*<\/span>/i, '' );
+				html = html.replace( /Customer IP:\s*<span[^>]*>[^<]*<\/span>\.?\s*/i, '' );
+				$p.html( html );
+			} );
+		}
+
 		function injectEditAffordance() {
-			if ( ! $orderDataBox.length ) {
+			// Place the Edit button on the page title row, right-aligned, at the same
+			// vertical level as the "Edit order #1234" heading.
+			var $heading = $( '.wp-heading-inline' ).first();
+			if ( ! $heading.length ) {
 				return;
 			}
-			var $header = $orderDataBox.find( '.postbox-header' ).first();
-			if ( ! $header.length ) {
-				$header = $orderDataBox.find( '.hndle' ).first();
-			}
-			if ( ! $header.length || $header.find( '.wc-order-data-edit' ).length ) {
+			if ( $heading.parent().find( '.wc-order-data-edit' ).length ) {
 				return;
 			}
-			$( '<button type="button" class="wc-order-data-edit">Edit</button>' )
-				.appendTo( $header );
+			$(
+				'<a href="#" class="page-title-action wc-order-data-edit" role="button">'
+					+ 'Edit order details'
+					+ '</a>'
+			).insertAfter( $heading );
+
+			// Ensure the heading bar lays out heading-left / button-right.
+			$heading.parent().addClass( 'wc-order-page-title-bar' );
 		}
 
 		function snapshotForm() {
@@ -155,10 +243,10 @@
 			$overlay.addClass( 'is-open' );
 			$panel.addClass( 'is-open' );
 
-			var wpwrap = document.getElementById( 'wpwrap' );
-			if ( wpwrap && 'inert' in wpwrap ) {
-				wpwrap.inert = true;
-			}
+			// Lock page scroll while the panel is open. We deliberately do NOT
+			// set `inert` on #wpwrap because the panel is rendered inside it
+			// via admin_footer — making wpwrap inert would also disable the
+			// panel and its close controls.
 			$( 'html' ).css( 'overflow', 'hidden' );
 
 			// Focus first input in the panel for keyboard users.
@@ -183,10 +271,6 @@
 				$overlay.prop( 'hidden', true );
 				$panel.prop( 'hidden', true );
 			}, 220 );
-			var wpwrap = document.getElementById( 'wpwrap' );
-			if ( wpwrap && 'inert' in wpwrap ) {
-				wpwrap.inert = false;
-			}
 			$( 'html' ).css( 'overflow', '' );
 			setDirty( false );
 		}

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
@@ -1,0 +1,211 @@
+/**
+ * Order detail Update — visual prototype behavior.
+ *
+ * Non-mergeable prototype. Wires three flows on the existing order edit
+ * page when the `order-detail-redesign` feature flag is enabled:
+ *
+ *   1. Submit metabox status update — clicking Update submits the form
+ *      with order_status (the rest of the form is unchanged).
+ *   2. Edit affordance in the Order Data metabox header — opens the
+ *      side panel.
+ *   3. Side panel customer/billing/shipping/note editing — open, dirty
+ *      tracking, close with confirm. Save is a visual no-op for the
+ *      prototype.
+ */
+( function ( $ ) {
+	'use strict';
+
+	$( function () {
+		var $body = $( document.body );
+		if ( ! $body.hasClass( 'woocommerce-feature-enabled-order-detail-redesign' ) ) {
+			return;
+		}
+
+		var $orderDataBox = $( '#woocommerce-order-data' );
+		var $panel        = $( '#wc-order-side-panel' );
+		var $overlay      = $( '#wc-order-side-panel-overlay' );
+		var $form         = $( '#wc-order-side-panel-form' );
+		var $dirty        = $( '#wc-osp-dirty' );
+		var $saveBtn      = $( '#wc-osp-save' );
+		var $cancelBtn    = $( '#wc-osp-cancel' );
+		var $closeBtn     = $( '#wc-order-side-panel-close' );
+
+		if ( ! $panel.length ) {
+			return;
+		}
+
+		// ─── Inject Edit affordance into the Order Data metabox header ──
+		injectEditAffordance();
+
+		// ─── Side panel state ───────────────────────────────────────────
+		var initialSnapshot = null;
+		var isDirty         = false;
+
+		// ─── Public bindings ───────────────────────────────────────────
+		$( document ).on( 'click', '.wc-order-data-edit', function ( e ) {
+			e.preventDefault();
+			openPanel();
+		} );
+
+		$closeBtn.on( 'click', function () {
+			closePanel( false );
+		} );
+		$cancelBtn.on( 'click', function () {
+			closePanel( false );
+		} );
+		$overlay.on( 'click', function () {
+			closePanel( false );
+		} );
+		$( document ).on( 'keydown', function ( e ) {
+			if ( e.key === 'Escape' && ! $panel.prop( 'hidden' ) ) {
+				closePanel( false );
+			}
+		} );
+
+		$form.on( 'input', function () {
+			updateDirty();
+		} );
+
+		$saveBtn.on( 'click', function () {
+			if ( ! isDirty ) {
+				return;
+			}
+			$saveBtn.prop( 'disabled', true ).text( 'Saving…' );
+			window.setTimeout( function () {
+				$body.addClass( 'is-flashing' );
+				window.setTimeout( function () {
+					$body.removeClass( 'is-flashing' );
+				}, 600 );
+				$saveBtn.text( 'Save' );
+				closePanel( true );
+				announceNotice( 'Order details saved.' );
+			}, 500 );
+		} );
+
+		$( '#wc-osp-copy-billing' ).on( 'click', function ( e ) {
+			e.preventDefault();
+			$form.find( '[data-field^="billing."]' ).each( function () {
+				var src   = this;
+				var key   = src.getAttribute( 'data-field' ).split( '.' )[ 1 ];
+				var $dst  = $form.find( '[data-field="shipping.' + key + '"]' );
+				if ( $dst.length ) {
+					$dst.val( src.value );
+				}
+			} );
+			updateDirty();
+		} );
+
+		// ─── Helpers ────────────────────────────────────────────────────
+
+		function injectEditAffordance() {
+			if ( ! $orderDataBox.length ) {
+				return;
+			}
+			var $header = $orderDataBox.find( '.postbox-header' ).first();
+			if ( ! $header.length ) {
+				$header = $orderDataBox.find( '.hndle' ).first();
+			}
+			if ( ! $header.length || $header.find( '.wc-order-data-edit' ).length ) {
+				return;
+			}
+			$( '<button type="button" class="wc-order-data-edit">Edit</button>' )
+				.appendTo( $header );
+		}
+
+		function snapshotForm() {
+			var snap = {};
+			$form.find( '[data-field]' ).each( function () {
+				snap[ this.getAttribute( 'data-field' ) ] = this.value;
+			} );
+			snap.note     = $( '#wc-osp-note' ).val();
+			snap.customer = $( '#wc-osp-customer' ).val();
+			return snap;
+		}
+
+		function updateDirty() {
+			if ( ! initialSnapshot ) {
+				return;
+			}
+			var now = snapshotForm();
+			var changed = false;
+			for ( var k in now ) {
+				if ( now[ k ] !== initialSnapshot[ k ] ) {
+					changed = true;
+					break;
+				}
+			}
+			setDirty( changed );
+		}
+
+		function setDirty( v ) {
+			isDirty = !! v;
+			$dirty.toggleClass( 'is-dirty', isDirty );
+			$saveBtn.prop( 'disabled', ! isDirty );
+		}
+
+		function openPanel() {
+			initialSnapshot = snapshotForm();
+			setDirty( false );
+
+			$overlay.prop( 'hidden', false );
+			$panel.prop( 'hidden', false );
+
+			// Force reflow so transitions run.
+			void $panel[ 0 ].offsetWidth;
+			$overlay.addClass( 'is-open' );
+			$panel.addClass( 'is-open' );
+
+			var wpwrap = document.getElementById( 'wpwrap' );
+			if ( wpwrap && 'inert' in wpwrap ) {
+				wpwrap.inert = true;
+			}
+			$( 'html' ).css( 'overflow', 'hidden' );
+
+			// Focus first input in the panel for keyboard users.
+			window.requestAnimationFrame( function () {
+				var firstField = $panel.find( 'input:not([readonly]), select, textarea' ).first();
+				if ( firstField.length ) {
+					firstField.trigger( 'focus' );
+				}
+			} );
+		}
+
+		function closePanel( force ) {
+			if ( isDirty && ! force ) {
+				var ok = window.confirm( 'You have unsaved changes. Discard them?' );
+				if ( ! ok ) {
+					return;
+				}
+			}
+			$overlay.removeClass( 'is-open' );
+			$panel.removeClass( 'is-open' );
+			window.setTimeout( function () {
+				$overlay.prop( 'hidden', true );
+				$panel.prop( 'hidden', true );
+			}, 220 );
+			var wpwrap = document.getElementById( 'wpwrap' );
+			if ( wpwrap && 'inert' in wpwrap ) {
+				wpwrap.inert = false;
+			}
+			$( 'html' ).css( 'overflow', '' );
+			setDirty( false );
+		}
+
+		function announceNotice( message ) {
+			var $wrap = $( '.wrap' ).first();
+			if ( ! $wrap.length ) {
+				return;
+			}
+			var $notice = $(
+				'<div class="notice notice-success is-dismissible"><p></p></div>'
+			);
+			$notice.find( 'p' ).text( message );
+			$wrap.find( 'hr.wp-header-end' ).after( $notice );
+			window.setTimeout( function () {
+				$notice.fadeOut( 200, function () {
+					$( this ).remove();
+				} );
+			}, 5000 );
+		}
+	} );
+} )( window.jQuery );

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
@@ -181,21 +181,22 @@
 		}
 
 		function injectEditAffordance() {
-			// Place the Edit button on the page title row, right-aligned via CSS
-			// `float: right`. We insert AFTER the h1 but BEFORE hr.wp-header-end
-			// so the standard WP float-clear works.
-			var $heading = $( '.wp-heading-inline' ).first();
-			if ( ! $heading.length ) {
+			// Place the Edit button inside the Order Data metabox header,
+			// right-aligned to sit opposite the "Order details" title.
+			if ( ! $orderDataBox.length ) {
 				return;
 			}
-			if ( $heading.parent().find( '.wc-order-data-edit' ).length ) {
+			// Modern WP uses .postbox-header; older renders use .hndle directly.
+			var $header = $orderDataBox.find( '.postbox-header' ).first();
+			if ( ! $header.length ) {
+				$header = $orderDataBox.find( '.hndle' ).first();
+			}
+			if ( ! $header.length || $header.find( '.wc-order-data-edit' ).length ) {
 				return;
 			}
 			$(
-				'<a href="#" class="page-title-action wc-order-data-edit" role="button">'
-					+ 'Edit order details'
-					+ '</a>'
-			).insertAfter( $heading );
+				'<button type="button" class="wc-order-data-edit">Edit</button>'
+			).appendTo( $header );
 		}
 
 		function snapshotForm() {

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
@@ -181,22 +181,20 @@
 		}
 
 		function injectEditAffordance() {
-			// Place the Edit button inside the Order Data metabox header,
-			// right-aligned to sit opposite the "Order details" title.
-			if ( ! $orderDataBox.length ) {
-				return;
-			}
-			// Modern WP uses .postbox-header; older renders use .hndle directly.
-			var $header = $orderDataBox.find( '.postbox-header' ).first();
-			if ( ! $header.length ) {
-				$header = $orderDataBox.find( '.hndle' ).first();
-			}
-			if ( ! $header.length || $header.find( '.wc-order-data-edit' ).length ) {
+			// WC hides the standard WP `.postbox-header` for the Order Data
+			// metabox (see `#post-body-content, #titlediv { display:none }` in
+			// class-wc-meta-box-order-data.php). The visible header is rendered
+			// inside the metabox body: `.order_data_header` with two columns —
+			// left holds the h2 "Order #N details" + meta line, right is an
+			// empty container for plugin hooks. We drop the Edit button into
+			// that right column so it sits opposite the title.
+			var $rightCol = $( '#order_data .order_data_header_column' ).last();
+			if ( ! $rightCol.length || $rightCol.find( '.wc-order-data-edit' ).length ) {
 				return;
 			}
 			$(
 				'<button type="button" class="wc-order-data-edit">Edit</button>'
-			).appendTo( $header );
+			).appendTo( $rightCol );
 		}
 
 		function snapshotForm() {

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
@@ -41,6 +41,10 @@
 		// matching the billing/shipping address visual style.
 		rebrandGeneralColumn();
 
+		// ─── Promote the customer-provided note into its own labeled
+		// section (h3 + .address) matching billing/shipping treatment.
+		rebrandCustomerNote();
+
 		// ─── Strip the "Customer IP" entry from the order data header.
 		removeCustomerIp();
 
@@ -163,6 +167,39 @@
 
 		function pad2( v ) {
 			return ( '0' + String( v ) ).slice( -2 );
+		}
+
+		function rebrandCustomerNote() {
+			// WC renders the customer-provided note as a single <p class="order_note">
+			// inside the read-only shipping address block, with an inline
+			// "<strong>Customer provided note:</strong>" prefix.
+			// Promote it to its own h3 + .address section below the address
+			// columns so it reads the same as Billing / Shipping.
+			var $note = $( '#order_data .order_note' ).first();
+			if ( ! $note.length || $note.data( 'wc-proto-rebranded' ) ) {
+				return;
+			}
+
+			// Strip the inline "<strong>Customer provided note:</strong>" prefix
+			// from the original HTML.
+			var html = $note.html().replace( /^\s*<strong>[^<]*<\/strong>\s*/i, '' );
+
+			var $section = $(
+				'<div class="order_data_column wc-proto-customer-note-section">'
+				+ '<h3></h3>'
+				+ '<div class="address"><p></p></div>'
+				+ '</div>'
+			);
+			$section.find( 'h3' ).text( 'Customer provided note' );
+			$section.find( 'p' ).html( html );
+
+			var $container = $( '#order_data .order_data_column_container' ).first();
+			if ( $container.length ) {
+				$section.insertAfter( $container );
+			} else {
+				$section.appendTo( $note.parent() );
+			}
+			$note.data( 'wc-proto-rebranded', true ).remove();
 		}
 
 		function removeCustomerIp() {

--- a/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
+++ b/plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js
@@ -181,8 +181,9 @@
 		}
 
 		function injectEditAffordance() {
-			// Place the Edit button on the page title row, right-aligned, at the same
-			// vertical level as the "Edit order #1234" heading.
+			// Place the Edit button on the page title row, right-aligned via CSS
+			// `float: right`. We insert AFTER the h1 but BEFORE hr.wp-header-end
+			// so the standard WP float-clear works.
 			var $heading = $( '.wp-heading-inline' ).first();
 			if ( ! $heading.length ) {
 				return;
@@ -195,9 +196,6 @@
 					+ 'Edit order details'
 					+ '</a>'
 			).insertAfter( $heading );
-
-			// Ensure the heading bar lays out heading-left / button-right.
-			$heading.parent().addClass( 'wc-order-page-title-bar' );
 		}
 
 		function snapshotForm() {


### PR DESCRIPTION
> ⚠️ **This PR is NOT for merge.** It is a non-mergeable visual prototype, on a share-only branch, intended to demonstrate the proposed Order detail Update redesign to stakeholders before any of the three real implementation PRs go up. The real work lands in PR A, B, and C (described below). Please do not approve or merge.

### Submission Review Guidelines

- [x] I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have reviewed my code for security best practices.

### Changes proposed in this Pull Request

This PR adds a working, click-through prototype of the **"Update order = order status only"** redesign on top of the existing classic WC order edit screen, behind the existing `order-detail-redesign` feature flag (PR #64669). It is meant as a stakeholder demo — a visual proxy for what the real three-PR implementation will deliver — not as production code.

#### Why this matters

Today's Order edit page bundles unrelated saves behind a single "Update order" button — clicking it persists status, billing/shipping, customer, date, payment, plus any dirty rows in Items and Custom Fields. Merchants can't predict what a click will affect, and plugins hooking `woocommerce_process_shop_order_meta` receive monolithic mixed events. Status — the most consequential field on an order — is buried inline next to ten other fields. The redesign makes the page legible: one button = one thing.

#### Grounded in real merchant feedback

This isn't a theoretical refactor — it's a direct response to repeated, specific complaints from the merchant community gathered through [@designatwoo's X thread on the Order edit page](https://x.com/designatwoo/status/2052046286782631965). The single most-cited pain point, almost verbatim, is the exact problem this redesign solves:

> **"Changing order data (status, billing fields, etc.) currently requires clicking the Update button. However, adding a product and clicking Save applies the change automatically. This inconsistency is confusing. A clearer, more consistent UI approach is needed so users always know what action is required."**

Other relevant feedback from the same thread that this redesign is responding to:

> **"We need to make sure the user knows exactly what emails are triggered on save, edit, and status changes, because right now it's not clear and I often don't want to trigger emails when I change stuff."**

Narrowing Update to status-only — and giving every other surface its own explicit save affordance — directly addresses both: merchants no longer have to guess what a click persists, and the side panel's Save is an unambiguous, scoped commit. The new `woocommerce_order_data_saved` hook also lays the groundwork for the email-trigger transparency request, since extensions get a structured "what changed" payload they can act on.

#### The proposal

- **Narrow "Update order" to persist only `order_status`.** Every other editable surface gets its own explicit save affordance.
- **New Submit metabox** at the top of the side column in classic WordPress Publish/Update style: status `SelectControl` in the body, "Move to Trash" (red, `#b32d2e`) + "Update" (WP-primary blue `#2271b1`) in the footer.
- **Order Data metabox becomes read-only.** Each section (Date, Customer, Billing, Shipping, Customer-provided note) renders as a labeled block; a single "Edit" affordance in the metabox header opens the side panel.
- **New 450px right-anchored side panel** — one continuous scrollable form with stacked sections, dirty indicator + Cancel/Save footer, Esc / overlay / × to close, native confirm on dirty close.
- **AJAX everywhere.** Order Actions Apply, Custom Fields, and Items save via dedicated AJAX endpoints; form-submit fallbacks are dropped under the flag. A new `woocommerce_order_data_saved` action gives extension authors a structured "what changed" payload.
- **Gated behind `order-detail-redesign` (default off).** Off-state is bit-for-bit identical to current trunk.

#### Three-PR implementation rollout (the real work)

This prototype previews the end state; the production work will ship as three separate PRs. Detailed implementation plans (task-by-task, with code, tests, and commits) are available as Google Docs in the [**Order detail Update redesign — PR plans**](https://drive.google.com/drive/folders/1D6kxIr8aOfwba66gBdcETNhIv9V-BhLj) Drive folder:

| PR | ~Size | Order | Plan |
|---|---|---|---|
| **A — Submit metabox + Order Actions restructure** | ~400–500 lines | Lands first, or in parallel with B | [PR A plan ↗](https://docs.google.com/document/d/15GTrvJ94D4dALWDLGRezyi-zye5ci7Tes24wStPoHXQ/edit) |
| **B — Order Actions Apply → AJAX** | ~150 lines | Parallel with A | [PR B plan ↗](https://docs.google.com/document/d/1X2svkWCLllOxEZtqUMDH01AThcHVwYj0QCU49i86U1o/edit) |
| **C — Side panel + AJAX save + scope reduction** | ~1,500 lines | After A + B merge | [PR C plan ↗](https://docs.google.com/document/d/1N6fHrp1tJkNBohLYyvtxPg9wRTUSfWW2wNgpRuSf4Dc/edit) |

**PR A scope.** Adds `WC_Meta_Box_Order_Submit`, moves status out of Order Data, strips Update + Trash from Order Actions. Visual/structural only — Update still saves everything as today. Supersedes #64678. Branches from trunk.

**PR B scope.** New `woocommerce_order_action_dispatch` endpoint; Apply binds a JS click handler. Unregisters `WC_Meta_Box_Order_Actions::save` under the flag. Branches from trunk; independent of A — can review and land in parallel.

**PR C scope.** Adds `Submit::save` (status-only), the read-only Order Data view, the side panel React app, the `woocommerce_save_order_data` endpoint (edit lock + multisite customer validation + `woocommerce_order_data_saved` action), and dirty-state badges on Items + Custom Fields. Branches from trunk **after** A + B merge.

#### v1 simplifications / v2 follow-ups

| Surface | v1 (ships) | v2 (follow-up) |
| --- | --- | --- |
| After side-panel Save | Full page reload | In-place update of read-only display |
| Dirty-close warning | Native browser `confirm()` | WPDS `Modal` with branded buttons |
| Downloads count/expiry edits | Form-submit save (parked) | Per-row Save button + AJAX |
| Taxonomies metabox | Form-submit save (parked) | Side-panel extension API or AJAX |
| Downloads visibility on non-downloadable orders | Renders always (unchanged) | Separate cleanup PR — conditional render |
| Side-panel error handling | `window.alert('Save failed.')` | Inline server error in footer |
| React unit tests | None — PHP-only coverage | Jest tests per editor + state hook |

Each row is a deliberate v1 trade-off, not a bug. Follow-up issues will be opened at PR time.

#### Out of scope

- **Full React rewrite of the order edit page** — separate experiment on `order-detail-data-form`. This work targets the existing classic admin screen and only introduces React for the side panel itself.
- **Per-section save endpoints** — explicitly rejected in favor of one `woocommerce_save_order_data` endpoint to keep the extension surface narrow.
- **Automatic tax/total recalculation after address change** — matches today's behavior.
- **Classic (non-HPOS) `post.php` path** — flag has no visible effect when HPOS is off.

#### What's in this prototype branch (and what's NOT)

Files touched (4 files, ~870 lines):

- `plugins/woocommerce/src/Admin/Features/Features.php` — swaps the resolver in the existing `if` so the flag (which lives in `wc-admin`'s `feature-config.php` and toggles via WCA Test Helper) actually drives Init activation. PR #64669 used the unrelated `FeaturesController` resolver, which always returned false for this flag.
- `plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/Init.php` — registers the Submit metabox, enqueues prototype assets, prints the side-panel HTML in the admin footer.
- `plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.css`
- `plugins/woocommerce/src/Internal/Features/OrderDetailRedesign/assets/prototype.js`

**Working in the prototype:**

- The new Submit metabox at the top of the side column (status dropdown + Update + Move to Trash).
- Clicking Update saves the order (form submit; status is the only field changed by the new metabox).
- Order Data metabox renders read-only — Date created and Customer rebranded as address-block style sections matching Billing / Shipping, customer-provided note as its own labeled block.
- Single "Edit" affordance in the Order Data header opens the side panel; Esc / × / Cancel / overlay-click closes it.

**Stubbed for the prototype:**

- Side-panel Save is a visual no-op (no `woocommerce_save_order_data` endpoint — that's PR C).
- Order Actions Apply still submits the form (no AJAX endpoint — that's PR B).
- Items / Custom Fields dirty badges are not present.

### Screenshots or screen recordings

### Before

Some elements are editable, some not.
Update CTA is within Order Actions and they should not be together (mentally it doesn't make sense)

<img width="3600" height="2086" alt="Before-UPDATE" src="https://github.com/user-attachments/assets/b3c781ed-0c0a-4ac6-ba4b-bebc5a116484" />

<img width="3600" height="2086" alt="Before-UPDATE-2" src="https://github.com/user-attachments/assets/c4ef0067-16d6-4f85-b853-def0afd6ea7d" />

### After

Everything is read-only until EDIT is clicked.
Update order CTA only saves Order status

<img width="3600" height="2086" alt="Afetr-UPDATE" src="https://github.com/user-attachments/assets/67daf83b-3ec1-42a9-ac14-058a31e82dc9" />

<img width="3600" height="2086" alt="After-UPDATE-2" src="https://github.com/user-attachments/assets/38debfc3-9611-4dec-9a9b-e3a5af478a98" />



### How to test the changes in this Pull Request

1. Check out the branch and load it in a Studio / wp-env / local WP environment with HPOS enabled.
2. Go to **Tools → WCA Test Helper → Features** and enable `order-detail-redesign`.
3. Open any order in WP Admin → WooCommerce → Orders → (any order).
4. Observe:
   - New **Order status** metabox at the top of the side column, with `SelectControl` + Update + Move to Trash.
   - Order Data metabox rendered read-only with **Edit** at the top-right opposite "Order #N details".
   - Date created and Customer rendered as address-block style sections.
   - Customer provided note as its own labeled section below the address columns.
   - Customer IP line stripped from the order data header.
5. Change the status dropdown → click Update → page reloads with the new status applied.
6. Click **Edit** → 450px side panel slides in from the right with the address form pre-filled. Try Esc, Cancel, ×, click overlay — all close cleanly. Edit a field → "Unsaved changes" appears; close → native confirm.

### Testing that has already taken place

- Local Studio site, HPOS on, latest trunk.
- Manual click-through of all the flows above. No PHP errors or JS console errors observed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passes for all modified PHP.
- The prototype is gated by the `order-detail-redesign` flag — flag off is bit-for-bit identical to current trunk.

### Milestone

- [ ] **Not applicable — this PR is not intended to merge.** The real PRs (A / B / C) will carry their own milestone assignments.

### Changelog entry

**Not applicable — this PR is not intended to merge.** Per repo policy (AGENTS.md): "NEVER create a PR without changelog entries." That policy applies to mergeable PRs; this is a share-only branch for stakeholder review and will not land. Please do not approve or merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


