### PR TITLE
Use ISO YYYY-MM-DD format in the analytics date range picker

### DIFF
--- a/packages/js/components/changelog/46504-localize-date-picker-format
+++ b/packages/js/components/changelog/46504-localize-date-picker-format
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use ISO YYYY-MM-DD format for the analytics date range picker inputs.

--- a/packages/js/components/src/date-range-filter-picker/index.js
+++ b/packages/js/components/src/date-range-filter-picker/index.js
@@ -14,8 +14,8 @@ import clsx from 'clsx';
 import DatePickerContent from './content';
 import DropdownButton from '../dropdown-button';
 
-const shortDateFormatPlaceholder = __( 'MM/DD/YYYY', 'woocommerce' );
-const shortDateFormat = 'MM/DD/YYYY';
+const shortDateFormatPlaceholder = __( 'YYYY-MM-DD', 'woocommerce' );
+const shortDateFormat = 'YYYY-MM-DD';
 
 /**
  * Select a range of dates or single dates.

--- a/plugins/woocommerce/changelog/46504-localize-date-picker-format
+++ b/plugins/woocommerce/changelog/46504-localize-date-picker-format
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use ISO YYYY-MM-DD format for the analytics date range picker inputs.


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The analytics date range picker hardcoded `MM/DD/YYYY`, which is US-centric and ambiguous to anyone outside the US. Switch the picker's input format and placeholder to ISO `YYYY-MM-DD` — unambiguous across locales and consistent with the date format already used in the analytics URL query (`?after=2026-05-12&before=2026-05-15`).

Closes woocommerce/woocommerce#46504.

### Screenshots or screen recordings:

<!-- linear:table-colwidths:400,400 -->
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>See original issue</td>
<td><img src="https://github.com/user-attachments/assets/45cd9ba5-3dd8-4dc1-b3b9-8ec011fd2d2a " alt="Screenshot 2026-05-21 at 13 08 44" width="365" data-linear-height="394" /></td>
</tr>
</tbody>
</table>

### How to test the changes in this Pull Request:

1. Go to **Analytics → Revenue** in WP Admin.
2. Open the **Date range** dropdown and switch to the **Custom** tab.
3. Confirm the two date input fields show the placeholder `yyyy-mm-dd`.
4. Pick a start and end date from the calendar.
5. Confirm both inputs render the selected dates as `YYYY-MM-DD` (e.g. `2026-05-12`).
6. Click **Update** and confirm the date-range button label still renders correctly above the calendar.

### Testing that has already taken place:

Verified manually in a local WordPress dev environment that the Custom date picker inputs render the ISO format for both placeholders and selected dates.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

### Changelog entry

- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Comment</summary>

Changelog entries added manually for `@woocommerce/components` and `@woocommerce/plugin-woocommerce`.

</details>

### Release Communication

- [X] **Feature Highlight** - For user-facing features (what changed, user impact)