### PR TITLE
Tailor variation row actions in the experimental products app

### DIFF
--- a/packages/js/experimental-products-app/changelog/update-products-app-variation-row-actions
+++ b/packages/js/experimental-products-app/changelog/update-products-app-variation-row-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Tailor the row actions on variation rows in the experimental products app product list: keep Quick edit and Edit, hide Duplicate, and replace Move to trash with Permanently delete (using the existing delete-confirmation modal).

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.test.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.test.tsx
@@ -505,10 +505,15 @@ describe( 'product list actions', () => {
 		): ActionModal< ProductEntityRecord > =>
 			action as ActionModal< ProductEntityRecord >;
 
-		it( 'is eligible only for trashed products', () => {
+		it( 'is eligible for trashed products and for any variation', () => {
 			const action = permanentlyDeleteAction();
+			const variation = {
+				...product,
+				type: 'variation',
+			} as ProductEntityRecord;
 
 			expect( action.isEligible?.( trashedProduct ) ).toBe( true );
+			expect( action.isEligible?.( variation ) ).toBe( true );
 			expect( action.isEligible?.( product ) ).toBe( false );
 		} );
 

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
@@ -333,7 +333,10 @@ export const duplicateProductAction = (): Action< ProductEntityRecord > => ( {
 	supportsBulk: true,
 	isEligible( item ) {
 		return (
-			!! item && item.status !== 'trash' && item.status !== 'auto-draft'
+			!! item &&
+			item.status !== 'trash' &&
+			item.status !== 'auto-draft' &&
+			item.type !== 'variation'
 		);
 	},
 	async callback( items, { onActionPerformed } ) {
@@ -360,7 +363,10 @@ export const moveToTrashAction = (): Action< ProductEntityRecord > => ( {
 	supportsBulk: true,
 	icon: trash,
 	isEligible( product ) {
-		return product.status !== 'trash';
+		// Variations skip the trash and go straight to permanent delete
+		// (see `permanentlyDeleteAction`), since the variations REST endpoint
+		// doesn't support a soft-trash state.
+		return product.status !== 'trash' && product.type !== 'variation';
 	},
 	async callback( items, { onActionPerformed } ) {
 		const { deleteEntityRecord } = dispatch( coreStore );
@@ -483,7 +489,9 @@ export const permanentlyDeleteAction = (): Action< ProductEntityRecord > => ( {
 	supportsBulk: true,
 	icon: trash,
 	isEligible( product ) {
-		return product.status === 'trash';
+		// Variations are deleted directly (no trash step), so show this
+		// action for them regardless of status.
+		return product.status === 'trash' || product.type === 'variation';
 	},
 	modalHeader: ( items ) =>
 		items.length === 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Variation rows in the experimental products app were inheriting the full product row-actions menu. Some of those don't make sense for a variation:

- **Duplicate** doesn't apply — variations can't be duplicated via the products REST endpoint.
- **Move to trash** doesn't apply — the variations endpoint deletes directly (no soft-trash state), so trashing a variation row never returns it to a "Trash" tab.

This PR adjusts the `isEligible` gates so a variation row shows:

- **Quick edit** — unchanged.
- **Edit** — unchanged.
- ~~Duplicate~~ — hidden (`item.type !== 'variation'` added).
- ~~Move to trash~~ — hidden (`product.type !== 'variation'` added).
- **Permanently delete** — newly eligible for variations (regardless of status) and reuses the existing delete-confirmation modal.

No new actions, no new modals, no API changes. The non-variation product actions are untouched.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="217" height="233" alt="image" src="https://github.com/user-attachments/assets/7f97cf0e-239f-485b-848e-e78bbbe970be" /> | <img width="220" height="179" alt="image" src="https://github.com/user-attachments/assets/bfd6daef-b33b-443d-adcb-579f68573ecb" /> |

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open **Products → All Products ( new )**.
2. Expand a **Variable product** so its variation rows are visible in the tree view.
3. Open the row actions (⋯) on a **variation** row. Confirm the menu lists exactly: **Quick edit**, **Edit**, **Permanently delete**. (No Duplicate, no Move to trash.)
4. Click **Permanently delete**. The existing delete-confirmation modal opens. Cancel returns to the list. Confirming deletes the variation and surfaces the existing success snackbar.
5. Open the row actions on a regular (non-variation) product row. Confirm the menu still shows **Quick edit**, **Edit**, **Duplicate**, **Move to trash** — i.e. unchanged for non-variations.
6. Move a regular product to Trash and switch to the **Trash** tab. Confirm trashed products still show **Permanently delete** (unchanged).

### Testing that has already taken place:

- Updated the `permanentlyDeleteAction` eligibility unit test to cover the new variation branch.
- Local visual check across variable, simple, and trashed products.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually under \`packages/js/experimental-products-app/changelog/update-products-app-variation-row-actions\`.

</details>