### PR TITLE
Fix variation table edit links

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-variation-parent-edit-link
+++ b/packages/js/experimental-products-app/changelog/fix-variation-parent-edit-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix variation table edit links to open the parent product.

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.test.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.test.tsx
@@ -343,6 +343,37 @@ describe( 'product list actions', () => {
 		} );
 	} );
 
+	it( 'opens the parent product editor when the Edit action is triggered for a variation', () => {
+		const { result } = renderHook( () => useProductActions() );
+		const editProductAction = result.current.find(
+			( action ) => action.id === 'edit-product'
+		);
+
+		expect( editProductAction ).toBeDefined();
+
+		if ( ! editProductAction ) {
+			throw new Error( 'Edit action not found.' );
+		}
+
+		const originalLocation = window.location;
+		Object.defineProperty( window, 'location', {
+			writable: true,
+			value: { href: '' },
+		} );
+
+		getCallbackAction( editProductAction ).callback( [ blueVariation ], {
+			onActionPerformed,
+		} );
+
+		expect( window.location.href ).toBe( 'post.php?post=78&action=edit' );
+		expect( onActionPerformed ).toHaveBeenCalledWith( [ blueVariation ] );
+
+		Object.defineProperty( window, 'location', {
+			writable: true,
+			value: originalLocation,
+		} );
+	} );
+
 	it( 'duplicates products through the WooCommerce duplicate endpoint', async () => {
 		const duplicatedProduct = {
 			...product,

--- a/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
+++ b/packages/js/experimental-products-app/src/dataviews-actions/actions.tsx
@@ -24,7 +24,10 @@ import { useMemo } from '@wordpress/element';
  */
 import type { ProductEntityRecord } from '../fields/types';
 import { unlock } from '../lock-unlock';
-import { getProductListNavigationPath } from '../product-list/utils';
+import {
+	getProductEditPostId,
+	getProductListNavigationPath,
+} from '../product-list/utils';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
@@ -189,7 +192,7 @@ export const editAction = (): Action< ProductEntityRecord > => ( {
 		if ( product ) {
 			window.location.href = getAdminLink(
 				addQueryArgs( 'post.php', {
-					post: product.id,
+					post: getProductEditPostId( product ),
 					action: 'edit',
 				} )
 			);

--- a/packages/js/experimental-products-app/src/product-list/index.tsx
+++ b/packages/js/experimental-products-app/src/product-list/index.tsx
@@ -28,6 +28,7 @@ import {
 import { productFields } from './fields';
 import {
 	getItemId,
+	getProductEditPostId,
 	getProductListNavigationPath,
 	getProductListTab,
 	getProductsWithEmbeddedVariations,
@@ -318,7 +319,7 @@ export default function ProductList( {
 						{ ...props }
 						href={ getAdminLink(
 							addQueryArgs( 'post.php', {
-								post: item.id,
+								post: getProductEditPostId( item ),
 								action: 'edit',
 							} )
 						) }

--- a/packages/js/experimental-products-app/src/product-list/utils.test.ts
+++ b/packages/js/experimental-products-app/src/product-list/utils.test.ts
@@ -8,6 +8,7 @@ import type { View } from '@wordpress/dataviews';
  */
 import type { ProductEntityRecord } from '../fields/types';
 import {
+	getProductEditPostId,
 	hasActiveProductListSearchOrFilters,
 	getProductListNavigationPath,
 	getProductsWithEmbeddedVariations,
@@ -64,6 +65,20 @@ describe( 'product list utils', () => {
 					}
 				)
 			).toBe( 'woocommerce-products-dashboard?post_type=product' );
+		} );
+	} );
+
+	describe( 'getProductEditPostId', () => {
+		it( 'returns the product ID for parent products', () => {
+			expect( getProductEditPostId( createProduct( 1 ) ) ).toBe( 1 );
+		} );
+
+		it( 'returns the parent product ID for variations', () => {
+			expect( getProductEditPostId( createProduct( 2, 1 ) ) ).toBe( 1 );
+		} );
+
+		it( 'falls back to the variation ID when a parent ID is missing', () => {
+			expect( getProductEditPostId( createProduct( 2, 0 ) ) ).toBe( 2 );
 		} );
 	} );
 

--- a/packages/js/experimental-products-app/src/product-list/utils.ts
+++ b/packages/js/experimental-products-app/src/product-list/utils.ts
@@ -33,6 +33,10 @@ export function getItemId( item: ProductEntityRecord ) {
 	return item.id.toString();
 }
 
+export function getProductEditPostId( item: ProductEntityRecord ) {
+	return item.parent_id && item.parent_id > 0 ? item.parent_id : item.id;
+}
+
 export function getProductsWithEmbeddedVariations(
 	items: ProductEntityRecord[]
 ): ProductEntityRecord[] {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Variations shown in the experimental products app table were opening the variation post directly when clicking the row or using the Edit action. This updates both paths to resolve variations to their parent product ID, while keeping normal products pointed at their own edit screen.

Bug introduced in PRs #64449 and #64702.

### How to test the changes in this Pull Request:

1. Enable the experimental products app and open the products table.
2. Use a variable product with visible embedded variations in the table.
3. Click a variation row and confirm the classic editor opens for the parent product.
4. Return to the products table, open the row actions for the variation, choose Edit, and confirm the classic editor opens for the parent product.
5. Repeat the row click and Edit action for a non-variation product and confirm it still opens that product.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- src/product-list/utils.test.ts src/dataviews-actions/actions.test.tsx`
-   `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/product-list/utils.ts src/product-list/utils.test.ts src/product-list/index.tsx src/dataviews-actions/actions.tsx src/dataviews-actions/actions.test.tsx`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually in `packages/js/experimental-products-app/changelog/fix-variation-parent-edit-link`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
