### PR TITLE
Gate community PR reviewer assignment on CodeRabbit approval

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,4 +1,5 @@
 reviews:
+    request_changes_workflow: true
     assess_linked_issues: false
     collapse_walkthrough: true
     high_level_summary: false

--- a/.github/workflows/automate-team-review-assignment.yml
+++ b/.github/workflows/automate-team-review-assignment.yml
@@ -60,22 +60,28 @@ jobs:
         - name: Check if community contribution
           id: check
           uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+          env:
+            PR_USER: ${{ github.event.pull_request.user.login }}
+            ACTION: ${{ github.event.action }}
+            LABEL_NAME: ${{ github.event.label.name }}
           with:
             retries: 2
             script: |
+              const username = process.env.PR_USER;
               const { data: { permission } } = await github.rest.repos.getCollaboratorPermissionLevel( {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  username: '${{ github.event.pull_request.user.login }}',
+                  username,
               } );
-              const isCommunity = ( permission === 'read' || permission === 'none' );
+              const isCommunity = ( permission === 'read' || permission === 'none' )
+                  && username !== 'gglobalstep'
+                  && username !== 'linear[bot]';
               core.setOutput( 'contributor', isCommunity ? 'yes' : 'no' );
 
               // Community PRs are only assigned when the coderabbit-approved label is added
-              const action = '${{ github.event.action }}';
               const shouldAssignCommunity = isCommunity
-                  && action === 'labeled'
-                  && '${{ github.event.label.name }}' === 'coderabbit-approved';
+                  && process.env.ACTION === 'labeled'
+                  && process.env.LABEL_NAME === 'coderabbit-approved';
               core.setOutput( 'assign_community', shouldAssignCommunity ? 'yes' : 'no' );
 
         - name: Check if reviewers already assigned

--- a/.github/workflows/automate-team-review-assignment.yml
+++ b/.github/workflows/automate-team-review-assignment.yml
@@ -2,12 +2,12 @@ name: Add community label, Assign reviewers
 
 on:
     pull_request_target:
-        types: [opened, ready_for_review, review_requested]
+        types: [opened, ready_for_review, labeled, review_requested]
     issues:
         types: [opened]
 
 concurrency:
-    group: automate-team-review-assignment-${{ github.event_name }}-${{ github.event.action }}-${{ github.event.pull_request.number || github.event.issue.number }}
+    group: automate-team-review-assignment-${{ github.event_name }}-${{ github.event.action }}-${{ github.event.label.name || '' }}-${{ github.event.pull_request.number || github.event.issue.number }}
     cancel-in-progress: true
 
 permissions:
@@ -49,7 +49,12 @@ jobs:
 
     assign-reviewers:
       name: Assign reviewers
-      if: ${{ github.event.pull_request && ( github.event.action == 'opened' || github.event.action == 'ready_for_review' ) }}
+      if: >
+        ${{ github.event.pull_request && (
+          github.event.action == 'opened' ||
+          github.event.action == 'ready_for_review' ||
+          ( github.event.action == 'labeled' && github.event.label.name == 'coderabbit-approved' )
+        ) }}
       runs-on: ubuntu-latest
       steps:
         - name: Check if community contribution
@@ -63,17 +68,40 @@ jobs:
                   repo: context.repo.repo,
                   username: '${{ github.event.pull_request.user.login }}',
               } );
-              core.setOutput( 'contributor', ( permission === 'read' || permission === 'none' ) ? 'yes' : 'no' );
+              const isCommunity = ( permission === 'read' || permission === 'none' );
+              core.setOutput( 'contributor', isCommunity ? 'yes' : 'no' );
+
+              // Community PRs are only assigned when the coderabbit-approved label is added
+              const action = '${{ github.event.action }}';
+              const shouldAssignCommunity = isCommunity
+                  && action === 'labeled'
+                  && '${{ github.event.label.name }}' === 'coderabbit-approved';
+              core.setOutput( 'assign_community', shouldAssignCommunity ? 'yes' : 'no' );
+
+        - name: Check if reviewers already assigned
+          if: ${{ steps.check.outputs.assign_community == 'yes' }}
+          id: reviewers
+          uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+          with:
+            retries: 2
+            script: |
+              const { data: pr } = await github.rest.pulls.get( {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: ${{ github.event.pull_request.number }},
+              } );
+              const hasReviewers = pr.requested_reviewers.length > 0 || pr.requested_teams.length > 0;
+              core.setOutput( 'already_assigned', hasReviewers ? 'yes' : 'no' );
 
         - name: Assign reviewers for a community PR
-          if: ${{ steps.check.outputs.contributor == 'yes' && github.event.pull_request.draft == false }}
+          if: ${{ steps.check.outputs.assign_community == 'yes' && github.event.pull_request.draft == false && steps.reviewers.outputs.already_assigned != 'yes' }}
           uses: shufo/auto-assign-reviewer-by-files@f5f3db9ef06bd72ab6978996988c6462cbdaabf6
           with:
               config: '.github/project-community-pr-assigner.yml'
               token: ${{ secrets.PR_ASSIGN_TOKEN }}
 
         - name: Assign reviewers for a teams PR
-          if: ${{ steps.check.outputs.contributor == 'no' && github.event.pull_request.draft == false && ! contains( github.event.pull_request.labels.*.name, 'Release' ) && ( github.event.pull_request.base.ref == 'trunk' || startsWith( github.event.pull_request.base.ref, 'release/' ) ) }}
+          if: ${{ steps.check.outputs.contributor == 'no' && ( github.event.action == 'opened' || github.event.action == 'ready_for_review' ) && github.event.pull_request.draft == false && ! contains( github.event.pull_request.labels.*.name, 'Release' ) && ( github.event.pull_request.base.ref == 'trunk' || startsWith( github.event.pull_request.base.ref, 'release/' ) ) }}
           continue-on-error: ${{ ( github.event.pull_request.head.repo.fork && 'true' ) || 'false' }}
           uses: acq688/Request-Reviewer-For-Team-Action@fca1c60fd0504aef59bdc925f3902c8a2d8bce62 # v1.1
           with:

--- a/.github/workflows/community-pr-coderabbit-gate.yml
+++ b/.github/workflows/community-pr-coderabbit-gate.yml
@@ -1,3 +1,21 @@
+# Gate community PR reviewer assignment on CodeRabbit's review status.
+#
+# Problem: Community PRs (from forks) get reviewer teams assigned immediately,
+# even when CodeRabbit has already flagged issues. Human reviewers waste time
+# re-discovering the same problems.
+#
+# Solution: This workflow listens for CodeRabbit's summary comment and checks
+# its formal review state. If approved, it adds a `coderabbit-approved` label
+# which triggers reviewer assignment in automate-team-review-assignment.yml.
+# If changes are requested, it posts a guidance comment to the contributor.
+#
+# Why issue_comment instead of pull_request_review?
+# For fork PRs, pull_request_review events have read-only GITHUB_TOKEN and no
+# access to secrets. The issue_comment event runs in the base repo context with
+# full permissions, even for fork PRs. The label bridges from this context to
+# pull_request_target (labeled) where the reviewer assignment action has the
+# github.event.pull_request context it needs.
+
 name: Community PR CodeRabbit Gate
 
 on:
@@ -120,8 +138,6 @@ jobs:
                   comment-id: ${{ steps.find-guidance.outputs.comment-id }}
                   issue-number: ${{ steps.gate.outputs.pr_number }}
                   body: |
-                      ## CodeRabbit Review Gate
-
                       CodeRabbit has requested changes on this PR. Please address the feedback in the review comments and push your changes — CodeRabbit will re-review automatically.
 
                       If you believe a comment is a false positive, you can resolve it with a brief explanation using GitHub's "Resolve conversation" button, or reply `@coderabbitai resolve` to resolve all comments at once.

--- a/.github/workflows/community-pr-coderabbit-gate.yml
+++ b/.github/workflows/community-pr-coderabbit-gate.yml
@@ -113,12 +113,14 @@ jobs:
             - name: Add coderabbit-approved label
               if: ${{ steps.gate.outputs.action == 'approve' }}
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+              env:
+                  PR_NUMBER: ${{ steps.gate.outputs.pr_number }}
               with:
                   script: |
                       await github.rest.issues.addLabels( {
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          issue_number: ${{ steps.gate.outputs.pr_number }},
+                          issue_number: Number( process.env.PR_NUMBER ),
                           labels: [ 'coderabbit-approved' ],
                       } );
 

--- a/.github/workflows/community-pr-coderabbit-gate.yml
+++ b/.github/workflows/community-pr-coderabbit-gate.yml
@@ -1,0 +1,130 @@
+name: Community PR CodeRabbit Gate
+
+on:
+    issue_comment:
+        types: [created]
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+jobs:
+    handle-coderabbit-review:
+        name: Handle CodeRabbit review for community PRs
+        if: ${{ github.event.issue.pull_request && github.event.comment.user.login == 'coderabbitai[bot]' }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Get PR details and check gate conditions
+              id: gate
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+              with:
+                  script: |
+                      const prNumber = context.payload.issue.number;
+
+                      // Get full PR details
+                      const { data: pr } = await github.rest.pulls.get({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          pull_number: prNumber,
+                      });
+
+                      // Skip drafts
+                      if ( pr.draft ) {
+                          core.info( 'PR is a draft, skipping.' );
+                          core.setOutput( 'action', 'none' );
+                          return;
+                      }
+
+                      // Check if community contribution
+                      const { data: { permission } } = await github.rest.repos.getCollaboratorPermissionLevel( {
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          username: pr.user.login,
+                      } );
+                      const isCommunity = ( permission === 'read' || permission === 'none' )
+                          && pr.user.login !== 'gglobalstep'
+                          && pr.user.login !== 'linear[bot]';
+
+                      if ( ! isCommunity ) {
+                          core.info( `Author ${ pr.user.login } is a collaborator, skipping.` );
+                          core.setOutput( 'action', 'none' );
+                          return;
+                      }
+
+                      // Check if reviewers are already assigned
+                      if ( pr.requested_reviewers.length > 0 || pr.requested_teams.length > 0 ) {
+                          core.info( 'Reviewers already assigned, skipping.' );
+                          core.setOutput( 'action', 'none' );
+                          return;
+                      }
+
+                      // Get CodeRabbit's latest review
+                      const { data: reviews } = await github.rest.pulls.listReviews( {
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          pull_number: prNumber,
+                          per_page: 100,
+                      } );
+
+                      const coderabbitReviews = reviews.filter(
+                          ( r ) => r.user.login === 'coderabbitai[bot]'
+                      );
+
+                      if ( coderabbitReviews.length === 0 ) {
+                          core.info( 'No CodeRabbit review found yet, skipping.' );
+                          core.setOutput( 'action', 'none' );
+                          return;
+                      }
+
+                      // Get the latest CodeRabbit review state
+                      const latestReview = coderabbitReviews[ coderabbitReviews.length - 1 ];
+                      const state = latestReview.state.toLowerCase();
+
+                      if ( state === 'approved' ) {
+                          core.setOutput( 'action', 'approve' );
+                      } else if ( state === 'changes_requested' ) {
+                          core.setOutput( 'action', 'request_changes' );
+                      } else {
+                          core.info( `CodeRabbit review state is "${ state }", no action needed.` );
+                          core.setOutput( 'action', 'none' );
+                      }
+
+                      core.setOutput( 'pr_number', prNumber );
+
+            - name: Add coderabbit-approved label
+              if: ${{ steps.gate.outputs.action == 'approve' }}
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+              with:
+                  script: |
+                      await github.rest.issues.addLabels( {
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: ${{ steps.gate.outputs.pr_number }},
+                          labels: [ 'coderabbit-approved' ],
+                      } );
+
+            - name: Find existing guidance comment
+              if: ${{ steps.gate.outputs.action == 'request_changes' }}
+              uses: peter-evans/find-comment@034abe94d3191f9c89d870519735beae326f2bdb
+              id: find-guidance
+              with:
+                  issue-number: ${{ steps.gate.outputs.pr_number }}
+                  comment-author: 'github-actions[bot]'
+                  body-includes: CodeRabbit has requested changes on this PR
+
+            - name: Post guidance comment
+              if: ${{ steps.gate.outputs.action == 'request_changes' }}
+              uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
+              with:
+                  comment-id: ${{ steps.find-guidance.outputs.comment-id }}
+                  issue-number: ${{ steps.gate.outputs.pr_number }}
+                  body: |
+                      ## CodeRabbit Review Gate
+
+                      CodeRabbit has requested changes on this PR. Please address the feedback in the review comments and push your changes — CodeRabbit will re-review automatically.
+
+                      If you believe a comment is a false positive, you can resolve it with a brief explanation using GitHub's "Resolve conversation" button, or reply `@coderabbitai resolve` to resolve all comments at once.
+
+                      Once all comments are resolved, a reviewer will be assigned automatically.
+                  edit-mode: replace

--- a/.github/workflows/community-pr-coderabbit-gate.yml
+++ b/.github/workflows/community-pr-coderabbit-gate.yml
@@ -22,6 +22,10 @@ on:
     issue_comment:
         types: [created]
 
+concurrency:
+    group: community-pr-coderabbit-gate-${{ github.event.issue.number }}
+    cancel-in-progress: false
+
 permissions:
     contents: read
     pull-requests: write
@@ -50,6 +54,13 @@ jobs:
                       // Skip drafts
                       if ( pr.draft ) {
                           core.info( 'PR is a draft, skipping.' );
+                          core.setOutput( 'action', 'none' );
+                          return;
+                      }
+
+                      // Skip closed/merged PRs
+                      if ( pr.state !== 'open' ) {
+                          core.info( `PR is ${ pr.state }, skipping.` );
                           core.setOutput( 'action', 'none' );
                           return;
                       }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request:

Currently, community (non-collaborator) PRs get reviewer teams assigned immediately on open. CodeRabbit reviews these PRs and flags issues, but contributors often ignore the feedback because it's posted as non-blocking comments. Human reviewers then get assigned, spend time reviewing, and find the same problems CodeRabbit already pointed out.

This PR delays community PR reviewer assignment until CodeRabbit has approved the PR. If CodeRabbit requests changes, a guidance comment tells the contributor how to address the feedback. Once resolved, CodeRabbit auto-approves and reviewers are assigned. Collaborator PRs are unaffected — they still get assigned immediately.

**What changed:**

- `.coderabbit.yml` — Enable `request_changes_workflow: true` so CodeRabbit submits formal Approved/Changes Requested reviews instead of non-blocking comments
- `.github/workflows/community-pr-coderabbit-gate.yml` (new) — Detects CodeRabbit's review outcome on community PRs and either adds a `coderabbit-approved` label (triggering assignment) or posts a guidance comment
- `.github/workflows/automate-team-review-assignment.yml` — Community PR assignment now triggers on the `coderabbit-approved` label instead of on PR open

**Why `issue_comment` + label?** Fork PRs give `pull_request_review` events read-only permissions and no secrets. The `issue_comment` event (fired when CodeRabbit posts its summary) runs with full base-repo permissions. The label bridges from that context to `pull_request_target: [labeled]` where the existing `shufo/auto-assign-reviewer-by-files` action has the event context it needs.

### How to test the changes in this Pull Request:

1. After merging, open a test PR from a fork
2. Confirm no reviewers are assigned on open
3. Wait for CodeRabbit to review (1-5 minutes)
4. If CodeRabbit approves: confirm `coderabbit-approved` label is added and reviewers are assigned
5. If CodeRabbit requests changes: confirm guidance comment is posted and no reviewers are assigned
6. Address CodeRabbit's feedback and push — confirm it re-reviews, approves, and reviewers are then assigned
7. Open an internal (collaborator) PR and confirm team reviewers are assigned immediately as before

### Testing that has already taken place:

- Verified CodeRabbit's `request_changes_workflow` behavior on repos that use it: confirmed it submits `APPROVED` reviews for clean PRs and `CHANGES_REQUESTED` for PRs with issues
- Verified `issue_comment` events have full permissions for fork PRs (unlike `pull_request_review` which is read-only)
- Traced through all scenarios: draft/ready, collaborator/non-collaborator, unreviewed/approved/changes-requested

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI/workflow-only change affecting GitHub Actions automation for PR reviewer assignment. No WooCommerce plugin code is changed.

</details>