### PR TITLE
Product Importing: Allow retries of import process

### DIFF
--- a/plugins/woocommerce/client/legacy/js/admin/wc-product-import.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-product-import.js
@@ -21,11 +21,23 @@
 		this.failed   = 0;
 		this.updated  = 0;
 		this.skipped  = 0;
+		this.retries = 0;
+		this.originalTitle = document.title.toString();
 
 		// Initial state.
 		this.$form.find('.woocommerce-importer-progress').val( 0 );
 
+		var $this = this;
+		this.$form.find('.woocommerce-importer__retry').click(function(){
+			// Let's give this another try
+			$this.$form.find('.spinner').addClass('is-active');
+			$this.$form.find('.woocommerce-importer__error').attr("aria-hidden", "true").addClass("hidden");
+			document.title = $this.originalTitle;
+			$this.run_import();
+		});
+
 		this.run_import = this.run_import.bind( this );
+		this.failed_import = this.failed_import.bind( this );
 
 		// Start importing.
 		this.run_import();
@@ -59,6 +71,7 @@
 					$this.failed   += response.data.failed;
 					$this.updated  += response.data.updated;
 					$this.skipped  += response.data.skipped;
+					$this.retries = 0;
 					$this.$form.find('.woocommerce-importer-progress').val( response.data.percentage );
 
 					if ( 'done' === response.data.position ) {
@@ -79,11 +92,32 @@
 					} else {
 						$this.run_import();
 					}
+				} else {
+					$this.failed_import();
 				}
 			}
 		} ).fail( function( response ) {
-			window.console.log( response );
+			$this.failed_import();
 		} );
+	};
+
+	/**
+	 * Function to handle a failure response from the server, either to retry or to alert the user
+	 */
+	productImportForm.prototype.failed_import = function() {
+		this.retries += 1;
+		if(this.retries > 3) {
+			// After 3 tries, there is likely a further problem beyond a temporary issue (i.e cloudflare)
+			this.$form.find('.spinner').removeClass('is-active');
+			this.$form.find('.woocommerce-importer__error').removeAttr("aria-hidden").removeClass("hidden");
+			document.title = '⚠️ ' + this.originalTitle;
+		} else {
+			// Hold off for a couple seconds while the server may recover
+			var $this = this;
+			setTimeout(function(){
+				$this.run_import();
+			}, 2500);
+		}
 	};
 
 	/**

--- a/plugins/woocommerce/client/legacy/js/admin/wc-product-import.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-product-import.js
@@ -21,11 +21,21 @@
 		this.failed   = 0;
 		this.updated  = 0;
 		this.skipped  = 0;
+		this.retries = 0;
 
 		// Initial state.
 		this.$form.find('.woocommerce-importer-progress').val( 0 );
 
+		var $this = this;
+		this.$form.find('.woocommerce-importer__retry').click(function(){
+			// Let's give this another try
+			$this.$form.find('.spinner').addClass('is-active');
+			$this.$form.find('woocommerce-importer__error').attr("aria-hidden", "true").addClass("hidden");
+			$this.run_import();
+		});
+
 		this.run_import = this.run_import.bind( this );
+		this.failed_import = this.failed_import.bind( this );
 
 		// Start importing.
 		this.run_import();
@@ -59,6 +69,7 @@
 					$this.failed   += response.data.failed;
 					$this.updated  += response.data.updated;
 					$this.skipped  += response.data.skipped;
+					$this.retries = 0;
 					$this.$form.find('.woocommerce-importer-progress').val( response.data.percentage );
 
 					if ( 'done' === response.data.position ) {
@@ -79,11 +90,30 @@
 					} else {
 						$this.run_import();
 					}
+				} else {
+					$this.failed_import();
 				}
 			}
 		} ).fail( function( response ) {
-			window.console.log( response );
+			$this.failed_import();
 		} );
+	};
+
+	/**
+	 * Function to handle a failure response from the server
+	 */
+	$.fn.failed_import = function() {
+		this.retries += 1;
+		if(this.retries > 3) {
+			// After 3 tries, there is likely a further problem beyond a temporary issue (i.e cloudflare)
+			this.$form.find('.spinner').removeClass('is-active');
+			this.$form.find('woocommerce-importer__error').removeAttr("aria-hidden").removeClass("hidden");
+		} else {
+			// Hold off for a couple seconds while the server may recover
+			setTimeout(function(){
+				this.run_import();
+			}, 2500);
+		}
 	};
 
 	/**

--- a/plugins/woocommerce/includes/admin/importers/views/html-csv-import-progress.php
+++ b/plugins/woocommerce/includes/admin/importers/views/html-csv-import-progress.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<progress class="woocommerce-importer-progress" max="100" value="0"></progress>
 	</section>
 	<section aria-hidden="true" class="hidden notice notice-error woocommerce-importer__error">
-		<p><?= esc_html_e( 'Your import has hit an error after multiple tries', 'woocommerce' ) ?></p>
-		<button class="woocommerce-importer__retry button" type="button"><?= esc_html_e( 'Retry', 'woocommerce' ) ?></button>
+		<p><?php esc_html_e( 'Your import has hit an error after multiple tries', 'woocommerce' ) ?></p>
+		<button class="woocommerce-importer__retry button" type="button"><?php esc_html_e( 'Retry', 'woocommerce' ) ?></button>
 	</section>
 </div>

--- a/plugins/woocommerce/includes/admin/importers/views/html-csv-import-progress.php
+++ b/plugins/woocommerce/includes/admin/importers/views/html-csv-import-progress.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<progress class="woocommerce-importer-progress" max="100" value="0"></progress>
 	</section>
 	<section aria-hidden="true" class="hidden notice notice-error woocommerce-importer__error">
-		<p><?php esc_html_e( 'Your import has hit an error after multiple tries', 'woocommerce' ) ?></p>
-		<button class="woocommerce-importer__retry button" type="button"><?php esc_html_e( 'Retry', 'woocommerce' ) ?></button>
+		<p><?php esc_html_e( 'Your import has hit an error after multiple tries', 'woocommerce' ); ?></p>
+		<button class="woocommerce-importer__retry button" type="button"><?php esc_html_e( 'Retry', 'woocommerce' ); ?></button>
 	</section>
 </div>

--- a/plugins/woocommerce/includes/admin/importers/views/html-csv-import-progress.php
+++ b/plugins/woocommerce/includes/admin/importers/views/html-csv-import-progress.php
@@ -18,4 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<section>
 		<progress class="woocommerce-importer-progress" max="100" value="0"></progress>
 	</section>
+	<section aria-hidden="true" class="hidden notice notice-error woocommerce-importer__error">
+		<p><?= esc_html_e( 'Your import has hit an error after multiple tries', 'woocommerce' ) ?></p>
+		<button class="woocommerce-importer__retry button" type="button"><?= esc_html_e( 'Retry', 'woocommerce' ) ?></button>
+	</section>
 </div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request works on a papercut I face a lot in WooCommerce whereby if the backend reports an error such as a timeout (especially behind Cloudflare), there is nothing handled on the frontend in this process to get the import process retried. There was also no indication to the user that their import had failed, instead the spinner keeps spinning and it just does nothing.

I have implemented a simple retry mechanism which is we try 3 times automatically, and if it fails after that to alert the user to step in.

### Screenshots or screen recordings:

<img width="1130" height="679" alt="image" src="https://github.com/user-attachments/assets/cfe18448-fbf5-4380-bdd9-982882717ee9" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Unfortunately I couldn't figure out how to unit test this.

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a file to import
2. Edit `do_ajax_product_import` to simply die before doing anything to simulate a network failure
3. Try to import a file
4. See the failure appear
5. Remove the die statement
6. Retry and see the process completes

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

I've tested this using the process mentioned above

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Allow reties of import process

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

"Improved Product Importer to allow retries"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
