### PR TITLE
Shopper lists: extract shared row renderer + add Wishlist block

### DIFF
--- a/plugins/woocommerce/changelog/add-wishlist-block
+++ b/plugins/woocommerce/changelog/add-wishlist-block
@@ -1,0 +1,5 @@
+Significance: minor
+Type: add
+Comment: Experimental Wishlist block, gated by the `product_wishlist` feature flag.
+
+Add the `woocommerce/wishlist` block: renders the shopper's wishlist via the shared `shopper-lists` Store API and iAPI store, composes the `ShopperListRenderer` shared row markup, and ships an "Add to cart" per-row action that adds the product to the cart and removes the row from the wishlist on confirmed success. The `/my-account/wishlist/` endpoint now renders this block instead of its placeholder.

--- a/plugins/woocommerce/changelog/refactor-extract-shopper-list-renderer
+++ b/plugins/woocommerce/changelog/refactor-extract-shopper-list-renderer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Shopper lists: extract the shared row markup (image, name, price, remove badge, variation overlay) into a `ShopperListRenderer` helper and a `_shopper-lists/item` SCSS partial. Saved for Later now composes the helper; the same scaffold is what the upcoming Wishlist block will reuse.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/edit.tsx
@@ -123,7 +123,7 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 					{ PREVIEW_ITEMS.map( ( item ) => (
 						<li
 							key={ item.key }
-							className="wc-block-saved-for-later-item"
+							className="wc-block-shopper-list-item"
 						>
 							<div className="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
 								<a
@@ -134,7 +134,7 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 								</a>
 								<button
 									type="button"
-									className="wc-block-saved-for-later-item__remove"
+									className="wc-block-shopper-list-item__remove"
 									aria-label={ sprintf(
 										/* translators: %s: product name. */
 										__(
@@ -148,7 +148,7 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 									<Icon icon={ trash } size={ 24 } />
 								</button>
 								{ item.variation && (
-									<span className="wc-block-saved-for-later-item__variation">
+									<span className="wc-block-shopper-list-item__variation">
 										{ item.variation }
 									</span>
 								) }
@@ -166,7 +166,7 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 									{ item.price }
 								</span>
 							</div>
-							<span className="wc-block-saved-for-later-item__quantity">
+							<span className="wc-block-shopper-list-item__quantity">
 								{ item.quantity }
 							</span>
 							<div className="wp-block-button wc-block-components-product-button">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/style.scss
@@ -5,6 +5,8 @@
 // which we declare as style dependencies in `block.json` so WordPress
 // enqueues them whenever this block renders. Don't duplicate those rules here.
 
+@import "../shopper-lists/item";
+
 // The outer `<section>` is a plain wrapper — no layout of its own. The
 // grid lives on the inner `<ul class="wc-block-saved-for-later__list">`
 // so it doesn't try to grid-place the seeded heading inner block.
@@ -31,117 +33,6 @@ $grid-gap: var(--wp--style--block-gap, 1.5em);
 				auto-fill,
 				minmax(max(#{$min-item-width}, #{$max-item-width}), 1fr)
 			);
-		}
-	}
-}
-
-.wc-block-saved-for-later-item {
-	display: flex;
-	flex-direction: column;
-	gap: 0.25em;
-
-	// Tombstone rows render `<a>` without an href so iAPI can keep
-	// reconciling them against the live-row template (swapping the
-	// element type would force a re-hydration). The browser already
-	// drops link semantics for hrefless anchors, but make the
-	// non-clickability explicit so any inherited link styles don't
-	// mislead pointer or keyboard users.
-	a:not([href]) {
-		cursor: default;
-		pointer-events: none;
-	}
-
-	// The atomic product-button's `display: flex` outspecifies `[hidden]`,
-	// so the move-to-cart wrapper wouldn't honor `hidden` without this.
-	.wp-block-button.wc-block-components-product-button[hidden] {
-		display: none;
-	}
-
-	// Title spacing/line-height matches Product Collection's default
-	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
-	// We target wp-block-post-title (core's post-title class) because the
-	// editor preview mirrors PC's editor render, which uses core/post-title.
-	.wp-block-post-title {
-		line-height: 1.4;
-		margin: 0 0 0.75rem;
-	}
-
-	// Quantity has no atomic equivalent in Product Collection, so we own
-	// its styling. Center-aligned and small to mirror the rest of the row
-	// (price + button use the WP `has-small-font-size` preset).
-	&__quantity {
-		color: rgba(0, 0, 0, 0.7);
-		display: block;
-		font-size: var(--wp--preset--font-size--small, 0.875em);
-		text-align: center;
-	}
-
-	// Variation overlay sits at the bottom of the image and shares the
-	// remove badge's border/background/radius so the two corner overlays
-	// read as a pair. Spans the full image width (with the same 4px inset
-	// the remove badge uses on top/right) and is only rendered for
-	// variation products, so when absent the image isn't pushed around.
-	&__variation {
-		background: #fff;
-		border: 1px solid #43454b;
-		border-radius: 4px;
-		bottom: 4px;
-		box-sizing: border-box;
-		color: #43454b;
-		font-size: var(--wp--preset--font-size--small, 0.875em);
-		left: 4px;
-		padding: 0.25em 0.75em;
-		position: absolute;
-		right: 4px;
-		text-align: center;
-		z-index: 10;
-	}
-
-	// Icon-only Remove button overlaying the image. Mirrors the
-	// `woocommerce-product-gallery__trigger` corner-overlay styles
-	// (white fill, circular, black icon, no border) so the affordance
-	// reads consistently with the gallery zoom trigger.
-	&__remove {
-		appearance: none;
-		background: #fff;
-		border: none;
-		border-radius: 100%;
-		box-sizing: border-box;
-		color: #000;
-		cursor: pointer;
-		display: block;
-		line-height: 0;
-		padding: 0.25em;
-		position: absolute;
-		right: 4px;
-		top: 4px;
-		transition: background-color 120ms ease, color 120ms ease;
-		z-index: 10;
-
-		svg {
-			display: block;
-			fill: currentColor;
-		}
-
-		&:hover:not([disabled]) {
-			background: #000;
-			color: #fff;
-		}
-
-		// Keyboard focus indicator. The default :focus-visible ring would
-		// land on a transparent border against the white badge body and
-		// be invisible, so paint our own — outline (so it sits outside the
-		// border without nudging layout) plus a soft offset to keep it
-		// readable over both the badge body and the product image behind
-		// it. Not applied to :hover-only — pointer users keep the invert.
-		&:focus-visible:not([disabled]) {
-			outline: 2px solid #000;
-			outline-offset: 1px;
-		}
-
-		&[disabled] {
-			cursor: not-allowed;
-			opacity: 0.7;
 		}
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-lists/_item.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-lists/_item.scss
@@ -1,0 +1,125 @@
+// Row styles shared by every block that renders a shopper-list item card
+// (Saved for Later, Wishlist, …). Consumers `@import` this partial and
+// keep their own layout (grid wrapper, empty-state, header) in their
+// block-local stylesheet.
+//
+// Layout rules for `.wc-block-components-product-image`,
+// `.wc-block-components-product-price` and `.wc-block-components-product-button`
+// come from the atomic product-image / -price / -button blocks' stylesheets,
+// which the consuming blocks declare as style dependencies in `block.json`.
+// Don't duplicate those rules here.
+
+.wc-block-shopper-list-item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em;
+
+	// Tombstone rows render `<a>` without an href so iAPI can keep
+	// reconciling them against the live-row template (swapping the
+	// element type would force a re-hydration). The browser already
+	// drops link semantics for hrefless anchors, but make the
+	// non-clickability explicit so any inherited link styles don't
+	// mislead pointer or keyboard users.
+	a:not([href]) {
+		cursor: default;
+		pointer-events: none;
+	}
+
+	// The atomic product-button's `display: flex` outspecifies `[hidden]`,
+	// so the action wrapper (Move to cart / Add to cart) wouldn't honor
+	// `hidden` without this.
+	.wp-block-button.wc-block-components-product-button[hidden] {
+		display: none;
+	}
+
+	// Title spacing/line-height matches Product Collection's default
+	// product-title attributes (level: 2, margin: 0 0 0.75rem, line-height: 1.4).
+	// We target wp-block-post-title (core's post-title class) because the
+	// editor preview mirrors PC's editor render, which uses core/post-title.
+	.wp-block-post-title {
+		line-height: 1.4;
+		margin: 0 0 0.75rem;
+	}
+
+	// Quantity has no atomic equivalent in Product Collection, so we own
+	// its styling. Center-aligned and small to mirror the rest of the row
+	// (price + button use the WP `has-small-font-size` preset). Only the
+	// Saved for Later block renders this element — Wishlist omits it — but
+	// the rule lives here so the row's visual language stays consistent
+	// across consumers.
+	&__quantity {
+		color: rgba(0, 0, 0, 0.7);
+		display: block;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		text-align: center;
+	}
+
+	// Variation overlay sits at the bottom of the image and shares the
+	// remove badge's border/background/radius so the two corner overlays
+	// read as a pair. Spans the full image width (with the same 4px inset
+	// the remove badge uses on top/right) and is only rendered for
+	// variation products, so when absent the image isn't pushed around.
+	&__variation {
+		background: #fff;
+		border: 1px solid #43454b;
+		border-radius: 4px;
+		bottom: 4px;
+		box-sizing: border-box;
+		color: #43454b;
+		font-size: var(--wp--preset--font-size--small, 0.875em);
+		left: 4px;
+		padding: 0.25em 0.75em;
+		position: absolute;
+		right: 4px;
+		text-align: center;
+		z-index: 10;
+	}
+
+	// Icon-only Remove button overlaying the image. Mirrors the
+	// `woocommerce-product-gallery__trigger` corner-overlay styles
+	// (white fill, circular, black icon, no border) so the affordance
+	// reads consistently with the gallery zoom trigger.
+	&__remove {
+		appearance: none;
+		background: #fff;
+		border: none;
+		border-radius: 100%;
+		box-sizing: border-box;
+		color: #000;
+		cursor: pointer;
+		display: block;
+		line-height: 0;
+		padding: 0.25em;
+		position: absolute;
+		right: 4px;
+		top: 4px;
+		transition: background-color 120ms ease, color 120ms ease;
+		z-index: 10;
+
+		svg {
+			display: block;
+			fill: currentColor;
+		}
+
+		&:hover:not([disabled]) {
+			background: #000;
+			color: #fff;
+		}
+
+		// Keyboard focus indicator. The default :focus-visible ring would
+		// land on a transparent border against the white badge body and
+		// be invisible, so paint our own — outline (so it sits outside the
+		// border without nudging layout) plus a soft offset to keep it
+		// readable over both the badge body and the product image behind
+		// it. Not applied to :hover-only — pointer users keep the invert.
+		&:focus-visible:not([disabled]) {
+			outline: 2px solid #000;
+			outline-offset: 1px;
+		}
+
+		&[disabled] {
+			cursor: not-allowed;
+			opacity: 0.7;
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-lists/_item.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-lists/_item.scss
@@ -2,7 +2,7 @@
 // (Saved for Later, Wishlist, …). Consumers `@import` this partial and
 // keep their own layout (grid wrapper, empty-state, header) in their
 // block-local stylesheet.
-//
+
 // Layout rules for `.wc-block-components-product-image`,
 // `.wc-block-components-product-price` and `.wc-block-components-product-button`
 // come from the atomic product-image / -price / -button blocks' stylesheets,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/block.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/wishlist",
+	"version": "1.0.0",
+	"title": "Wishlist",
+	"description": "Display the shopper's wishlist.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce", "Wishlist" ],
+	"textdomain": "woocommerce",
+	"attributes": {
+		"columnCount": {
+			"type": "number",
+			"default": 5
+		}
+	},
+	"allowedBlocks": [ "core/heading" ],
+	"supports": {
+		 "align": [ "wide", "full" ],
+		"interactivity": true,
+		"html": false,
+		"reusable": false,
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		},
+		"color": {
+			"text": true,
+			"background": true
+		}
+	},
+	"viewScriptModule": "woocommerce/wishlist",
+	"style": [
+		"file:../woocommerce/wishlist-style.css",
+		"wc-blocks-style-product-image",
+		"woocommerce-product-price-style",
+		"woocommerce-product-button-style"
+	]
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/block.json
@@ -16,7 +16,7 @@
 	},
 	"allowedBlocks": [ "core/heading" ],
 	"supports": {
-		 "align": [ "wide", "full" ],
+		"align": [ "wide", "full" ],
 		"interactivity": true,
 		"html": false,
 		"reusable": false,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/edit.tsx
@@ -1,0 +1,177 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { Icon, trash } from '@wordpress/icons';
+import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
+
+interface WishlistAttributes {
+	columnCount: number;
+}
+
+interface EditProps {
+	attributes: WishlistAttributes;
+	setAttributes: ( attrs: Partial< WishlistAttributes > ) => void;
+}
+
+const MIN_COLUMNS = 2;
+const MAX_COLUMNS = 6;
+
+// Lives in JS because `__()` is needed for the heading copy. `block.json`
+// strings aren't run through translation, so keeping the template here
+// is the only way to ship a localized default.
+const TEMPLATE: [ string, Record< string, unknown > ][] = [
+	[ 'core/heading', { content: __( 'Wishlist', 'woocommerce' ), level: 2 } ],
+];
+
+const PREVIEW_ITEMS = [
+	{
+		key: 'preview-1',
+		name: __( 'Sample product one', 'woocommerce' ),
+		variation: __( 'Size: M', 'woocommerce' ),
+		price: '$19.99',
+	},
+	{
+		key: 'preview-2',
+		name: __( 'Sample product two', 'woocommerce' ),
+		variation: __( 'Color: Blue', 'woocommerce' ),
+		price: '$29.99',
+	},
+	{
+		key: 'preview-3',
+		name: __( 'Sample product three', 'woocommerce' ),
+		variation: '',
+		price: '$9.99',
+	},
+	{
+		key: 'preview-4',
+		name: __( 'Sample product four', 'woocommerce' ),
+		variation: __( 'Size: L', 'woocommerce' ),
+		price: '$24.99',
+	},
+	{
+		key: 'preview-5',
+		name: __( 'Sample product five', 'woocommerce' ),
+		variation: '',
+		price: '$14.99',
+	},
+	{
+		key: 'preview-6',
+		name: __( 'Sample product six', 'woocommerce' ),
+		variation: __( 'Color: Red', 'woocommerce' ),
+		price: '$39.99',
+	},
+];
+
+const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
+	const { columnCount } = attributes;
+
+	const blockProps = useBlockProps( {
+		className: 'wc-block-wishlist',
+	} );
+
+	// `allowedBlocks` is read from block.json automatically — passing it
+	// here would just duplicate the declaration. `templateLock: false`
+	// is the default so we omit that too. The className matches the
+	// `<div>` PHP wraps `$content` in on the frontend, so any CSS keyed
+	// off `__header` applies in both contexts.
+	const innerBlocksProps = useInnerBlocksProps(
+		{ className: 'wc-block-wishlist__header' },
+		{ template: TEMPLATE }
+	);
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
+					<RangeControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Columns', 'woocommerce' ) }
+						value={ columnCount }
+						onChange={ ( value?: number ) => {
+							if ( typeof value !== 'number' ) {
+								return;
+							}
+							setAttributes( { columnCount: value } );
+						} }
+						min={ MIN_COLUMNS }
+						max={ MAX_COLUMNS }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<section { ...blockProps }>
+				<div { ...innerBlocksProps } />
+				<ul
+					className={ `wc-block-wishlist__list columns-${ columnCount }` }
+				>
+					{ PREVIEW_ITEMS.map( ( item ) => (
+						<li
+							key={ item.key }
+							className="wc-block-shopper-list-item"
+						>
+							<div className="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+								<a
+									href="#preview"
+									onClick={ ( e ) => e.preventDefault() }
+								>
+									<img src={ PLACEHOLDER_IMG_SRC } alt="" />
+								</a>
+								<button
+									type="button"
+									className="wc-block-shopper-list-item__remove"
+									aria-label={ sprintf(
+										/* translators: %s: product name. */
+										__(
+											'Remove %s from wishlist',
+											'woocommerce'
+										),
+										item.name
+									) }
+									disabled
+								>
+									<Icon icon={ trash } size={ 24 } />
+								</button>
+								{ item.variation && (
+									<span className="wc-block-shopper-list-item__variation">
+										{ item.variation }
+									</span>
+								) }
+							</div>
+							<h2 className="wp-block-post-title has-text-align-center has-medium-font-size">
+								<a
+									href="#preview"
+									onClick={ ( e ) => e.preventDefault() }
+								>
+									{ item.name }
+								</a>
+							</h2>
+							<div className="price wc-block-components-product-price has-text-align-center has-small-font-size">
+								<span className="wc-block-components-product-price__value">
+									{ item.price }
+								</span>
+							</div>
+							<div className="wp-block-button wc-block-components-product-button">
+								<button
+									type="button"
+									className="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+									disabled
+								>
+									{ __( 'Add to cart', 'woocommerce' ) }
+								</button>
+							</div>
+						</li>
+					) ) }
+				</ul>
+			</section>
+		</>
+	);
+};
+
+export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/frontend.ts
@@ -1,0 +1,309 @@
+/**
+ * External dependencies
+ */
+import {
+	getConfig,
+	getContext,
+	getElement,
+	store,
+	type AsyncAction,
+} from '@wordpress/interactivity';
+import '@woocommerce/stores/woocommerce/shopper-lists';
+import '@woocommerce/stores/woocommerce/cart';
+import type {
+	RawShopperListItem,
+	Store as ShopperListsStore,
+} from '@woocommerce/stores/woocommerce/shopper-lists';
+import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
+import { sanitizeHTML } from '@woocommerce/sanitize';
+
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+const LIST_SLUG = 'wishlist';
+
+type WishlistConfig = {
+	removeLabelTemplate: string;
+};
+
+type BlockContext = {
+	listItem?: RawShopperListItem;
+	htmlField?: 'price_html' | 'image_html';
+	// Item keys currently mid-mutation, used to disable per-row buttons.
+	pendingKeys: Record< string, true >;
+};
+
+type BlockStore = {
+	state: {
+		currentItems: RawShopperListItem[];
+		isCurrentItemPending: boolean;
+		isEmpty: boolean;
+		isAddToCartHidden: boolean;
+		isPriceHidden: boolean;
+		currentItemDisplayName: string;
+		currentItemRemoveLabel: string;
+		currentItemVariationLabel: string;
+	};
+	actions: {
+		onClickRemove: () => Generator< unknown, void >;
+		onClickAddToCart: () => Generator< unknown, void >;
+	};
+	callbacks: {
+		updateInnerHtml: () => void;
+	};
+};
+
+// Allow-list for sanitizing the schema's preformatted strings on innerHTML
+// swap. Covers what `wc_price` (sale/discount markup, currency symbol) and
+// `wp_get_attachment_image` / `wc_placeholder_img` emit (responsive image
+// + dimensions + lazy loading).
+const ALLOWED_TAGS = [
+	'a',
+	'b',
+	'em',
+	'i',
+	'strong',
+	'p',
+	'br',
+	'span',
+	'bdi',
+	'del',
+	'ins',
+	'img',
+	'picture',
+	'source',
+];
+const ALLOWED_ATTR = [
+	'class',
+	'target',
+	'href',
+	'rel',
+	'name',
+	'download',
+	'aria-hidden',
+	'src',
+	'srcset',
+	'sizes',
+	'alt',
+	'width',
+	'height',
+	'loading',
+	'decoding',
+];
+
+const { state: shopperListsState, actions: shopperListsActions } =
+	store< ShopperListsStore >(
+		'woocommerce/shopper-lists',
+		{},
+		{ lock: universalLock }
+	);
+
+const { state: cartState, actions: cartActions } = store< WooCommerce >(
+	'woocommerce',
+	{},
+	{ lock: universalLock }
+);
+
+const decodeEntities = ( encoded: string ): string => {
+	const txt = document.createElement( 'textarea' );
+	txt.innerHTML = encoded;
+	return txt.value;
+};
+
+const formatVariationLabel = ( item: RawShopperListItem ): string => {
+	if ( ! item.variation || item.variation.length === 0 ) {
+		return '';
+	}
+	return item.variation
+		.map(
+			( v ) =>
+				`${ decodeEntities( v.attribute ) }: ${ decodeEntities(
+					v.value
+				) }`
+		)
+		.join( ', ' );
+};
+
+const getList = ( slug: string ) => shopperListsState.lists[ slug ] ?? null;
+
+store< BlockStore >(
+	'woocommerce/wishlist',
+	{
+		state: {
+			get currentItems(): RawShopperListItem[] {
+				return getList( LIST_SLUG )?.items ?? [];
+			},
+
+			get isCurrentItemPending(): boolean {
+				const { listItem, pendingKeys } = getContext< BlockContext >();
+				return !! listItem && !! pendingKeys[ listItem.key ];
+			},
+
+			// No `hasShownItems` gate: the visitor reached this block
+			// deliberately (My Account endpoint or merchant-placed), so
+			// showing the empty message immediately when the list is
+			// empty is the right signal.
+			get isEmpty(): boolean {
+				const list = getList( LIST_SLUG );
+				if ( ! list ) {
+					return false;
+				}
+				return ! list.isLoading && list.items.length === 0;
+			},
+
+			get isPriceHidden(): boolean {
+				const { listItem } = getContext< BlockContext >();
+				return ! listItem?.price_html;
+			},
+
+			get isAddToCartHidden(): boolean {
+				const { listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return true;
+				}
+				return ! listItem.is_purchasable;
+			},
+
+			// `data-wp-text` writes its argument as text-content without
+			// running entity decoding, so a name returned by the schema as
+			// `Tom &amp; Jerry` would render literally that way. Bind
+			// templates and SSR text spans to this getter instead of the
+			// raw context field so what the browser shows matches what
+			// PHP wrote on first paint.
+			get currentItemDisplayName(): string {
+				const { listItem } = getContext< BlockContext >();
+				return listItem ? decodeEntities( listItem.name ) : '';
+			},
+
+			get currentItemRemoveLabel(): string {
+				const { listItem } = getContext< BlockContext >();
+				if ( ! listItem ) {
+					return '';
+				}
+				const { removeLabelTemplate } = getConfig(
+					'woocommerce/wishlist'
+				) as WishlistConfig;
+				return removeLabelTemplate.replace(
+					'%s',
+					decodeEntities( listItem.name )
+				);
+			},
+
+			get currentItemVariationLabel(): string {
+				const { listItem } = getContext< BlockContext >();
+				return listItem ? formatVariationLabel( listItem ) : '';
+			},
+		},
+
+		actions: {
+			*onClickRemove(): AsyncAction< void > {
+				const { listItem, pendingKeys } = getContext< BlockContext >();
+				if ( ! listItem || pendingKeys[ listItem.key ] ) {
+					return;
+				}
+				pendingKeys[ listItem.key ] = true;
+				try {
+					yield shopperListsActions.removeItem(
+						LIST_SLUG,
+						listItem.key
+					);
+				} finally {
+					delete pendingKeys[ listItem.key ];
+				}
+			},
+
+			*onClickAddToCart(): AsyncAction< void > {
+				const { listItem, pendingKeys } = getContext< BlockContext >();
+				if (
+					! listItem ||
+					! listItem.is_purchasable ||
+					pendingKeys[ listItem.key ]
+				) {
+					return;
+				}
+
+				// Map the schema's `variation` shape to the cart's
+				// SelectedAttributes shape. The schema returns the
+				// slug-form attribute under `raw_attribute` (e.g.
+				// `attribute_pa_color`) plus a display label under
+				// `attribute` (e.g. "Color"); the cart matches by the
+				// slug-form, so override `attribute` with `raw_attribute`.
+				// Empty for simple products.
+				const variation = listItem.variation.map(
+					( { raw_attribute: rawAttribute, value, attribute } ) => ( {
+						attribute: rawAttribute || attribute,
+						value,
+					} )
+				);
+				const isVariation = listItem.variation_id > 0;
+
+				// Wishlist always adds quantity 1 (no quantity column).
+				// `cartActions.addCartItem` catches its own errors and
+				// surfaces them as store notices, so the yield resolves
+				// the same way on success and failure. Snapshot the
+				// matching line's quantity, run the add, then only remove
+				// from the wishlist if the cart line actually grew — that
+				// guards against partial-stock and silent-failure paths
+				// where we shouldn't drop the wishlist entry.
+				const lookup = {
+					id: listItem.id,
+					...( isVariation && { variation } ),
+				};
+				const beforeItem = cartState.findItemInCart( lookup );
+				const beforeQuantity = beforeItem?.quantity ?? 0;
+
+				pendingKeys[ listItem.key ] = true;
+				try {
+					yield cartActions.addCartItem( {
+						id: listItem.id,
+						quantityToAdd: 1,
+						type: isVariation ? 'variation' : 'simple',
+						...( isVariation && { variation } ),
+					} );
+
+					const afterItem = cartState.findItemInCart( lookup );
+					const afterQuantity = afterItem?.quantity ?? 0;
+
+					if ( afterQuantity <= beforeQuantity ) {
+						return;
+					}
+
+					yield shopperListsActions.removeItem(
+						LIST_SLUG,
+						listItem.key
+					);
+				} finally {
+					delete pendingKeys[ listItem.key ];
+				}
+			},
+		},
+
+		callbacks: {
+			// Single shared innerHTML-swap callback for any slot whose
+			// content is one of the schema's preformatted HTML fields.
+			// Mirrors the atomic product-elements `updateValue` callback:
+			// the watched element carries `data-wp-context='{"htmlField":"price_html"}'`
+			// (or `"image_html"`), and this callback reads that field
+			// off the row's `listItem` and pastes its sanitized HTML into
+			// `element.ref`. PHP renders the same HTML server-side, so
+			// hydration is a no-op when the row's listItem hasn't changed,
+			// and a clean swap when it has (e.g. after Remove shifts the
+			// next item into this slot).
+			updateInnerHtml: () => {
+				const { ref } = getElement();
+				const { listItem, htmlField } = getContext< BlockContext >();
+				if ( ! ref || ! listItem || ! htmlField ) {
+					return;
+				}
+				const html = listItem[ htmlField ];
+				if ( typeof html === 'string' ) {
+					ref.innerHTML = sanitizeHTML( html, {
+						tags: ALLOWED_TAGS,
+						attr: ALLOWED_ATTR,
+					} );
+				}
+			},
+		},
+	},
+	{ lock: universalLock }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/index.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { Icon, starEmpty } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import Save from './save';
+import './style.scss';
+
+registerBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				icon={ starEmpty }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+	save: Save,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/save.tsx
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * The block is rendered server-side, but the inner blocks (default
+ * `core/heading`) must be serialized to `post_content` so user edits
+ * persist — returning `null` would drop them. `<InnerBlocks.Content />`
+ * emits only the inner blocks' static markup.
+ */
+const Save = (): JSX.Element => <InnerBlocks.Content />;
+
+export default Save;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/style.scss
@@ -1,0 +1,45 @@
+// Frontend stylesheet for the Wishlist block.
+// Layout rules for `.wc-block-components-product-image`,
+// `.wc-block-components-product-price` and `.wc-block-components-product-button`
+// come from the atomic product-image / -price / -button blocks' stylesheets,
+// which we declare as style dependencies in `block.json` so WordPress
+// enqueues them whenever this block renders. Don't duplicate those rules here.
+
+@import "../shopper-lists/item";
+
+// The outer `<section>` is a plain wrapper — no layout of its own. The
+// grid lives on the inner `<ul class="wc-block-wishlist__list">`
+// so it doesn't try to grid-place the seeded heading inner block.
+// One concrete `.columns-N` class per supported column count so narrow
+// viewports reflow to fewer columns instead of shrinking items uniformly.
+// Mirrors Product Collection's `__responsive` formula.
+$min-item-width: 150px;
+$grid-gap: var(--wp--style--block-gap, 1.5em);
+
+.wc-block-wishlist__list {
+	display: grid;
+	gap: $grid-gap;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+
+	@for $i from 2 through 6 {
+		$gap-count: calc(#{$i} - 1);
+		$total-gap-width: calc(#{$gap-count} * #{$grid-gap});
+		$max-item-width: calc((100% - #{$total-gap-width}) / #{$i});
+
+		&.columns-#{ $i } {
+			grid-template-columns: repeat(
+				auto-fill,
+				minmax(max(#{$min-item-width}, #{$max-item-width}), 1fr)
+			);
+		}
+	}
+}
+
+.wc-block-wishlist__empty {
+	color: rgba(0, 0, 0, 0.7);
+	grid-column: 1 / -1;
+	padding: 1em 0;
+	text-align: left;
+}

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -116,7 +116,7 @@ const blocks = {
 		customDir: 'reviews/reviews-by-product',
 	},
 	'saved-for-later': {},
-	'wishlist': {},
+	wishlist: {},
 	'single-product': {},
 	'stock-filter': {},
 	'store-notices': {},

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -116,6 +116,7 @@ const blocks = {
 		customDir: 'reviews/reviews-by-product',
 	},
 	'saved-for-later': {},
+	'wishlist': {},
 	'single-product': {},
 	'stock-filter': {},
 	'store-notices': {},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/SavedForLater.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/SavedForLater.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListRenderer;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 
 /**
@@ -14,6 +15,13 @@ use Automattic\WooCommerce\Proxies\LegacyProxy;
  * Store API endpoints via the shared `woocommerce/shopper-lists` iAPI store.
  * PHP prefetches the list so the first paint is already populated; JS then
  * takes over for adds, removes, and Move-to-cart.
+ *
+ * The row markup (image, name, price, remove badge, variation overlay) is
+ * shared with other shopper-list blocks via `ShopperListRenderer`. This
+ * class composes those fragments and adds the bits that are unique to
+ * Saved for Later: auto-injection via the Block Hooks API, the
+ * `hasShownItems` empty-state gating, the per-row quantity span, and the
+ * Move-to-cart action button.
  */
 final class SavedForLater extends AbstractBlock {
 	/**
@@ -230,23 +238,10 @@ final class SavedForLater extends AbstractBlock {
 
 		$list_class = sprintf( 'wc-block-saved-for-later__list columns-%d', $column_count );
 
-		// The heading inner block (and any future siblings rendered into
-		// `$content`) is wrapped so its visibility matches the empty-state
-		// gating: hidden on first paint for shoppers who have never had
-		// items in this session, revealed once the iAPI watcher flips
-		// `context.hasShownItems` to `true`. Without this wrapper a heading
-		// would be visible even on a fresh empty page, with no list under
-		// it — visually disconnected from anything.
-		return sprintf(
-			'<section %1$s>%5$s%6$s<ul class="%7$s">%2$s%3$s%4$s</ul></section>',
-			get_block_wrapper_attributes( $wrapper_attributes ),
-			$this->render_template_markup(),
-			$this->render_items_markup( $items ),
-			$this->render_empty_markup(),
-			$this->render_header_markup( $content, empty( $items ) ),
-			$this->render_interactivity_notices_region(),
-			esc_attr( $list_class )
-		);
+		$ul_inner    = $this->render_template_markup() . $this->render_items_markup( $items ) . $this->render_empty_markup();
+		$before_list = $this->render_header_markup( $content, empty( $items ) ) . ShopperListRenderer::render_interactivity_notices_region( 'wc-block-saved-for-later__notices' );
+
+		return ShopperListRenderer::render_grid_wrapper( $wrapper_attributes, $list_class, $ul_inner, $before_list );
 	}
 
 	/**
@@ -298,62 +293,16 @@ final class SavedForLater extends AbstractBlock {
 	/**
 	 * The `<template data-wp-each>` describing how each item is rendered on
 	 * the client. Pre-rendered children sit alongside as `data-wp-each-child`
-	 * elements so first paint is populated.
+	 * elements so first paint is populated. Composes the shared row markup
+	 * with Saved for Later's quantity span and Move-to-cart action button.
 	 *
 	 * @return string
 	 */
 	private function render_template_markup(): string {
-		ob_start();
-		?>
-		<template
-			data-wp-each--list-item="state.currentItems"
-			data-wp-each-key="context.listItem.key"
-		>
-			<li class="wc-block-saved-for-later-item">
-				<?php
-				// Single anchor for both live products and tombstones. For
-				// tombstones `permalink` is empty, so iAPI removes the `href`
-				// attribute and the anchor degrades to non-clickable.
-				// Image and price markup come pre-formatted from the schema
-				// (`image_html`, `price_html`) — `data-wp-watch` callbacks
-				// swap each slot's innerHTML on hydrate / state change so we
-				// don't reimplement WC's `wc_price` / `wp_get_attachment_image`
-				// in JS.
-				?>
-				<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
-					<a data-wp-bind--href="context.listItem.permalink">
-						<span class="wc-block-saved-for-later-item__image-slot" data-wp-context='{"htmlField":"image_html"}' data-wp-watch="callbacks.updateInnerHtml"></span>
-					</a>
-					<button
-						type="button"
-						class="wc-block-saved-for-later-item__remove"
-						data-wp-on--click="actions.onClickRemove"
-						data-wp-bind--aria-label="state.currentItemRemoveLabel"
-						data-wp-bind--disabled="state.isCurrentItemPending"
-					>
-						<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
-					</button>
-					<span class="wc-block-saved-for-later-item__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
-				</div>
-				<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
-					<a data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"></a>
-				</h2>
-				<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="state.isPriceHidden" data-wp-context='{"htmlField":"price_html"}' data-wp-watch="callbacks.updateInnerHtml"></div>
-				<span class="wc-block-saved-for-later-item__quantity" data-wp-text="state.currentItemQuantityLabel"></span>
-				<div class="wp-block-button wc-block-components-product-button" data-wp-bind--hidden="state.isMoveToCartHidden">
-					<button
-						type="button"
-						class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
-						data-wp-on--click="actions.onClickMoveToCart"
-						data-wp-bind--disabled="state.isCurrentItemPending"
-					>
-						<?php echo esc_html( $this->get_move_to_cart_label() ); ?>
-					</button>
-				</div>
-			</li>
-		</template>
-		<?php
-		return (string) ob_get_clean();
+		$row_inner = ShopperListRenderer::render_template_common_row()
+			. $this->render_template_quantity()
+			. $this->render_template_move_to_cart();
+		return ShopperListRenderer::render_each_template( $row_inner );
 	}
 
 	/**
@@ -372,131 +321,101 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Render a single SSR item.
+	 * Render a single SSR item. Composes the shared image / name / price
+	 * markup with the SFL-specific quantity span and Move-to-cart button.
 	 *
 	 * @param array<string, mixed> $item Schema-shape item.
 	 * @return string
 	 */
 	private function render_item_markup( array $item ): string {
-		$is_live         = ! empty( $item['is_live'] );
-		$is_purchasable  = ! empty( $item['is_purchasable'] );
-		$name            = (string) ( $item['name'] ?? '' );
-		$permalink       = (string) ( $item['permalink'] ?? '' );
-		$quantity        = (int) ( $item['quantity'] ?? 1 );
-		$alt             = html_entity_decode( $name, ENT_QUOTES, 'UTF-8' );
-		$image_html      = (string) ( $item['image_html'] ?? '' );
-		$price_html      = (string) ( $item['price_html'] ?? '' );
-		$variation_label = $this->get_variation_label( $item );
+		$row_inner = ShopperListRenderer::render_ssr_common_row( $item, $this->get_remove_label_template() )
+			. $this->render_ssr_quantity( $item )
+			. $this->render_ssr_move_to_cart( $item );
+		return ShopperListRenderer::render_each_child( $item, $row_inner );
+	}
 
-		$quantity_label = sprintf( $this->get_quantity_label_template(), $quantity );
-		$remove_aria    = sprintf( $this->get_remove_label_template(), $alt );
-
-		$is_price_hidden = '' === $price_html;
-
-		$context = array(
-			'listItem' => $item,
+	/**
+	 * Template-mode markup for the quantity span. SFL-specific — Wishlist
+	 * has no quantity column.
+	 *
+	 * @return string
+	 */
+	private function render_template_quantity(): string {
+		return sprintf(
+			'<span class="%s__quantity" data-wp-text="state.currentItemQuantityLabel"></span>',
+			esc_attr( ShopperListRenderer::ROW_CLASS )
 		);
+	}
 
+	/**
+	 * Template-mode markup for the Move-to-cart action button. SFL-specific.
+	 *
+	 * @return string
+	 */
+	private function render_template_move_to_cart(): string {
 		ob_start();
 		?>
-		<li
-			class="wc-block-saved-for-later-item"
-			data-wp-each-child
-			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-			<?php echo wp_interactivity_data_wp_context( $context ); ?>
+		<div class="wp-block-button wc-block-components-product-button" data-wp-bind--hidden="state.isMoveToCartHidden">
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+				data-wp-on--click="actions.onClickMoveToCart"
+				data-wp-bind--disabled="state.isCurrentItemPending"
+			>
+				<?php echo esc_html( $this->get_move_to_cart_label() ); ?>
+			</button>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * SSR-mode markup for the quantity span. SFL-specific.
+	 *
+	 * @param array<string, mixed> $item Schema-shape item.
+	 * @return string
+	 */
+	private function render_ssr_quantity( array $item ): string {
+		$quantity       = (int) ( $item['quantity'] ?? 1 );
+		$quantity_label = sprintf( $this->get_quantity_label_template(), $quantity );
+		return sprintf(
+			'<span class="%s__quantity">%s</span>',
+			esc_attr( ShopperListRenderer::ROW_CLASS ),
+			esc_html( $quantity_label )
+		);
+	}
+
+	/**
+	 * SSR-mode markup for the Move-to-cart action button. SFL-specific.
+	 * Always emits the wrapper so iAPI can toggle `hidden` after hydration
+	 * without swapping the row out. Starts hidden when the row isn't
+	 * purchasable.
+	 *
+	 * @param array<string, mixed> $item Schema-shape item.
+	 * @return string
+	 */
+	private function render_ssr_move_to_cart( array $item ): string {
+		$is_move_to_cart_hidden = empty( $item['is_purchasable'] );
+		ob_start();
+		?>
+		<div
+			class="wp-block-button wc-block-components-product-button"
+			data-wp-bind--hidden="state.isMoveToCartHidden"
+			<?php
+			if ( $is_move_to_cart_hidden ) {
+				echo 'hidden';
+			}
+			?>
 		>
-			<?php
-			// Emit the same structure as the `<template>` so iAPI
-			// hydration is a no-op diff. For tombstones the anchor's
-			// href is omitted (the anchor degrades to non-clickable
-			// rather than self-linking back to the current page).
-			// Image and price markup come pre-formatted from the
-			// schema (`image_html`, `price_html`) and are echoed into
-			// the watcher slots — the JS-side `updateInnerHtml`
-			// callback takes over after hydration to swap the slot's
-			// innerHTML when the row's context.listItem changes.
-			?>
-			<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
-				<a <?php echo $is_live && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink">
-					<span
-						class="wc-block-saved-for-later-item__image-slot"
-						data-wp-context='{"htmlField":"image_html"}'
-						data-wp-watch="callbacks.updateInnerHtml"
-					>
-						<?php echo wp_kses_post( $image_html ); ?>
-					</span>
-				</a>
-				<button
-					type="button"
-					class="wc-block-saved-for-later-item__remove"
-					aria-label="<?php echo esc_attr( $remove_aria ); ?>"
-					data-wp-on--click="actions.onClickRemove"
-					data-wp-bind--aria-label="state.currentItemRemoveLabel"
-					data-wp-bind--disabled="state.isCurrentItemPending"
-				>
-					<?php echo $this->get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
-				</button>
-				<span
-					class="wc-block-saved-for-later-item__variation"
-					data-wp-bind--hidden="!state.currentItemVariationLabel"
-					data-wp-text="state.currentItemVariationLabel"
-					<?php
-					if ( '' === $variation_label ) {
-						echo 'hidden';
-					}
-					?>
-				><?php echo esc_html( $variation_label ); ?></span>
-			</div>
-			<?php
-			// Render the decoded display name as plain text so the SSR
-			// output matches what `data-wp-text="state.currentItemDisplayName"`
-			// will write after hydration. Names like "Tom &amp; Jerry"
-			// must show as "Tom & Jerry" both before and after JS.
-			// Same single-anchor pattern as the image — href omitted
-			// for tombstones.
-			?>
-			<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
-				<a <?php echo $is_live && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
-			</h2>
-			<div
-				class="price wc-block-components-product-price has-text-align-center has-small-font-size"
-				data-wp-bind--hidden="state.isPriceHidden"
-				data-wp-context='{"htmlField":"price_html"}'
-				data-wp-watch="callbacks.updateInnerHtml"
-				<?php
-				if ( $is_price_hidden ) {
-					echo 'hidden';
-				}
-				?>
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+				data-wp-on--click="actions.onClickMoveToCart"
+				data-wp-bind--disabled="state.isCurrentItemPending"
 			>
-				<?php echo wp_kses_post( $price_html ); ?>
-			</div>
-			<span class="wc-block-saved-for-later-item__quantity"><?php echo esc_html( $quantity_label ); ?></span>
-			<?php
-			// Always emit the wrapper so iAPI can toggle `hidden` after
-			// hydration without swapping the row out. Start hidden when
-			// the row isn't purchasable.
-			$is_move_to_cart_hidden = ! $is_purchasable;
-			?>
-			<div
-				class="wp-block-button wc-block-components-product-button"
-				data-wp-bind--hidden="state.isMoveToCartHidden"
-				<?php
-				if ( $is_move_to_cart_hidden ) {
-					echo 'hidden';
-				}
-				?>
-			>
-				<button
-					type="button"
-					class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
-					data-wp-on--click="actions.onClickMoveToCart"
-					data-wp-bind--disabled="state.isCurrentItemPending"
-				>
-					<?php echo esc_html( $this->get_move_to_cart_label() ); ?>
-				</button>
-			</div>
-		</li>
+				<?php echo esc_html( $this->get_move_to_cart_label() ); ?>
+			</button>
+		</div>
 		<?php
 		return (string) ob_get_clean();
 	}
@@ -534,57 +453,16 @@ final class SavedForLater extends AbstractBlock {
 	 * @return string
 	 */
 	private function render_empty_markup(): string {
-		return sprintf(
-			'<li class="wc-block-saved-for-later__empty" data-wp-bind--hidden="!state.isEmpty" hidden>%s</li>',
-			esc_html__( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' )
+		return ShopperListRenderer::render_empty_state(
+			__( 'Nothing saved yet — items you save from the cart will appear here.', 'woocommerce' ),
+			'wc-block-saved-for-later__empty',
+			true
 		);
 	}
 
 	/**
-	 * Render the iAPI store-notices region. Mirrors
-	 * `AddToCartWithOptions::render_interactivity_notices_region()` —
-	 * keep in sync if the shape changes.
-	 *
-	 * @return string
-	 */
-	private function render_interactivity_notices_region(): string {
-		ob_start();
-		?>
-		<div class="wc-block-saved-for-later__notices wc-block-components-notices" data-wp-interactive="woocommerce/store-notices" data-wp-bind--hidden="!context.notices.length" hidden>
-			<template data-wp-each--notice="context.notices" data-wp-each-key="context.notice.id">
-				<div
-					class="wc-block-components-notice-banner"
-					data-wp-class--is-error="state.isError"
-					data-wp-class--is-success="state.isSuccess"
-					data-wp-class--is-info="state.isInfo"
-					data-wp-class--is-dismissible="context.notice.dismissible"
-					data-wp-bind--role="state.role"
-					data-wp-watch="callbacks.injectIcon"
-				>
-					<div class="wc-block-components-notice-banner__content">
-						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive" aria-atomic="true"></span>
-					</div>
-					<button
-						type="button"
-						data-wp-bind--hidden="!context.notice.dismissible"
-						class="wc-block-components-button wp-element-button wc-block-components-notice-banner__dismiss contained"
-						aria-label="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce' ); ?>"
-						data-wp-on--click="actions.removeNotice"
-					>
-						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-							<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z" />
-						</svg>
-					</button>
-				</div>
-			</template>
-		</div>
-		<?php
-		return (string) ob_get_clean();
-	}
-
-	/**
 	 * Sprintf template for the per-row quantity label. Used both by PHP SSR
-	 * (`render_item_markup()`) and by the JS-side getter (via
+	 * (`render_ssr_quantity()`) and by the JS-side getter (via
 	 * `wp_interactivity_config`) so both paths produce the same string after
 	 * `%d` interpolation.
 	 */
@@ -608,45 +486,6 @@ final class SavedForLater extends AbstractBlock {
 	 */
 	private function get_move_to_cart_label(): string {
 		return __( 'Move to cart', 'woocommerce' );
-	}
-
-	/**
-	 * Markup for the trash icon used in the remove-item button. Mirrors the
-	 * `trash` icon from `@wordpress/icons` that the cart line item uses for
-	 * `wc-block-cart-item__remove-link`, inlined here so SSR first paint
-	 * matches what JS would render after hydration. `currentColor` lets the
-	 * surrounding badge wrapper drive the fill.
-	 *
-	 * @return string
-	 */
-	private function get_remove_icon_svg(): string {
-		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"/></svg>';
-	}
-
-	/**
-	 * Build a comma-separated variation label like "Color: Blue, Size: M".
-	 *
-	 * @param array<string, mixed> $item Schema-shape item.
-	 * @return string
-	 */
-	private function get_variation_label( array $item ): string {
-		$variation = $item['variation'] ?? array();
-		if ( ! is_array( $variation ) || empty( $variation ) ) {
-			return '';
-		}
-		$parts = array();
-		foreach ( $variation as $entry ) {
-			if ( ! is_array( $entry ) ) {
-				continue;
-			}
-			$attribute = isset( $entry['attribute'] ) ? html_entity_decode( (string) $entry['attribute'], ENT_QUOTES, 'UTF-8' ) : '';
-			$value     = isset( $entry['value'] ) ? html_entity_decode( (string) $entry['value'], ENT_QUOTES, 'UTF-8' ) : '';
-			if ( '' === $attribute && '' === $value ) {
-				continue;
-			}
-			$parts[] = $attribute . ': ' . $value;
-		}
-		return implode( ', ', $parts );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php
@@ -1,0 +1,370 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListRenderer;
+
+/**
+ * Wishlist block.
+ *
+ * Renders the shopper's wishlist, wired to the `shopper-lists` Store API
+ * endpoints via the shared `woocommerce/shopper-lists` iAPI store. PHP
+ * prefetches the list so the first paint is already populated; JS then
+ * takes over for adds, removes, and the per-row "Add to cart" action.
+ *
+ * Unlike Saved for Later, this block is merchant-placed — no Block Hooks
+ * API integration. It's rendered by the `/my-account/wishlist/` endpoint
+ * (gated by the `product_wishlist` feature flag) and can also be placed
+ * on any other page or template. "Add to cart" mirrors Saved for Later's
+ * Move-to-cart flow: add the product to the cart, then remove it from the
+ * wishlist on confirmed success.
+ */
+final class Wishlist extends AbstractBlock {
+	/**
+	 * The list slug this block renders. Constant — when additional list
+	 * types ship as their own blocks, each one hardcodes its own slug.
+	 */
+	private const LIST_SLUG = 'wishlist';
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'wishlist';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Block content.
+	 * @param \WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		// Guests have no personal list — bail before enqueuing assets or
+		// seeding state. The My Account endpoint isn't reachable for
+		// guests, but the block can also be placed by a merchant on any
+		// page, where this guard is what stops it from rendering an
+		// empty shell for logged-out visitors.
+		if ( ! is_user_logged_in() ) {
+			return '';
+		}
+
+		// Clamp to the 2-6 range the SCSS `@for $i from 2 through 6` loop
+		// and the editor `RangeControl` both support. `absint()` first
+		// defends against a code-editor override (the attribute can be set
+		// to any JSON value there); the `min`/`max` then keep the value
+		// within the range where a `&.columns-#{$i}` rule actually exists.
+		$column_count = min( 6, max( 2, absint( $attributes['columnCount'] ?? 5 ) ) );
+
+		wp_enqueue_script_module( $this->get_full_block_name() );
+
+		$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
+		BlocksSharedState::load_store_config( $consent );
+		BlocksSharedState::load_placeholder_image( $consent );
+		// `Add to cart` calls into the shared cart store, which expects
+		// `state.cart.items` and friends. Without this load the cart store
+		// would have no hydrated cart and the action would throw on the
+		// first click.
+		BlocksSharedState::load_cart_state( $consent );
+
+		$items = $this->prefetch_items();
+
+		// Seed the shared shopper-lists store with the rest URL, the
+		// pre-fetched items, and a starter nonce. The starter nonce is
+		// what the cart store also seeds via `state.nonce` — the JS layer
+		// keeps it fresh by reading the `Nonce` response header on every
+		// subsequent request, so this is just the bootstrap value (and
+		// avoids deadlocking mutations that await `isNonceReady` before
+		// any GET has fired).
+		wp_interactivity_state(
+			'woocommerce/shopper-lists',
+			array(
+				'restUrl' => get_rest_url(),
+				'nonce'   => wp_create_nonce( 'wc_store_api' ),
+				'lists'   => array(
+					self::LIST_SLUG => array(
+						'items'     => $items,
+						'isLoading' => false,
+					),
+				),
+			)
+		);
+
+		// Only the remove-button aria-label template needs JS-side
+		// interpolation; visible strings (empty state, action label) are
+		// rendered server-side and toggled with directives.
+		wp_interactivity_config(
+			'woocommerce/wishlist',
+			array(
+				'removeLabelTemplate' => $this->get_remove_label_template(),
+			)
+		);
+
+		// No `hasShownItems` flag: unlike Saved for Later (which auto-
+		// renders on every cart visit and must avoid flashing an empty
+		// message before a runtime save lands), Wishlist is reached
+		// deliberately — by the My Account endpoint or because a merchant
+		// placed it. Showing the empty message immediately is the right
+		// signal: the visitor came to look at their wishlist, and it's
+		// empty. `data-wp-context---notices` seeds the store-notices
+		// namespace alongside the block's own context on the same wrapper.
+		$wrapper_attributes = array(
+			'class'                     => 'wc-block-wishlist',
+			'data-wp-interactive'       => 'woocommerce/wishlist',
+			'data-wp-context'           => (string) wp_json_encode(
+				array(
+					// `stdClass` so it serialises as `{}`, not `[]` —
+					// iAPI's reactive proxy only fires updates on object
+					// writes, not array expandos.
+					'pendingKeys' => new \stdClass(),
+				)
+			),
+			'data-wp-context---notices' => 'woocommerce/store-notices::' . (string) wp_json_encode( array( 'notices' => array() ) ),
+		);
+
+		$list_class  = sprintf( 'wc-block-wishlist__list columns-%d', $column_count );
+		$ul_inner    = $this->render_template_markup() . $this->render_items_markup( $items ) . $this->render_empty_markup( $items );
+		$before_list = $this->render_header_markup( $content ) . ShopperListRenderer::render_interactivity_notices_region( 'wc-block-wishlist__notices' );
+
+		return ShopperListRenderer::render_grid_wrapper( $wrapper_attributes, $list_class, $ul_inner, $before_list );
+	}
+
+	/**
+	 * Prefetch the wishlist items via `rest_do_request()`. Logged-out
+	 * users short-circuit to an empty list — the route requires
+	 * authentication and we don't want to fire an API call that's only
+	 * going to 401.
+	 *
+	 * @return array<int, array<string, mixed>> Items in the schema response shape.
+	 */
+	private function prefetch_items(): array {
+		if ( ! is_user_logged_in() ) {
+			return array();
+		}
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/shopper-lists/' . self::LIST_SLUG . '/items' );
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			$error   = $response->as_error();
+			$message = $error instanceof \WP_Error ? $error->get_error_message() : 'Unknown error';
+			// Logged at debug level on purpose: prefetch failures are
+			// often transient (network blips, auth refresh races) and
+			// the user-visible behaviour is the empty state — nothing
+			// for ops to act on.
+			wc_get_logger()->debug(
+				sprintf( 'Wishlist prefetch failed: %s', $message ),
+				array(
+					'source' => 'wishlist',
+					'data'   => array( 'slug' => self::LIST_SLUG ),
+				)
+			);
+			return array();
+		}
+
+		$data = $response->get_data();
+		if ( ! is_array( $data ) && ! is_object( $data ) ) {
+			return array();
+		}
+
+		// The schema casts `prices` and image entries to stdClass so the
+		// JSON response renders objects, not arrays. Round-trip through
+		// JSON encode/decode to normalise everything to nested arrays so
+		// the SSR markup helpers can treat fields uniformly.
+		$decoded = json_decode( (string) wp_json_encode( $data ), true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * The `<template data-wp-each>` describing how each item is rendered
+	 * on the client. Pre-rendered children sit alongside as
+	 * `data-wp-each-child` elements so first paint is populated. Composes
+	 * the shared row markup with the Wishlist-specific "Add to cart"
+	 * action button.
+	 *
+	 * @return string
+	 */
+	private function render_template_markup(): string {
+		$row_inner = ShopperListRenderer::render_template_common_row()
+			. $this->render_template_add_to_cart();
+		return ShopperListRenderer::render_each_template( $row_inner );
+	}
+
+	/**
+	 * Render the SSR markup for each item. JS will reconcile these via
+	 * `data-wp-each-child` after hydration.
+	 *
+	 * @param array<int, array<string, mixed>> $items Schema-shape items.
+	 * @return string
+	 */
+	private function render_items_markup( array $items ): string {
+		$markup = '';
+		foreach ( $items as $item ) {
+			$markup .= $this->render_item_markup( $item );
+		}
+		return $markup;
+	}
+
+	/**
+	 * Render a single SSR item. Composes the shared image / name / price
+	 * markup with the Wishlist-specific "Add to cart" button.
+	 *
+	 * @param array<string, mixed> $item Schema-shape item.
+	 * @return string
+	 */
+	private function render_item_markup( array $item ): string {
+		$row_inner = ShopperListRenderer::render_ssr_common_row( $item, $this->get_remove_label_template() )
+			. $this->render_ssr_add_to_cart( $item );
+		return ShopperListRenderer::render_each_child( $item, $row_inner );
+	}
+
+	/**
+	 * Template-mode markup for the "Add to cart" action button. iAPI
+	 * substitutes the per-row state through `data-wp-bind--hidden` and
+	 * `data-wp-bind--disabled`.
+	 *
+	 * @return string
+	 */
+	private function render_template_add_to_cart(): string {
+		ob_start();
+		?>
+		<div class="wp-block-button wc-block-components-product-button" data-wp-bind--hidden="state.isAddToCartHidden">
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+				data-wp-on--click="actions.onClickAddToCart"
+				data-wp-bind--disabled="state.isCurrentItemPending"
+			>
+				<?php echo esc_html( $this->get_add_to_cart_label() ); ?>
+			</button>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * SSR-mode markup for the "Add to cart" action button. Always emits
+	 * the wrapper so iAPI can toggle `hidden` after hydration without
+	 * swapping the row out. Starts hidden when the row isn't purchasable.
+	 *
+	 * @param array<string, mixed> $item Schema-shape item.
+	 * @return string
+	 */
+	private function render_ssr_add_to_cart( array $item ): string {
+		$is_hidden = empty( $item['is_purchasable'] );
+		ob_start();
+		?>
+		<div
+			class="wp-block-button wc-block-components-product-button"
+			data-wp-bind--hidden="state.isAddToCartHidden"
+			<?php
+			if ( $is_hidden ) {
+				echo 'hidden';
+			}
+			?>
+		>
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button add_to_cart_button wc-block-components-product-button__button"
+				data-wp-on--click="actions.onClickAddToCart"
+				data-wp-bind--disabled="state.isCurrentItemPending"
+			>
+				<?php echo esc_html( $this->get_add_to_cart_label() ); ?>
+			</button>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Wrap the inner-block content (heading + any future siblings) in a
+	 * div. Unlike Saved for Later, no `hasShownItems` gating — the header
+	 * is always shown when there's content for it. Returns an empty
+	 * string when there's no content to wrap, so we don't emit an empty
+	 * `<div>`.
+	 *
+	 * @param string $content Rendered inner-block content (typically the heading HTML).
+	 * @return string
+	 */
+	private function render_header_markup( string $content ): string {
+		if ( '' === $content ) {
+			return '';
+		}
+		return '<div class="wc-block-wishlist__header">' . $content . '</div>';
+	}
+
+	/**
+	 * Render the empty-state markup. Visible on first paint when the
+	 * list is empty (no `hasShownItems` gate), then iAPI takes over via
+	 * `state.isEmpty` for runtime transitions.
+	 *
+	 * @param array<int, array<string, mixed>> $items Schema-shape items.
+	 * @return string
+	 */
+	private function render_empty_markup( array $items ): string {
+		return ShopperListRenderer::render_empty_state(
+			__( 'Your wishlist is empty. Items you add to your wishlist will appear here.', 'woocommerce' ),
+			'wc-block-wishlist__empty',
+			! empty( $items )
+		);
+	}
+
+	/**
+	 * Sprintf template for the per-row remove button's aria-label. Used
+	 * both by PHP SSR and by the JS-side getter (via
+	 * `wp_interactivity_config`) so both paths produce the same string
+	 * after `%s` interpolation.
+	 */
+	private function get_remove_label_template(): string {
+		/* translators: %s: product name. */
+		return __( 'Remove %s from wishlist', 'woocommerce' );
+	}
+
+	/**
+	 * Visible label for the add-to-cart action button, used by both the
+	 * iAPI `<template>` and the SSR per-row markup.
+	 */
+	private function get_add_to_cart_label(): string {
+		return __( 'Add to cart', 'woocommerce' );
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * Scripts are loaded via `viewScriptModule` in block.json.
+	 *
+	 * @param string|null $key The key of the script to get.
+	 * @return null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * Returning null lets WP use the `style` array from block.json, which
+	 * lists this block's own stylesheet plus the atomic
+	 * product-image / product-price / product-button stylesheets we
+	 * borrow class names from.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+
+	/**
+	 * Disable the editor style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_editor_style() {
+		return null;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -560,6 +560,10 @@ final class BlockTypesController {
 			$block_types[] = 'SavedForLater';
 		}
 
+		if ( wc_get_container()->get( ShopperListsController::class )->is_enabled( 'wishlist' ) ) {
+			$block_types[] = 'Wishlist';
+		}
+
 		if ( wp_is_block_theme() ) {
 			$block_types[] = 'AddToCartWithOptions\AddToCartWithOptions';
 			$block_types[] = 'AddToCartWithOptions\QuantitySelector';

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListRenderer.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListRenderer.php
@@ -28,6 +28,10 @@ final class ShopperListRenderer {
 	 * grid scaffold. `$wrapper_attrs` are merged with the block's wrapper
 	 * attributes via `get_block_wrapper_attributes()`.
 	 *
+	 * Trust contract: callers are responsible for ensuring `$inner` and
+	 * `$before_list` contain only safe, escaped HTML — typically composed
+	 * from the section helpers below, never from raw schema/request input.
+	 *
 	 * @param array<string, mixed> $wrapper_attrs Attributes for the outer `<section>`.
 	 * @param string               $list_class    Class attribute for the inner `<ul>`.
 	 * @param string               $inner         Markup placed inside the `<ul>` (template + SSR rows + empty state).
@@ -49,6 +53,9 @@ final class ShopperListRenderer {
 	 * iAPI uses to render new rows. `$row_inner_markup` is the inner HTML
 	 * for the `<li>` — everything between `<li>` and `</li>`.
 	 *
+	 * Trust contract: caller is responsible for ensuring `$row_inner_markup`
+	 * contains only safe, escaped HTML.
+	 *
 	 * @param string $row_inner_markup Inner markup for the `<li>`.
 	 * @return string
 	 */
@@ -65,6 +72,9 @@ final class ShopperListRenderer {
 	 * seeded with the per-row iAPI context derived from `$item`. iAPI's
 	 * hydration treats this as a no-op diff against the `<template>` if
 	 * the inner markup matches.
+	 *
+	 * Trust contract: caller is responsible for ensuring `$row_inner_markup`
+	 * contains only safe, escaped HTML.
 	 *
 	 * @param array<string, mixed> $item             Schema-shape item.
 	 * @param string               $row_inner_markup Inner markup for the `<li>`.
@@ -133,12 +143,16 @@ final class ShopperListRenderer {
 		$variation_label = self::get_variation_label( $item );
 		$remove_aria     = sprintf( $remove_aria_label_template, $alt );
 		$is_price_hidden = '' === $price_html;
-		$has_live_href   = $is_live && '' !== $permalink;
+		// Tombstone rows (`is_live=false` or empty permalink) render `<a>`
+		// without an href — keeps the element shape stable for iAPI
+		// reconciliation against the live-row template, and the CSS in the
+		// shared partial drops link affordances when the anchor has no href.
+		$href_attr = $is_live && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : '';
 
 		ob_start();
 		?>
 		<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
-			<a <?php echo $has_live_href ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink">
+			<a <?php echo $href_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped above with esc_url(). ?> data-wp-bind--href="context.listItem.permalink">
 				<span
 					class="<?php echo esc_attr( self::ROW_CLASS ); ?>__image-slot"
 					data-wp-context='{"htmlField":"image_html"}'
@@ -169,7 +183,7 @@ final class ShopperListRenderer {
 			><?php echo esc_html( $variation_label ); ?></span>
 		</div>
 		<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
-			<a <?php echo $has_live_href ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
+			<a <?php echo $href_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped above with esc_url(). ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
 		</h2>
 		<div
 			class="price wc-block-components-product-price has-text-align-center has-small-font-size"

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListRenderer.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListRenderer.php
@@ -1,0 +1,293 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ShopperLists;
+
+/**
+ * Shared markup helpers for blocks that render a shopper-list item card
+ * (Saved for Later, Wishlist, …). Static helpers, not an abstract base —
+ * the two blocks' lifecycles diverge enough (auto-injected vs merchant-
+ * placed, different actions, different empty-state gating) that inheritance
+ * is not a clean fit. Consumers stitch the fragments together with their
+ * own quantity / action button / heading bits.
+ *
+ * Any change here is co-reviewed with every consuming block — drift in the
+ * shared row shape will break first paint for whoever didn't get the memo.
+ */
+final class ShopperListRenderer {
+
+	/**
+	 * Shared CSS root class for the row. Each section helper outputs
+	 * BEM-style modifiers off this base (`__image-slot`, `__remove`, …).
+	 */
+	public const ROW_CLASS = 'wc-block-shopper-list-item';
+
+	/**
+	 * Wrap `$inner` in the block's outer `<section><ul>…</ul></section>`
+	 * grid scaffold. `$wrapper_attrs` are merged with the block's wrapper
+	 * attributes via `get_block_wrapper_attributes()`.
+	 *
+	 * @param array<string, mixed> $wrapper_attrs Attributes for the outer `<section>`.
+	 * @param string               $list_class    Class attribute for the inner `<ul>`.
+	 * @param string               $inner         Markup placed inside the `<ul>` (template + SSR rows + empty state).
+	 * @param string               $before_list   Markup placed between `<section>` and `<ul>` (header, notices region).
+	 * @return string
+	 */
+	public static function render_grid_wrapper( array $wrapper_attrs, string $list_class, string $inner, string $before_list = '' ): string {
+		return sprintf(
+			'<section %1$s>%2$s<ul class="%3$s">%4$s</ul></section>',
+			get_block_wrapper_attributes( $wrapper_attrs ),
+			$before_list,
+			esc_attr( $list_class ),
+			$inner
+		);
+	}
+
+	/**
+	 * Wrap `$row_inner_markup` in a `<template data-wp-each>` element that
+	 * iAPI uses to render new rows. `$row_inner_markup` is the inner HTML
+	 * for the `<li>` — everything between `<li>` and `</li>`.
+	 *
+	 * @param string $row_inner_markup Inner markup for the `<li>`.
+	 * @return string
+	 */
+	public static function render_each_template( string $row_inner_markup ): string {
+		return sprintf(
+			'<template data-wp-each--list-item="state.currentItems" data-wp-each-key="context.listItem.key"><li class="%1$s">%2$s</li></template>',
+			esc_attr( self::ROW_CLASS ),
+			$row_inner_markup
+		);
+	}
+
+	/**
+	 * Wrap `$row_inner_markup` in an SSR `<li data-wp-each-child>` element
+	 * seeded with the per-row iAPI context derived from `$item`. iAPI's
+	 * hydration treats this as a no-op diff against the `<template>` if
+	 * the inner markup matches.
+	 *
+	 * @param array<string, mixed> $item             Schema-shape item.
+	 * @param string               $row_inner_markup Inner markup for the `<li>`.
+	 * @return string
+	 */
+	public static function render_each_child( array $item, string $row_inner_markup ): string {
+		$context = array( 'listItem' => $item );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_interactivity_data_wp_context() returns a safely-encoded attribute pair; $row_inner_markup is composed of escaped fragments from the section helpers below.
+		return sprintf(
+			'<li class="%1$s" data-wp-each-child %2$s>%3$s</li>',
+			esc_attr( self::ROW_CLASS ),
+			wp_interactivity_data_wp_context( $context ),
+			$row_inner_markup
+		);
+	}
+
+	/**
+	 * Render the image + title + price triplet for the template-mode row
+	 * (no static attrs; bindings only). Identical between consumer blocks.
+	 *
+	 * @return string
+	 */
+	public static function render_template_common_row(): string {
+		ob_start();
+		?>
+		<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+			<a data-wp-bind--href="context.listItem.permalink">
+				<span class="<?php echo esc_attr( self::ROW_CLASS ); ?>__image-slot" data-wp-context='{"htmlField":"image_html"}' data-wp-watch="callbacks.updateInnerHtml"></span>
+			</a>
+			<button
+				type="button"
+				class="<?php echo esc_attr( self::ROW_CLASS ); ?>__remove"
+				data-wp-on--click="actions.onClickRemove"
+				data-wp-bind--aria-label="state.currentItemRemoveLabel"
+				data-wp-bind--disabled="state.isCurrentItemPending"
+			>
+				<?php echo self::get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
+			</button>
+			<span class="<?php echo esc_attr( self::ROW_CLASS ); ?>__variation" data-wp-bind--hidden="!state.currentItemVariationLabel" data-wp-text="state.currentItemVariationLabel"></span>
+		</div>
+		<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
+			<a data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"></a>
+		</h2>
+		<div class="price wc-block-components-product-price has-text-align-center has-small-font-size" data-wp-bind--hidden="state.isPriceHidden" data-wp-context='{"htmlField":"price_html"}' data-wp-watch="callbacks.updateInnerHtml"></div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Render the image + title + price triplet for the SSR-mode row, with
+	 * values populated from `$item` and `$remove_aria_label_template`. The
+	 * binding directives match the template-mode markup so iAPI's hydration
+	 * is a no-op diff after first paint.
+	 *
+	 * @param array<string, mixed> $item                        Schema-shape item.
+	 * @param string               $remove_aria_label_template  Sprintf template for the remove button's aria-label. `%s` is replaced with the product name.
+	 * @return string
+	 */
+	public static function render_ssr_common_row( array $item, string $remove_aria_label_template ): string {
+		$is_live         = ! empty( $item['is_live'] );
+		$name            = (string) ( $item['name'] ?? '' );
+		$permalink       = (string) ( $item['permalink'] ?? '' );
+		$alt             = html_entity_decode( $name, ENT_QUOTES, 'UTF-8' );
+		$image_html      = (string) ( $item['image_html'] ?? '' );
+		$price_html      = (string) ( $item['price_html'] ?? '' );
+		$variation_label = self::get_variation_label( $item );
+		$remove_aria     = sprintf( $remove_aria_label_template, $alt );
+		$is_price_hidden = '' === $price_html;
+		$has_live_href   = $is_live && '' !== $permalink;
+
+		ob_start();
+		?>
+		<div class="wc-block-components-product-image wc-block-components-product-image--aspect-ratio-auto">
+			<a <?php echo $has_live_href ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink">
+				<span
+					class="<?php echo esc_attr( self::ROW_CLASS ); ?>__image-slot"
+					data-wp-context='{"htmlField":"image_html"}'
+					data-wp-watch="callbacks.updateInnerHtml"
+				>
+					<?php echo wp_kses_post( $image_html ); ?>
+				</span>
+			</a>
+			<button
+				type="button"
+				class="<?php echo esc_attr( self::ROW_CLASS ); ?>__remove"
+				aria-label="<?php echo esc_attr( $remove_aria ); ?>"
+				data-wp-on--click="actions.onClickRemove"
+				data-wp-bind--aria-label="state.currentItemRemoveLabel"
+				data-wp-bind--disabled="state.isCurrentItemPending"
+			>
+				<?php echo self::get_remove_icon_svg(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?>
+			</button>
+			<span
+				class="<?php echo esc_attr( self::ROW_CLASS ); ?>__variation"
+				data-wp-bind--hidden="!state.currentItemVariationLabel"
+				data-wp-text="state.currentItemVariationLabel"
+				<?php
+				if ( '' === $variation_label ) {
+					echo 'hidden';
+				}
+				?>
+			><?php echo esc_html( $variation_label ); ?></span>
+		</div>
+		<h2 class="wp-block-post-title has-text-align-center has-medium-font-size">
+			<a <?php echo $has_live_href ? 'href="' . esc_url( $permalink ) . '"' : ''; ?> data-wp-bind--href="context.listItem.permalink" data-wp-text="state.currentItemDisplayName"><?php echo esc_html( $alt ); ?></a>
+		</h2>
+		<div
+			class="price wc-block-components-product-price has-text-align-center has-small-font-size"
+			data-wp-bind--hidden="state.isPriceHidden"
+			data-wp-context='{"htmlField":"price_html"}'
+			data-wp-watch="callbacks.updateInnerHtml"
+			<?php
+			if ( $is_price_hidden ) {
+				echo 'hidden';
+			}
+			?>
+		>
+			<?php echo wp_kses_post( $price_html ); ?>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Empty-state `<li>` that the block toggles on once `state.isEmpty`
+	 * flips. `$start_hidden = true` makes SSR ship with `hidden` so the
+	 * message doesn't flash for shoppers whose list is being populated
+	 * client-side. `$start_hidden = false` is for blocks (e.g. Wishlist)
+	 * where the message should show on first paint when the list is empty.
+	 *
+	 * @param string $message      Visible empty-state message.
+	 * @param string $css_class    Class attribute for the `<li>`.
+	 * @param bool   $start_hidden Whether the `<li>` should be `hidden` on first paint.
+	 * @return string
+	 */
+	public static function render_empty_state( string $message, string $css_class, bool $start_hidden = true ): string {
+		return sprintf(
+			'<li class="%1$s" data-wp-bind--hidden="!state.isEmpty"%2$s>%3$s</li>',
+			esc_attr( $css_class ),
+			$start_hidden ? ' hidden' : '',
+			esc_html( $message )
+		);
+	}
+
+	/**
+	 * Render the iAPI store-notices region used by the row-level error
+	 * banners. Mirrors `AddToCartWithOptions::render_interactivity_notices_region()`
+	 * — keep in sync if the shape changes.
+	 *
+	 * @param string $wrapper_class Class attribute for the outer `<div>`.
+	 * @return string
+	 */
+	public static function render_interactivity_notices_region( string $wrapper_class ): string {
+		ob_start();
+		?>
+		<div class="<?php echo esc_attr( $wrapper_class ); ?> wc-block-components-notices" data-wp-interactive="woocommerce/store-notices" data-wp-bind--hidden="!context.notices.length" hidden>
+			<template data-wp-each--notice="context.notices" data-wp-each-key="context.notice.id">
+				<div
+					class="wc-block-components-notice-banner"
+					data-wp-class--is-error="state.isError"
+					data-wp-class--is-success="state.isSuccess"
+					data-wp-class--is-info="state.isInfo"
+					data-wp-class--is-dismissible="context.notice.dismissible"
+					data-wp-bind--role="state.role"
+					data-wp-watch="callbacks.injectIcon"
+				>
+					<div class="wc-block-components-notice-banner__content">
+						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive" aria-atomic="true"></span>
+					</div>
+					<button
+						type="button"
+						data-wp-bind--hidden="!context.notice.dismissible"
+						class="wc-block-components-button wp-element-button wc-block-components-notice-banner__dismiss contained"
+						aria-label="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce' ); ?>"
+						data-wp-on--click="actions.removeNotice"
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+							<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z" />
+						</svg>
+					</button>
+				</div>
+			</template>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Markup for the trash icon used in the remove-item button. Mirrors the
+	 * `trash` icon from `@wordpress/icons` that the cart line item uses for
+	 * `wc-block-cart-item__remove-link`, inlined here so SSR first paint
+	 * matches what JS would render after hydration. `currentColor` lets the
+	 * surrounding badge wrapper drive the fill.
+	 *
+	 * @return string
+	 */
+	public static function get_remove_icon_svg(): string {
+		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"/></svg>';
+	}
+
+	/**
+	 * Build a comma-separated variation label like "Color: Blue, Size: M".
+	 *
+	 * @param array<string, mixed> $item Schema-shape item.
+	 * @return string
+	 */
+	public static function get_variation_label( array $item ): string {
+		$variation = $item['variation'] ?? array();
+		if ( ! is_array( $variation ) || empty( $variation ) ) {
+			return '';
+		}
+		$parts = array();
+		foreach ( $variation as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$attribute = isset( $entry['attribute'] ) ? html_entity_decode( (string) $entry['attribute'], ENT_QUOTES, 'UTF-8' ) : '';
+			$value     = isset( $entry['value'] ) ? html_entity_decode( (string) $entry['value'], ENT_QUOTES, 'UTF-8' ) : '';
+			if ( '' === $attribute && '' === $value ) {
+				continue;
+			}
+			$parts[] = $attribute . ': ' . $value;
+		}
+		return implode( ', ', $parts );
+	}
+}

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListsController.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListsController.php
@@ -149,9 +149,12 @@ final class ShopperListsController implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Placeholder rendered until the wishlist block variation lands.
+	 * Render the wishlist endpoint by dispatching to the
+	 * `woocommerce/wishlist` block. The block handles the empty state,
+	 * logged-out guard, asset enqueues, and item rendering.
 	 */
 	public function render_wishlist_endpoint(): void {
-		echo '<p>' . esc_html__( 'Your wishlist is empty.', 'woocommerce' ) . '</p>';
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- the block string is a static literal; `do_blocks()` returns escaped HTML.
+		echo do_blocks( '<!-- wp:woocommerce/wishlist /-->' );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListsController.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListsController.php
@@ -154,7 +154,7 @@ final class ShopperListsController implements RegisterHooksInterface {
 	 * logged-out guard, asset enqueues, and item rendering.
 	 */
 	public function render_wishlist_endpoint(): void {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- the block string is a static literal; `do_blocks()` returns escaped HTML.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- the block string is a static literal; `do_blocks()` invokes the registered block's render callback, which is responsible for its own escaping.
 		echo do_blocks( '<!-- wp:woocommerce/wishlist /-->' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Builds on PRs #65179 (standalone Saved for Later block) and #65152 (`product_wishlist` feature flag + My Account endpoint). Two commits:

**1. `Shopper lists: extract shared row renderer`** — pulls the row markup that Saved for Later and the new Wishlist block share (image, name, price, remove badge, variation overlay, notices region, empty-state, grid wrapper) into a `ShopperListRenderer` static helper, and the matching row CSS into a `_shopper-lists/item` SCSS partial. The row's CSS class moves from `wc-block-saved-for-later-item` to the slug-agnostic `wc-block-shopper-list-item`. `SavedForLater::render()` is rewired to compose the helper; everything specific to SFL (Block Hooks API auto-injection, `hasShownItems` empty-state gating, the per-row quantity span, the Move-to-cart action) stays in the block class.

**2. `Add Wishlist block`** — a merchant-placed block (gated by `product_wishlist`) that renders the shopper's wishlist via the shared `shopper-lists` Store API and iAPI store. Composes the new helper with a Wishlist-specific "Add to cart" per-row action that mirrors SFL's Move-to-cart flow: add the product to the cart, then remove the row from the wishlist on confirmed success (pre/post quantity-diff guard handles partial-stock and silent-failure paths). The `/my-account/wishlist/` endpoint now does `do_blocks( '<!-- wp:woocommerce/wishlist /-->' )` instead of its placeholder.

Differences vs Saved for Later: no Block Hooks API integration, no quantity column ("Add to cart" always adds 1), empty state shows immediately on first paint when the list is empty (no `hasShownItems` gate), no `cartPageHasSavedForLater`-equivalent registry flag.

Adding to the wishlist still requires direct Store API calls; an "Add to wishlist" trigger UI (single-product page, product collection) will ship in a follow-up PR.

### How to test the changes in this Pull Request:

**Prep refactor (commit 1):**

1. Enable Saved for Later (Tools → Features → "Saved for later").
2. Go to the cart page with an item saved for later.
3. Confirm the SFL block renders identically to before: image, title, price, quantity, remove badge, "Move to cart" button. Variation rows show their attributes overlay.
4. Inspect the rendered HTML: each row's `<li>` should have class `wc-block-shopper-list-item` (renamed from `wc-block-saved-for-later-item`). All BEM modifiers follow (`__remove`, `__variation`, `__quantity`, `__image-slot`).
5. Click "Move to cart" — item moves to the cart, removed from saved-for-later. Empty-state message appears when the last item is moved/removed. Add another item from cart → list re-populates, empty message hides.
6. Verify the same flow in the editor preview (cart page → SFL block) — preview items use the new class name.

**Wishlist block (commit 2):**

1. Enable the experimental Wishlist (Tools → Features → "Product wishlist").
2. Visit `/my-account/wishlist/` while logged in. Confirm the empty-state message renders: "Your wishlist is empty. Items you add to your wishlist will appear here." (header "Wishlist" above).
3. Populate the wishlist via the Store API: `POST /wc/store/v1/shopper-lists/wishlist/items` with body `{ "id": <product_id>, "quantity": 1 }` and a valid `Nonce` header (logged-in session).
4. Reload `/my-account/wishlist/`. The product card appears in the grid. Confirm: image, title, price, remove badge, "Add to cart" button. Variation products show the attributes overlay.
5. Click "Add to cart" — product is added to the cart (check cart icon / cart page) **and removed from the wishlist** (the row disappears). If the cart line didn't actually grow (e.g. product went out of stock between page load and click), the row stays.
6. Click the trash icon on a row — item is removed from the wishlist. Empty-state message returns when the list is empty.
7. Place the `Wishlist` block on a regular page (block editor). Confirm preview rendering. Visit the page logged-in — same behaviour as the My Account endpoint. Visit logged-out — block renders nothing (same as SFL).
8. Disable the `product_wishlist` feature flag. Visit `/my-account/wishlist/` — endpoint returns 404 (and the menu item is gone). Placing the block in the editor — block type is unregistered.

### Testing that has already taken place:

- PHPStan: clean on all changed PHP files
- PHPCS: clean on all new files (`Wishlist.php`, `ShopperListRenderer.php`, refactored `SavedForLater.php`); pre-existing nits in unrelated parts of `BlockTypesController.php` left untouched
- Branch-level lint (`pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`): 0 errors
- PHP syntax check: clean
- SFL unit tests: **not run locally** — port conflict with another wp-env on this machine. Tests don't reference any of the renamed classes; refactor preserves DOM shape by inspection. **CI will run them.**

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Both changelog files were added manually in the corresponding commits (`refactor-extract-shopper-list-renderer`, `add-wishlist-block`).

- [x] This Pull Request does not require an additional changelog entry — entries are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)