### PR TITLE
e2e: get Core e2e tests passing under Gutenberg nightly

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-gutenberg-nightly-title-locator
+++ b/plugins/woocommerce/changelog/e2e-fix-gutenberg-nightly-title-locator
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Update the post/page title locator in e2e tests so it works against Gutenberg trunk in addition to older releases.

--- a/plugins/woocommerce/changelog/fix-gutenberg-nightly-is-shallow-equal-default-import
+++ b/plugins/woocommerce/changelog/fix-gutenberg-nightly-is-shallow-equal-default-import
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Cart and checkout blocks now render against Gutenberg trunk by resolving `isShallowEqual` through the namespace, so the function is picked up regardless of whether `window.wp.isShallowEqual` exposes `__esModule`.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -28,7 +28,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { dispatch, select } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../../../utils/is-shallow-equal';
 import clsx from 'clsx';
 import fastDeepEqual from 'fast-deep-equal/es6';
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -28,13 +28,13 @@ import { useInstanceId } from '@wordpress/compose';
 import { dispatch, select } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import isShallowEqual from '../../../../utils/is-shallow-equal';
 import clsx from 'clsx';
 import fastDeepEqual from 'fast-deep-equal/es6';
 
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../../../../utils/is-shallow-equal';
 import { Select } from '../../select';
 import AddressLineFields from './address-line-fields';
 import { FormProps } from './types';

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/validate-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/validate-state.ts
@@ -5,7 +5,7 @@ import { dispatch, select } from '@wordpress/data';
 import { KeyedFormFields, ShippingAddress } from '@woocommerce/settings';
 import { validationStore } from '@woocommerce/block-data';
 import { __, sprintf } from '@wordpress/i18n';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../../../utils/is-shallow-equal';
 
 function previousAddress( initialValue?: ShippingAddress ) {
 	let lastValue = initialValue;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/validate-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/validate-state.ts
@@ -5,6 +5,10 @@ import { dispatch, select } from '@wordpress/data';
 import { KeyedFormFields, ShippingAddress } from '@woocommerce/settings';
 import { validationStore } from '@woocommerce/block-data';
 import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import isShallowEqual from '../../../../utils/is-shallow-equal';
 
 function previousAddress( initialValue?: ShippingAddress ) {

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -9,11 +9,11 @@ import {
 	hasCollectableRate,
 	deriveSelectedShippingRates,
 } from '@woocommerce/base-utils';
-import isShallowEqual from '../../../../utils/is-shallow-equal';
 
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../../../../utils/is-shallow-equal';
 import { useStoreEvents } from '../use-store-events';
 import type { ShippingData } from './types';
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -9,7 +9,7 @@ import {
 	hasCollectableRate,
 	deriveSelectedShippingRates,
 } from '@woocommerce/base-utils';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../../../utils/is-shallow-equal';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-query-state.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-query-state.js
@@ -4,7 +4,7 @@
 import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../../utils/is-shallow-equal';
 import { useShallowEqual, usePrevious } from '@woocommerce/base-hooks';
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-query-state.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-query-state.js
@@ -4,13 +4,12 @@
 import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
-import isShallowEqual from '../../../utils/is-shallow-equal';
 import { useShallowEqual, usePrevious } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
  */
-
+import isShallowEqual from '../../../utils/is-shallow-equal';
 import { useQueryStateContext } from '../providers/query-state-context';
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/base/hocs/with-reviews.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hocs/with-reviews.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import isShallowEqual from '../../utils/is-shallow-equal';
 import type { Review } from '@woocommerce/base-components/reviews/types';
 import { ErrorObject } from '@woocommerce/editor-components/error-placeholder';
 
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { getReviews } from '../../blocks/reviews/utils';
 import { formatError } from '../utils/errors';
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/hocs/with-reviews.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hocs/with-reviews.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../utils/is-shallow-equal';
 import type { Review } from '@woocommerce/base-components/reviews/types';
 import { ErrorObject } from '@woocommerce/editor-components/error-placeholder';
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-shallow-equal.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-shallow-equal.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useRef } from '@wordpress/element';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../utils/is-shallow-equal';
 
 /**
  * A custom hook that compares the provided value across renders and returns the

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-shallow-equal.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-shallow-equal.ts
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import isShallowEqual from '../../utils/is-shallow-equal';
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/block.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useState, useMemo } from '@wordpress/element';
 import Label from '@woocommerce/base-components/filter-element-label';
 import FilterResetButton from '@woocommerce/base-components/filter-reset-button';
 import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { getQueryArgs, removeQueryArgs } from '@wordpress/url';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/block.tsx
@@ -13,7 +13,6 @@ import { useCallback, useEffect, useState, useMemo } from '@wordpress/element';
 import Label from '@woocommerce/base-components/filter-element-label';
 import FilterResetButton from '@woocommerce/base-components/filter-reset-button';
 import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';
-import isShallowEqual from '../../utils/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { getQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -40,6 +39,7 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { getAttributeFromID } from '../../utils/attributes';
 import { updateAttributeFilter } from '../../utils/attributes-query';
 import { previewAttributeObject, previewOptions } from './preview';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/rating-filter/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/rating-filter/block.tsx
@@ -13,7 +13,7 @@ import {
 } from '@woocommerce/base-context/hooks';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean, isObject, objectHasProp } from '@woocommerce/types';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { useState, useCallback, useMemo, useEffect } from '@wordpress/element';
 import { CheckboxList } from '@woocommerce/blocks-components';
 import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/rating-filter/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/rating-filter/block.tsx
@@ -13,7 +13,6 @@ import {
 } from '@woocommerce/base-context/hooks';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean, isObject, objectHasProp } from '@woocommerce/types';
-import isShallowEqual from '../../utils/is-shallow-equal';
 import { useState, useCallback, useMemo, useEffect } from '@wordpress/element';
 import { CheckboxList } from '@woocommerce/blocks-components';
 import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';
@@ -31,6 +30,7 @@ import type { ReactElement } from 'react';
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { previewOptions } from './preview';
 import './style.scss';
 import { Attributes } from './types';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/stock-filter/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/stock-filter/block.tsx
@@ -24,7 +24,7 @@ import FilterResetButton from '@woocommerce/base-components/filter-reset-button'
 import FilterTitlePlaceholder from '@woocommerce/base-components/filter-placeholder';
 import Label from '@woocommerce/base-components/filter-element-label';
 import FormTokenField from '@woocommerce/base-components/form-token-field';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
 import { isBoolean, objectHasProp } from '@woocommerce/types';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/stock-filter/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/stock-filter/block.tsx
@@ -24,7 +24,6 @@ import FilterResetButton from '@woocommerce/base-components/filter-reset-button'
 import FilterTitlePlaceholder from '@woocommerce/base-components/filter-placeholder';
 import Label from '@woocommerce/base-components/filter-element-label';
 import FormTokenField from '@woocommerce/base-components/form-token-field';
-import isShallowEqual from '../../utils/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
 import { isBoolean, objectHasProp } from '@woocommerce/types';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -39,6 +38,7 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { previewOptions } from './preview';
 import './style.scss';
 import { formatSlug, getActiveFilters } from './utils';

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/push-changes.ts
@@ -7,7 +7,7 @@ import {
 } from '@woocommerce/base-utils';
 import { CartBillingAddress, CartShippingAddress } from '@woocommerce/types';
 import { select, dispatch } from '@wordpress/data';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../utils/is-shallow-equal';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/push-changes.ts
@@ -7,11 +7,11 @@ import {
 } from '@woocommerce/base-utils';
 import { CartBillingAddress, CartShippingAddress } from '@woocommerce/types';
 import { select, dispatch } from '@wordpress/data';
-import isShallowEqual from '../../utils/is-shallow-equal';
 
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { store as cartStore } from './index';
 import { processErrorResponse } from '../utils';
 import { getDirtyKeys, validateDirtyProps, BaseAddressKey } from './utils';

--- a/plugins/woocommerce/client/blocks/assets/js/data/validation/reducers.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/validation/reducers.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import type { Reducer } from 'redux';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { isString, FieldValidationStatus } from '@woocommerce/types';
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/data/validation/reducers.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/validation/reducers.ts
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import type { Reducer } from 'redux';
-import isShallowEqual from '../../utils/is-shallow-equal';
 import { isString, FieldValidationStatus } from '@woocommerce/types';
 
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../../utils/is-shallow-equal';
 import { ACTION_TYPES as types } from './action-types';
 
 const reducer: Reducer< Record< string, FieldValidationStatus > > = (

--- a/plugins/woocommerce/client/blocks/assets/js/hocs/with-product-variations.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/hocs/with-product-variations.tsx
@@ -3,7 +3,6 @@
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import isShallowEqual from '../utils/is-shallow-equal';
 import { getProductVariationsWithTotal } from '@woocommerce/editor-components/utils';
 import { ErrorObject } from '@woocommerce/editor-components/error-placeholder';
 import {
@@ -14,6 +13,7 @@ import {
 /**
  * Internal dependencies
  */
+import isShallowEqual from '../utils/is-shallow-equal';
 import { formatError } from '../base/utils/errors';
 
 interface WithProductVariationsProps {

--- a/plugins/woocommerce/client/blocks/assets/js/hocs/with-product-variations.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/hocs/with-product-variations.tsx
@@ -3,7 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '../utils/is-shallow-equal';
 import { getProductVariationsWithTotal } from '@woocommerce/editor-components/utils';
 import { ErrorObject } from '@woocommerce/editor-components/error-placeholder';
 import {

--- a/plugins/woocommerce/client/blocks/assets/js/utils/is-shallow-equal.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/is-shallow-equal.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import * as IsShallowEqualModule from '@wordpress/is-shallow-equal';
+
+type IsShallowEqualFn = ( a: unknown, b: unknown ) => boolean;
+
+// Gutenberg's new esbuild-based bundling pipeline (PR
+// WordPress/gutenberg#72140) appends a `wp.X = Object.assign({}, wp.X)`
+// footer to every `window.wp.*` global. `Object.assign` only copies
+// enumerable own properties, so the non-enumerable `__esModule: true`
+// flag is dropped — which breaks webpack's default-import interop
+// (`__webpack_require__.n` returns the whole namespace object instead
+// of `.default`). The upstream Gutenberg source has started adding
+// named exports as a migration aid, but the npm package only exposes
+// `default`, so we fall back to that for WordPress core's bundled
+// version. See: https://github.com/WordPress/gutenberg/issues/XXXXX.
+const moduleExports = IsShallowEqualModule as unknown as {
+	default?: IsShallowEqualFn;
+	isShallowEqual?: IsShallowEqualFn;
+};
+
+const isShallowEqual: IsShallowEqualFn =
+	moduleExports.default ??
+	moduleExports.isShallowEqual ??
+	( IsShallowEqualModule as unknown as IsShallowEqualFn );
+
+export default isShallowEqual;

--- a/plugins/woocommerce/client/blocks/assets/js/utils/is-shallow-equal.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/is-shallow-equal.ts
@@ -14,15 +14,33 @@ type IsShallowEqualFn = ( a: unknown, b: unknown ) => boolean;
 // of `.default`). The upstream Gutenberg source has started adding
 // named exports as a migration aid, but the npm package only exposes
 // `default`, so we fall back to that for WordPress core's bundled
-// version. See: https://github.com/WordPress/gutenberg/issues/XXXXX.
+// version. See: https://github.com/WordPress/gutenberg/issues/78697.
 const moduleExports = IsShallowEqualModule as unknown as {
-	default?: IsShallowEqualFn;
-	isShallowEqual?: IsShallowEqualFn;
+	default?: unknown;
+	isShallowEqual?: unknown;
 };
 
-const isShallowEqual: IsShallowEqualFn =
-	moduleExports.default ??
-	moduleExports.isShallowEqual ??
-	( IsShallowEqualModule as unknown as IsShallowEqualFn );
+// Pick the first candidate that is actually callable. Guarding against
+// non-function values avoids a delayed crash if some future build of
+// `@wordpress/is-shallow-equal` ships a non-callable `default`/named
+// export but still passes truthy checks.
+const candidates: unknown[] = [
+	moduleExports.default,
+	moduleExports.isShallowEqual,
+	IsShallowEqualModule,
+];
+const callable = candidates.find(
+	( candidate ): candidate is IsShallowEqualFn =>
+		typeof candidate === 'function'
+);
+
+if ( ! callable ) {
+	throw new Error(
+		'WooCommerce: `@wordpress/is-shallow-equal` did not expose a callable export. ' +
+			'This usually means the runtime build of the package has changed in an incompatible way.'
+	);
+}
+
+const isShallowEqual: IsShallowEqualFn = callable;
 
 export default isShallowEqual;

--- a/plugins/woocommerce/client/blocks/packages/checkout/filter-registry/index.ts
+++ b/plugins/woocommerce/client/blocks/packages/checkout/filter-registry/index.ts
@@ -4,9 +4,25 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
 import deprecated from '@wordpress/deprecated';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import * as IsShallowEqualModule from '@wordpress/is-shallow-equal';
 import type { ComparableObject } from '@wordpress/is-shallow-equal';
 import { isNull, isObject, objectHasProp } from '@woocommerce/types';
+
+// Gutenberg's new esbuild-based bundling pipeline appends a
+// `wp.X = Object.assign({}, wp.X)` footer to every `window.wp.*` global,
+// which drops the non-enumerable `__esModule` flag and breaks webpack's
+// default-import interop. Resolve `isShallowEqual` through the namespace
+// so we still get the function whether the runtime exposes it as
+// `default` (WordPress core) or as a named export (Gutenberg trunk).
+type IsShallowEqualFn = ( a: unknown, b: unknown ) => boolean;
+const isShallowEqualModule = IsShallowEqualModule as unknown as {
+	default?: IsShallowEqualFn;
+	isShallowEqual?: IsShallowEqualFn;
+};
+const isShallowEqual: IsShallowEqualFn =
+	isShallowEqualModule.default ??
+	isShallowEqualModule.isShallowEqual ??
+	( IsShallowEqualModule as unknown as IsShallowEqualFn );
 
 /**
  * A function that always return true.

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.ts
@@ -18,6 +18,21 @@ const fillPageTitle = async ( page: Page, title: string ) => {
 		await page.getByLabel( 'Close Block Inserter' ).click();
 	}
 
+	// Wait for the editor canvas iframe to attach before resolving the
+	// canvas. `getCanvas` checks for the iframe synchronously, so on
+	// recent Gutenberg builds (where the iframe is mounted slightly
+	// after initial paint) it can return the outer page and the title
+	// locator then waits forever against the wrong frame. The wait is
+	// short and soft-fails so older Gutenberg releases that render the
+	// title directly in the page DOM keep working.
+	await page
+		.locator( 'iframe[name="editor-canvas"]' )
+		.first()
+		.waitFor( { timeout: 10_000 } )
+		.catch( () => {
+			/* No iframe — older Gutenberg, fall through to page. */
+		} );
+
 	const canvas = await getCanvas( page );
 	// Match by role/name to stay compatible across Gutenberg versions:
 	// older releases expose the title as an `aria-label` ("Add title"

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.ts
@@ -19,8 +19,13 @@ const fillPageTitle = async ( page: Page, title: string ) => {
 	}
 
 	const canvas = await getCanvas( page );
-	// Gutenberg (since 19.9) uses the "Block: Title" label.
-	const block_title = canvas.getByLabel( /Add title|Block: Title/ );
+	// Match by role/name to stay compatible across Gutenberg versions:
+	// older releases expose the title as an `aria-label` ("Add title"
+	// or "Block: Title"), while recent trunk only exposes the accessible
+	// name through the textbox role.
+	const block_title = canvas.getByRole( 'textbox', {
+		name: /^(Add title|Block: Title)$/,
+	} );
 	await block_title.click();
 	await block_title.fill( title );
 };


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Brings the `Core e2e tests - Gutenberg nightly` job back to green. Four tests were failing on the 10.8.0 release run ([job](https://github.com/woocommerce/woocommerce/actions/runs/26462580391/job/77921456477)); they decompose into three independent issues.

#### 1. Cart block crashes under Gutenberg trunk (3 failures)

Affects `tests/e2e-pw/tests/product/product-create-simple.spec.ts` (virtual / non-virtual / downloadable).

Gutenberg's new esbuild-based bundling pipeline appends `wp.X = Object.assign({}, wp.X)` to every `window.wp.*` global to materialize getter-based exports. `Object.assign` only copies enumerable own properties, so the non-enumerable `__esModule: true` flag is dropped. That breaks webpack's default-import interop (`__webpack_require__.n` falls back to returning the whole namespace object instead of `.default`), and any external consumer doing `import isShallowEqual from '@wordpress/is-shallow-equal'` ends up calling the namespace object as a function. The first observable failure was the Cart block's error boundary: in `client/blocks/assets/js/data/cart/push-changes.ts:197`, `isShallowEqual(localState.customerData, …)` throws and crashes the whole block.

This is an upstream Gutenberg regression; filed as [WordPress/gutenberg issue 78697](https://github.com/WordPress/gutenberg/issues/78697) so the build pipeline can preserve `__esModule`. Until that lands, this PR routes `isShallowEqual` through a small namespace-aware shim that picks `.default` if present, falls back to the new named `isShallowEqual` export, and finally to the module object itself. Works on both WordPress core's bundled Gutenberg and Gutenberg trunk.

12 default imports in `client/blocks/assets/js/` get redirected through `assets/js/utils/is-shallow-equal.ts`; the one default import in `packages/checkout/filter-registry/index.ts` gets the workaround inlined because it crosses a package boundary.

#### 2. Post title locator stale on Gutenberg trunk (1 failure)

Affects `tests/e2e-pw/tests/wp-core/create-post.spec.ts`.

`canvas.getByLabel( /Add title|Block: Title/ )` no longer matched the title field, but the underlying issue was actually two:

- The title is still exposed as a `textbox` whose accessible name is `Add title`, but in recent Gutenberg builds it's no longer surfaced through `aria-label`. Switched to `getByRole( 'textbox', { name: /^(Add title|Block: Title)$/ } )`, which works on both Gutenberg trunk and older releases that exposed the same accessible name via `aria-label` / `Block: Title`.
- `getCanvas` in the `e2e-utils-playwright` package checks for `iframe[name="editor-canvas"]` synchronously. On recent Gutenberg builds the iframe mounts slightly after initial paint, so `getCanvas` was returning the outer page and the locator then waited forever against the wrong frame. Added a short, soft-failing wait on the iframe so older Gutenberg releases (no iframe) keep working.

### Screenshots or screen recordings:

Not applicable — e2e + a small runtime shim.

### How to test the changes in this Pull Request:

1. Set up wp-env on this branch, then install Gutenberg nightly:
   ```sh
   pnpm install
   pnpm --filter='@woocommerce/plugin-woocommerce' build
   cd plugins/woocommerce
   pnpm wp-env start
   bash tests/e2e-pw/envs/gutenberg-nightly/env-setup.sh
   ```
2. Run the previously failing tests against Gutenberg nightly:
   ```sh
   pnpm exec playwright test \
     --config tests/e2e-pw/envs/gutenberg-nightly/playwright.config.ts \
     tests/e2e-pw/tests/product/product-create-simple.spec.ts \
     tests/e2e-pw/tests/wp-core/create-post.spec.ts
   ```
3. Confirm all four originally failing tests pass:
   - `can create a simple virtual product`
   - `can create a simple non virtual product`
   - `can create a simple downloadable product`
   - `can create new post`
4. Also run against `gutenberg-stable` (older Gutenberg) to confirm no regression on the previously-working path.

### Testing that has already taken place:

- Reproduced the cart-block crash locally against Gutenberg nightly 23.3.20260523 (loaded from `bph/gutenberg`) before the fix: console showed `TypeError: vr(...) is not a function` originating in `wc-blocks-data.js` at the `isShallowEqual(localState.customerData, …)` call site, and the cart hit its error boundary.
- After applying the shim and rebuilding: the cart renders the product line, totals, and Proceed-to-Checkout button with zero console errors.
- Ran the four originally failing tests under the local Gutenberg nightly env: all pass (`6 passed (38.6s)`, including the `[site setup]` setup project).
- `pnpm --filter=block-library ts:check` reports the same number of errors before and after this PR (2096 pre-existing errors, none introduced by the change).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries already added:
- `plugins/woocommerce/changelog/e2e-fix-gutenberg-nightly-title-locator`
- `plugins/woocommerce/changelog/fix-gutenberg-nightly-is-shallow-equal-default-import`