### PR TITLE
Fix products app drawer close query state

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-app-drawer-close-query
+++ b/packages/js/experimental-products-app/changelog/fix-products-app-drawer-close-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the experimental products app quick edit drawer closes when using the close icon or Cancel button.

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
@@ -73,11 +73,10 @@ function getSelectionPath(
 		{} as Record< string, string >
 	);
 
-	delete nextQuery.quickEdit;
-
 	return getProductListNavigationPath( path, {
 		...nextQuery,
 		postId: productIds.join( ',' ),
+		quickEdit: undefined,
 	} );
 }
 

--- a/packages/js/experimental-products-app/src/product-edit/index.tsx
+++ b/packages/js/experimental-products-app/src/product-edit/index.tsx
@@ -669,15 +669,14 @@ export default function ProductEdit( { products, isOpen }: ProductEditProps ) {
 		);
 		const nextQuery = {
 			...query,
-		} as Record< string, string >;
+			quickEdit: undefined,
+		} as Record< string, string | undefined >;
 
 		editedProductIds.forEach( ( productId ) => {
 			clearEntityRecordEdits( 'root', 'product', productId );
 		} );
 
 		setBulkEditData( {} as ProductBulkEditFormData );
-
-		delete nextQuery.quickEdit;
 
 		navigate( getProductListNavigationPath( path, nextQuery ) );
 	}, [ clearEntityRecordEdits, navigate, path, query, selectedProducts ] );

--- a/packages/js/experimental-products-app/src/product-list/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/index.tsx
@@ -97,7 +97,7 @@ export default function ProductList( {
 			if ( items.length > 0 ) {
 				nextParams.postId = items.join( ',' );
 			} else {
-				delete nextParams.postId;
+				nextParams.postId = undefined;
 			}
 
 			navigate(
@@ -125,9 +125,8 @@ export default function ProductList( {
 			const nextParams = {
 				...currentQuery,
 				activeView: nextTab,
+				postId: undefined,
 			};
-
-			delete nextParams.postId;
 
 			navigate(
 				getProductListNavigationPath( location.path, nextParams )

--- a/packages/js/experimental-products-app/src/product-list/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-list/utils.test.ts
@@ -47,6 +47,18 @@ describe( 'product list utils', () => {
 				'woocommerce-products-dashboard?post_type=product&activeView=draft'
 			);
 		} );
+
+		it( 'removes existing query args when a param is set to undefined', () => {
+			expect(
+				getProductListNavigationPath(
+					'woocommerce-products-dashboard?post_type=product&postId=12&quickEdit=true',
+					{
+						postId: undefined,
+						quickEdit: undefined,
+					}
+				)
+			).toBe( 'woocommerce-products-dashboard?post_type=product' );
+		} );
 	} );
 
 	describe( 'getProductsWithEmbeddedVariations', () => {

--- a/packages/js/experimental-products-app/src/variation-view/index.tsx
+++ b/packages/js/experimental-products-app/src/variation-view/index.tsx
@@ -182,7 +182,7 @@ export function VariationView( { productId }: VariationViewProps ) {
 			if ( items.length > 0 ) {
 				nextQuery.postId = items.join( ',' );
 			} else {
-				delete nextQuery.postId;
+				nextQuery.postId = undefined;
 			}
 
 			navigate(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental products app quick edit drawer could stay open after using the close icon or Cancel button because `quickEdit=true` was preserved from the current URL path while rebuilding navigation state.

This updates the quick edit, product list, and variation selection paths to explicitly remove stale query params by passing `undefined`, and adds regression coverage for removing existing query args.

Bug introduced in PR #64481.

### How to test the changes in this Pull Request:

1. Go to Products > All Products in the experimental products app.
2. Open Quick edit for a product.
3. Click the close icon in the drawer header and confirm the drawer closes and `quickEdit=true` is removed from the URL.
4. Open Quick edit again.
5. Click Cancel and confirm the drawer closes and `quickEdit=true` is removed from the URL.
6. Select one or more products, then clear the selection or switch status tabs and confirm stale `postId` values are removed from the URL.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/product-list/utils.test.ts src/dataviews-actions/actions.test.tsx`
-   `pnpm --filter=@woocommerce/experimental-products-app exec tsc --project tsconfig.json --noEmit`
-   `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/product-list/index.tsx src/product-list/utils.test.ts src/product-edit/index.tsx src/dataviews-actions/actions.tsx src/variation-view/index.tsx`

ESLint reported existing warnings for experimental WordPress component APIs and one existing hook dependency warning, with no errors.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was created manually in `packages/js/experimental-products-app/changelog/fix-products-app-drawer-close-query`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
