### PR TITLE
Fix product dashboard snackbar z-index

### DIFF
--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -38,6 +38,7 @@
 
 .product_page_woocommerce-products-dashboard-snackbar {
 	@include snackbar-container;
+	z-index: 100002;
 }
 
 .product_page_woocommerce-products-dashboard .edit-site-layout__content {

--- a/plugins/woocommerce/changelog/fix-products-dashboard-snackbar-z-index
+++ b/plugins/woocommerce/changelog/fix-products-dashboard-snackbar-z-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep product dashboard snackbar notices visible above the quick edit drawer.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When product quick edit saves fail, snackbar notices can render underneath the drawer and become hidden. This raises the products dashboard snackbar layer above the quick edit drawer and select popover layers so errors remain visible while editing.

Bug introduced in PR #64697.

### Screenshots or screen recordings:

Author to add before marking ready.

### How to test the changes in this Pull Request:

1. Go to **Products > All Products** and open the products dashboard.
2. Open quick edit for a product.
3. Trigger a snackbar error while the quick edit drawer remains open.
4. Confirm the snackbar appears above the drawer instead of underneath it.

### Testing that has already taken place:

-   Ran `pnpm --filter=@woocommerce/experimental-products-app build:project:bundle`.
-   Build passed with existing webpack asset-size warnings.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A manual changelog entry is included in `plugins/woocommerce/changelog/fix-products-dashboard-snackbar-z-index`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
