### PR TITLE
Fix MCP provider ability registration tests

### DIFF
--- a/plugins/woocommerce/changelog/65207-fix-mcp-provider-test-lifecycle
+++ b/plugins/woocommerce/changelog/65207-fix-mcp-provider-test-lifecycle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix MCP provider test Abilities API registry bootstrap.

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -67,6 +67,13 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	private $original_wp_abilities_api_categories_init_action_count;
 
 	/**
+	 * Original value of $wp_actions['init'] to restore in tearDown.
+	 *
+	 * @var int|null
+	 */
+	private $original_init_action_count;
+
+	/**
 	 * Set up before each test.
 	 */
 	public function setUp(): void {
@@ -74,8 +81,12 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 
 		parent::setUp();
 
+		$this->original_init_action_count                             = $wp_actions['init'] ?? null;
 		$this->original_wp_abilities_api_init_action_count            = $wp_actions['wp_abilities_api_init'] ?? null;
 		$this->original_wp_abilities_api_categories_init_action_count = $wp_actions['wp_abilities_api_categories_init'] ?? null;
+
+		// WordPress 6.9+ requires init to have fired before the Abilities API registry can be initialized.
+		$wp_actions['init'] = max( 1, (int) ( $wp_actions['init'] ?? 0 ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		// Bootstrap the WordPress Abilities API for tests.
 		if ( ! function_exists( 'wp_register_ability' ) ) {
@@ -159,6 +170,12 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			$wp_actions['wp_abilities_api_categories_init'] = $this->original_wp_abilities_api_categories_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		} elseif ( isset( $wp_actions['wp_abilities_api_categories_init'] ) ) {
 			unset( $wp_actions['wp_abilities_api_categories_init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		if ( null !== $this->original_init_action_count ) {
+			$wp_actions['init'] = $this->original_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $wp_actions['init'] ) ) {
+			unset( $wp_actions['init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		parent::tearDown();
@@ -426,6 +443,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 	 */
 	private function register_test_ability( string $ability_id, array $meta ): void {
 		$this->ensure_test_ability_category( 'woocommerce-rest' );
+		$this->ensure_abilities_registry_initialized();
 
 		$ability  = null;
 		$callback = null;
@@ -474,6 +492,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
 			return;
 		}
+		$this->ensure_ability_categories_registry_initialized();
 
 		if ( wp_has_ability_category( $category_id ) ) {
 			return;
@@ -508,5 +527,29 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		}
 
 		$this->assertTrue( wp_has_ability_category( $category_id ), 'Test ability category should be available.' );
+	}
+
+	/**
+	 * Ensure the ability registry is ready before adding one-off test callbacks.
+	 *
+	 * Registry initialization fires wp_abilities_api_init. If the test callback is
+	 * already attached, the same ability can be registered twice and return null.
+	 */
+	private function ensure_abilities_registry_initialized(): void {
+		if ( class_exists( '\WP_Abilities_Registry' ) ) {
+			\WP_Abilities_Registry::get_instance();
+		}
+	}
+
+	/**
+	 * Ensure the ability category registry is ready before adding one-off test callbacks.
+	 *
+	 * Registry initialization fires wp_abilities_api_categories_init. If the test
+	 * callback is already attached, the same category can be registered twice.
+	 */
+	private function ensure_ability_categories_registry_initialized(): void {
+		if ( class_exists( '\WP_Ability_Categories_Registry' ) ) {
+			\WP_Ability_Categories_Registry::get_instance();
+		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The PHPUnit triage report in #65207 surfaced that `MCPAdapterProviderTest::test_get_woocommerce_mcp_abilities_includes_marked_abilities_across_namespaces` failed once the suite resumed running past the earlier Back in Stock Notifications abort. The failing path was the test fixture, not the production MCP inclusion logic: the helper attached one-off Abilities API registration callbacks before the registries were initialized, so registry bootstrap could fire the same hooks and run the same test registration twice.

This PR primes the Abilities API registries before attaching those one-off callbacks, preserves the temporary `init` action count required by the vendored Abilities API, and restores it in `tearDown()`.

Bug introduced in PR #64425.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter MCPAdapterProviderTest`.
3. Confirm the focused PHPUnit class completes with `OK (11 tests, 30 assertions)`.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter MCPAdapterProviderTest` -> `OK (11 tests, 30 assertions)`.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` -> passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` -> passed.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was added manually in `plugins/woocommerce/changelog/65207-fix-mcp-provider-test-lifecycle`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
