### PR TITLE
Fix Variation Selector inner blocks showing duplicate attributes in the sidebar

### DIFF
--- a/plugins/woocommerce/changelog/fix-duplicated-attributes-variation-selector
+++ b/plugins/woocommerce/changelog/fix-duplicated-attributes-variation-selector
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Variation Selector inner blocks showing duplicate attributes in the sidebar
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/edit.tsx
@@ -55,7 +55,7 @@ const ProductItem = ( {
 		blocks,
 	} );
 	const innerBlocksProps = useInnerBlocksProps(
-		{ role: 'listitem' },
+		{},
 		{ templateLock: 'insert' }
 	);
 
@@ -64,20 +64,12 @@ const ProductItem = ( {
 			{ isSelected ? (
 				<div { ...innerBlocksProps } />
 			) : (
-				<div role="listitem">
-					<div
-						{ ...blockPreviewProps }
-						role="button"
-						tabIndex={ 0 }
-						onClick={ onSelect }
-						onKeyDown={ ( e ) => {
-							if ( e.key === 'Enter' || e.key === ' ' ) {
-								e.preventDefault();
-								onSelect();
-							}
-						} }
-					/>
-				</div>
+				// We don't need this element to be interactive with the
+				// keyboard because the first child row is always editable.
+				// We allow clicking on the blocks of other children rows
+				// but it's not critical, so we disable the keyboard events.
+				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+				<div { ...blockPreviewProps } onClick={ onSelect } />
 			) }
 		</ProductDataContextProvider>
 	);
@@ -227,7 +219,7 @@ export default function ProductItemTemplateEdit(
 	return (
 		<div { ...blockProps }>
 			<InnerBlockLayoutContextProvider parentName="woocommerce/add-to-cart-with-options-grouped-product-item">
-				<div role="list">{ productList }</div>
+				{ productList }
 			</InnerBlockLayoutContextProvider>
 		</div>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -277,7 +277,7 @@ export default function AttributeItemTemplateEdit(
 				</ToolsPanel>
 			</InspectorControls>
 
-			<div { ...blockProps } role="list">
+			<div { ...blockProps }>
 				{ productAttributes.map( ( attribute ) => (
 					<CustomDataProvider
 						key={ attribute.id }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -107,7 +107,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 	const blockPreviewProps = useBlockPreview( {
 		blocks,
 	} );
-	const innerBlocksProps = useInnerBlocksProps( { role: 'listitem' } );
+	const innerBlocksProps = useInnerBlocksProps();
 
 	if ( ! attribute ) {
 		return null;
@@ -127,13 +127,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 				// editable. We allow clicking on the blocks of other attributes
 				// but it's not critical, so we disable the keyboard events.
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-				<div
-					{ ...blockPreviewProps }
-					tabIndex={ 0 }
-					onClick={ onSelect }
-				>
-					<div { ...innerBlocksProps } />
-				</div>
+				<div { ...blockPreviewProps } onClick={ onSelect } />
 			) }
 		</BlockContextProvider>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
+import { Disabled } from '@wordpress/components';
 import clsx from 'clsx';
 import { decodeHtmlEntities } from '@woocommerce/utils';
 import {
@@ -91,56 +92,60 @@ const Edit = ( props: EditProps ): JSX.Element => {
 	return (
 		<>
 			<div { ...blockProps }>
-				<div className="wc-block-product-filter-chips__items">
-					{ isLoading && loadingState }
-					{ ! isLoading &&
-						( isLongList
-							? items.slice( 0, threshold )
-							: items
-						).map( ( item, index ) => (
-							<div
-								key={ index }
-								className="wc-block-product-filter-chips__item"
-								aria-checked={ !! item.selected }
-							>
-								<span className="wc-block-product-filter-chips__label">
-									<span
-										className={ clsx(
-											'wc-block-product-filter-chips__swatch',
-											{
-												'wc-block-product-filter-chips__swatch--no-color':
-													! item.color,
+				<Disabled>
+					<div className="wc-block-product-filter-chips__items">
+						{ isLoading && loadingState }
+						{ ! isLoading &&
+							( isLongList
+								? items.slice( 0, threshold )
+								: items
+							).map( ( item, index ) => (
+								<div
+									key={ index }
+									className="wc-block-product-filter-chips__item"
+									aria-checked={ !! item.selected }
+								>
+									<span className="wc-block-product-filter-chips__label">
+										<span
+											className={ clsx(
+												'wc-block-product-filter-chips__swatch',
+												{
+													'wc-block-product-filter-chips__swatch--no-color':
+														! item.color,
+												}
+											) }
+											style={
+												item.color
+													? {
+															backgroundColor:
+																item.color,
+													  }
+													: undefined
 											}
-										) }
-										style={
-											item.color
-												? {
-														backgroundColor:
-															item.color,
-												  }
-												: undefined
-										}
-										aria-hidden="true"
-									/>
-									<span className="wc-block-product-filter-chips__text">
-										{ typeof item.label === 'string'
-											? decodeHtmlEntities( item.label )
-											: item.label }
-									</span>
-									{ item.count !== undefined && (
-										<span className="wc-block-product-filter-chips__count">
-											{ ` (${ item.count })` }
+											aria-hidden="true"
+										/>
+										<span className="wc-block-product-filter-chips__text">
+											{ typeof item.label === 'string'
+												? decodeHtmlEntities(
+														item.label
+												  )
+												: item.label }
 										</span>
-									) }
-								</span>
-							</div>
-						) ) }
-				</div>
-				{ ! isLoading && isLongList && (
-					<button className="wc-block-product-filter-chips__show-more">
-						{ __( 'Show more…', 'woocommerce' ) }
-					</button>
-				) }
+										{ item.count !== undefined && (
+											<span className="wc-block-product-filter-chips__count">
+												{ ` (${ item.count })` }
+											</span>
+										) }
+									</span>
+								</div>
+							) ) }
+					</div>
+					{ ! isLoading && isLongList && (
+						<button className="wc-block-product-filter-chips__show-more">
+							{ __( 'Show more…', 'woocommerce' ) }
+						</button>
+					) }
+				</Disabled>
 			</div>
 			<InspectorControls group="color">
 				{ colorGradientSettings.hasColorsOrGradients && (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR:

* Fixes an issue in the Variation Selector inner blocks that made them display duplicate attributes in the sidebar (c43d27fa76c49261945bcc514ebac2bee88084e2).
* It also disables hover states in the color swatches in the editor (4fde67434496471abb7c626bbbad14a4b9b2dd23).
* Removes some hard-coded `role` attributes in editor components (ae5292b5d91e28f5914190b0fb4bfd93da1e1978).

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Template parts_ > _Add to Cart + Options_ and edit the variable products template part.
2. Select the _Variation Selector: Attribute Name_ or the _Chips_/_Dropdown_ block.
3. Verify attributes in the sidebar are not duplicated:

Before | After
--- | ---
<img width="1868" height="1121" alt="image" src="https://github.com/user-attachments/assets/dc9b8969-2d2e-487d-90e1-66986ba19129" /> | <img width="1868" height="1121" alt="image" src="https://github.com/user-attachments/assets/116d6606-358e-4656-80ee-b8321ccf9232" />

4. If selecting a `wc-visual` attribute, verify color swatches don't show hover styles in the editor.