### PR TITLE
Fix products dashboard URL query handling

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-dashboard-undefined-url
+++ b/packages/js/experimental-products-app/changelog/fix-products-dashboard-undefined-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent product dashboard interactions from adding an invalid undefined query parameter to the URL.

--- a/packages/js/experimental-products-app/src/app.tsx
+++ b/packages/js/experimental-products-app/src/app.tsx
@@ -35,7 +35,7 @@ export function ProductsApp() {
 	return (
 		<NewNavigationProvider>
 			<UnsavedChangesWarning />
-			<RouterProvider>
+			<RouterProvider pathArg="page">
 				<ThemeProvider isRoot>
 					<ProductsLayout />
 				</ThemeProvider>

--- a/packages/js/experimental-products-app/src/product-list/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-list/utils.test.ts
@@ -2,7 +2,10 @@
  * Internal dependencies
  */
 import type { ProductEntityRecord } from '../fields/types';
-import { getProductsWithEmbeddedVariations } from './utils';
+import {
+	getProductListNavigationPath,
+	getProductsWithEmbeddedVariations,
+} from './utils';
 
 function createProduct(
 	id: number,
@@ -17,6 +20,35 @@ function createProduct(
 }
 
 describe( 'product list utils', () => {
+	describe( 'getProductListNavigationPath', () => {
+		it( 'preserves existing query args when adding new params', () => {
+			expect(
+				getProductListNavigationPath(
+					'woocommerce-products-dashboard?post_type=product',
+					{
+						activeView: 'draft',
+					}
+				)
+			).toBe(
+				'woocommerce-products-dashboard?post_type=product&activeView=draft'
+			);
+		} );
+
+		it( 'removes invalid undefined params from the existing query and new params', () => {
+			expect(
+				getProductListNavigationPath(
+					'woocommerce-products-dashboard?undefined=%2F&post_type=product',
+					{
+						undefined: '/',
+						activeView: 'draft',
+					}
+				)
+			).toBe(
+				'woocommerce-products-dashboard?post_type=product&activeView=draft'
+			);
+		} );
+	} );
+
 	describe( 'getProductsWithEmbeddedVariations', () => {
 		it( 'adds embedded variations after their parent product', () => {
 			const variation = createProduct( 2, 1 );

--- a/packages/js/experimental-products-app/src/product-list/utils.ts
+++ b/packages/js/experimental-products-app/src/product-list/utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { addQueryArgs } from '@wordpress/url';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -11,11 +11,21 @@ import { PRODUCT_LIST_TAB_VALUES, type StatusTab } from './constants';
 
 export function getProductListNavigationPath(
 	path: string,
-	params: Record< string, string >
+	params: Record< string, string | undefined >
 ) {
 	const [ pathname = '/' ] = path.split( '?' );
+	const query = {
+		...getQueryArgs( path ),
+		...params,
+	};
+	const sanitizedQuery = Object.fromEntries(
+		Object.entries( query ).filter(
+			( [ key, value ] ) =>
+				key !== 'undefined' && typeof value !== 'undefined'
+		)
+	);
 
-	return addQueryArgs( pathname, params );
+	return addQueryArgs( pathname, sanitizedQuery );
 }
 
 export function getItemId( item: ProductEntityRecord ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Dashboard interactions in the experimental products app were adding an invalid `undefined=%2F` query parameter to the URL. This configures the WordPress router to use the existing `page` query arg and hardens product list navigation URL generation so stale invalid `undefined` params are removed instead of preserved.

### How to test the changes in this Pull Request:

1. Open `wp-admin/edit.php?post_type=product&page=woocommerce-products-dashboard`.
2. Click the `Draft` status tab.
3. Confirm the URL includes `page=woocommerce-products-dashboard`, `post_type=product`, and `activeView=draft`, and does not include `undefined=%2F`.
4. Open Quick edit for a product.
5. Confirm the URL includes the expected `postId` and `quickEdit=true` params, and still does not include `undefined=%2F`.
6. Manually visit `wp-admin/edit.php?undefined=%2F&post_type=product&page=woocommerce-products-dashboard`.
7. Click the `Draft` status tab again and confirm the resulting URL removes the invalid `undefined` param.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/product-list/utils.test.ts`
-   `pnpm --filter=@woocommerce/experimental-products-app test:js`
-   `pnpm --filter=@woocommerce/experimental-products-app lint:lang:js` passed with existing warnings only.
-   Browser smoke tested the local products dashboard by switching to `Draft`, opening Quick edit, and starting from a stale `undefined=%2F` URL.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually in `packages/js/experimental-products-app/changelog/fix-products-dashboard-undefined-url`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
