### PR TITLE
Match the products app drawer title to the design-system Drawer header (20px)

### DIFF
--- a/packages/js/experimental-products-app/changelog/tweak-products-app-drawer-title-20px
+++ b/packages/js/experimental-products-app/changelog/tweak-products-app-drawer-title-20px
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Bump the experimental products app quick-edit drawer title to 20px so it matches the design-system Drawer header treatment.

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -135,12 +135,13 @@
 	border-bottom: 1px solid var(--wp-components-color-gray-300, #ddd);
 }
 
-// Qualified to beat `@wordpress/ui`'s unlayered `:is(h1-h6).heading` defense rule, which would otherwise apply heading-xl (20px).
+// Qualified to beat `@wordpress/ui`'s unlayered `:is(h1-h6).heading` defense rule.
+// Matches the design-system Drawer header treatment (heading-xl, 20px).
 .woocommerce-product-edit__drawer .woocommerce-product-edit__title {
 	margin: 0;
-	font-size: 15px;
+	font-size: 20px;
 	font-weight: 500;
-	line-height: 20px;
+	line-height: 28px;
 	color: var(--wp-components-color-foreground, #1e1e1e);
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The experimental products app's quick-edit drawer title (e.g. "Affiliate product") was rendering at 15px. The design-system [`Drawer`](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-drawer--docs) header uses heading-xl (20px). The current 15px exists as an explicit override of `@wordpress/ui`'s defense rule.

This PR bumps the title to **20px / 500 / 28px line-height** so the drawer header matches the design-system Drawer story (the "Navigation" example). Other properties (text ellipsis, color) are unchanged.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="460" height="383" alt="image" src="https://github.com/user-attachments/assets/c1636f5b-ea81-42ef-884e-6e4983d0ef2d" /> | <img width="464" height="312" alt="image" src="https://github.com/user-attachments/assets/41ad42c9-41b6-4278-b7db-b87cb0a8f618" /> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open **Products → All Products ( new )**.
2. Open Quick edit on any product. The drawer slides in.
3. Confirm the product name in the header reads at **20px / weight 500 / 28px line height**.
4. Try a product with a long name — the title should still ellipsize with a single line and not push the close button.

### Testing that has already taken place:

Local visual check of the drawer header on a few products with varying name lengths.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under \`packages/js/experimental-products-app/changelog/tweak-products-app-drawer-title-20px\`.

</details>