### PR TITLE
Fix variation gallery snapping to first slide on same-image variation pick

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-gallery-spurious-slide-reset
+++ b/plugins/woocommerce/changelog/fix-variation-gallery-spurious-slide-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix variation gallery sliding back to the first position when picking a variation that already shows the same image.

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -854,7 +854,9 @@
 			$product_gallery = $product.find( '.images' ),
 			reset_slide_position = false,
 			new_image_id =
-				variation && variation.image_id ? variation.image_id : '';
+				variation && variation.image_id
+					? String( variation.image_id )
+					: '';
 
 		if ( $form.attr( 'current-image' ) !== new_image_id ) {
 			reset_slide_position = true;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`wc_maybe_trigger_slide_position_reset` in the classic add-to-cart-variation script decides whether to fire the gallery slide reset by strict-comparing the variation's `image_id` against the form's `current-image` attribute. The former is a number (read from `get_post_thumbnail_id()` on the PHP side), the latter is always a string (DOM attributes are always strings). So `123 !== "123"` was always true and the slide reset fired on every variation change — even when the displayed image hadn't actually changed.

The one-line fix casts `variation.image_id` to a string before the compare, restoring the function's original "only reset when the image actually changed" semantics.

### How to test the changes in this Pull Request:

**Quick console-only verification:**

1. On any variable product page (classic theme / classic add-to-cart template), open DevTools.
2. Paste:
    ```js
    let count = 0;
    jQuery( '.images' ).on(
        'woocommerce_gallery_reset_slide_position',
        () => count++
    );
    const $f = jQuery( 'form.variations_form' );
    $f.attr( 'current-image', '' );
    $f.wc_maybe_trigger_slide_position_reset( { image_id: 5684 } );
    $f.wc_maybe_trigger_slide_position_reset( { image_id: 5684 } );
    $f.wc_maybe_trigger_slide_position_reset( { image_id: 1234 } );
    console.log( 'reset events:', count );
    ```
3. **Before the fix:** logs `reset events: 3` (one per call — bug).
4. **After the fix:** logs `reset events: 2` (only when the image changes — correct).

**End-to-end UI repro** (requires a specific product setup):

1. Create a variable product with multiple parent gallery images.
2. Add at least one variation with an image that's **not** in the parent gallery, and a second variation with the same image as the first.
3. On the storefront, pick the first variation — the main image swaps to the variation's image.
4. Use the gallery thumbnails to navigate to a different slide (e.g. slide 3 of the parent gallery).
5. Pick the second variation (same image as the first).
6. **Before the fix:** gallery snaps back to slide 1.
7. **After the fix:** gallery stays on slide 3 (the displayed image didn't change).

### Testing that has already taken place:

Verified the fix in isolation against a local install with WC trunk: the function's strict-equality compare correctly identifies same-image transitions after the cast, and `woocommerce_gallery_reset_slide_position` no longer fires on those transitions. The wider variation-pick paths (gallery HTML swap, gallery reset, slide-to-existing-image) are untouched.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog file created manually at `plugins/woocommerce/changelog/fix-variation-gallery-spurious-slide-reset`.