### PR TITLE
Update Products App schedule sale control

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-schedule-sale-control
+++ b/packages/js/experimental-products-app/changelog/update-schedule-sale-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Move the sale schedule date pickers into the schedule sale field.

--- a/packages/js/experimental-products-app/src/fields/schedule_sale/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/schedule_sale/field.tsx
@@ -1,16 +1,9 @@
 /**
  * External dependencies
  */
-import {
-	BaseControl,
-	FlexBlock,
-	FormToggle,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 
-import { useInstanceId } from '@wordpress/compose';
-
-import { useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 
 import { __ } from '@wordpress/i18n';
 
@@ -22,6 +15,11 @@ import type { Field } from '@wordpress/dataviews';
 import type { ProductEntityRecord } from '../types';
 
 import { getLocalDefaultSaleStart } from '../price/utils';
+import {
+	DatePicker,
+	formatDateTimeLocal,
+	parseDateTimeLocal,
+} from '../components/date-picker';
 
 const fieldDefinition = {
 	type: 'boolean',
@@ -34,7 +32,6 @@ const fieldDefinition = {
 export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 	...fieldDefinition,
 	Edit: ( { data, onChange, field } ) => {
-		const toggleId = useInstanceId( FormToggle, 'schedule-sale-toggle' );
 		const [ tempDateOnSaleFrom, setTempDateOnSaleFrom ] = useState(
 			data.date_on_sale_from || ''
 		);
@@ -42,51 +39,152 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 			data.date_on_sale_to || ''
 		);
 		const checked = !! data.date_on_sale_to || !! data.date_on_sale_from;
-		return (
-			<BaseControl className="components-toggle-control">
-				<HStack justify="flex-start" spacing={ 2 }>
-					<FormToggle
-						id={ toggleId }
-						checked={ checked }
-						onChange={ () => {
-							if ( checked ) {
-								setTempDateOnSaleFrom(
-									data.date_on_sale_from || ''
-								);
-								setTempDateOnSaleTo(
-									data.date_on_sale_to || ''
-								);
-								onChange( {
-									date_on_sale_from: '',
-									date_on_sale_to: '',
-								} );
-							} else {
-								let dateOnSaleFrom =
-									data.date_on_sale_from ||
-									tempDateOnSaleFrom;
-								const dateOnSaleTo =
-									data.date_on_sale_to || tempDateOnSaleTo;
-
-								if ( ! dateOnSaleFrom && ! dateOnSaleTo ) {
-									dateOnSaleFrom = getLocalDefaultSaleStart();
-								}
-
-								onChange( {
-									date_on_sale_from: dateOnSaleFrom,
-									date_on_sale_to: dateOnSaleTo,
-								} );
-							}
-						} }
-					/>
-					<FlexBlock
-						as="label"
-						htmlFor={ toggleId }
-						className="components-toggle-control__label"
-					>
-						{ field.label }
-					</FlexBlock>
-				</HStack>
-			</BaseControl>
+		const today = useMemo( () => {
+			const d = new Date();
+			d.setHours( 0, 0, 0, 0 );
+			return d;
+		}, [] );
+		const dateOnSaleFrom = useMemo(
+			() =>
+				typeof data.date_on_sale_from === 'string' &&
+				data.date_on_sale_from
+					? parseDateTimeLocal( data.date_on_sale_from )
+					: null,
+			[ data.date_on_sale_from ]
 		);
+		const minDateOnSaleTo = useMemo( () => {
+			if ( dateOnSaleFrom ) {
+				const min = new Date( dateOnSaleFrom );
+				min.setMinutes( min.getMinutes() + 1 );
+				return min;
+			}
+
+			return today;
+		}, [ dateOnSaleFrom, today ] );
+		const handleScheduleChange = useCallback(
+			( value: boolean ) => {
+				if ( ! value ) {
+					setTempDateOnSaleFrom( data.date_on_sale_from || '' );
+					setTempDateOnSaleTo( data.date_on_sale_to || '' );
+					onChange( {
+						date_on_sale_from: '',
+						date_on_sale_to: '',
+					} );
+					return;
+				}
+
+				let nextDateOnSaleFrom =
+					data.date_on_sale_from || tempDateOnSaleFrom;
+				const nextDateOnSaleTo =
+					data.date_on_sale_to || tempDateOnSaleTo;
+
+				if ( ! nextDateOnSaleFrom && ! nextDateOnSaleTo ) {
+					nextDateOnSaleFrom = getLocalDefaultSaleStart();
+				}
+
+				onChange( {
+					date_on_sale_from: nextDateOnSaleFrom,
+					date_on_sale_to: nextDateOnSaleTo,
+				} );
+			},
+			[
+				data.date_on_sale_from,
+				data.date_on_sale_to,
+				onChange,
+				tempDateOnSaleFrom,
+				tempDateOnSaleTo,
+			]
+		);
+		const handleDateOnSaleFromChange = useCallback(
+			( value: { date_on_sale_from?: string | null } ) => {
+				const newStart = value.date_on_sale_from;
+				const currentEnd = data.date_on_sale_to;
+
+				if (
+					typeof newStart !== 'string' ||
+					! newStart ||
+					typeof currentEnd !== 'string' ||
+					! currentEnd
+				) {
+					onChange( value );
+					return;
+				}
+
+				const startDate = parseDateTimeLocal( newStart );
+				const endDate = parseDateTimeLocal( currentEnd );
+
+				if (
+					startDate &&
+					endDate &&
+					startDate.getTime() >= endDate.getTime()
+				) {
+					const newEndDate = new Date( startDate );
+					newEndDate.setDate( newEndDate.getDate() + 1 );
+
+					onChange( {
+						...value,
+						date_on_sale_to: formatDateTimeLocal( newEndDate ),
+					} );
+					return;
+				}
+
+				onChange( value );
+			},
+			[ data.date_on_sale_to, onChange ]
+		);
+
+		return (
+			<div className="woocommerce-schedule-sale-control">
+				<CheckboxControl
+					label={ field.label }
+					checked={ checked }
+					onChange={ handleScheduleChange }
+				/>
+				{ checked && (
+					<div className="woocommerce-schedule-sale-control__dates">
+						<DatePicker
+							data={ data }
+							onChange={ handleDateOnSaleFromChange }
+							field={ {
+								label: __( 'Start sale on', 'woocommerce' ),
+							} }
+							fieldKey="date_on_sale_from"
+							min={ today }
+						/>
+						<DatePicker
+							data={ data }
+							onChange={ onChange }
+							field={ {
+								label: __( 'End sale on', 'woocommerce' ),
+							} }
+							fieldKey="date_on_sale_to"
+							min={ minDateOnSaleTo }
+						/>
+					</div>
+				) }
+			</div>
+		);
+	},
+	getValue: ( { item } ) =>
+		!! item.date_on_sale_to || !! item.date_on_sale_from,
+	setValue: ( { item, value } ) => {
+		if ( ! value ) {
+			return {
+				date_on_sale_from: '',
+				date_on_sale_to: '',
+			};
+		}
+
+		let dateOnSaleFrom = item.date_on_sale_from || '';
+		const dateOnSaleTo = item.date_on_sale_to || '';
+
+		if ( ! dateOnSaleFrom && ! dateOnSaleTo ) {
+			dateOnSaleFrom = getLocalDefaultSaleStart();
+		}
+
+		return {
+			date_on_sale_from: dateOnSaleFrom,
+			date_on_sale_to: dateOnSaleTo,
+		};
 	},
 };

--- a/packages/js/experimental-products-app/src/fields/schedule_sale/style.scss
+++ b/packages/js/experimental-products-app/src/fields/schedule_sale/style.scss
@@ -1,0 +1,11 @@
+.woocommerce-schedule-sale-control {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.woocommerce-schedule-sale-control__dates {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 16px;
+}

--- a/packages/js/experimental-products-app/src/product-edit/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.test.ts
@@ -564,8 +564,6 @@ describe( 'product edit utils', () => {
 			'regular_price',
 			'sale_price',
 			'schedule_sale',
-			'date_on_sale_from',
-			'date_on_sale_to',
 			'cost_of_goods_sold',
 		];
 		const basePriceFieldIds = [ 'regular_price', 'sale_price' ];
@@ -607,8 +605,6 @@ describe( 'product edit utils', () => {
 				'regular_price',
 				'sale_price',
 				'schedule_sale',
-				'date_on_sale_from',
-				'date_on_sale_to',
 				'cost_of_goods_sold',
 				'images',
 				'sku',
@@ -662,8 +658,6 @@ describe( 'product edit utils', () => {
 				'regular_price',
 				'sale_price',
 				'schedule_sale',
-				'date_on_sale_from',
-				'date_on_sale_to',
 				'cost_of_goods_sold',
 			] );
 		} );
@@ -954,8 +948,6 @@ describe( 'product edit utils', () => {
 					'regular_price',
 					'sale_price',
 					'schedule_sale',
-					'date_on_sale_from',
-					'date_on_sale_to',
 					'cost_of_goods_sold',
 					'images',
 					'sku',
@@ -997,8 +989,6 @@ describe( 'product edit utils', () => {
 					'regular_price',
 					'sale_price',
 					'schedule_sale',
-					'date_on_sale_from',
-					'date_on_sale_to',
 					'cost_of_goods_sold',
 					'stock',
 					'manage_stock',
@@ -1078,8 +1068,6 @@ describe( 'product edit utils', () => {
 					'regular_price',
 					'sale_price',
 					'schedule_sale',
-					'date_on_sale_from',
-					'date_on_sale_to',
 					'cost_of_goods_sold',
 					...bulkSellableInstanceFieldIds,
 				] )
@@ -1349,7 +1337,7 @@ describe( 'product edit utils', () => {
 			[ 'simple product', 'simple' ],
 			[ 'variation product', 'variation' ],
 		] as const )(
-			'groups sale schedule date fields on the same row for %s',
+			'uses schedule sale as a compound price field for %s',
 			( _label, productType ) => {
 				const product = buildProduct( {
 					type: productType,
@@ -1370,14 +1358,6 @@ describe( 'product edit utils', () => {
 						'regular_price',
 						'sale_price',
 						'schedule_sale',
-						{
-							id: 'sale-schedule-dates',
-							layout: { type: 'row' },
-							children: [
-								'date_on_sale_from',
-								'date_on_sale_to',
-							],
-						},
 						'cost_of_goods_sold',
 					],
 				} );

--- a/packages/js/experimental-products-app/src/product-edit/utils.ts
+++ b/packages/js/experimental-products-app/src/product-edit/utils.ts
@@ -119,11 +119,6 @@ const SIMPLE_PRODUCT_EDIT_FORM_FIELDS = [
 		'regular_price',
 		'sale_price',
 		'schedule_sale',
-		{
-			id: 'sale-schedule-dates',
-			layout: { type: 'row' as const },
-			children: [ 'date_on_sale_from', 'date_on_sale_to' ],
-		},
 		'cost_of_goods_sold',
 	] ),
 	createProductEditFormGroup( 'image-fields', __( 'Images', 'woocommerce' ), [
@@ -157,11 +152,6 @@ const VARIATION_PRODUCT_EDIT_FORM_FIELDS = [
 		'regular_price',
 		'sale_price',
 		'schedule_sale',
-		{
-			id: 'sale-schedule-dates',
-			layout: { type: 'row' as const },
-			children: [ 'date_on_sale_from', 'date_on_sale_to' ],
-		},
 		'cost_of_goods_sold',
 	] ),
 	createProductEditFormGroup( 'image-fields', __( 'Images', 'woocommerce' ), [
@@ -216,11 +206,6 @@ const EXTERNAL_PRODUCT_EDIT_FORM_FIELDS = [
 		'regular_price',
 		'sale_price',
 		'schedule_sale',
-		{
-			id: 'sale-schedule-dates',
-			layout: { type: 'row' as const },
-			children: [ 'date_on_sale_from', 'date_on_sale_to' ],
-		},
 	] ),
 	createProductEditFormGroup( 'image-fields', __( 'Images', 'woocommerce' ), [
 		'images',

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -28,6 +28,7 @@
 	@import "./fields/components/taxonomy-edit/style.scss";
 	@import "./fields/downloadable/style.scss";
 	@import "./fields/images/style.scss";
+	@import "./fields/schedule_sale/style.scss";
 	@import "./fields/stock/style.scss";
 	@import "./fields/visibility_summary/style.scss";
 	--wp-ui-drawer-z-index: 100000;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The schedule sale control now owns the sale start and end date inputs, so merchants can enable scheduling and choose the dates in one place. This removes the standalone sale schedule date row from product edit forms and updates the field tests to reflect the compound schedule control.

### Screenshots or screen recordings:


### How to test the changes in this Pull Request:

1. Build or run the experimental products app and open the product edit form for a simple product.
2. In the price fields, enable **Schedule sale** and confirm the start and end sale date inputs appear under the checkbox.
3. Set a start date and confirm the end date cannot be earlier than the selected start date.
4. Disable **Schedule sale** and confirm the sale date inputs are hidden and the saved sale schedule values are cleared.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/product-edit/utils.test.ts --runInBand`
-   `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/fields/schedule_sale/field.tsx src/product-edit/utils.ts src/product-edit/utils.test.ts`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually in `packages/js/experimental-products-app/changelog/update-schedule-sale-control`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
