### PR TITLE
Document gallery_image_ids field on product_variations REST API

### DIFF
--- a/docs/apis/rest-api/v3/api-reference.mdx
+++ b/docs/apis/rest-api/v3/api-reference.mdx
@@ -7112,7 +7112,7 @@ woocommerce.get("").parsed_response
 						},
 						"gallery_image_ids": {
 							"required": false,
-							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\"). Mirrors how galleries work on parent products.",
+							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\").",
 							"type": "array",
 							"items": {
 								"type": "integer"
@@ -7362,7 +7362,7 @@ woocommerce.get("").parsed_response
 						},
 						"gallery_image_ids": {
 							"required": false,
-							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\"). Mirrors how galleries work on parent products.",
+							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\").",
 							"type": "array",
 							"items": {
 								"type": "integer"
@@ -7606,7 +7606,7 @@ woocommerce.get("").parsed_response
 						},
 						"gallery_image_ids": {
 							"required": false,
-							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\"). Mirrors how galleries work on parent products.",
+							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\").",
 							"type": "array",
 							"items": {
 								"type": "integer"

--- a/docs/apis/rest-api/v3/api-reference.mdx
+++ b/docs/apis/rest-api/v3/api-reference.mdx
@@ -7110,6 +7110,14 @@ woocommerce.get("").parsed_response
 							"description": "Variation image data.",
 							"type": "object"
 						},
+						"gallery_image_ids": {
+							"required": false,
+							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\"). Mirrors how galleries work on parent products.",
+							"type": "array",
+							"items": {
+								"type": "integer"
+							}
+						},
 						"attributes": {
 							"required": false,
 							"description": "List of attributes.",
@@ -7352,6 +7360,14 @@ woocommerce.get("").parsed_response
 							"description": "Variation image data.",
 							"type": "object"
 						},
+						"gallery_image_ids": {
+							"required": false,
+							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\"). Mirrors how galleries work on parent products.",
+							"type": "array",
+							"items": {
+								"type": "integer"
+							}
+						},
 						"attributes": {
 							"required": false,
 							"description": "List of attributes.",
@@ -7587,6 +7603,14 @@ woocommerce.get("").parsed_response
 							"required": false,
 							"description": "Variation image data.",
 							"type": "object"
+						},
+						"gallery_image_ids": {
+							"required": false,
+							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\"). Mirrors how galleries work on parent products.",
+							"type": "array",
+							"items": {
+								"type": "integer"
+							}
 						},
 						"attributes": {
 							"required": false,

--- a/docs/apis/rest-api/v3/api-reference.mdx
+++ b/docs/apis/rest-api/v3/api-reference.mdx
@@ -7115,7 +7115,8 @@ woocommerce.get("").parsed_response
 							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\").",
 							"type": "array",
 							"items": {
-								"type": "integer"
+								"type": "integer",
+								"minimum": 1
 							}
 						},
 						"attributes": {
@@ -7365,7 +7366,8 @@ woocommerce.get("").parsed_response
 							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\").",
 							"type": "array",
 							"items": {
-								"type": "integer"
+								"type": "integer",
+								"minimum": 1
 							}
 						},
 						"attributes": {
@@ -7609,7 +7611,8 @@ woocommerce.get("").parsed_response
 							"description": "Variation gallery image IDs, excluding the featured image (which is set via \"image\").",
 							"type": "array",
 							"items": {
-								"type": "integer"
+								"type": "integer",
+								"minimum": 1
 							}
 						},
 						"attributes": {

--- a/docs/apis/rest-api/v3/product-variations.mdx
+++ b/docs/apis/rest-api/v3/product-variations.mdx
@@ -51,6 +51,7 @@ The product variations API allows you to create, view, update, and delete indivi
 | `shipping_class`        | string          | Shipping class slug.                                                                                                |
 | `shipping_class_id`     | string          | Shipping class ID. `READ-ONLY`                                                        |
 | `image`                 | object          | Variation image data. See [Product variation - Image properties](#product-variation---image-properties)               |
+| `gallery_image_ids`     | array           | Variation gallery image IDs, excluding the featured image (which is set via `image`).                               |
 | `attributes`            | array           | List of attributes. See [Product variation - Attributes properties](#product-variation---attributes-properties)       |
 | `menu_order`            | integer         | Menu order, used to custom sort products.                                                                           |
 | `meta_data`             | array           | Meta data. See [Product variation - Meta data properties](#product-variation---meta-data-properties)                  |
@@ -271,6 +272,7 @@ woocommerce.post("products/22/variations", data).parsed_response
 		"name": "",
 		"alt": ""
 	},
+	"gallery_image_ids": [],
 	"attributes": [
 		{
 			"id": 6,
@@ -407,6 +409,7 @@ woocommerce.get("products/22/variations/732").parsed_response
 		"name": "",
 		"alt": ""
 	},
+	"gallery_image_ids": [],
 	"attributes": [
 		{
 			"id": 6,
@@ -544,6 +547,7 @@ woocommerce.get("products/22/variations").parsed_response
 			"name": "",
 			"alt": ""
 		},
+		"gallery_image_ids": [],
 		"attributes": [
 			{
 				"id": 6,
@@ -621,6 +625,7 @@ woocommerce.get("products/22/variations").parsed_response
 			"name": "",
 			"alt": ""
 		},
+		"gallery_image_ids": [],
 		"attributes": [
 			{
 				"id": 6,
@@ -811,6 +816,7 @@ woocommerce.put("products/22/variations/733", data).parsed_response
 		"name": "",
 		"alt": ""
 	},
+	"gallery_image_ids": [],
 	"attributes": [
 		{
 			"id": 6,
@@ -949,6 +955,7 @@ woocommerce.delete("products/22/variations/733", force: true).parsed_response
 		"name": "",
 		"alt": ""
 	},
+	"gallery_image_ids": [],
 	"attributes": [
 		{
 			"id": 6,
@@ -1258,6 +1265,7 @@ woocommerce.post("products/22/variations/batch", data).parsed_response
 				"name": "Placeholder",
 				"alt": "Placeholder"
 			},
+			"gallery_image_ids": [],
 			"attributes": [
 				{
 					"id": 6,
@@ -1335,6 +1343,7 @@ woocommerce.post("products/22/variations/batch", data).parsed_response
 				"name": "Placeholder",
 				"alt": "Placeholder"
 			},
+			"gallery_image_ids": [],
 			"attributes": [
 				{
 					"id": 6,
@@ -1414,6 +1423,7 @@ woocommerce.post("products/22/variations/batch", data).parsed_response
 				"name": "",
 				"alt": ""
 			},
+			"gallery_image_ids": [],
 			"attributes": [
 				{
 					"id": 6,
@@ -1493,6 +1503,7 @@ woocommerce.post("products/22/variations/batch", data).parsed_response
 				"name": "",
 				"alt": ""
 			},
+			"gallery_image_ids": [],
 			"attributes": [
 				{
 					"id": 6,

--- a/plugins/woocommerce/changelog/update-rest-api-docs
+++ b/plugins/woocommerce/changelog/update-rest-api-docs
@@ -2,4 +2,4 @@ Significance: patch
 Type: dev
 Comment: Docs-only change. No plugin code impact.
 
-Document new gallery_image_ids field on /wc/v3/product_variations endpoint (added in #64524).
+Document new gallery_image_ids field on /wc/v3/products/<product_id>/variations endpoint (added in #64524).

--- a/plugins/woocommerce/changelog/update-rest-api-docs
+++ b/plugins/woocommerce/changelog/update-rest-api-docs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Docs-only change. No plugin code impact.
+
+Document new gallery_image_ids field on /wc/v3/product_variations endpoint (added in #64524).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

PR #64524 added a new `gallery_image_ids` field on `wc/v3/product_variations` (read + write), but the REST API docs in the monorepo weren't updated to reflect it. This PR documents the field in:

- `docs/apis/rest-api/v3/product-variations.mdx` — property table and all JSON response examples
- `docs/apis/rest-api/v3/api-reference.mdx` — schema reference for all three variation routes (list, single, batch).

Docs only — no plugin code changes. The v2 endpoint isn't updated because PR #64524 only modified the v3 controller.