### PR TITLE
Color swatches tweaks

### DIFF
--- a/plugins/woocommerce/changelog/fix-color-swatches-tweaks
+++ b/plugins/woocommerce/changelog/fix-color-swatches-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Color swatches tweaks
+
+

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -274,7 +274,7 @@ function wc_get_attribute_types() {
 	}
 
 	if ( $allow_visual_attribute_type ) {
-		$attribute_types['wc-visual'] = __( 'Color / Image', 'woocommerce' );
+		$attribute_types['wc-visual'] = __( 'Color', 'woocommerce' );
 	}
 
 	return (array) apply_filters(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -102,6 +102,9 @@ final class ProductFilterChips extends AbstractBlock {
 							<?php if ( ! empty( $item['ariaLabel'] ) ) : ?>
 								aria-label="<?php echo esc_attr( $item['ariaLabel'] ); ?>"
 							<?php endif; ?>
+							<?php if ( $has_color_swatches ) : ?>
+								title="<?php echo esc_attr( $item['label'] ); ?>"
+							<?php endif; ?>
 							value="<?php echo esc_attr( $item['value'] ); ?>"
 							aria-checked="<?php echo ! empty( $item['selected'] ) ? 'true' : 'false'; ?>"
 							<?php disabled( ! empty( $item['disabled'] ) ); ?>
@@ -143,6 +146,9 @@ final class ProductFilterChips extends AbstractBlock {
 							role="checkbox"
 							data-wp-bind--id="context.item.id"
 							data-wp-bind--aria-label="context.item.ariaLabel"
+							<?php if ( $has_color_swatches ) : ?>
+								data-wp-bind--title="context.item.label"
+							<?php endif; ?>
 							data-wp-bind--value="context.item.value"
 							data-wp-bind--aria-checked="context.item.selected"
 							data-wp-bind--disabled="context.item.disabled"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Two small tweaks:

* Rename the new attribute type from 'Color / Image' to 'Color' image. As in the first iteration it will only support colors.
* Add title to the color swatches so it's possible to see the color name when hovering the swatch.

### How to test the changes in this Pull Request:

1. Go to _Products_ > _Attributes_.
2. Verify the two types are 'Text' and 'Color'.
3. Now, in the frontend, check a _Product Filters_ block rendering a Color attribute.
4. Verify hovering the swatches with the mouse shows the color name.

Attribute types | Swatch titles
--- | ---
<img width="543" height="236" alt="imatge" src="https://github.com/user-attachments/assets/6809de09-53b9-48c6-b5b7-980dcdbd07b4" /> | <img width="543" height="236" alt="imatge" src="https://github.com/user-attachments/assets/81e119c4-de75-4d96-afc6-71a9945b9065" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->