### PR TITLE
Prime attachment post caches when listing product variations and products via REST API

### DIFF
--- a/plugins/woocommerce/changelog/64069-prime-caches-variations-rest
+++ b/plugins/woocommerce/changelog/64069-prime-caches-variations-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduce database queries when listing product variations and products via the REST API by priming attachment post caches before iterating over images.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -1135,6 +1135,12 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			$this->exclude_status = array();
 		}
 
+		$attachment_ids = array_filter( array_map( fn( $variation ) => (int) $variation->get_image_id(), $result['objects'] ) );
+		if ( ! empty( $attachment_ids ) ) {
+			// Prime caches to reduce future queries.
+			_prime_post_caches( $attachment_ids );
+		}
+
 		return $result;
 	}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -283,6 +283,11 @@ class Controller extends WC_REST_Products_V2_Controller {
 		// Add gallery images.
 		$attachment_ids = array_merge( $attachment_ids, $product->get_gallery_image_ids() );
 
+		if ( ! empty( $attachment_ids ) ) {
+			// Prime caches to reduce future queries.
+			_prime_post_caches( $attachment_ids );
+		}
+
 		// Build image data.
 		foreach ( $attachment_ids as $attachment_id ) {
 			$attachment_post = get_post( $attachment_id );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Prime attachment post caches in two REST API controllers to eliminate N+1 queries when serializing product images:

- **`WC_REST_Product_Variations_Controller::get_objects()`**: after loading the variation objects, collect all their image attachment IDs and call `_prime_post_caches()` once before `get_items()` iterates and calls `get_post($attachment_id)` per variation.
- **`Controller::get_images()` (v4 products)**: collect the featured image and all gallery image IDs for a product, call `_prime_post_caches()` once before the `foreach` that calls `get_post($attachment_id)` per image.

Closes https://github.com/woocommerce/woocommerce/issues/64069.

### How to test the changes in this Pull Request:

**Fix 1: v3 variations endpoint:**

1. Install and activate the [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin.
2. Create a variable product with 3-5 variations and assign a unique image to each variation.
3. Using a REST client (or browser while logged in as admin), call `GET /wp-json/wc/v3/products/{id}/variations` with valid credentials.
4. In Query Monitor, open the **Queries** panel and note the total query count.
5. Apply this PR's changes and repeat step 3.
6. Confirm the query count is lower, you should see one fewer query per variation that has an image (replaced by a single batch prime).

**Fix 2: v4 products endpoint:**

1. Enable the `rest-api-v4` and `products-catalog-api` feature flags via **Tools → WC Admin Test Helper → Features**.
2. Ensure several products have gallery images (multiple images per product).
3. Call `GET /wp-json/wc/v4/products` with valid credentials.
4. Check Query Monitor's **Queries** panel and note the query count for products with multiple images.
5. Revert the fix and repeat each additional gallery image should add 2 extra queries per product.
6. Re-apply the fix and confirm multi-image products batch into 2 queries regardless of image count.

### Testing that has already taken place:

Tested on a local `wp-env` environment (PHP 8.1, WordPress 7.0, WooCommerce 10.9.0-dev). Query counts measured using `$wpdb->num_queries` instrumentation per request.

**Fix 1: `GET /wc/v3/products/16/variations`** (4 variations, each with 1 image):

- **Before:** 35 queries, each `get_post($attachment_id)` fires individually (1 post query + 1 meta query per variation image)
- **After:** 29 queries, a single `_prime_post_caches()` call loads all 4 attachment posts and their meta in two batched queries; subsequent `get_post()` calls are served from cache
- **Saved: 6 queries**

**Fix 2 — `GET /wc/v4/products`** (10 products, mixed image counts):

- **Before:** 22 image-related queries: 2 queries per image fired individually (1 post + 1 meta each); a product with 4 gallery images triggered 8 queries
- **After:** 16 image-related queries: 2 queries per product regardless of how many images it has; the same 4-image product now costs 2 queries
- **Saved: 6 queries**

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
