### PR TITLE
Fix mirror push for PHP packages targeting the Automattic org

### DIFF
--- a/.github/workflows/package-php-mirror.yml
+++ b/.github/workflows/package-php-mirror.yml
@@ -22,15 +22,33 @@ jobs:
               uses: ./.github/actions/setup-woocommerce-monorepo
 
             - name: Build package for mirroring
+              env:
+                  PACKAGE: ${{ github.event.inputs.package }}
               run: |
-                  pnpm --filter "${{ github.event.inputs.package }}" build:composer-package
-                  echo "mirror_dir=$( pnpm --filter ${{ github.event.inputs.package }} list --json | jq --compact-output '.[]' | jq --raw-output '( .path + "/build")' )" >> $GITHUB_ENV
+                  pnpm --filter "$PACKAGE" build:composer-package
+                  mirror_dir=$( pnpm --filter "$PACKAGE" list --json | jq --compact-output '.[]' | jq --raw-output '( .path + "/build")' )
+                  echo "mirror_dir=$mirror_dir" >> $GITHUB_ENV
+                  # The target org is the first path segment of the package's mirrors.txt.
+                  # It determines which user/token can push to the mirror repo (see below).
+                  echo "mirror_org=$( cut -d/ -f1 "$mirror_dir/mirrors.txt" )" >> $GITHUB_ENV
+
+            # woocommercebot belongs to the woocommerce org and cannot push to Automattic
+            # repos, so packages mirrored to the Automattic org must use matticbot instead.
+            - name: Verify Automattic mirror token is set
+              if: env.mirror_org == 'Automattic'
+              env:
+                  TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+              run: |
+                  if [[ -z "$TOKEN" ]]; then
+                    echo '::error::Mirroring to the Automattic org requires the API_TOKEN_GITHUB secret to be set.'
+                    exit 1
+                  fi
 
             - name: Push to mirror
               uses: Automattic/action-push-to-mirrors@4dfc139699dff77d96af45b2aaf70888c8cd963d #v2.2.2
               with:
-                  token: ${{ secrets.PR_ASSIGN_TOKEN }}
-                  username: woocommercebot
+                  token: ${{ env.mirror_org == 'Automattic' && secrets.API_TOKEN_GITHUB || secrets.PR_ASSIGN_TOKEN }}
+                  username: ${{ env.mirror_org == 'Automattic' && 'matticbot' || 'woocommercebot' }}
                   working-directory: ${{ env.mirror_dir }}
                   commit-message: 'Mirror package ${{ github.event.inputs.package }} from WooCommerce'
               timeout-minutes: 5 # Normally should take up to 30 seconds


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related to pfKYZu-39p-p2#comment-3242

The `woocommerce-analytics` package was migrated into the monorepo (`packages/php/woocommerce-analytics/`) and is released to Packagist by mirroring to `Automattic/woocommerce-analytics`. The first release through this flow (0.16.4) hit a permission wall: the `package-php-mirror.yml` workflow authenticates the mirror push as `woocommercebot` (`PR_ASSIGN_TOKEN`), but that bot belongs to the `woocommerce` org and gets a 403 pushing to the **Automattic** org. Fine-grained PATs can't target an org the bot isn't a member of.

This makes the mirror push pick the user/token by target org, derived from the first path segment of the package's `mirrors.txt`:

- `Automattic/*` → `matticbot` + `secrets.API_TOKEN_GITHUB` (same identity the mirror repo's own `autotagger.yml` already uses)
- everything else → `woocommercebot` + `secrets.PR_ASSIGN_TOKEN` (unchanged; `email-editor` behavior is untouched)

A guard step fails loudly if `API_TOKEN_GITHUB` is missing for an Automattic push, so the credential fallback can never silently push with the wrong token. The package input is also moved into an `env:` var to avoid interpolating a workflow input directly into the shell.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Review the workflow logic in `.github/workflows/package-php-mirror.yml`: `mirror_org` is parsed from the first path segment of `<mirror_dir>/mirrors.txt`.
2. Run the `package-php-mirror.yml` workflow on this branch with `@automattic/woocommerce-analytics` and confirm the push to `Automattic/woocommerce-analytics` succeeds  (See https://github.com/woocommerce/woocommerce/actions/runs/26430386935/job/77802274912)



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Validated the workflow YAML parses cleanly.
- Verified the conditional logic by tracing both packages' `mirrors.txt` values (`woocommerce/email-editor` and `Automattic/woocommerce-analytics`) against the org-detection step.
- End-to-end mirror push is pending Systems provisioning the `matticbot` `API_TOKEN_GITHUB` secret.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

CI-only change to a GitHub Actions workflow (`.github/workflows/package-php-mirror.yml`). No code is shipped in any WooCommerce package, so no changelog entry is required.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>