### PR TITLE
Fix variation image save payload

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-variation-image-save
+++ b/packages/js/experimental-products-app/changelog/fix-variation-image-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix variation image updates in the experimental products app.

--- a/packages/js/experimental-products-app/src/fields/images/field.test.tsx
+++ b/packages/js/experimental-products-app/src/fields/images/field.test.tsx
@@ -55,15 +55,40 @@ describe( 'images field', () => {
 			...overrides,
 		} as ProductEntityRecord );
 
+	const renderImagesEdit = (
+		data: ProductEntityRecord,
+		onChange = jest.fn()
+	) => {
+		if ( ! fieldExtensions.Edit ) {
+			throw new Error( 'images edit not implemented' );
+		}
+
+		const Edit = fieldExtensions.Edit as React.ComponentType<
+			DataFormControlProps< ProductEntityRecord >
+		>;
+
+		render(
+			<Edit
+				data={ data }
+				field={
+					{
+						...fieldExtensions,
+						id: 'images',
+						label: 'Images',
+					} as DataFormControlProps< ProductEntityRecord >[ 'field' ]
+				}
+				onChange={ onChange }
+			/>
+		);
+
+		return onChange;
+	};
+
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );
 
 	it( 'replaces the current images with the selected media attachments', () => {
-		if ( ! fieldExtensions.Edit ) {
-			throw new Error( 'images edit not implemented' );
-		}
-
 		const attachments = [
 			{
 				id: 34,
@@ -78,30 +103,18 @@ describe( 'images field', () => {
 			},
 		];
 		const onChange = jest.fn();
-		const Edit = fieldExtensions.Edit as React.ComponentType<
-			DataFormControlProps< ProductEntityRecord >
-		>;
 
-		render(
-			<Edit
-				data={ buildProduct( {
-					images: [
-						{
-							id: 15,
-							src: 'old-image.jpg',
-							alt: 'Old image',
-						} as ProductEntityRecord[ 'images' ][ number ],
-					],
-				} ) }
-				field={
+		renderImagesEdit(
+			buildProduct( {
+				images: [
 					{
-						...fieldExtensions,
-						id: 'images',
-						label: 'Images',
-					} as DataFormControlProps< ProductEntityRecord >[ 'field' ]
-				}
-				onChange={ onChange }
-			/>
+						id: 15,
+						src: 'old-image.jpg',
+						alt: 'Old image',
+					} as ProductEntityRecord[ 'images' ][ number ],
+				],
+			} ),
+			onChange
 		);
 
 		expect( mockMediaUpload ).toHaveBeenCalledWith(
@@ -142,6 +155,106 @@ describe( 'images field', () => {
 					alt: 'New image',
 					name: 'New image title',
 					thumbnail: 'new-image-thumbnail.jpg',
+				} ),
+			],
+		} );
+	} );
+
+	it( 'limits variations to a single selected image', () => {
+		const attachments = [
+			{
+				id: 34,
+				url: 'new-variation-image.jpg',
+				alt: 'New variation image',
+				title: 'New variation image title',
+				sizes: {
+					thumbnail: {
+						url: 'new-variation-image-thumbnail.jpg',
+					},
+				},
+			},
+			{
+				id: 35,
+				url: 'extra-variation-image.jpg',
+				alt: 'Extra variation image',
+				title: 'Extra variation image title',
+			},
+		];
+		const onChange = jest.fn();
+
+		renderImagesEdit(
+			buildProduct( {
+				type: 'variation',
+				images: [
+					{
+						id: 15,
+						src: 'old-variation-image.jpg',
+						alt: 'Old variation image',
+					} as ProductEntityRecord[ 'images' ][ number ],
+					{
+						id: 16,
+						src: 'second-variation-image.jpg',
+						alt: 'Second variation image',
+					} as ProductEntityRecord[ 'images' ][ number ],
+				],
+			} ),
+			onChange
+		);
+
+		expect( mockMediaUpload ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				allowedTypes: [ 'image' ],
+				multiple: false,
+				title: 'Add image',
+				value: [ 15 ],
+			} )
+		);
+
+		expect(
+			screen.getByRole( 'img', {
+				name: 'Old variation image',
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'img', {
+				name: 'Second variation image',
+			} )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', {
+				name: 'Drag to reorder',
+			} )
+		).not.toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole( 'button', {
+				name: 'Add image',
+			} )
+		);
+		expect( mockOpenMediaUploadModal ).toHaveBeenCalled();
+
+		act( () => {
+			mockMediaUpload.mock.calls[ 0 ][ 0 ].onSelect( attachments );
+		} );
+
+		expect(
+			screen.getByRole( 'img', {
+				name: 'New variation image',
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'img', {
+				name: 'Extra variation image',
+			} )
+		).not.toBeInTheDocument();
+		expect( onChange ).toHaveBeenCalledWith( {
+			images: [
+				expect.objectContaining( {
+					id: 34,
+					src: 'new-variation-image.jpg',
+					alt: 'New variation image',
+					name: 'New variation image title',
+					thumbnail: 'new-variation-image-thumbnail.jpg',
 				} ),
 			],
 		} );

--- a/packages/js/experimental-products-app/src/fields/images/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/images/field.tsx
@@ -150,8 +150,16 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 		);
 	},
 	Edit: ( { data, onChange } ) => {
-		const dataImages = useMemo( () => data.images ?? [], [ data.images ] );
+		const isVariation = data.type === 'variation';
+		const dataImages = useMemo( () => {
+			const nextImages = data.images ?? [];
+
+			return isVariation ? nextImages.slice( 0, 1 ) : nextImages;
+		}, [ data.images, isVariation ] );
 		const [ images, setImages ] = useState( dataImages );
+		const uploadLabel = isVariation
+			? __( 'Add image', 'woocommerce' )
+			: __( 'Add images', 'woocommerce' );
 
 		useEffect( () => {
 			setImages( dataImages );
@@ -174,9 +182,11 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 					: [ selection ];
 				const mappedImages = attachments.map( toProductImage );
 
-				commitImages( mappedImages );
+				commitImages(
+					isVariation ? mappedImages.slice( 0, 1 ) : mappedImages
+				);
 			},
-			[ commitImages ]
+			[ commitImages, isVariation ]
 		);
 
 		const handleRemoveImage = useCallback(
@@ -253,7 +263,10 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 										index={ index }
 										alt={ image.alt || data.name }
 										onRemove={ onRemove }
-										showDragHandle={ images.length > 1 }
+										showDragHandle={
+											! isVariation &&
+											images.length > 1
+										}
 									/>
 								);
 							} ) }
@@ -261,18 +274,15 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 						<div className="woocommerce-fields-control__featured-image-actions">
 							<MediaUpload
 								allowedTypes={ [ 'image' ] }
-								multiple="add"
+								multiple={ isVariation ? false : 'add' }
 								onSelect={ handleSelect }
-								title={ __( 'Add images', 'woocommerce' ) }
+								title={ uploadLabel }
 								value={ images.map( ( image ) => image.id ) }
 								render={ ( { open }: { open: () => void } ) => (
 									<IconButton
 										variant="minimal"
 										icon={ upload }
-										label={ __(
-											'Add images',
-											'woocommerce'
-										) }
+										label={ uploadLabel }
 										onClick={ open }
 									/>
 								) }

--- a/packages/js/experimental-products-app/src/fields/images/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/images/field.tsx
@@ -264,8 +264,7 @@ export const fieldExtensions: Partial< Field< ProductEntityRecord > > = {
 										alt={ image.alt || data.name }
 										onRemove={ onRemove }
 										showDragHandle={
-											! isVariation &&
-											images.length > 1
+											! isVariation && images.length > 1
 										}
 									/>
 								);

--- a/packages/js/experimental-products-app/src/product-edit/save.test.ts
+++ b/packages/js/experimental-products-app/src/product-edit/save.test.ts
@@ -58,6 +58,137 @@ describe( 'saveSelectedProducts', () => {
 		jest.clearAllMocks();
 	} );
 
+	it( 'sends variation image updates using the variation REST image field', async () => {
+		const editedVariation = buildVariation( {
+			id: 101,
+			images: [
+				{
+					id: 55,
+					src: 'https://example.com/blue.jpg',
+					alt: 'Blue',
+					name: 'Blue image',
+					thumbnail: 'https://example.com/blue-thumbnail.jpg',
+					date_created: '',
+					date_created_gmt: '',
+					date_modified: '',
+					date_modified_gmt: '',
+				},
+			],
+		} );
+		const editedParent = buildProduct( {
+			id: 10,
+			type: 'variable',
+			_embedded: {
+				variations: [ editedVariation ],
+			},
+		} );
+		const editEntityRecord = jest.fn(
+			(
+				_kind,
+				_name,
+				_recordId,
+				edits: Partial< ProductEntityRecord >
+			) => {
+				Object.assign( editedParent, edits );
+			}
+		);
+		const saveEditedEntityRecord = jest.fn( async () => editedParent );
+
+		mockGetEditedEntityRecord.mockImplementation( ( _kind, _name, id ) =>
+			id === editedParent.id ? editedParent : undefined
+		);
+		( apiFetch as unknown as jest.Mock ).mockResolvedValueOnce( {
+			id: 101,
+			parent_id: 10,
+			name: 'Blue saved',
+			image: {
+				id: 55,
+				src: 'https://example.com/blue.jpg',
+				alt: 'Blue',
+				name: 'Blue image',
+			},
+			manage_stock: false,
+		} );
+
+		await saveSelectedProducts( {
+			selectedProducts: [ editedVariation ],
+			editEntityRecord,
+			saveEditedEntityRecord,
+		} );
+
+		const request = ( apiFetch as unknown as jest.Mock ).mock
+			.calls[ 0 ][ 0 ];
+
+		expect( request ).toEqual(
+			expect.objectContaining( {
+				path: '/wc/v3/products/10/variations/101',
+				method: 'PUT',
+				data: expect.objectContaining( {
+					image: expect.objectContaining( {
+						id: 55,
+						src: 'https://example.com/blue.jpg',
+						alt: 'Blue',
+						name: 'Blue image',
+					} ),
+				} ),
+			} )
+		);
+		expect( request.data.images ).toBeUndefined();
+		expect( request.data.image.thumbnail ).toBeUndefined();
+	} );
+
+	it( 'sends an empty variation image object when removing a variation image', async () => {
+		const editedVariation = buildVariation( {
+			id: 101,
+			images: [],
+		} );
+		const editedParent = buildProduct( {
+			id: 10,
+			type: 'variable',
+			_embedded: {
+				variations: [ editedVariation ],
+			},
+		} );
+		const editEntityRecord = jest.fn(
+			(
+				_kind,
+				_name,
+				_recordId,
+				edits: Partial< ProductEntityRecord >
+			) => {
+				Object.assign( editedParent, edits );
+			}
+		);
+		const saveEditedEntityRecord = jest.fn( async () => editedParent );
+
+		mockGetEditedEntityRecord.mockImplementation( ( _kind, _name, id ) =>
+			id === editedParent.id ? editedParent : undefined
+		);
+		( apiFetch as unknown as jest.Mock ).mockResolvedValueOnce( {
+			id: 101,
+			parent_id: 10,
+			name: 'Blue saved',
+			image: null,
+			manage_stock: false,
+		} );
+
+		await saveSelectedProducts( {
+			selectedProducts: [ editedVariation ],
+			editEntityRecord,
+			saveEditedEntityRecord,
+		} );
+
+		const request = ( apiFetch as unknown as jest.Mock ).mock
+			.calls[ 0 ][ 0 ];
+
+		expect( request.data ).toEqual(
+			expect.objectContaining( {
+				image: {},
+			} )
+		);
+		expect( request.data.images ).toBeUndefined();
+	} );
+
 	it( 'keeps edits for selected variations that failed after another variation saved', async () => {
 		const originalSavedVariation = buildVariation( {
 			id: 101,

--- a/packages/js/experimental-products-app/src/product-edit/save.ts
+++ b/packages/js/experimental-products-app/src/product-edit/save.ts
@@ -21,6 +21,15 @@ type ProductVariationEntityRecord = ProductEntityRecord & {
 	parent_id: number;
 };
 
+type ProductVariationSaveData = Omit<
+	Partial< ProductEntityRecord >,
+	'images'
+> & {
+	image?:
+		| NonNullable< ProductVariation[ 'image' ] >
+		| Record< string, never >;
+};
+
 type ProductSaveResult = PromiseSettledResult<
 	ProductEntityRecord | ProductVariation
 >;
@@ -50,6 +59,29 @@ function getEditedProduct( productId: number ) {
 	return product !== false ? product : undefined;
 }
 
+function getVariationImageSaveData(
+	image: ProductEntityRecord[ 'images' ][ number ] | undefined
+) {
+	if ( ! image ) {
+		return {};
+	}
+
+	const { thumbnail, ...variationImage } = image;
+
+	return variationImage;
+}
+
+function getVariationSaveData(
+	variation: ProductEntityRecord
+): ProductVariationSaveData {
+	const { images, ...data } = variation;
+
+	return {
+		...data,
+		image: getVariationImageSaveData( images?.[ 0 ] ),
+	};
+}
+
 async function saveVariation(
 	product: ProductVariationEntityRecord,
 	editEntityRecord: EditProductRecord
@@ -62,7 +94,7 @@ async function saveVariation(
 	const savedVariation = await apiFetch< ProductVariation >( {
 		path: getProductVariationUpdatePath( product ),
 		method: 'PUT',
-		data: editedVariation,
+		data: getVariationSaveData( editedVariation ),
 	} );
 
 	if ( parentProduct ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Variation quick edits in the experimental products app normalized variation images into the product-style `images` field, but the variation REST endpoint expects a single `image` field. This updates the variation save payload to convert the first UI image back into `image`, strip UI-only image data, and send an empty image object when the image is removed.

Bug introduced in PR #64688.

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open a variable product with at least one variation.
2. Quick edit a variation, set or replace its image, and save the changes.
3. Refresh the variation list and confirm the variation shows the newly saved image.
4. Quick edit the same variation again, remove the image, and save the changes.
5. Refresh the variation list and confirm the variation image remains removed.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/product-edit/save.test.ts`
-   `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/product-edit/save.ts src/product-edit/save.test.ts`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually in `packages/js/experimental-products-app/changelog/fix-variation-image-save`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
