### PR TITLE
Add products app crash fallback

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-products-app-crash-fallback
+++ b/packages/js/experimental-products-app/changelog/fix-products-app-crash-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show a recovery message with GitHub and survey links when the experimental products app crashes.

--- a/packages/js/experimental-products-app/src/app-error-boundary.test.tsx
+++ b/packages/js/experimental-products-app/src/app-error-boundary.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { AppErrorBoundary } from './app-error-boundary';
+import { FEEDBACK_URL, GITHUB_ISSUES_URL } from './constants';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: jest.fn( ( message ) => message ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		href,
+		onClick,
+		rel,
+		target,
+	}: React.PropsWithChildren< {
+		href?: string;
+		onClick?: () => void;
+		rel?: string;
+		target?: string;
+	} > ) =>
+		href ? (
+			<a href={ href } rel={ rel } target={ target }>
+				{ children }
+			</a>
+		) : (
+			<button onClick={ onClick }>{ children }</button>
+		),
+} ) );
+
+jest.mock( '@wordpress/ui', () => ( {
+	EmptyState: {
+		Root: ( {
+			children,
+			className,
+		}: React.PropsWithChildren< { className?: string } > ) => (
+			<section className={ className }>{ children }</section>
+		),
+		Title: ( { children }: React.PropsWithChildren ) => (
+			<h2>{ children }</h2>
+		),
+		Description: ( {
+			children,
+			className,
+		}: React.PropsWithChildren< { className?: string } > ) => (
+			<p className={ className }>{ children }</p>
+		),
+		Actions: ( { children }: React.PropsWithChildren ) => (
+			<div>{ children }</div>
+		),
+	},
+	Stack: ( { children }: React.PropsWithChildren ) => <div>{ children }</div>,
+} ) );
+
+function BrokenComponent(): React.ReactElement {
+	throw new Error( 'Broken component' );
+}
+
+describe( 'AppErrorBoundary', () => {
+	let consoleErrorSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		consoleErrorSpy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		consoleErrorSpy.mockRestore();
+	} );
+
+	it( 'renders children when there is no error', () => {
+		render(
+			<AppErrorBoundary>
+				<div>Products app</div>
+			</AppErrorBoundary>
+		);
+
+		expect( screen.getByText( 'Products app' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders recovery actions when a child crashes', () => {
+		render(
+			<AppErrorBoundary>
+				<BrokenComponent />
+			</AppErrorBoundary>
+		);
+
+		expect(
+			screen.getByText(
+				'Oops, the experimental products experience ran into a problem'
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', {
+				name: 'Report an issue on GitHub',
+			} )
+		).toHaveAttribute( 'href', GITHUB_ISSUES_URL );
+		expect(
+			screen.getByRole( 'link', {
+				name: 'Share feedback in survey',
+			} )
+		).toHaveAttribute( 'href', FEEDBACK_URL );
+		expect(
+			screen.getByRole( 'button', { name: 'Reload page' } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/packages/js/experimental-products-app/src/app-error-boundary.tsx
+++ b/packages/js/experimental-products-app/src/app-error-boundary.tsx
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { EmptyState, Stack } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { FEEDBACK_URL, GITHUB_ISSUES_URL } from './constants';
+
+type AppErrorBoundaryProps = {
+	children: ReactNode;
+};
+
+type AppErrorBoundaryState = {
+	error: Error | null;
+	hasError: boolean;
+};
+
+export class AppErrorBoundary extends Component<
+	AppErrorBoundaryProps,
+	AppErrorBoundaryState
+> {
+	state: AppErrorBoundaryState = {
+		error: null,
+		hasError: false,
+	};
+
+	static getDerivedStateFromError(
+		error: Error
+	): Partial< AppErrorBoundaryState > {
+		return {
+			error,
+			hasError: true,
+		};
+	}
+
+	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
+		// eslint-disable-next-line no-console
+		console.error( error, errorInfo );
+	}
+
+	handleReload = () => {
+		window.location.reload();
+	};
+
+	render() {
+		if ( this.state.hasError ) {
+			return (
+				<EmptyState.Root className="woocommerce-experimental-products-app-error">
+					<EmptyState.Title>
+						{ __(
+							'Oops, the experimental products experience ran into a problem',
+							'woocommerce'
+						) }
+					</EmptyState.Title>
+					<EmptyState.Description className="woocommerce-experimental-products-app-error__description">
+						{ __(
+							'This experience is still experimental. Please report the issue on GitHub or share feedback in the survey so we can improve it.',
+							'woocommerce'
+						) }
+					</EmptyState.Description>
+					<EmptyState.Actions>
+						<Stack direction="row" gap="xs" justify="center">
+							<Button
+								href={ GITHUB_ISSUES_URL }
+								target="_blank"
+								rel="noopener noreferrer"
+								variant="primary"
+							>
+								{ __(
+									'Report an issue on GitHub',
+									'woocommerce'
+								) }
+							</Button>
+							<Button
+								href={ FEEDBACK_URL }
+								target="_blank"
+								rel="noopener noreferrer"
+								variant="secondary"
+							>
+								{ __(
+									'Share feedback in survey',
+									'woocommerce'
+								) }
+							</Button>
+							<Button
+								onClick={ this.handleReload }
+								variant="secondary"
+							>
+								{ __( 'Reload page', 'woocommerce' ) }
+							</Button>
+						</Stack>
+					</EmptyState.Actions>
+				</EmptyState.Root>
+			);
+		}
+
+		return this.props.children;
+	}
+}

--- a/packages/js/experimental-products-app/src/constants.ts
+++ b/packages/js/experimental-products-app/src/constants.ts
@@ -6,3 +6,7 @@ export const OPERATOR_IS = 'is';
 export const OPERATOR_IS_NOT = 'isNot';
 export const OPERATOR_IS_ANY = 'isAny';
 export const OPERATOR_IS_NONE = 'isNone';
+
+export const FEEDBACK_URL = 'https://usabi.li/do/mqc0hscbzp2i/yejxei';
+export const GITHUB_ISSUES_URL =
+	'https://github.com/woocommerce/woocommerce/issues/new/choose';

--- a/packages/js/experimental-products-app/src/product-list/page/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/page/index.tsx
@@ -5,7 +5,10 @@ import { Page } from '@wordpress/admin-ui';
 import { Badge, Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 
-const FEEDBACK_URL = 'https://usabi.li/do/mqc0hscbzp2i/yejxei';
+/**
+ * Internal dependencies
+ */
+import { FEEDBACK_URL } from '../../constants';
 
 type ProductListPageProps = {
 	ariaLabel: string;

--- a/packages/js/experimental-products-app/src/products.tsx
+++ b/packages/js/experimental-products-app/src/products.tsx
@@ -10,6 +10,7 @@ import {
 /**
  * Internal dependencies
  */
+import { AppErrorBoundary } from './app-error-boundary';
 
 const ProductsApp = lazy( () =>
 	import( './app' ).then( ( module ) => ( {
@@ -24,12 +25,21 @@ const ProductsApp = lazy( () =>
  */
 export function initializeProductsDashboard( id: string ): Root {
 	const target = document.getElementById( id );
-	const root = createRoot( target! );
+
+	if ( ! target ) {
+		throw new Error(
+			`Could not initialize products dashboard: element with id "${ id }" was not found.`
+		);
+	}
+
+	const root = createRoot( target );
 	root.render(
 		<StrictMode>
-			<Suspense fallback={ null }>
-				<ProductsApp />
-			</Suspense>
+			<AppErrorBoundary>
+				<Suspense fallback={ null }>
+					<ProductsApp />
+				</Suspense>
+			</AppErrorBoundary>
 		</StrictMode>
 	);
 

--- a/packages/js/experimental-products-app/src/style.scss
+++ b/packages/js/experimental-products-app/src/style.scss
@@ -41,6 +41,16 @@
 	z-index: 100002;
 }
 
+.woocommerce-experimental-products-app-error {
+	box-sizing: border-box;
+	min-height: calc(100vh - var(--wp-admin--admin-bar--height, 32px));
+	padding: var(--wpds-dimension-padding-2xl, 24px);
+}
+
+.woocommerce-experimental-products-app-error__description {
+	max-width: 520px;
+}
+
 .product_page_woocommerce-products-dashboard .edit-site-layout__content {
 	display: flex;
 	align-items: stretch;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental products dashboard could render a blank screen if the React app crashed during rendering. This adds an app-level error boundary for the products dashboard entry point, using the existing EmptyState UI to show recovery actions for reporting the issue on GitHub, sharing survey feedback, or reloading the page.

The existing survey link is centralized so it can be reused by both the header feedback badge and the crash fallback.

### Screenshots or screen recordings:

Author to add before marking ready.

### How to test the changes in this Pull Request:

1. Open the experimental products dashboard and confirm it loads normally.
2. Temporarily throw an error from a component rendered by the products dashboard, then rebuild or reload the development bundle.
3. Open the experimental products dashboard again and confirm the fallback message appears instead of a blank screen.
4. Confirm the "Report an issue on GitHub" and "Share feedback in survey" actions open in a new tab.
5. Confirm "Reload page" reloads the current page.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/experimental-products-app test:js`
- `pnpm --filter=@woocommerce/experimental-products-app build:project:esm`
- `pnpm --filter=@woocommerce/experimental-products-app lint:lang:js`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually in `packages/js/experimental-products-app/changelog/fix-products-app-crash-fallback`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
