### PR TITLE
Fix active Chips not being correctly styled in the editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-chips-style-editor
+++ b/plugins/woocommerce/changelog/fix-chips-style-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix active Chips not being correctly styled in the editor
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import clsx from 'clsx';
 import { decodeHtmlEntities } from '@woocommerce/utils';
+import { getSetting } from '@woocommerce/settings';
 import {
 	InspectorControls,
 	useBlockProps,
@@ -57,13 +58,39 @@ const Edit = ( props: EditProps ): JSX.Element => {
 
 	const hasColorSwatches = items.some( ( item ) => 'color' in item );
 
+	const globalColors = getSetting< { background?: string; text?: string } >(
+		'globalStylesColors',
+		{}
+	);
+	const colorVars = getColorVars( attributes );
+
 	const blockProps = useBlockProps( {
 		className: clsx( 'wc-block-product-filter-chips', {
 			'is-loading': isLoading,
 			'is-style-swatch': hasColorSwatches,
 			...getColorClasses( attributes ),
 		} ),
-		style: getColorVars( attributes ),
+		style: {
+			'--wc-product-filter-chips-text':
+				colorVars[ '--wc-product-filter-chips-text' ] ||
+				globalColors.text ||
+				undefined,
+			'--wc-product-filter-chips-background':
+				colorVars[ '--wc-product-filter-chips-background' ] ||
+				globalColors.background ||
+				undefined,
+			'--wc-product-filter-chips-border':
+				colorVars[ '--wc-product-filter-chips-border' ] || undefined,
+			'--wc-product-filter-chips-selected-text':
+				colorVars[ '--wc-product-filter-chips-selected-text' ] ||
+				undefined,
+			'--wc-product-filter-chips-selected-background':
+				colorVars[ '--wc-product-filter-chips-selected-background' ] ||
+				undefined,
+			'--wc-product-filter-chips-selected-border':
+				colorVars[ '--wc-product-filter-chips-selected-border' ] ||
+				undefined,
+		},
 	} );
 
 	const loadingState = useMemo( () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -79,17 +79,6 @@ const Edit = ( props: EditProps ): JSX.Element => {
 				colorVars[ '--wc-product-filter-chips-background' ] ||
 				globalColors.background ||
 				undefined,
-			'--wc-product-filter-chips-border':
-				colorVars[ '--wc-product-filter-chips-border' ] || undefined,
-			'--wc-product-filter-chips-selected-text':
-				colorVars[ '--wc-product-filter-chips-selected-text' ] ||
-				undefined,
-			'--wc-product-filter-chips-selected-background':
-				colorVars[ '--wc-product-filter-chips-selected-background' ] ||
-				undefined,
-			'--wc-product-filter-chips-selected-border':
-				colorVars[ '--wc-product-filter-chips-selected-border' ] ||
-				undefined,
 		},
 	} );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -23,6 +23,7 @@ final class ProductFilterChips extends AbstractBlock {
 	 * @param array $attributes  Any attributes that currently are available from the block.
 	 *                           Note, this will be empty in the editor context when the block is
 	 *                           not in the post content on editor load.
+	 * @return void
 	 */
 	protected function enqueue_data( array $attributes = array() ) {
 		parent::enqueue_data( $attributes );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -18,6 +18,21 @@ final class ProductFilterChips extends AbstractBlock {
 	protected $block_name = 'product-filter-chips';
 
 	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = array() ) {
+		parent::enqueue_data( $attributes );
+
+		if ( is_admin() ) {
+			$this->asset_data_registry->add( 'globalStylesColors', wp_get_global_styles( array( 'color' ) ) );
+		}
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array     $attributes Block attributes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -39,7 +39,9 @@ class ProductFilters extends AbstractBlock {
 	protected function enqueue_data( array $attributes = array() ) {
 		parent::enqueue_data( $attributes );
 
-		$this->asset_data_registry->add( 'globalStylesColors', wp_get_global_styles( array( 'color' ) ) );
+		if ( is_admin() ) {
+			$this->asset_data_registry->add( 'globalStylesColors', wp_get_global_styles( array( 'color' ) ) );
+		}
 
 		BlocksSharedState::load_store_config( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/65200.

In https://github.com/woocommerce/woocommerce/pull/65200 we changed the variables used by the _Chips_ block colors, that made that the existing variables set by the Product Filters block in the editor wouldn't apply anymore to the _Chips_. This PR fixes that by adding some logic to inint the CSS variables needed by chips colors in the editor.

### How to test the changes in this Pull Request:

1. Add the _Product Filters_ block to a post or page, making sure at least one of them has the _Chips_ style.
2. Verify the selected chip colors match the theme.

Before | After
--- | ---
<img width="781" height="428" alt="imatge" src="https://github.com/user-attachments/assets/5f94c307-912a-4cc2-bb80-b8098b4f350e" /> | <img width="781" height="428" alt="imatge" src="https://github.com/user-attachments/assets/e2710baf-901d-4299-b6fb-b23aa9af3635" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
