### PR TITLE
Remove human-stall instructions from autoloaded skills

### DIFF
--- a/.ai/skills/woocommerce-git-commit/SKILL.md
+++ b/.ai/skills/woocommerce-git-commit/SKILL.md
@@ -35,7 +35,7 @@ Two files changed for the same reason = one commit. Don't over-split.
 
 ### 3. Draft Commit Message(s)
 
-Use the current session context to understand what work was done and why. If motivation is still unclear after reviewing the diff and conversation, ask the user in a single question.
+Use the current session context to understand what work was done and why. If motivation is still unclear after reviewing the diff and conversation, infer the best reasonable description from the diff and commit conventions.
 
 **Format** — verb-first imperative, under 72 chars:
 
@@ -53,9 +53,9 @@ Do NOT include issue/PR refs — GitHub adds those on squash-merge.
 
 If $ARGUMENTS is provided, use it as guidance for the commit message.
 
-### 4. Preview and Confirm
+### 4. Preview
 
-Show the user each proposed commit:
+State each proposed commit before executing:
 
 ```text
 Commit 1: Fix double margin-top in flex layout
@@ -65,8 +65,6 @@ Commit 1: Fix double margin-top in flex layout
 Commit 2: Add changelog entries for email editor fix
   files: plugins/woocommerce/changelog/fix-email-margin
 ```
-
-Wait for user approval or corrections before executing.
 
 ### 5. Execute
 

--- a/.ai/skills/woocommerce-git-draft-pr/SKILL.md
+++ b/.ai/skills/woocommerce-git-draft-pr/SKILL.md
@@ -20,7 +20,7 @@ Create a concise, reviewer-friendly draft PR from the current branch.
 
 ### 1. Preflight and Analyze
 
-Verify from dynamic context: not on trunk (ask which branch if so), commits exist ahead of trunk (stop if none), no uncommitted changes (ask user to commit/stash if dirty).
+Verify from dynamic context: not on trunk (stop if so), commits exist ahead of trunk (stop if none), no uncommitted changes (stop if dirty).
 
 **Base branch**: use `release/*` if the branch was created from one, otherwise `trunk`.
 
@@ -32,13 +32,13 @@ From the dynamic context above (read full diffs only if the stat summary is ambi
 - **UI changes?** Changes in `client/`, `templates/`, CSS/SCSS, JSX/TSX
 - **Plugin-affecting?** Code shipped to users = yes. CI/CD, workflows, tooling, docs = no. This drives changelog, milestone, and PR body complexity — non-plugin PRs use a simplified body (see Step 3).
 
-### 2. Gather Context from User
+### 2. Gather Context
 
-Extract issue/PR refs from commits and branch name. Ask the user (combine into one prompt):
+Extract issue/PR refs from commits and branch name:
 
-- If no issue ref: "Is there a GitHub issue?" (Linear is internal — only reference GitHub issues in PRs)
-- If bug fix, no origin PR found: "Which PR introduced this bug?"
-- If motivation unclear from code: "What's the context?"
+- **Issue ref**: use what's in commits/branch if present; otherwise omit `Closes #` (Linear refs are internal — only reference GitHub issues in PRs).
+- **Bug-fix origin PR**: if a bug fix and no PR ref is in the diff/commits, search history (`git log -S` on touched lines) to find the introducing PR; omit `Bug introduced in PR #XXXX.` if not found.
+- **Motivation**: infer from diff and commit messages. Use the strongest summary you can; don't block on missing context.
 
 ### 3. Generate PR Title + Body
 
@@ -68,16 +68,16 @@ Use the full template:
 - **Submission Review Guidelines**: Keep as-is from template.
 - **Changes proposed**: 2-3 sentences. Lead with WHY, then WHAT. No filler ("This PR addresses..."). Include `Closes #1234.` if applicable. For bugs: `Bug introduced in PR #XXXX.` (omit this line entirely if not a bug fix).
 - **Screenshots**: Remove section if no UI changes. For UI changes, use Chrome DevTools MCP to capture screenshots if available; otherwise remind user to add them before marking ready.
-- **Testing instructions**: Concrete numbered steps with expected outcomes. Ask user to verify before finalizing. Each step must be actionable — don't reference links that won't exist yet.
-- **Testing done**: Ask user what testing they've performed.
+- **Testing instructions**: Concrete numbered steps with expected outcomes derived from the diff. Each step must be actionable — don't reference links that won't exist yet.
+- **Testing done**: Fill with what's verifiable from the session (commits, test runs, lint runs). If nothing is verifiable, write "Author to fill in before marking ready."
 - **Milestone**: Check auto-assign `[x]` if plugin-affecting.
 - **Changelog**: If changelogs already in diff → "does not require" (created manually). Otherwise → "Automatically create" `[x]` with Significance, Type, and a user-facing Message.
 
 Strip all HTML comments (`<!-- -->`) and unfilled placeholder lines (e.g., `Closes # .`, `Bug introduced in PR # .`) from output.
 
-### 4. Preview and Confirm
+### 4. Preview
 
-Show the user the generated title and body. Apply any corrections before proceeding.
+State the generated title and body before executing.
 
 ### 5. Push and Create
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `woocommerce-git-commit` and `woocommerce-git-draft-pr` skills contained directives to wait for user approval mid-procedure and to ask follow-up questions when context was missing. Autoloaded skills get matched against any agent session whose prompt contains their trigger keywords (`commit`, `create a PR`, etc.), so those imperatives also fire in non-interactive runs — including AI Coder PR revisions — where there is no human to answer. The observed result (see [PAY-669](https://linear.app/a8c/issue/PAY-669)) was that Claude produced a correct fix, printed `Shall I proceed?`, and waited; the orchestrator's bail detector saw zero commits and discarded the working-tree change.

This PR rewrites the stall imperatives in both skills:

-   Replaces "ask the user" / "wait for approval" with "infer the best reasonable description from context" so autonomous runs proceed instead of waiting.
-   Converts the draft-PR preflight's ambiguous "ask which branch / ask user to commit/stash" checks into hard stops, matching the existing "stop if no commits" pattern.
-   Keeps the preview blocks in both skills as informational output — they cost nothing in autonomous runs and still let interactive users see what is about to happen.

Note: this PR closes the trap at the skill layer. The complementary runner-side fix (treating uncommitted working-tree changes as recoverable rather than bailing) lives in the AI Coder pipeline and is tracked separately in PAY-669.

### How to test the changes in this Pull Request:

1.  Read the diff for `.ai/skills/woocommerce-git-commit/SKILL.md` and confirm step 4 no longer contains "Wait for user approval or corrections before executing," and that step 3 no longer instructs the agent to ask the user when motivation is unclear.
2.  Read the diff for `.ai/skills/woocommerce-git-draft-pr/SKILL.md` and confirm: the preflight in step 1 now says "stop if so / stop if dirty" instead of "ask"; step 2 lists infer-from-context fallbacks rather than user-facing questions; the Testing instructions / Testing done bullets in step 3 no longer ask the user; step 4 is renamed "Preview" with the corrections-gate removed.
3.  In an interactive Claude Code session in this repo, with at least one uncommitted change, invoke `/woocommerce-git-commit`. Expected: the skill prints the proposed-commit preview and proceeds to commit without first asking for approval. Verify with `git log --oneline -n 1` that a new commit landed and matches the previewed message.
4.  In an interactive Claude Code session in this repo, on a feature branch with one or more commits ahead of `trunk` and a clean working tree, invoke `/woocommerce-git-draft-pr`. Expected: the skill drafts a title and body, prints them as a preview, and proceeds to `git push` + `gh pr create --draft` without asking follow-up questions. The created PR should be a draft.

### Testing that has already taken place:

-   Diff reviewed line by line against the two SKILL.md files; re-grepped both files for the original stall-trigger phrases (`wait for`, `shall i`, `ask the user`, `confirm with`, `user approval`, `proceed\?`) — no matches remain.
-   Verified the changes are scoped to `.ai/skills/` and do not touch plugin code, CI, or shipped templates.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

`.ai/skills/` is internal AI-agent tooling. It is not shipped to merchants or extension developers, so no user-facing changelog entry is warranted.

</details>