### PR TITLE
Disable product list name and price sorting

### DIFF
--- a/packages/js/experimental-products-app/changelog/fix-disable-name-price-sort
+++ b/packages/js/experimental-products-app/changelog/fix-disable-name-price-sort
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disable sorting by product name and price in the product list.

--- a/packages/js/experimental-products-app/src/fields/name/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/name/field.tsx
@@ -13,7 +13,7 @@ import { type ProductEntityRecord } from '../types';
 const fieldDefinition = {
 	type: 'text',
 	label: __( 'Name', 'woocommerce' ),
-	enableSorting: true,
+	enableSorting: false,
 	filterBy: false,
 	enableHiding: false,
 } satisfies Partial< Field< ProductEntityRecord > >;

--- a/packages/js/experimental-products-app/src/fields/price/field.tsx
+++ b/packages/js/experimental-products-app/src/fields/price/field.tsx
@@ -57,7 +57,7 @@ const CurrencySuffixSlot = () => {
 
 const fieldDefinition = {
 	label: __( 'Price', 'woocommerce' ),
-	enableSorting: true,
+	enableSorting: false,
 	filterBy: {
 		operators: [ 'is', 'between', 'greaterThanOrEqual', 'lessThanOrEqual' ],
 	},

--- a/packages/js/experimental-products-app/src/product-list/query.test.ts
+++ b/packages/js/experimental-products-app/src/product-list/query.test.ts
@@ -26,12 +26,26 @@ describe( 'buildProductListQuery', () => {
 			expect.objectContaining( {
 				per_page: 25,
 				page: 3,
-				order: 'asc',
-				orderby: 'title',
 				_embed: 1,
 				search_name_or_sku: 'hoodie',
 			} )
 		);
+	} );
+
+	it( 'does not map disabled sort fields to query params', () => {
+		const nameSortQuery = buildProductListQuery( baseView );
+		const priceSortQuery = buildProductListQuery( {
+			...baseView,
+			sort: {
+				field: 'price',
+				direction: 'desc',
+			},
+		} as View );
+
+		expect( nameSortQuery.order ).toBeUndefined();
+		expect( nameSortQuery.orderby ).toBeUndefined();
+		expect( priceSortQuery.order ).toBeUndefined();
+		expect( priceSortQuery.orderby ).toBeUndefined();
 	} );
 
 	it( 'maps supported filters to the v4 product query', () => {

--- a/packages/js/experimental-products-app/src/product-list/query.ts
+++ b/packages/js/experimental-products-app/src/product-list/query.ts
@@ -29,6 +29,7 @@ export type ProductListQuery = Omit<
 };
 
 const SUPPORTED_STATUS_FILTER_FIELDS = [ 'status', 'product_status' ];
+const DISABLED_SORT_FIELDS = [ 'name', 'price' ];
 
 function isStringArray( value: unknown ): value is string[] {
 	return (
@@ -232,15 +233,19 @@ function applyStockQuantityFilter( query: ProductListQuery, filter: Filter ) {
 }
 
 export function buildProductListQuery( view: View ): ProductListQuery {
+	const sort =
+		view.sort && ! DISABLED_SORT_FIELDS.includes( view.sort.field )
+			? view.sort
+			: undefined;
 	const query: ProductListQuery = {
 		_embed: 1,
 		per_page: view.perPage,
 		page: view.page,
-		order: view.sort?.direction,
+		order: sort?.direction,
 		orderby:
-			view.sort?.field === 'name'
+			sort?.field === 'name'
 				? 'title'
-				: ( view.sort?.field as ProductQuery[ 'orderby' ] ),
+				: ( sort?.field as ProductQuery[ 'orderby' ] ),
 		search_name_or_sku: view.search || undefined,
 	};
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental products table should no longer allow sorting by product name or price. This disables sorting for those two field definitions and guards the product list query builder so stale `name` or `price` sort state is not translated into REST `order` or `orderby` params.

### Screenshots or screen recordings:

Not included; this removes sorting affordances and behavior from existing product table columns.

### How to test the changes in this Pull Request:

1. Open the experimental products app product list.
2. Confirm the Product and Price columns do not offer sorting controls.
3. Use search, filters, and pagination, and confirm the product list continues to load normally.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/experimental-products-app test:js -- product-list/query.test.ts`
-   `pnpm --filter=@woocommerce/experimental-products-app exec eslint src/fields/name/field.tsx src/fields/price/field.tsx src/product-list/query.ts src/product-list/query.test.ts`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

A changelog entry was created manually in `packages/js/experimental-products-app/changelog/fix-disable-name-price-sort`.

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
