### PR TITLE
Replace PanelBody with ToolsPanel in Related By control

### DIFF
--- a/plugins/woocommerce/changelog/fix-59464-use-toolspanel-in-related-by-control
+++ b/plugins/woocommerce/changelog/fix-59464-use-toolspanel-in-related-by-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace PanelBody with ToolsPanel in Related By control of Product Collection block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/related-by-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/related-by-control.tsx
@@ -2,7 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, PanelBody } from '@wordpress/components';
+import {
+	CheckboxControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -33,8 +39,22 @@ const RelatedByControl = ( {
 	};
 
 	return (
-		<PanelBody title={ __( 'Related by', 'woocommerce' ) }>
-			<div className="wc-block-editor-product-collection-inspector-controls__relate-by">
+		<ToolsPanel
+			label={ __( 'Related by', 'woocommerce' ) }
+			className="wc-block-editor-product-collection-inspector-controls__relate-by"
+			resetAll={ () => {
+				setQueryAttribute( {
+					relatedBy: { categories: true, tags: true },
+				} );
+				trackInteraction( CoreFilterNames.RELATED_BY );
+			} }
+		>
+			<ToolsPanelItem
+				label={ __( 'Categories', 'woocommerce' ) }
+				hasValue={ () => relatedBy?.categories !== true }
+				onDeselect={ () => handleRelatedByChange( true, 'categories' ) }
+				isShownByDefault
+			>
 				<CheckboxControl
 					__nextHasNoMarginBottom
 					label={ __( 'Categories', 'woocommerce' ) }
@@ -43,7 +63,13 @@ const RelatedByControl = ( {
 						handleRelatedByChange( value, 'categories' );
 					} }
 				/>
-
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				label={ __( 'Tags', 'woocommerce' ) }
+				hasValue={ () => relatedBy?.tags !== true }
+				onDeselect={ () => handleRelatedByChange( true, 'tags' ) }
+				isShownByDefault
+			>
 				<CheckboxControl
 					__nextHasNoMarginBottom
 					label={ __( 'Tags', 'woocommerce' ) }
@@ -52,8 +78,8 @@ const RelatedByControl = ( {
 						handleRelatedByChange( value, 'tags' );
 					} }
 				/>
-			</div>
-		</PanelBody>
+			</ToolsPanelItem>
+		</ToolsPanel>
 	);
 };
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR removes `PanelBody` and replaces it with `ToolsPanel` in the Related By inspector control of the Product Collection block.

Each checkbox (Categories, Tags) is now wrapped in its own `ToolsPanelItem` with `hasValue` and `onDeselect` handlers. The `className` previously on the inner `<div>` has been moved to the `ToolsPanel` root element to preserve the existing E2E test selector.

Part of #59464 

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="284" height="124" alt="Screenshot 2026-05-26 at 12 41 07 PM" src="https://github.com/user-attachments/assets/8fb70e8c-f946-455f-8e5e-4da40a9bfa2f" /> | <img width="278" height="117" alt="Screenshot 2026-05-26 at 12 39 42 PM" src="https://github.com/user-attachments/assets/5541ed6d-e1aa-4841-bf70-42ea8a2c57d7" /> |
| <img width="282" height="123" alt="Screenshot 2026-05-26 at 12 41 18 PM" src="https://github.com/user-attachments/assets/9cdabbc5-1efa-407f-b023-ada9eeaf6fc1" /> | <img width="285" height="235" alt="Screenshot 2026-05-26 at 12 39 53 PM" src="https://github.com/user-attachments/assets/fd47da38-004e-40eb-ad9f-eabc17aa062f" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to **Appearance → Editor** in the WordPress admin.
2. Open any page or post and insert a **Product Collection** block.
3. In the block toolbar, switch the collection type to **Related Products** and pick a product when prompted.
4. Open the **Inspector Controls** sidebar.
5. Verify the "Related by" section now renders as a `ToolsPanel` (flat layout, no collapse arrow, has a ⋮ menu).
6. Both **Categories** and **Tags** checkboxes should be checked by default.
7. Uncheck **Categories** and verify the product list updates accordingly.
8. Open the ⋮ menu and click **Reset all** and verify both checkboxes return to checked.

### Testing that has already taken place:

- `hasValue` correctly returns `false` when both checkboxes are at their defaults (`true`), and `true` when either is unchecked.
- `resetAll` resets both `categories` and `tags` to `true`.
- `isShownByDefault` preserves the previous `PanelBody` behavior of always showing both controls.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
