### PR TITLE
Fix product list filter empty state

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-dashboard-filter-empty-state
+++ b/packages/js/experimental-products-app/changelog/fix-products-dashboard-filter-empty-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show a search and filter empty state when product filters return no results.

--- a/packages/js/experimental-products-app/src/product-list/empty-state/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/empty-state/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { EmptyState } from '@wordpress/ui';
+import { Button, EmptyState } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -15,7 +15,20 @@ type EmptyStateCopy = {
 	description: string;
 };
 
-function getEmptyStateCopy( tab: StatusTab ): EmptyStateCopy {
+function getEmptyStateCopy(
+	tab: StatusTab,
+	isSearchOrFilterResult: boolean
+): EmptyStateCopy {
+	if ( isSearchOrFilterResult ) {
+		return {
+			title: __( 'No products match your filters', 'woocommerce' ),
+			description: __(
+				'Try clearing some filters or adjusting your search query.',
+				'woocommerce'
+			),
+		};
+	}
+
 	switch ( tab ) {
 		case 'publish':
 			return {
@@ -62,11 +75,20 @@ function getEmptyStateCopy( tab: StatusTab ): EmptyStateCopy {
 }
 
 type ProductListEmptyStateProps = {
+	isSearchOrFilterResult?: boolean;
+	onClearFilters?: () => void;
 	tab: StatusTab;
 };
 
-export function ProductListEmptyState( { tab }: ProductListEmptyStateProps ) {
-	const { title, description } = getEmptyStateCopy( tab );
+export function ProductListEmptyState( {
+	isSearchOrFilterResult = false,
+	onClearFilters,
+	tab,
+}: ProductListEmptyStateProps ) {
+	const { title, description } = getEmptyStateCopy(
+		tab,
+		isSearchOrFilterResult
+	);
 
 	return (
 		<EmptyState.Root className="woocommerce-product-list__empty-state">
@@ -74,7 +96,16 @@ export function ProductListEmptyState( { tab }: ProductListEmptyStateProps ) {
 				<ProductListEmptyStateIcon />
 			</EmptyState.Visual>
 			<EmptyState.Title>{ title }</EmptyState.Title>
-			<EmptyState.Description>{ description }</EmptyState.Description>
+			<EmptyState.Description className="woocommerce-product-list__empty-state-description">
+				{ description }
+			</EmptyState.Description>
+			{ isSearchOrFilterResult && onClearFilters && (
+				<EmptyState.Actions>
+					<Button variant="outline" onClick={ onClearFilters }>
+						{ __( 'Clear filters', 'woocommerce' ) }
+					</Button>
+				</EmptyState.Actions>
+			) }
 		</EmptyState.Root>
 	);
 }

--- a/packages/js/experimental-products-app/src/product-list/empty-state/style.scss
+++ b/packages/js/experimental-products-app/src/product-list/empty-state/style.scss
@@ -1,0 +1,3 @@
+.woocommerce-product-list__empty-state-description {
+	width: max-content;
+}

--- a/packages/js/experimental-products-app/src/product-list/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/index.tsx
@@ -32,6 +32,7 @@ import {
 	getProductListTab,
 	getProductsWithEmbeddedVariations,
 	getSelectionFromPostId,
+	hasActiveProductListSearchOrFilters,
 	isProductEditorAccessible,
 } from './utils';
 import { useProductActions } from '../dataviews-actions';
@@ -150,6 +151,18 @@ export default function ProductList( {
 		() => getProductsWithEmbeddedVariations( records || EMPTY_ARRAY ),
 		[ records ]
 	);
+	const hasActiveSearchOrFilters =
+		hasActiveProductListSearchOrFilters( view );
+
+	const onClearSearchOrFilters = useCallback( () => {
+		setView( {
+			...view,
+			filters: [],
+			page: 1,
+			search: '',
+		} );
+	}, [ setView, view ] );
+
 	const getItemParentId = useCallback(
 		( item: ProductEntityRecord ) =>
 			item.parent_id && item.parent_id > 0 ? item.parent_id : undefined,
@@ -294,7 +307,13 @@ export default function ProductList( {
 				selection={ selection }
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				isItemClickable={ isProductEditorAccessible }
-				empty={ <ProductListEmptyState tab={ selectedTab } /> }
+				empty={
+					<ProductListEmptyState
+						isSearchOrFilterResult={ hasActiveSearchOrFilters }
+						onClearFilters={ onClearSearchOrFilters }
+						tab={ selectedTab }
+					/>
+				}
 				renderItemLink={ ( { item, ...props } ) => (
 					<a
 						{ ...props }

--- a/packages/js/experimental-products-app/src/product-list/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-list/utils.test.ts
@@ -1,8 +1,16 @@
 /**
+ * External dependencies
+ */
+import type { View } from '@wordpress/dataviews';
+
+/**
  * Internal dependencies
  */
 import type { ProductEntityRecord } from '../fields/types';
-import { getProductsWithEmbeddedVariations } from './utils';
+import {
+	getProductsWithEmbeddedVariations,
+	hasActiveProductListSearchOrFilters,
+} from './utils';
 
 function createProduct(
 	id: number,
@@ -48,6 +56,60 @@ describe( 'product list utils', () => {
 			expect(
 				getProductsWithEmbeddedVariations( [ parent, listedVariation ] )
 			).toEqual( [ parent, listedVariation ] );
+		} );
+	} );
+
+	describe( 'hasActiveProductListSearchOrFilters', () => {
+		const baseView = {
+			type: 'table',
+			page: 1,
+			perPage: 20,
+			filters: [],
+		} as View;
+
+		it( 'returns true when the view has a search query', () => {
+			expect(
+				hasActiveProductListSearchOrFilters( {
+					...baseView,
+					search: ' hoodie ',
+				} )
+			).toBe( true );
+		} );
+
+		it( 'returns true when the view has a filter value', () => {
+			expect(
+				hasActiveProductListSearchOrFilters( {
+					...baseView,
+					filters: [
+						{
+							field: 'stock_quantity',
+							operator: 'is',
+							value: 0,
+						},
+					],
+				} as View )
+			).toBe( true );
+		} );
+
+		it( 'ignores empty search and filter values', () => {
+			expect(
+				hasActiveProductListSearchOrFilters( {
+					...baseView,
+					search: ' ',
+					filters: [
+						{
+							field: 'categories',
+							operator: 'isAny',
+							value: [],
+						},
+						{
+							field: 'tags',
+							operator: 'isAny',
+							value: [ '', undefined ],
+						},
+					],
+				} as View )
+			).toBe( false );
 		} );
 	} );
 } );

--- a/packages/js/experimental-products-app/src/product-list/utils.ts
+++ b/packages/js/experimental-products-app/src/product-list/utils.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { Filter, View } from '@wordpress/dataviews';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -83,4 +84,24 @@ export function getSelectionFromPostId( postId?: string ) {
 
 export function isProductEditorAccessible( item: ProductEntityRecord ) {
 	return item.status !== 'trash';
+}
+
+function hasFilterValue( value: Filter[ 'value' ] ): boolean {
+	if ( Array.isArray( value ) ) {
+		return value.some( hasFilterValue );
+	}
+
+	if ( typeof value === 'string' ) {
+		return value.trim() !== '';
+	}
+
+	return value !== undefined && value !== null;
+}
+
+export function hasActiveProductListSearchOrFilters( view: View ) {
+	return (
+		( typeof view.search === 'string' && view.search.trim() !== '' ) ||
+		view.filters?.some( ( filter ) => hasFilterValue( filter.value ) ) ===
+			true
+	);
 }

--- a/packages/js/experimental-products-app/src/product-list/utils.ts
+++ b/packages/js/experimental-products-app/src/product-list/utils.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
+import { Filter, View } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -203,4 +203,5 @@
 	gap: 8px;
 }
 
+@import "./product-list/empty-state/style.scss";
 @import "./variation-view/style.scss";


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When product search or filters return no results in the experimental Products app, the empty state should guide merchants back to their product list instead of showing a generic tab-based empty state.

This PR detects active search/filter state, shows dedicated no-results copy, and adds a Clear filters action that resets search, filters, and pagination. It also colocates empty-state styling with the empty-state component.

### Screenshots or screen recordings:

Author to add screenshots before marking ready for review.

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. Go to Products in the experimental Products app.
2. Apply a search term or filter that returns no products.
3. Confirm the empty state says no products match the filters and shows a Clear filters button.
4. Click Clear filters.
5. Confirm search and filters are cleared, pagination resets to page 1, and products display again.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/product-list/utils.test.ts`
-   `pnpm --filter=@woocommerce/experimental-products-app lint:lang:js` passed with existing package warnings only.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually in `packages/js/experimental-products-app/changelog/fix-products-dashboard-filter-empty-state`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

