### PR TITLE
Fix variation gallery tests surfaced by #65207

### DIFF
--- a/plugins/woocommerce/src/Internal/VariationGallery/Migration.php
+++ b/plugins/woocommerce/src/Internal/VariationGallery/Migration.php
@@ -67,7 +67,9 @@ class Migration {
 		$variation_ids = $select_variation_ids( self::BATCH_SIZE );
 
 		foreach ( $variation_ids as $variation_id ) {
-			$legacy_gallery_image_ids = wp_parse_id_list( get_post_meta( $variation_id, $legacy_meta_key, true ) );
+			$legacy_gallery_image_ids = array_values(
+				array_filter( wp_parse_id_list( get_post_meta( $variation_id, $legacy_meta_key, true ) ) )
+			);
 			$core_gallery_image_ids   = wp_parse_id_list( get_post_meta( $variation_id, $core_gallery_meta, true ) );
 
 			if ( empty( $core_gallery_image_ids ) && ! empty( $legacy_gallery_image_ids ) ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -292,8 +292,8 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$available_variation = $product->get_available_variation( $variation );
 
 		$this->assertSame( $variation_gallery_id, $available_variation['image_id'] );
-		$this->assertStringContainsString( 'wp-image-' . $variation_gallery_id, $available_variation['gallery_images_html'] );
-		$this->assertStringNotContainsString( 'wp-image-' . $parent_featured_id, $available_variation['gallery_images_html'] );
+		$this->assertStringContainsString( 'variation-gallery.jpg', $available_variation['gallery_images_html'] );
+		$this->assertStringNotContainsString( 'parent-featured.jpg', $available_variation['gallery_images_html'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/VariationGallery/ClassicVariationGalleryAdminTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/VariationGallery/ClassicVariationGalleryAdminTest.php
@@ -21,17 +21,29 @@ class ClassicVariationGalleryAdminTest extends \WC_Unit_Test_Case {
 	private $sut;
 
 	/**
-	 * Set up test dependencies.
+	 * @var LegacyVariationGalleryCompatibility
+	 */
+	private $legacy_compat;
+
+	/**
+	 * Set up.
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->sut = new ClassicVariationGalleryAdmin();
+		$this->sut           = new ClassicVariationGalleryAdmin();
+		$this->legacy_compat = new LegacyVariationGalleryCompatibility();
+		$this->legacy_compat->register();
 	}
 
 	/**
-	 * Reset globals after each test.
+	 * Tear down.
 	 */
 	public function tearDown(): void {
+		remove_filter(
+			'woocommerce_product_variation_get_gallery_image_ids',
+			array( $this->legacy_compat, 'maybe_read_legacy_gallery_image_ids' ),
+			10
+		);
 		unset( $_POST['variable_gallery_image_ids'] );
 		parent::tearDown();
 	}
@@ -198,18 +210,20 @@ class ClassicVariationGalleryAdminTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Create a test attachment.
-	 *
 	 * @param string $title Attachment title.
 	 * @return int
 	 */
 	private function create_attachment( string $title ): int {
-		return wp_insert_attachment(
+		$attachment_id = wp_insert_attachment(
 			array(
 				'post_title'     => $title,
 				'post_type'      => 'attachment',
 				'post_mime_type' => 'image/jpeg',
 			)
 		);
+
+		update_post_meta( $attachment_id, '_wp_attached_file', sanitize_title( $title ) . '.jpg' );
+
+		return $attachment_id;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[#65207](https://github.com/woocommerce/woocommerce/pull/65207) fixed a PHPUnit halt that was hiding four variation-gallery test failures from CI. Three were latent test bugs; one was a real `Migration::run()` bug masked by the same halt.

- **`Migration::run()`** (real bug): malformed legacy meta like `'not-an-id'` parses through `wp_parse_id_list` as `[0]` (zero, not empty), and was being written into the core gallery as the literal string `"0"`. Filter zeros before writing so malformed meta becomes empty as intended.
- **`ClassicVariationGalleryAdminTest::setUp()`**: register `LegacyVariationGalleryCompatibility` explicitly. `Package::init()` runs at WC bootstrap with the feature flag off (default); flipping the option mid-test doesn't re-invoke init, so the legacy-fallback filter wouldn't otherwise be installed.
- **`ClassicVariationGalleryAdminTest::create_attachment()`**: set `_wp_attached_file` so `wp_get_attachment_image()` resolves a file and the rendered thumbnail doesn't pick up the `is-broken` class that broke the regex assertion.
- **`WC_Product_Variable_Test` stale-featured fallback**: assert on the attachment filename rather than a `wp-image-{id}` class. WC's gallery template doesn't emit that class; the filename is in the rendered `src`/`data-thumb`/`data-src` attributes and is the stable signal that this specific attachment is the one shown.

### How to test the changes in this Pull Request:

1. Check out `trunk` and run:
   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "WC_Product_Variable_Test|ClassicVariationGalleryAdminTest|MigrationTest"
   ```
   Expected: 4 failures (the ones [#65207](https://github.com/woocommerce/woocommerce/pull/65207) surfaced).
2. Check out this branch and re-run the same command. Expected: `OK (20 tests, 302 assertions)`.

### Testing that has already taken place:

- Each of the four targeted tests run in isolation: green.
- Full test classes: `OK (20 tests, 302 assertions)`.
- Branch lint clean, PHPStan clean on `Migration.php`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry.

Test-only and an internal migration helper fix; no user-facing behavior change. The malformed-meta `Migration::run()` fix only affects a feature path that's off by default in 10.9 and hasn't shipped to any production stores yet.