### PR TITLE
Add tracking for attribute type when updating or saving product attributes

### DIFF
--- a/plugins/woocommerce/changelog/add-attribute-type-tracking
+++ b/plugins/woocommerce/changelog/add-attribute-type-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add tracking for attribute type when updating or saving product attributes

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/attributes-tracking/index.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/attributes-tracking/index.js
@@ -10,11 +10,13 @@ const configureTerms = document.querySelectorAll( '.configure-terms' );
 
 addNewAttribute?.addEventListener( 'click', function () {
 	const archiveInput = document.querySelector( '#attribute_public' );
+	const attributeTypeInput = document.querySelector( '#attribute_type' );
 	const sortOrder = document.querySelector( '#attribute_orderby' );
 	const name = document.querySelector( '#attribute_label' );
 	const slug = document.querySelector( '#attribute_name' );
 	recordEvent( 'product_attributes_add', {
 		enable_archive: archiveInput?.checked ? 'yes' : 'no',
+		attribute_type: attributeTypeInput?.value,
 		default_sort_order: sortOrder?.value,
 		name: name?.value,
 		slug: slug?.value,
@@ -24,8 +26,10 @@ addNewAttribute?.addEventListener( 'click', function () {
 
 saveAttribute?.addEventListener( 'click', function () {
 	const archiveInput = document.querySelector( '#attribute_public' );
+	const attributeTypeInput = document.querySelector( '#attribute_type' );
 	const sortOrder = document.querySelector( '#attribute_orderby' );
 	recordEvent( 'product_attributes_update', {
+		attribute_type: attributeTypeInput?.value,
 		enable_archive: archiveInput?.checked ? 'yes' : 'no',
 		default_sort_order: sortOrder?.value,
 		page: 'attributes',

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/attributes-tracking/index.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/attributes-tracking/index.js
@@ -29,8 +29,8 @@ saveAttribute?.addEventListener( 'click', function () {
 	const attributeTypeInput = document.querySelector( '#attribute_type' );
 	const sortOrder = document.querySelector( '#attribute_orderby' );
 	recordEvent( 'product_attributes_update', {
-		attribute_type: attributeTypeInput?.value,
 		enable_archive: archiveInput?.checked ? 'yes' : 'no',
+		attribute_type: attributeTypeInput?.value,
 		default_sort_order: sortOrder?.value,
 		page: 'attributes',
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the tracking when updating or saving product attributes so we track the attribute type.

### How to test the changes in this Pull Request:

0. Enable color swatches in _WooCommerce_ > _Advanced_ > _Features_.
1. Enable tracking debugging: `localStorage.setItem( 'debug', 'wc-admin:*' );`.
2. Go to Products > Attributes.
3. Create two attributes, one of type 'Text' and the other of type 'Color'.
4. Check your browser console, verify the events were registered correctly.
5. Now update those attributes, verify the update events were registered correctly too.
6. Optionally, try with the color swatches feature disabled (and making sure you don't have any `wc-visual` attribute in your store) and verify the events don't fail and `attribute_type` is set to `undefined`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
