### PR TITLE
Update products app add new button

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-products-app-add-new-button
+++ b/packages/js/experimental-products-app/changelog/update-products-app-add-new-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Restore the single add new product button in the experimental products app header.

--- a/packages/js/experimental-products-app/src/product-list/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/index.tsx
@@ -7,20 +7,11 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
-import { Button, Icon, Stack, Tabs } from '@wordpress/ui';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { Button, Stack, Tabs } from '@wordpress/ui';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { addQueryArgs } from '@wordpress/url';
 import { getAdminLink } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
-import {
-	tag,
-	alignNone,
-	category,
-	link,
-	chevronDown,
-	chevronUp,
-} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -47,46 +38,8 @@ import { useProductActions } from '../dataviews-actions';
 import { ProductListEmptyState } from './empty-state';
 import { ProductListPage, ProductListPageHeader } from './page';
 
-const { Menu } = unlock( componentsPrivateApis );
 const { usePostActions } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
-
-const PRODUCT_TYPE_MENU_ITEMS = [
-	{
-		key: 'simple',
-		icon: tag,
-		label: __( 'Simple product', 'woocommerce' ),
-		info: __( 'A standalone item with no variations.', 'woocommerce' ),
-		queryArgs: {},
-	},
-	{
-		key: 'variable',
-		icon: alignNone,
-		label: __( 'Variable product', 'woocommerce' ),
-		info: __(
-			'An item with variations like color or size.',
-			'woocommerce'
-		),
-		queryArgs: { product_type: 'variable' },
-	},
-	{
-		key: 'grouped',
-		icon: category,
-		label: __( 'Grouped product', 'woocommerce' ),
-		info: __( 'A collection of related products.', 'woocommerce' ),
-		queryArgs: { product_type: 'grouped' },
-	},
-	{
-		key: 'external',
-		icon: link,
-		label: __( 'Affiliate product', 'woocommerce' ),
-		info: __(
-			'A product you promote and earn commission on.',
-			'woocommerce'
-		),
-		queryArgs: { product_type: 'external' },
-	},
-] as const;
 
 export type ProductListProps = {
 	subTitle?: string;
@@ -130,7 +83,6 @@ export default function ProductList( {
 	const [ selection, setSelection ] = useState( () =>
 		getSelectionFromPostId( postId )
 	);
-	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
 
 	useEffect( () => {
 		setSelection( getSelectionFromPostId( postId ) );
@@ -272,40 +224,20 @@ export default function ProductList( {
 			>
 				{ __( 'Import', 'woocommerce' ) }
 			</Button>
-			<Menu onOpenChange={ setIsMenuOpen } placement="bottom-end">
-				<Menu.TriggerButton
-					disabled={ canCreateRecord === false }
-					render={ <Button variant="solid" size="compact" /> }
-				>
-					{ __( 'Add new', 'woocommerce' ) }
-					<Button.Icon
-						icon={ isMenuOpen ? chevronUp : chevronDown }
-					/>
-				</Menu.TriggerButton>
-				<Menu.Popover>
-					<Menu.Group>
-						{ PRODUCT_TYPE_MENU_ITEMS.map( ( item ) => (
-							<Menu.Item
-								key={ item.key }
-								prefix={ <Icon icon={ item.icon } /> }
-								onClick={ () => {
-									window.location.href = getAdminLink(
-										addQueryArgs( 'post-new.php', {
-											post_type: 'product',
-											...item.queryArgs,
-										} )
-									);
-								} }
-							>
-								<Menu.ItemLabel>{ item.label }</Menu.ItemLabel>
-								<Menu.ItemHelpText>
-									{ item.info }
-								</Menu.ItemHelpText>
-							</Menu.Item>
-						) ) }
-					</Menu.Group>
-				</Menu.Popover>
-			</Menu>
+			<Button
+				disabled={ canCreateRecord === false }
+				size="compact"
+				variant="solid"
+				onClick={ () =>
+					( window.location.href = getAdminLink(
+						addQueryArgs( 'post-new.php', {
+							post_type: 'product',
+						} )
+					) )
+				}
+			>
+				{ __( 'Add new product', 'woocommerce' ) }
+			</Button>
 		</Stack>
 	);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental products app should send merchants directly to the standard new product screen from the product list header. This restores the single "Add new product" button and removes the product-type dropdown menu and related unused imports/state.


### How to test the changes in this Pull Request:

1. Go to WooCommerce > Products with the experimental products app enabled.
2. Select the **Add new product** button in the product list header.
3. Confirm you are taken to the standard product creation screen at `post-new.php?post_type=product`.
4. Confirm the button is disabled when the current user cannot create products.

### Testing that has already taken place:

-   Ran `pnpm --filter=@woocommerce/experimental-products-app lint:lang:js`.
-   Ran `pnpm --filter=@woocommerce/experimental-products-app test:js -- --runTestsByPath src/product-list/query.test.ts`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was added manually in `packages/js/experimental-products-app/changelog/update-products-app-add-new-button`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
