### PR TITLE
Discover display styles via block support

### DIFF
--- a/plugins/woocommerce/changelog/update-display-style-switch-to-editor-components
+++ b/plugins/woocommerce/changelog/update-display-style-switch-to-editor-components
@@ -1,5 +1,3 @@
 Significance: patch
 Type: tweak
-Comment: Move DisplayStyleSwitcher to editor-components
-
-
+Comment: Move DisplayStyleSwitcher to editor-components and discover display styles via block supports

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -10,7 +10,7 @@ import {
 	store as blockEditorStore,
 	__experimentalUseBlockPreview as useBlockPreview,
 } from '@wordpress/block-editor';
-import { BlockInstance, type BlockEditProps } from '@wordpress/blocks';
+import type { BlockEditProps, BlockInstance } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
 	CustomDataProvider,
@@ -43,6 +43,24 @@ import type {
 } from '../../../../types/type-defs/selectable-items';
 
 const INNER_CHIPS = 'woocommerce/product-filter-chips';
+
+const getDisplayStyleInsertionPoint = ( parentBlock: BlockInstance ) => {
+	const groupBlock = parentBlock.innerBlocks.find(
+		( block ) => block.name === 'core/group'
+	);
+
+	if ( groupBlock ) {
+		return {
+			rootClientId: groupBlock.clientId,
+			index: groupBlock.innerBlocks.length,
+		};
+	}
+
+	return {
+		rootClientId: parentBlock.clientId,
+		index: parentBlock.innerBlocks.length,
+	};
+};
 
 interface Attributes {
 	className?: string;
@@ -177,7 +195,11 @@ export default function AttributeItemTemplateEdit(
 					label={ __( 'Style', 'woocommerce' ) }
 					resetAll={ () => {
 						setAttributes( { displayStyle: INNER_CHIPS } );
-						resetDisplayStyleBlock( clientId, INNER_CHIPS );
+						resetDisplayStyleBlock(
+							clientId,
+							INNER_CHIPS,
+							getDisplayStyleInsertionPoint
+						);
 					} }
 				>
 					<ToolsPanelItem
@@ -185,7 +207,11 @@ export default function AttributeItemTemplateEdit(
 						label={ __( 'Style', 'woocommerce' ) }
 						onDeselect={ () => {
 							setAttributes( { displayStyle: INNER_CHIPS } );
-							resetDisplayStyleBlock( clientId, INNER_CHIPS );
+							resetDisplayStyleBlock(
+								clientId,
+								INNER_CHIPS,
+								getDisplayStyleInsertionPoint
+							);
 						} }
 						isShownByDefault
 					>
@@ -196,6 +222,9 @@ export default function AttributeItemTemplateEdit(
 							<DisplayStyleSwitcher
 								clientId={ clientId }
 								currentStyle={ displayStyle }
+								getFallbackInsertionPoint={
+									getDisplayStyleInsertionPoint
+								}
 								onChange={ ( value ) => {
 									setAttributes( {
 										displayStyle: value,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -44,7 +44,9 @@ import type {
 
 const INNER_CHIPS = 'woocommerce/product-filter-chips';
 
-const getDisplayStyleInsertionPoint = ( parentBlock: BlockInstance ) => {
+const getFallbackDisplayStyleInsertionPoint = (
+	parentBlock: BlockInstance
+) => {
 	const groupBlock = parentBlock.innerBlocks.find(
 		( block ) => block.name === 'core/group'
 	);
@@ -198,7 +200,7 @@ export default function AttributeItemTemplateEdit(
 						resetDisplayStyleBlock(
 							clientId,
 							INNER_CHIPS,
-							getDisplayStyleInsertionPoint
+							getFallbackDisplayStyleInsertionPoint
 						);
 					} }
 				>
@@ -210,7 +212,7 @@ export default function AttributeItemTemplateEdit(
 							resetDisplayStyleBlock(
 								clientId,
 								INNER_CHIPS,
-								getDisplayStyleInsertionPoint
+								getFallbackDisplayStyleInsertionPoint
 							);
 						} }
 						isShownByDefault
@@ -223,7 +225,7 @@ export default function AttributeItemTemplateEdit(
 								clientId={ clientId }
 								currentStyle={ displayStyle }
 								getFallbackDisplayStyleInsertionPoint={
-									getDisplayStyleInsertionPoint
+									getFallbackDisplayStyleInsertionPoint
 								}
 								onChange={ ( value ) => {
 									setAttributes( {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -222,7 +222,7 @@ export default function AttributeItemTemplateEdit(
 							<DisplayStyleSwitcher
 								clientId={ clientId }
 								currentStyle={ displayStyle }
-								getFallbackInsertionPoint={
+								getFallbackDisplayStyleInsertionPoint={
 									getDisplayStyleInsertionPoint
 								}
 								onChange={ ( value ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/dropdown/block.json
@@ -11,7 +11,10 @@
 		"woocommerce/add-to-cart-with-options-variation-selector-attribute"
 	],
 	"supports": {
-		"interactivity": true
+		"interactivity": true,
+		"woocommerce": {
+			"innerBlockDisplayStyle": true
+		}
 	},
 	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
@@ -4,7 +4,6 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Block, getBlockTypes } from '@wordpress/blocks';
 import {
 	DisplayStyleSwitcher,
 	resetDisplayStyleBlock,
@@ -29,8 +28,6 @@ import { sortOrderOptions, sortOrders } from './constants';
 import { EditProps, DEFAULT_SORT_ORDER, DEFAULT_QUERY_TYPE } from './types';
 import metadata from './block.json';
 
-let displayStyleOptions: Block[] = [];
-
 export const Inspector = ( {
 	clientId,
 	attributes,
@@ -38,14 +35,6 @@ export const Inspector = ( {
 }: EditProps ) => {
 	const { sortOrder, queryType, displayStyle, showCounts, hideEmpty } =
 		attributes;
-
-	if ( displayStyleOptions.length === 0 ) {
-		displayStyleOptions = getBlockTypes().filter( ( blockType ) =>
-			blockType.ancestor?.includes(
-				'woocommerce/product-filter-attribute'
-			)
-		);
-	}
 
 	return (
 		<>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/block.json
@@ -14,7 +14,10 @@
 		"woocommerce/product-filter-rating"
 	],
 	"supports": {
-		"interactivity": true
+		"interactivity": true,
+		"woocommerce": {
+			"innerBlockDisplayStyle": true
+		}
 	},
 	"usesContext": [ "woocommerce/selectableItems" ],
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
@@ -14,7 +14,10 @@
 		"woocommerce/add-to-cart-with-options-variation-selector-attribute"
 	],
 	"supports": {
-		"interactivity": true
+		"interactivity": true,
+		"woocommerce": {
+			"innerBlockDisplayStyle": true
+		}
 	},
 	"usesContext": [ "woocommerce/selectableItems", "woocommerce/attributeId" ],
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/constants.ts
@@ -1,7 +1,0 @@
-/**
- * Block types that declare a product filter or variation-selector parent in `ancestor`
- * but are not interchangeable display styles for the style toggle (chips vs dropdown).
- */
-export const DISPLAY_STYLE_SWITCHER_EXCLUDED_BLOCK_NAMES: string[] = [
-	'woocommerce/add-to-cart-with-options-variation-selector-attribute-name',
-];

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/index.tsx
@@ -3,7 +3,6 @@
  */
 import {
 	createBlock,
-	getBlockSupport,
 	getBlockTypes,
 	type BlockInstance,
 } from '@wordpress/blocks';
@@ -24,28 +23,29 @@ type DisplayStyleInsertionPoint = {
 	index: number;
 };
 
+type DisplayStyleBlockSupport = {
+	woocommerce?: {
+		innerBlockDisplayStyle?: unknown;
+	};
+};
+
+type GetFallbackDisplayStyleInsertionPoint = (
+	parentBlock: BlockInstance
+) => DisplayStyleInsertionPoint;
+
 type DisplayStyleBlockType = ReturnType< typeof getBlockTypes >[ number ] & {
 	ancestor?: readonly string[] | string;
 	usesContext?: readonly string[] | string;
+	supports?: DisplayStyleBlockSupport;
 };
-
-type DisplayStyleSupportReader = (
-	blockName: string,
-	feature: 'woocommerce.innerBlockDisplayStyle',
-	defaultSupports: false
-) => unknown;
 
 type DisplayStyleSwitcherProps = {
 	clientId: string;
 	currentStyle: string;
 	onChange: ( value: string ) => void;
 	contextKey?: string;
-	getFallbackInsertionPoint?: (
-		parentBlock: BlockInstance
-	) => DisplayStyleInsertionPoint;
+	getFallbackDisplayStyleInsertionPoint?: GetFallbackDisplayStyleInsertionPoint;
 };
-
-const getDisplayStyleSupport = getBlockSupport as DisplayStyleSupportReader;
 
 function isBlockInstance(
 	block: BlockInstance | null
@@ -65,13 +65,7 @@ function getBlockTypeList(
 function hasInnerBlockDisplayStyleSupport(
 	blockType: DisplayStyleBlockType
 ): boolean {
-	return (
-		getDisplayStyleSupport(
-			blockType.name,
-			'woocommerce.innerBlockDisplayStyle',
-			false
-		) === true
-	);
+	return blockType.supports?.woocommerce?.innerBlockDisplayStyle === true;
 }
 
 function isDisplayStyleCandidate(
@@ -118,12 +112,10 @@ function getCurrentDisplayStyleBlock(
 
 function getDisplayStyleInsertionPoint(
 	parentBlock: BlockInstance,
-	getFallbackInsertionPoint?: (
-		parentBlock: BlockInstance
-	) => DisplayStyleInsertionPoint
+	getFallbackDisplayStyleInsertionPoint?: GetFallbackDisplayStyleInsertionPoint
 ): DisplayStyleInsertionPoint {
 	return (
-		getFallbackInsertionPoint?.( parentBlock ) ?? {
+		getFallbackDisplayStyleInsertionPoint?.( parentBlock ) ?? {
 			rootClientId: parentBlock.clientId,
 			index: parentBlock.innerBlocks.length,
 		}
@@ -135,7 +127,7 @@ export const DisplayStyleSwitcher = ( {
 	currentStyle,
 	onChange,
 	contextKey = SELECTABLE_ITEMS_CONTEXT,
-	getFallbackInsertionPoint,
+	getFallbackDisplayStyleInsertionPoint,
 }: DisplayStyleSwitcherProps ) => {
 	const parentBlock = select( 'core/block-editor' ).getBlock( clientId );
 	const parentBlockName = parentBlock?.name;
@@ -187,7 +179,7 @@ export const DisplayStyleSwitcher = ( {
 				} else {
 					const insertionPoint = getDisplayStyleInsertionPoint(
 						parentBlock,
-						getFallbackInsertionPoint
+						getFallbackDisplayStyleInsertionPoint
 					);
 
 					insertBlock(
@@ -215,9 +207,7 @@ export const DisplayStyleSwitcher = ( {
 export function resetDisplayStyleBlock(
 	clientId: string,
 	defaultStyle: string,
-	getFallbackInsertionPoint?: (
-		parentBlock: BlockInstance
-	) => DisplayStyleInsertionPoint,
+	getFallbackDisplayStyleInsertionPoint?: GetFallbackDisplayStyleInsertionPoint,
 	contextKey = SELECTABLE_ITEMS_CONTEXT
 ) {
 	const parentBlock = select( 'core/block-editor' ).getBlock( clientId );
@@ -238,7 +228,7 @@ export function resetDisplayStyleBlock(
 	} else {
 		const insertionPoint = getDisplayStyleInsertionPoint(
 			parentBlock,
-			getFallbackInsertionPoint
+			getFallbackDisplayStyleInsertionPoint
 		);
 
 		insertBlock(

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/index.tsx
@@ -29,6 +29,11 @@ type DisplayStyleBlockSupport = {
 	};
 };
 
+/**
+ * By default, the current parent block is the insertion point. For complex
+ * block compositions, the default insertion point can be an inner block of
+ * the parent, such as the Variation Attribute Selector block.
+ */
 type GetFallbackDisplayStyleInsertionPoint = (
 	parentBlock: BlockInstance
 ) => DisplayStyleInsertionPoint;

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/index.tsx
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { createBlock, getBlockTypes } from '@wordpress/blocks';
+import {
+	createBlock,
+	getBlockSupport,
+	getBlockTypes,
+	type BlockInstance,
+} from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import { dispatch, select, useDispatch } from '@wordpress/data';
 import { getInnerBlockByName } from '@woocommerce/utils';
@@ -14,51 +19,123 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 
-/**
- * Internal dependencies
- */
-import { DISPLAY_STYLE_SWITCHER_EXCLUDED_BLOCK_NAMES } from './constants';
+const SELECTABLE_ITEMS_CONTEXT = 'woocommerce/selectableItems';
+
+type DisplayStyleInsertionPoint = {
+	rootClientId: string;
+	index: number;
+};
+
+type DisplayStyleBlockType = ReturnType< typeof getBlockTypes >[ number ] & {
+	ancestor?: readonly string[] | string;
+	usesContext?: readonly string[] | string;
+};
+
+type DisplayStyleSwitcherProps = {
+	clientId: string;
+	currentStyle: string;
+	onChange: ( value: string ) => void;
+	contextKey?: string;
+	getFallbackInsertionPoint?: (
+		parentBlock: BlockInstance
+	) => DisplayStyleInsertionPoint;
+};
+
+function isBlockInstance(
+	block: BlockInstance | null
+): block is BlockInstance {
+	return Boolean( block );
+}
+
+function getBlockTypeList(
+	value: readonly string[] | string | undefined
+): readonly string[] {
+	if ( ! value ) {
+		return [];
+	}
+	return Array.isArray( value ) ? value : [ value ];
+}
 
 function isDisplayStyleCandidate(
-	blockTypeName: string,
+	blockType: DisplayStyleBlockType,
 	parentBlockName: string | undefined,
-	blockAncestor: readonly string[] | undefined
+	contextKey: string
 ): boolean {
 	if ( ! parentBlockName ) {
 		return false;
 	}
+
 	if (
-		DISPLAY_STYLE_SWITCHER_EXCLUDED_BLOCK_NAMES.includes( blockTypeName )
+		getBlockSupport(
+			blockType.name,
+			'woocommerce.innerBlockDisplayStyle',
+			false
+		) !== true
 	) {
 		return false;
 	}
-	return blockAncestor?.includes( parentBlockName ) ?? false;
+
+	return (
+		getBlockTypeList( blockType.ancestor ).includes( parentBlockName ) &&
+		getBlockTypeList( blockType.usesContext ).includes( contextKey )
+	);
+}
+
+function getDisplayStyleOptions(
+	parentBlockName: string | undefined,
+	contextKey: string
+): DisplayStyleBlockType[] {
+	return ( getBlockTypes() as DisplayStyleBlockType[] ).filter(
+		( blockType ) =>
+			isDisplayStyleCandidate( blockType, parentBlockName, contextKey )
+	);
+}
+
+function getCurrentDisplayStyleBlock(
+	parentBlock: BlockInstance,
+	displayStyleOptions: DisplayStyleBlockType[]
+): BlockInstance | null {
+	return (
+		displayStyleOptions
+			.map( ( blockType ) =>
+				getInnerBlockByName( parentBlock, blockType.name )
+			)
+			.find( isBlockInstance ) ?? null
+	);
+}
+
+function getDisplayStyleInsertionPoint(
+	parentBlock: BlockInstance,
+	getFallbackInsertionPoint?: (
+		parentBlock: BlockInstance
+	) => DisplayStyleInsertionPoint
+): DisplayStyleInsertionPoint {
+	return (
+		getFallbackInsertionPoint?.( parentBlock ) ?? {
+			rootClientId: parentBlock.clientId,
+			index: parentBlock.innerBlocks.length,
+		}
+	);
 }
 
 export const DisplayStyleSwitcher = ( {
 	clientId,
 	currentStyle,
 	onChange,
-}: {
-	clientId: string;
-	currentStyle: string;
-	onChange: ( value: string ) => void;
-} ) => {
+	contextKey = SELECTABLE_ITEMS_CONTEXT,
+	getFallbackInsertionPoint,
+}: DisplayStyleSwitcherProps ) => {
 	const parentBlock = select( 'core/block-editor' ).getBlock( clientId );
 	const parentBlockName = parentBlock?.name;
-
-	const displayStyleOptions = getBlockTypes().filter( ( blockType ) =>
-		isDisplayStyleCandidate(
-			blockType.name,
-			parentBlockName,
-			blockType.ancestor
-		)
+	const displayStyleOptions = getDisplayStyleOptions(
+		parentBlockName,
+		contextKey
 	);
 
 	const { insertBlock, replaceBlock } = useDispatch( 'core/block-editor' );
 
 	const [ displayStyleBlocksAttributes, setDisplayStyleBlocksAttributes ] =
-		useState< Record< string, unknown > >( {} );
+		useState< Record< string, Record< string, unknown > > >( {} );
 
 	if ( displayStyleOptions.length === 0 ) return null;
 
@@ -79,22 +156,31 @@ export const DisplayStyleSwitcher = ( {
 				);
 
 				if ( currentStyleBlock ) {
-					setDisplayStyleBlocksAttributes( {
+					const nextDisplayStyleBlocksAttributes = {
 						...displayStyleBlocksAttributes,
 						[ currentStyle ]: currentStyleBlock.attributes,
-					} );
+					};
+
+					setDisplayStyleBlocksAttributes(
+						nextDisplayStyleBlocksAttributes
+					);
 					replaceBlock(
 						currentStyleBlock.clientId,
 						createBlock(
 							value,
-							displayStyleBlocksAttributes[ value ] || {}
+							nextDisplayStyleBlocksAttributes[ value ] || {}
 						)
 					);
 				} else {
+					const insertionPoint = getDisplayStyleInsertionPoint(
+						parentBlock,
+						getFallbackInsertionPoint
+					);
+
 					insertBlock(
 						createBlock( value ),
-						parentBlock.innerBlocks.length,
-						parentBlock.clientId,
+						insertionPoint.index,
+						insertionPoint.rootClientId,
 						false
 					);
 				}
@@ -115,36 +201,37 @@ export const DisplayStyleSwitcher = ( {
 
 export function resetDisplayStyleBlock(
 	clientId: string,
-	defaultStyle: string
+	defaultStyle: string,
+	getFallbackInsertionPoint?: (
+		parentBlock: BlockInstance
+	) => DisplayStyleInsertionPoint,
+	contextKey = SELECTABLE_ITEMS_CONTEXT
 ) {
 	const parentBlock = select( 'core/block-editor' ).getBlock( clientId );
 	if ( ! parentBlock ) return;
 
-	const parentBlockName = parentBlock.name;
-	const displayStyleOptions = getBlockTypes().filter( ( blockType ) =>
-		isDisplayStyleCandidate(
-			blockType.name,
-			parentBlockName,
-			blockType.ancestor
-		)
+	const displayStyleOptions = getDisplayStyleOptions(
+		parentBlock.name,
+		contextKey
 	);
-
-	const currentStyle = displayStyleOptions.find( ( blockType ) =>
-		getInnerBlockByName( parentBlock, blockType.name )
+	const currentStyleBlock = getCurrentDisplayStyleBlock(
+		parentBlock,
+		displayStyleOptions
 	);
-
-	const currentStyleBlock = currentStyle
-		? getInnerBlockByName( parentBlock, currentStyle.name )
-		: null;
 
 	const { insertBlock, replaceBlock } = dispatch( 'core/block-editor' );
 	if ( currentStyleBlock ) {
 		replaceBlock( currentStyleBlock.clientId, createBlock( defaultStyle ) );
 	} else {
+		const insertionPoint = getDisplayStyleInsertionPoint(
+			parentBlock,
+			getFallbackInsertionPoint
+		);
+
 		insertBlock(
 			createBlock( defaultStyle ),
-			parentBlock.innerBlocks.length,
-			parentBlock.clientId,
+			insertionPoint.index,
+			insertionPoint.rootClientId,
 			false
 		);
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/index.tsx
@@ -11,10 +11,8 @@ import { useState } from '@wordpress/element';
 import { dispatch, select, useDispatch } from '@wordpress/data';
 import { getInnerBlockByName } from '@woocommerce/utils';
 import {
-	// @ts-expect-error - no types.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
-	// @ts-expect-error - no types.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
@@ -31,6 +29,12 @@ type DisplayStyleBlockType = ReturnType< typeof getBlockTypes >[ number ] & {
 	usesContext?: readonly string[] | string;
 };
 
+type DisplayStyleSupportReader = (
+	blockName: string,
+	feature: 'woocommerce.innerBlockDisplayStyle',
+	defaultSupports: false
+) => unknown;
+
 type DisplayStyleSwitcherProps = {
 	clientId: string;
 	currentStyle: string;
@@ -40,6 +44,8 @@ type DisplayStyleSwitcherProps = {
 		parentBlock: BlockInstance
 	) => DisplayStyleInsertionPoint;
 };
+
+const getDisplayStyleSupport = getBlockSupport as DisplayStyleSupportReader;
 
 function isBlockInstance(
 	block: BlockInstance | null
@@ -56,6 +62,18 @@ function getBlockTypeList(
 	return Array.isArray( value ) ? value : [ value ];
 }
 
+function hasInnerBlockDisplayStyleSupport(
+	blockType: DisplayStyleBlockType
+): boolean {
+	return (
+		getDisplayStyleSupport(
+			blockType.name,
+			'woocommerce.innerBlockDisplayStyle',
+			false
+		) === true
+	);
+}
+
 function isDisplayStyleCandidate(
 	blockType: DisplayStyleBlockType,
 	parentBlockName: string | undefined,
@@ -65,13 +83,7 @@ function isDisplayStyleCandidate(
 		return false;
 	}
 
-	if (
-		getBlockSupport(
-			blockType.name,
-			'woocommerce.innerBlockDisplayStyle',
-			false
-		) !== true
-	) {
+	if ( ! hasInnerBlockDisplayStyleSupport( blockType ) ) {
 		return false;
 	}
 
@@ -150,15 +162,16 @@ export const DisplayStyleSwitcher = ( {
 			onChange={ ( value: string | number | undefined ) => {
 				if ( ! value || typeof value !== 'string' ) return;
 				if ( ! parentBlock ) return;
-				const currentStyleBlock = getInnerBlockByName(
+				const currentStyleBlock = getCurrentDisplayStyleBlock(
 					parentBlock,
-					currentStyle
+					displayStyleOptions
 				);
 
 				if ( currentStyleBlock ) {
 					const nextDisplayStyleBlocksAttributes = {
 						...displayStyleBlocksAttributes,
-						[ currentStyle ]: currentStyleBlock.attributes,
+						[ currentStyleBlock.name ]:
+							currentStyleBlock.attributes,
 					};
 
 					setDisplayStyleBlocksAttributes(

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/test/index.tsx
@@ -26,33 +26,18 @@ type MockBlockType = {
 let mockBlockTypes: MockBlockType[] = [];
 let mockParentBlock: MockBlock | null = null;
 
-const mockCreateBlock = jest.fn( ( name, attributes = {} ) => ( {
-	name,
-	attributes,
-} ) );
+const mockCreateBlock = jest.fn(
+	( name: string, attributes: Record< string, unknown > = {} ) => ( {
+		name,
+		attributes,
+	} )
+);
 const mockInsertBlock = jest.fn();
 const mockReplaceBlock = jest.fn();
 
 jest.mock( '@wordpress/blocks', () => ( {
-	createBlock: ( ...args: unknown[] ) => mockCreateBlock( ...args ),
-	getBlockSupport: (
-		blockName: string,
-		feature: string,
-		defaultSupports: unknown
-	) => {
-		const blockType = mockBlockTypes.find(
-			( block ) => block.name === blockName
-		);
-
-		return (
-			feature.split( '.' ).reduce< unknown >( ( value, key ) => {
-				if ( value && typeof value === 'object' && key in value ) {
-					return ( value as Record< string, unknown > )[ key ];
-				}
-				return undefined;
-			}, blockType?.supports ) ?? defaultSupports
-		);
-	},
+	createBlock: ( name: string, attributes?: Record< string, unknown > ) =>
+		mockCreateBlock( name, attributes ),
 	getBlockTypes: () => mockBlockTypes,
 } ) );
 
@@ -329,7 +314,7 @@ describe( 'DisplayStyleSwitcher', () => {
 			<DisplayStyleSwitcher
 				clientId="parent-client-id"
 				currentStyle="woocommerce/product-filter-chips"
-				getFallbackInsertionPoint={ () => ( {
+				getFallbackDisplayStyleInsertionPoint={ () => ( {
 					rootClientId: 'group-client-id',
 					index: 0,
 				} ) }

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/display-style-switcher/test/index.tsx
@@ -1,0 +1,388 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { DisplayStyleSwitcher, resetDisplayStyleBlock } from '../index';
+
+type MockBlock = {
+	clientId: string;
+	name: string;
+	attributes?: Record< string, unknown >;
+	innerBlocks: MockBlock[];
+};
+
+type MockBlockType = {
+	name: string;
+	title: string;
+	ancestor?: string[];
+	usesContext?: string[];
+	supports?: Record< string, unknown >;
+};
+
+let mockBlockTypes: MockBlockType[] = [];
+let mockParentBlock: MockBlock | null = null;
+
+const mockCreateBlock = jest.fn( ( name, attributes = {} ) => ( {
+	name,
+	attributes,
+} ) );
+const mockInsertBlock = jest.fn();
+const mockReplaceBlock = jest.fn();
+
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: ( ...args: unknown[] ) => mockCreateBlock( ...args ),
+	getBlockSupport: (
+		blockName: string,
+		feature: string,
+		defaultSupports: unknown
+	) => {
+		const blockType = mockBlockTypes.find(
+			( block ) => block.name === blockName
+		);
+
+		return (
+			feature.split( '.' ).reduce< unknown >( ( value, key ) => {
+				if ( value && typeof value === 'object' && key in value ) {
+					return ( value as Record< string, unknown > )[ key ];
+				}
+				return undefined;
+			}, blockType?.supports ) ?? defaultSupports
+		);
+	},
+	getBlockTypes: () => mockBlockTypes,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	select: () => ( {
+		getBlock: () => mockParentBlock,
+	} ),
+	useDispatch: () => ( {
+		insertBlock: mockInsertBlock,
+		replaceBlock: mockReplaceBlock,
+	} ),
+	dispatch: () => ( {
+		insertBlock: mockInsertBlock,
+		replaceBlock: mockReplaceBlock,
+	} ),
+} ) );
+
+jest.mock( '@woocommerce/utils', () => ( {
+	getInnerBlockByName: ( block: MockBlock | null, name: string ) => {
+		if ( ! block ) {
+			return null;
+		}
+
+		for ( const innerBlock of block.innerBlocks ) {
+			if ( innerBlock.name === name ) {
+				return innerBlock;
+			}
+
+			const nestedBlock = jest
+				.requireMock( '@woocommerce/utils' )
+				.getInnerBlockByName( innerBlock, name );
+
+			if ( nestedBlock ) {
+				return nestedBlock;
+			}
+		}
+
+		return null;
+	},
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const element = jest.requireActual( '@wordpress/element' );
+	return {
+		__experimentalToggleGroupControl: ( {
+			children,
+			onChange,
+		}: {
+			children: JSX.Element[];
+			onChange: ( value: string ) => void;
+		} ) =>
+			element.createElement(
+				'div',
+				{},
+				element.Children.map( children, ( child: JSX.Element ) =>
+					element.cloneElement( child, { onSelect: onChange } )
+				)
+			),
+		__experimentalToggleGroupControlOption: ( {
+			label,
+			value,
+			onSelect,
+		}: {
+			label: string;
+			value: string;
+			onSelect: ( value: string ) => void;
+		} ) =>
+			element.createElement(
+				'button',
+				{ type: 'button', onClick: () => onSelect( value ) },
+				label
+			),
+	};
+} );
+
+const makeBlockType = ( overrides: Partial< MockBlockType > ) => ( {
+	name: 'woocommerce/product-filter-chips',
+	title: 'Chips',
+	ancestor: [ 'woocommerce/product-filter-attribute' ],
+	usesContext: [ 'woocommerce/selectableItems' ],
+	supports: {
+		woocommerce: {
+			innerBlockDisplayStyle: true,
+		},
+	},
+	...overrides,
+} );
+
+describe( 'DisplayStyleSwitcher', () => {
+	beforeEach( () => {
+		mockBlockTypes = [];
+		mockParentBlock = {
+			clientId: 'parent-client-id',
+			name: 'woocommerce/product-filter-attribute',
+			innerBlocks: [],
+		};
+		mockCreateBlock.mockClear();
+		mockInsertBlock.mockClear();
+		mockReplaceBlock.mockClear();
+	} );
+
+	it( 'includes only blocks with display style support, matching ancestor, and matching context', () => {
+		mockBlockTypes = [
+			makeBlockType( {
+				name: 'woocommerce/product-filter-chips',
+				title: 'Chips',
+			} ),
+			makeBlockType( {
+				name: 'woocommerce/no-support',
+				title: 'No support',
+				supports: {},
+			} ),
+			makeBlockType( {
+				name: 'woocommerce/wrong-ancestor',
+				title: 'Wrong ancestor',
+				ancestor: [ 'woocommerce/other-parent' ],
+			} ),
+			makeBlockType( {
+				name: 'woocommerce/wrong-context',
+				title: 'Wrong context',
+				usesContext: [ 'woocommerce/removableItems' ],
+			} ),
+		];
+
+		render(
+			<DisplayStyleSwitcher
+				clientId="parent-client-id"
+				currentStyle="woocommerce/product-filter-chips"
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Chips' } ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'button', { name: 'No support' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Wrong ancestor' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Wrong context' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'replaces the actual display style block when the attribute is stale', () => {
+		mockBlockTypes = [
+			makeBlockType( {
+				name: 'woocommerce/product-filter-chips',
+				title: 'Chips',
+			} ),
+			makeBlockType( {
+				name: 'woocommerce/product-filter-checkbox-list',
+				title: 'List',
+			} ),
+		];
+		mockParentBlock = {
+			clientId: 'parent-client-id',
+			name: 'woocommerce/product-filter-attribute',
+			innerBlocks: [
+				{
+					clientId: 'chips-client-id',
+					name: 'woocommerce/product-filter-chips',
+					attributes: { chipText: 'blue' },
+					innerBlocks: [],
+				},
+			],
+		};
+
+		render(
+			<DisplayStyleSwitcher
+				clientId="parent-client-id"
+				currentStyle="woocommerce/missing-style"
+				onChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'List' } ) );
+
+		expect( mockReplaceBlock ).toHaveBeenCalledWith( 'chips-client-id', {
+			name: 'woocommerce/product-filter-checkbox-list',
+			attributes: {},
+		} );
+		expect( mockInsertBlock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'restores attributes using the actual display style block name', () => {
+		mockBlockTypes = [
+			makeBlockType( {
+				name: 'woocommerce/product-filter-chips',
+				title: 'Chips',
+			} ),
+			makeBlockType( {
+				name: 'woocommerce/product-filter-checkbox-list',
+				title: 'List',
+			} ),
+		];
+		mockParentBlock = {
+			clientId: 'parent-client-id',
+			name: 'woocommerce/product-filter-attribute',
+			innerBlocks: [
+				{
+					clientId: 'style-client-id',
+					name: 'woocommerce/product-filter-chips',
+					attributes: { chipText: 'blue' },
+					innerBlocks: [],
+				},
+			],
+		};
+
+		const { rerender } = render(
+			<DisplayStyleSwitcher
+				clientId="parent-client-id"
+				currentStyle="woocommerce/missing-style"
+				onChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'List' } ) );
+
+		mockParentBlock = {
+			clientId: 'parent-client-id',
+			name: 'woocommerce/product-filter-attribute',
+			innerBlocks: [
+				{
+					clientId: 'style-client-id',
+					name: 'woocommerce/product-filter-checkbox-list',
+					attributes: {},
+					innerBlocks: [],
+				},
+			],
+		};
+		mockCreateBlock.mockClear();
+		mockReplaceBlock.mockClear();
+
+		rerender(
+			<DisplayStyleSwitcher
+				clientId="parent-client-id"
+				currentStyle="woocommerce/product-filter-checkbox-list"
+				onChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Chips' } ) );
+
+		expect( mockCreateBlock ).toHaveBeenCalledWith(
+			'woocommerce/product-filter-chips',
+			{ chipText: 'blue' }
+		);
+	} );
+
+	it( 'uses fallback placement when no display style block exists', () => {
+		mockBlockTypes = [
+			makeBlockType( {
+				name: 'woocommerce/product-filter-chips',
+				title: 'Chips',
+				ancestor: [
+					'woocommerce/add-to-cart-with-options-variation-selector-attribute',
+				],
+			} ),
+		];
+		mockParentBlock = {
+			clientId: 'parent-client-id',
+			name: 'woocommerce/add-to-cart-with-options-variation-selector-attribute',
+			innerBlocks: [
+				{
+					clientId: 'group-client-id',
+					name: 'core/group',
+					innerBlocks: [],
+				},
+			],
+		};
+
+		render(
+			<DisplayStyleSwitcher
+				clientId="parent-client-id"
+				currentStyle="woocommerce/product-filter-chips"
+				getFallbackInsertionPoint={ () => ( {
+					rootClientId: 'group-client-id',
+					index: 0,
+				} ) }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Chips' } ) );
+
+		expect( mockInsertBlock ).toHaveBeenCalledWith(
+			{
+				name: 'woocommerce/product-filter-chips',
+				attributes: {},
+			},
+			0,
+			'group-client-id',
+			false
+		);
+	} );
+
+	it( 'uses fallback placement when resetting without a display style block', () => {
+		mockBlockTypes = [
+			makeBlockType( {
+				name: 'woocommerce/product-filter-chips',
+				title: 'Chips',
+				ancestor: [
+					'woocommerce/add-to-cart-with-options-variation-selector-attribute',
+				],
+			} ),
+		];
+		mockParentBlock = {
+			clientId: 'parent-client-id',
+			name: 'woocommerce/add-to-cart-with-options-variation-selector-attribute',
+			innerBlocks: [],
+		};
+
+		resetDisplayStyleBlock(
+			'parent-client-id',
+			'woocommerce/product-filter-chips',
+			() => ( {
+				rootClientId: 'group-client-id',
+				index: 0,
+			} )
+		);
+
+		expect( mockInsertBlock ).toHaveBeenCalledWith(
+			{
+				name: 'woocommerce/product-filter-chips',
+				attributes: {},
+			},
+			0,
+			'group-client-id',
+			false
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
@@ -20,6 +20,30 @@ WooCommerce reusable inner blocks use small context protocols so they can render
 - Inner blocks may derive presentation-only data locally. Parent data should not include child-owned fields such as list indexes.
 - Server-rendered fallback items use `data-wp-each-child` with per-item `data-wp-context`; hydration reconciles them with the inner store.
 
+## Display styles
+
+A display style block is an inner block that renders a protocol context for a specific parent block. Display style blocks opt in through block support metadata:
+
+```json
+{
+    "supports": {
+        "woocommerce": {
+            "innerBlockDisplayStyle": true
+        }
+    }
+}
+```
+
+Display style blocks must:
+
+- Declare `supports.woocommerce.innerBlockDisplayStyle` as `true`.
+- Declare the protocol context in `usesContext`.
+- Declare the supported parent block in `ancestor`.
+- Render from protocol fields, not from parent-specific stores.
+- Treat extension fields as optional.
+
+The editor uses the support flag for discovery. `usesContext` and `ancestor` are validation signals so unrelated inner blocks do not appear in display style controls.
+
 ## Selectable Items
 
 Context key: `woocommerce/selectableItems`


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR updates the Display Style Switcher component to fix some design issues that were acceptable previously when used inside Product Filters, but not anymore, as it is now a shared component.

- opt in: `supports.woocommerce.innerBlockDisplayStyle: true`
- validate `ancestor` + `usesContext`
- switch actual inner display-style block; ignore stale attr
- keep variation fallback insertion point parent-owned, this is needed for case like Add to Cart since the inner block structure is more complex and the display style block should not be nested directly under the Variation Attribute Selector block.

### Screenshots or screen recordings:

N/A. No visual change.

### How to test the changes in this Pull Request:

Ensure no regression to current blocks that have display style switcher.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Manual: `plugins/woocommerce/changelog/update-display-style-switch-to-editor-components`.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Discover inner block display styles via block support metadata.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
