### PR TITLE
Fix products dashboard mobile layout

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-dashboard-mobile-layout
+++ b/packages/js/experimental-products-app/changelog/fix-products-dashboard-mobile-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render the products dashboard content on mobile-width viewports.

--- a/packages/js/experimental-products-app/src/layout.tsx
+++ b/packages/js/experimental-products-app/src/layout.tsx
@@ -36,6 +36,7 @@ export function Layout( { route, showNewNavigation = false }: LayoutProps ) {
 	const disableMotion = useReducedMotion();
 
 	const { key: routeKey, areas, widths } = route;
+	const mobileArea = areas.mobile === true ? areas.content : areas.mobile;
 
 	return (
 		<>
@@ -87,6 +88,12 @@ export function Layout( { route, showNewNavigation = false }: LayoutProps ) {
 							} }
 						>
 							{ areas.content }
+						</div>
+					) }
+
+					{ isMobileViewport && mobileArea && (
+						<div className="edit-site-layout__area">
+							{ mobileArea }
 						</div>
 					) }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The products dashboard route already provides a mobile content area, but the layout suppressed the desktop content below the medium breakpoint without rendering the mobile area. This PR renders the route's mobile area on mobile-width viewports, with a fallback to the content area when a route opts into mobile rendering with `mobile: true`.

### Screenshots or screen recordings:

Screenshots should be added before marking this draft PR ready for review. A browser capture was not completed in this session because the Chrome DevTools MCP browser profile was already in use.

### How to test the changes in this Pull Request:

1. Open `wp-admin/edit.php?post_type=product&page=woocommerce-products-dashboard`.
2. Resize the browser below desktop width, for example `390px` or `768px`, and reload the page.
3. Confirm the products dashboard content renders after reload, including the Products heading, search controls, and product list content.
4. Resize back to desktop width and reload the page.
5. Confirm the products dashboard content still renders normally at desktop width.

### Testing that has already taken place:

- `pnpm --dir packages/js/experimental-products-app exec tsc --project tsconfig.json --noEmit`
- `pnpm --dir packages/js/experimental-products-app exec eslint src/layout.tsx`

The focused ESLint command reported the existing unsafe private API warnings in `layout.tsx`, with no lint errors.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was created manually for `@woocommerce/experimental-products-app`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
