### PR TITLE
Add product image color swatches block

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
@@ -11,7 +11,8 @@
 		"woocommerce/product-filter-attribute",
 		"woocommerce/product-filter-taxonomy",
 		"woocommerce/product-filter-status",
-		"woocommerce/add-to-cart-with-options-variation-selector-attribute"
+		"woocommerce/add-to-cart-with-options-variation-selector-attribute",
+		"woocommerce/product-image-with-color-swatches"
 	],
 	"supports": {
 		"interactivity": true

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/__tests__/frontend.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Internal dependencies
+ */
+import type { ProductImageWithColorSwatchesStore } from '../frontend';
+
+const mockGetContext = jest.fn();
+let mockRegisteredStore: ProductImageWithColorSwatchesStore | null = null;
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		getContext: mockGetContext,
+		store: jest.fn( ( _name, definition ) => {
+			mockRegisteredStore = definition;
+			return mockRegisteredStore;
+		} ),
+	} ),
+	{ virtual: true }
+);
+
+const defaultImage = {
+	id: 10,
+	src: 'default.jpg',
+	srcset: '',
+	sizes: '',
+	alt: 'Default',
+	width: '300',
+	height: '300',
+};
+
+const blueImage = {
+	id: 11,
+	src: 'blue.jpg',
+	srcset: '',
+	sizes: '',
+	alt: 'Blue',
+	width: '300',
+	height: '300',
+};
+
+const blueItem = {
+	id: 'blue',
+	label: 'Blue',
+	value: 'blue',
+	image: blueImage,
+};
+
+const redItem = {
+	id: 'red',
+	label: 'Red',
+	value: 'red',
+	image: {
+		...blueImage,
+		id: 12,
+		src: 'red.jpg',
+		alt: 'Red',
+	},
+};
+
+describe( 'product image with color swatches interactivity store', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		mockGetContext.mockReset();
+		mockRegisteredStore = null;
+
+		jest.isolateModules( () => {
+			require( '../frontend' );
+		} );
+	} );
+
+	it( 'provides selectable items with selected state from context', () => {
+		if ( ! mockRegisteredStore ) {
+			throw new Error( 'Store was not registered.' );
+		}
+
+		mockGetContext.mockReturnValue( {
+			items: [ blueItem, redItem ],
+			selectedItemId: 'red',
+			defaultImage,
+		} );
+
+		expect( mockRegisteredStore.state.selectableItems ).toEqual( [
+			{ ...blueItem, selected: false },
+			{ ...redItem, selected: true },
+		] );
+	} );
+
+	it( 'returns selected image data when a swatch is selected', () => {
+		if ( ! mockRegisteredStore ) {
+			throw new Error( 'Store was not registered.' );
+		}
+
+		mockGetContext.mockReturnValue( {
+			items: [ blueItem, redItem ],
+			selectedItemId: 'blue',
+			defaultImage,
+		} );
+
+		expect( mockRegisteredStore.state.currentImage ).toEqual( blueImage );
+	} );
+
+	it( 'falls back to default image when no swatch is selected', () => {
+		if ( ! mockRegisteredStore ) {
+			throw new Error( 'Store was not registered.' );
+		}
+
+		mockGetContext.mockReturnValue( {
+			items: [ blueItem ],
+			selectedItemId: null,
+			defaultImage,
+		} );
+
+		expect( mockRegisteredStore.state.currentImage ).toEqual( defaultImage );
+	} );
+
+	it( 'toggles selected swatch id', () => {
+		if ( ! mockRegisteredStore ) {
+			throw new Error( 'Store was not registered.' );
+		}
+
+		const context = {
+			items: [ blueItem ],
+			selectedItemId: null,
+			defaultImage,
+		};
+		mockGetContext.mockReturnValue( context );
+
+		mockRegisteredStore.actions.toggle( blueItem );
+		expect( context.selectedItemId ).toBe( 'blue' );
+
+		mockRegisteredStore.actions.toggle( blueItem );
+		expect( context.selectedItemId ).toBeNull();
+	} );
+
+	it( 'does not select disabled items', () => {
+		if ( ! mockRegisteredStore ) {
+			throw new Error( 'Store was not registered.' );
+		}
+
+		const context = {
+			items: [ blueItem ],
+			selectedItemId: null,
+			defaultImage,
+		};
+		mockGetContext.mockReturnValue( context );
+
+		mockRegisteredStore.actions.toggle( {
+			...blueItem,
+			disabled: true,
+		} );
+
+		expect( context.selectedItemId ).toBeNull();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/block.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/product-image-with-color-swatches",
+	"title": "Product Image with Color Swatches",
+	"description": "Display a product image with color swatches that preview variation images.",
+	"category": "woocommerce-product-elements",
+	"keywords": [ "WooCommerce", "variation", "swatches", "color" ],
+	"textdomain": "woocommerce",
+	"usesContext": [ "postId", "query", "queryId" ],
+	"ancestor": [ "woocommerce/product-template", "core/post-template" ],
+	"supports": {
+		"interactivity": true,
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"viewScriptModule": "woocommerce/product-image-with-color-swatches"
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/edit.tsx
@@ -9,7 +9,11 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings';
-import { isProductResponseItem, useProduct } from '@woocommerce/entities';
+import { isProductResponseItem } from '@woocommerce/entities';
+import { useCollection } from '@woocommerce/base-context/hooks';
+import { useProductDataContext } from '@woocommerce/shared-context';
+import type { ProductEntityResponse } from '@woocommerce/entities';
+import type { ProductResponseItem } from '@woocommerce/types';
 import type { BlockEditProps, TemplateArray } from '@wordpress/blocks';
 
 /**
@@ -110,9 +114,23 @@ function getSelectableItems(
 	} ) );
 }
 
+function getProductId( postId: unknown ): number | undefined {
+	if ( typeof postId === 'number' ) {
+		return postId;
+	}
+
+	if ( typeof postId === 'string' ) {
+		const parsedPostId = parseInt( postId, 10 );
+		return Number.isNaN( parsedPostId ) ? undefined : parsedPostId;
+	}
+
+	return undefined;
+}
+
 const Edit = ( {
 	context,
 }: BlockEditProps< Record< string, never > > ): JSX.Element => {
+	const productId = getProductId( context.postId );
 	const blockProps = useBlockProps( {
 		className: 'wc-block-product-image-with-color-swatches',
 	} );
@@ -120,7 +138,23 @@ const Edit = ( {
 		template: TEMPLATE,
 		allowedBlocks: ALLOWED_BLOCKS,
 	} );
-	const { product } = useProduct( context.postId as number );
+	const productDataContext = useProductDataContext();
+	const contextProduct = productDataContext.product;
+	const hasContext =
+		'hasContext' in productDataContext && productDataContext.hasContext;
+	const shouldFetchProduct = ! hasContext && !! productId && productId > 0;
+	const { results: products } = useCollection< ProductResponseItem >( {
+		namespace: '/wc/store/v1',
+		resourceName: 'products',
+		query: shouldFetchProduct ? { include: productId } : {},
+		shouldSelect: shouldFetchProduct,
+	} );
+	let product: ProductResponseItem | ProductEntityResponse | undefined;
+	if ( hasContext ) {
+		product = contextProduct;
+	} else if ( shouldFetchProduct ) {
+		product = products[ 0 ];
+	}
 	const termColors = getSetting< Record< string, string > >(
 		'productImageWithColorSwatchesTermColors',
 		{}
@@ -140,8 +174,6 @@ const Edit = ( {
 			groupLabel: colorAttribute?.name || __( 'Color', 'woocommerce' ),
 		} satisfies SelectableItemsContext< SwatchFields >;
 	}, [ product, termColors ] );
-
-	console.log(selectableContext)
 
 	return (
 		<BlockContextProvider

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/edit.tsx
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import {
+	BlockContextProvider,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { getSetting } from '@woocommerce/settings';
+import { isProductResponseItem, useProduct } from '@woocommerce/entities';
+import type { BlockEditProps, TemplateArray } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import type {
+	SelectableItem,
+	SelectableItemsContext,
+} from '../../types/type-defs/selectable-items';
+
+type Term = {
+	id: number;
+	slug: string;
+	name: string;
+};
+
+type ProductAttribute = {
+	id: number;
+	name: string;
+	taxonomy?: string;
+	terms?: Term[];
+};
+
+type SwatchFields = {
+	color?: string;
+};
+
+const STORE_NAMESPACE = 'woocommerce/product-image-with-color-swatches';
+
+const TEMPLATE: TemplateArray = [
+	[
+		'woocommerce/product-image',
+		{
+			imageSizing: 'thumbnail',
+			showSaleBadge: false,
+		},
+		[
+			[
+				'woocommerce/product-sale-badge',
+				{
+					align: 'right',
+				},
+			],
+		],
+	],
+	[ 'woocommerce/product-filter-chips' ],
+];
+
+const ALLOWED_BLOCKS = [
+	'woocommerce/product-image',
+	'woocommerce/product-filter-chips',
+];
+
+function getAttributeKey( attribute: ProductAttribute ): string {
+	const taxonomy = attribute.taxonomy || attribute.name;
+	return taxonomy.replace( /^pa_/, '' ).toLowerCase();
+}
+
+function getColorAttribute(
+	attributes: ProductAttribute[] | undefined,
+	termColors: Record< string, string >
+): ProductAttribute | undefined {
+	if ( ! Array.isArray( attributes ) ) {
+		return undefined;
+	}
+
+	return (
+		attributes.find( ( attribute ) =>
+			attribute.terms?.some( ( term ) => String( term.id ) in termColors )
+		) ||
+		attributes.find( ( attribute ) => {
+			const attributeKey = getAttributeKey( attribute );
+			return attributeKey === 'color' || attributeKey === 'colour';
+		} )
+	);
+}
+
+function getSelectableItems(
+	attribute: ProductAttribute | undefined,
+	termColors: Record< string, string >
+): SelectableItem< SwatchFields >[] {
+	if ( ! attribute || ! Array.isArray( attribute.terms ) ) {
+		return [];
+	}
+
+	return attribute.terms.map( ( term ) => ( {
+		id: `product-image-swatch-${ term.slug }`,
+		label: term.name,
+		ariaLabel: sprintf(
+			/* translators: %s: color name */
+			__( 'Show %s image', 'woocommerce' ),
+			term.name
+		),
+		value: term.slug,
+		...( String( term.id ) in termColors
+			? { color: termColors[ String( term.id ) ] }
+			: {} ),
+	} ) );
+}
+
+const Edit = ( {
+	context,
+}: BlockEditProps< Record< string, never > > ): JSX.Element => {
+	const blockProps = useBlockProps( {
+		className: 'wc-block-product-image-with-color-swatches',
+	} );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: TEMPLATE,
+		allowedBlocks: ALLOWED_BLOCKS,
+	} );
+	const { product } = useProduct( context.postId as number );
+	const termColors = getSetting< Record< string, string > >(
+		'productImageWithColorSwatchesTermColors',
+		{}
+	);
+
+	const selectableContext = useMemo( () => {
+		const attributes =
+			isProductResponseItem( product ) && product.type === 'variable'
+				? ( product.attributes as ProductAttribute[] )
+				: [];
+		const colorAttribute = getColorAttribute( attributes, termColors );
+
+		return {
+			items: getSelectableItems( colorAttribute, termColors ),
+			selectionMode: 'single' as const,
+			storeNamespace: STORE_NAMESPACE,
+			groupLabel: colorAttribute?.name || __( 'Color', 'woocommerce' ),
+		} satisfies SelectableItemsContext< SwatchFields >;
+	}, [ product, termColors ] );
+
+	console.log(selectableContext)
+
+	return (
+		<BlockContextProvider
+			value={ {
+				'woocommerce/selectableItems': selectableContext,
+			} }
+		>
+			<div { ...innerBlocksProps } />
+		</BlockContextProvider>
+	);
+};
+
+export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/frontend.ts
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+/**
+ * Internal dependencies
+ */
+import type {
+	SelectableItem,
+	SelectableItemsParentStore,
+} from '../../types/type-defs/selectable-items';
+
+export type SwatchImage = {
+	id: number;
+	src: string;
+	srcset: string;
+	sizes: string;
+	alt: string;
+	width: string;
+	height: string;
+};
+
+type SwatchItemFields = {
+	color?: string;
+	image: SwatchImage;
+};
+
+export type SwatchItem = SelectableItem< SwatchItemFields >;
+
+type Context = {
+	items?: SwatchItem[];
+	selectedItemId?: string | null;
+	defaultImage?: SwatchImage;
+	item?: SwatchItem;
+};
+
+type ProductImageWithColorSwatchesStore = {
+	state: {
+		selectableItems: readonly SwatchItem[];
+		currentImage: SwatchImage;
+	};
+	actions: {
+		toggle: ( item?: SwatchItem | Event ) => void;
+	};
+};
+
+const EMPTY_IMAGE: SwatchImage = {
+	id: 0,
+	src: '',
+	srcset: '',
+	sizes: '',
+	alt: '',
+	width: '',
+	height: '',
+};
+
+function isEvent( value: unknown ): value is Event {
+	return typeof Event !== 'undefined' && value instanceof Event;
+}
+
+function getCurrentItem( itemArg?: SwatchItem | Event ): SwatchItem | undefined {
+	if ( itemArg && ! isEvent( itemArg ) ) {
+		return itemArg;
+	}
+
+	return getContext< Context >().item;
+}
+
+const { state, actions } = store< ProductImageWithColorSwatchesStore >(
+	'woocommerce/product-image-with-color-swatches',
+	{
+		state: {
+			get selectableItems(): readonly SwatchItem[] {
+				const context = getContext< Context >();
+				const items = Array.isArray( context.items ) ? context.items : [];
+				return items.map( ( item ) => ( {
+					...item,
+					selected: context.selectedItemId === item.id,
+				} ) );
+			},
+			get currentImage(): SwatchImage {
+				const context = getContext< Context >();
+				const defaultImage = context.defaultImage || EMPTY_IMAGE;
+
+				if ( ! context.selectedItemId ) {
+					return defaultImage;
+				}
+
+				return (
+					state.selectableItems.find(
+						( item ) => item.id === context.selectedItemId
+					)?.image || defaultImage
+				);
+			},
+		},
+		actions: {
+			toggle( itemArg?: SwatchItem | Event ) {
+				const item = getCurrentItem( itemArg );
+				if ( ! item || item.disabled || item.hidden ) {
+					return;
+				}
+
+				const context = getContext< Context >();
+				context.selectedItemId =
+					context.selectedItemId === item.id ? null : item.id;
+			},
+		},
+	} satisfies ProductImageWithColorSwatchesStore &
+		SelectableItemsParentStore< SwatchItemFields >
+);
+
+export type { ProductImageWithColorSwatchesStore };
+export {
+	actions as productImageWithColorSwatchesActions,
+	state as productImageWithColorSwatchesState,
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { Icon, image } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import Save from './save';
+
+registerBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				icon={ image }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+	save: Save,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-image-with-color-swatches/save.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const Save = (): JSX.Element => {
+	const blockProps = useBlockProps.save( {
+		className: 'wc-block-product-image-with-color-swatches',
+	} );
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+
+	return <div { ...innerBlocksProps } />;
+};
+
+export default Save;

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -96,6 +96,7 @@ const blocks = {
 	'product-gallery-thumbnails': {
 		customDir: 'product-gallery/inner-blocks/product-gallery-thumbnails',
 	},
+	'product-image-with-color-swatches': {},
 	'product-new': {},
 	'product-on-sale': {},
 	'product-query': {},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImageWithColorSwatches.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImageWithColorSwatches.php
@@ -1,0 +1,647 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+use WC_Product_Variable;
+use WC_Product_Variation;
+use WP_Block;
+use WP_HTML_Tag_Processor;
+use WP_Term;
+
+/**
+ * Product Image with Color Swatches block.
+ */
+class ProductImageWithColorSwatches extends AbstractBlock {
+
+	use EnableBlockJsonAssetsTrait;
+
+	private const STORE_NAMESPACE = 'woocommerce/product-image-with-color-swatches';
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-image-with-color-swatches';
+
+	/**
+	 * Cached map of term ID to color value, keyed by attribute taxonomy.
+	 *
+	 * @var array<string, array<int, string>>
+	 */
+	private $term_colors = array();
+
+	/**
+	 * Get block context consumed by the block.
+	 *
+	 * @return array
+	 *
+	 * @since 10.9.0
+	 */
+	protected function get_block_type_uses_context() {
+		return array( 'postId', 'query', 'queryId' );
+	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes Any attributes that currently are available from the block.
+	 * @return void
+	 *
+	 * @since 10.9.0
+	 */
+	protected function enqueue_data( array $attributes = array() ) {
+		parent::enqueue_data( $attributes );
+
+		if ( is_admin() ) {
+			$this->asset_data_registry->add( 'productImageWithColorSwatchesTermColors', $this->get_visual_attribute_term_colors() );
+		}
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block output.
+	 *
+	 * @since 10.9.0
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$post_id = isset( $block->context['postId'] ) ? (int) $block->context['postId'] : 0;
+		$product = wc_get_product( $post_id );
+
+		if ( ! $product ) {
+			return '';
+		}
+
+		$swatch_data  = $product instanceof WC_Product_Variable ? $this->get_swatch_data( $product, $block ) : $this->get_empty_swatch_data();
+		$items        = $swatch_data['items'];
+		$inner_markup = $this->render_inner_blocks( $block, $swatch_data );
+
+		if ( '' === $inner_markup ) {
+			return '';
+		}
+
+		$default_image = $this->get_product_image_data_from_html( $inner_markup );
+
+		if ( ! empty( $items ) && ! empty( $default_image ) ) {
+			$inner_markup = $this->inject_image_directives( $inner_markup );
+		}
+
+		$wrapper_attributes = array(
+			'class' => 'wc-block-product-image-with-color-swatches',
+		);
+
+		if ( ! empty( $items ) ) {
+			$wrapper_attributes['data-wp-interactive'] = self::STORE_NAMESPACE;
+			$wrapper_attributes['data-wp-context']     = (string) wp_json_encode(
+				array(
+					'items'          => $items,
+					'selectedItemId' => null,
+					'defaultImage'   => ! empty( $default_image ) ? $default_image : $this->get_empty_image_data(),
+				),
+				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+			);
+		}
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			get_block_wrapper_attributes( $wrapper_attributes ),
+			$inner_markup
+		);
+	}
+
+	/**
+	 * Get empty swatch data.
+	 *
+	 * @return array{items: array<int, array<string, mixed>>, groupLabel: string}
+	 */
+	private function get_empty_swatch_data(): array {
+		return array(
+			'items'      => array(),
+			'groupLabel' => __( 'Color', 'woocommerce' ),
+		);
+	}
+
+	/**
+	 * Render inner blocks with selectable items context.
+	 *
+	 * @param WP_Block $block       Block instance.
+	 * @param array    $swatch_data Swatch data.
+	 * @return string Rendered inner blocks.
+	 */
+	private function render_inner_blocks( WP_Block $block, array $swatch_data ): string {
+		$inner_blocks = $block->parsed_block['innerBlocks'] ?? array();
+
+		if ( empty( $inner_blocks ) ) {
+			return '';
+		}
+
+		$items              = $swatch_data['items'];
+		$selectable_context = array(
+			'items'          => $items,
+			'selectionMode'  => 'single',
+			'storeNamespace' => self::STORE_NAMESPACE,
+			'groupLabel'     => $swatch_data['groupLabel'],
+		);
+		$context            = array_merge(
+			(array) $block->context,
+			array(
+				'woocommerce/selectableItems' => $selectable_context,
+			)
+		);
+		$inner_markup       = '';
+
+		foreach ( $inner_blocks as $inner_block ) {
+			if ( empty( $items ) && 'woocommerce/product-filter-chips' === ( $inner_block['blockName'] ?? '' ) ) {
+				continue;
+			}
+
+			$inner_markup .= ( new WP_Block( $inner_block, $context ) )->render();
+		}
+
+		return $inner_markup;
+	}
+
+	/**
+	 * Build swatch data for the first color-like variation attribute.
+	 *
+	 * @param WC_Product_Variable $product Product instance.
+	 * @param WP_Block            $block   Block instance.
+	 * @return array{items: array<int, array<string, mixed>>, groupLabel: string}
+	 */
+	private function get_swatch_data( WC_Product_Variable $product, WP_Block $block ): array {
+		$attribute_name = $this->get_color_variation_attribute_name( $product );
+
+		if ( null === $attribute_name ) {
+			return $this->get_empty_swatch_data();
+		}
+
+		$image_ids_by_value = $this->get_first_variation_image_ids_by_attribute_value( $product, $attribute_name );
+
+		if ( empty( $image_ids_by_value ) ) {
+			return array(
+				'items'      => array(),
+				'groupLabel' => wc_attribute_label( $attribute_name ),
+			);
+		}
+
+		$product_image_attributes = $this->get_product_image_block_attributes( $block->parsed_block['innerBlocks'] ?? array() );
+		$image_size               = $this->get_image_size( $product_image_attributes );
+		$image_style              = $this->get_image_style( $product_image_attributes );
+		$terms_by_value           = $this->get_attribute_terms_by_value( $product, $attribute_name );
+		$term_colors              = $this->get_visual_attribute_term_colors( $attribute_name );
+		$variation_attributes     = $product->get_variation_attributes();
+		$attribute_values         = $variation_attributes[ $attribute_name ] ?? array_keys( $image_ids_by_value );
+		$type                     = 'attribute/' . $this->get_attribute_key( $attribute_name );
+		$items                    = array();
+
+		foreach ( $attribute_values as $attribute_value ) {
+			$value = (string) $attribute_value;
+
+			if ( '' === $value || empty( $image_ids_by_value[ $value ] ) ) {
+				continue;
+			}
+
+			$image = $this->get_image_data( (int) $image_ids_by_value[ $value ], $product, $image_size, $image_style );
+
+			if ( empty( $image ) ) {
+				continue;
+			}
+
+			$term  = $terms_by_value[ $value ] ?? null;
+			$label = $term instanceof WP_Term ? $term->name : $value;
+			$item  = array(
+				'id'        => 'product-image-swatch-' . sanitize_title( $attribute_name ) . '-' . sanitize_title( $value ),
+				'label'     => $label,
+				'ariaLabel' => sprintf(
+					/* translators: %s: color name */
+					__( 'Show %s image', 'woocommerce' ),
+					$label
+				),
+				'value'     => $value,
+				'type'      => $type,
+				'selected'  => false,
+				'image'     => $image,
+			);
+
+			if ( $term instanceof WP_Term && array_key_exists( $term->term_id, $term_colors ) ) {
+				$item['color'] = $term_colors[ $term->term_id ];
+			}
+
+			$items[] = $item;
+		}
+
+		return array(
+			'items'      => $items,
+			'groupLabel' => wc_attribute_label( $attribute_name ),
+		);
+	}
+
+	/**
+	 * Get the first visual or color variation attribute name.
+	 *
+	 * @param WC_Product_Variable $product Product instance.
+	 * @return string|null Attribute name.
+	 */
+	private function get_color_variation_attribute_name( WC_Product_Variable $product ): ?string {
+		$variation_attributes = $product->get_variation_attributes();
+
+		if ( empty( $variation_attributes ) ) {
+			return null;
+		}
+
+		$visual_attributes = $this->get_visual_attribute_taxonomies();
+
+		foreach ( array_keys( $variation_attributes ) as $attribute_name ) {
+			if ( isset( $visual_attributes[ $attribute_name ] ) ) {
+				return $attribute_name;
+			}
+		}
+
+		foreach ( array_keys( $variation_attributes ) as $attribute_name ) {
+			$attribute_key = $this->get_attribute_key( $attribute_name );
+			if ( 'color' === $attribute_key || 'colour' === $attribute_key ) {
+				return $attribute_name;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get wc-visual attribute taxonomies.
+	 *
+	 * @return array<string, true> Attribute taxonomy map.
+	 */
+	private function get_visual_attribute_taxonomies(): array {
+		$attributes = wc_get_attribute_taxonomies();
+		$visual     = array();
+
+		foreach ( $attributes as $attribute ) {
+			if ( 'wc-visual' === $attribute->attribute_type ) {
+				$visual[ wc_attribute_taxonomy_name( $attribute->attribute_name ) ] = true;
+			}
+		}
+
+		return $visual;
+	}
+
+	/**
+	 * Get the first variation image ID for each attribute value.
+	 *
+	 * @param WC_Product_Variable $product        Product instance.
+	 * @param string              $attribute_name Attribute name.
+	 * @return array<string, int> Image IDs keyed by attribute value.
+	 */
+	private function get_first_variation_image_ids_by_attribute_value( WC_Product_Variable $product, string $attribute_name ): array {
+		$variation_ids = $product->get_children();
+
+		if ( empty( $variation_ids ) ) {
+			return array();
+		}
+
+		// Prime caches to reduce future queries.
+		_prime_post_caches( $variation_ids );
+
+		$attribute_slug               = wc_variation_attribute_name( $attribute_name );
+		$candidate_image_ids_by_value = array();
+
+		foreach ( $variation_ids as $variation_id ) {
+			$variation = wc_get_product( $variation_id );
+
+			if ( ! $variation instanceof WC_Product_Variation || ! $variation->variation_is_visible() ) {
+				continue;
+			}
+
+			$variation_attributes = $variation->get_variation_attributes();
+			$value                = (string) ( $variation_attributes[ $attribute_slug ] ?? '' );
+
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$image_id = (int) $variation->get_image_id( 'edit' );
+			if ( $image_id > 0 ) {
+				$candidate_image_ids_by_value[ $value ][] = $image_id;
+			}
+		}
+
+		$candidate_image_ids = array();
+		foreach ( $candidate_image_ids_by_value as $candidate_ids ) {
+			$candidate_image_ids = array_merge( $candidate_image_ids, $candidate_ids );
+		}
+		$candidate_image_ids = array_values( array_unique( $candidate_image_ids ) );
+
+		if ( ! empty( $candidate_image_ids ) ) {
+			// Prime caches to reduce future queries.
+			_prime_post_caches( $candidate_image_ids );
+		}
+
+		$image_ids_by_value = array();
+		foreach ( $candidate_image_ids_by_value as $value => $candidate_ids ) {
+			foreach ( $candidate_ids as $image_id ) {
+				if ( wp_attachment_is_image( $image_id ) ) {
+					$image_ids_by_value[ $value ] = $image_id;
+					break;
+				}
+			}
+		}
+
+		return $image_ids_by_value;
+	}
+
+	/**
+	 * Get taxonomy terms keyed by variation attribute value.
+	 *
+	 * @param WC_Product_Variable $product        Product instance.
+	 * @param string              $attribute_name Attribute taxonomy.
+	 * @return array<string, WP_Term> Terms keyed by slug.
+	 */
+	private function get_attribute_terms_by_value( WC_Product_Variable $product, string $attribute_name ): array {
+		if ( ! taxonomy_exists( $attribute_name ) ) {
+			return array();
+		}
+
+		$terms = wc_get_product_terms( $product->get_id(), $attribute_name, array( 'fields' => 'all' ) );
+
+		if ( ! is_array( $terms ) ) {
+			return array();
+		}
+
+		$terms_by_value = array();
+		foreach ( $terms as $term ) {
+			if ( $term instanceof WP_Term ) {
+				$terms_by_value[ $term->slug ] = $term;
+			}
+		}
+
+		return $terms_by_value;
+	}
+
+	/**
+	 * Get color values for wc-visual attribute terms.
+	 *
+	 * @param string|null $attribute_name Optional attribute taxonomy name.
+	 * @return array<int, string> Map of term ID to hex color.
+	 */
+	private function get_visual_attribute_term_colors( ?string $attribute_name = null ): array {
+		$cache_key = $attribute_name ?? '__all';
+		if ( isset( $this->term_colors[ $cache_key ] ) ) {
+			return $this->term_colors[ $cache_key ];
+		}
+
+		$colors     = array();
+		$attributes = wc_get_attribute_taxonomies();
+
+		foreach ( $attributes as $attribute ) {
+			$taxonomy = wc_attribute_taxonomy_name( $attribute->attribute_name );
+
+			if ( 'wc-visual' !== $attribute->attribute_type ) {
+				continue;
+			}
+
+			if ( $attribute_name && $taxonomy !== $attribute_name ) {
+				continue;
+			}
+
+			$terms = get_terms(
+				array(
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => false,
+				)
+			);
+
+			if ( is_wp_error( $terms ) ) {
+				continue;
+			}
+
+			foreach ( $terms as $term ) {
+				if ( $term instanceof WP_Term ) {
+					$color                    = sanitize_hex_color( get_term_meta( $term->term_id, 'color', true ) );
+					$colors[ $term->term_id ] = $color ? $color : '';
+				}
+			}
+		}
+
+		$this->term_colors[ $cache_key ] = $colors;
+
+		return $this->term_colors[ $cache_key ];
+	}
+
+	/**
+	 * Get the product image block attributes from inner blocks.
+	 *
+	 * @param array $inner_blocks Inner blocks.
+	 * @return array<string, mixed> Product image block attributes.
+	 */
+	private function get_product_image_block_attributes( array $inner_blocks ): array {
+		foreach ( $inner_blocks as $inner_block ) {
+			if ( 'woocommerce/product-image' === ( $inner_block['blockName'] ?? '' ) ) {
+				return is_array( $inner_block['attrs'] ?? null ) ? $inner_block['attrs'] : array();
+			}
+
+			if ( ! empty( $inner_block['innerBlocks'] ) && is_array( $inner_block['innerBlocks'] ) ) {
+				$attributes = $this->get_product_image_block_attributes( $inner_block['innerBlocks'] );
+
+				if ( ! empty( $attributes ) ) {
+					return $attributes;
+				}
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Get the image size for product image block attributes.
+	 *
+	 * @param array $attributes Product image block attributes.
+	 * @return string Image size.
+	 */
+	private function get_image_size( array $attributes ): string {
+		return 'single' === ( $attributes['imageSizing'] ?? 'single' ) ? 'woocommerce_single' : 'woocommerce_thumbnail';
+	}
+
+	/**
+	 * Get inline image style for product image block attributes.
+	 *
+	 * @param array $attributes Product image block attributes.
+	 * @return string Inline style.
+	 */
+	private function get_image_style( array $attributes ): string {
+		$image_style = '';
+
+		if ( ! empty( $attributes['height'] ) ) {
+			$image_style .= sprintf( 'height:%s;', $attributes['height'] );
+		}
+		if ( ! empty( $attributes['width'] ) ) {
+			$image_style .= sprintf( 'width:%s;', $attributes['width'] );
+		}
+		if ( ! empty( $attributes['scale'] ) ) {
+			$image_style .= sprintf( 'object-fit:%s;', $attributes['scale'] );
+		}
+		if ( ! empty( $attributes['aspectRatio'] ) ) {
+			$image_style .= sprintf( 'aspect-ratio:%s;', $attributes['aspectRatio'] );
+		}
+		if ( ! empty( $attributes['style']['dimensions']['aspectRatio'] ) ) {
+			$image_style .= sprintf( 'aspect-ratio:%s;', $attributes['style']['dimensions']['aspectRatio'] );
+		}
+		if ( ! empty( $attributes['style']['dimensions']['minHeight'] ) ) {
+			$image_style .= sprintf( 'min-height:%s;', $attributes['style']['dimensions']['minHeight'] );
+		}
+
+		return $image_style;
+	}
+
+	/**
+	 * Get image data for a variation image.
+	 *
+	 * @param int                 $image_id    Image ID.
+	 * @param WC_Product_Variable $product     Product instance.
+	 * @param string              $image_size  Image size.
+	 * @param string              $image_style Inline image style.
+	 * @return array<string, string|int> Image data.
+	 */
+	private function get_image_data( int $image_id, WC_Product_Variable $product, string $image_size, string $image_style ): array {
+		$alt_text = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+		$attr     = array(
+			'alt'           => empty( $alt_text ) ? $product->get_title() : $alt_text,
+			'data-image-id' => $image_id,
+		);
+
+		if ( '' !== $image_style ) {
+			$attr['style'] = $image_style;
+		}
+
+		$image = wp_get_attachment_image( $image_id, $image_size, false, $attr );
+
+		if ( ! is_string( $image ) || '' === $image ) {
+			return array();
+		}
+
+		return $this->get_image_data_from_html( $image );
+	}
+
+	/**
+	 * Get empty image data.
+	 *
+	 * @return array<string, string|int> Image data.
+	 */
+	private function get_empty_image_data(): array {
+		return array(
+			'id'     => 0,
+			'src'    => '',
+			'srcset' => '',
+			'sizes'  => '',
+			'alt'    => '',
+			'width'  => '',
+			'height' => '',
+		);
+	}
+
+	/**
+	 * Extract product image data from rendered block markup.
+	 *
+	 * @param string $html Rendered HTML.
+	 * @return array<string, string|int> Image data.
+	 */
+	private function get_product_image_data_from_html( string $html ): array {
+		$tags = new WP_HTML_Tag_Processor( $html );
+
+		while ( $tags->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+			if ( 'product-image' === $tags->get_attribute( 'data-testid' ) ) {
+				return $this->get_image_data_from_current_tag( $tags );
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Extract image data from an image HTML fragment.
+	 *
+	 * @param string $html Image HTML.
+	 * @return array<string, string|int> Image data.
+	 */
+	private function get_image_data_from_html( string $html ): array {
+		$tags = new WP_HTML_Tag_Processor( $html );
+
+		if ( $tags->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+			return $this->get_image_data_from_current_tag( $tags );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Extract image data from the current image tag.
+	 *
+	 * @param WP_HTML_Tag_Processor $tags Tag processor.
+	 * @return array<string, string|int> Image data.
+	 */
+	private function get_image_data_from_current_tag( WP_HTML_Tag_Processor $tags ): array {
+		$attribute_map = array(
+			'id'     => 'data-image-id',
+			'src'    => 'src',
+			'srcset' => 'srcset',
+			'sizes'  => 'sizes',
+			'alt'    => 'alt',
+			'width'  => 'width',
+			'height' => 'height',
+		);
+		$image_data    = array();
+
+		foreach ( $attribute_map as $key => $attribute_name ) {
+			$value              = $tags->get_attribute( $attribute_name );
+			$image_data[ $key ] = is_string( $value ) ? $value : '';
+		}
+
+		$image_data['id'] = (int) $image_data['id'];
+
+		return '' !== $image_data['src'] ? $image_data : array();
+	}
+
+	/**
+	 * Inject image binding directives into the product image.
+	 *
+	 * @param string $html Rendered block markup.
+	 * @return string Updated markup.
+	 */
+	private function inject_image_directives( string $html ): string {
+		$tags = new WP_HTML_Tag_Processor( $html );
+
+		while ( $tags->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+			if ( 'product-image' !== $tags->get_attribute( 'data-testid' ) ) {
+				continue;
+			}
+
+			$tags->set_attribute( 'data-wp-bind--src', 'state.currentImage.src' );
+			$tags->set_attribute( 'data-wp-bind--srcset', 'state.currentImage.srcset' );
+			$tags->set_attribute( 'data-wp-bind--sizes', 'state.currentImage.sizes' );
+			$tags->set_attribute( 'data-wp-bind--alt', 'state.currentImage.alt' );
+			$tags->set_attribute( 'data-wp-bind--width', 'state.currentImage.width' );
+			$tags->set_attribute( 'data-wp-bind--height', 'state.currentImage.height' );
+			$tags->set_attribute( 'data-wp-bind--data-image-id', 'state.currentImage.id' );
+			break;
+		}
+
+		return $tags->get_updated_html();
+	}
+
+	/**
+	 * Get normalized attribute key without the pa_ prefix.
+	 *
+	 * @param string $attribute_name Attribute name.
+	 * @return string Attribute key.
+	 */
+	private function get_attribute_key( string $attribute_name ): string {
+		$attribute_key = 0 === strpos( $attribute_name, 'pa_' ) ? substr( $attribute_name, 3 ) : $attribute_name;
+
+		return sanitize_title( $attribute_key );
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -484,6 +484,7 @@ final class BlockTypesController {
 			'ProductGalleryLargeImage',
 			'ProductGalleryThumbnails',
 			'ProductImage',
+			'ProductImageWithColorSwatches',
 			'ProductImageGallery',
 			'ProductMeta',
 			'ProductNew',

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImageWithColorSwatchesTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImageWithColorSwatchesTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\ProductImageWithColorSwatchesMock;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the ProductImageWithColorSwatches block type.
+ */
+class ProductImageWithColorSwatchesTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Tracks whether blocks have been registered.
+	 *
+	 * @var bool
+	 */
+	protected static $are_blocks_registered = false;
+
+	/**
+	 * Register blocks required for do_blocks tests.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! self::$are_blocks_registered && ! \WP_Block_Type_Registry::get_instance()->is_registered( 'woocommerce/product-image-with-color-swatches' ) ) {
+			new ProductImageWithColorSwatchesMock();
+		}
+
+		self::$are_blocks_registered = true;
+	}
+
+	/**
+	 * @testdox Renders color swatches with first variation image for each color.
+	 */
+	public function test_renders_color_swatches_with_first_variation_image_for_each_color(): void {
+		$data = $this->create_variable_product_with_color_variation_images();
+
+		try {
+			$markup  = $this->render_block_for_product( $data['product']->get_id() );
+			$decoded = html_entity_decode( $markup, ENT_QUOTES );
+
+			$this->assertStringContainsString( 'data-wp-interactive="woocommerce/product-image-with-color-swatches"', $markup, 'Wrapper should register the swatch store namespace.' );
+			$this->assertStringContainsString( 'data-wp-bind--src="state.currentImage.src"', $markup, 'Product image should bind src to the selected swatch image.' );
+			$this->assertStringContainsString( 'data-wp-bind--data-image-id="state.currentImage.id"', $markup, 'Product image should bind image ID to the selected swatch image.' );
+			$this->assertStringContainsString( 'background-color: #aa0000', $markup, 'Red swatch should use term color meta.' );
+			$this->assertStringContainsString( 'background-color: #0000aa', $markup, 'Blue swatch should use term color meta.' );
+			$this->assertStringContainsString( '"id":' . $data['red_image_id'], $decoded, 'Red swatch should use the first red variation image that has an image.' );
+			$this->assertStringContainsString( '"id":' . $data['blue_image_id'], $decoded, 'Blue swatch should use the first blue variation image that has an image.' );
+			$this->assertStringNotContainsString( 'red-second.jpg', $decoded, 'Second red variation image should not be used.' );
+		} finally {
+			$this->cleanup_variable_product_data( $data );
+		}
+	}
+
+	/**
+	 * @testdox Renders only the product image for products without color variation images.
+	 */
+	public function test_renders_only_product_image_without_color_variation_images(): void {
+		$product  = new \WC_Product_Simple();
+		$image_id = $this->create_image_attachment( 'Simple image', 'simple.jpg' );
+		$product->set_regular_price( 10 );
+		$product->set_image_id( $image_id );
+		$product->save();
+
+		try {
+			$markup = $this->render_block_for_product( $product->get_id() );
+
+			$this->assertStringContainsString( 'wc-block-components-product-image', $markup, 'Product image should still render.' );
+			$this->assertStringNotContainsString( 'wc-block-product-filter-chips', $markup, 'Chips should not render without color variation images.' );
+			$this->assertStringNotContainsString( 'data-wp-interactive="woocommerce/product-image-with-color-swatches"', $markup, 'Wrapper should not initialize swatch interactivity without items.' );
+		} finally {
+			$product->delete( true );
+			wp_delete_attachment( $image_id, true );
+		}
+	}
+
+	/**
+	 * Create a variable product with color variation images.
+	 *
+	 * @return array<string, mixed> Test data.
+	 */
+	private function create_variable_product_with_color_variation_images(): array {
+		$fixtures  = new FixtureData();
+		$attribute = FixtureData::get_product_attribute( 'pcswatch', array( 'red', 'blue' ) );
+		$taxonomy  = $attribute['attribute_taxonomy'];
+		$term_red  = get_term( $attribute['term_ids'][0] );
+		$term_blue = get_term( $attribute['term_ids'][1] );
+
+		$this->assertInstanceOf( \WP_Term::class, $term_red );
+		$this->assertInstanceOf( \WP_Term::class, $term_blue );
+
+		$this->set_attribute_type( (int) $attribute['attribute_id'], 'wc-visual' );
+		update_term_meta( $term_red->term_id, 'color', '#aa0000' );
+		update_term_meta( $term_blue->term_id, 'color', '#0000aa' );
+
+		$product = $fixtures->get_variable_product( array(), array( $attribute ) );
+		$this->assertInstanceOf( \WC_Product_Variable::class, $product );
+
+		$parent_image_id = $this->create_image_attachment( 'Parent image', 'parent.jpg' );
+		$red_image_id    = $this->create_image_attachment( 'Red image', 'red-first.jpg' );
+		$red_second_id   = $this->create_image_attachment( 'Second red image', 'red-second.jpg' );
+		$blue_image_id   = $this->create_image_attachment( 'Blue image', 'blue.jpg' );
+
+		$product->set_image_id( $parent_image_id );
+		$product->save();
+
+		$fixtures->get_variation_product(
+			$product->get_id(),
+			array( $taxonomy => $term_red->slug ),
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		$red_variation = $fixtures->get_variation_product(
+			$product->get_id(),
+			array( $taxonomy => $term_red->slug ),
+			array(
+				'regular_price' => 11,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$red_variation->set_image_id( $red_image_id );
+		$red_variation->save();
+
+		$red_second_variation = $fixtures->get_variation_product(
+			$product->get_id(),
+			array( $taxonomy => $term_red->slug ),
+			array(
+				'regular_price' => 12,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$red_second_variation->set_image_id( $red_second_id );
+		$red_second_variation->save();
+
+		$blue_variation = $fixtures->get_variation_product(
+			$product->get_id(),
+			array( $taxonomy => $term_blue->slug ),
+			array(
+				'regular_price' => 13,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$blue_variation->set_image_id( $blue_image_id );
+		$blue_variation->save();
+
+		\WC_Product_Variable::sync( $product->get_id() );
+
+		$product = wc_get_product( $product->get_id() );
+		$this->assertInstanceOf( \WC_Product_Variable::class, $product );
+
+		return array(
+			'product'         => $product,
+			'attribute_id'    => (int) $attribute['attribute_id'],
+			'term_ids'        => $attribute['term_ids'],
+			'parent_image_id' => $parent_image_id,
+			'red_image_id'    => $red_image_id,
+			'red_second_id'   => $red_second_id,
+			'blue_image_id'   => $blue_image_id,
+		);
+	}
+
+	/**
+	 * Render the block for a product.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return string Rendered markup.
+	 */
+	private function render_block_for_product( int $product_id ): string {
+		return do_blocks(
+			'<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} -->
+				<!-- wp:woocommerce/product-image-with-color-swatches -->
+					<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","showSaleBadge":false} /-->
+					<!-- wp:woocommerce/product-filter-chips /-->
+				<!-- /wp:woocommerce/product-image-with-color-swatches -->
+			<!-- /wp:woocommerce/single-product -->'
+		);
+	}
+
+	/**
+	 * Create an image attachment that passes image checks.
+	 *
+	 * @param string $title         Attachment title.
+	 * @param string $attached_file Synthetic file path.
+	 * @return int Attachment ID.
+	 */
+	private function create_image_attachment( string $title, string $attached_file ): int {
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_title'     => $title,
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		update_post_meta( $attachment_id, '_wp_attached_file', $attached_file );
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Set product attribute type and clear WooCommerce attribute caches.
+	 *
+	 * @param int    $attribute_id Attribute ID.
+	 * @param string $type         Attribute type.
+	 */
+	private function set_attribute_type( int $attribute_id, string $type ): void {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->prefix . 'woocommerce_attribute_taxonomies',
+			array( 'attribute_type' => $type ),
+			array( 'attribute_id' => $attribute_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		delete_transient( 'wc_attribute_taxonomies' );
+		\WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
+	}
+
+	/**
+	 * Clean up variable product data.
+	 *
+	 * @param array<string, mixed> $data Test data.
+	 */
+	private function cleanup_variable_product_data( array $data ): void {
+		$this->set_attribute_type( (int) $data['attribute_id'], 'select' );
+
+		foreach ( $data['term_ids'] as $term_id ) {
+			delete_term_meta( (int) $term_id, 'color' );
+		}
+
+		foreach ( array( 'parent_image_id', 'red_image_id', 'red_second_id', 'blue_image_id' ) as $key ) {
+			wp_delete_attachment( (int) $data[ $key ], true );
+		}
+
+		if ( $data['product'] instanceof \WC_Product_Variable ) {
+			$data['product']->delete( true );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductImageWithColorSwatchesMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductImageWithColorSwatchesMock.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\BlockTypes\ProductImageWithColorSwatches;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+use Automattic\WooCommerce\Blocks\Package;
+
+/**
+ * ProductImageWithColorSwatchesMock used to test ProductImageWithColorSwatches block functions.
+ */
+class ProductImageWithColorSwatchesMock extends ProductImageWithColorSwatches {
+
+	/**
+	 * Initialize our mock class.
+	 */
+	public function __construct() {
+		parent::__construct(
+			Package::container()->get( Api::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry(),
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Product collection layouts need a way to preview variation images from color choices without leaving the card. This adds a Product Image with Color Swatches block, renders swatch data from the first visual/color variation attribute, and wires the Product Filter Chips child block to the image via Interactivity API.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Author to add before marking ready.

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a variable product with a Color/visual attribute, multiple terms, and variation images for each color.
2. Add the Product Image with Color Swatches block inside a Product Collection/Product Template, keeping its Product Image and Product Filter Chips inner blocks.
3. View the collection on the frontend and confirm each swatch changes the product image to the matching variation image; selecting the same swatch again restores the default image.
4. Confirm products without color variation images still render the product image and do not render swatches.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Not run; user requested skipping testing for now.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a Product Image with Color Swatches block.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
