### PR TITLE
Fix typo in PaymentGatewaysController method name (successfull -> successful)

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
@@ -20,7 +20,7 @@ class PaymentGatewaysController {
 	public static function init() {
 		add_filter( 'woocommerce_rest_prepare_payment_gateway', array( __CLASS__, 'extend_response' ), 10, 3 );
 		add_filter( 'admin_init', array( __CLASS__, 'possibly_do_connection_return_action' ) );
-		add_action( 'woocommerce_admin_payment_gateway_connection_return', array( __CLASS__, 'handle_successfull_connection' ) );
+		add_action( 'woocommerce_admin_payment_gateway_connection_return', array( __CLASS__, 'handle_successful_connection' ) );
 	}
 
 	/**
@@ -107,7 +107,7 @@ class PaymentGatewaysController {
 	 *
 	 * @param string $gateway_id Gateway ID.
 	 */
-	public static function handle_successfull_connection( $gateway_id ) {
+	public static function handle_successful_connection( $gateway_id ) {
 		// phpcs:disable WordPress.Security.NonceVerification
 		if ( ! isset( $_GET['success'] ) || 1 !== intval( $_GET['success'] ) ) {
 			return;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`PaymentGatewaysController::handle_successfull_connection` contained a double-L typo in both the `add_action` callback string and the method definition. Both are corrected to `handle_successful_connection`. The docblock on the same method already used the correct spelling, making the inconsistency obvious on inspection.

### How to test the changes in this Pull Request:

1. Set up a payment gateway that uses the `woocommerce_admin_payment_gateway_connection_return` action (e.g. a gateway that calls `do_action( 'woocommerce_admin_payment_gateway_connection_return', $gateway_id )`).
2. Trigger a successful connection return by navigating to the WooCommerce admin Payments task with `?connection-return=<gateway_id>&success=1&_wpnonce=<nonce>`.
3. Verify the success transient notice ("X connected successfully") appears as expected — confirming the action callback is still wired correctly after the rename.

### Testing that has already taken place:

- Grepped the entire repo for `handle_successfull_connection` — no other references exist; the rename is self-contained.
- Confirmed the `add_action` callback string and method definition are updated consistently.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix typo in `PaymentGatewaysController` method name (`handle_successfull_connection` → `handle_successful_connection`).

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>