### PR TITLE
Avoid building unnecessary styling files in legacy Product Filters block

### DIFF
--- a/plugins/woocommerce/changelog/fix-filters-wrapper-styling-files
+++ b/plugins/woocommerce/changelog/fix-filters-wrapper-styling-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Avoid building unnecessary styling files in Product Filters block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/filter-wrapper/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/filter-wrapper/block.tsx
@@ -6,7 +6,6 @@ import { useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import './register-components';
 import { FilterBlockContext } from './context';
 
 type Props = {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/filter-wrapper/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/filter-wrapper/frontend.ts
@@ -7,6 +7,7 @@ import { getRegisteredBlockComponents } from '@woocommerce/blocks-registry';
 /**
  * Internal dependencies
  */
+import './register-components';
 import Block from './block';
 
 renderParentBlock( {

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -69,7 +69,13 @@ const blocks = {
 	'featured-product': {
 		customDir: 'featured-items/featured-product',
 	},
-	'filter-wrapper': {},
+	'filter-wrapper': {
+		// Frontend-only lazy component registration; exclude from styling build.
+		stylingExcludePatterns: [
+			/\/frontend\.(t|j)sx?$/,
+			/\/block\.(t|j)sx?$/,
+		],
+	},
 	'handpicked-products': {},
 	// We need to keep the legacy-template id, so we need to add a custom config to point to the renamed classic-template folder
 	'legacy-template': {
@@ -266,15 +272,32 @@ const cartAndCheckoutBlocks = {
 // Returns the entries for each block given a relative path (ie: `index.js`,
 // `**/*.scss`...).
 // It also filters out elements with undefined props and experimental blocks.
-const getBlockEntries = ( relativePath, blockEntries = blocks ) => {
+const getBlockEntries = (
+	relativePath,
+	blockEntries = blocks,
+	{ applyStylingExclusions = false } = {}
+) => {
 	return Object.fromEntries(
 		Object.entries( blockEntries )
 			.map( ( [ blockCode, config ] ) => {
-				const filePaths = glob.sync(
-					`./assets/js/blocks/${ config.customDir || blockCode }/` +
-						relativePath,
-					{ dotRelative: true }
-				);
+				const filePaths = glob
+					.sync(
+						`./assets/js/blocks/${
+							config.customDir || blockCode
+						}/` + relativePath,
+						{ dotRelative: true }
+					)
+					.filter( ( filePath ) => {
+						if ( ! applyStylingExclusions ) {
+							return true;
+						}
+
+						const excludePatterns =
+							config.stylingExcludePatterns || [];
+						return ! excludePatterns.some( ( pattern ) =>
+							pattern.test( filePath )
+						);
+					} );
 				if ( filePaths.length > 0 ) {
 					return [ blockCode, filePaths ];
 				}
@@ -317,7 +340,8 @@ const blockStylingEntries = getBlockEntries(
 				);
 			} )
 		),
-	}
+	},
+	{ applyStylingExclusions: true }
 );
 
 const entries = {

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -71,10 +71,7 @@ const blocks = {
 	},
 	'filter-wrapper': {
 		// Frontend-only lazy component registration; exclude from styling build.
-		stylingExcludePatterns: [
-			/\/frontend\.(t|j)sx?$/,
-			/\/block\.(t|j)sx?$/,
-		],
+		skipStyling: true,
 	},
 	'handpicked-products': {},
 	// We need to keep the legacy-template id, so we need to add a custom config to point to the renamed classic-template folder
@@ -272,32 +269,15 @@ const cartAndCheckoutBlocks = {
 // Returns the entries for each block given a relative path (ie: `index.js`,
 // `**/*.scss`...).
 // It also filters out elements with undefined props and experimental blocks.
-const getBlockEntries = (
-	relativePath,
-	blockEntries = blocks,
-	{ applyStylingExclusions = false } = {}
-) => {
+const getBlockEntries = ( relativePath, blockEntries = blocks ) => {
 	return Object.fromEntries(
 		Object.entries( blockEntries )
 			.map( ( [ blockCode, config ] ) => {
-				const filePaths = glob
-					.sync(
-						`./assets/js/blocks/${
-							config.customDir || blockCode
-						}/` + relativePath,
-						{ dotRelative: true }
-					)
-					.filter( ( filePath ) => {
-						if ( ! applyStylingExclusions ) {
-							return true;
-						}
-
-						const excludePatterns =
-							config.stylingExcludePatterns || [];
-						return ! excludePatterns.some( ( pattern ) =>
-							pattern.test( filePath )
-						);
-					} );
+				const filePaths = glob.sync(
+					`./assets/js/blocks/${ config.customDir || blockCode }/` +
+						relativePath,
+					{ dotRelative: true }
+				);
 				if ( filePaths.length > 0 ) {
 					return [ blockCode, filePaths ];
 				}
@@ -334,14 +314,16 @@ const blockStylingEntries = getBlockEntries(
 				...blocks,
 				...genericBlocks,
 				...cartAndCheckoutBlocks,
-			} ).filter( ( [ blockName ] ) => {
+			} ).filter( ( [ blockName, config ] ) => {
+				if ( config.skipStyling ) {
+					return false;
+				}
 				return ! frontendScriptModuleBlocksToSkip.includes(
 					`woocommerce/${ blockName }`
 				);
 			} )
 		),
-	},
-	{ applyStylingExclusions: true }
+	}
 );
 
 const entries = {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

During the build process, we were generating a couple of unnecessary CSS files for the Product Filters block. That was because it had dynamic imports of the inner filter blocks, so the styles of the inner blocks was being built as if it was part of the Product Filters blocks.

This PR adds a system to exclude certain blocks from the process of generating the CSS files.

### How to test the changes in this Pull Request:

1. Build WooCommerce (`pnpm run build`).
2. Go to `/plugins/woocommerce/assets/client/blocks/`.
3. Verify there are no files like `base-components-stock-filter-wrapper~attribute-filter-wrapper~rating-filter-wrapper-style.scss.css` or `base-components-stock-filter-wrapper~attribute-filter-wrapper~rating-filter-wrapper-style.scss-rtl.css`.
4. In the frontend of your store, verify the _Product Filters_ block and its inner blocks are correctly styled.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->