### PR TITLE
Add product attributes to Quick Edit

### DIFF
--- a/plugins/woocommerce/changelog/add-quick-edit-product-attributes
+++ b/plugins/woocommerce/changelog/add-quick-edit-product-attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add global product attributes to the classic Products quick edit panel.

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -177,13 +177,13 @@ class ProductCollectionPage {
 		}
 
 		await this.clickChooseCollectionButton( placeholderSelector );
-
-		await this.admin.page
-			.locator(
-				'.wc-blocks-product-collection__collections-dropdown-content'
-			)
-			.getByRole( 'button', { name: buttonName, exact: true } )
-			.click();
+		await this.clickCollectionDropdownOption(
+			buttonName,
+			[ this.admin.page, this.editor.canvas ],
+			async () => {
+				await this.clickChooseCollectionButton( placeholderSelector );
+			}
+		);
 	}
 
 	async chooseCollectionInTemplate( collection?: Collections ) {
@@ -207,13 +207,15 @@ class ProductCollectionPage {
 
 		if ( isDropdown ) {
 			await this.clickChooseCollectionButton( this.editor.canvas );
-
-			await this.editor.canvas
-				.locator(
-					'.wc-blocks-product-collection__collections-dropdown-content'
-				)
-				.getByRole( 'button', { name: buttonName, exact: true } )
-				.click();
+			await this.clickCollectionDropdownOption(
+				buttonName,
+				[ this.editor.canvas, this.admin.page ],
+				async () => {
+					await this.clickChooseCollectionButton(
+						this.editor.canvas
+					);
+				}
+			);
 		} else {
 			await this.editor.canvas
 				.locator( SELECTORS.collectionPlaceholder )
@@ -825,6 +827,50 @@ class ProductCollectionPage {
 				await this.dismissBlockEditorCardPopover();
 				await chooseCollectionButton.click( { force: true } );
 			} );
+	}
+
+	private async clickCollectionDropdownOption(
+		buttonName: string,
+		containers: Array< Page | FrameLocator >,
+		openDropdown: () => Promise< void >
+	) {
+		let lastError: unknown;
+
+		for ( let attempt = 0; attempt < 2; attempt++ ) {
+			if ( attempt > 0 ) {
+				await this.dismissBlockEditorCardPopover();
+				await openDropdown();
+			}
+
+			for ( const container of containers ) {
+				const option = container
+					.locator(
+						'.wc-blocks-product-collection__collections-dropdown-content'
+					)
+					.getByRole( 'button', {
+						name: buttonName,
+						exact: true,
+					} );
+
+				try {
+					await option.waitFor( {
+						state: 'visible',
+						timeout: 3000,
+					} );
+					await option.scrollIntoViewIfNeeded();
+					await option.click( { timeout: 5000 } ).catch( async () => {
+						await option.click( { force: true } );
+					} );
+					return;
+				} catch ( error ) {
+					lastError = error;
+				}
+			}
+		}
+
+		throw lastError instanceof Error
+			? lastError
+			: new Error( `Unable to choose collection "${ buttonName }".` );
 	}
 
 	async refreshLocators( currentUI: 'editor' | 'frontend' ) {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -176,11 +176,7 @@ class ProductCollectionPage {
 			return;
 		}
 
-		await placeholderSelector
-			.getByRole( 'button', {
-				name: 'Choose collection',
-			} )
-			.click();
+		await this.clickChooseCollectionButton( placeholderSelector );
 
 		await this.admin.page
 			.locator(
@@ -210,9 +206,7 @@ class ProductCollectionPage {
 		await this.dismissBlockEditorCardPopover();
 
 		if ( isDropdown ) {
-			await this.editor.canvas
-				.getByRole( 'button', { name: 'Choose collection' } )
-				.click();
+			await this.clickChooseCollectionButton( this.editor.canvas );
 
 			await this.editor.canvas
 				.locator(
@@ -792,7 +786,7 @@ class ProductCollectionPage {
 		await this.page.keyboard.press( 'Escape' );
 		await blockCardPopover
 			.waitFor( { state: 'hidden', timeout: 3000 } )
-			.catch( () => {} );
+			.catch( () => undefined );
 	}
 
 	async getCollectionHeading() {
@@ -817,6 +811,20 @@ class ProductCollectionPage {
 			.nth( 0 )
 			.click();
 		await singleProductBlock.getByText( 'Done' ).click();
+	}
+
+	private async clickChooseCollectionButton( container: Locator ) {
+		const chooseCollectionButton = container.getByRole( 'button', {
+			name: 'Choose collection',
+		} );
+
+		await chooseCollectionButton.scrollIntoViewIfNeeded();
+		await chooseCollectionButton
+			.click( { timeout: 5000 } )
+			.catch( async () => {
+				await this.dismissBlockEditorCardPopover();
+				await chooseCollectionButton.click( { force: true } );
+			} );
 	}
 
 	async refreshLocators( currentUI: 'editor' | 'frontend' ) {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -790,7 +790,9 @@ class ProductCollectionPage {
 		);
 
 		await this.page.keyboard.press( 'Escape' );
-		await blockCardPopover.waitFor( { state: 'hidden', timeout: 3000 } );
+		await blockCardPopover
+			.waitFor( { state: 'hidden', timeout: 3000 } )
+			.catch( () => {} );
 	}
 
 	async getCollectionHeading() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -157,32 +157,37 @@ class ProductCollectionPage {
 		const placeholderSelector = this.editor.canvas.locator(
 			SELECTORS.collectionPlaceholder
 		);
+		const inserter = placeholderSelector.locator(
+			'.wc-blocks-product-collection__collections-grid, .wc-blocks-product-collection__collections-dropdown'
+		);
 
-		const chooseCollectionFromPlaceholder = async () => {
+		await inserter.waitFor( { state: 'visible' } );
+		await this.dismissBlockEditorCardPopover();
+
+		const inserterClass = await inserter.getAttribute( 'class' );
+		const isDropdown = inserterClass?.includes(
+			'wc-blocks-product-collection__collections-dropdown'
+		);
+
+		if ( ! isDropdown ) {
 			await placeholderSelector
 				.getByRole( 'button', { name: buttonName, exact: true } )
 				.click();
-		};
+			return;
+		}
 
-		const chooseCollectionFromDropdown = async () => {
-			await placeholderSelector
-				.getByRole( 'button', {
-					name: 'Choose collection',
-				} )
-				.click();
+		await placeholderSelector
+			.getByRole( 'button', {
+				name: 'Choose collection',
+			} )
+			.click();
 
-			await this.admin.page
-				.locator(
-					'.wc-blocks-product-collection__collections-dropdown-content'
-				)
-				.getByRole( 'button', { name: buttonName, exact: true } )
-				.click();
-		};
-
-		await Promise.any( [
-			chooseCollectionFromPlaceholder(),
-			chooseCollectionFromDropdown(),
-		] );
+		await this.admin.page
+			.locator(
+				'.wc-blocks-product-collection__collections-dropdown-content'
+			)
+			.getByRole( 'button', { name: buttonName, exact: true } )
+			.click();
 	}
 
 	async chooseCollectionInTemplate( collection?: Collections ) {
@@ -202,6 +207,7 @@ class ProductCollectionPage {
 		const isDropdown = inserterClass?.includes(
 			'wc-blocks-product-collection__collections-dropdown'
 		);
+		await this.dismissBlockEditorCardPopover();
 
 		if ( isDropdown ) {
 			await this.editor.canvas
@@ -776,6 +782,15 @@ class ProductCollectionPage {
 
 	locateByTestId( testId: string ) {
 		return this.page.getByTestId( testId );
+	}
+
+	async dismissBlockEditorCardPopover() {
+		const blockCardPopover = this.page.locator(
+			'.components-popover__fallback-container .block-editor-block-card'
+		);
+
+		await this.page.keyboard.press( 'Escape' );
+		await blockCardPopover.waitFor( { state: 'hidden', timeout: 3000 } );
 	}
 
 	async getCollectionHeading() {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1746,12 +1746,16 @@ table.wc_status_table--tools {
 
 	.product_attributes_fields {
 		clear: both;
-		margin: 0.2em 0 0.4em;
+		margin: 0.2em 0 1em;
 
 		label {
 			clear: both;
 			display: block;
 			margin: 0.2em 0;
+		}
+
+		.wc-product-attribute-field {
+			display: none;
 		}
 
 		span.title {
@@ -1772,6 +1776,54 @@ table.wc_status_table--tools {
 
 		.select2-selection--multiple {
 			border-radius: 2px;
+		}
+
+		.wc-product-attribute-add-field {
+			margin-bottom: 0.45em;
+			margin-top: 0.55em;
+
+			span.title {
+				align-items: center;
+				display: flex;
+				line-height: 1.25;
+				min-height: 32px;
+			}
+
+			span.title[hidden] {
+				display: none;
+			}
+
+			.select2-selection--single {
+				align-items: center;
+				box-sizing: border-box;
+				border-radius: 2px;
+				display: flex;
+				height: 32px;
+			}
+
+			.select2-selection__rendered {
+				flex: 1;
+				line-height: normal;
+				min-width: 0;
+			}
+
+			.select2-selection__arrow {
+				height: 30px;
+			}
+
+			.wc-product-attribute-add-message {
+				align-items: center;
+				box-sizing: border-box;
+				color: #646970;
+				display: flex;
+				line-height: 1.4;
+				margin-left: 1px;
+				min-height: 32px;
+			}
+
+			.wc-product-attribute-add-message[hidden] {
+				display: none;
+			}
 		}
 
 		.select2-container:not(.select2-container--open) {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1684,6 +1684,10 @@ table.wc_status_table--tools {
  * Inline edit
  */
 .inline-edit-product.quick-edit-row {
+	.inline-edit-col-left {
+		min-width: 0;
+	}
+
 	.inline-edit-col-center,
 	.inline-edit-col-right {
 		float: right !important;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1812,6 +1812,22 @@ table.wc_status_table--tools {
 	}
 }
 
+.select2-container--open {
+	.wc-product-quick-edit-attribute-dropdown {
+		border-radius: 2px;
+	}
+
+	.wc-product-quick-edit-attribute-dropdown.select2-dropdown--below {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+	}
+
+	.wc-product-quick-edit-attribute-dropdown.select2-dropdown--above {
+		border-bottom-left-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+}
+
 #woocommerce-fields-bulk.inline-edit-col {
 	label {
 		clear: left;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1771,6 +1771,17 @@ table.wc_status_table--tools {
 		}
 
 		.select2-container:not(.select2-container--open) {
+			.select2-selection__rendered {
+				box-sizing: border-box;
+				min-height: 38px;
+				padding: 6px 5px;
+			}
+
+			.select2-selection__choice {
+				margin-top: 0;
+				margin-bottom: 0;
+			}
+
 			.select2-search--inline {
 				width: 0;
 				height: 0;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1688,6 +1688,10 @@ table.wc_status_table--tools {
 		min-width: 0;
 	}
 
+	.woocommerce-product-data-fields {
+		clear: left;
+	}
+
 	.inline-edit-col-center,
 	.inline-edit-col-right {
 		float: right !important;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1790,6 +1790,8 @@ table.wc_status_table--tools {
 			}
 
 			.select2-selection__choice {
+				margin-left: 0;
+				margin-right: 0;
 				margin-top: 0;
 				margin-bottom: 0;
 				padding: 1px 5px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1788,6 +1788,7 @@ table.wc_status_table--tools {
 			.select2-selection__choice {
 				margin-top: 0;
 				margin-bottom: 0;
+				padding: 1px 5px;
 			}
 
 			.select2-search--inline {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1710,12 +1710,12 @@ table.wc_status_table--tools {
 		span.title {
 			display: block;
 			float: left;
-			width: 5em;
+			width: 6em;
 		}
 
 		span.input-text-wrap {
 			display: block;
-			margin-left: 5em;
+			margin-left: 6em;
 		}
 	}
 
@@ -1734,6 +1734,53 @@ table.wc_status_table--tools {
 
 	.height {
 		margin-right: 0;
+	}
+
+	.product_attributes_fields {
+		clear: both;
+		margin: 0.2em 0 0.4em;
+
+		label {
+			clear: both;
+			display: block;
+			margin: 0.2em 0;
+		}
+
+		span.title {
+			display: block;
+			float: left;
+			width: 6em;
+		}
+
+		span.input-text-wrap {
+			display: block;
+			margin-left: 6em;
+		}
+
+		.select2-container {
+			margin-left: 1px;
+			width: 99% !important;
+		}
+
+		.select2-selection--multiple {
+			border-radius: 2px;
+		}
+
+		.select2-container:not(.select2-container--open) {
+			.select2-search--inline {
+				width: 0;
+				height: 0;
+				overflow: hidden;
+			}
+
+			.select2-search__field {
+				width: 0 !important;
+				min-width: 0;
+				min-height: 0;
+				height: 0;
+				padding: 0;
+			}
+		}
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1771,10 +1771,18 @@ table.wc_status_table--tools {
 		}
 
 		.select2-container:not(.select2-container--open) {
+			.select2-selection--multiple {
+				min-height: 32px;
+			}
+
 			.select2-selection__rendered {
+				align-items: center;
 				box-sizing: border-box;
-				min-height: 38px;
-				padding: 6px 5px;
+				display: flex;
+				flex-wrap: wrap;
+				gap: 4px 6px;
+				min-height: 30px;
+				padding: 2px 5px;
 			}
 
 			.select2-selection__choice {

--- a/plugins/woocommerce/client/legacy/js/admin/quick-edit.js
+++ b/plugins/woocommerce/client/legacy/js/admin/quick-edit.js
@@ -1,6 +1,29 @@
 /*global inlineEditPost, woocommerce_admin, woocommerce_quick_edit */
 jQuery(
 	function( $ ) {
+		function populateProductAttributes( $quick_edit_row, $wc_inline_data ) {
+			var attributes = $wc_inline_data.find( '.product_attributes' ).data( 'attributes' ) || {};
+
+			$quick_edit_row.find( 'select.wc-product-attribute-values' ).each(
+				function() {
+					var $select  = $( this ),
+						taxonomy = $select.data( 'taxonomy' ),
+						terms    = attributes[ taxonomy ] ? attributes[ taxonomy ].terms : [];
+
+					$select.empty();
+
+					$.each(
+						terms,
+						function( index, term ) {
+							$select.append( new Option( term.name, term.id, true, true ) );
+						}
+					);
+
+					$select.trigger( 'change' );
+				}
+			);
+		}
+
 		$( '#the-list' ).on(
 			'click',
 			'.editinline',
@@ -49,6 +72,7 @@ jQuery(
 				$( 'input[name="_length"]', '.inline-edit-row' ).val( length );
 				$( 'input[name="_width"]', '.inline-edit-row' ).val( width );
 				$( 'input[name="_height"]', '.inline-edit-row' ).val( height );
+				populateProductAttributes( $( '#edit-' + post_id ), $wc_inline_data );
 
 				$( 'select[name="_shipping_class"] option:selected', '.inline-edit-row' ).attr( 'selected', false ).trigger( 'change' );
 				$( 'select[name="_shipping_class"] option[value="' + shipping_class + '"]' ).attr( 'selected', 'selected' )
@@ -144,6 +168,7 @@ jQuery(
 			function() {
 				$( 'input.text', '.inline-edit-row' ).val( '' );
 				$( '#woocommerce-fields' ).find( 'select' ).prop( 'selectedIndex', 0 );
+				$( '#woocommerce-fields' ).find( 'select.wc-product-attribute-values' ).val( [] ).trigger( 'change' );
 				$( '#woocommerce-fields-bulk' ).find( '.inline-edit-group .change-input' ).hide();
 			}
 		);

--- a/plugins/woocommerce/client/legacy/js/admin/quick-edit.js
+++ b/plugins/woocommerce/client/legacy/js/admin/quick-edit.js
@@ -1,14 +1,120 @@
 /*global inlineEditPost, woocommerce_admin, woocommerce_quick_edit */
 jQuery(
 	function( $ ) {
+		function attributeDataHasTaxonomy( attributes, taxonomy ) {
+			return Object.prototype.hasOwnProperty.call( attributes, taxonomy );
+		}
+
+		function setProductAttributeFieldVisibility( $select, isVisible ) {
+			var $label = $select.closest( 'label' );
+
+			if ( ! isVisible ) {
+				if ( $select.hasClass( 'select2-hidden-accessible' ) ) {
+					$select.selectWoo( 'close' );
+				}
+
+				clearProductAttributeDropdownSpacing( $select );
+			}
+
+			$select.prop( 'disabled', ! isVisible );
+			$label
+				.find( 'input.wc-product-attribute-taxonomy' )
+				.prop( 'disabled', ! isVisible );
+			$label.css( 'display', isVisible ? 'block' : 'none' );
+		}
+
+		function getVisibleProductAttributeTaxonomies( $quick_edit_row ) {
+			var taxonomies = [];
+
+			$quick_edit_row.find( 'select.wc-product-attribute-values' ).each(
+				function() {
+					var $select  = $( this ),
+						taxonomy = $select.data( 'taxonomy' );
+
+					if ( taxonomy && ! $select.prop( 'disabled' ) ) {
+						taxonomies.push( taxonomy );
+					}
+				}
+			);
+
+			return taxonomies;
+		}
+
+		function updateProductAttributeAddSearch( $quick_edit_row ) {
+			var visibleTaxonomies  = getVisibleProductAttributeTaxonomies(
+					$quick_edit_row
+				),
+				hasHiddenTaxonomies = false,
+				$addField           = $quick_edit_row.find(
+					'.wc-product-attribute-add-field'
+				),
+				$addSelect          = $quick_edit_row.find(
+					'select.wc-product-attribute-add'
+				),
+				$addTitle           = $addField.find( 'span.title' ),
+				$addMessage         = $addField.find(
+					'.wc-product-attribute-add-message'
+				);
+
+			if ( ! $addField.length ) {
+				return;
+			}
+
+			$quick_edit_row.find( 'select.wc-product-attribute-values' ).each(
+				function() {
+					if ( $( this ).prop( 'disabled' ) ) {
+						hasHiddenTaxonomies = true;
+						return false;
+					}
+				}
+			);
+
+			$addSelect.data( 'disabled-items', visibleTaxonomies );
+			$addField.css( 'display', 'block' );
+			$addSelect.prop( 'disabled', ! hasHiddenTaxonomies );
+			$addSelect
+				.next( '.select2-container' )
+				.css( 'display', hasHiddenTaxonomies ? '' : 'none' );
+			$addTitle.prop( 'hidden', ! hasHiddenTaxonomies );
+			$addMessage.prop( 'hidden', hasHiddenTaxonomies );
+
+			if (
+				! hasHiddenTaxonomies &&
+				$addSelect.hasClass( 'select2-hidden-accessible' )
+			) {
+				$addSelect.selectWoo( 'close' );
+				$addSelect.val( null ).trigger( 'change' );
+			}
+		}
+
+		function showProductAttributeField( $quick_edit_row, taxonomy ) {
+			var $select = $quick_edit_row
+				.find( 'select.wc-product-attribute-values' )
+				.filter(
+					function() {
+						return $( this ).data( 'taxonomy' ) === taxonomy;
+					}
+				)
+				.first();
+
+			if ( ! $select.length ) {
+				return;
+			}
+
+			setProductAttributeFieldVisibility( $select, true );
+			$select.trigger( 'change' );
+			updateProductAttributeAddSearch( $quick_edit_row );
+		}
+
 		function populateProductAttributes( $quick_edit_row, $wc_inline_data ) {
 			var attributes = $wc_inline_data.find( '.product_attributes' ).data( 'attributes' ) || {};
 
 			$quick_edit_row.find( 'select.wc-product-attribute-values' ).each(
 				function() {
-					var $select  = $( this ),
-						taxonomy = $select.data( 'taxonomy' ),
-						terms    = attributes[ taxonomy ] ? attributes[ taxonomy ].terms : [];
+					var $select      = $( this ),
+						taxonomy     = $select.data( 'taxonomy' ),
+						hasAttribute = attributeDataHasTaxonomy( attributes, taxonomy ),
+						terms        = hasAttribute && attributes[ taxonomy ].terms ? attributes[ taxonomy ].terms : [];
 
 					$select.empty();
 
@@ -19,37 +125,47 @@ jQuery(
 						}
 					);
 
+					setProductAttributeFieldVisibility( $select, hasAttribute );
 					$select.trigger( 'change' );
 				}
 			);
+
+			updateProductAttributeAddSearch( $quick_edit_row );
 		}
 
 		function updateProductAttributeDropdownSpacing( $select ) {
 			var $label    = $select.closest( 'label' ),
 				$dropdown = $( '.select2-container--open .select2-dropdown' ).last(),
+				$selection = $label.find( '.select2-selection' ).first(),
 				dropdownRect,
 				labelRect,
-				dropdownOverlap;
+				selectionRect,
+				dropdownOverlap,
+				openLabelHeight;
 
 			if (
 				! $label.hasClass( 'wc-product-attribute-values-open' ) ||
 				! $dropdown.length ||
 				$dropdown.hasClass( 'select2-dropdown--above' )
 			) {
-				$label.css( 'margin-bottom', '' );
+				$label.css( { 'margin-bottom': '', 'min-height': '' } );
 				return;
 			}
 
 			dropdownRect = $dropdown[0].getBoundingClientRect();
-			labelRect    = $label[0].getBoundingClientRect();
+			labelRect = $label[0].getBoundingClientRect();
+			selectionRect = (
+				$selection.length ? $selection[0] : $label[0]
+			).getBoundingClientRect();
 
-			dropdownOverlap = Math.ceil( dropdownRect.bottom - labelRect.bottom );
-			$label.css( 'margin-bottom', 0 < dropdownOverlap ? dropdownOverlap + 6 + 'px' : '' );
+			dropdownOverlap = Math.ceil( dropdownRect.bottom - selectionRect.bottom );
+			openLabelHeight = Math.ceil( dropdownRect.bottom - labelRect.top + 6 );
+			$label.css( 'min-height', 0 < dropdownOverlap ? openLabelHeight + 'px' : '' );
 		}
 
 		function scheduleProductAttributeDropdownSpacing( $select ) {
 			$.each(
-				[ 0, 100, 500 ],
+				[ 0, 50, 100, 250, 500 ],
 				function( index, delay ) {
 					window.setTimeout(
 						function() {
@@ -61,15 +177,30 @@ jQuery(
 			);
 		}
 
-		function observeProductAttributeDropdownSpacing( $select ) {
+		function observeProductAttributeDropdownSpacing( $select, attempts ) {
 			var observer  = $select.data( 'wcQuickEditAttributeDropdownObserver' ),
 				$dropdown = $( '.select2-container--open .select2-dropdown' ).last();
+
+			attempts = attempts || 0;
 
 			if ( observer ) {
 				observer.disconnect();
 			}
 
-			if ( ! window.MutationObserver || ! $dropdown.length ) {
+			if ( ! window.MutationObserver ) {
+				return;
+			}
+
+			if ( ! $dropdown.length ) {
+				if ( attempts < 10 ) {
+					window.setTimeout(
+						function() {
+							observeProductAttributeDropdownSpacing( $select, attempts + 1 );
+						},
+						50
+					);
+				}
+
 				return;
 			}
 
@@ -103,12 +234,13 @@ jQuery(
 			$select
 				.closest( 'label' )
 				.removeClass( 'wc-product-attribute-values-open' )
-				.css( 'margin-bottom', '' );
+				.css( { 'margin-bottom': '', 'min-height': '' } );
 		}
 
 		function initProductAttributes( postId, $wc_inline_data, attempts ) {
 			var $quick_edit_row = $( '#edit-' + postId ),
-				$attribute_selects;
+				$attribute_selects,
+				$attribute_add_select;
 
 			attempts = attempts || 0;
 
@@ -143,6 +275,31 @@ jQuery(
 					'select2:close.wcQuickEditAttributes',
 					function() {
 						clearProductAttributeDropdownSpacing( $( this ) );
+					}
+				);
+
+			$attribute_add_select = $quick_edit_row.find(
+				'select.wc-product-attribute-add'
+			);
+			$attribute_add_select
+				.addClass( 'wc-attribute-search' )
+				.off( '.wcQuickEditAttributeAdd' )
+				.on(
+					'select2:select.wcQuickEditAttributeAdd',
+					function( event ) {
+						var taxonomy =
+							event &&
+							event.params &&
+							event.params.data &&
+							event.params.data.id;
+
+						if ( taxonomy ) {
+							showProductAttributeField( $quick_edit_row, taxonomy );
+						}
+
+						$( this ).val( null ).trigger( 'change' );
+
+						return false;
 					}
 				);
 

--- a/plugins/woocommerce/client/legacy/js/admin/quick-edit.js
+++ b/plugins/woocommerce/client/legacy/js/admin/quick-edit.js
@@ -24,6 +24,34 @@ jQuery(
 			);
 		}
 
+		function initProductAttributes( postId, $wc_inline_data, attempts ) {
+			var $quick_edit_row = $( '#edit-' + postId ),
+				$attribute_selects;
+
+			attempts = attempts || 0;
+
+			if ( ! $quick_edit_row.length || ! $quick_edit_row.is( ':visible' ) ) {
+				if ( attempts < 10 ) {
+					window.setTimeout(
+						function() {
+							initProductAttributes( postId, $wc_inline_data, attempts + 1 );
+						},
+						50
+					);
+				}
+
+				return;
+			}
+
+			$attribute_selects = $quick_edit_row.find( 'select.wc-product-attribute-values' );
+			$attribute_selects
+				.addClass( 'wc-taxonomy-term-search' )
+				.off( '.wcQuickEditAttributes' );
+
+			$( document.body ).trigger( 'wc-enhanced-select-init' );
+			populateProductAttributes( $quick_edit_row, $wc_inline_data );
+		}
+
 		$( '#the-list' ).on(
 			'click',
 			'.editinline',
@@ -72,7 +100,7 @@ jQuery(
 				$( 'input[name="_length"]', '.inline-edit-row' ).val( length );
 				$( 'input[name="_width"]', '.inline-edit-row' ).val( width );
 				$( 'input[name="_height"]', '.inline-edit-row' ).val( height );
-				populateProductAttributes( $( '#edit-' + post_id ), $wc_inline_data );
+				initProductAttributes( post_id, $wc_inline_data );
 
 				$( 'select[name="_shipping_class"] option:selected', '.inline-edit-row' ).attr( 'selected', false ).trigger( 'change' );
 				$( 'select[name="_shipping_class"] option[value="' + shipping_class + '"]' ).attr( 'selected', 'selected' )

--- a/plugins/woocommerce/client/legacy/js/admin/quick-edit.js
+++ b/plugins/woocommerce/client/legacy/js/admin/quick-edit.js
@@ -24,6 +24,88 @@ jQuery(
 			);
 		}
 
+		function updateProductAttributeDropdownSpacing( $select ) {
+			var $label    = $select.closest( 'label' ),
+				$dropdown = $( '.select2-container--open .select2-dropdown' ).last(),
+				dropdownRect,
+				labelRect,
+				dropdownOverlap;
+
+			if (
+				! $label.hasClass( 'wc-product-attribute-values-open' ) ||
+				! $dropdown.length ||
+				$dropdown.hasClass( 'select2-dropdown--above' )
+			) {
+				$label.css( 'margin-bottom', '' );
+				return;
+			}
+
+			dropdownRect = $dropdown[0].getBoundingClientRect();
+			labelRect    = $label[0].getBoundingClientRect();
+
+			dropdownOverlap = Math.ceil( dropdownRect.bottom - labelRect.bottom );
+			$label.css( 'margin-bottom', 0 < dropdownOverlap ? dropdownOverlap + 6 + 'px' : '' );
+		}
+
+		function scheduleProductAttributeDropdownSpacing( $select ) {
+			$.each(
+				[ 0, 100, 500 ],
+				function( index, delay ) {
+					window.setTimeout(
+						function() {
+							updateProductAttributeDropdownSpacing( $select );
+						},
+						delay
+					);
+				}
+			);
+		}
+
+		function observeProductAttributeDropdownSpacing( $select ) {
+			var observer  = $select.data( 'wcQuickEditAttributeDropdownObserver' ),
+				$dropdown = $( '.select2-container--open .select2-dropdown' ).last();
+
+			if ( observer ) {
+				observer.disconnect();
+			}
+
+			if ( ! window.MutationObserver || ! $dropdown.length ) {
+				return;
+			}
+
+			observer = new window.MutationObserver(
+				function() {
+					updateProductAttributeDropdownSpacing( $select );
+				}
+			);
+
+			observer.observe(
+				$dropdown[0],
+				{
+					attributes: true,
+					childList: true,
+					characterData: true,
+					subtree: true,
+				}
+			);
+
+			$select.data( 'wcQuickEditAttributeDropdownObserver', observer );
+		}
+
+		function clearProductAttributeDropdownSpacing( $select ) {
+			var observer = $select.data( 'wcQuickEditAttributeDropdownObserver' );
+
+			if ( observer ) {
+				observer.disconnect();
+				$select.removeData( 'wcQuickEditAttributeDropdownObserver' );
+			}
+
+			$select
+				.closest( 'label' )
+				.removeClass( 'wc-product-attribute-values-open' )
+				.css( 'margin-bottom', '' );
+		}
+
 		function initProductAttributes( postId, $wc_inline_data, attempts ) {
 			var $quick_edit_row = $( '#edit-' + postId ),
 				$attribute_selects;
@@ -46,7 +128,23 @@ jQuery(
 			$attribute_selects = $quick_edit_row.find( 'select.wc-product-attribute-values' );
 			$attribute_selects
 				.addClass( 'wc-taxonomy-term-search' )
-				.off( '.wcQuickEditAttributes' );
+				.off( '.wcQuickEditAttributes' )
+				.on(
+					'select2:open.wcQuickEditAttributes',
+					function() {
+						var $select = $( this );
+
+						$select.closest( 'label' ).addClass( 'wc-product-attribute-values-open' );
+						scheduleProductAttributeDropdownSpacing( $select );
+						observeProductAttributeDropdownSpacing( $select );
+					}
+				)
+				.on(
+					'select2:close.wcQuickEditAttributes',
+					function() {
+						clearProductAttributeDropdownSpacing( $( this ) );
+					}
+				);
 
 			$( document.body ).trigger( 'wc-enhanced-select-init' );
 			populateProductAttributes( $quick_edit_row, $wc_inline_data );

--- a/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
@@ -1,7 +1,10 @@
 /*global wc_enhanced_select_params */
 jQuery( function( $ ) {
+	var taxonomyTermSearchCache = {};
 
-	function getEnhancedSelectFormatString() {
+	function getEnhancedSelectFormatString( options ) {
+		options = options || {};
+
 		return {
 			'language': {
 				errorLoading: function() {
@@ -39,11 +42,57 @@ jQuery( function( $ ) {
 				noResults: function() {
 					return wc_enhanced_select_params.i18n_no_matches;
 				},
-				searching: function() {
+				searching: function( args ) {
+					if ( options.loadingWithoutSearchTerm && ( ! args || ! args.term ) ) {
+						return wc_enhanced_select_params.i18n_loading;
+					}
+
 					return wc_enhanced_select_params.i18n_searching;
 				}
 			}
 		};
+	}
+
+	function getMinimumInputLength( element, default_length ) {
+		var minimum_input_length = $( element ).data( 'minimum_input_length' );
+
+		return minimum_input_length !== null && minimum_input_length !== undefined ? minimum_input_length : default_length;
+	}
+
+	function getTaxonomyTermSearchCacheKey( data ) {
+		data = data || {};
+
+		return JSON.stringify( [
+			data.action || '',
+			data.taxonomy || '',
+			data.limit || '',
+			data.orderby || '',
+			data.order || '',
+			data.term || ''
+		] );
+	}
+
+	function cachedTaxonomyTermSearchTransport( params, success, failure ) {
+		var cache_key = getTaxonomyTermSearchCacheKey( params.data );
+
+		if ( Object.prototype.hasOwnProperty.call( taxonomyTermSearchCache, cache_key ) ) {
+			success( taxonomyTermSearchCache[ cache_key ] );
+
+			return {
+				abort: function() {}
+			};
+		}
+
+		var request = $.ajax( params );
+
+		request.then( function( data ) {
+			taxonomyTermSearchCache[ cache_key ] = data;
+			success( data );
+		} );
+
+		request.fail( failure );
+
+		return request;
 	}
 
 	try {
@@ -307,19 +356,21 @@ jQuery( function( $ ) {
 
 				// Ajax category search boxes
 				$( ':input.wc-taxonomy-term-search' ).filter( ':not(.enhanced)' ).each( function() {
-					var return_format = $( this ).data( 'return_id' ) ? 'id' : 'slug';
+					var return_format                = $( this ).data( 'return_id' ) ? 'id' : 'slug',
+						cache_results                = $( this ).data( 'cache_results' ) ? true : false,
+						loading_without_search_term = $( this ).data( 'loading_without_search_term' ) ? true : false;
 
 					var select2_args = $.extend( {
 						allowClear        : $( this ).data( 'allow_clear' ) ? true : false,
 						placeholder       : $( this ).data( 'placeholder' ),
-						minimumInputLength: $( this ).data( 'minimum_input_length' ) !== null && $( this ).data( 'minimum_input_length' ) !== undefined ? $( this ).data( 'minimum_input_length' ) : '3',
+						minimumInputLength: getMinimumInputLength( this, '3' ),
 						escapeMarkup      : function( m ) {
 							return m;
 						},
 						ajax: {
 							url:         wc_enhanced_select_params.ajax_url,
 							dataType:    'json',
-							delay:       250,
+							delay:       cache_results ? 0 : 250,
 							data:        function( params ) {
 								return {
 									taxonomy: $( this ).data( 'taxonomy' ),
@@ -346,7 +397,11 @@ jQuery( function( $ ) {
 							},
 							cache: true
 						}
-					}, getEnhancedSelectFormatString() );
+					}, getEnhancedSelectFormatString( { loadingWithoutSearchTerm: loading_without_search_term } ) );
+
+					if ( cache_results ) {
+						select2_args.ajax.transport = cachedTaxonomyTermSearchTransport;
+					}
 
 					$( this ).selectWoo( select2_args ).addClass( 'enhanced' );
 				});
@@ -356,7 +411,7 @@ jQuery( function( $ ) {
 					var select2_args = $.extend( {
 						allowClear        : $( this ).data( 'allow_clear' ) ? true : false,
 						placeholder       : $( this ).data( 'placeholder' ),
-						minimumInputLength: $( this ).data( 'minimum_input_length' ) !== null && $( this ).data( 'minimum_input_length' ) !== undefined ? $( this ).data( 'minimum_input_length' ) : '3',
+						minimumInputLength: getMinimumInputLength( this, '3' ),
 						escapeMarkup      : function( m ) {
 							return m;
 						},

--- a/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
@@ -408,6 +408,9 @@ jQuery( function( $ ) {
 
 				$( ':input.wc-attribute-search' ).filter( ':not(.enhanced)' ).each( function() {
 					var select2Element = this;
+					var loading_without_search_term = $( this ).data( 'loading_without_search_term' ) === true || (
+						$( this ).data( 'loading_without_search_term' ) === 'true'
+					);
 					var select2_args = $.extend( {
 						allowClear        : $( this ).data( 'allow_clear' ) ? true : false,
 						placeholder       : $( this ).data( 'placeholder' ),
@@ -444,7 +447,7 @@ jQuery( function( $ ) {
 							},
 							cache: true
 						}
-					}, getEnhancedSelectFormatString() );
+					}, getEnhancedSelectFormatString( { loadingWithoutSearchTerm: loading_without_search_term } ) );
 
 					$( this ).selectWoo( select2_args ).addClass( 'enhanced' );
 				});

--- a/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
@@ -59,6 +59,12 @@ jQuery( function( $ ) {
 		return minimum_input_length !== null && minimum_input_length !== undefined ? minimum_input_length : default_length;
 	}
 
+	function isDataTrue( element, name ) {
+		var value = $( element ).data( name );
+
+		return value === true || value === 'true';
+	}
+
 	function getTaxonomyTermSearchCacheKey( data ) {
 		data = data || {};
 
@@ -358,7 +364,7 @@ jQuery( function( $ ) {
 				$( ':input.wc-taxonomy-term-search' ).filter( ':not(.enhanced)' ).each( function() {
 					var return_format                = $( this ).data( 'return_id' ) ? 'id' : 'slug',
 						cache_results                = $( this ).data( 'cache_results' ) ? true : false,
-						loading_without_search_term = $( this ).data( 'loading_without_search_term' ) ? true : false;
+						loading_without_search_term = isDataTrue( this, 'loading_without_search_term' );
 
 					var select2_args = $.extend( {
 						allowClear        : $( this ).data( 'allow_clear' ) ? true : false,
@@ -370,7 +376,7 @@ jQuery( function( $ ) {
 						ajax: {
 							url:         wc_enhanced_select_params.ajax_url,
 							dataType:    'json',
-							delay:       cache_results ? 0 : 250,
+							delay:       250,
 							data:        function( params ) {
 								return {
 									taxonomy: $( this ).data( 'taxonomy' ),
@@ -408,9 +414,7 @@ jQuery( function( $ ) {
 
 				$( ':input.wc-attribute-search' ).filter( ':not(.enhanced)' ).each( function() {
 					var select2Element = this;
-					var loading_without_search_term = $( this ).data( 'loading_without_search_term' ) === true || (
-						$( this ).data( 'loading_without_search_term' ) === 'true'
-					);
+					var loading_without_search_term = isDataTrue( this, 'loading_without_search_term' );
 					var select2_args = $.extend( {
 						allowClear        : $( this ).data( 'allow_clear' ) ? true : false,
 						placeholder       : $( this ).data( 'placeholder' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -415,6 +415,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_input_too_long_n'           => _x( 'Please delete %qty% characters', 'enhanced select', 'woocommerce' ),
 					'i18n_selection_too_long_1'       => _x( 'You can only select 1 item', 'enhanced select', 'woocommerce' ),
 					'i18n_selection_too_long_n'       => _x( 'You can only select %qty% items', 'enhanced select', 'woocommerce' ),
+					'i18n_loading'                    => _x( 'Loading&hellip;', 'enhanced select', 'woocommerce' ),
 					'i18n_load_more'                  => _x( 'Loading more results&hellip;', 'enhanced select', 'woocommerce' ),
 					'i18n_searching'                  => _x( 'Searching&hellip;', 'enhanced select', 'woocommerce' ),
 					'ajax_url'                        => admin_url( 'admin-ajax.php' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -609,6 +609,9 @@ class WC_Admin_Post_Types {
 		$variation_ids = wp_parse_id_list( $variation_ids );
 		$query_in      = '(' . implode( ',', array_fill( 0, count( $variation_ids ), '%d' ) ) . ')';
 		$query_args    = array_merge( array( wc_variation_attribute_name( $taxonomy ) ), $variation_ids );
+		$attributes    = $product->get_attributes( 'edit' );
+		$attribute_key = sanitize_title( $taxonomy );
+		$current_terms = isset( $attributes[ $attribute_key ] ) && $attributes[ $attribute_key ] instanceof WC_Product_Attribute ? $attributes[ $attribute_key ]->get_options() : $term_ids;
 
 		$variation_term_slugs = $wpdb->get_col(
 			$wpdb->prepare(
@@ -619,26 +622,36 @@ class WC_Admin_Post_Types {
 		);
 
 		if ( empty( $variation_term_slugs ) ) {
-			return wp_parse_id_list( $term_ids );
+			return wp_parse_id_list(
+				array_unique(
+					array_merge( $term_ids, $current_terms )
+				)
+			);
 		}
 
-		if ( in_array( '', $variation_term_slugs, true ) ) {
-			$attributes    = $product->get_attributes( 'edit' );
-			$attribute_key = sanitize_title( $taxonomy );
-
-			if ( isset( $attributes[ $attribute_key ] ) && $attributes[ $attribute_key ] instanceof WC_Product_Attribute ) {
-				return wp_parse_id_list( array_unique( array_merge( $term_ids, $attributes[ $attribute_key ]->get_options() ) ) );
+		$has_wildcard_variation    = false;
+		$variation_term_slug_names = array();
+		foreach ( $variation_term_slugs as $variation_term_slug ) {
+			if ( null === $variation_term_slug || '' === $variation_term_slug ) {
+				$has_wildcard_variation = true;
+				continue;
 			}
 
-			return wp_parse_id_list( $term_ids );
+			$variation_term_slug_names[] = (string) $variation_term_slug;
 		}
 
-		$variation_term_slugs = array_filter( $variation_term_slugs, 'strlen' );
+		if ( $has_wildcard_variation || empty( $variation_term_slug_names ) ) {
+			return wp_parse_id_list(
+				array_unique(
+					array_merge( $term_ids, $current_terms )
+				)
+			);
+		}
 
 		$variation_term_ids = get_terms(
 			array(
 				'taxonomy'   => $taxonomy,
-				'slug'       => $variation_term_slugs,
+				'slug'       => $variation_term_slug_names,
 				'hide_empty' => false,
 				'fields'     => 'ids',
 			)

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -513,10 +513,116 @@ class WC_Admin_Post_Types {
 		}
 
 		$product = $this->maybe_update_stock_status( $product, $stock_status );
+		$this->quick_edit_save_attributes( $product, $request_data );
 
 		$product->save();
 
 		do_action( 'woocommerce_product_quick_edit_save', $product );
+	}
+
+	/**
+	 * Save product attributes from Quick Edit.
+	 *
+	 * @param WC_Product $product Product object.
+	 * @param array      $request_data Request data.
+	 */
+	private function quick_edit_save_attributes( $product, $request_data ): void {
+		if ( empty( $request_data['quick_edit_product_attribute_taxonomies'] ) || ! is_array( $request_data['quick_edit_product_attribute_taxonomies'] ) ) {
+			return;
+		}
+
+		$submitted_attributes = array();
+		if ( ! empty( $request_data['quick_edit_product_attributes'] ) && is_array( $request_data['quick_edit_product_attributes'] ) ) {
+			$submitted_attributes = $request_data['quick_edit_product_attributes'];
+		}
+
+		$attributes = $product->get_attributes( 'edit' );
+		$taxonomies = wp_unslash( $request_data['quick_edit_product_attribute_taxonomies'] );
+		if ( ! is_array( $taxonomies ) ) {
+			return;
+		}
+
+		$taxonomies = array_map( 'wc_clean', $taxonomies );
+
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( ! is_string( $taxonomy ) || '' === $taxonomy || ! taxonomy_is_product_attribute( $taxonomy ) ) {
+				continue;
+			}
+
+			$attribute_key = sanitize_title( $taxonomy );
+			$term_ids      = array();
+
+			if ( isset( $submitted_attributes[ $taxonomy ] ) && is_array( $submitted_attributes[ $taxonomy ] ) ) {
+				$term_ids = wp_parse_id_list( wp_unslash( $submitted_attributes[ $taxonomy ] ) );
+			}
+
+			$is_existing_attribute = isset( $attributes[ $attribute_key ] ) && $attributes[ $attribute_key ] instanceof WC_Product_Attribute;
+
+			if ( $is_existing_attribute && $attributes[ $attribute_key ]->get_variation() && $product->is_type( 'variable' ) ) {
+				$term_ids = $this->get_quick_edit_variation_attribute_term_ids( $product, $taxonomy, $attributes[ $attribute_key ], $term_ids );
+			}
+
+			$set_terms = wp_set_object_terms( $product->get_id(), $term_ids, $taxonomy );
+			if ( is_wp_error( $set_terms ) ) {
+				continue;
+			}
+
+			if ( empty( $term_ids ) ) {
+				unset( $attributes[ $attribute_key ] );
+				continue;
+			}
+
+			$attribute             = $is_existing_attribute ? $attributes[ $attribute_key ] : new WC_Product_Attribute();
+
+			$attribute->set_id( wc_attribute_taxonomy_id_by_name( $taxonomy ) );
+			$attribute->set_name( $taxonomy );
+			$attribute->set_options( $term_ids );
+
+			if ( ! $is_existing_attribute ) {
+				$attribute->set_position( count( $attributes ) );
+				$attribute->set_visible( true );
+				$attribute->set_variation( false );
+			}
+
+			$attributes[ $attribute_key ] = $attribute;
+		}
+
+		$product->set_attributes( $attributes );
+	}
+
+	/**
+	 * Preserve terms required by existing variations when saving a variation attribute from Quick Edit.
+	 *
+	 * @param WC_Product           $product Product object.
+	 * @param string               $taxonomy Attribute taxonomy.
+	 * @param WC_Product_Attribute $attribute Existing product attribute.
+	 * @param array                $term_ids Submitted term IDs.
+	 * @return array Term IDs safe to save.
+	 */
+	private function get_quick_edit_variation_attribute_term_ids( $product, string $taxonomy, WC_Product_Attribute $attribute, array $term_ids ): array {
+		if ( empty( $term_ids ) ) {
+			return wp_parse_id_list( $attribute->get_options() );
+		}
+
+		foreach ( $product->get_children() as $variation_id ) {
+			$variation = wc_get_product( $variation_id );
+			if ( ! $variation instanceof WC_Product_Variation ) {
+				continue;
+			}
+
+			$variation_attributes = $variation->get_attributes();
+			$variation_term_slug  = $variation_attributes[ $taxonomy ] ?? '';
+			if ( '' === $variation_term_slug ) {
+				continue;
+			}
+
+			$variation_term = get_term_by( 'slug', $variation_term_slug, $taxonomy );
+			if ( $variation_term instanceof WP_Term ) {
+				$term_ids[] = (int) $variation_term->term_id;
+			}
+		}
+
+		return wp_parse_id_list( array_unique( $term_ids ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -559,7 +559,7 @@ class WC_Admin_Post_Types {
 			$is_existing_attribute = isset( $attributes[ $attribute_key ] ) && $attributes[ $attribute_key ] instanceof WC_Product_Attribute;
 
 			if ( $is_existing_attribute && $attributes[ $attribute_key ]->get_variation() && $product->is_type( 'variable' ) ) {
-				$term_ids = $this->get_quick_edit_variation_attribute_term_ids( $product, $taxonomy, $attributes[ $attribute_key ], $term_ids );
+				$term_ids = $this->get_quick_edit_variation_attribute_term_ids( $product, $taxonomy, $term_ids );
 			}
 
 			$set_terms = wp_set_object_terms( $product->get_id(), $term_ids, $taxonomy );
@@ -593,36 +593,49 @@ class WC_Admin_Post_Types {
 	/**
 	 * Preserve terms required by existing variations when saving a variation attribute from Quick Edit.
 	 *
-	 * @param WC_Product           $product Product object.
-	 * @param string               $taxonomy Attribute taxonomy.
-	 * @param WC_Product_Attribute $attribute Existing product attribute.
-	 * @param array                $term_ids Submitted term IDs.
+	 * @param WC_Product $product Product object.
+	 * @param string     $taxonomy Attribute taxonomy.
+	 * @param array      $term_ids Submitted term IDs.
 	 * @return array Term IDs safe to save.
 	 */
-	private function get_quick_edit_variation_attribute_term_ids( $product, string $taxonomy, WC_Product_Attribute $attribute, array $term_ids ): array {
-		if ( empty( $term_ids ) ) {
-			return wp_parse_id_list( $attribute->get_options() );
+	private function get_quick_edit_variation_attribute_term_ids( $product, string $taxonomy, array $term_ids ): array {
+		global $wpdb;
+
+		$variation_ids = $product->get_children();
+		if ( empty( $variation_ids ) ) {
+			return wp_parse_id_list( $term_ids );
 		}
 
-		foreach ( $product->get_children() as $variation_id ) {
-			$variation = wc_get_product( $variation_id );
-			if ( ! $variation instanceof WC_Product_Variation ) {
-				continue;
-			}
+		$variation_ids = wp_parse_id_list( $variation_ids );
+		$query_in      = '(' . implode( ',', array_fill( 0, count( $variation_ids ), '%d' ) ) . ')';
+		$query_args    = array_merge( array( wc_variation_attribute_name( $taxonomy ) ), $variation_ids );
 
-			$variation_attributes = $variation->get_attributes();
-			$variation_term_slug  = $variation_attributes[ $taxonomy ] ?? '';
-			if ( '' === $variation_term_slug ) {
-				continue;
-			}
+		$variation_term_slugs = $wpdb->get_col(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value <> '' AND post_id IN {$query_in}",
+				$query_args
+			)
+		);
 
-			$variation_term = get_term_by( 'slug', $variation_term_slug, $taxonomy );
-			if ( $variation_term instanceof WP_Term ) {
-				$term_ids[] = (int) $variation_term->term_id;
-			}
+		if ( empty( $variation_term_slugs ) ) {
+			return wp_parse_id_list( $term_ids );
 		}
 
-		return wp_parse_id_list( array_unique( $term_ids ) );
+		$variation_term_ids = get_terms(
+			array(
+				'taxonomy'   => $taxonomy,
+				'slug'       => $variation_term_slugs,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		if ( is_wp_error( $variation_term_ids ) ) {
+			return wp_parse_id_list( $term_ids );
+		}
+
+		return wp_parse_id_list( array_unique( array_merge( $term_ids, $variation_term_ids ) ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -572,7 +572,7 @@ class WC_Admin_Post_Types {
 				continue;
 			}
 
-			$attribute             = $is_existing_attribute ? $attributes[ $attribute_key ] : new WC_Product_Attribute();
+			$attribute = $is_existing_attribute ? $attributes[ $attribute_key ] : new WC_Product_Attribute();
 
 			$attribute->set_id( wc_attribute_taxonomy_id_by_name( $taxonomy ) );
 			$attribute->set_name( $taxonomy );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -613,7 +613,7 @@ class WC_Admin_Post_Types {
 		$variation_term_slugs = $wpdb->get_col(
 			$wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value <> '' AND post_id IN {$query_in}",
+				"SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN {$query_in}",
 				$query_args
 			)
 		);
@@ -621,6 +621,19 @@ class WC_Admin_Post_Types {
 		if ( empty( $variation_term_slugs ) ) {
 			return wp_parse_id_list( $term_ids );
 		}
+
+		if ( in_array( '', $variation_term_slugs, true ) ) {
+			$attributes    = $product->get_attributes( 'edit' );
+			$attribute_key = sanitize_title( $taxonomy );
+
+			if ( isset( $attributes[ $attribute_key ] ) && $attributes[ $attribute_key ] instanceof WC_Product_Attribute ) {
+				return wp_parse_id_list( array_unique( array_merge( $term_ids, $attributes[ $attribute_key ]->get_options() ) ) );
+			}
+
+			return wp_parse_id_list( $term_ids );
+		}
+
+		$variation_term_slugs = array_filter( $variation_term_slugs, 'strlen' );
 
 		$variation_term_ids = get_terms(
 			array(

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -268,7 +268,10 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * @return array
 	 */
 	private function get_quick_edit_attributes_data() {
-		$attributes_data = array();
+		$attributes_data       = array();
+		$attribute_options     = array();
+		$attribute_taxonomies  = array();
+		$attribute_option_ids  = array();
 
 		if ( ! $this->object instanceof WC_Product ) {
 			return $attributes_data;
@@ -279,17 +282,55 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 				continue;
 			}
 
-			$terms = $attribute->get_terms();
-			if ( empty( $terms ) ) {
+			$taxonomy = $attribute->get_name();
+			$options  = wp_parse_id_list( $attribute->get_options() );
+			if ( empty( $options ) ) {
 				continue;
 			}
 
-			$attributes_data[ $attribute->get_name() ] = array(
+			$attribute_options[ $taxonomy ] = $options;
+			$attribute_taxonomies[]         = $taxonomy;
+			$attribute_option_ids           = array_merge( $attribute_option_ids, $options );
+		}
+
+		if ( empty( $attribute_options ) ) {
+			return $attributes_data;
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => array_unique( $attribute_taxonomies ),
+				'include'    => array_unique( $attribute_option_ids ),
+				'hide_empty' => false,
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return $attributes_data;
+		}
+
+		$terms_by_taxonomy = array();
+		foreach ( $terms as $term ) {
+			$terms_by_taxonomy[ $term->taxonomy ][ $term->term_id ] = $term;
+		}
+
+		foreach ( $attribute_options as $taxonomy => $options ) {
+			if ( empty( $terms_by_taxonomy[ $taxonomy ] ) ) {
+				continue;
+			}
+
+			$attributes_data[ $taxonomy ] = array(
 				'terms' => array(),
 			);
 
-			foreach ( $terms as $term ) {
-				$attributes_data[ $attribute->get_name() ]['terms'][] = array(
+			foreach ( $options as $term_id ) {
+				if ( empty( $terms_by_taxonomy[ $taxonomy ][ $term_id ] ) ) {
+					continue;
+				}
+
+				$term = $terms_by_taxonomy[ $taxonomy ][ $term_id ];
+
+				$attributes_data[ $taxonomy ]['terms'][] = array(
 					'id'   => $term->term_id,
 					'name' => $term->name,
 				);

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -289,9 +289,11 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			return $attributes_data;
 		}
 
+		$product = $this->object;
+
 		$this->prefetch_quick_edit_attribute_terms();
 
-		foreach ( $this->object->get_attributes( 'edit' ) as $attribute ) {
+		foreach ( $product->get_attributes( 'edit' ) as $attribute ) {
 			if ( ! $attribute->is_taxonomy() ) {
 				continue;
 			}
@@ -343,7 +345,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * The name column renders hidden inline-edit data for each row. Without this cache,
 	 * rendering products with global attributes can run a separate term query per row.
 	 */
-	private function prefetch_quick_edit_attribute_terms() {
+	private function prefetch_quick_edit_attribute_terms(): void {
 		global $wp_query;
 
 		if ( $this->quick_edit_attribute_terms_prefetched ) {
@@ -378,7 +380,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 					continue;
 				}
 
-				$taxonomy = $attribute->get_name();
+				$taxonomy                       = $attribute->get_name();
 				$attribute_options[ $taxonomy ] = array_merge(
 					$attribute_options[ $taxonomy ] ?? array(),
 					$options
@@ -394,7 +396,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 *
 	 * @param array $attribute_options Product attribute term IDs grouped by taxonomy.
 	 */
-	private function cache_quick_edit_attribute_terms( $attribute_options ) {
+	private function cache_quick_edit_attribute_terms( $attribute_options ): void {
 		$missing_term_ids_by_taxonomy = array();
 		$missing_term_ids             = array();
 
@@ -414,8 +416,8 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 				}
 
 				$this->quick_edit_attribute_terms[ $taxonomy ][ $term_id ] = null;
-				$missing_term_ids_by_taxonomy[ $taxonomy ][]             = $term_id;
-				$missing_term_ids[]                                       = $term_id;
+				$missing_term_ids_by_taxonomy[ $taxonomy ][]               = $term_id;
+				$missing_term_ids[]                                        = $term_id;
 			}
 		}
 

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -227,8 +227,11 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		$cogs_value_html = $this->cogs_is_enabled ?
 				'<div class="cogs_value">' . esc_html( $this->object->get_cogs_value() ?? '0' ) . '</div>' :
 				'';
+		$attributes_data = $this->get_quick_edit_attributes_data();
+		$attributes_json = wp_json_encode( $attributes_data );
+		$attributes_json = false === $attributes_json ? '{}' : $attributes_json;
 
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- the COGS value is already escaped.
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Custom inline data is escaped below.
 		/* Custom inline data for woocommerce. */
 		echo '
 			<div class="hidden" id="woocommerce_inline_' . absint( $this->object->get_id() ) . '">
@@ -253,9 +256,47 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 				<div class="tax_class">' . esc_html( $this->object->get_tax_class() ) . '</div>
 				<div class="backorders">' . esc_html( $this->object->get_backorders() ) . '</div>
 				<div class="low_stock_amount">' . esc_html( $this->object->get_low_stock_amount() ) . '</div>'
+				. '<div class="product_attributes" data-attributes="' . esc_attr( $attributes_json ) . '"></div>'
 				. $cogs_value_html .
 			'</div>';
 		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Get product attribute data used to populate the Quick Edit form.
+	 *
+	 * @return array
+	 */
+	private function get_quick_edit_attributes_data() {
+		$attributes_data = array();
+
+		if ( ! $this->object instanceof WC_Product ) {
+			return $attributes_data;
+		}
+
+		foreach ( $this->object->get_attributes( 'edit' ) as $attribute ) {
+			if ( ! $attribute->is_taxonomy() ) {
+				continue;
+			}
+
+			$terms = $attribute->get_terms();
+			if ( empty( $terms ) ) {
+				continue;
+			}
+
+			$attributes_data[ $attribute->get_name() ] = array(
+				'terms' => array(),
+			);
+
+			foreach ( $terms as $term ) {
+				$attributes_data[ $attribute->get_name() ]['terms'][] = array(
+					'id'   => $term->term_id,
+					'name' => $term->name,
+				);
+			}
+		}
+
+		return $attributes_data;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -268,10 +268,10 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * @return array
 	 */
 	private function get_quick_edit_attributes_data() {
-		$attributes_data       = array();
-		$attribute_options     = array();
-		$attribute_taxonomies  = array();
-		$attribute_option_ids  = array();
+		$attributes_data      = array();
+		$attribute_options    = array();
+		$attribute_taxonomies = array();
+		$attribute_option_ids = array();
 
 		if ( ! $this->object instanceof WC_Product ) {
 			return $attributes_data;

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -48,6 +48,20 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	private bool $use_cogs_lookup_column;
 
 	/**
+	 * Global attribute terms used by Quick Edit on the current Products list screen.
+	 *
+	 * @var array
+	 */
+	private array $quick_edit_attribute_terms = array();
+
+	/**
+	 * Whether Quick Edit attribute terms have been prefetched for the current list table.
+	 *
+	 * @var bool
+	 */
+	private bool $quick_edit_attribute_terms_prefetched = false;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -268,14 +282,14 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * @return array
 	 */
 	private function get_quick_edit_attributes_data() {
-		$attributes_data      = array();
-		$attribute_options    = array();
-		$attribute_taxonomies = array();
-		$attribute_option_ids = array();
+		$attributes_data   = array();
+		$attribute_options = array();
 
 		if ( ! $this->object instanceof WC_Product ) {
 			return $attributes_data;
 		}
+
+		$this->prefetch_quick_edit_attribute_terms();
 
 		foreach ( $this->object->get_attributes( 'edit' ) as $attribute ) {
 			if ( ! $attribute->is_taxonomy() ) {
@@ -289,33 +303,16 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			}
 
 			$attribute_options[ $taxonomy ] = $options;
-			$attribute_taxonomies[]         = $taxonomy;
-			$attribute_option_ids           = array_merge( $attribute_option_ids, $options );
 		}
 
 		if ( empty( $attribute_options ) ) {
 			return $attributes_data;
 		}
 
-		$terms = get_terms(
-			array(
-				'taxonomy'   => array_unique( $attribute_taxonomies ),
-				'include'    => array_unique( $attribute_option_ids ),
-				'hide_empty' => false,
-			)
-		);
-
-		if ( is_wp_error( $terms ) || empty( $terms ) ) {
-			return $attributes_data;
-		}
-
-		$terms_by_taxonomy = array();
-		foreach ( $terms as $term ) {
-			$terms_by_taxonomy[ $term->taxonomy ][ $term->term_id ] = $term;
-		}
+		$this->cache_quick_edit_attribute_terms( $attribute_options );
 
 		foreach ( $attribute_options as $taxonomy => $options ) {
-			if ( empty( $terms_by_taxonomy[ $taxonomy ] ) ) {
+			if ( empty( $this->quick_edit_attribute_terms[ $taxonomy ] ) ) {
 				continue;
 			}
 
@@ -324,11 +321,11 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			);
 
 			foreach ( $options as $term_id ) {
-				if ( empty( $terms_by_taxonomy[ $taxonomy ][ $term_id ] ) ) {
+				if ( empty( $this->quick_edit_attribute_terms[ $taxonomy ][ $term_id ] ) ) {
 					continue;
 				}
 
-				$term = $terms_by_taxonomy[ $taxonomy ][ $term_id ];
+				$term = $this->quick_edit_attribute_terms[ $taxonomy ][ $term_id ];
 
 				$attributes_data[ $taxonomy ]['terms'][] = array(
 					'id'   => $term->term_id,
@@ -338,6 +335,109 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		}
 
 		return $attributes_data;
+	}
+
+	/**
+	 * Prefetch Quick Edit attribute terms for the current Products list.
+	 *
+	 * The name column renders hidden inline-edit data for each row. Without this cache,
+	 * rendering products with global attributes can run a separate term query per row.
+	 */
+	private function prefetch_quick_edit_attribute_terms() {
+		global $wp_query;
+
+		if ( $this->quick_edit_attribute_terms_prefetched ) {
+			return;
+		}
+
+		$this->quick_edit_attribute_terms_prefetched = true;
+
+		if ( empty( $wp_query->posts ) || ! is_array( $wp_query->posts ) ) {
+			return;
+		}
+
+		$attribute_options = array();
+
+		foreach ( $wp_query->posts as $post ) {
+			if ( ! $post instanceof WP_Post || 'product' !== $post->post_type ) {
+				continue;
+			}
+
+			$product = wc_get_product( $post->ID );
+			if ( ! $product instanceof WC_Product ) {
+				continue;
+			}
+
+			foreach ( $product->get_attributes( 'edit' ) as $attribute ) {
+				if ( ! $attribute->is_taxonomy() ) {
+					continue;
+				}
+
+				$options = wp_parse_id_list( $attribute->get_options() );
+				if ( empty( $options ) ) {
+					continue;
+				}
+
+				$taxonomy = $attribute->get_name();
+				$attribute_options[ $taxonomy ] = array_merge(
+					$attribute_options[ $taxonomy ] ?? array(),
+					$options
+				);
+			}
+		}
+
+		$this->cache_quick_edit_attribute_terms( $attribute_options );
+	}
+
+	/**
+	 * Cache Quick Edit attribute terms by taxonomy and term ID.
+	 *
+	 * @param array $attribute_options Product attribute term IDs grouped by taxonomy.
+	 */
+	private function cache_quick_edit_attribute_terms( $attribute_options ) {
+		$missing_term_ids_by_taxonomy = array();
+		$missing_term_ids             = array();
+
+		foreach ( $attribute_options as $taxonomy => $options ) {
+			$options = wp_parse_id_list( $options );
+			if ( empty( $options ) ) {
+				continue;
+			}
+
+			if ( empty( $this->quick_edit_attribute_terms[ $taxonomy ] ) ) {
+				$this->quick_edit_attribute_terms[ $taxonomy ] = array();
+			}
+
+			foreach ( $options as $term_id ) {
+				if ( array_key_exists( $term_id, $this->quick_edit_attribute_terms[ $taxonomy ] ) ) {
+					continue;
+				}
+
+				$this->quick_edit_attribute_terms[ $taxonomy ][ $term_id ] = null;
+				$missing_term_ids_by_taxonomy[ $taxonomy ][]             = $term_id;
+				$missing_term_ids[]                                       = $term_id;
+			}
+		}
+
+		if ( empty( $missing_term_ids_by_taxonomy ) ) {
+			return;
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => array_keys( $missing_term_ids_by_taxonomy ),
+				'include'    => array_unique( $missing_term_ids ),
+				'hide_empty' => false,
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return;
+		}
+
+		foreach ( $terms as $term ) {
+			$this->quick_edit_attribute_terms[ $term->taxonomy ][ $term->term_id ] = $term;
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 defined( 'ABSPATH' ) || exit;
 ?>
 
-<fieldset class="inline-edit-col-left">
+<fieldset class="inline-edit-col-left woocommerce-product-data-fields">
 	<div id="woocommerce-fields" class="inline-edit-col">
 
 		<h4><?php esc_html_e( 'Product data', 'woocommerce' ); ?></h4>

--- a/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
@@ -174,11 +174,12 @@ defined( 'ABSPATH' ) || exit;
 					<label class="wc-product-attribute-field">
 						<span class="title"><?php echo esc_html( $attribute_label ); ?></span>
 						<span class="input-text-wrap">
-							<input type="hidden" class="wc-product-attribute-taxonomy" name="quick_edit_product_attribute_taxonomies[]" value="<?php echo esc_attr( $attribute_taxonomy_name ); ?>" />
+							<input type="hidden" class="wc-product-attribute-taxonomy" name="quick_edit_product_attribute_taxonomies[]" value="<?php echo esc_attr( $attribute_taxonomy_name ); ?>" disabled="disabled" />
 							<select
 								class="wc-product-attribute-values"
 								name="quick_edit_product_attributes[<?php echo esc_attr( $attribute_taxonomy_name ); ?>][]"
 								multiple="multiple"
+								disabled="disabled"
 								data-taxonomy="<?php echo esc_attr( $attribute_taxonomy_name ); ?>"
 								data-return_id="id"
 								data-orderby="<?php echo esc_attr( $attribute_orderby ); ?>"

--- a/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
@@ -183,6 +183,8 @@ defined( 'ABSPATH' ) || exit;
 								data-return_id="id"
 								data-orderby="<?php echo esc_attr( $attribute_orderby ); ?>"
 								data-minimum_input_length="0"
+								data-cache_results="true"
+								data-loading_without_search_term="true"
 								data-placeholder="<?php echo esc_attr( $placeholder ); ?>"
 								style="width:99%;"
 							></select>

--- a/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
@@ -185,6 +185,7 @@ defined( 'ABSPATH' ) || exit;
 								data-minimum_input_length="0"
 								data-cache_results="true"
 								data-loading_without_search_term="true"
+								data-dropdown-css-class="wc-product-quick-edit-attribute-dropdown"
 								data-placeholder="<?php echo esc_attr( $placeholder ); ?>"
 								style="width:99%;"
 							></select>

--- a/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
@@ -171,10 +171,10 @@ defined( 'ABSPATH' ) || exit;
 						$attribute_label
 					);
 					?>
-					<label>
+					<label class="wc-product-attribute-field">
 						<span class="title"><?php echo esc_html( $attribute_label ); ?></span>
 						<span class="input-text-wrap">
-							<input type="hidden" name="quick_edit_product_attribute_taxonomies[]" value="<?php echo esc_attr( $attribute_taxonomy_name ); ?>" />
+							<input type="hidden" class="wc-product-attribute-taxonomy" name="quick_edit_product_attribute_taxonomies[]" value="<?php echo esc_attr( $attribute_taxonomy_name ); ?>" />
 							<select
 								class="wc-product-attribute-values"
 								name="quick_edit_product_attributes[<?php echo esc_attr( $attribute_taxonomy_name ); ?>][]"
@@ -192,6 +192,27 @@ defined( 'ABSPATH' ) || exit;
 						</span>
 					</label>
 				<?php endforeach; ?>
+				<label class="wc-product-attribute-add-field">
+					<span class="title"><?php esc_html_e( 'Add attribute', 'woocommerce' ); ?></span>
+					<span class="input-text-wrap">
+						<select
+							class="wc-product-attribute-add"
+							data-placeholder="<?php esc_attr_e( 'Search attributes', 'woocommerce' ); ?>"
+							data-minimum_input_length="0"
+							data-loading_without_search_term="true"
+							data-dropdown-css-class="wc-product-quick-edit-attribute-dropdown"
+							style="width:99%;"
+						></select>
+						<span class="wc-product-attribute-add-message" hidden>
+							<?php
+							esc_html_e(
+								'All available attributes have been added.',
+								'woocommerce'
+							);
+							?>
+						</span>
+					</span>
+				</label>
 			</div>
 		<?php endif; ?>
 

--- a/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-quick-edit-product.php
@@ -149,6 +149,49 @@ defined( 'ABSPATH' ) || exit;
 			</span>
 		</div>
 
+		<?php
+		$attribute_taxonomies = wc_get_attribute_taxonomies();
+		if ( ! empty( $attribute_taxonomies ) ) :
+			?>
+			<h4><?php esc_html_e( 'Attributes', 'woocommerce' ); ?></h4>
+			<div class="inline-edit-group product_attributes_fields">
+				<?php
+				foreach ( $attribute_taxonomies as $attribute_taxonomy ) :
+					$attribute_taxonomy_name = wc_attribute_taxonomy_name( $attribute_taxonomy->attribute_name );
+
+					if ( ! taxonomy_exists( $attribute_taxonomy_name ) ) {
+						continue;
+					}
+
+					$attribute_orderby = ! empty( $attribute_taxonomy->attribute_orderby ) ? $attribute_taxonomy->attribute_orderby : 'name';
+					$attribute_label   = wc_attribute_label( $attribute_taxonomy_name );
+					$placeholder       = sprintf(
+						/* translators: %s: Product attribute name. */
+						__( 'Select %s', 'woocommerce' ),
+						$attribute_label
+					);
+					?>
+					<label>
+						<span class="title"><?php echo esc_html( $attribute_label ); ?></span>
+						<span class="input-text-wrap">
+							<input type="hidden" name="quick_edit_product_attribute_taxonomies[]" value="<?php echo esc_attr( $attribute_taxonomy_name ); ?>" />
+							<select
+								class="wc-product-attribute-values"
+								name="quick_edit_product_attributes[<?php echo esc_attr( $attribute_taxonomy_name ); ?>][]"
+								multiple="multiple"
+								data-taxonomy="<?php echo esc_attr( $attribute_taxonomy_name ); ?>"
+								data-return_id="id"
+								data-orderby="<?php echo esc_attr( $attribute_orderby ); ?>"
+								data-minimum_input_length="0"
+								data-placeholder="<?php echo esc_attr( $placeholder ); ?>"
+								style="width:99%;"
+							></select>
+						</span>
+					</label>
+				<?php endforeach; ?>
+			</div>
+		<?php endif; ?>
+
 		<div class="inline-edit-group">
 			<label class="alignleft">
 				<span class="title"><?php esc_html_e( 'Visibility', 'woocommerce' ); ?></span>

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
@@ -153,9 +153,13 @@ async function openQuickEdit( page: Page, product: Product ) {
 
 	const quickEditRow = page.locator( `#edit-${ product.id }` );
 	await expect( quickEditRow ).toBeVisible();
-	await expect(
-		quickEditRow.locator( 'select.wc-product-attribute-values.enhanced' )
-	).toHaveCount( 2 );
+	await expect
+		.poll( async () =>
+			quickEditRow
+				.locator( 'select.wc-product-attribute-values.enhanced' )
+				.count()
+		)
+		.toBeGreaterThanOrEqual( 2 );
 
 	return quickEditRow;
 }

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
@@ -534,6 +534,9 @@ test.describe( 'Product Quick Edit attributes', () => {
 			quickEditRow,
 			styleAttribute.name
 		);
+		const closedSizeSelectionBox = await expectBoundingBox(
+			sizeField.locator( '.select2-selection' )
+		);
 
 		await sizeField.locator( '.select2-selection' ).click();
 		await expect(
@@ -546,8 +549,14 @@ test.describe( 'Product Quick Edit attributes', () => {
 		const dropdownBox = await expectBoundingBox(
 			page.locator( '.select2-container--open .select2-dropdown' )
 		);
+		const openSizeSelectionBox = await expectBoundingBox(
+			sizeField.locator( '.select2-selection' )
+		);
 		const styleFieldBox = await expectBoundingBox( styleField );
 
+		expect( Math.round( openSizeSelectionBox.width ) ).toBe(
+			Math.round( closedSizeSelectionBox.width )
+		);
 		expect( styleFieldBox.y ).toBeGreaterThanOrEqual(
 			dropdownBox.y + dropdownBox.height
 		);

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
@@ -50,6 +50,8 @@ const createdAttributeIds: number[] = [];
 let sizeAttribute: GlobalAttribute;
 let styleAttribute: GlobalAttribute;
 let emptyProduct: Product;
+let addAttributeProduct: Product;
+let singleAttributeProduct: Product;
 let simpleProduct: Product;
 let manySelectedProduct: Product;
 let variableProduct: Product;
@@ -165,6 +167,10 @@ function getAttributeField( quickEditRow: Locator, attributeName: string ) {
 		.first();
 }
 
+function getAddAttributeField( quickEditRow: Locator ) {
+	return quickEditRow.locator( '.wc-product-attribute-add-field' );
+}
+
 async function expectAttributeChips(
 	quickEditRow: Locator,
 	attributeName: string,
@@ -173,11 +179,34 @@ async function expectAttributeChips(
 	const field = getAttributeField( quickEditRow, attributeName );
 	const chips = field.locator( '.select2-selection__choice' );
 
+	await expect( field ).toBeVisible();
 	await expect( chips ).toHaveCount( expectedTerms.length );
 
 	for ( const termName of expectedTerms ) {
 		await expect( chips.filter( { hasText: termName } ) ).toHaveCount( 1 );
 	}
+}
+
+async function addAttributeField(
+	page: Page,
+	quickEditRow: Locator,
+	attribute: GlobalAttribute
+) {
+	const addField = getAddAttributeField( quickEditRow );
+	const searchField = page.locator(
+		'.select2-container--open .select2-search__field'
+	);
+
+	await expect( addField ).toBeVisible();
+	await addField.locator( '.select2-selection' ).click();
+	await expect( searchField ).toBeVisible();
+	await searchField.fill( attribute.name );
+	await page
+		.getByRole( 'option', { name: attribute.name, exact: true } )
+		.click();
+	await expect(
+		getAttributeField( quickEditRow, attribute.name )
+	).toBeVisible();
 }
 
 async function openAttributeSearch( page: Page, field: Locator ) {
@@ -292,6 +321,20 @@ function isTaxonomyTermSearchRequest( request: Request, taxonomy: string ) {
 	);
 }
 
+function isProductAttributeSearchRequest( request: Request ) {
+	const url = new URL( request.url() );
+	const postData = request.postData() || '';
+	const postParams = new URLSearchParams( postData );
+
+	return (
+		url.pathname.endsWith( 'admin-ajax.php' ) &&
+		( url.searchParams.get( 'action' ) ===
+			'woocommerce_json_search_product_attributes' ||
+			postParams.get( 'action' ) ===
+				'woocommerce_json_search_product_attributes' )
+	);
+}
+
 test.describe( 'Product Quick Edit attributes', () => {
 	test.use( { storageState: ADMIN_STATE_PATH } );
 
@@ -313,6 +356,23 @@ test.describe( 'Product Quick Edit attributes', () => {
 			name: `Quick Edit Attributes Empty ${ suffix }`,
 			type: 'simple',
 			regular_price: '10',
+		} );
+		addAttributeProduct = await createProduct( restApi, {
+			name: `Quick Edit Attributes Add ${ suffix }`,
+			type: 'simple',
+			regular_price: '11',
+		} );
+		singleAttributeProduct = await createProduct( restApi, {
+			name: `Quick Edit Attributes Single ${ suffix }`,
+			type: 'simple',
+			regular_price: '11.50',
+			attributes: [
+				{
+					id: sizeAttribute.id,
+					visible: true,
+					options: [ 'Medium' ],
+				},
+			],
 		} );
 		simpleProduct = await createProduct( restApi, {
 			name: `Quick Edit Attributes Simple ${ suffix }`,
@@ -395,24 +455,53 @@ test.describe( 'Product Quick Edit attributes', () => {
 		page,
 	} ) => {
 		await page.setViewportSize( { width: 900, height: 900 } );
+		await page.route( '**/wp-admin/admin-ajax.php', async ( route ) => {
+			if ( isProductAttributeSearchRequest( route.request() ) ) {
+				await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+			}
+
+			await route.continue();
+		} );
 
 		await goToProductList( page, emptyProduct );
 		let quickEditRow = await openQuickEdit( page, emptyProduct );
 		await expect(
 			quickEditRow.getByRole( 'heading', { name: 'Attributes' } )
 		).toBeVisible();
-		await expectAttributeChips( quickEditRow, sizeAttribute.name, [] );
-		await expectAttributeChips( quickEditRow, styleAttribute.name, [] );
+		await expect(
+			getAttributeField( quickEditRow, sizeAttribute.name )
+		).toBeHidden();
+		await expect(
+			getAttributeField( quickEditRow, styleAttribute.name )
+		).toBeHidden();
+		await expect( getAddAttributeField( quickEditRow ) ).toBeVisible();
+		await getAddAttributeField( quickEditRow )
+			.locator( '.select2-selection' )
+			.click();
+		await expect(
+			page.locator( '.select2-container--open .loading-results' )
+		).toContainText( 'Loading' );
+		await expect(
+			page.getByRole( 'option', {
+				name: sizeAttribute.name,
+				exact: true,
+			} )
+		).toBeVisible();
+		await quickEditRow.locator( 'input[name="post_title"]' ).click();
+		await expect( page.locator( '.select2-container--open' ) ).toHaveCount(
+			0
+		);
 		await cancelQuickEdit( quickEditRow );
 
-		await goToProductList( page, simpleProduct );
-		quickEditRow = await openQuickEdit( page, simpleProduct );
+		await goToProductList( page, singleAttributeProduct );
+		quickEditRow = await openQuickEdit( page, singleAttributeProduct );
 		await expectAttributeChips( quickEditRow, sizeAttribute.name, [
 			'Medium',
 		] );
-		await expectAttributeChips( quickEditRow, styleAttribute.name, [
-			'Regular',
-		] );
+		await expect(
+			getAttributeField( quickEditRow, styleAttribute.name )
+		).toBeHidden();
+		await expect( getAddAttributeField( quickEditRow ) ).toBeVisible();
 		await cancelQuickEdit( quickEditRow );
 
 		await goToProductList( page, manySelectedProduct );
@@ -427,6 +516,19 @@ test.describe( 'Product Quick Edit attributes', () => {
 			styleAttribute.name,
 			styleAttribute.terms.map( ( term ) => term.name )
 		);
+		const allAttributesAddedField = getAddAttributeField( quickEditRow );
+		await expect( allAttributesAddedField ).toBeVisible();
+		await expect(
+			allAttributesAddedField.locator( '.select2-container' )
+		).toBeHidden();
+		await expect(
+			allAttributesAddedField.locator( '.title' )
+		).toBeHidden();
+		await expect(
+			allAttributesAddedField.locator(
+				'.wc-product-attribute-add-message'
+			)
+		).toHaveText( 'All available attributes have been added.' );
 
 		const styleField = getAttributeField(
 			quickEditRow,
@@ -443,19 +545,34 @@ test.describe( 'Product Quick Edit attributes', () => {
 		page,
 		restApi,
 	} ) => {
-		await goToProductList( page, emptyProduct );
-		let quickEditRow = await openQuickEdit( page, emptyProduct );
+		await goToProductList( page, addAttributeProduct );
+		let quickEditRow = await openQuickEdit( page, addAttributeProduct );
 		await expect( quickEditRow ).toBeVisible();
 
+		await addAttributeField( page, quickEditRow, sizeAttribute );
 		await selectAttributeTerms( page, quickEditRow, sizeAttribute.name, [
 			'Medium',
 		] );
 		await cancelQuickEdit( quickEditRow );
 		await expectProductAttributeOptions(
 			restApi,
-			emptyProduct.id,
+			addAttributeProduct.id,
 			sizeAttribute.id,
 			[]
+		);
+
+		await goToProductList( page, addAttributeProduct );
+		quickEditRow = await openQuickEdit( page, addAttributeProduct );
+		await addAttributeField( page, quickEditRow, sizeAttribute );
+		await selectAttributeTerms( page, quickEditRow, sizeAttribute.name, [
+			'Medium',
+		] );
+		await saveQuickEdit( page, quickEditRow );
+		await expectProductAttributeOptions(
+			restApi,
+			addAttributeProduct.id,
+			sizeAttribute.id,
+			[ 'Medium' ]
 		);
 
 		await goToProductList( page, simpleProduct );
@@ -524,8 +641,8 @@ test.describe( 'Product Quick Edit attributes', () => {
 			}
 		} );
 
-		await goToProductList( page, emptyProduct );
-		const quickEditRow = await openQuickEdit( page, emptyProduct );
+		await goToProductList( page, manySelectedProduct );
+		const quickEditRow = await openQuickEdit( page, manySelectedProduct );
 		const sizeField = getAttributeField( quickEditRow, sizeAttribute.name );
 		const styleField = getAttributeField(
 			quickEditRow,

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
@@ -225,7 +225,7 @@ async function removeAttributeTerm(
 		.locator( '.select2-selection__choice' )
 		.filter( { hasText: termName } );
 
-	await chip.locator( '.select2-selection__choice__remove' ).click();
+	await chip.click( { position: { x: 8, y: 12 } } );
 }
 
 async function removeAllAttributeTerms(
@@ -237,10 +237,7 @@ async function removeAllAttributeTerms(
 	let remainingChips = await chips.count();
 
 	while ( remainingChips ) {
-		await chips
-			.first()
-			.locator( '.select2-selection__choice__remove' )
-			.click();
+		await chips.first().click( { position: { x: 8, y: 12 } } );
 		await expect( chips ).toHaveCount( remainingChips - 1 );
 		remainingChips = await chips.count();
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-quick-edit-attributes.spec.ts
@@ -1,0 +1,610 @@
+/**
+ * External dependencies
+ */
+import type { Locator, Page, Request } from '@playwright/test';
+import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../../fixtures/fixtures';
+import { ADMIN_STATE_PATH } from '../../playwright.config';
+
+type RestApi = {
+	get: ( path: string ) => Promise< { data: Record< string, unknown > } >;
+	post: (
+		path: string,
+		data?: Record< string, unknown >
+	) => Promise< { data: Record< string, unknown > } >;
+};
+
+type Term = {
+	id: number;
+	name: string;
+	slug: string;
+};
+
+type GlobalAttribute = {
+	id: number;
+	name: string;
+	taxonomy: string;
+	terms: Term[];
+};
+
+type Product = {
+	id: number;
+	name: string;
+	slug: string;
+};
+
+type BoundingBox = {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+
+const createdProductIds: number[] = [];
+const createdAttributeIds: number[] = [];
+
+let sizeAttribute: GlobalAttribute;
+let styleAttribute: GlobalAttribute;
+let emptyProduct: Product;
+let simpleProduct: Product;
+let manySelectedProduct: Product;
+let variableProduct: Product;
+
+async function createGlobalAttribute(
+	restApi: RestApi,
+	name: string,
+	termNames: string[]
+): Promise< GlobalAttribute > {
+	const attribute = (
+		await restApi.post( `${ WC_API_PATH }/products/attributes`, {
+			name,
+		} )
+	 ).data as { id: number; name: string; slug: string };
+
+	createdAttributeIds.push( attribute.id );
+
+	const terms: Term[] = [];
+	for ( const termName of termNames ) {
+		const term = (
+			await restApi.post(
+				`${ WC_API_PATH }/products/attributes/${ attribute.id }/terms`,
+				{
+					name: termName,
+				}
+			)
+		 ).data as Term;
+
+		terms.push( term );
+	}
+
+	return {
+		id: attribute.id,
+		name: attribute.name,
+		taxonomy: attribute.slug.startsWith( 'pa_' )
+			? attribute.slug
+			: `pa_${ attribute.slug }`,
+		terms,
+	};
+}
+
+async function createProduct(
+	restApi: RestApi,
+	data: Record< string, unknown >
+): Promise< Product > {
+	const product = ( await restApi.post( `${ WC_API_PATH }/products`, data ) )
+		.data as Product;
+
+	createdProductIds.push( product.id );
+
+	return product;
+}
+
+function productAttributeOptions(
+	product: Record< string, unknown >,
+	attributeId: number
+): string[] {
+	const attributes = product.attributes as
+		| Array< { id: number; options?: string[] } >
+		| undefined;
+	const attribute = attributes?.find(
+		( currentAttribute ) => currentAttribute.id === attributeId
+	);
+
+	return [ ...( attribute?.options || [] ) ].sort();
+}
+
+async function expectProductAttributeOptions(
+	restApi: RestApi,
+	productId: number,
+	attributeId: number,
+	expectedOptions: string[]
+) {
+	await expect
+		.poll( async () => {
+			const product = (
+				await restApi.get( `${ WC_API_PATH }/products/${ productId }` )
+			 ).data;
+
+			return productAttributeOptions( product, attributeId );
+		} )
+		.toEqual( [ ...expectedOptions ].sort() );
+}
+
+async function goToProductList( page: Page, product: Product ) {
+	await page.goto(
+		`wp-admin/edit.php?post_type=product&s=${ encodeURIComponent(
+			product.name
+		) }`
+	);
+	await expect( page.locator( `#post-${ product.id }` ) ).toBeVisible();
+}
+
+async function openQuickEdit( page: Page, product: Product ) {
+	const productRow = page.locator( `#post-${ product.id }` );
+
+	await productRow.hover();
+	await productRow.getByRole( 'button', { name: 'Quick Edit' } ).click();
+
+	const quickEditRow = page.locator( `#edit-${ product.id }` );
+	await expect( quickEditRow ).toBeVisible();
+	await expect(
+		quickEditRow.locator( 'select.wc-product-attribute-values.enhanced' )
+	).toHaveCount( 2 );
+
+	return quickEditRow;
+}
+
+function getAttributeField( quickEditRow: Locator, attributeName: string ) {
+	return quickEditRow
+		.locator( '.product_attributes_fields label' )
+		.filter( { hasText: attributeName } )
+		.first();
+}
+
+async function expectAttributeChips(
+	quickEditRow: Locator,
+	attributeName: string,
+	expectedTerms: string[]
+) {
+	const field = getAttributeField( quickEditRow, attributeName );
+	const chips = field.locator( '.select2-selection__choice' );
+
+	await expect( chips ).toHaveCount( expectedTerms.length );
+
+	for ( const termName of expectedTerms ) {
+		await expect( chips.filter( { hasText: termName } ) ).toHaveCount( 1 );
+	}
+}
+
+async function openAttributeSearch( page: Page, field: Locator ) {
+	const searchField = page.locator(
+		'.select2-container--open .select2-search__field'
+	);
+
+	await field.locator( '.select2-selection' ).click();
+
+	try {
+		await expect( searchField ).toBeVisible( { timeout: 1000 } );
+	} catch {
+		await field.locator( '.select2-selection' ).click();
+		await expect( searchField ).toBeVisible();
+	}
+
+	return searchField;
+}
+
+async function selectAttributeTerms(
+	page: Page,
+	quickEditRow: Locator,
+	attributeName: string,
+	termNames: string[]
+) {
+	const field = getAttributeField( quickEditRow, attributeName );
+
+	for ( const termName of termNames ) {
+		const searchField = await openAttributeSearch( page, field );
+
+		await searchField.fill( termName );
+		await page
+			.getByRole( 'option', { name: termName, exact: true } )
+			.click();
+	}
+}
+
+async function removeAttributeTerm(
+	quickEditRow: Locator,
+	attributeName: string,
+	termName: string
+) {
+	const field = getAttributeField( quickEditRow, attributeName );
+	const chip = field
+		.locator( '.select2-selection__choice' )
+		.filter( { hasText: termName } );
+
+	await chip.locator( '.select2-selection__choice__remove' ).click();
+}
+
+async function removeAllAttributeTerms(
+	quickEditRow: Locator,
+	attributeName: string
+) {
+	const field = getAttributeField( quickEditRow, attributeName );
+	const chips = field.locator( '.select2-selection__choice' );
+	let remainingChips = await chips.count();
+
+	while ( remainingChips ) {
+		await chips
+			.first()
+			.locator( '.select2-selection__choice__remove' )
+			.click();
+		await expect( chips ).toHaveCount( remainingChips - 1 );
+		remainingChips = await chips.count();
+	}
+}
+
+async function saveQuickEdit( page: Page, quickEditRow: Locator ) {
+	await quickEditRow.locator( 'input[name="post_title"]' ).click();
+	await expect( page.locator( '.select2-container--open' ) ).toHaveCount( 0 );
+
+	await Promise.all( [
+		page.waitForResponse(
+			( response ) =>
+				response.url().includes( 'admin-ajax.php' ) &&
+				( response.request().postData() || '' ).includes(
+					'inline-save'
+				)
+		),
+		quickEditRow.locator( '.button.save' ).click(),
+	] );
+
+	await expect( quickEditRow ).toBeHidden();
+}
+
+async function cancelQuickEdit( quickEditRow: Locator ) {
+	await quickEditRow.locator( '.button.cancel' ).click();
+	await expect( quickEditRow ).toBeHidden();
+}
+
+async function expectBoundingBox( locator: Locator ): Promise< BoundingBox > {
+	const box = await locator.boundingBox();
+
+	if ( ! box ) {
+		throw new Error( 'Expected visible bounding box.' );
+	}
+
+	return box;
+}
+
+function isTaxonomyTermSearchRequest( request: Request, taxonomy: string ) {
+	const url = new URL( request.url() );
+	const postData = request.postData() || '';
+	const postParams = new URLSearchParams( postData );
+
+	return (
+		url.pathname.endsWith( 'admin-ajax.php' ) &&
+		( url.searchParams.get( 'action' ) ===
+			'woocommerce_json_search_taxonomy_terms' ||
+			postParams.get( 'action' ) ===
+				'woocommerce_json_search_taxonomy_terms' ) &&
+		( url.searchParams.get( 'taxonomy' ) === taxonomy ||
+			postParams.get( 'taxonomy' ) === taxonomy )
+	);
+}
+
+test.describe( 'Product Quick Edit attributes', () => {
+	test.use( { storageState: ADMIN_STATE_PATH } );
+
+	test.beforeAll( async ( { restApi } ) => {
+		const suffix = Date.now().toString( 36 );
+
+		sizeAttribute = await createGlobalAttribute(
+			restApi,
+			`QE Size ${ suffix }`,
+			[ 'Small', 'Medium', 'Large' ]
+		);
+		styleAttribute = await createGlobalAttribute(
+			restApi,
+			`QE Style ${ suffix }`,
+			[ 'Logo', 'Polka dot', 'Regular', 'Pockets', 'Stripped' ]
+		);
+
+		emptyProduct = await createProduct( restApi, {
+			name: `Quick Edit Attributes Empty ${ suffix }`,
+			type: 'simple',
+			regular_price: '10',
+		} );
+		simpleProduct = await createProduct( restApi, {
+			name: `Quick Edit Attributes Simple ${ suffix }`,
+			type: 'simple',
+			regular_price: '12',
+			attributes: [
+				{
+					id: sizeAttribute.id,
+					visible: true,
+					options: [ 'Medium' ],
+				},
+				{
+					id: styleAttribute.id,
+					visible: true,
+					options: [ 'Regular' ],
+				},
+			],
+		} );
+		manySelectedProduct = await createProduct( restApi, {
+			name: `Quick Edit Attributes Many ${ suffix }`,
+			type: 'simple',
+			regular_price: '14',
+			attributes: [
+				{
+					id: sizeAttribute.id,
+					visible: true,
+					options: sizeAttribute.terms.map( ( term ) => term.name ),
+				},
+				{
+					id: styleAttribute.id,
+					visible: true,
+					options: styleAttribute.terms.map( ( term ) => term.name ),
+				},
+			],
+		} );
+		variableProduct = await createProduct( restApi, {
+			name: `Quick Edit Attributes Variable ${ suffix }`,
+			type: 'variable',
+			attributes: [
+				{
+					id: sizeAttribute.id,
+					visible: true,
+					variation: true,
+					options: sizeAttribute.terms.map( ( term ) => term.name ),
+				},
+			],
+		} );
+
+		for ( const [ index, term ] of sizeAttribute.terms.entries() ) {
+			await restApi.post(
+				`${ WC_API_PATH }/products/${ variableProduct.id }/variations`,
+				{
+					regular_price: String( 20 + index ),
+					attributes: [
+						{
+							id: sizeAttribute.id,
+							option: term.name,
+						},
+					],
+				}
+			);
+		}
+	} );
+
+	test.afterAll( async ( { restApi } ) => {
+		if ( createdProductIds.length ) {
+			await restApi.post( `${ WC_API_PATH }/products/batch`, {
+				delete: createdProductIds,
+			} );
+		}
+
+		if ( createdAttributeIds.length ) {
+			await restApi.post( `${ WC_API_PATH }/products/attributes/batch`, {
+				delete: createdAttributeIds,
+			} );
+		}
+	} );
+
+	test( 'hydrates no, one, and all selected global attribute states', async ( {
+		page,
+	} ) => {
+		await page.setViewportSize( { width: 900, height: 900 } );
+
+		await goToProductList( page, emptyProduct );
+		let quickEditRow = await openQuickEdit( page, emptyProduct );
+		await expect(
+			quickEditRow.getByRole( 'heading', { name: 'Attributes' } )
+		).toBeVisible();
+		await expectAttributeChips( quickEditRow, sizeAttribute.name, [] );
+		await expectAttributeChips( quickEditRow, styleAttribute.name, [] );
+		await cancelQuickEdit( quickEditRow );
+
+		await goToProductList( page, simpleProduct );
+		quickEditRow = await openQuickEdit( page, simpleProduct );
+		await expectAttributeChips( quickEditRow, sizeAttribute.name, [
+			'Medium',
+		] );
+		await expectAttributeChips( quickEditRow, styleAttribute.name, [
+			'Regular',
+		] );
+		await cancelQuickEdit( quickEditRow );
+
+		await goToProductList( page, manySelectedProduct );
+		quickEditRow = await openQuickEdit( page, manySelectedProduct );
+		await expectAttributeChips(
+			quickEditRow,
+			sizeAttribute.name,
+			sizeAttribute.terms.map( ( term ) => term.name )
+		);
+		await expectAttributeChips(
+			quickEditRow,
+			styleAttribute.name,
+			styleAttribute.terms.map( ( term ) => term.name )
+		);
+
+		const styleField = getAttributeField(
+			quickEditRow,
+			styleAttribute.name
+		);
+		await expect(
+			styleField.locator( '.select2-search__field' )
+		).toHaveCSS( 'height', '0px' );
+
+		await cancelQuickEdit( quickEditRow );
+	} );
+
+	test( 'cancels, changes, clears, and preserves unrelated attributes', async ( {
+		page,
+		restApi,
+	} ) => {
+		await goToProductList( page, emptyProduct );
+		let quickEditRow = await openQuickEdit( page, emptyProduct );
+		await expect( quickEditRow ).toBeVisible();
+
+		await selectAttributeTerms( page, quickEditRow, sizeAttribute.name, [
+			'Medium',
+		] );
+		await cancelQuickEdit( quickEditRow );
+		await expectProductAttributeOptions(
+			restApi,
+			emptyProduct.id,
+			sizeAttribute.id,
+			[]
+		);
+
+		await goToProductList( page, simpleProduct );
+		quickEditRow = await openQuickEdit( page, simpleProduct );
+
+		await removeAttributeTerm( quickEditRow, sizeAttribute.name, 'Medium' );
+		await selectAttributeTerms( page, quickEditRow, sizeAttribute.name, [
+			'Large',
+			'Small',
+		] );
+		await saveQuickEdit( page, quickEditRow );
+		await expectProductAttributeOptions(
+			restApi,
+			simpleProduct.id,
+			sizeAttribute.id,
+			[ 'Large', 'Small' ]
+		);
+		await expectProductAttributeOptions(
+			restApi,
+			simpleProduct.id,
+			styleAttribute.id,
+			[ 'Regular' ]
+		);
+
+		await goToProductList( page, simpleProduct );
+		quickEditRow = await openQuickEdit( page, simpleProduct );
+		await removeAllAttributeTerms( quickEditRow, sizeAttribute.name );
+		await saveQuickEdit( page, quickEditRow );
+		await expectProductAttributeOptions(
+			restApi,
+			simpleProduct.id,
+			sizeAttribute.id,
+			[]
+		);
+		await expectProductAttributeOptions(
+			restApi,
+			simpleProduct.id,
+			styleAttribute.id,
+			[ 'Regular' ]
+		);
+	} );
+
+	test( 'keeps dropdown results spaced and caches term searches per page session', async ( {
+		page,
+	} ) => {
+		let sizeTermSearchRequests = 0;
+
+		await page.route( '**/wp-admin/admin-ajax.php', async ( route ) => {
+			if (
+				isTaxonomyTermSearchRequest(
+					route.request(),
+					sizeAttribute.taxonomy
+				)
+			) {
+				await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+			}
+
+			await route.continue();
+		} );
+
+		page.on( 'request', ( request ) => {
+			if (
+				isTaxonomyTermSearchRequest( request, sizeAttribute.taxonomy )
+			) {
+				sizeTermSearchRequests++;
+			}
+		} );
+
+		await goToProductList( page, emptyProduct );
+		const quickEditRow = await openQuickEdit( page, emptyProduct );
+		const sizeField = getAttributeField( quickEditRow, sizeAttribute.name );
+		const styleField = getAttributeField(
+			quickEditRow,
+			styleAttribute.name
+		);
+
+		await sizeField.locator( '.select2-selection' ).click();
+		await expect(
+			page.locator( '.select2-container--open .loading-results' )
+		).toContainText( 'Loading' );
+		await expect(
+			page.getByRole( 'option', { name: 'Small', exact: true } )
+		).toBeVisible();
+
+		const dropdownBox = await expectBoundingBox(
+			page.locator( '.select2-container--open .select2-dropdown' )
+		);
+		const styleFieldBox = await expectBoundingBox( styleField );
+
+		expect( styleFieldBox.y ).toBeGreaterThanOrEqual(
+			dropdownBox.y + dropdownBox.height
+		);
+		expect( sizeTermSearchRequests ).toBe( 1 );
+
+		await quickEditRow.locator( 'input[name="post_title"]' ).click();
+		await expect( page.locator( '.select2-container--open' ) ).toHaveCount(
+			0
+		);
+		const secondRequest = page
+			.waitForRequest(
+				( request ) =>
+					isTaxonomyTermSearchRequest(
+						request,
+						sizeAttribute.taxonomy
+					),
+				{ timeout: 500 }
+			)
+			.then( () => true )
+			.catch( () => false );
+
+		await sizeField.locator( '.select2-selection' ).click();
+		await expect(
+			page.getByRole( 'option', { name: 'Small', exact: true } )
+		).toBeVisible();
+
+		await expect( secondRequest ).resolves.toBe( false );
+		expect( sizeTermSearchRequests ).toBe( 1 );
+
+		await quickEditRow.locator( 'input[name="post_title"]' ).click();
+		await expect( page.locator( '.select2-container--open' ) ).toHaveCount(
+			0
+		);
+		await cancelQuickEdit( quickEditRow );
+	} );
+
+	test( 'keeps variable product variations selectable after quick edit save', async ( {
+		page,
+	} ) => {
+		await goToProductList( page, variableProduct );
+		const quickEditRow = await openQuickEdit( page, variableProduct );
+
+		await saveQuickEdit( page, quickEditRow );
+
+		await page.goto( `product/${ variableProduct.slug }` );
+		await page
+			.locator( '.variations_form select' )
+			.first()
+			.selectOption( { label: 'Medium' } );
+
+		await expect(
+			page.locator(
+				'.single_variation_wrap .woocommerce-variation-price'
+			)
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: 'Add to cart', exact: true } )
+		).toBeEnabled();
+	} );
+} );

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
@@ -22,6 +22,7 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 		$sut = $this
 			->getMockBuilder( WC_Admin_Post_Types::class )
 			->setMethods( array( 'request_data' ) )
+			->disableOriginalConstructor()
 			->getMock();
 
 		$sut->method( 'request_data' )->willReturn( $request_data );
@@ -331,6 +332,49 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 		$this->assertTrue( $updated_attributes[ $taxonomy ]->get_variation(), 'Quick edit should keep the attribute available for variations.' );
 		$this->assertEqualsCanonicalizing( $original_options, array_values( $updated_attributes[ $taxonomy ]->get_options() ), 'Quick edit should keep the variation attribute terms.' );
 		$this->assertEqualsCanonicalizing( $original_options, wp_list_pluck( wp_get_object_terms( $product->get_id(), $taxonomy ), 'term_id' ), 'Quick edit should keep the assigned variation attribute terms.' );
+	}
+
+	/**
+	 * @test
+	 * @testdox Variable product variation attributes should only preserve terms used by existing variations when cleared.
+	 */
+	public function quick_edit_preserves_only_used_variable_product_variation_attribute_terms_when_cleared() {
+		$attribute_data = WC_Helper_Product::create_attribute( 'Quick edit variation size', array( 'Small', 'Medium', 'Large' ) );
+
+		try {
+			$taxonomy  = $attribute_data['attribute_taxonomy'];
+			$small_id  = $attribute_data['term_ids'][0];
+			$medium_id = $attribute_data['term_ids'][1];
+			$large_id  = $attribute_data['term_ids'][2];
+			$product   = new WC_Product_Variable();
+			$attribute = $this->create_product_attribute( $attribute_data, array( $small_id, $medium_id, $large_id ) );
+
+			$attribute->set_variation( true );
+			$product->set_name( 'Quick Edit Variable Product' );
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
+
+			WC_Helper_Product::create_product_variation_object(
+				$product->get_id(),
+				'QUICK-EDIT-VARIATION-SMALL',
+				10,
+				array(
+					$taxonomy => 'small',
+				)
+			);
+
+			$this->quick_edit_save_product_attributes( $product, array( $taxonomy ) );
+
+			$updated_product    = wc_get_product( $product->get_id() );
+			$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+			$this->assertArrayHasKey( $taxonomy, $updated_attributes, 'Quick edit should preserve the variation attribute.' );
+			$this->assertTrue( $updated_attributes[ $taxonomy ]->get_variation(), 'Quick edit should keep the attribute available for variations.' );
+			$this->assertSame( array( $small_id ), array_values( $updated_attributes[ $taxonomy ]->get_options() ), 'Quick edit should keep only terms used by existing variations.' );
+			$this->assertSame( array( $small_id ), wp_list_pluck( wp_get_object_terms( $product->get_id(), $taxonomy ), 'term_id' ), 'Quick edit should assign only terms used by existing variations.' );
+		} finally {
+			$this->delete_test_attribute( $attribute_data );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
@@ -1,0 +1,411 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Unit tests for the WC_Admin_Post_Types class.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+
+/**
+ * Class WC_Admin_Post_Types_Test
+ */
+class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Get a new SUT (System Under Test) instance and configure the specified fake request data.
+	 *
+	 * @param array $request_data Fake request data to configure.
+	 * @return WC_Admin_Post_Types
+	 */
+	private function get_sut_with_request_data( $request_data ) {
+		$sut = $this
+			->getMockBuilder( WC_Admin_Post_Types::class )
+			->setMethods( array( 'request_data' ) )
+			->getMock();
+
+		$sut->method( 'request_data' )->willReturn( $request_data );
+
+		return $sut;
+	}
+
+	/**
+	 * @test
+	 * @testdox Product attributes should update when requested via quick edit.
+	 */
+	public function quick_edit_updates_product_attributes() {
+		$attribute_data = WC_Helper_Product::create_attribute( 'Quick edit color', array( 'Red', 'Blue' ) );
+
+		try {
+			$taxonomy = $attribute_data['attribute_taxonomy'];
+			$red_id   = $attribute_data['term_ids'][0];
+			$blue_id  = $attribute_data['term_ids'][1];
+			$product  = WC_Helper_Product::create_simple_product();
+
+			$attribute = new WC_Product_Attribute();
+			$attribute->set_id( $attribute_data['attribute_id'] );
+			$attribute->set_name( $taxonomy );
+			$attribute->set_options( array( $red_id ) );
+			$attribute->set_position( 1 );
+			$attribute->set_visible( true );
+			$attribute->set_variation( true );
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
+
+			$this->login_as_administrator();
+
+			$request_data = array(
+				'woocommerce_quick_edit'                  => '1',
+				'woocommerce_quick_edit_nonce'            => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+				'quick_edit_product_attribute_taxonomies' => array( $taxonomy ),
+				'quick_edit_product_attributes'           => array(
+					$taxonomy => array( $blue_id ),
+				),
+			);
+
+			$sut = $this->get_sut_with_request_data( $request_data );
+
+			$sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+			$updated_product    = wc_get_product( $product->get_id() );
+			$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+			$this->assertArrayHasKey( $taxonomy, $updated_attributes, 'Updated product should keep the global attribute.' );
+			$this->assertSame( array( $blue_id ), array_values( $updated_attributes[ $taxonomy ]->get_options() ), 'Quick edit should save the selected attribute term.' );
+			$this->assertTrue( $updated_attributes[ $taxonomy ]->get_visible(), 'Quick edit should preserve attribute visibility.' );
+			$this->assertTrue( $updated_attributes[ $taxonomy ]->get_variation(), 'Quick edit should preserve variation usage.' );
+			$this->assertSame( array( $blue_id ), wp_list_pluck( wp_get_object_terms( $product->get_id(), $taxonomy ), 'term_id' ), 'Quick edit should update assigned product terms.' );
+		} finally {
+			$this->delete_test_attribute( $attribute_data );
+		}
+	}
+
+	/**
+	 * @test
+	 * @testdox Product attributes should be added to products without existing attributes via quick edit.
+	 */
+	public function quick_edit_adds_product_attributes_to_product_without_existing_attributes() {
+		$attribute_data = WC_Helper_Product::create_attribute( 'Quick edit add size', array( 'Small', 'Medium', 'Large' ) );
+
+		try {
+			$taxonomy  = $attribute_data['attribute_taxonomy'];
+			$medium_id = $attribute_data['term_ids'][1];
+			$large_id  = $attribute_data['term_ids'][2];
+			$product   = WC_Helper_Product::create_simple_product();
+			$term_ids  = array( $medium_id, $large_id );
+
+			$this->quick_edit_save_product_attributes(
+				$product,
+				array( $taxonomy ),
+				array(
+					$taxonomy => $term_ids,
+				)
+			);
+
+			$updated_product    = wc_get_product( $product->get_id() );
+			$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+			$this->assertArrayHasKey( $taxonomy, $updated_attributes, 'Quick edit should add the global attribute.' );
+			$this->assertEqualsCanonicalizing( $term_ids, array_values( $updated_attributes[ $taxonomy ]->get_options() ) );
+			$this->assertTrue( $updated_attributes[ $taxonomy ]->get_visible() );
+			$this->assertFalse( $updated_attributes[ $taxonomy ]->get_variation() );
+			$this->assertEqualsCanonicalizing(
+				$term_ids,
+				wp_list_pluck( wp_get_object_terms( $product->get_id(), $taxonomy ), 'term_id' )
+			);
+		} finally {
+			$this->delete_test_attribute( $attribute_data );
+		}
+	}
+
+	/**
+	 * Product types that should accept global attribute updates from quick edit.
+	 *
+	 * @return array
+	 */
+	public function data_provider_quick_edit_adds_attributes_for_product_types() {
+		return array(
+			'simple product'   => array( 'simple' ),
+			'external product' => array( 'external' ),
+			'grouped product'  => array( 'grouped' ),
+			'variable product' => array( 'variable' ),
+		);
+	}
+
+	/**
+	 * @test
+	 * @testdox Product attributes should be added to supported product types via quick edit.
+	 * @dataProvider data_provider_quick_edit_adds_attributes_for_product_types
+	 *
+	 * @param string $product_type Product type to create.
+	 */
+	public function quick_edit_adds_product_attributes_for_product_types( $product_type ) {
+		$attribute_data = WC_Helper_Product::create_attribute( 'Quick edit product type', array( 'Standard' ) );
+
+		try {
+			$taxonomy = $attribute_data['attribute_taxonomy'];
+			$term_id  = $attribute_data['term_ids'][0];
+			$product  = $this->create_product_by_type( $product_type );
+
+			$this->quick_edit_save_product_attributes(
+				$product,
+				array( $taxonomy ),
+				array(
+					$taxonomy => array( $term_id ),
+				)
+			);
+
+			$updated_product    = wc_get_product( $product->get_id() );
+			$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+			$this->assertArrayHasKey( $taxonomy, $updated_attributes );
+			$this->assertSame( array( $term_id ), array_values( $updated_attributes[ $taxonomy ]->get_options() ) );
+		} finally {
+			$this->delete_test_attribute( $attribute_data );
+		}
+	}
+
+	/**
+	 * @test
+	 * @testdox Updating one product attribute via quick edit should not remove another submitted attribute.
+	 */
+	public function quick_edit_updates_one_product_attribute_without_removing_another() {
+		$size_data  = WC_Helper_Product::create_attribute( 'Quick edit update size', array( 'Small', 'Large' ) );
+		$style_data = WC_Helper_Product::create_attribute( 'Quick edit update style', array( 'Logo', 'Regular' ) );
+
+		try {
+			$size_taxonomy  = $size_data['attribute_taxonomy'];
+			$style_taxonomy = $style_data['attribute_taxonomy'];
+			$small_id       = $size_data['term_ids'][0];
+			$large_id       = $size_data['term_ids'][1];
+			$regular_id     = $style_data['term_ids'][1];
+			$product        = WC_Helper_Product::create_simple_product();
+
+			$product->set_attributes(
+				array(
+					$this->create_product_attribute( $size_data, array( $small_id ) ),
+					$this->create_product_attribute( $style_data, array( $regular_id ) ),
+				)
+			);
+			$product->save();
+
+			$this->quick_edit_save_product_attributes(
+				$product,
+				array( $size_taxonomy, $style_taxonomy ),
+				array(
+					$size_taxonomy  => array( $large_id ),
+					$style_taxonomy => array( $regular_id ),
+				)
+			);
+
+			$updated_product    = wc_get_product( $product->get_id() );
+			$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+			$this->assertSame( array( $large_id ), array_values( $updated_attributes[ $size_taxonomy ]->get_options() ) );
+			$this->assertSame( array( $regular_id ), array_values( $updated_attributes[ $style_taxonomy ]->get_options() ) );
+		} finally {
+			$this->delete_test_attribute( $size_data );
+			$this->delete_test_attribute( $style_data );
+		}
+	}
+
+	/**
+	 * @test
+	 * @testdox Clearing one product attribute via quick edit should not remove another submitted attribute.
+	 */
+	public function quick_edit_clears_one_product_attribute_without_removing_another() {
+		$size_data  = WC_Helper_Product::create_attribute( 'Quick edit clear size', array( 'Small', 'Large' ) );
+		$style_data = WC_Helper_Product::create_attribute( 'Quick edit clear style', array( 'Logo', 'Regular' ) );
+
+		try {
+			$size_taxonomy  = $size_data['attribute_taxonomy'];
+			$style_taxonomy = $style_data['attribute_taxonomy'];
+			$small_id       = $size_data['term_ids'][0];
+			$regular_id     = $style_data['term_ids'][1];
+			$product        = WC_Helper_Product::create_simple_product();
+
+			$product->set_attributes(
+				array(
+					$this->create_product_attribute( $size_data, array( $small_id ) ),
+					$this->create_product_attribute( $style_data, array( $regular_id ) ),
+				)
+			);
+			$product->save();
+
+			$this->quick_edit_save_product_attributes(
+				$product,
+				array( $size_taxonomy, $style_taxonomy ),
+				array(
+					$style_taxonomy => array( $regular_id ),
+				)
+			);
+
+			$updated_product    = wc_get_product( $product->get_id() );
+			$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+			$this->assertArrayNotHasKey( $size_taxonomy, $updated_attributes );
+			$this->assertArrayHasKey( $style_taxonomy, $updated_attributes );
+			$this->assertSame( array( $regular_id ), array_values( $updated_attributes[ $style_taxonomy ]->get_options() ) );
+			$this->assertSame( array(), wp_get_object_terms( $product->get_id(), $size_taxonomy ) );
+		} finally {
+			$this->delete_test_attribute( $size_data );
+			$this->delete_test_attribute( $style_data );
+		}
+	}
+
+	/**
+	 * @test
+	 * @testdox Product attributes should be removed when no terms are selected via quick edit.
+	 */
+	public function quick_edit_removes_product_attributes_when_no_terms_are_selected() {
+		$attribute_data = WC_Helper_Product::create_attribute( 'Quick edit size', array( 'Small', 'Large' ) );
+
+		try {
+			$taxonomy         = $attribute_data['attribute_taxonomy'];
+			$small_id         = $attribute_data['term_ids'][0];
+			$product          = WC_Helper_Product::create_simple_product();
+			$global_attribute = new WC_Product_Attribute();
+			$custom_attribute = new WC_Product_Attribute();
+
+			$global_attribute->set_id( $attribute_data['attribute_id'] );
+			$global_attribute->set_name( $taxonomy );
+			$global_attribute->set_options( array( $small_id ) );
+			$global_attribute->set_visible( true );
+
+			$custom_attribute->set_name( 'Material' );
+			$custom_attribute->set_options( array( 'Cotton' ) );
+			$custom_attribute->set_visible( true );
+
+			$product->set_attributes( array( $global_attribute, $custom_attribute ) );
+			$product->save();
+
+			$this->login_as_administrator();
+
+			$request_data = array(
+				'woocommerce_quick_edit'                  => '1',
+				'woocommerce_quick_edit_nonce'            => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+				'quick_edit_product_attribute_taxonomies' => array( $taxonomy ),
+			);
+
+			$sut = $this->get_sut_with_request_data( $request_data );
+
+			$sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+			$updated_product    = wc_get_product( $product->get_id() );
+			$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+			$this->assertArrayNotHasKey( $taxonomy, $updated_attributes, 'Quick edit should remove cleared global attributes.' );
+			$this->assertArrayHasKey( 'material', $updated_attributes, 'Quick edit should preserve custom product attributes.' );
+			$this->assertSame( array(), wp_get_object_terms( $product->get_id(), $taxonomy ), 'Quick edit should clear assigned product terms.' );
+		} finally {
+			$this->delete_test_attribute( $attribute_data );
+		}
+	}
+
+	/**
+	 * @test
+	 * @testdox Variation attributes should not be removed from variable products when no terms are selected via quick edit.
+	 */
+	public function quick_edit_preserves_variable_product_variation_attributes_when_no_terms_are_selected() {
+		$product          = WC_Helper_Product::create_variation_product();
+		$taxonomy         = 'pa_size';
+		$attributes       = $product->get_attributes( 'edit' );
+		$original_options = array_values( $attributes[ $taxonomy ]->get_options() );
+
+		$this->login_as_administrator();
+
+		$request_data = array(
+			'woocommerce_quick_edit'                  => '1',
+			'woocommerce_quick_edit_nonce'            => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+			'quick_edit_product_attribute_taxonomies' => array( $taxonomy ),
+		);
+
+		$sut = $this->get_sut_with_request_data( $request_data );
+
+		$sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		$updated_product    = wc_get_product( $product->get_id() );
+		$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+		$this->assertArrayHasKey( $taxonomy, $updated_attributes, 'Quick edit should preserve variation attributes on variable products.' );
+		$this->assertTrue( $updated_attributes[ $taxonomy ]->get_variation(), 'Quick edit should keep the attribute available for variations.' );
+		$this->assertEqualsCanonicalizing( $original_options, array_values( $updated_attributes[ $taxonomy ]->get_options() ), 'Quick edit should keep the variation attribute terms.' );
+		$this->assertEqualsCanonicalizing( $original_options, wp_list_pluck( wp_get_object_terms( $product->get_id(), $taxonomy ), 'term_id' ), 'Quick edit should keep the assigned variation attribute terms.' );
+	}
+
+	/**
+	 * Save global attribute request data through the Quick Edit save handler.
+	 *
+	 * @param WC_Product $product Product to save.
+	 * @param array      $taxonomies Submitted attribute taxonomies.
+	 * @param array      $selected_terms Submitted term IDs keyed by taxonomy.
+	 */
+	private function quick_edit_save_product_attributes( $product, $taxonomies, $selected_terms = array() ) {
+		$this->login_as_administrator();
+
+		$request_data = array(
+			'woocommerce_quick_edit'                  => '1',
+			'woocommerce_quick_edit_nonce'            => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+			'quick_edit_product_attribute_taxonomies' => $taxonomies,
+		);
+
+		if ( ! empty( $selected_terms ) ) {
+			$request_data['quick_edit_product_attributes'] = $selected_terms;
+		}
+
+		$sut = $this->get_sut_with_request_data( $request_data );
+		$sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+	}
+
+	/**
+	 * Create a product for quick edit product type coverage.
+	 *
+	 * @param string $product_type Product type.
+	 * @return WC_Product
+	 */
+	private function create_product_by_type( $product_type ) {
+		switch ( $product_type ) {
+			case 'external':
+				return WC_Helper_Product::create_external_product();
+			case 'grouped':
+				return WC_Helper_Product::create_grouped_product();
+			case 'variable':
+				return WC_Helper_Product::create_variation_product();
+			case 'simple':
+			default:
+				return WC_Helper_Product::create_simple_product();
+		}
+	}
+
+	/**
+	 * Create a product attribute object from test attribute data.
+	 *
+	 * @param array $attribute_data Attribute data from WC_Helper_Product::create_attribute().
+	 * @param array $term_ids Term IDs to set.
+	 * @return WC_Product_Attribute
+	 */
+	private function create_product_attribute( $attribute_data, $term_ids ) {
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( $attribute_data['attribute_id'] );
+		$attribute->set_name( $attribute_data['attribute_taxonomy'] );
+		$attribute->set_options( $term_ids );
+		$attribute->set_visible( true );
+
+		return $attribute;
+	}
+
+	/**
+	 * Delete a test attribute and clear its taxonomy caches.
+	 *
+	 * @param array $attribute_data Attribute data from WC_Helper_Product::create_attribute().
+	 */
+	private function delete_test_attribute( $attribute_data ) {
+		global $wc_product_attributes;
+
+		WC_Helper_Product::delete_attribute( $attribute_data['attribute_id'] );
+		unregister_taxonomy( $attribute_data['attribute_taxonomy'] );
+		unset( $wc_product_attributes[ $attribute_data['attribute_taxonomy'] ] );
+		delete_transient( 'wc_attribute_taxonomies' );
+		WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
@@ -404,6 +404,8 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 				)
 			);
 
+			$product = wc_get_product( $product->get_id() );
+
 			$this->quick_edit_save_product_attributes( $product, array( $taxonomy ) );
 
 			$updated_product    = wc_get_product( $product->get_id() );

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
@@ -378,6 +378,47 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @test
+	 * @testdox Variable product variation attributes should preserve current terms when cleared and an existing variation allows any attribute value.
+	 */
+	public function quick_edit_preserves_all_variable_product_variation_attribute_terms_when_any_variation_is_cleared() {
+		$attribute_data = WC_Helper_Product::create_attribute( 'Quick edit any size', array( 'Small', 'Medium', 'Large' ) );
+
+		try {
+			$taxonomy         = $attribute_data['attribute_taxonomy'];
+			$original_options = $attribute_data['term_ids'];
+			$product          = new WC_Product_Variable();
+			$attribute        = $this->create_product_attribute( $attribute_data, $original_options );
+
+			$attribute->set_variation( true );
+			$product->set_name( 'Quick Edit Any Variation Product' );
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
+
+			WC_Helper_Product::create_product_variation_object(
+				$product->get_id(),
+				'QUICK-EDIT-VARIATION-ANY-SIZE',
+				10,
+				array(
+					$taxonomy => '',
+				)
+			);
+
+			$this->quick_edit_save_product_attributes( $product, array( $taxonomy ) );
+
+			$updated_product    = wc_get_product( $product->get_id() );
+			$updated_attributes = $updated_product->get_attributes( 'edit' );
+
+			$this->assertArrayHasKey( $taxonomy, $updated_attributes, 'Quick edit should preserve the variation attribute.' );
+			$this->assertTrue( $updated_attributes[ $taxonomy ]->get_variation(), 'Quick edit should keep the attribute available for wildcard variations.' );
+			$this->assertEqualsCanonicalizing( $original_options, array_values( $updated_attributes[ $taxonomy ]->get_options() ), 'Quick edit should keep all current terms used by wildcard variations.' );
+			$this->assertEqualsCanonicalizing( $original_options, wp_list_pluck( wp_get_object_terms( $product->get_id(), $taxonomy ), 'term_id' ), 'Quick edit should keep assigned terms for wildcard variations.' );
+		} finally {
+			$this->delete_test_attribute( $attribute_data );
+		}
+	}
+
+	/**
 	 * Save global attribute request data through the Quick Edit save handler.
 	 *
 	 * @param WC_Product $product Product to save.


### PR DESCRIPTION
### Summary
- Add global product attributes to the classic Products Quick Edit panel.
- Populate existing attribute selections, allow adding hidden global attributes, and save/clear selected terms.
- Polish SelectWoo layout, loading copy, caching, and the all-attributes-added empty state.

### Testing
- `npx --yes pnpm@10.33.0 --dir plugins/woocommerce test:e2e tests/product/product-quick-edit-attributes.spec.ts --workers=1`
- `npx --yes pnpm@10.33.0 --dir plugins/woocommerce test:php:env -- --filter WC_Admin_Post_Types_Test`
- `npx --yes pnpm@10.33.0 --dir plugins/woocommerce lint:changes:branch origin/trunk`
- `git diff --check origin/trunk...HEAD`