### PR TITLE
Fix order milestone easter egg performance

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-milestone-easter-egg-performance
+++ b/plugins/woocommerce/changelog/fix-order-milestone-easter-egg-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve order edit page performance by resolving milestone easter egg orders with a bounded HPOS ID query instead of hydrating order objects.

--- a/plugins/woocommerce/src/Internal/Admin/OrderMilestoneEasterEgg.php
+++ b/plugins/woocommerce/src/Internal/Admin/OrderMilestoneEasterEgg.php
@@ -4,6 +4,9 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Admin;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 /**
  * Displays a full-screen animated piñata overlay when a merchant opens a
  * milestone order (1st, 100th, or 1000th real order) in the admin.
@@ -21,14 +24,14 @@ class OrderMilestoneEasterEgg {
 	private const MILESTONE_CACHE_OPTION = '_wc_order_milestone_egg_order_ids';
 
 	/**
+	 * Option key used to track whether all milestone order IDs have been found.
+	 */
+	private const MILESTONES_COMPLETE_OPTION = '_wc_order_milestone_egg_milestones_complete';
+
+	/**
 	 * Maximum number of qualifying orders needed to resolve all milestones.
 	 */
 	private const MAX_QUALIFYING_ORDERS = 1000;
-
-	/**
-	 * Number of orders to inspect per milestone scan batch.
-	 */
-	private const QUERY_BATCH_SIZE = 100;
 
 	/**
 	 * Milestone positions mapped to milestone message keys.
@@ -57,11 +60,19 @@ class OrderMilestoneEasterEgg {
 	}
 
 	/**
-	 * Clears the cached milestone order IDs.
+	 * Clears cached milestone order IDs until all milestones are complete.
+	 *
+	 * Once the 1st, 100th, and 1000th qualifying order IDs have been found,
+	 * later orders cannot create additional milestone overlays, so keep the cache
+	 * stable and avoid recomputing it after routine order changes.
 	 *
 	 * @internal
 	 */
 	public function clear_milestone_cache(): void {
+		if ( wc_string_to_bool( get_option( self::MILESTONES_COMPLETE_OPTION, 'no' ) ) ) {
+			return;
+		}
+
 		delete_option( self::MILESTONE_CACHE_OPTION );
 	}
 
@@ -109,7 +120,7 @@ class OrderMilestoneEasterEgg {
 			return;
 		}
 
-		if ( ! function_exists( 'wc_get_orders' ) ) {
+		if ( ! function_exists( 'wc_get_order' ) ) {
 			return;
 		}
 
@@ -129,7 +140,7 @@ class OrderMilestoneEasterEgg {
 			return;
 		}
 
-		// Only run the order query on the HPOS order edit page to avoid overhead on every admin page.
+		// Only run milestone logic on the HPOS order edit page to avoid overhead on every admin page.
 		$is_order_edit_page = 'wc-orders' === $page_param && 'edit' === $action_param;
 
 		if ( ! $is_debug_preview && ! $is_order_edit_page ) {
@@ -137,9 +148,13 @@ class OrderMilestoneEasterEgg {
 		}
 
 		// For real order pages: check cheaply whether the current order qualifies
-		// before running the more expensive milestone count query.
+		// before running the milestone lookup. The lookup relies on HPOS columns.
 		if ( ! $is_debug_preview ) {
-			if ( $id_param <= 0 || ! $this->is_qualifying_order( $id_param ) ) {
+			if (
+				! OrderUtil::custom_orders_table_usage_is_enabled()
+				|| $id_param <= 0
+				|| ! $this->is_qualifying_order( $id_param )
+			) {
 				return;
 			}
 		}
@@ -234,6 +249,7 @@ class OrderMilestoneEasterEgg {
 		if ( null === $milestone_order_ids ) {
 			$milestone_order_ids = $this->compute_milestone_order_ids();
 			update_option( self::MILESTONE_CACHE_OPTION, $milestone_order_ids, false );
+			$this->update_milestones_complete_option( $milestone_order_ids );
 		}
 
 		$messages      = $this->get_milestone_messages();
@@ -280,47 +296,52 @@ class OrderMilestoneEasterEgg {
 	}
 
 	/**
-	 * Computes milestone order IDs by scanning qualifying orders in chronological order.
+	 * Updates the complete option when all milestone IDs have been found.
+	 *
+	 * @param array<string, int> $milestone_order_ids Milestone order IDs keyed by milestone name.
+	 */
+	private function update_milestones_complete_option( array $milestone_order_ids ): void {
+		if ( count( $milestone_order_ids ) === count( self::MILESTONE_POSITIONS ) ) {
+			update_option( self::MILESTONES_COMPLETE_OPTION, 'yes', false );
+			return;
+		}
+
+		delete_option( self::MILESTONES_COMPLETE_OPTION );
+	}
+
+	/**
+	 * Computes milestone order IDs from HPOS without hydrating order objects.
 	 *
 	 * @return array<string, int>
 	 */
 	private function compute_milestone_order_ids(): array {
-		$qualifying_order_ids       = array();
-		$qualifying_order_ids_count = 0;
-		$page                       = 1;
+		global $wpdb;
 
-		while ( $qualifying_order_ids_count < self::MAX_QUALIFYING_ORDERS ) {
-			$batch = (array) wc_get_orders(
-				array(
-					'limit'   => self::QUERY_BATCH_SIZE,
-					'paged'   => $page,
-					'orderby' => 'date',
-					'order'   => 'ASC',
-					'status'  => array( 'processing', 'completed' ),
-					'return'  => 'objects',
-				)
-			);
-
-			if ( empty( $batch ) ) {
-				break;
-			}
-
-			foreach ( $batch as $order ) {
-				if ( $order instanceof \WC_Order && '' !== $order->get_transaction_id() ) {
-					$qualifying_order_ids[] = $order->get_id();
-					++$qualifying_order_ids_count;
-					if ( $qualifying_order_ids_count >= self::MAX_QUALIFYING_ORDERS ) {
-						break 2;
-					}
-				}
-			}
-
-			if ( count( $batch ) < self::QUERY_BATCH_SIZE ) {
-				break;
-			}
-
-			++$page;
+		if ( ! OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			return array();
 		}
+
+		$qualifying_order_ids = array_map(
+			'absint',
+			$wpdb->get_col(
+				$wpdb->prepare(
+					'SELECT id
+					FROM %i
+					WHERE type = %s
+					AND status IN ( %s, %s )
+					AND transaction_id IS NOT NULL
+					AND transaction_id <> %s
+					ORDER BY date_created_gmt ASC, id ASC
+					LIMIT %d',
+					OrdersTableDataStore::get_orders_table_name(),
+					'shop_order',
+					'wc-processing',
+					'wc-completed',
+					'',
+					self::MAX_QUALIFYING_ORDERS
+				)
+			)
+		);
 
 		$milestone_order_ids = array();
 		foreach ( self::MILESTONE_POSITIONS as $pos => $key ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/OrderMilestoneEasterEggTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/OrderMilestoneEasterEggTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\Admin\OrderMilestoneEasterEgg;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 
@@ -38,6 +39,7 @@ class OrderMilestoneEasterEggTest extends \WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		delete_option( $this->get_cache_option_name() );
+		delete_option( $this->get_complete_option_name() );
 		remove_action( 'admin_enqueue_scripts', array( $this->sut, 'handle_admin_enqueue_scripts' ) );
 		remove_action( 'wp_ajax_wc_egg_dismiss', array( $this->sut, 'handle_ajax_dismiss' ) );
 		remove_action( 'wp_ajax_wc_egg_opt_out', array( $this->sut, 'handle_ajax_opt_out' ) );
@@ -226,6 +228,68 @@ class OrderMilestoneEasterEggTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_milestone_map identifies the first, hundredth, and thousandth qualifying orders.
+	 */
+	public function test_get_milestone_map_identifies_first_hundredth_and_thousandth_orders(): void {
+		$base_id = 900000000;
+		for ( $i = 0; $i < 1000; ++$i ) {
+			$this->insert_hpos_order( $base_id + $i, gmdate( 'Y-m-d H:i:s', strtotime( '2020-01-01 00:00:00' ) + $i ) );
+		}
+
+		$map = $this->get_milestone_map_via_filter();
+
+		$this->assertSame( 'llama', $map[ $base_id ]['variant'] );
+		$this->assertSame( 'octo', $map[ $base_id + 99 ]['variant'] );
+		$this->assertSame( 'whale', $map[ $base_id + 999 ]['variant'] );
+		$this->assertSame( 'yes', get_option( $this->get_complete_option_name() ) );
+	}
+
+	/**
+	 * @testdox get_milestone_map ignores orders without transaction IDs.
+	 */
+	public function test_get_milestone_map_ignores_orders_without_transaction_ids(): void {
+		$this->insert_hpos_order( 900001000, '2020-01-01 00:00:00', 'wc-processing', '' );
+		$this->insert_hpos_order( 900001001, '2020-01-01 00:00:01', 'wc-processing', 'txn_live_900001001' );
+
+		$map = $this->get_milestone_map_via_filter();
+
+		$this->assertArrayNotHasKey( 900001000, $map );
+		$this->assertArrayHasKey( 900001001, $map );
+	}
+
+	/**
+	 * @testdox get_milestone_map uses a bounded number of DB queries for sparse qualifying orders.
+	 */
+	public function test_get_milestone_map_uses_bounded_queries_for_sparse_qualifying_orders(): void {
+		$base_id = 900002000;
+		$orders  = array();
+
+		for ( $i = 0; $i < 2000; ++$i ) {
+			$order_id = $base_id + $i;
+			$orders[] = array(
+				'id'               => $order_id,
+				'status'           => 'wc-processing',
+				'type'             => 'shop_order',
+				'date_created_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '2020-01-01 00:00:00' ) + $i ),
+				'date_updated_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '2020-01-01 00:00:00' ) + $i ),
+				'transaction_id'   => 0 === $i % 2 ? 'txn_live_' . $order_id : '',
+			);
+		}
+
+		$this->insert_hpos_orders( $orders );
+
+		global $wpdb;
+		$queries_before = $wpdb->num_queries;
+		$map            = $this->get_milestone_map_via_filter();
+		$queries_used   = $wpdb->num_queries - $queries_before;
+
+		$this->assertLessThanOrEqual( 10, $queries_used );
+		$this->assertSame( 'llama', $map[ $base_id ]['variant'] );
+		$this->assertSame( 'octo', $map[ $base_id + 198 ]['variant'] );
+		$this->assertSame( 'whale', $map[ $base_id + 1998 ]['variant'] );
+	}
+
+	/**
 	 * @testdox get_milestone_map applies the wc_order_milestone_egg_map filter.
 	 */
 	public function test_get_milestone_map_applies_wc_order_milestone_egg_map_filter(): void {
@@ -258,6 +322,7 @@ class OrderMilestoneEasterEggTest extends \WC_Unit_Test_Case {
 			array( 'first' => $order->get_id() ),
 			get_option( $this->get_cache_option_name(), array() )
 		);
+		$this->assertFalse( get_option( $this->get_complete_option_name(), false ) );
 	}
 
 	/**
@@ -272,14 +337,31 @@ class OrderMilestoneEasterEggTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox clear_milestone_cache deletes cached milestone order IDs.
+	 * @testdox clear_milestone_cache deletes cached milestone order IDs until all milestones are complete.
 	 */
-	public function test_clear_milestone_cache_deletes_cached_milestone_order_ids(): void {
+	public function test_clear_milestone_cache_deletes_cached_milestone_order_ids_until_all_milestones_are_complete(): void {
 		update_option( $this->get_cache_option_name(), array( 'first' => 12345 ), false );
 
 		$this->sut->clear_milestone_cache();
 
 		$this->assertFalse( get_option( $this->get_cache_option_name(), false ) );
+	}
+
+	/**
+	 * @testdox clear_milestone_cache keeps cached milestone order IDs after all milestones are complete.
+	 */
+	public function test_clear_milestone_cache_keeps_cached_milestone_order_ids_after_all_milestones_are_complete(): void {
+		$cached = array(
+			'first'    => 12345,
+			'hundred'  => 12346,
+			'thousand' => 12347,
+		);
+		update_option( $this->get_cache_option_name(), $cached, false );
+		update_option( $this->get_complete_option_name(), 'yes', false );
+
+		$this->sut->clear_milestone_cache();
+
+		$this->assertSame( $cached, get_option( $this->get_cache_option_name(), array() ) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -376,6 +458,67 @@ class OrderMilestoneEasterEggTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Inserts a minimal HPOS order row for milestone computation tests.
+	 *
+	 * @param int         $order_id Order ID.
+	 * @param string      $date_created_gmt Order creation date in GMT.
+	 * @param string      $status Order status.
+	 * @param string|null $transaction_id Transaction ID. Null creates a default transaction ID.
+	 */
+	private function insert_hpos_order( int $order_id, string $date_created_gmt, string $status = 'wc-processing', ?string $transaction_id = null ): void {
+		global $wpdb;
+
+		if ( null === $transaction_id ) {
+			$transaction_id = 'txn_live_' . $order_id;
+		}
+
+		$this->insert_hpos_orders(
+			array(
+				array(
+					'id'               => $order_id,
+					'status'           => $status,
+					'type'             => 'shop_order',
+					'date_created_gmt' => $date_created_gmt,
+					'date_updated_gmt' => $date_created_gmt,
+					'transaction_id'   => $transaction_id,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Inserts minimal HPOS order rows for milestone computation tests.
+	 *
+	 * @param array<int, array<string, int|string>> $orders Order rows to insert.
+	 */
+	private function insert_hpos_orders( array $orders ): void {
+		global $wpdb;
+
+		$values = array();
+		foreach ( $orders as $order ) {
+			$values[] = $wpdb->prepare(
+				'(%d,%s,%s,%s,%s,%s)',
+				$order['id'],
+				$order['status'],
+				$order['type'],
+				$order['date_created_gmt'],
+				$order['date_updated_gmt'],
+				$order['transaction_id']
+			);
+		}
+
+		$sql  = $wpdb->prepare(
+			'INSERT INTO %i (id,status,type,date_created_gmt,date_updated_gmt,transaction_id) VALUES ',
+			OrdersTableDataStore::get_orders_table_name()
+		);
+		$sql .= implode( ',', $values );
+
+		$result = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table name and row values are prepared above.
+
+		$this->assertNotFalse( $result, $wpdb->last_error );
+	}
+
+	/**
 	 * Returns the private milestone cache option name.
 	 *
 	 * @return string
@@ -383,6 +526,16 @@ class OrderMilestoneEasterEggTest extends \WC_Unit_Test_Case {
 	private function get_cache_option_name(): string {
 		$ref = new \ReflectionClass( OrderMilestoneEasterEgg::class );
 		return (string) $ref->getConstant( 'MILESTONE_CACHE_OPTION' );
+	}
+
+	/**
+	 * Returns the private milestones complete option name.
+	 *
+	 * @return string
+	 */
+	private function get_complete_option_name(): string {
+		$ref = new \ReflectionClass( OrderMilestoneEasterEgg::class );
+		return (string) $ref->getConstant( 'MILESTONES_COMPLETE_OPTION' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Opening an HPOS order edit page could synchronously recompute milestone easter egg order IDs after cache invalidation, scanning paid orders in batches and hydrating `WC_Order` objects just to check transaction IDs. On large stores where many paid orders do not have transaction IDs, that can make admin order edit loads extremely slow.

This replaces the cache-miss computation with a single bounded, prepared HPOS query that returns only order IDs for the first 1,000 qualifying orders, then maps the 1st, 100th, and 1,000th IDs to milestones without order hydration. Once all three milestone IDs have been found, a small `milestones_complete` option keeps the cache stable so routine order changes no longer trigger recomputation.

Bug introduced in PR #64679.

### How to test the changes in this Pull Request:

1. Run the targeted test:

    ```sh
    pnpm --filter=@woocommerce/plugin-woocommerce env:dev
    pnpm --filter=@woocommerce/plugin-woocommerce test:php:env --filter OrderMilestoneEasterEggTest
    ```

2. Confirm it ends with `OK`.

Optional browser smoke test:

1. Open any HPOS order edit page, for example `/wp-admin/admin.php?page=wc-orders&action=edit&id=<order_id>`.
2. Confirm the order edit page loads normally.
3. Add `&woo_egg=first` to the URL and confirm the preview celebration modal appears.

### Testing that has already taken place:

- `vendor/bin/phpcs src/Internal/Admin/OrderMilestoneEasterEgg.php tests/php/src/Internal/Admin/OrderMilestoneEasterEggTest.php` ✅
- `composer exec -- phpstan analyse src/Internal/Admin/OrderMilestoneEasterEgg.php --memory-limit=2G` ✅
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` ✅
- `php -l` on changed PHP files ✅
- `pnpm --filter=@woocommerce/plugin-woocommerce env:dev` to start the wp-env test setup ✅
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env --filter OrderMilestoneEasterEggTest` ✅
- WP-CLI smoke test with 1,000 synthetic HPOS rows selected the expected first/100th/1,000th milestone IDs in ~2.5ms ✅
- Chrome MCP smoke test on local order #151: preview URL showed the “Cha-ching! Order number one” modal; normal order edit URL loaded without the preview modal ✅

Benchmarking was performed locally with synthetic HPOS rows inserted inside a DB transaction and rolled back afterward:

| Scenario | Current object scan | `wc_get_orders` IDs + field query | Direct HPOS SQL |
| --- | ---: | ---: | ---: |
| 500k orders, all qualifying | 268.93ms, 101 DB queries, 1,000 objects, +7.71MB PHP usage | 19.51ms, 2 DB queries, 0 objects, +1.38MB | 1.95ms, 1 DB query, 0 objects, +0.001MB |
| 500k orders, 1-in-100 with transaction IDs | 411,390ms, 10,001 DB queries, 100,000 objects, +763.56MB PHP usage | 53.43ms, 2 DB queries, 0 objects, +1.05MB | 57.87ms, 1 DB query, 0 objects, +0.001MB |

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A manual changelog entry is included in `plugins/woocommerce/changelog/fix-order-milestone-easter-egg-performance`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
