### PR TITLE
Fix WooPayments onboarding business type dropdown crash

### DIFF
--- a/plugins/woocommerce/changelog/fix-woopayments-onboarding-select-crash
+++ b/plugins/woocommerce/changelog/fix-woopayments-onboarding-select-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPayments onboarding business type dropdown crash.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/custom-select-control/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/custom-select-control/index.tsx
@@ -42,44 +42,6 @@ export interface ControlProps< ItemType > {
 }
 
 const itemToString = ( item: { name?: string } | null ) => item?.name || '';
-// This is needed so that in Windows, where
-// the menu does not necessarily open on
-// key up/down, you can still switch between
-// options with the menu closed.
-const stateReducer = (
-	{ selectedItem }: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-	{ type, changes, props: { items } }: any // eslint-disable-line @typescript-eslint/no-explicit-any
-) => {
-	switch ( type ) {
-		case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowDown:
-			// If we already have a selected item, try to select the next one,
-			// without circular navigation. Otherwise, select the first item.
-			return {
-				selectedItem:
-					items[
-						selectedItem
-							? Math.min(
-									items.indexOf( selectedItem ) + 1,
-									items.length - 1
-							  )
-							: 0
-					],
-			};
-		case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowUp:
-			// If we already have a selected item, try to select the previous one,
-			// without circular navigation. Otherwise, select the last item.
-			return {
-				selectedItem:
-					items[
-						selectedItem
-							? Math.max( items.indexOf( selectedItem ) - 1, 0 )
-							: items.length - 1
-					],
-			};
-		default:
-			return changes;
-	}
-};
 
 function CustomSelectControl< ItemType extends Item >( {
 	name,
@@ -106,7 +68,6 @@ function CustomSelectControl< ItemType extends Item >( {
 		itemToString,
 		onSelectedItemChange,
 		selectedItem: value || ( {} as ItemType ),
-		stateReducer,
 	} );
 
 	const itemString = itemToString( selectedItem );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/custom-select-control/test/index.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/custom-select-control/test/index.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CustomSelectControl from '..';
+
+const options = [
+	{ key: 'individual', name: 'Individual' },
+	{ key: 'company', name: 'Company' },
+];
+
+describe( 'CustomSelectControl', () => {
+	it( 'opens the options menu when the toggle button is clicked', () => {
+		render(
+			<CustomSelectControl
+				label="Business type"
+				options={ options }
+				placeholder="Select an option"
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'combobox', { name: 'Business type' } )
+		);
+
+		expect( screen.getByText( 'Individual' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Company' ) ).toBeInTheDocument();
+	} );
+
+	it( 'selects the highlighted option when navigating with keyboard commands', () => {
+		const onChange = jest.fn();
+
+		render(
+			<CustomSelectControl
+				label="Business type"
+				options={ options }
+				onChange={ onChange }
+				placeholder="Select an option"
+				value={ options[ 0 ] }
+			/>
+		);
+
+		const select = screen.getByRole( 'combobox', {
+			name: 'Business type',
+		} );
+
+		fireEvent.keyDown( select, { key: 'ArrowDown' } );
+		fireEvent.keyDown( select, { key: 'ArrowDown' } );
+		fireEvent.keyDown( select, { key: 'Enter' } );
+
+		expect( onChange ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				selectedItem: options[ 1 ],
+			} )
+		);
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a crash in the WooPayments in-context onboarding modal on the payments settings page when opening the business type dropdown.

The copied custom select reducer was reading `items` from Downshift's internal `action.props`. That worked with the previously resolved Downshift version, but Downshift 9.3.2 no longer includes `props` on the reducer action. This removes the custom reducer and lets Downshift handle option highlighting and selection, avoiding reliance on changed internals and preserving keyboard navigation behavior.

Also adds focused regression tests that open the custom select menu and select an option via ArrowDown/Enter keyboard navigation. Without the fix, opening the menu fails with `TypeError: (destructured parameter).props is undefined`; the keyboard test guards against regressing selection behavior.

(For Bug Fixes) Bug introduced in PR #64114.

### Screenshots or screen recordings:

N/A. The visual UI is unchanged.

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Settings > Payments**.
2. Start or resume the WooPayments setup flow.
3. Proceed to the **Activate payments** step.
4. Click the **What type of legal entity is your business?** dropdown.
5. Confirm the dropdown opens and options are shown without the modal crashing.
6. Confirm you can change the input on the dropdown with ArrowUp/ArrowDown and Enter.

<img width="1479" height="792" alt="Screenshot 2026-05-27 at 14 00 25" src="https://github.com/user-attachments/assets/bb6f0921-2a3c-4e1f-afb4-9d7ad804e433" />

### Testing that has already taken place:

- Ran the focused Jest regression test:
  - `cd plugins/woocommerce/client/admin && pnpm test:js -- client/settings-payments/onboarding/providers/woopayments/components/custom-select-control/test/index.test.tsx`
- Ran ESLint for the changed TS/TSX files:
  - `cd plugins/woocommerce/client/admin && pnpm exec eslint client/settings-payments/onboarding/providers/woopayments/components/custom-select-control/index.tsx client/settings-payments/onboarding/providers/woopayments/components/custom-select-control/test/index.test.tsx --ext=js,ts,tsx`
- Built the admin assets and copied them into the WooCommerce plugin assets:
  - `pnpm --filter=@woocommerce/admin-library build`
  - `pnpm --filter=@woocommerce/plugin-woocommerce build:project:copy-assets:admin`
- Smoke tested locally at `http://localhost:8082` using Chrome:
  - Opened WooCommerce payments settings.
  - Started the WooPayments onboarding modal.
  - Clicked the business type dropdown.
  - Confirmed the options rendered and there were no relevant console errors.
  - Selected `Company` and confirmed the next business structure field appeared.
  - Changed the business type with keyboard navigation (`ArrowUp` + `Enter`) and confirmed the selected value persisted as `Individual` with the expected next field.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

Manual changelog entry added: `plugins/woocommerce/changelog/fix-woopayments-onboarding-select-crash`.

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

