### PR TITLE
Updates to color swatch styles

### DIFF
--- a/plugins/woocommerce/changelog/update-swatches-styles
+++ b/plugins/woocommerce/changelog/update-swatches-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Updates to color swatches styles
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -147,25 +147,33 @@ const Edit = ( props: EditProps ): JSX.Element => {
 					<ColorGradientSettingsDropdown
 						__experimentalIsRenderedInSidebar
 						settings={ [
-							{
-								label: __(
-									'Unselected Chip Text',
-									'woocommerce'
-								),
-								colorValue: chipText.color || customChipText,
-								onColorChange: ( colorValue: string ) => {
-									setChipText( colorValue );
-									setAttributes( {
-										customChipText: colorValue,
-									} );
-								},
-								resetAllFilter: () => {
-									setChipText( '' );
-									setAttributes( {
-										customChipText: '',
-									} );
-								},
-							},
+							...( ! hasColorSwatches
+								? [
+										{
+											label: __(
+												'Unselected Chip Text',
+												'woocommerce'
+											),
+											colorValue:
+												chipText.color ||
+												customChipText,
+											onColorChange: (
+												colorValue: string
+											) => {
+												setChipText( colorValue );
+												setAttributes( {
+													customChipText: colorValue,
+												} );
+											},
+											resetAllFilter: () => {
+												setChipText( '' );
+												setAttributes( {
+													customChipText: '',
+												} );
+											},
+										},
+								  ]
+								: [] ),
 							{
 								label: __(
 									'Unselected Chip Border',
@@ -186,48 +194,60 @@ const Edit = ( props: EditProps ): JSX.Element => {
 									} );
 								},
 							},
-							{
-								label: __(
-									'Unselected Chip Background',
-									'woocommerce'
-								),
-								colorValue:
-									chipBackground.color ||
-									customChipBackground,
-								onColorChange: ( colorValue: string ) => {
-									setChipBackground( colorValue );
-									setAttributes( {
-										customChipBackground: colorValue,
-									} );
-								},
-								resetAllFilter: () => {
-									setChipBackground( '' );
-									setAttributes( {
-										customChipBackground: '',
-									} );
-								},
-							},
-							{
-								label: __(
-									'Selected Chip Text',
-									'woocommerce'
-								),
-								colorValue:
-									selectedChipText.color ||
-									customSelectedChipText,
-								onColorChange: ( colorValue: string ) => {
-									setSelectedChipText( colorValue );
-									setAttributes( {
-										customSelectedChipText: colorValue,
-									} );
-								},
-								resetAllFilter: () => {
-									setSelectedChipText( '' );
-									setAttributes( {
-										customSelectedChipText: '',
-									} );
-								},
-							},
+							...( ! hasColorSwatches
+								? [
+										{
+											label: __(
+												'Unselected Chip Background',
+												'woocommerce'
+											),
+											colorValue:
+												chipBackground.color ||
+												customChipBackground,
+											onColorChange: (
+												colorValue: string
+											) => {
+												setChipBackground( colorValue );
+												setAttributes( {
+													customChipBackground:
+														colorValue,
+												} );
+											},
+											resetAllFilter: () => {
+												setChipBackground( '' );
+												setAttributes( {
+													customChipBackground: '',
+												} );
+											},
+										},
+										{
+											label: __(
+												'Selected Chip Text',
+												'woocommerce'
+											),
+											colorValue:
+												selectedChipText.color ||
+												customSelectedChipText,
+											onColorChange: (
+												colorValue: string
+											) => {
+												setSelectedChipText(
+													colorValue
+												);
+												setAttributes( {
+													customSelectedChipText:
+														colorValue,
+												} );
+											},
+											resetAllFilter: () => {
+												setSelectedChipText( '' );
+												setAttributes( {
+													customSelectedChipText: '',
+												} );
+											},
+										},
+								  ]
+								: [] ),
 							{
 								label: __(
 									'Selected Chip Border',
@@ -249,28 +269,37 @@ const Edit = ( props: EditProps ): JSX.Element => {
 									} );
 								},
 							},
-							{
-								label: __(
-									'Selected Chip Background',
-									'woocommerce'
-								),
-								colorValue:
-									selectedChipBackground.color ||
-									customSelectedChipBackground,
-								onColorChange: ( colorValue: string ) => {
-									setSelectedChipBackground( colorValue );
-									setAttributes( {
-										customSelectedChipBackground:
-											colorValue,
-									} );
-								},
-								resetAllFilter: () => {
-									setSelectedChipBackground( '' );
-									setAttributes( {
-										customSelectedChipBackground: '',
-									} );
-								},
-							},
+							...( ! hasColorSwatches
+								? [
+										{
+											label: __(
+												'Selected Chip Background',
+												'woocommerce'
+											),
+											colorValue:
+												selectedChipBackground.color ||
+												customSelectedChipBackground,
+											onColorChange: (
+												colorValue: string
+											) => {
+												setSelectedChipBackground(
+													colorValue
+												);
+												setAttributes( {
+													customSelectedChipBackground:
+														colorValue,
+												} );
+											},
+											resetAllFilter: () => {
+												setSelectedChipBackground( '' );
+												setAttributes( {
+													customSelectedChipBackground:
+														'',
+												} );
+											},
+										},
+								  ]
+								: [] ),
 						] }
 						panelId={ clientId }
 						{ ...colorGradientSettings }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -146,7 +146,7 @@
 		flex-shrink: 0;
 	}
 
-	.wc-block-product-filter-chips__swatch--no-color {
+	:where(.wc-block-product-filter-chips__swatch--no-color) {
 		display: inline-block;
 		background: linear-gradient(
 			to top left,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -76,23 +76,22 @@
 	vertical-align: bottom;
 }
 
-.wc-block-product-filter-chips__swatch {
+:where(.wc-block-product-filter-chips__swatch) {
 	display: inline-block;
 	width: 1.25em;
 	height: 1.25em;
 	border-radius: 50%;
 	border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
 	flex-shrink: 0;
-
-	&--no-color {
-		display: none;
-	}
-	.has-chip-border-color & {
-		border-color: var(--wc-product-filter-chips-border);
-	}
-	.has-selected-chip-border-color .wc-block-product-filter-chips__item[aria-checked="true"] & {
-		border-color: transparent;
-	}
+}
+:where(.wc-block-product-filter-chips__swatch--no-color) {
+	display: none;
+}
+:where(.has-chip-border-color .wc-block-product-filter-chips__swatch) {
+	border-color: var(--wc-product-filter-chips-border);
+}
+:where(.has-selected-chip-border-color .wc-block-product-filter-chips__item[aria-checked="true"] .wc-block-product-filter-chips__swatch) {
+	border-color: transparent;
 }
 
 .wc-block-product-filter-chips__text {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -87,6 +87,12 @@
 	&--no-color {
 		display: none;
 	}
+	.has-chip-border-color & {
+		border-color: var(--wc-product-filter-chips-border);
+	}
+	.has-selected-chip-border-color .wc-block-product-filter-chips__item[aria-checked="true"] & {
+		border-color: transparent;
+	}
 }
 
 .wc-block-product-filter-chips__text {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -76,24 +76,6 @@
 	vertical-align: bottom;
 }
 
-:where(.wc-block-product-filter-chips__swatch) {
-	display: inline-block;
-	width: 1.25em;
-	height: 1.25em;
-	border-radius: 50%;
-	border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
-	flex-shrink: 0;
-}
-:where(.wc-block-product-filter-chips__swatch--no-color) {
-	display: none;
-}
-:where(.has-chip-border-color .wc-block-product-filter-chips__swatch) {
-	border-color: var(--wc-product-filter-chips-border);
-}
-:where(.has-selected-chip-border-color .wc-block-product-filter-chips__item[aria-checked="true"] .wc-block-product-filter-chips__swatch) {
-	border-color: transparent;
-}
-
 .wc-block-product-filter-chips__text {
 	display: contents;
 }
@@ -155,19 +137,33 @@
 		justify-content: center;
 	}
 
-	.wc-block-product-filter-chips__swatch {
-		&--no-color {
-			display: inline-block;
-			background: linear-gradient(
-				to top left,
-				transparent calc(50% - 0.5px),
-				color-mix(in srgb, currentColor 20%, transparent)
-					calc(50% - 0.5px),
-				color-mix(in srgb, currentColor 20%, transparent)
-					calc(50% + 0.5px),
-				transparent calc(50% + 0.5px)
-			);
-		}
+	:where(.wc-block-product-filter-chips__swatch) {
+		display: inline-block;
+		width: 1.25em;
+		height: 1.25em;
+		border-radius: 50%;
+		border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+		flex-shrink: 0;
+	}
+
+	.wc-block-product-filter-chips__swatch--no-color {
+		display: inline-block;
+		background: linear-gradient(
+			to top left,
+			transparent calc(50% - 0.5px),
+			color-mix(in srgb, currentColor 20%, transparent)
+				calc(50% - 0.5px),
+			color-mix(in srgb, currentColor 20%, transparent)
+				calc(50% + 0.5px),
+			transparent calc(50% + 0.5px)
+		);
+	}
+
+	&.has-chip-border-color :where(.wc-block-product-filter-chips__item:not([aria-checked="true"]) .wc-block-product-filter-chips__swatch) {
+		border-color: var(--wc-product-filter-chips-border);
+	}
+	&.has-selected-chip-border-color :where(.wc-block-product-filter-chips__item[aria-checked="true"] .wc-block-product-filter-chips__swatch) {
+		border-color: transparent;
 	}
 
 	.wc-block-product-filter-chips__text,

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9694,6 +9694,7 @@ body.woocommerce-settings-payments-section_legacy {
 
 	&.is-empty::before {
 		content: '';
+		border-radius: 50%;
 		position: absolute;
 		top: 0;
 		right: 0;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9685,7 +9685,7 @@ body.woocommerce-settings-payments-section_legacy {
 	display: inline-block;
 	vertical-align: middle;
 	border: 1px solid #7e8993;
-	border-radius: 2px;
+	border-radius: 50%;
 	margin-right: 0.5em;
 	height: 1em;
 	width: 1em;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes RSM-2818.
Fixes RSM-2884.

* This PR makes color swatches in the admin circular, to align with the frontend.
* Updates the swatches styles in the frontend so border colors defined in the block styles are applied.
* Reorganizes the code a bit and adds some `:where()`, so the specificity is lower.

### How to test the changes in this Pull Request:

1. In wp-admin, go to Products > Attributes and view the terms a color attribute.
2. Verify the color swatches next to the terms are circles.
3. Now, go to the Shop page, edit the Chips block of a color attribute so it has selected and unselected custom border colors.
4. In the frontend, verify the colors are correctly applied to the swatches.

Admin | Frontend
--- | ---
<img width="1049" height="618" alt="image" src="https://github.com/user-attachments/assets/1cfc3ae0-03e3-44c6-bc71-e65f7b7916f7" /> | <img width="860" height="395" alt="image" src="https://github.com/user-attachments/assets/5a077da4-b82f-4e59-9666-633c4016db35" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
