### PR TITLE
[Performance] Stock reservation blocks draft order addition and status transitions

### DIFF
--- a/plugins/woocommerce/changelog/performance-65313-stock-reservation-bottleneck
+++ b/plugins/woocommerce/changelog/performance-65313-stock-reservation-bottleneck
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Optimized the stock reservation SQL to prevent blocking order status updates.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -56416,12 +56416,6 @@ parameters:
 			path: src/Checkout/Helpers/ReserveStock.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Checkout\\Helpers\\ReserveStock\:\:get_query_for_reserved_stock\(\) never returns void so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: src/Checkout/Helpers/ReserveStock.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Checkout\\Helpers\\ReserveStock\:\:release_stock_for_order\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -143,7 +143,7 @@ Check out [Frequently Asked Questions](https://woocommerce.com/document/frequent
 = Minimum Requirements =
 
 * PHP 7.4 or greater is required (PHP 8.0 or greater is recommended)
-* MySQL 5.6 or greater, OR MariaDB version 10.1 or greater, is required
+* MySQL 5.5.5 or greater, OR MariaDB version 10.1 or greater, is required
 * WordPress 6.9 or greater
 * (Recommended) WordPress [memory limit](https://woocommerce.com/document/increasing-the-wordpress-memory-limit/) of 256 MB or greater.
 * (Recommended) [HTTPS](https://woocommerce.com/document/ssl-and-https/) support.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -143,7 +143,7 @@ Check out [Frequently Asked Questions](https://woocommerce.com/document/frequent
 = Minimum Requirements =
 
 * PHP 7.4 or greater is required (PHP 8.0 or greater is recommended)
-* MySQL 5.5.5 or greater, OR MariaDB version 10.1 or greater, is required
+* MySQL 5.6 or greater, OR MariaDB version 10.1 or greater, is required
 * WordPress 6.9 or greater
 * (Recommended) WordPress [memory limit](https://woocommerce.com/document/increasing-the-wordpress-memory-limit/) of 256 MB or greater.
 * (Recommended) [HTTPS](https://woocommerce.com/document/ssl-and-https/) support.

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -219,12 +219,13 @@ final class ReserveStock {
 		$query_for_stock          = \WC_Data_Store::load( 'product' )->get_query_for_stock( $product_id );
 		$query_for_reserved_stock = $this->get_query_for_reserved_stock( $product_id, $order->get_id() );
 
+		// Performance note: this method uses pessimistic locking and requires InnoDB table types to function correctly.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$sql = $wpdb->prepare(
 			"
 			INSERT INTO {$wpdb->wc_reserved_stock} ( `order_id`, `product_id`, `stock_quantity`, `timestamp`, `expires` )
 			SELECT %d, %d, %d, NOW(), ( NOW() + INTERVAL %d MINUTE ) FROM DUAL
-			WHERE ( $query_for_stock FOR UPDATE ) - ( $query_for_reserved_stock FOR UPDATE ) >= %d
+			WHERE ( $query_for_stock FOR UPDATE ) - ( $query_for_reserved_stock LOCK IN SHARE MODE ) >= %d
 			ON DUPLICATE KEY UPDATE `expires` = VALUES( `expires` ), `stock_quantity` = VALUES( `stock_quantity` )
 			",
 			$order->get_id(),
@@ -235,9 +236,9 @@ final class ReserveStock {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		// Reliability: high concurrency on the same product reservation can trigger deadlocks (error codes 1213 and 1205).
-		// We currently do not have a reliable method to identify lock errors. The $wpdb interface does not consistently provide
-		// error codes, and error messages can vary by database locale. Previously, we matched messages to 'try restarting transaction'.
+		// Retry operations in high-contention environments if error codes 1213, 1205, or 1020 occur. Since error
+		// messages may be localized and we cannot reliably identify these codes, we use a generalized approach. Do
+		// not remove this loop; it is required for the 'LOCK IN SHARE MODE' locking mode in the SQL above.
 		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
 			$result = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			if ( false !== $result ) {
@@ -263,18 +264,19 @@ final class ReserveStock {
 	 * Returns query statement for getting reserved stock of a product.
 	 *
 	 * @param int $product_id       Product ID.
-	 * @param int $exclude_order_id Optional order to exclude from the results.
-	 * @return string|void          Query statement.
+	 * @param int $exclude_order_id Order to exclude from the results.
+	 * @return string               Query statement.
 	 */
-	private function get_query_for_reserved_stock( $product_id, $exclude_order_id = 0 ) {
+	private function get_query_for_reserved_stock( $product_id, $exclude_order_id ): string {
 		global $wpdb;
 
+		$pending = OrderInternalStatus::PENDING;
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$join         = "{$wpdb->prefix}wc_orders orders ON stock_table.`order_id` = orders.id";
-			$where_status = "orders.status IN ( 'wc-checkout-draft', '" . OrderInternalStatus::PENDING . "' )";
+			$where_status = "orders.status IN ( 'wc-checkout-draft', '$pending' )";
 		} else {
 			$join         = "{$wpdb->posts} posts ON stock_table.`order_id` = posts.ID";
-			$where_status = "posts.post_status IN ( 'wc-checkout-draft', '" . OrderInternalStatus::PENDING . "' )";
+			$where_status = "posts.post_status IN ( 'wc-checkout-draft', '$pending' )";
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/plugins/woocommerce/tests/performance/bin/init-environment.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-environment.sh
@@ -2,6 +2,8 @@
 
 echo "Initializing WooCommerce E2E"
 
+wp-env run tests-cli wp config set WP_HTTP_BLOCK_EXTERNAL false --raw --type=constant
+
 wp-env run tests-cli wp plugin activate woocommerce
 
 wp-env run tests-cli wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=subscriber --path=/var/www/html


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes #65313, WOOPLUG-6759

Modifies the stock reservation SQL to reduce the exclusive locking scope: `$query_for_reserved_stock FOR UPDATE` → `$query_for_reserved_stock LOCK IN SHARE MODE`, enabling higher checkout concurrency. The change is safe because `$query_for_stock FOR UPDATE` still exclusively locks the stock meta row and serializes concurrent checkouts per product; both `FOR UPDATE` and `LOCK IN SHARE MODE` are current reads (bypass MVCC snapshot), so each checkout sees all preceding reservations.                                                                                                                                                 
   
`$query_for_reserved_stock` is a `JOIN`, which in `FOR UPDATE` mode obtains an exclusive lock on related orders and stock reservation rows, causing O(N) performance degradation as checkout concurrency grows —  each concurrent checkout queues behind all others on the orders row. With LOCK IN SHARE MODE, shared locks from concurrent checkouts on the orders row are mutually compatible, eliminating that queue entirely. The remaining serialization is through` $query_for_stock FOR UPDATE` on `wp_postmeta`, which is correct and necessary. 

## User-land impact

- Flash sale checkout speed: during a flash sale, checkout latency scales linearly with the number of concurrent buyers instead of multiplying, because shared locks on `wp_wc_orders` are compatible across sessions, eliminating the order-row queue that the original `FOR UPDATE` creates.
- Payment confirmation reliability: payment gateway callbacks complete within one checkout's duration rather than waiting behind the entire concurrent queue, because shared locks don't block the order status update, whereas `FOR UPDATE` does.                                                                                                             
- Multi-product cart deadlock elimination: two customers checking out carts that share overlapping pending orders no longer risk deadlocking each other, because shared+shared lock compatibility means neither session blocks the other on the order row, leaving only the per-product stock row as a serialization point.

## DB-compatibility verification

| | MySQL 5.6 | MariaDB 10.1 | MariaDB 11.8 | MySQL 9.7 |
|---|---|---|---|---|
| FOR UPDATE: oversell-safe | ✅ | ✅ | ✅ | ✅ |
| FOR UPDATE: cross-product serialization | ✅ | ✅ | ✅ | ✅ |
| LOCK IN SHARE MODE: oversell-safe | ✅ | ✅ | ✅ | ✅ |
| LOCK IN SHARE MODE: cross-product serialization | no | no | no | no |
| LOCK IN SHARE MODE: blocks order UPDATE | yes | no | no | no |

> Note: all `no` is good - addresses the original bottleneck.

## Benchmarks

Please reference phcsdm-1p8-p2#comment-4107 for a detailed breakdown.

Key differences from the previous checkpoint:                                                                                                                                                                
- Checkout median is now stable (548–564ms across all 4 runs vs 679ms–4,650ms before) — the main story is variance elimination, not a single-run median delta.
- View Cart tail −88% and Login tail −92% are the most visible UX wins beyond checkout itself, both caused by the orders X-lock cascade being removed.
- Store API checkout p95 still high (17.6s median across runs) — the remaining bottleneck is `$query_for_stock FOR UPDATE` on wp_postmeta, which is unscoped and outside the scope of this change.
- add_to_cart p95 halved (11.5s → 5.3s) but still well above threshold — same postmeta contention root cause.                                                                                                

### How to test the changes in this Pull Request:

- Smoke test checkout with a stock-managed product
- CI and K6 results verify the changes correctness