### PR TITLE
Fix media-text RTL test text lookup

### DIFF
--- a/packages/php/email-editor/changelog/fix-media-text-rtl-test-assertion
+++ b/packages/php/email-editor/changelog/fix-media-text-rtl-test-assertion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Email Editor: fix media-text RTL renderer test assertion.

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Core_Renderers_Rtl_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Core_Renderers_Rtl_Test.php
@@ -105,7 +105,7 @@ class Core_Renderers_Rtl_Test extends \Email_Editor_Integration_Test_Case {
 		$rendered = $renderer->render( $content, $block, $this->rtl_context );
 
 		$media_position = strpos( $rendered, 'https://example.com/image.jpg' );
-		$text_position  = strpos( $rendered, '<p>Text</p>' );
+		$text_position  = strpos( $rendered, 'Text' );
 
 		$this->assertNotFalse( $media_position );
 		$this->assertNotFalse( $text_position );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Email Editor media-text RTL integration test asserted against exact raw paragraph markup. The paragraph renderer may add wrappers or attributes around paragraph content, so this updates the assertion to locate the rendered text content while preserving the media/text ordering and RTL alignment checks.

### Screenshots or screen recordings:

_N/A - test-only change._

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/email-editor-config exec wp-env run tests-cli --env-cwd=wp-content/plugins/email-editor ./vendor/bin/phpunit --configuration phpunit-integration.xml.dist --filter Core_Renderers_Rtl_Test`.
2. Confirm the RTL renderer test class passes.

<!-- End testing instructions -->

### Testing that has already taken place:

- Ran the focused failing test: `testMediaTextUsesRtlAlignmentAndPreservesExplicitPosition`.
- Ran the full `Core_Renderers_Rtl_Test` class.
- Ran the full Email Editor integration suite.
- Ran `pnpm --filter=@woocommerce/email-editor-config run lint:lang:php`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Email Editor: fix media-text RTL renderer test assertion.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

A changelog entry was created manually in `packages/php/email-editor/changelog/fix-media-text-rtl-test-assertion`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
