### PR TITLE
Fix: Improve contrast of instock status color to meet WCAG 2.2 SC 1.4.3

### DIFF
--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -3,7 +3,7 @@
  */
 
 $woocommerce:   	#720eec !default;
-$green:         	#008a20 !default;
+$green:         	#00811e !default;
 $red:           	#a00 !default;
 $orange:        	#ffba00 !default;
 $blue:          	#2ea2cc !default;

--- a/plugins/woocommerce/client/legacy/css/order-review.scss
+++ b/plugins/woocommerce/client/legacy/css/order-review.scss
@@ -82,7 +82,7 @@
 		margin: 0.5em 0 0;
 
 		&--ok {
-			color: var(--wc-green, #008a20);
+			color: var(--wc-green, #00811e);
 		}
 
 		&--error {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The green color used for the `.instock` stock status label (`#008a20`) fails WCAG 2.2 SC 1.4.3 (minimum contrast) when rendered on the alternating light grey row background (`#F6F7F7`) in the Products list table — achieving only a 4.2:1 contrast ratio against the 4.5:1 AA requirement.

This PR updates the green color from `#008a20` to `#00811e`, achieving a 4.7:1 contrast ratio against the grey background while remaining visually indistinguishable from the original, as suggested in the issue description.

The change applies to:
- `$green` SCSS variable (and the derived `--wc-green` CSS custom property)
- Hardcoded `var(--wc-green, #008a20)`

Closes #64745.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before (`#008a20`, 4.2:1 on grey row) | After (`#00811e`, 4.7:1 on grey row) |
| ------ | ----- |
| <img width="246" height="156" alt="Before" src="https://github.com/user-attachments/assets/1bfac3b1-3ada-4e71-9451-9d4807a2fd34" /> |  <img width="193" height="157" alt="Afer" src="https://github.com/user-attachments/assets/fe7eab95-1ac7-4442-bff5-98ce91c2c6f0" /> |
|  <img width="397" height="239" alt="Screenshot 2026-05-22 at 2 12 23 PM" src="https://github.com/user-attachments/assets/9468737c-b642-4927-adfc-cfcbbe9ddcab" /> |  <img width="426" height="240" alt="Screenshot 2026-05-22 at 2 11 46 PM" src="https://github.com/user-attachments/assets/6b77d1dd-9571-438e-b539-5d399b5b553b" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Log in to the WordPress Admin dashboard.
2. Navigate to WooCommerce → Products → All Products.
3. Locate a product that is currently "In stock" and positioned on a light grey (odd) background row.
4. Open DevTools (F12), and inspect the status element.
5. In the Styles pane, observe that the text colour is #00811e.
6. Click the DevTools colour swatch to open the colour picker and note that the contrast ratio fails WCAG AA requirements against the light grey (odd) background.

<!-- End testing instructions -->

### Testing that has already taken place:

- Verified contrast ratio of `#00811e` against `#F6F7F7` (light grey row) (passes WCAG AA).
- Verified contrast ratio of `#00811e` against `#ffffff` (white row) (passes WCAG AA).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
