### PR TITLE
Drop wrapping quotes around the product name in the delete confirmation modal

### DIFF
--- a/packages/js/experimental-products-app/changelog/tweak-products-app-delete-modal-no-quotes
+++ b/packages/js/experimental-products-app/changelog/tweak-products-app-delete-modal-no-quotes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Drop the wrapping quotes around the product name in the experimental products app delete confirmation modal.

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
@@ -550,7 +550,7 @@ export const permanentlyDeleteAction = (): Action< ProductEntityRecord > => ( {
 						? sprintf(
 								/* translators: %s: The product's name. */
 								__(
-									'%s will be permanently deleted and can\'t be restored.',
+									"%s will be permanently deleted and can't be restored.",
 									'woocommerce'
 								),
 								items[ 0 ]?.name ?? ''

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
@@ -550,7 +550,7 @@ export const permanentlyDeleteAction = (): Action< ProductEntityRecord > => ( {
 						? sprintf(
 								/* translators: %s: The product's name. */
 								__(
-									'"%s" will be permanently deleted and can\'t be restored.',
+									'%s will be permanently deleted and can\'t be restored.',
 									'woocommerce'
 								),
 								items[ 0 ]?.name ?? ''


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The experimental products app's single-item delete confirmation modal wrapped the product name in straight double quotes:

> "Belt" will be permanently deleted and can't be restored.

The quotes are visual noise — the product name is unambiguously the subject of the sentence. This PR drops them so the copy reads:

> Belt will be permanently deleted and can't be restored.

The multi-select variant ("X products will be permanently deleted…") wasn't using quotes and is unchanged.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="639" height="257" alt="image" src="https://github.com/user-attachments/assets/0d815bd4-ca14-4f87-bf5f-a517a4e0296e" /> | <img width="625" height="246" alt="image" src="https://github.com/user-attachments/assets/83343837-957a-4c83-86b6-af2e0a9a4cd2" /> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open **Products → All Products ( new )**.
2. Move a single product to **Trash**, switch to the **Trash** tab.
3. Select the trashed product and choose **Delete permanently** from the row actions / bulk actions.
4. Confirm the modal body reads `<Product name> will be permanently deleted and can't be restored.` (no wrapping quotes).
5. Select two or more trashed products and trigger the same action. The modal should read `2 products will be permanently deleted and can't be restored.` (unchanged).

### Testing that has already taken place:

Local visual check of the single- and multi-item delete confirmation copy.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under \`packages/js/experimental-products-app/changelog/tweak-products-app-delete-modal-no-quotes\`.

</details>