### PR TITLE
Point draft-PR skill at PULL_REQUEST_TEMPLATE.md directly

### DIFF
--- a/.ai/skills/woocommerce-git-draft-pr/SKILL.md
+++ b/.ai/skills/woocommerce-git-draft-pr/SKILL.md
@@ -30,7 +30,7 @@ From the dynamic context above (read full diffs only if the stat summary is ambi
 - **Significance**: Patch (most common), Minor (new features), Major (breaking — rare)
 - **Bug fix?** Look for issue refs in commits/branch name (e.g., `#12345`, `fix/issue-12345`)
 - **UI changes?** Changes in `client/`, `templates/`, CSS/SCSS, JSX/TSX
-- **Plugin-affecting?** Code shipped to users = yes. CI/CD, workflows, tooling, docs = no. This drives changelog, testing, and PR body complexity — non-plugin PRs use a simplified body (see Step 3).
+- **Plugin-affecting?** Code shipped to users = yes. CI/CD, workflows, tooling, docs = no. This drives the Milestone, Changelog, and Release Communication decisions in Step 3.
 
 ### 2. Gather Context
 
@@ -42,39 +42,23 @@ Extract issue/PR refs from commits and branch name:
 
 ### 3. Generate PR Title + Body
 
-Use the PR template from the dynamic context above. Preserve HTML comments from the template in every retained section; several comments are automation markers or test fixtures for milestone, changelog, and other GitHub checks.
-
 **Title** (under 70 chars, verb-first — the repo convention):
 
 - `Fix <what was broken>`, `Add <what>`, or other verb (Restore, Bump, Prepare, etc.)
 - Optional area prefix: `[Email Editor] Fix double margin-top in flex layout`
 - No `fix:`/`feat:` prefixes. No Linear ticket refs — Linear is internal, PRs are public.
 
-**Body** — depends on whether the change is plugin-affecting:
+**Body** — fill in `.github/PULL_REQUEST_TEMPLATE.md` (loaded in dynamic context above) section by section, in order. The template's HTML comments describe what each section is for — follow them as the per-section instructions. Repo-specific rules that the template doesn't carry, layered on top:
 
-#### Non-plugin changes (CI/CD, tooling, docs, `.ai/skills/`, workflows)
+- **Changes proposed**: 2-3 sentences. Lead with WHY, then WHAT. No filler ("This PR addresses..."). Drop the `Closes # .` line if you don't have a GitHub issue ref. Drop the `Bug introduced in PR # .` line if not a bug fix or origin PR unknown.
+- **Milestone**: tick the auto-assign box only for plugin-affecting changes. The section itself stays — the template marks it do-not-remove.
+- **Changelog entry**:
+  - Plugin-affecting, no changelog files in the diff → tick `Automatically create` with Significance, Type, and a user-facing Message.
+  - Plugin-affecting with changelog files already in the diff → tick `does not require` with the Comment "Created manually."
+  - Not plugin-affecting → tick `does not require` with a Comment explaining why (e.g., "Internal tooling, not shipped to merchants").
+- **Release Communication**: tick `Feature Highlight` for user-visible features merchants will notice, or `Developer Advisory` for changes affecting extension/theme developers (hook signatures, deprecations, REST API field changes). Otherwise leave both unchecked.
 
-Use a simplified body with only these sections:
-
-- **Submission Review Guidelines**: Keep as-is from template.
-- **Changes proposed**: 2-3 sentences. Lead with WHY, then WHAT.
-- **Milestone**: Keep the section and check auto-assign `[x]` unless a milestone will be assigned manually. Keep the surrounding template comments, including `<!-- milestone-target-selection -->` and `<!-- /milestone-target-selection -->`.
-
-Skip Screenshots, Testing instructions, Testing done, and Changelog sections entirely.
-
-#### Plugin-affecting changes
-
-Use the full template:
-
-- **Submission Review Guidelines**: Keep as-is from template.
-- **Changes proposed**: 2-3 sentences. Lead with WHY, then WHAT. No filler ("This PR addresses..."). Include `Closes #1234.` if applicable. For bugs: `Bug introduced in PR #XXXX.` (omit this line entirely if not a bug fix).
-- **Screenshots**: Remove section if no UI changes. For UI changes, use Chrome DevTools MCP to capture screenshots if available; otherwise remind user to add them before marking ready.
-- **Testing instructions**: Concrete numbered steps with expected outcomes derived from the diff. Each step must be actionable — don't reference links that won't exist yet.
-- **Testing done**: Fill with what's verifiable from the session (commits, test runs, lint runs). If nothing is verifiable, write "Author to fill in before marking ready."
-- **Milestone**: Check auto-assign `[x]` unless a milestone will be assigned manually. Keep the surrounding template comments, including `<!-- milestone-target-selection -->` and `<!-- /milestone-target-selection -->`.
-- **Changelog**: If changelogs already in diff → "does not require" (created manually). Otherwise → "Automatically create" `[x]` with Significance, Type, and a user-facing Message. Keep the template comments in this section, including inline comments after headings such as `#### Message <!-- Add a changelog message here -->`.
-
-Do not strip HTML comments (`<!-- -->`) from retained template sections. They support PR automation and GitHub tests. Remove only unfilled placeholder lines that are actual visible placeholders (e.g., `Closes # .`, `Bug introduced in PR # .`).
+After filling, keep the template's HTML comments (`<!-- -->`) — they support PR automation and GitHub tests. Remove only unfilled placeholder lines that are actual visible placeholders (e.g., `Closes # .`, `Bug introduced in PR # .`).
 
 ### 4. Preview
 
@@ -96,5 +80,5 @@ Output the PR URL. If UI changes need screenshots, remind the user.
 
 - No Co-Authored-By lines or self-attribution
 - Never commit code — pushing is fine
-- Preserve the PR template section headings and HTML comments exactly in retained sections; the Milestone section is required for all PRs unless a milestone is assigned manually
+- Preserve the PR template section headings and HTML comments exactly
 - Changelog checkboxes must match CI automation format

--- a/.ai/skills/woocommerce-git-draft-pr/SKILL.md
+++ b/.ai/skills/woocommerce-git-draft-pr/SKILL.md
@@ -53,9 +53,9 @@ Extract issue/PR refs from commits and branch name:
 - **Changes proposed**: 2-3 sentences. Lead with WHY, then WHAT. No filler ("This PR addresses..."). Drop the `Closes # .` line if you don't have a GitHub issue ref. Drop the `Bug introduced in PR # .` line if not a bug fix or origin PR unknown.
 - **Milestone**: tick the auto-assign box only for plugin-affecting changes. The section itself stays — the template marks it do-not-remove.
 - **Changelog entry**:
-  - Plugin-affecting, no changelog files in the diff → tick `Automatically create` with Significance, Type, and a user-facing Message.
-  - Plugin-affecting with changelog files already in the diff → tick `does not require` with the Comment "Created manually."
-  - Not plugin-affecting → tick `does not require` with a Comment explaining why (e.g., "Internal tooling, not shipped to merchants").
+    - Plugin-affecting, no changelog files in the diff → tick `Automatically create` with Significance, Type, and a user-facing Message.
+    - Plugin-affecting with changelog files already in the diff → tick `does not require` with the Comment "Created manually."
+    - Not plugin-affecting → tick `does not require` with a Comment explaining why (e.g., "Internal tooling, not shipped to merchants").
 - **Release Communication**: tick `Feature Highlight` for user-visible features merchants will notice, or `Developer Advisory` for changes affecting extension/theme developers (hook signatures, deprecations, REST API field changes). Otherwise leave both unchecked.
 
 After filling, keep the template's HTML comments (`<!-- -->`) — they support PR automation and GitHub tests. Remove only unfilled placeholder lines that are actual visible placeholders (e.g., `Closes # .`, `Bug introduced in PR # .`).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `woocommerce-git-draft-pr` skill carried its own per-section structure of the PR body, branched into a "simplified" (non-plugin) and a "full" (plugin-affecting) variant. Both variants duplicated `.github/PULL_REQUEST_TEMPLATE.md`, and the simplified branch had drifted: it instructed the agent to skip the Milestone section entirely, even though the template explicitly marks Milestone do-not-remove. The duplication is the root cause — any future change to the template requires a matching change to the skill, and the two will keep drifting.

Replace section 3 with a lean version that points the agent at the canonical template (already loaded into dynamic context as `cat .github/PULL_REQUEST_TEMPLATE.md`) and only carries the meta-rules the template can't express: title format, the three plugin-affecting-driven checkbox decisions (Milestone, Changelog, Release Communication), and post-fill cleanup of HTML comments and unfilled placeholders. Per-section prose instructions are left to the template's own HTML comments.

Follow-up to #65202.

### How to test the changes in this Pull Request:

1.  Read the diff for `.ai/skills/woocommerce-git-draft-pr/SKILL.md`. Confirm section 3 no longer contains the two branched body templates (`#### Non-plugin changes` / `#### Plugin-affecting changes`), and instead points at `.github/PULL_REQUEST_TEMPLATE.md` plus four meta-rule bullets (Changes proposed, Milestone, Changelog entry, Release Communication). Confirm the Constraints section drops the `(for plugin-affecting PRs)` qualifier on "Preserve the PR template section headings exactly."
2.  In an interactive Claude Code session in this repo, on a feature branch with one or more commits ahead of `trunk` and a clean working tree, invoke `/woocommerce-git-draft-pr`. Expected: the generated PR body includes every section from `.github/PULL_REQUEST_TEMPLATE.md`, including Milestone (with the auto-assign box ticked only if the change is plugin-affecting) and Release Communication. Sections the template marks removable (Screenshots when no UI changes) may be removed; sections it marks do-not-remove (Milestone) must remain.
3.  Repeat step 2 on a branch whose changes touch only `.ai/skills/`, `.github/workflows/`, or other non-plugin paths. Expected: the Milestone section is still present (with auto-assign unticked) and the Changelog entry section has "does not require" ticked with an explanatory comment.

### Testing that has already taken place:

-   Diff reviewed line by line.
-   Re-read the new section 3 against `.github/PULL_REQUEST_TEMPLATE.md` to confirm every checkbox-style decision in the template is covered by a meta-rule, and no prose-section guidance is duplicated from the template's HTML comments.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

`.ai/skills/` is internal AI-agent tooling. It is not shipped to merchants or extension developers, so no user-facing changelog entry is warranted.

</details>

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**