### PR TITLE
Fix deferred email and checkout PHPUnit assertions

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-checkout-ci-tests
+++ b/plugins/woocommerce/changelog/fix-email-checkout-ci-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix PHPUnit assertions for deferred email queue object round trips and Store API checkout failed-payment retries.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -2246,7 +2246,18 @@ class Checkout extends MockeryTestCase {
 		remove_action( 'woocommerce_store_api_checkout_order_processed', $fail_hook, 999 );
 
 		// Second POST on the same session should reuse the existing pending order.
-		$second_response = rest_get_server()->dispatch( $this->build_valid_post_request() );
+		$session_order_id_during_retry = null;
+		$capture_session_order_id      = function () use ( &$session_order_id_during_retry ) {
+			$session_order_id_during_retry = (int) WC()->session->get( 'store_api_draft_order' );
+		};
+		add_action( 'woocommerce_store_api_checkout_order_processed', $capture_session_order_id, 999, 0 );
+
+		try {
+			$second_response = rest_get_server()->dispatch( $this->build_valid_post_request() );
+		} finally {
+			remove_action( 'woocommerce_store_api_checkout_order_processed', $capture_session_order_id, 999 );
+		}
+
 		$this->assertEquals( 200, $second_response->get_status(), print_r( $second_response->get_data(), true ) );
 
 		$second_order_id = (int) $second_response->get_data()['order_id'];
@@ -2255,6 +2266,7 @@ class Checkout extends MockeryTestCase {
 			$second_order_id,
 			'Second POST must reuse the existing pending order, not create a new one (regression: issue #64792).'
 		);
+		$this->assertSame( $first_order_id, $session_order_id_during_retry, 'Session pointer should reference the reused order while the second POST is being processed.' );
 		$this->assertEmpty( WC()->session->get( 'store_api_draft_order' ), 'Successful checkout should clear the draft order pointer when the cart is emptied.' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -2255,7 +2255,7 @@ class Checkout extends MockeryTestCase {
 			$second_order_id,
 			'Second POST must reuse the existing pending order, not create a new one (regression: issue #64792).'
 		);
-		$this->assertSame( $first_order_id, (int) WC()->session->get( 'store_api_draft_order' ), 'Session pointer should still reference the reused order.' );
+		$this->assertEmpty( WC()->session->get( 'store_api_draft_order' ), 'Successful checkout should clear the draft order pointer when the cart is emptied.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
@@ -469,8 +469,7 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 		$this->sut->push( $filter, $args );
 		$this->sut->dispatch();
 
-		$queue         = $this->get_test_queue();
-		$scheduled_arg = $queue->actions[0]['args'];
+		$scheduled_arg = $this->get_scheduled_email_action()['args'];
 		$encoded_arg   = wp_json_encode( $scheduled_arg );
 
 		$this->assert_queued_object_reference( $scheduled_arg[1][ $wrapped_position ], $expected_type, $expected_id );
@@ -526,6 +525,30 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 			},
 			10,
 			3
+		);
+	}
+
+	/**
+	 * Get the scheduled Action Scheduler email action from the test queue.
+	 *
+	 * Other fixture setup can enqueue unrelated actions before the email queue
+	 * dispatches, so object round-trip assertions must target the email action.
+	 *
+	 * @return array{timestamp: int, hook: string, args: array, group: string}
+	 */
+	private function get_scheduled_email_action(): array {
+		foreach ( $this->get_test_queue()->actions as $action ) {
+			if ( 'woocommerce_send_queued_transactional_email' === $action['hook'] ) {
+				return $action;
+			}
+		}
+
+		$this->fail( 'Expected a queued transactional email action to be scheduled.' );
+		return array(
+			'timestamp' => 0,
+			'hook'      => '',
+			'args'      => array(),
+			'group'     => '',
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

PR #65207 surfaced hidden PHPUnit failures after the Back in Stock Notifications tests stopped halting the suite early. This PR fixes two test assumptions from that report: deferred email object round-trip assertions now inspect the scheduled email action instead of the first unrelated queued fixture action, and the Store API checkout retry test now expects the draft-order session pointer to be cleared after the successful retry empties the cart.

Bug introduced in PR #64820 and PR #64806.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'DeferredEmailQueueTest::test_dispatch_preserves_product_args_after_action_scheduler_json_round_trip|DeferredEmailQueueTest::test_dispatch_preserves_order_args_after_action_scheduler_json_round_trip|DeferredEmailQueueTest::test_dispatch_preserves_stock_notification_args_after_action_scheduler_json_round_trip|Checkout::test_post_reuses_pending_order_from_session_on_retry'`.
2. Confirm all four filtered tests pass.
3. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testsuite wc-phpunit-main`.
4. Confirm the main PHPUnit suite no longer reports these four failures.

### Testing that has already taken place:

- `php -l plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php` - no syntax errors.
- `php -l plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php` - no syntax errors.
- `git diff --check` - clean.
- Local PHPUnit was not run because this workspace has no `node_modules`/`vendor`, `wp-env` is unavailable, and Docker/Colima is not running. CI is the authoritative verification for this PR.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was created manually in `plugins/woocommerce/changelog/fix-email-checkout-ci-tests`.

</details>
