### PR TITLE
Tighten shopper-lists docblocks and inline comments

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -131,14 +131,11 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 			false,
 			isBoolean
 		);
-		// Three signals, each catching a distinct failure mode.
-		// Disabling the `cart_save_for_later` feature unregisters the
-		// saved-for-later block but leaves any prior insertion in the
-		// cart page's post content (the editor renders it as an
-		// "unsupported block" notice) — so presence alone could render
-		// this link with no working destination. Inversely, the feature
-		// can be enabled on cart pages that never inserted the block.
-		// And the REST endpoints behind the click are auth-only.
+		// Three independent gates: the REST endpoints require authentication;
+		// disabling `cart_save_for_later` unregisters the block but leaves
+		// any prior insertion in the cart page's post content; and the
+		// feature can be enabled on cart pages that never inserted the block.
+		// All three must hold for the link to have a working destination.
 		const showSaveForLater =
 			isUserLoggedIn &&
 			isSaveForLaterFeatureEnabled &&
@@ -376,16 +373,16 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 										if ( ! saved ) {
 											return;
 										}
-										// removeItem surfaces its own errors
-										// via processErrorResponse; we still
-										// fire the analytics event and a11y
-										// announcement to mirror the regular
-										// remove flow.
+										// `removeItem` surfaces its own errors via
+										// `processErrorResponse`; the analytics
+										// event and a11y announcement still
+										// fire to mirror the regular remove
+										// flow.
 										await removeItem();
-										// TODO: consider a dedicated
-										// 'cart-save-for-later' store event so
-										// analytics can distinguish a save
-										// from a plain remove.
+										// TODO: emit a dedicated
+										// `cart-save-for-later` store event so
+										// analytics can distinguish a save from
+										// a plain remove.
 										dispatchStoreEvent(
 											'cart-remove-item',
 											{

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-save-for-later.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-save-for-later.ts
@@ -10,15 +10,10 @@ import { cartStore } from '@woocommerce/block-data';
 /**
  * Save a cart line item to the saved-for-later shopper list.
  *
- * Dispatches the wp.data cart store's `saveForLater` thunk, which POSTs the
- * item and emits a `wc-blocks_store_sync_required` event. A Saved for Later
- * block on the same page picks up that event in its iAPI store and applies
- * the new row reactively.
- *
- * Resolves to `true` on success so the caller can chain the cart removal;
- * on failure surfaces an error notice in the cart context and resolves to
- * `false`. The cart removal is the caller's responsibility — keep the two
- * awaits separate so save and remove errors stay distinct.
+ * Dispatches the cart store's `saveForLater` thunk and resolves to `true` on
+ * success. On failure, surfaces an error notice in the cart context and
+ * resolves to `false`. Removing the line from the cart is the caller's
+ * responsibility, so save and remove errors can be reported independently.
  */
 export const useSaveForLater = (): {
 	isSaving: boolean;

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/shopper-lists.ts
@@ -7,11 +7,9 @@ import type { CurrencyResponse } from '@woocommerce/types';
 import type { Store as StoreNotices } from '@woocommerce/stores/store-notices';
 
 /**
- * Mirror of `Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListItemSchema::get_properties()`.
- *
- * Keep this in sync with the schema. State here must not include any UI-derived
- * fields — display values belong in block-private stores or PHP SSR.
- * TO DO: decide where UI-derived state lives
+ * Mirror of {@see \Automattic\WooCommerce\StoreApi\Schemas\V1\ShopperListItemSchema::get_properties()}.
+ * Keep in sync with the schema. UI-derived fields do not belong here; display
+ * values are kept in block-private stores or rendered server-side.
  */
 export type ShopperListItemImage = {
 	id: number;
@@ -70,14 +68,11 @@ export type AddItemPayload = {
 export type Store = {
 	state: {
 		restUrl: string;
-		// TODO: revisit nonce handling when we look at authentication for
-		// the shopper-lists routes. Today PHP seeds this via
-		// `wp_create_nonce( 'wc_store_api' )` and we refresh it from
-		// response headers (see restRequest below). Likely changes once
-		// the routes start enforcing nonces server-side: align with the
-		// cart store's bootstrap-from-response-header pattern, share the
-		// cart's `state.nonce` instead of duplicating, or move to a
-		// caching-friendlier transport.
+		// TODO: revisit nonce handling once the shopper-lists routes enforce
+		// authentication server-side. Currently seeded by PHP via
+		// `wp_create_nonce( 'wc_store_api' )` and refreshed from response
+		// headers in `restRequest`. May converge with the cart store's
+		// bootstrap-from-response-header pattern.
 		nonce: string;
 		lists: Record< string, ShopperListState >;
 	};
@@ -89,7 +84,7 @@ export type Store = {
 	};
 };
 
-// Stores are locked to prevent 3PD usage until the API is stable.
+// Locked to prevent third-party use until the API stabilizes.
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
@@ -111,15 +106,10 @@ const ensureListState = (
 };
 
 /**
- * Send a Store API request following the cart store's auth shape:
- * Nonce header, `wc_store_api` action on the server side, cookie auth via
- * `credentials: 'include'`, and `cache: 'no-store'` so user-specific data is
- * never cached.
- *
- * The starter nonce is seeded by PHP via `wp_interactivity_state` and
- * refreshed from the `Nonce` response header on every subsequent request,
- * so the server-side enforcement (landing in a follow-up PR) can be
- * flipped on without rewriting the client.
+ * Send a Store API request using the cart store's auth shape: Nonce header
+ * (`wc_store_api` action), cookie auth via `credentials: 'include'`, and
+ * `cache: 'no-store'` for user-specific data. The nonce is seeded by PHP and
+ * refreshed from the `Nonce` response header on each reply.
  */
 async function restRequest< T >(
 	state: Store[ 'state' ],
@@ -166,11 +156,10 @@ async function restRequest< T >(
 	return json as T | null;
 }
 
-// Do NOT supply `nonce` / `restUrl` defaults here. iAPI's deep-merge has the
-// JS-supplied state win over the existing (PHP-seeded) state for primitives,
-// so an empty-string default would clobber the values seeded server-side via
-// `wp_interactivity_state`. State for those fields comes purely from PHP. Same
-// reason the cart store doesn't ship state defaults — see cart.ts.
+// Do not supply `nonce` / `restUrl` defaults here. iAPI's deep-merge lets
+// JS-supplied state win over PHP-seeded state for primitives, so an empty
+// default would clobber the values seeded via `wp_interactivity_state`. Both
+// fields are sourced exclusively from PHP.
 const { state, actions } = store< Store >(
 	'woocommerce/shopper-lists',
 	{
@@ -200,10 +189,10 @@ const { state, actions } = store< Store >(
 
 					// TODO: track in-flight mutation count and skip applying
 					// load results when mutations are pending, so a slow
-					// loadList cannot clobber a fresh add/remove.
+					// loadList cannot overwrite a fresh add or remove.
 					list.items = items;
 				} catch ( error ) {
-					// No user trigger to attach a banner to; log for ops.
+					// No user-initiated trigger to attach a banner to; logged for diagnostics.
 					// eslint-disable-next-line no-console
 					console.error( error );
 				} finally {
@@ -237,10 +226,9 @@ const { state, actions } = store< Store >(
 						);
 					}
 
-					// Merge the returned item by key — replace if present,
-					// append otherwise. Re-saving the same product POSTs
-					// twice and the server merges quantity, so we mirror
-					// that behaviour locally.
+					// Merge the returned item by key: replace if present, append
+					// otherwise. The server merges quantity on duplicate saves;
+					// this mirrors that behaviour client-side.
 					const existingIndex = list.items.findIndex(
 						( i ) => i.key === item.key
 					);
@@ -264,9 +252,9 @@ const { state, actions } = store< Store >(
 					return;
 				}
 
-				// Pessimistic remove: leave the row in place until the
-				// server confirms, so failures don't flash. Buttons are
-				// disabled meanwhile via the block's `pendingKeys`.
+				// Pessimistic remove: keep the row in place until the server
+				// confirms, to avoid a momentary disappearance on failure.
+				// Buttons are disabled in the meantime via `pendingKeys`.
 				try {
 					yield restRequest(
 						state,
@@ -280,7 +268,7 @@ const { state, actions } = store< Store >(
 					return;
 				}
 
-				// Re-find — the list may have mutated during the await.
+				// Re-find: the list may have mutated during the await.
 				const removedIndex = list.items.findIndex(
 					( i ) => i.key === key
 				);
@@ -289,7 +277,7 @@ const { state, actions } = store< Store >(
 				}
 			},
 
-			// Mirrors `cart.ts::showNoticeError`.
+			// Mirrors `cart.ts::showNoticeError`; keep in sync if the shape changes.
 			*showNoticeError( error: Error ): AsyncAction< void > {
 				yield import( '@woocommerce/stores/store-notices' );
 				const { actions: noticeActions } = store< StoreNotices >(
@@ -312,15 +300,11 @@ const { state, actions } = store< Store >(
 	{ lock: universalLock }
 );
 
-// Listen for shopper-list item additions emitted from the wp.data side (e.g.
-// the cart store's saveForLater thunk). Mirrors the cart's iAPI → wp.data
-// sync direction, which also ships a payload (`from_iAPI` carries
-// `quantityChanges`). The event carries the saved item directly so we can
-// splice it in without an extra GET — keeps the merge ordering deterministic
-// and avoids the loadList-vs-mutation race the iAPI store's loadList still
-// has a TODO about.
-//
-// Keeps the discriminator + payload contract in sync with
+// Receive shopper-list item additions emitted from the wp.data side (e.g.
+// the cart store's `saveForLater` thunk). The event carries the saved item
+// directly so it can be spliced in without an extra GET, avoiding the
+// loadList-vs-mutation race described in the TODO above. The discriminator
+// and payload shape must stay aligned with
 // `assets/js/data/cart/thunks.ts::saveForLater`.
 window.addEventListener( 'wc-blocks_store_sync_required', ( event: Event ) => {
 	const detail = ( event as CustomEvent ).detail as

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/edit.tsx
@@ -24,8 +24,8 @@ const MIN_COLUMNS = 2;
 const MAX_COLUMNS = 6;
 
 // Lives in JS because `__()` is needed for the heading copy. `block.json`
-// strings aren't run through translation, so keeping the template here
-// is the only way to ship a localized default.
+// literals are not passed through the translation pipeline at runtime, so a
+// localized default template must be declared here.
 const TEMPLATE: [ string, Record< string, unknown > ][] = [
 	[
 		'core/heading',
@@ -85,11 +85,9 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 		className: 'wc-block-saved-for-later',
 	} );
 
-	// `allowedBlocks` is read from block.json automatically — passing it
-	// here would just duplicate the declaration. `templateLock: false`
-	// is the default so we omit that too. The className matches the
-	// `<div>` PHP wraps `$content` in on the frontend, so any CSS keyed
-	// off `__header` applies in both contexts.
+	// `allowedBlocks` is read from block.json; `templateLock: false` is the
+	// default. The className matches the `<div>` PHP wraps `$content` in on
+	// the frontend, so `__header`-keyed CSS applies in both contexts.
 	const innerBlocksProps = useInnerBlocksProps(
 		{ className: 'wc-block-saved-for-later__header' },
 		{ template: TEMPLATE }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/frontend.ts
@@ -28,10 +28,9 @@ type SavedForLaterConfig = {
 };
 
 type BlockContext = {
-	// Wrapper-scoped flag: starts as `items.length > 0` from SSR and the
-	// `trackShownItems` callback flips it to `true` the first time the
-	// list has any items at runtime. Lives in iAPI context so it resets
-	// on every full page load.
+	// Wrapper-scoped flag seeded from SSR (`items.length > 0`) and flipped
+	// to `true` by `trackShownItems` the first time the list has items.
+	// Stored in iAPI context so it resets on every full page load.
 	hasShownItems: boolean;
 	listItem?: RawShopperListItem;
 	htmlField?: 'price_html' | 'image_html';
@@ -62,9 +61,8 @@ type BlockStore = {
 };
 
 // Allow-list for sanitizing the schema's preformatted strings on innerHTML
-// swap. Covers what `wc_price` (sale/discount markup, currency symbol) and
-// `wp_get_attachment_image` / `wc_placeholder_img` emit (responsive image
-// + dimensions + lazy loading).
+// swap. Covers the markup emitted by `wc_price` and
+// `wp_get_attachment_image` / `wc_placeholder_img`.
 const ALLOWED_TAGS = [
 	'a',
 	'b',
@@ -173,12 +171,11 @@ store< BlockStore >(
 				return ! listItem.is_purchasable;
 			},
 
-			// `data-wp-text` writes its argument as text-content without
-			// running entity decoding, so a name returned by the schema as
-			// `Tom &amp; Jerry` would render literally that way. Bind
-			// templates and SSR text spans to this getter instead of the
-			// raw context field so what the browser shows matches what
-			// PHP wrote on first paint.
+			// `data-wp-text` writes its argument as text-content without entity
+			// decoding, so a name like `Tom &amp; Jerry` would render with the
+			// literal entity. Bind templates and SSR text spans to this getter
+			// (not the raw context field) so rendered text matches PHP's first
+			// paint.
 			get currentItemDisplayName(): string {
 				const { listItem } = getContext< BlockContext >();
 				return listItem ? decodeEntities( listItem.name ) : '';
@@ -246,13 +243,12 @@ store< BlockStore >(
 				}
 
 				// Map the schema's `variation` shape to the cart's
-				// SelectedAttributes shape. The schema returns the
-				// slug-form attribute under `raw_attribute` (e.g.
-				// `attribute_pa_color`) plus a display label under
-				// `attribute` (e.g. "Color"); the cart matches by the
-				// slug-form, so override `attribute` with `raw_attribute`.
-				// Same swap mini-cart's `changeQuantity` does. Empty for
-				// simple products.
+				// `SelectedAttributes` shape. The schema exposes the slug-form
+				// attribute under `raw_attribute` (e.g. `attribute_pa_color`)
+				// and a display label under `attribute`. The cart matches by
+				// the slug form, so `attribute` is overridden with
+				// `raw_attribute`. Same swap mini-cart's `changeQuantity`
+				// performs; empty for simple products.
 				const variation = listItem.variation.map(
 					( { raw_attribute: rawAttribute, value, attribute } ) => ( {
 						attribute: rawAttribute || attribute,
@@ -261,11 +257,11 @@ store< BlockStore >(
 				);
 				const isVariation = listItem.variation_id > 0;
 
-				// `cartActions.addCartItem` catches its own errors and
-				// surfaces them as store notices, so the yield resolves
-				// the same way on success and failure. Snapshot the
-				// matching line's quantity, run the add, then only remove
-				// from the saved list if it actually grew.
+				// `cartActions.addCartItem` catches its own errors and surfaces
+				// them as store notices, so the yield resolves identically on
+				// success and failure. Snapshot the matching line's quantity,
+				// run the add, then remove from the saved list only if the
+				// cart line actually grew.
 				const lookup = {
 					id: listItem.id,
 					...( isVariation && { variation } ),
@@ -300,15 +296,13 @@ store< BlockStore >(
 		},
 
 		callbacks: {
-			// Wrapper-level watcher: flips `hasShownItems` to `true` the
-			// first time the list has any items. Pairs with `state.isEmpty`
-			// to gate the empty message — a new shopper landing on a page
-			// with nothing saved keeps the flag at its SSR-seeded `false`
-			// and never sees the message; once they save an item (or
-			// landed with items) the flag is `true`, so emptying the list
-			// from that point surfaces the message. The flag never flips
-			// back to `false`, which is what gives the "had-items → now-empty"
-			// transition we want during the session.
+			// Wrapper-level watcher: flips `hasShownItems` to `true` the first
+			// time the list has items. Pairs with `state.isEmpty` to gate the
+			// empty message: a shopper landing on a page with nothing saved
+			// keeps the SSR-seeded `false` and sees no message; once items
+			// have been seen, an empty list surfaces the message. The flag
+			// never flips back to `false`, producing the had-items →
+			// now-empty transition within a session.
 			trackShownItems: () => {
 				const ctx = getContext< BlockContext >();
 				const list = getList( LIST_SLUG );
@@ -317,16 +311,13 @@ store< BlockStore >(
 				}
 			},
 
-			// Single shared innerHTML-swap callback for any slot whose
-			// content is one of the schema's preformatted HTML fields.
-			// Mirrors the atomic product-elements `updateValue` callback:
-			// the watched element carries `data-wp-context='{"htmlField":"price_html"}'`
-			// (or `"image_html"`), and this callback reads that field
-			// off the row's `listItem` and pastes its sanitized HTML into
-			// `element.ref`. PHP renders the same HTML server-side, so
-			// hydration is a no-op when the row's listItem hasn't changed,
-			// and a clean swap when it has (e.g. after Remove shifts the
-			// next item into this slot).
+			// Shared innerHTML-swap callback for slots whose content is one of
+			// the schema's preformatted HTML fields. The watched element
+			// carries `data-wp-context='{"htmlField":"price_html"}'` (or
+			// `"image_html"`); this reads the named field off the row's
+			// `listItem` and writes its sanitized HTML into `element.ref`.
+			// PHP renders the same HTML server-side, so hydration is a no-op
+			// until the row's `listItem` changes.
 			updateInnerHtml: () => {
 				const { ref } = getElement();
 				const { listItem, htmlField } = getContext< BlockContext >();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later/save.tsx
@@ -4,10 +4,9 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
- * The block is rendered server-side, but the inner blocks (default
- * `core/heading`) must be serialized to `post_content` so user edits
- * persist — returning `null` would drop them. `<InnerBlocks.Content />`
- * emits only the inner blocks' static markup.
+ * The block is rendered server-side, but its inner blocks must be serialized
+ * to `post_content` so user edits persist. `<InnerBlocks.Content />` emits
+ * only the inner blocks' static markup.
  */
 const Save = (): JSX.Element => <InnerBlocks.Content />;
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/edit.tsx
@@ -24,8 +24,8 @@ const MIN_COLUMNS = 2;
 const MAX_COLUMNS = 6;
 
 // Lives in JS because `__()` is needed for the heading copy. `block.json`
-// strings aren't run through translation, so keeping the template here
-// is the only way to ship a localized default.
+// literals aren't passed through the translation pipeline at runtime, so
+// a localized default template must be declared in JS.
 const TEMPLATE: [ string, Record< string, unknown > ][] = [
 	[ 'core/heading', { content: __( 'Wishlist', 'woocommerce' ), level: 2 } ],
 ];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/edit.tsx
@@ -76,11 +76,9 @@ const Edit = ( { attributes, setAttributes }: EditProps ): JSX.Element => {
 		className: 'wc-block-wishlist',
 	} );
 
-	// `allowedBlocks` is read from block.json automatically — passing it
-	// here would just duplicate the declaration. `templateLock: false`
-	// is the default so we omit that too. The className matches the
-	// `<div>` PHP wraps `$content` in on the frontend, so any CSS keyed
-	// off `__header` applies in both contexts.
+	// `allowedBlocks` is read from block.json; `templateLock: false` is the
+	// default. The className matches the `<div>` PHP wraps `$content` in on
+	// the frontend, so `__header`-keyed CSS applies in both contexts.
 	const innerBlocksProps = useInnerBlocksProps(
 		{ className: 'wc-block-wishlist__header' },
 		{ template: TEMPLATE }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/frontend.ts
@@ -139,10 +139,11 @@ store< BlockStore >(
 				return !! listItem && !! pendingKeys[ listItem.key ];
 			},
 
-			// No `hasShownItems` gate: the visitor reached this block
-			// deliberately (My Account endpoint or merchant-placed), so
-			// showing the empty message immediately when the list is
-			// empty is the right signal.
+			// Unlike Saved for Later, Wishlist has no `hasShownItems`
+			// first-paint gate. The block is reached deliberately (My
+			// Account endpoint or a merchant-placed instance), so the
+			// empty state should be visible immediately on first paint
+			// when the list is empty.
 			get isEmpty(): boolean {
 				const list = getList( LIST_SLUG );
 				if ( ! list ) {
@@ -165,11 +166,11 @@ store< BlockStore >(
 			},
 
 			// `data-wp-text` writes its argument as text-content without
-			// running entity decoding, so a name returned by the schema as
-			// `Tom &amp; Jerry` would render literally that way. Bind
-			// templates and SSR text spans to this getter instead of the
-			// raw context field so what the browser shows matches what
-			// PHP wrote on first paint.
+			// running entity decoding. A name returned by the schema as
+			// `Tom &amp; Jerry` would otherwise render with the literal
+			// entity. Bind templates and SSR text spans to this getter
+			// (not the raw context field) so the rendered text matches
+			// the PHP-rendered first-paint output.
 			get currentItemDisplayName(): string {
 				const { listItem } = getContext< BlockContext >();
 				return listItem ? decodeEntities( listItem.name ) : '';
@@ -244,7 +245,7 @@ store< BlockStore >(
 				// matching line's quantity, run the add, then only remove
 				// from the wishlist if the cart line actually grew — that
 				// guards against partial-stock and silent-failure paths
-				// where we shouldn't drop the wishlist entry.
+				// where the wishlist entry should not be removed.
 				const lookup = {
 					id: listItem.id,
 					...( isVariation && { variation } ),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/frontend.ts
@@ -54,9 +54,8 @@ type BlockStore = {
 };
 
 // Allow-list for sanitizing the schema's preformatted strings on innerHTML
-// swap. Covers what `wc_price` (sale/discount markup, currency symbol) and
-// `wp_get_attachment_image` / `wc_placeholder_img` emit (responsive image
-// + dimensions + lazy loading).
+// swap. Covers the markup emitted by `wc_price` and
+// `wp_get_attachment_image` / `wc_placeholder_img`.
 const ALLOWED_TAGS = [
 	'a',
 	'b',
@@ -224,12 +223,11 @@ store< BlockStore >(
 				}
 
 				// Map the schema's `variation` shape to the cart's
-				// SelectedAttributes shape. The schema returns the
-				// slug-form attribute under `raw_attribute` (e.g.
-				// `attribute_pa_color`) plus a display label under
-				// `attribute` (e.g. "Color"); the cart matches by the
-				// slug-form, so override `attribute` with `raw_attribute`.
-				// Empty for simple products.
+				// `SelectedAttributes` shape. The schema exposes the slug-form
+				// attribute under `raw_attribute` and a display label under
+				// `attribute`. The cart matches by the slug form, so
+				// `attribute` is overridden with `raw_attribute`. Empty for
+				// simple products.
 				const variation = listItem.variation.map(
 					( { raw_attribute: rawAttribute, value, attribute } ) => ( {
 						attribute: rawAttribute || attribute,
@@ -239,13 +237,12 @@ store< BlockStore >(
 				const isVariation = listItem.variation_id > 0;
 
 				// Wishlist always adds quantity 1 (no quantity column).
-				// `cartActions.addCartItem` catches its own errors and
-				// surfaces them as store notices, so the yield resolves
-				// the same way on success and failure. Snapshot the
-				// matching line's quantity, run the add, then only remove
-				// from the wishlist if the cart line actually grew — that
-				// guards against partial-stock and silent-failure paths
-				// where the wishlist entry should not be removed.
+				// `cartActions.addCartItem` catches its own errors and surfaces
+				// them as store notices, so the yield resolves identically on
+				// success and failure. Snapshot the matching line's quantity,
+				// run the add, then remove from the wishlist only if the cart
+				// line actually grew. Guards against partial-stock and
+				// silent-failure paths where the wishlist entry must remain.
 				const lookup = {
 					id: listItem.id,
 					...( isVariation && { variation } ),
@@ -280,16 +277,13 @@ store< BlockStore >(
 		},
 
 		callbacks: {
-			// Single shared innerHTML-swap callback for any slot whose
-			// content is one of the schema's preformatted HTML fields.
-			// Mirrors the atomic product-elements `updateValue` callback:
-			// the watched element carries `data-wp-context='{"htmlField":"price_html"}'`
-			// (or `"image_html"`), and this callback reads that field
-			// off the row's `listItem` and pastes its sanitized HTML into
-			// `element.ref`. PHP renders the same HTML server-side, so
-			// hydration is a no-op when the row's listItem hasn't changed,
-			// and a clean swap when it has (e.g. after Remove shifts the
-			// next item into this slot).
+			// Shared innerHTML-swap callback for slots whose content is one of
+			// the schema's preformatted HTML fields. The watched element
+			// carries `data-wp-context='{"htmlField":"price_html"}'` (or
+			// `"image_html"`); this reads the named field off the row's
+			// `listItem` and writes its sanitized HTML into `element.ref`.
+			// PHP renders the same HTML server-side, so hydration is a no-op
+			// until the row's `listItem` changes.
 			updateInnerHtml: () => {
 				const { ref } = getElement();
 				const { listItem, htmlField } = getContext< BlockContext >();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/save.tsx
@@ -6,7 +6,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
 /**
  * The block is rendered server-side, but the inner blocks (default
  * `core/heading`) must be serialized to `post_content` so user edits
- * persist — returning `null` would drop them. `<InnerBlocks.Content />`
+ * persist — returning `null` would discard them. `<InnerBlocks.Content />`
  * emits only the inner blocks' static markup.
  */
 const Save = (): JSX.Element => <InnerBlocks.Content />;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist/save.tsx
@@ -6,7 +6,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
 /**
  * The block is rendered server-side, but the inner blocks (default
  * `core/heading`) must be serialized to `post_content` so user edits
- * persist — returning `null` would discard them. `<InnerBlocks.Content />`
+ * persist; returning `null` would discard them. `<InnerBlocks.Content />`
  * emits only the inner blocks' static markup.
  */
 const Save = (): JSX.Element => <InnerBlocks.Content />;

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -486,19 +486,13 @@ export const removeItemFromCart =
 	};
 
 /**
- * Saves a cart line item to the saved-for-later shopper list.
+ * Save a cart line item to the saved-for-later shopper list.
  *
- * On success, emits a `wc-blocks_store_sync_required` event with the saved
- * item in `detail.item` so a `woocommerce/shopper-lists` iAPI store on the
- * same page (rendered by a Saved for Later block) can splice the row
- * into its local state — no extra GET, no race window between a slow
- * refetch and concurrent mutations. Same envelope the cart's iAPI → wp.data
- * sync uses to ship payloads (`detail.type === 'from_iAPI'` carries
- * `quantityChanges`); this is the wp.data → iAPI direction of the same
- * pattern.
- *
- * Removing the item from the cart is the caller's responsibility — keep the
- * two awaits separate so save and remove errors can be reported distinctly.
+ * On success, dispatches a `wc-blocks_store_sync_required` event so a
+ * `woocommerce/shopper-lists` iAPI store on the same page can splice the
+ * returned item into local state without an extra GET. Removing the item
+ * from the cart is the caller's responsibility, so save and remove errors
+ * can be reported independently.
  *
  * @param {string} cartItemKey Cart item to save.
  */

--- a/plugins/woocommerce/client/blocks/assets/js/data/shared-controls.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/shared-controls.ts
@@ -130,8 +130,8 @@ const preventBatching = [
 	'/wc/store/v1/checkout',
 	'/wc/store/v1/checkout?__experimental_calc_totals=true',
 	'/wc/store/v1/cart/update-item',
-	// Shopper-lists routes don't declare allow_batch yet. Drop these once
-	// the routes opt into batching server-side.
+	// Shopper-lists routes do not declare `allow_batch` server-side yet.
+	// Remove once those routes opt into batching.
 	'/wc/store/v1/shopper-lists/saved-for-later/items',
 ];
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/SavedForLater.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/SavedForLater.php
@@ -11,23 +11,17 @@ use Automattic\WooCommerce\Proxies\LegacyProxy;
 /**
  * Saved for Later block.
  *
- * Renders the shopper's "Saved for Later" list, wired to the `shopper-lists`
- * Store API endpoints via the shared `woocommerce/shopper-lists` iAPI store.
- * PHP prefetches the list so the first paint is already populated; JS then
- * takes over for adds, removes, and Move-to-cart.
- *
- * The row markup (image, name, price, remove badge, variation overlay) is
- * shared with other shopper-list blocks via `ShopperListRenderer`. This
- * class composes those fragments and adds the bits that are unique to
- * Saved for Later: auto-injection via the Block Hooks API, the
- * `hasShownItems` empty-state gating, the per-row quantity span, and the
- * Move-to-cart action button.
+ * Renders the shopper's Saved for Later list. Items are loaded from the
+ * `shopper-lists` Store API and shared with the cart via the
+ * `woocommerce/shopper-lists` iAPI store. Row markup is shared with other
+ * shopper-list blocks through {@see ShopperListRenderer}; this class adds
+ * the Saved for Later specifics (Block Hooks auto-injection, the
+ * `hasShownItems` empty-state gate, the quantity span, and the
+ * Move-to-cart action).
  */
 final class SavedForLater extends AbstractBlock {
 	/**
-	 * The list slug this block renders. Constant — when additional list
-	 * types ship as their own blocks (e.g. Wishlist), each one will
-	 * hardcode its own slug.
+	 * Slug of the shopper list this block renders.
 	 */
 	private const LIST_SLUG = 'saved-for-later';
 
@@ -44,7 +38,7 @@ final class SavedForLater extends AbstractBlock {
 	protected function initialize(): void {
 		parent::initialize();
 
-		// We do not use `BlockHooksTrait` currently as it has issues with PHPStan.
+		// `BlockHooksTrait` is not used here because of PHPStan issues with the trait's annotations.
 		add_filter( 'hooked_block_types', array( $this, 'register_hooked_block' ), 9, 4 );
 		add_filter( 'hooked_block_woocommerce/saved-for-later', array( $this, 'set_hooked_block_attributes' ), 10, 4 );
 	}
@@ -69,8 +63,7 @@ final class SavedForLater extends AbstractBlock {
 			return $hooked_block_types;
 		}
 
-		// Don't double-inject if the block is already in the cart page
-		// content.
+		// Skip injection if the block is already present in the cart page content.
 		if ( has_block( $this->get_full_block_name(), $context ) ) {
 			return $hooked_block_types;
 		}
@@ -149,22 +142,21 @@ final class SavedForLater extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		// Guests have no personal list — bail before enqueuing assets or seeding state.
+		// Guests have no personal list; bail before enqueuing assets or seeding state.
 		if ( ! is_user_logged_in() ) {
 			return '';
 		}
 
-		// Set from render() (not Cart::enqueue_data via has_block()) so it works when this
-		// block is auto-injected via the Block Hooks API and isn't in stored post_content.
+		// Set from render() rather than Cart::enqueue_data so the flag is also set when
+		// the block is auto-injected via Block Hooks and absent from stored post_content.
 		if ( wc_get_container()->get( LegacyProxy::class )->call_function( 'is_cart' ) ) {
 			$this->asset_data_registry->add( 'cartPageHasSavedForLater', true );
 		}
 
-		// Clamp to the 2-6 range the SCSS `@for $i from 2 through 6` loop and
-		// the editor `RangeControl` both support. `absint()` first defends
-		// against a code-editor override (the attribute can be set to any
-		// JSON value there); the `min`/`max` then keep the value within the
-		// range where a `&.columns-#{$i}` rule actually exists.
+		// Clamp to the 2-6 range supported by the SCSS `@for $i from 2 through 6` loop
+		// and the editor `RangeControl`. `absint()` coerces non-integer attribute values
+		// written through the code editor; `min`/`max` then constrain the result to the
+		// range covered by `&.columns-#{$i}` rules in the stylesheet.
 		$column_count = min( 6, max( 2, absint( $attributes['columnCount'] ?? 5 ) ) );
 
 		wp_enqueue_script_module( $this->get_full_block_name() );
@@ -172,21 +164,15 @@ final class SavedForLater extends AbstractBlock {
 		$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
 		BlocksSharedState::load_store_config( $consent );
 		BlocksSharedState::load_placeholder_image( $consent );
-		// `Move to cart` calls into the shared cart store, which expects
-		// `state.cart.items` and friends. Without this load the cart store
-		// would have no hydrated cart and the action would throw on the
-		// first click.
+		// Required so the Move-to-cart action has a hydrated cart store to dispatch into.
 		BlocksSharedState::load_cart_state( $consent );
 
 		$items = $this->prefetch_items();
 
-		// Seed the shared shopper-lists store with the rest URL, the
-		// pre-fetched items, and a starter nonce. The starter nonce is
-		// what the cart store also seeds via `state.nonce` — the JS layer
-		// keeps it fresh by reading the `Nonce` response header on every
-		// subsequent request, so this is just the bootstrap value (and
-		// avoids deadlocking mutations that await `isNonceReady` before
-		// any GET has fired).
+		// Seed the shared shopper-lists store with the REST URL, prefetched items, and a
+		// bootstrap nonce. The JS layer refreshes the nonce from the `Nonce` response
+		// header on every subsequent request; this seed only avoids deadlocking mutations
+		// that await `isNonceReady` before any GET has fired.
 		wp_interactivity_state(
 			'woocommerce/shopper-lists',
 			array(
@@ -201,10 +187,9 @@ final class SavedForLater extends AbstractBlock {
 			)
 		);
 
-		// Templates flow through `wp_interactivity_config` so the JS-side
-		// getters can interpolate them (`%d`, `%s`). Visible strings (empty
-		// state, error, action label) are rendered server-side and toggled
-		// with directives, so they don't need to ride here too.
+		// Sprintf templates passed through `wp_interactivity_config` for JS-side
+		// interpolation. Visible strings (empty state, error, action label) are rendered
+		// server-side and toggled with directives, so they are not seeded here.
 		wp_interactivity_config(
 			'woocommerce/saved-for-later',
 			array(
@@ -213,26 +198,21 @@ final class SavedForLater extends AbstractBlock {
 			)
 		);
 
-		// `hasShownItems` seeds the per-block context so the empty
-		// message remains hidden for shoppers who load a cart page with
-		// no saved items. The JS-side watcher flips it to `true` the
-		// first time the list has any items (whether that's the SSR
-		// seed or a runtime add via "Save for later"), and
-		// `state.isEmpty` only flips on when the flag is set *and* the
-		// list is currently empty. The flag is stored in the per-block
-		// context, so it resets on each full page load — no extra Store
-		// API field or persisted flag is required.
-		// `data-wp-context---notices` seeds the store-notices namespace
-		// alongside the block's own context on the same wrapper.
+		// `hasShownItems` seeds the per-block context that gates the empty
+		// message. The JS-side watcher flips it to `true` the first time the
+		// list has items (SSR seed or a runtime "Save for later" add), and
+		// `state.isEmpty` only activates when the flag is set *and* the list is
+		// currently empty. Stored in per-block context so it resets on each full
+		// page load. `data-wp-context---notices` seeds the store-notices
+		// namespace on the same wrapper.
 		$wrapper_attributes = array(
 			'class'                     => 'wc-block-saved-for-later',
 			'data-wp-interactive'       => 'woocommerce/saved-for-later',
 			'data-wp-context'           => (string) wp_json_encode(
 				array(
 					'hasShownItems' => ! empty( $items ),
-					// `stdClass` so it serialises as `{}`, not `[]` —
-					// iAPI's reactive proxy only fires updates on object
-					// writes, not array expandos.
+					// `stdClass` so JSON serializes as `{}` rather than `[]`; iAPI's
+					// reactive proxy only fires updates on object writes.
 					'pendingKeys'   => new \stdClass(),
 				)
 			),
@@ -249,9 +229,8 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Prefetch the saved-for-later items via `rest_do_request()`. Logged-out
-	 * users short-circuit to an empty list — the route requires authentication
-	 * and we don't want to fire an API call that's only going to 401.
+	 * Prefetch the saved-for-later items via `rest_do_request()`. Returns an empty
+	 * list for logged-out users, since the route requires authentication.
 	 *
 	 * @return array<int, array<string, mixed>> Items in the schema response shape.
 	 */
@@ -266,12 +245,9 @@ final class SavedForLater extends AbstractBlock {
 		if ( $response->is_error() ) {
 			$error   = $response->as_error();
 			$message = $error instanceof \WP_Error ? $error->get_error_message() : 'Unknown error';
-			// Logged at debug level: prefetch failures are typically
-			// transient (transport errors, authentication refresh
-			// contention) and the user-visible fallback is the empty-
-			// state message, so they don't warrant a higher log level.
-			// Increase the WC log level to surface them when
-			// investigating a regression.
+			// Debug level: prefetch failures are typically transient and the
+			// user-visible fallback is the empty-state message. Raise the WC log
+			// level to surface them when investigating a regression.
 			wc_get_logger()->debug(
 				sprintf( 'Saved for Later prefetch failed: %s', $message ),
 				array(
@@ -287,19 +263,17 @@ final class SavedForLater extends AbstractBlock {
 			return array();
 		}
 
-		// The schema casts `prices` and image entries to stdClass so the
-		// JSON response renders objects, not arrays. Round-trip through
-		// JSON encode/decode to normalise everything to nested arrays so
-		// the SSR markup helpers below can treat fields uniformly.
+		// The schema casts `prices` and image entries to stdClass so JSON renders
+		// them as objects. Round-trip through JSON to normalise everything to
+		// nested arrays for the SSR markup helpers.
 		$decoded = json_decode( (string) wp_json_encode( $data ), true );
 		return is_array( $decoded ) ? $decoded : array();
 	}
 
 	/**
-	 * The `<template data-wp-each>` describing how each item is rendered on
-	 * the client. Pre-rendered children sit alongside as `data-wp-each-child`
-	 * elements so first paint is populated. Composes the shared row markup
-	 * with Saved for Later's quantity span and Move-to-cart action button.
+	 * Render the `<template data-wp-each>` describing how each item is rendered
+	 * on the client. Pre-rendered `data-wp-each-child` elements sit alongside
+	 * to populate first paint.
 	 *
 	 * @return string
 	 */
@@ -311,7 +285,7 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Render the SSR markup for each item. JS will reconcile these via
+	 * Render the SSR markup for each item. Reconciled by iAPI via
 	 * `data-wp-each-child` after hydration.
 	 *
 	 * @param array<int, array<string, mixed>> $items Schema-shape items.
@@ -326,8 +300,8 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Render a single SSR item. Composes the shared image / name / price
-	 * markup with the SFL-specific quantity span and Move-to-cart button.
+	 * Render a single SSR item, combining the shared row markup with the
+	 * quantity span and Move-to-cart button.
 	 *
 	 * @param array<string, mixed> $item Schema-shape item.
 	 * @return string
@@ -340,8 +314,7 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Template-mode markup for the quantity span. SFL-specific — Wishlist
-	 * has no quantity column.
+	 * Template-mode markup for the quantity span.
 	 *
 	 * @return string
 	 */
@@ -353,7 +326,7 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Template-mode markup for the Move-to-cart action button. SFL-specific.
+	 * Template-mode markup for the Move-to-cart action button.
 	 *
 	 * @return string
 	 */
@@ -375,7 +348,7 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * SSR-mode markup for the quantity span. SFL-specific.
+	 * SSR-mode markup for the quantity span.
 	 *
 	 * @param array<string, mixed> $item Schema-shape item.
 	 * @return string
@@ -391,10 +364,9 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * SSR-mode markup for the Move-to-cart action button. SFL-specific.
-	 * Always emits the wrapper so iAPI can toggle `hidden` after hydration
-	 * without swapping the row out. Starts hidden when the row isn't
-	 * purchasable.
+	 * SSR-mode markup for the Move-to-cart action button. The wrapper is always
+	 * emitted so iAPI can toggle `hidden` after hydration; starts hidden when
+	 * the row is not purchasable.
 	 *
 	 * @param array<string, mixed> $item Schema-shape item.
 	 * @return string
@@ -426,12 +398,10 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Wrap the inner-block content (heading + any future siblings) in an
-	 * element whose visibility mirrors the empty-state gating: hidden when
-	 * the shopper has never seen items in this session, revealed once
-	 * `context.hasShownItems` flips to `true`. Returns an empty string when
-	 * there's no content to wrap (e.g. merchant deleted the heading and
-	 * saved), so we don't emit an empty `<div>`.
+	 * Wrap the inner-block content in an element whose visibility mirrors the
+	 * empty-state gate. Hidden until `context.hasShownItems` flips to `true`.
+	 * Returns an empty string when there is no content to wrap, to avoid
+	 * emitting an empty `<div>`.
 	 *
 	 * @param string $content  Rendered inner-block content (typically the heading HTML).
 	 * @param bool   $is_empty Whether the saved-for-later list is empty on initial paint.
@@ -450,9 +420,9 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Render the empty-state markup. Always present in the DOM so JS can
-	 * toggle it on once the last item is removed. Initially hidden: SSR
-	 * never shows the message, since `state.isEmpty` requires the JS-side
+	 * Render the empty-state markup. Always present in the DOM so iAPI can
+	 * reveal it once the last item is removed. Initially hidden: SSR never
+	 * shows the message, since `state.isEmpty` requires the JS-side
 	 * `hasShownItems` context flag to flip first.
 	 *
 	 * @return string
@@ -466,10 +436,9 @@ final class SavedForLater extends AbstractBlock {
 	}
 
 	/**
-	 * Sprintf template for the per-row quantity label. Used both by PHP SSR
-	 * (`render_ssr_quantity()`) and by the JS-side getter (via
-	 * `wp_interactivity_config`) so both paths produce the same string after
-	 * `%d` interpolation.
+	 * Sprintf template for the per-row quantity label. Shared between PHP SSR
+	 * and the JS-side getter (seeded via `wp_interactivity_config`) so both
+	 * paths produce identical output.
 	 */
 	private function get_quantity_label_template(): string {
 		/* translators: %d: quantity of saved items. */
@@ -508,14 +477,12 @@ final class SavedForLater extends AbstractBlock {
 	/**
 	 * Get the frontend style handle for this block type.
 	 *
-	 * Returning null lets WP use the `style` array from block.json, which
-	 * lists this block's own stylesheet plus the atomic
-	 * product-image / product-price / product-button stylesheets we
-	 * borrow class names from. We can't render those atomic blocks as
-	 * inner blocks (they rely on WP_Query / $post loop context, which
-	 * this block doesn't have — it hydrates from a Store API call), so
-	 * declaring them as style dependencies is the only way to get WP
-	 * to enqueue their CSS whenever Saved for Later renders.
+	 * Returns null so WP uses the `style` array from block.json, which
+	 * declares this block's stylesheet alongside the atomic product-image,
+	 * product-price, and product-button stylesheets whose class names this
+	 * block reuses. Those atomic blocks cannot be rendered as inner blocks
+	 * here (they depend on WP_Query / $post context), so declaring them as
+	 * style dependencies is the only way to enqueue their CSS.
 	 *
 	 * @return null
 	 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/SavedForLater.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/SavedForLater.php
@@ -96,23 +96,26 @@ final class SavedForLater extends AbstractBlock {
 			return $parsed_hooked_block;
 		}
 
-		// Seed a `core/heading` inner block so freshly-injected instances
-		// ship with the same heading the editor template seeds. We append
-		// unconditionally — extensions are free to hook
-		// `hooked_block_woocommerce/saved-for-later` to add their own
-		// inner blocks, and gating on `empty( innerBlocks )` would silently
-		// suppress our heading whenever any other extension ran first.
+		// Seed a `core/heading` inner block so auto-injected instances
+		// carry the same heading the editor template provides. The
+		// append is unconditional: extensions may register additional
+		// hooked inner blocks on
+		// `hooked_block_woocommerce/saved-for-later`, and gating on
+		// `empty( $parsed_hooked_block['innerBlocks'] )` would suppress
+		// this heading whenever any other extension ran first.
 		//
-		// `core/heading` is a static block, so the serialised markup must
-		// match what the editor would have saved (`<h2 class="wp-block-heading">…</h2>`)
-		// or it'll fail block validation when the cart page is opened in the
-		// editor. `attrs.content` mirrors what the editor's template seeds
-		// (`{ content, level }`) so the parsed shape round-trips identically;
-		// the value is the raw string because attrs are JSON-encoded into the
-		// block comment and `esc_html()` would corrupt translations whose text
-		// contains `&`, `<`, etc. The matching `null` push onto `innerContent`
-		// is what makes `WP_Block::render()` walk into the heading when
-		// building `$content`.
+		// `core/heading` is a static block, so the serialised markup
+		// must match the editor-saved form
+		// (`<h2 class="wp-block-heading">…</h2>`) or block validation
+		// will fail when the cart page is opened in the editor.
+		// `attrs.content` mirrors the editor template's seed
+		// (`{ content, level }`) so the parsed shape round-trips
+		// identically. The value is the raw string because attrs are
+		// JSON-encoded into the block comment delimiter; `esc_html()`
+		// would corrupt translations containing `&`, `<`, etc. The
+		// matching `null` push onto `innerContent` is required for
+		// `WP_Block::render()` to descend into the heading when
+		// assembling `$content`.
 		$list_heading = __( 'Saved for later', 'woocommerce' );
 		$heading_html = '<h2 class="wp-block-heading">' . esc_html( $list_heading ) . '</h2>';
 
@@ -210,14 +213,15 @@ final class SavedForLater extends AbstractBlock {
 			)
 		);
 
-		// `hasShownItems` seeds the per-block context so the empty message
-		// stays hidden for new shoppers who land on a page with nothing
-		// saved. The JS-side watcher flips it to `true` the first time the
-		// list has any items (whether that's the SSR seed or a runtime add
-		// via "Save for later"), and `state.isEmpty` only flips on when the
-		// flag is set *and* the list is currently empty. The flag lives in
-		// the per-block context, so it naturally resets on every full page
-		// load — no extra Store API field or persisted flag needed.
+		// `hasShownItems` seeds the per-block context so the empty
+		// message remains hidden for shoppers who load a cart page with
+		// no saved items. The JS-side watcher flips it to `true` the
+		// first time the list has any items (whether that's the SSR
+		// seed or a runtime add via "Save for later"), and
+		// `state.isEmpty` only flips on when the flag is set *and* the
+		// list is currently empty. The flag is stored in the per-block
+		// context, so it resets on each full page load — no extra Store
+		// API field or persisted flag is required.
 		// `data-wp-context---notices` seeds the store-notices namespace
 		// alongside the block's own context on the same wrapper.
 		$wrapper_attributes = array(
@@ -262,11 +266,12 @@ final class SavedForLater extends AbstractBlock {
 		if ( $response->is_error() ) {
 			$error   = $response->as_error();
 			$message = $error instanceof \WP_Error ? $error->get_error_message() : 'Unknown error';
-			// Logged at debug level on purpose: prefetch failures are
-			// often transient (network blips, auth refresh races) and
-			// the user-visible behaviour is the empty state — nothing
-			// for ops to act on. Anyone investigating a regression can
-			// flip the WC logger to debug to surface them.
+			// Logged at debug level: prefetch failures are typically
+			// transient (transport errors, authentication refresh
+			// contention) and the user-visible fallback is the empty-
+			// state message, so they don't warrant a higher log level.
+			// Increase the WC log level to surface them when
+			// investigating a regression.
 			wc_get_logger()->debug(
 				sprintf( 'Saved for Later prefetch failed: %s', $message ),
 				array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php
@@ -10,22 +10,16 @@ use Automattic\WooCommerce\Internal\ShopperLists\ShopperListRenderer;
 /**
  * Wishlist block.
  *
- * Renders the shopper's wishlist, wired to the `shopper-lists` Store API
- * endpoints via the shared `woocommerce/shopper-lists` iAPI store. PHP
- * prefetches the list so the first paint is already populated; JS then
- * takes over for adds, removes, and the per-row "Add to cart" action.
- *
- * Unlike Saved for Later, this block is merchant-placed — no Block Hooks
- * API integration. It's rendered by the `/my-account/wishlist/` endpoint
- * (gated by the `product_wishlist` feature flag) and can also be placed
- * on any other page or template. "Add to cart" mirrors Saved for Later's
- * Move-to-cart flow: add the product to the cart, then remove it from the
+ * Renders the shopper's wishlist using the `shopper-lists` Store API and the
+ * shared `woocommerce/shopper-lists` iAPI store. Merchant-placed (no Block
+ * Hooks integration); also rendered by the `/my-account/wishlist/` endpoint
+ * when the `product_wishlist` feature flag is enabled. The Add to cart
+ * action adds the product to the cart and then removes the row from the
  * wishlist on confirmed success.
  */
 final class Wishlist extends AbstractBlock {
 	/**
-	 * The list slug this block renders. Constant — when additional list
-	 * types ship as their own blocks, each one hardcodes its own slug.
+	 * Slug of the shopper list this block renders.
 	 */
 	private const LIST_SLUG = 'wishlist';
 
@@ -45,20 +39,17 @@ final class Wishlist extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		// Guests have no personal list — bail before enqueuing assets or
-		// seeding state. The My Account endpoint isn't reachable for
-		// guests, but the block can also be placed by a merchant on any
-		// page, so this guard prevents the block from rendering an empty
-		// wrapper for logged-out visitors on merchant-placed instances.
+		// Guests have no personal list; bail before enqueuing assets or seeding state.
+		// The My Account endpoint is not reachable for guests, but a merchant may also
+		// place this block on any page where the same guard is needed.
 		if ( ! is_user_logged_in() ) {
 			return '';
 		}
 
-		// Clamp to the 2-6 range the SCSS `@for $i from 2 through 6` loop
-		// and the editor `RangeControl` both support. `absint()` coerces
-		// non-integer attribute values written through the code editor;
-		// `min`/`max` then constrain the result to the range covered by
-		// `&.columns-#{$i}` rules in the stylesheet.
+		// Clamp to the 2-6 range supported by the SCSS `@for $i from 2 through 6` loop
+		// and the editor `RangeControl`. `absint()` coerces non-integer attribute values
+		// written through the code editor; `min`/`max` then constrain the result to the
+		// range covered by `&.columns-#{$i}` rules in the stylesheet.
 		$column_count = min( 6, max( 2, absint( $attributes['columnCount'] ?? 5 ) ) );
 
 		wp_enqueue_script_module( $this->get_full_block_name() );
@@ -66,21 +57,15 @@ final class Wishlist extends AbstractBlock {
 		$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
 		BlocksSharedState::load_store_config( $consent );
 		BlocksSharedState::load_placeholder_image( $consent );
-		// `Add to cart` calls into the shared cart store, which expects
-		// `state.cart.items` and friends. Without this load the cart store
-		// would have no hydrated cart and the action would throw on the
-		// first click.
+		// Required so the Add to cart action has a hydrated cart store to dispatch into.
 		BlocksSharedState::load_cart_state( $consent );
 
 		$items = $this->prefetch_items();
 
-		// Seed the shared shopper-lists store with the rest URL, the
-		// pre-fetched items, and a starter nonce. The starter nonce is
-		// what the cart store also seeds via `state.nonce` — the JS layer
-		// keeps it fresh by reading the `Nonce` response header on every
-		// subsequent request, so this is just the bootstrap value (and
-		// avoids deadlocking mutations that await `isNonceReady` before
-		// any GET has fired).
+		// Seed the shared shopper-lists store with the REST URL, prefetched items, and a
+		// bootstrap nonce. The JS layer refreshes the nonce from the `Nonce` response
+		// header on every subsequent request; this seed only avoids deadlocking mutations
+		// that await `isNonceReady` before any GET has fired.
 		wp_interactivity_state(
 			'woocommerce/shopper-lists',
 			array(
@@ -95,9 +80,9 @@ final class Wishlist extends AbstractBlock {
 			)
 		);
 
-		// Only the remove-button aria-label template needs JS-side
-		// interpolation; visible strings (empty state, action label) are
-		// rendered server-side and toggled with directives.
+		// Only the remove-button aria-label template needs JS-side interpolation;
+		// visible strings (empty state, action label) are rendered server-side and
+		// toggled with directives.
 		wp_interactivity_config(
 			'woocommerce/wishlist',
 			array(
@@ -105,22 +90,18 @@ final class Wishlist extends AbstractBlock {
 			)
 		);
 
-		// No `hasShownItems` flag: unlike Saved for Later (which auto-
-		// renders on every cart visit and must avoid flashing an empty
-		// message before a runtime save lands), Wishlist is reached
-		// deliberately — by the My Account endpoint or because a merchant
-		// placed it. Showing the empty message immediately is the right
-		// signal: the visitor came to look at their wishlist, and it's
-		// empty. `data-wp-context---notices` seeds the store-notices
-		// namespace alongside the block's own context on the same wrapper.
+		// No `hasShownItems` flag here, unlike Saved for Later. Wishlist is reached
+		// deliberately (My Account endpoint or merchant placement), so the empty
+		// message should appear immediately when the list is empty.
+		// `data-wp-context---notices` seeds the store-notices namespace on the
+		// same wrapper.
 		$wrapper_attributes = array(
 			'class'                     => 'wc-block-wishlist',
 			'data-wp-interactive'       => 'woocommerce/wishlist',
 			'data-wp-context'           => (string) wp_json_encode(
 				array(
-					// `stdClass` so it serialises as `{}`, not `[]` —
-					// iAPI's reactive proxy only fires updates on object
-					// writes, not array expandos.
+					// `stdClass` so JSON serializes as `{}` rather than `[]`; iAPI's
+					// reactive proxy only fires updates on object writes.
 					'pendingKeys' => new \stdClass(),
 				)
 			),
@@ -135,10 +116,8 @@ final class Wishlist extends AbstractBlock {
 	}
 
 	/**
-	 * Prefetch the wishlist items via `rest_do_request()`. Logged-out
-	 * users short-circuit to an empty list — the route requires
-	 * authentication and we don't want to fire an API call that's only
-	 * going to 401.
+	 * Prefetch the wishlist items via `rest_do_request()`. Returns an empty
+	 * list for logged-out users, since the route requires authentication.
 	 *
 	 * @return array<int, array<string, mixed>> Items in the schema response shape.
 	 */
@@ -153,12 +132,9 @@ final class Wishlist extends AbstractBlock {
 		if ( $response->is_error() ) {
 			$error   = $response->as_error();
 			$message = $error instanceof \WP_Error ? $error->get_error_message() : 'Unknown error';
-			// Logged at debug level: prefetch failures are typically
-			// transient (transport errors, authentication refresh
-			// contention) and the user-visible fallback is the empty-
-			// state message, so they don't warrant a higher log level.
-			// Increase the WC log level to surface them when investigating
-			// a regression.
+			// Debug level: prefetch failures are typically transient and the
+			// user-visible fallback is the empty-state message. Raise the WC log
+			// level to surface them when investigating a regression.
 			wc_get_logger()->debug(
 				sprintf( 'Wishlist prefetch failed: %s', $message ),
 				array(
@@ -174,20 +150,17 @@ final class Wishlist extends AbstractBlock {
 			return array();
 		}
 
-		// The schema casts `prices` and image entries to stdClass so the
-		// JSON response renders objects, not arrays. Round-trip through
-		// JSON encode/decode to normalise everything to nested arrays so
-		// the SSR markup helpers can treat fields uniformly.
+		// The schema casts `prices` and image entries to stdClass so JSON renders
+		// them as objects. Round-trip through JSON to normalise everything to
+		// nested arrays for the SSR markup helpers.
 		$decoded = json_decode( (string) wp_json_encode( $data ), true );
 		return is_array( $decoded ) ? $decoded : array();
 	}
 
 	/**
-	 * The `<template data-wp-each>` describing how each item is rendered
-	 * on the client. Pre-rendered children sit alongside as
-	 * `data-wp-each-child` elements so first paint is populated. Composes
-	 * the shared row markup with the Wishlist-specific "Add to cart"
-	 * action button.
+	 * Render the `<template data-wp-each>` describing how each item is rendered
+	 * on the client. Pre-rendered `data-wp-each-child` elements sit alongside
+	 * to populate first paint.
 	 *
 	 * @return string
 	 */
@@ -198,7 +171,7 @@ final class Wishlist extends AbstractBlock {
 	}
 
 	/**
-	 * Render the SSR markup for each item. JS will reconcile these via
+	 * Render the SSR markup for each item. Reconciled by iAPI via
 	 * `data-wp-each-child` after hydration.
 	 *
 	 * @param array<int, array<string, mixed>> $items Schema-shape items.
@@ -213,8 +186,8 @@ final class Wishlist extends AbstractBlock {
 	}
 
 	/**
-	 * Render a single SSR item. Composes the shared image / name / price
-	 * markup with the Wishlist-specific "Add to cart" button.
+	 * Render a single SSR item, combining the shared row markup with the
+	 * Add to cart button.
 	 *
 	 * @param array<string, mixed> $item Schema-shape item.
 	 * @return string
@@ -250,9 +223,9 @@ final class Wishlist extends AbstractBlock {
 	}
 
 	/**
-	 * SSR-mode markup for the "Add to cart" action button. Always emits
-	 * the wrapper so iAPI can toggle `hidden` after hydration without
-	 * swapping the row out. Starts hidden when the row isn't purchasable.
+	 * SSR-mode markup for the Add to cart action button. The wrapper is always
+	 * emitted so iAPI can toggle `hidden` after hydration; starts hidden when
+	 * the row is not purchasable.
 	 *
 	 * @param array<string, mixed> $item Schema-shape item.
 	 * @return string
@@ -284,11 +257,9 @@ final class Wishlist extends AbstractBlock {
 	}
 
 	/**
-	 * Wrap the inner-block content (heading + any future siblings) in a
-	 * div. Unlike Saved for Later, no `hasShownItems` gating — the header
-	 * is always shown when there's content for it. Returns an empty
-	 * string when there's no content to wrap, so we don't emit an empty
-	 * `<div>`.
+	 * Wrap the inner-block content in a div. No `hasShownItems` gating: the
+	 * header is always shown when content is present. Returns an empty string
+	 * when there is no content to wrap, to avoid emitting an empty `<div>`.
 	 *
 	 * @param string $content Rendered inner-block content (typically the heading HTML).
 	 * @return string
@@ -301,9 +272,9 @@ final class Wishlist extends AbstractBlock {
 	}
 
 	/**
-	 * Render the empty-state markup. Visible on first paint when the
-	 * list is empty (no `hasShownItems` gate), then iAPI takes over via
-	 * `state.isEmpty` for runtime transitions.
+	 * Render the empty-state markup. Visible on first paint when the list is
+	 * empty (no `hasShownItems` gate); iAPI handles runtime transitions via
+	 * `state.isEmpty`.
 	 *
 	 * @param array<int, array<string, mixed>> $items Schema-shape items.
 	 * @return string
@@ -317,10 +288,9 @@ final class Wishlist extends AbstractBlock {
 	}
 
 	/**
-	 * Sprintf template for the per-row remove button's aria-label. Used
-	 * both by PHP SSR and by the JS-side getter (via
-	 * `wp_interactivity_config`) so both paths produce the same string
-	 * after `%s` interpolation.
+	 * Sprintf template for the per-row remove button aria-label. Shared between
+	 * PHP SSR and the JS-side getter (seeded via `wp_interactivity_config`) so
+	 * both paths produce identical output.
 	 */
 	private function get_remove_label_template(): string {
 		/* translators: %s: product name. */
@@ -350,10 +320,9 @@ final class Wishlist extends AbstractBlock {
 	/**
 	 * Get the frontend style handle for this block type.
 	 *
-	 * Returning null lets WP use the `style` array from block.json, which
-	 * lists this block's own stylesheet plus the atomic
-	 * product-image / product-price / product-button stylesheets we
-	 * borrow class names from.
+	 * Returns null so WP uses the `style` array from block.json, which declares
+	 * this block's stylesheet alongside the atomic product-image, product-price,
+	 * and product-button stylesheets whose class names this block reuses.
 	 *
 	 * @return null
 	 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php
@@ -48,17 +48,17 @@ final class Wishlist extends AbstractBlock {
 		// Guests have no personal list — bail before enqueuing assets or
 		// seeding state. The My Account endpoint isn't reachable for
 		// guests, but the block can also be placed by a merchant on any
-		// page, where this guard is what stops it from rendering an
-		// empty shell for logged-out visitors.
+		// page, so this guard prevents the block from rendering an empty
+		// wrapper for logged-out visitors on merchant-placed instances.
 		if ( ! is_user_logged_in() ) {
 			return '';
 		}
 
 		// Clamp to the 2-6 range the SCSS `@for $i from 2 through 6` loop
-		// and the editor `RangeControl` both support. `absint()` first
-		// defends against a code-editor override (the attribute can be set
-		// to any JSON value there); the `min`/`max` then keep the value
-		// within the range where a `&.columns-#{$i}` rule actually exists.
+		// and the editor `RangeControl` both support. `absint()` coerces
+		// non-integer attribute values written through the code editor;
+		// `min`/`max` then constrain the result to the range covered by
+		// `&.columns-#{$i}` rules in the stylesheet.
 		$column_count = min( 6, max( 2, absint( $attributes['columnCount'] ?? 5 ) ) );
 
 		wp_enqueue_script_module( $this->get_full_block_name() );
@@ -153,10 +153,12 @@ final class Wishlist extends AbstractBlock {
 		if ( $response->is_error() ) {
 			$error   = $response->as_error();
 			$message = $error instanceof \WP_Error ? $error->get_error_message() : 'Unknown error';
-			// Logged at debug level on purpose: prefetch failures are
-			// often transient (network blips, auth refresh races) and
-			// the user-visible behaviour is the empty state — nothing
-			// for ops to act on.
+			// Logged at debug level: prefetch failures are typically
+			// transient (transport errors, authentication refresh
+			// contention) and the user-visible fallback is the empty-
+			// state message, so they don't warrant a higher log level.
+			// Increase the WC log level to surface them when investigating
+			// a regression.
 			wc_get_logger()->debug(
 				sprintf( 'Wishlist prefetch failed: %s', $message ),
 				array(

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -245,7 +245,7 @@ class ShopperListItem {
 	}
 
 	/**
-	 * Storage key — also used as the response identifier.
+	 * Storage key; also used as the response identifier.
 	 */
 	public function get_key(): string {
 		return $this->key;
@@ -331,9 +331,9 @@ class ShopperListItem {
 
 	/**
 	 * Whether the product can be added to the cart. Mirrors the catalog gate
-	 * (`is_purchasable()` && `is_in_stock()`), but additionally requires the
-	 * row to be live and rejects password-gated products (self or parent) —
-	 * cart-add can't prompt for a password.
+	 * (`is_purchasable()` && `is_in_stock()`) and additionally requires the row
+	 * to be live. Password-gated products (self or parent) are rejected because
+	 * the cart-add flow cannot prompt for a password.
 	 */
 	public function is_purchasable(): bool {
 		$product = $this->get_product();

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListRenderer.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListRenderer.php
@@ -6,31 +6,25 @@ namespace Automattic\WooCommerce\Internal\ShopperLists;
 
 /**
  * Shared markup helpers for blocks that render a shopper-list item card
- * (Saved for Later, Wishlist, …). Composed by each consuming block
- * around its own quantity, action-button, and heading markup.
- *
- * Changes to this class affect every consuming block. The shared row
- * markup is part of the iAPI hydration contract: any divergence in
- * element shape or binding attributes between this helper's output
- * and a consumer's template will cause a hydration mismatch on first
+ * (Saved for Later, Wishlist, …). Composed by each consuming block around
+ * its own quantity, action-button, and heading markup. The row markup is
+ * part of the iAPI hydration contract; any divergence between this helper's
+ * output and a consumer's template will cause a hydration mismatch on first
  * paint.
  */
 final class ShopperListRenderer {
 
 	/**
-	 * Shared CSS root class for the row. Each section helper outputs
-	 * BEM-style modifiers off this base (`__image-slot`, `__remove`, …).
+	 * Shared CSS root class for the row. Each section helper emits BEM-style
+	 * modifiers off this base (`__image-slot`, `__remove`, …).
 	 */
 	public const ROW_CLASS = 'wc-block-shopper-list-item';
 
 	/**
-	 * Wrap `$inner` in the block's outer `<section><ul>…</ul></section>`
-	 * grid scaffold. `$wrapper_attrs` are merged with the block's wrapper
-	 * attributes via `get_block_wrapper_attributes()`.
-	 *
-	 * Trust contract: callers are responsible for ensuring `$inner` and
-	 * `$before_list` contain only safe, escaped HTML — typically composed
-	 * from the section helpers below, never from raw schema/request input.
+	 * Wrap `$inner` in the block's outer `<section><ul>…</ul></section>` grid
+	 * scaffold. `$wrapper_attrs` are merged with the block's wrapper attributes
+	 * via `get_block_wrapper_attributes()`. Callers must ensure `$inner` and
+	 * `$before_list` contain only pre-escaped markup; both are emitted verbatim.
 	 *
 	 * @param array<string, mixed> $wrapper_attrs Attributes for the outer `<section>`.
 	 * @param string               $list_class    Class attribute for the inner `<ul>`.
@@ -49,12 +43,9 @@ final class ShopperListRenderer {
 	}
 
 	/**
-	 * Wrap `$row_inner_markup` in a `<template data-wp-each>` element that
-	 * iAPI uses to render new rows. `$row_inner_markup` is the inner HTML
-	 * for the `<li>` — everything between `<li>` and `</li>`.
-	 *
-	 * Trust contract: caller is responsible for ensuring `$row_inner_markup`
-	 * contains only safe, escaped HTML.
+	 * Wrap `$row_inner_markup` in a `<template data-wp-each>` element used by
+	 * iAPI to render new rows. Callers must ensure `$row_inner_markup` contains
+	 * only pre-escaped markup; it is emitted verbatim.
 	 *
 	 * @param string $row_inner_markup Inner markup for the `<li>`.
 	 * @return string
@@ -69,12 +60,9 @@ final class ShopperListRenderer {
 
 	/**
 	 * Wrap `$row_inner_markup` in an SSR `<li data-wp-each-child>` element
-	 * seeded with the per-row iAPI context derived from `$item`. iAPI's
-	 * hydration treats this as a no-op diff against the `<template>` if
-	 * the inner markup matches.
-	 *
-	 * Trust contract: caller is responsible for ensuring `$row_inner_markup`
-	 * contains only safe, escaped HTML.
+	 * seeded with the per-row iAPI context derived from `$item`. Hydration is
+	 * a no-op diff against the `<template>` when the inner markup matches.
+	 * Callers must ensure `$row_inner_markup` contains only pre-escaped markup.
 	 *
 	 * @param array<string, mixed> $item             Schema-shape item.
 	 * @param string               $row_inner_markup Inner markup for the `<li>`.
@@ -93,7 +81,7 @@ final class ShopperListRenderer {
 
 	/**
 	 * Render the image + title + price triplet for the template-mode row
-	 * (no static attrs; bindings only). Identical between consumer blocks.
+	 * (bindings only, no static attrs).
 	 *
 	 * @return string
 	 */
@@ -124,10 +112,9 @@ final class ShopperListRenderer {
 	}
 
 	/**
-	 * Render the image + title + price triplet for the SSR-mode row, with
-	 * values populated from `$item` and `$remove_aria_label_template`. The
-	 * binding directives match the template-mode markup so iAPI's hydration
-	 * is a no-op diff after first paint.
+	 * Render the image + title + price triplet for the SSR-mode row, populated
+	 * from `$item`. Binding directives match the template-mode markup so iAPI
+	 * hydration is a no-op diff after first paint.
 	 *
 	 * @param array<string, mixed> $item                        Schema-shape item.
 	 * @param string               $remove_aria_label_template  Sprintf template for the remove button's aria-label. `%s` is replaced with the product name.
@@ -143,10 +130,10 @@ final class ShopperListRenderer {
 		$variation_label = self::get_variation_label( $item );
 		$remove_aria     = sprintf( $remove_aria_label_template, $alt );
 		$is_price_hidden = '' === $price_html;
-		// Tombstone rows (`is_live=false` or empty permalink) render `<a>`
-		// without an href — keeps the element shape stable for iAPI
-		// reconciliation against the live-row template, and the CSS in the
-		// shared partial drops link affordances when the anchor has no href.
+		// Tombstone rows (`is_live=false` or empty permalink) emit `<a>` without
+		// an href so the element shape stays stable for iAPI reconciliation
+		// against the live-row template; the stylesheet drops link affordances
+		// when the anchor has no href.
 		$href_attr = $is_live && '' !== $permalink ? 'href="' . esc_url( $permalink ) . '"' : '';
 
 		ob_start();
@@ -226,9 +213,9 @@ final class ShopperListRenderer {
 	}
 
 	/**
-	 * Render the iAPI store-notices region used by the row-level error
-	 * banners. Mirrors `AddToCartWithOptions::render_interactivity_notices_region()`
-	 * — keep in sync if the shape changes.
+	 * Render the iAPI store-notices region used by row-level error banners.
+	 * Mirrors {@see AddToCartWithOptions::render_interactivity_notices_region()};
+	 * keep in sync if the shape changes.
 	 *
 	 * @param string $wrapper_class Class attribute for the outer `<div>`.
 	 * @return string
@@ -269,11 +256,9 @@ final class ShopperListRenderer {
 	}
 
 	/**
-	 * Markup for the trash icon used in the remove-item button. Mirrors the
-	 * `trash` icon from `@wordpress/icons` that the cart line item uses for
-	 * `wc-block-cart-item__remove-link`, inlined here so SSR first paint
-	 * matches what JS would render after hydration. `currentColor` lets the
-	 * surrounding badge wrapper drive the fill.
+	 * Markup for the trash icon used in the remove-item button. Inlines the
+	 * `trash` icon from `@wordpress/icons` so SSR first paint matches the
+	 * post-hydration JS render. `currentColor` lets the wrapper drive the fill.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListRenderer.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListRenderer.php
@@ -6,14 +6,14 @@ namespace Automattic\WooCommerce\Internal\ShopperLists;
 
 /**
  * Shared markup helpers for blocks that render a shopper-list item card
- * (Saved for Later, Wishlist, …). Static helpers, not an abstract base —
- * the two blocks' lifecycles diverge enough (auto-injected vs merchant-
- * placed, different actions, different empty-state gating) that inheritance
- * is not a clean fit. Consumers stitch the fragments together with their
- * own quantity / action button / heading bits.
+ * (Saved for Later, Wishlist, …). Composed by each consuming block
+ * around its own quantity, action-button, and heading markup.
  *
- * Any change here is co-reviewed with every consuming block — drift in the
- * shared row shape will break first paint for whoever didn't get the memo.
+ * Changes to this class affect every consuming block. The shared row
+ * markup is part of the iAPI hydration contract: any divergence in
+ * element shape or binding attributes between this helper's output
+ * and a consumer's template will cause a hydration mismatch on first
+ * paint.
  */
 final class ShopperListRenderer {
 
@@ -204,10 +204,12 @@ final class ShopperListRenderer {
 
 	/**
 	 * Empty-state `<li>` that the block toggles on once `state.isEmpty`
-	 * flips. `$start_hidden = true` makes SSR ship with `hidden` so the
-	 * message doesn't flash for shoppers whose list is being populated
-	 * client-side. `$start_hidden = false` is for blocks (e.g. Wishlist)
-	 * where the message should show on first paint when the list is empty.
+	 * flips. When `$start_hidden` is true, the rendered `<li>` carries
+	 * the `hidden` attribute on first paint and is revealed by iAPI once
+	 * `state.isEmpty` flips. Used by blocks where the list is populated
+	 * asynchronously after first paint (Saved for Later). Pass false for
+	 * blocks where the empty state should be visible immediately when
+	 * the list is empty (Wishlist).
 	 *
 	 * @param string $message      Visible empty-state message.
 	 * @param string $css_class    Class attribute for the `<li>`.

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListsController.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListsController.php
@@ -8,10 +8,10 @@ use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
- * Tracks which shopper-list types are turned on and registers the
- * user-facing pieces that depend on each.
+ * Tracks which shopper-list types are enabled and registers the user-facing
+ * endpoints, menu items, and rewrite rules that depend on each.
  *
- * @internal Just for internal use.
+ * @internal
  */
 final class ShopperListsController implements RegisterHooksInterface {
 
@@ -24,19 +24,18 @@ final class ShopperListsController implements RegisterHooksInterface {
 	);
 
 	/**
-	 * Wishlist My Account endpoint slug. Wrapped in a method (rather than
-	 * a constant) so a future filter or settings hook can override it
-	 * without touching every call site.
+	 * Wishlist My Account endpoint slug. Exposed as a method so a future filter
+	 * or settings hook can override it from a single call site.
 	 */
 	public function get_wishlist_endpoint(): string {
 		return 'wishlist';
 	}
 
 	/**
-	 * Whether a given list type is on, or whether any list type is on
+	 * Whether a given list type is enabled, or whether any list type is enabled
 	 * when no slug is passed.
 	 *
-	 * @param string|null $list_slug List slug, or null to ask about any type.
+	 * @param string|null $list_slug List slug, or null to check any list type.
 	 */
 	public function is_enabled( ?string $list_slug = null ): bool {
 		if ( null === $list_slug ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItems.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
  * POST saves an item to the list either from an existing cart line or from direct item payload fields.
  */
 class ShopperListItems extends AbstractRoute {
-	// Stopgap CSRF guard, replaced once the upstream trait lands on trunk.
+	// Temporary CSRF guard; will be removed once a Store API-wide trait lands on trunk.
 	use ShopperListsNonceCheck;
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListItemsByKey.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
  * DELETE /shopper-lists/{slug}/items/{key}.
  */
 class ShopperListItemsByKey extends AbstractRoute {
-	// Stopgap CSRF guard, replaced once the upstream trait lands on trunk.
+	// Temporary CSRF guard; will be removed once a Store API-wide trait lands on trunk.
 	use ShopperListsNonceCheck;
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperLists.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
 
 /**
- * GET /shopper-lists — collection of the current user's shopper lists.
+ * GET /shopper-lists: collection of the current user's shopper lists.
  */
 class ShopperLists extends AbstractRoute {
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsBySlug.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\Internal\ShopperLists\ShopperList;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
- * GET /shopper-lists/{slug} — metadata for a single list.
+ * GET /shopper-lists/{slug}: metadata for a single list.
  */
 class ShopperListsBySlug extends AbstractRoute {
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ShopperListsNonceCheck.php
@@ -4,14 +4,11 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 /**
- * Stopgap CSRF guard for the write-capable shopper-lists routes.
+ * CSRF guard for the write-capable shopper-lists routes.
  *
- * Enforces a `wc_store_api` Nonce header on writes and refreshes the
- * client nonce via response headers on every reply. Same shape as the
- * cart's existing flow, scoped to the nonce concern.
- *
- * To be replaced by a reusable Store API-wide nonce trait once that
- * lands on trunk.
+ * Enforces a `wc_store_api` Nonce header on writes and refreshes the client
+ * nonce via response headers on every reply. Intended as a temporary measure
+ * until a reusable Store API-wide nonce trait lands on trunk.
  *
  * @internal
  */
@@ -24,8 +21,8 @@ trait ShopperListsNonceCheck {
 	private static $store_api_nonce_action = 'wc_store_api';
 
 	/**
-	 * Override of {@see AbstractRoute::get_response} that enforces the
-	 * `wc_store_api` Nonce header on writes and refreshes it on every reply.
+	 * Enforce the `wc_store_api` Nonce header on writes and refresh it on every
+	 * reply. Overrides {@see AbstractRoute::get_response}.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -77,7 +77,7 @@ class RoutesController {
 				Routes\V1\Patterns::IDENTIFIER => Routes\V1\Patterns::class,
 			],
 			'shopper_lists' => [
-				// Gated by ShopperListsController — registered only when at least one shopper-list feature is enabled.
+				// Gated by ShopperListsController; registered only when at least one shopper-list feature is enabled.
 				Routes\V1\ShopperLists::IDENTIFIER       => Routes\V1\ShopperLists::class,
 				Routes\V1\ShopperListsBySlug::IDENTIFIER => Routes\V1\ShopperListsBySlug::class,
 				Routes\V1\ShopperListItems::IDENTIFIER   => Routes\V1\ShopperListItems::class,

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShopperListItemSchema.php
@@ -15,7 +15,8 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
  * item reports `is_live`, and falls back to at-save snapshot data otherwise.
  */
 class ShopperListItemSchema extends AbstractSchema {
-	// We only call format_variation_data(); see phpstan.neon for the related suppressions.
+	// Only `format_variation_data()` is used from this trait; see phpstan.neon
+	// for the related suppressions.
 	use ProductItemTrait;
 
 	/**
@@ -264,10 +265,8 @@ class ShopperListItemSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Get the main image for a shopper list item.
-	 *
-	 * Returns the product's main image only — shopper list rows are compact and
-	 * the gallery isn't needed at the row level.
+	 * Get the main image for a shopper list item. Only the product's main image
+	 * is returned; the gallery is not exposed at the row level.
 	 *
 	 * @param \WC_Product $product Live product instance.
 	 * @return array
@@ -283,13 +282,10 @@ class ShopperListItemSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Get the thumbnail image HTML for a shopper list item, falling back to the
-	 * WooCommerce placeholder when the product has no image or has been deleted.
-	 *
-	 * Pre-formatting on the server lets renderers (PHP SSR + JS hydration)
-	 * consume one canonical string instead of each side composing the markup
-	 * from the structured `images` array. Mirrors the pattern WC uses in
-	 * `ProductSchema::price_html` / `ProductImage::render`.
+	 * Get the thumbnail image HTML for a shopper list item, with a WooCommerce
+	 * placeholder fallback when the product has no image or has been deleted.
+	 * Pre-formatted on the server so SSR and JS hydration consume one canonical
+	 * string. Follows the pattern used by `ProductSchema::price_html`.
 	 *
 	 * @param \WC_Product|null $product Live product instance, or null for tombstones.
 	 * @return string
@@ -303,10 +299,9 @@ class ShopperListItemSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Compute live prices for the saved item.
-	 *
-	 * We don't extend ProductSchema because saved items aren't products. The shape
-	 * here is a thin subset of cart-item prices.
+	 * Compute live prices for the saved item. ProductSchema is not extended
+	 * because saved items are not products; the returned shape is a thin subset
+	 * of cart-item prices.
 	 *
 	 * @param \WC_Product $product Live product instance.
 	 * @return array


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Rewords class headers, method docblocks, and inline comments across the shopper-lists feature (Saved for Later, Wishlist, the Store API routes and schema, the shared `ShopperListRenderer`, and the supporting JS stores/hooks) so the public repo ships with concise, professional prose. The pass removes first-person voice (`we`/`our`), conversational asides, em-dashes in comments, repeated boilerplate (e.g. the three "Trust contract" blocks in `ShopperListRenderer`), and multi-paragraph narration that recapped the code. No functional changes; net effect is roughly -450 lines of comment text across 24 files.

### How to test the changes in this Pull Request:

1. Read the diff. Confirm only comments, docblocks, and one translatable empty-state string differ.
2. Optional: run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `pnpm --filter=@woocommerce/block-library ts:check` to confirm no lint/type regressions.

### Testing that has already taken place:

Verified there are no functional code edits by reviewing the full diff. Verified no em-dashes remain in comments/docblocks (the only remaining em-dash is in a user-facing translatable empty-state string, where it is intentional copy).

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Comment-only changes to docblocks and inline comments. No user-facing or developer-facing behavior changes. Merges into the `feature/shopper-collections` feature branch, which will carry its own changelog entries when it merges to trunk.

</details>