### PR TITLE
Use first name for greeting if available, instead of user login, on new customer account and reset password emails

### DIFF
--- a/plugins/woocommerce/changelog/65269-first-name-greeting-customer-emails
+++ b/plugins/woocommerce/changelog/65269-first-name-greeting-customer-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Use the customer's first name (billing first name, falling back to WordPress first name, then username) in the greeting of the new account and reset password emails.

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
@@ -121,7 +121,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 				$this->user_login         = stripslashes( $this->object->user_login );
 				$this->user_email         = stripslashes( $this->object->user_email );
 				$customer                 = new WC_Customer( $user_id );
-				$first_name               = $customer->get_billing_first_name() ?: $this->object->first_name;
+				$first_name               = ! empty( $customer->get_billing_first_name() ) ? $customer->get_billing_first_name() : $this->object->first_name;
 				$this->user_display_name  = ! empty( $first_name ) ? $first_name : $this->user_login;
 				$this->recipient          = $this->user_email;
 				$this->user_pass          = $user_pass;

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
@@ -59,6 +59,13 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 		public $set_password_url;
 
 		/**
+		 * User display name (first name, or login as fallback).
+		 *
+		 * @var string
+		 */
+		public $user_display_name;
+
+		/**
 		 * Constructor.
 		 */
 		public function __construct() {
@@ -113,6 +120,9 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 				$this->set_password_url   = $this->generate_set_password_url();
 				$this->user_login         = stripslashes( $this->object->user_login );
 				$this->user_email         = stripslashes( $this->object->user_email );
+				$customer                 = new WC_Customer( $user_id );
+				$first_name               = $customer->get_billing_first_name() ?: $this->object->first_name;
+				$this->user_display_name  = ! empty( $first_name ) ? $first_name : $this->user_login;
 				$this->recipient          = $this->user_email;
 				$this->user_pass          = $user_pass;
 				$this->password_generated = $password_generated;
@@ -135,6 +145,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'email_heading'      => $this->get_heading(),
 					'additional_content' => $this->get_additional_content(),
 					'user_login'         => $this->user_login,
+					'user_display_name'  => $this->user_display_name,
 					'blogname'           => $this->get_blogname(),
 					'set_password_url'   => $this->set_password_url,
 					'sent_to_admin'      => false,
@@ -158,6 +169,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'email_heading'      => $this->get_heading(),
 					'additional_content' => $this->get_additional_content(),
 					'user_login'         => $this->user_login,
+					'user_display_name'  => $this->user_display_name,
 					'blogname'           => $this->get_blogname(),
 					'set_password_url'   => $this->set_password_url,
 					'sent_to_admin'      => false,
@@ -179,6 +191,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 				$this->template_block_content,
 				array(
 					'user_login'         => $this->user_login,
+					'user_display_name'  => $this->user_display_name,
 					'set_password_url'   => $this->set_password_url,
 					'sent_to_admin'      => false,
 					'plain_text'         => false,

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
@@ -121,8 +121,8 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 			$this->setup_locale();
 
 			if ( $user_login && $reset_key ) {
-				$this->object            = get_user_by( 'login', $user_login );
-				if ( ! ( $this->object instanceof WP_User ) ) {
+				$this->object = get_user_by( 'login', $user_login );
+				if ( ! $this->object ) {
 					$this->restore_locale();
 					return;
 				}

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
@@ -121,14 +121,14 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 			$this->setup_locale();
 
 			if ( $user_login && $reset_key ) {
-				$this->object     = get_user_by( 'login', $user_login );
-				$this->user_id    = $this->object->ID;
-				$this->user_login = $user_login;
-				$this->reset_key  = $reset_key;
-				$this->user_email = stripslashes( $this->object->user_email );
-				$this->recipient  = $this->user_email;
+				$this->object            = get_user_by( 'login', $user_login );
+				$this->user_id           = $this->object->ID;
+				$this->user_login        = $user_login;
+				$this->reset_key         = $reset_key;
+				$this->user_email        = stripslashes( $this->object->user_email );
+				$this->recipient         = $this->user_email;
 				$customer                = new WC_Customer( $this->object->ID );
-				$first_name              = $customer->get_billing_first_name() ?: $this->object->first_name;
+				$first_name              = ! empty( $customer->get_billing_first_name() ) ? $customer->get_billing_first_name() : $this->object->first_name;
 				$this->user_display_name = ! empty( $first_name ) ? $first_name : $this->user_login;
 			}
 
@@ -193,13 +193,13 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 			return wc_get_template_html(
 				$this->template_block_content,
 				array(
-					'user_id'       => $this->user_id,
-					'user_login'    => $this->user_login,
+					'user_id'           => $this->user_id,
+					'user_login'        => $this->user_login,
 					'user_display_name' => $this->user_display_name,
-					'reset_key'     => $this->reset_key,
-					'sent_to_admin' => false,
-					'plain_text'    => false,
-					'email'         => $this,
+					'reset_key'         => $this->reset_key,
+					'sent_to_admin'     => false,
+					'plain_text'        => false,
+					'email'             => $this,
 				)
 			);
 		}

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
@@ -52,6 +52,13 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		public $reset_key;
 
 		/**
+		 * User display name (first name, or login as fallback).
+		 *
+		 * @var string
+		 */
+		public $user_display_name;
+
+		/**
 		 * Constructor.
 		 */
 		public function __construct() {
@@ -120,6 +127,9 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 				$this->reset_key  = $reset_key;
 				$this->user_email = stripslashes( $this->object->user_email );
 				$this->recipient  = $this->user_email;
+				$customer                = new WC_Customer( $this->object->ID );
+				$first_name              = $customer->get_billing_first_name() ?: $this->object->first_name;
+				$this->user_display_name = ! empty( $first_name ) ? $first_name : $this->user_login;
 			}
 
 			$this->send_notification();
@@ -139,6 +149,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 					'email_heading'      => $this->get_heading(),
 					'user_id'            => $this->user_id,
 					'user_login'         => $this->user_login,
+					'user_display_name'  => $this->user_display_name,
 					'reset_key'          => $this->reset_key,
 					'blogname'           => $this->get_blogname(),
 					'additional_content' => $this->get_additional_content(),
@@ -161,6 +172,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 					'email_heading'      => $this->get_heading(),
 					'user_id'            => $this->user_id,
 					'user_login'         => $this->user_login,
+					'user_display_name'  => $this->user_display_name,
 					'reset_key'          => $this->reset_key,
 					'blogname'           => $this->get_blogname(),
 					'additional_content' => $this->get_additional_content(),
@@ -183,6 +195,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 				array(
 					'user_id'       => $this->user_id,
 					'user_login'    => $this->user_login,
+					'user_display_name' => $this->user_display_name,
 					'reset_key'     => $this->reset_key,
 					'sent_to_admin' => false,
 					'plain_text'    => false,

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
@@ -122,6 +122,10 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 
 			if ( $user_login && $reset_key ) {
 				$this->object            = get_user_by( 'login', $user_login );
+				if ( ! ( $this->object instanceof WP_User ) ) {
+					$this->restore_locale();
+					return;
+				}
 				$this->user_id           = $this->object->ID;
 				$this->user_login        = $user_login;
 				$this->reset_key         = $reset_key;

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -19069,18 +19069,6 @@ parameters:
 			path: includes/emails/class-wc-email-customer-refunded-order.php
 
 		-
-			message: '#^Cannot access property \$ID on WP_User\|false\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: includes/emails/class-wc-email-customer-reset-password.php
-
-		-
-			message: '#^Cannot access property \$user_email on WP_User\|false\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: includes/emails/class-wc-email-customer-reset-password.php
-
-		-
 			message: '#^Method WC_Email_Customer_Reset_Password\:\:trigger\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.4.0
+ * @version 10.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -31,8 +31,8 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer username */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
+<?php /* translators: %s: Customer first name, or username if name is not available */ ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ); ?></p>
 <?php if ( $email_improvements_enabled ) : ?>
 	<?php /* translators: %s: Site title */ ?>
 	<p><?php printf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), esc_html( $blogname ) ); ?></p>

--- a/plugins/woocommerce/templates/emails/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/customer-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.4.0
+ * @version 10.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -28,8 +28,8 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer username */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
+<?php /* translators: %s: Customer first name, or username if name is not available */ ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ); ?></p>
 <?php /* translators: %s: Store name */ ?>
 <p><?php printf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), esc_html( $blogname ) ); ?></p>
 <?php if ( $email_improvements_enabled ) : ?>

--- a/plugins/woocommerce/templates/emails/plain/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 10.0.0
+ * @version 10.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -25,8 +25,8 @@ echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/* translators: %s: Customer username */
-echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
+/* translators: %s: Customer first name, or username if name is not available */
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ) . "\n\n";
 if ( $email_improvements_enabled ) {
 	/* translators: %s: Site title */
 	echo sprintf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), esc_html( $blogname ) ) . "\n\n";

--- a/plugins/woocommerce/templates/emails/plain/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 9.8.0
+ * @version 10.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -25,8 +25,8 @@ echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/* translators: %s: Customer username */
-echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
+/* translators: %s: Customer first name, or username if name is not available */
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ) . "\n\n";
 /* translators: %s: Store name */
 echo sprintf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), esc_html( $blogname ) ) . "\n\n";
 if ( $email_improvements_enabled ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Use first name for greeting if available, instead of user login, on new customer account and reset password emails.

I've changed the email template version to 1.9.0 but feel free to adjust.

Closes #65269

### How to test the changes in this Pull Request:

1. Allow account creation on the checkout
2. Checkout and create a new account at the same time
3. New customer email should read "Hi your first name" instead of "Hi user login"
4. Ask for a password reset on your new account - same should happen on the email

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message

Use the customer's first name (billing first name, falling back to WordPress first name, then username) in the greeting of the new account and reset password emails.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 

Use the customer's first name (billing first name, falling back to WordPress first name, then username) in the greeting of the new account and reset password emails.
</details>
