### PR TITLE
Check parent product visibility in get_variation AJAX endpoint

### DIFF
--- a/plugins/woocommerce/changelog/fix-get-variation-parent-visibility
+++ b/plugins/woocommerce/changelog/fix-get-variation-parent-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check parent product visibility in get_variation AJAX endpoint before returning variation data

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -617,6 +617,10 @@ class WC_AJAX {
 			wp_die();
 		}
 
+		if ( ProductStatus::PUBLISH !== $variable_product->get_status() && ! current_user_can( 'edit_post', $variable_product->get_id() ) ) {
+			wp_die();
+		}
+
 		$data_store   = WC_Data_Store::load( 'product' );
 		$variation_id = $data_store->find_matching_product_variation( $variable_product, wp_unslash( $_POST ) );
 		$variation    = $variation_id ? $variable_product->get_available_variation( $variation_id ) : false;


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When fetching product variations via its AJAX endpoint (that runs on product page), we don't check if the parent product is visible or not, which means we would return variation data for a hidden product, this PR fixes it.

```php
if ( ProductStatus::PUBLISH !== $variable_product->get_status() && ! current_user_can( 'edit_post', $variable_product->get_id() ) ) {
    wp_die();
}
```

No PR to close as this came via a report.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Reproduce the issue on trunk (before this patch):**

1. As an admin, create a variable product. Add at least one attribute used for variations (e.g. *Color* with terms *red*, *blue*) and generate variations with prices/SKUs filled in.
2. Save the product as **Draft** (don't publish it).
3. Note the product ID (e.g. `123`) and the attribute slug (e.g. `pa_color`).
4. In a private / incognito window (unauthenticated), open DevTools and run:
   ```js
   fetch('/?wc-ajax=get_variation', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: 'product_id=123&attribute_pa_color=red',
   }).then(r => r.json()).then(console.log);
   ```
5. **Without the patch:** response is the full variation object — `display_price`, `sku`, `dimensions`, `weight`, `variation_description`, `image`, etc.

**Verify the fix:**

6. Apply this branch.
7. Repeat step 4 in the incognito window → response is empty (`null` / no body).
8. Switch the draft product to **Published** and repeat → response is the variation object again. (No regression on the normal flow.)
9. With the product back in **Draft**, sign in as an admin (or shop manager) in the same browser and repeat → response is the variation object, so the admin-preview path is preserved.
10. Load any published variable product page logged out and switch variations via the dropdowns → no regression in the front-end add-to-cart form.

### Testing that has already taken place:

- Static: `phpcs-changed` (clean), branch-level `lint:changes:branch` (clean), `phpstan analyse includes/class-wc-ajax.php` (no errors, no new baseline entries).
- Code review: confirmed the parent-visibility check matches the established WC pattern across `abstract-wc-product.php`, `class-wc-product-variation.php`, and `wc-product-functions.php`; confirmed `ProductStatus` is already imported in the file (line 10); confirmed `find_matching_product_variation()` already filters child status in SQL so per-variation status is unaffected; confirmed Store API (`StoreApi/Utilities/ProductQuery.php:41`) constrains parent status to `publish` so no analogous gap exists there.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was created manually in this branch (`plugins/woocommerce/changelog/fix-get-variation-parent-visibility`), so the auto-create checkbox below is intentionally left unchecked.

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Check parent product visibility in get_variation AJAX endpoint before returning variation data

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)