### PR TITLE
Fix DefaultCustomerAddress autoload race during 10.7→10.8 in-place upgrade

### DIFF
--- a/plugins/woocommerce/changelog/fix-defaultcustomeraddress-autoload-race
+++ b/plugins/woocommerce/changelog/fix-defaultcustomeraddress-autoload-race
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a fatal error during in-place upgrade to 10.8.0 caused by the new DefaultCustomerAddress enum being referenced from class-wc-settings-general.php before the in-process autoloader classmap is refreshed.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -19,9 +19,16 @@ defined( 'ABSPATH' ) || exit;
  * would trigger an autoloader miss and a "Class not found" fatal during the
  * upgrade-completion iframe of /wp-admin/update.php.
  *
+ * The class_exists() guard (with autoload disabled) matches the defensive
+ * pattern used elsewhere in includes/, e.g. class-wc-gateway-paypal.php, and
+ * keeps this safe under opcache.preload or any other mechanism that may have
+ * already defined the class before the file is included.
+ *
  * The architectural fix lives in https://github.com/woocommerce/woocommerce/issues/54657.
  */
-require_once dirname( WC_PLUGIN_FILE ) . '/src/Enums/DefaultCustomerAddress.php';
+if ( ! class_exists( '\Automattic\WooCommerce\Enums\DefaultCustomerAddress', false ) ) {
+	require_once dirname( WC_PLUGIN_FILE ) . '/src/Enums/DefaultCustomerAddress.php';
+}
 
 if ( class_exists( 'WC_Settings_General', false ) ) {
 	return new WC_Settings_General();

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -11,6 +11,18 @@ use Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController;
 
 defined( 'ABSPATH' ) || exit;
 
+/*
+ * Pre-load the enum file because the in-process Jetpack autoloader classmap is
+ * captured at request start by the pre-upgrade plugin version, so during a same-
+ * request in-place upgrade it will not contain new src/Enums/* classes added in
+ * the new version. Without this, the DefaultCustomerAddress::* references below
+ * would trigger an autoloader miss and a "Class not found" fatal during the
+ * upgrade-completion iframe of /wp-admin/update.php.
+ *
+ * The architectural fix lives in https://github.com/woocommerce/woocommerce/issues/54657.
+ */
+require_once dirname( WC_PLUGIN_FILE ) . '/src/Enums/DefaultCustomerAddress.php';
+
 if ( class_exists( 'WC_Settings_General', false ) ) {
 	return new WC_Settings_General();
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Multiple wp.org reports after the 10.8.0 release ([1](https://wordpress.org/support/topic/error-during-the-update-from-version-10-7-0-to-version-10-8-0/), [2](https://wordpress.org/support/topic/10-8-0-update-error/)) hit a fatal during the in-place upgrade flow:

```
Uncaught Error: Class "Automattic\WooCommerce\Enums\DefaultCustomerAddress" not found
in includes/admin/settings/class-wc-settings-general.php:237
  ... class-wp-hook.php(341)
  ... AssetDataRegistry->enqueue_asset_data('')
  ... admin_print_footer_scripts (do_action)
  ... wp-admin/update.php(53): iframe_footer()
```

Root cause is a same-request autoloader race. The Jetpack autoloader's `Version_Loader::$classmap` is captured once at request start; WP's in-place upgrade swaps plugin files mid-request; the post-upgrade `update.php` iframe footer triggers `AssetDataRegistry::enqueue_asset_data()` which walks the REST settings tree and lazy-loads `WC_Settings_General` fresh from the new 10.8 file; that file references `DefaultCustomerAddress::*` constants; the autoloader checks its pre-upgrade snapshot, misses, has no PSR-4 fallback in the shipped `vendor/composer/jetpack_autoload_psr4.php` (which isn't generated), and fatals at line 237. The DB upgrade completes (`10.8.0-2`), the site front-end works, the next request works — but admins get a fatal-error email from WP.

This PR sidesteps the race for the one specific file users reported, by `require_once`'ing the enum file at the top of `class-wc-settings-general.php`. The enum is `final` and dependency-free, so the explicit include is safe and idempotent. The other eight `includes/` files that reference the enum stay as-is because they are loaded during WC's normal boot (their class definitions get pinned to the pre-upgrade version in PHP's class table, so the post-swap method bodies never execute in the upgrade request).

The underlying bug class — any new `src/Enums/*` class referenced from files reachable during the `update.php` iframe footer — is structural and tracked in #54657. The cleaner long-term fix is to hook `AssetDataRegistry::enqueue_asset_data()` earlier on `admin_enqueue_scripts` so the settings registration happens BEFORE the file swap. A previous draft PR (#65005) prototyped that approach; a follow-up PR (#65338) revives it for 10.9.x.

Refs #54657. Architectural follow-up: #65338.

### How to test the changes in this Pull Request:

> **Why this needs special tooling**: this PR's build isn't on wp.org yet, so the standard WP "Update Now" link won't pull this code. And the bug is gated by WP's iframe-based bulk-update flow (`/wp-admin/update.php`); the AJAX inline "update now" link on the plugins page uses a different code path (`WP_Ajax_Upgrader_Skin`, finishes with `wp_send_json_*`, no `iframe_footer`) and does NOT reproduce the bug. Whatever test path you take, make sure it routes through the iframe flow with this PR's build as the source.

> **Heads-up about WC Beta Tester**: its "Live Branches" feature does NOT use WP's `Plugin_Upgrader` — it does a side-by-side `download_url + unzip_file + move()` into `wc_beta_tester_live_branch_<version>/` (confirmed by reading `class-wc-beta-tester-live-branches-installer.php`). That code path doesn't render the upgrade iframe and **does not reproduce this bug**. Use the mu-plugin recipe below instead.

#### Primary path — mu-plugin that injects a synthetic update + dir-rename hook

1. Set up a clean WP 6.9 install. Install vanilla WC 10.7.0 from wp.org and activate it: `wp plugin install woocommerce --version=10.7.0 --activate --force`.
2. Drop this file at `wp-content/mu-plugins/inject-wc-update.php`:

   ```php
   <?php
   /**
    * Plugin Name: Inject WC PR build as an update
    * Description: Hotfix testing only — makes WordPress think a "10.8.1-pr65337"
    *   update is available for WooCommerce, pointing at this PR's betadownload
    *   artifact. Also renames the extracted woocommerce-dev/ directory to
    *   woocommerce/ so the upgrade lands at the same path as a real wp.org upgrade
    *   (path consistency is required to reproduce the in-place autoload race).
    */

   defined( 'ABSPATH' ) || exit;

   const WC_REPRO_PR_PACKAGE_URL = 'https://betadownload.jetpack.me/data/woocommerce/fix_wc-settings-general-defaultcustomeraddress-autoload-race/woocommerce-dev.zip';
   const WC_REPRO_NEW_VERSION    = '10.8.1-pr65337';

   add_filter( 'pre_set_site_transient_update_plugins', function ( $transient ) {
       if ( ! is_object( $transient ) ) {
           $transient = new stdClass();
       }
       if ( ! isset( $transient->response ) || ! is_array( $transient->response ) ) {
           $transient->response = array();
       }

       $transient->response['woocommerce/woocommerce.php'] = (object) array(
           'id'          => 'w.org/plugins/woocommerce',
           'slug'        => 'woocommerce',
           'plugin'      => 'woocommerce/woocommerce.php',
           'new_version' => WC_REPRO_NEW_VERSION,
           'url'         => 'https://github.com/woocommerce/woocommerce/pull/65337',
           'package'     => WC_REPRO_PR_PACKAGE_URL,
           'icons'       => array(),
           'banners'     => array(),
           'banners_rtl' => array(),
       );

       if ( isset( $transient->no_update['woocommerce/woocommerce.php'] ) ) {
           unset( $transient->no_update['woocommerce/woocommerce.php'] );
       }

       return $transient;
   }, 99 );

   // The betadownload zip unpacks to woocommerce-dev/ but the running upgrade
   // expects woocommerce/. Rename the source dir on the fly so the in-place
   // upgrade replaces wp-content/plugins/woocommerce/ exactly like a real
   // wp.org upgrade would.
   add_filter( 'upgrader_source_selection', function ( $source, $remote_source, $upgrader, $hook_extra = array() ) {
       if ( empty( $hook_extra['plugin'] ) || 'woocommerce/woocommerce.php' !== $hook_extra['plugin'] ) {
           return $source;
       }
       $basename = basename( $source );
       if ( 'woocommerce' === $basename ) {
           return $source;
       }
       $desired = trailingslashit( dirname( $source ) ) . 'woocommerce';
       global $wp_filesystem;
       if ( $wp_filesystem && $wp_filesystem->move( untrailingslashit( $source ), $desired ) ) {
           return trailingslashit( $desired );
       }
       return $source;
   }, 10, 4 );
   ```

3. Force WP to refresh the update transient so it picks up the synthetic update: `wp eval 'delete_site_transient("update_plugins"); wp_update_plugins();'`. Confirm with `wp plugin list` — WooCommerce should now show an "available" update to `10.8.1-pr65337`.
4. In wp-admin, click "Update Now" on the WooCommerce row in **Plugins** (or use the bulk update on **Dashboard → Updates**). Either path renders `/wp-admin/update.php` with the iframe footer — exactly the trigger for this bug.
5. **Expected with this fix**: the iframe shows "Plugin updated successfully" → "Plugin reactivated successfully", `wp-content/debug.log` stays clean of any `Class "Automattic\WooCommerce\Enums\DefaultCustomerAddress" not found` entry, and no WP fatal-error email arrives.

#### <a name="jn-testing-path"></a>Alternative path — Jurassic Ninja with the In-Place Upgrade Tester helper plugin (a8c reviewers)

Same reproduction recipe as the Primary path, but the mu-plugin glue is packaged as a proper WP plugin with a settings page under **Tools → In-Place Upgrade Tester**. This is the path I'd recommend for a8c reviewers spinning up a fresh JN store.

1. **Spin up a JN store** with WooCommerce and WC Beta Tester active: [direct create link](https://jurassic.ninja/create/?shortlived&woocommerce&woocommerce-beta-tester). No `&branches.woocommerce=…` flag — the test needs the site to BOOT on stable WC 10.7.x, then we inject this PR's build as an "update" the reviewer triggers manually.
2. **Downgrade WooCommerce to 10.7.0** so the in-place upgrade has somewhere meaningful to start from. SSH in (the JN page gives you the command) and run:
   ```bash
   wp plugin install woocommerce --version=10.7.0 --activate --force
   ```
3. **Install the In-Place Upgrade Tester helper plugin.** [Download the zip](https://github.com/user-attachments/files/28309919/in-place-upgrade-tester.zip) and upload it via **Plugins → Add New → Upload Plugin** (or `wp plugin install <url> --activate` via SSH if you have it on a public URL). It's a single-file ~330 LOC plugin that adds a settings page where you pick any active plugin from a dropdown and supply any zip URL — it injects a synthetic update entry and renames the extracted source dir to match the target's existing directory, so the upgrade is truly in-place regardless of what the source zip's internal folder is called.
4. **Configure the injection.** Go to **Tools → In-Place Upgrade Tester** and fill:
   - **Target plugin**: `WooCommerce — woocommerce/woocommerce.php (v10.7.0)`
   - **Source zip URL**: `https://betadownload.jetpack.me/data/woocommerce/fix_wc-settings-general-defaultcustomeraddress-autoload-race/woocommerce-dev.zip`
   - **Version label**: `10.8.1-pr65337` (optional, cosmetic)

   Click **Inject update**. WP now sees an available "update" for WooCommerce pointing at this PR's build.
5. **Trigger the upgrade.** Go to **Dashboard → Updates**, check WooCommerce, click **Update Plugins** — this routes through the same `/wp-admin/update.php` iframe flow that fires the bug.
6. **Expected**: same outcome as the Primary path — "Plugin updated successfully" → "Plugin reactivated successfully", no critical-error snippet, no `DefaultCustomerAddress` fatal in `wp-content/debug.log`, no WP fatal-error email.
7. **Negative control for this path**: in **Tools → In-Place Upgrade Tester**, click "Clear current injection", then re-inject with **Source zip URL** = `https://downloads.wordpress.org/plugin/woocommerce.10.8.0.zip` and **Version label** = `10.8.0-negative-control`. Trigger the upgrade the same way. You should see the fatal-error email arrive and `wp-content/debug.log` contain a trace matching the user reports at the top of this PR exactly (same class FQCN, same file, line 237).
8. **Cleanup**: click "Clear current injection" in IPUT before deactivating it. The JN site has `&shortlived` so it self-expires anyway.

#### Negative control (verify the fix is doing real work)

Repeat the above, but change one line in the mu-plugin:

```php
const WC_REPRO_PR_PACKAGE_URL = 'https://downloads.wordpress.org/plugin/woocommerce.10.8.0.zip';
const WC_REPRO_NEW_VERSION    = '10.8.0-negative-control';
```

This points the synthetic update at vanilla 10.8.0 from wp.org (no fix). After triggering the upgrade you should see the exact fatal from the user reports in `wp-content/debug.log` — same class FQCN, same file, line 237, same `AssetDataRegistry::execute_lazy_data() → admin_print_footer_scripts → update.php(76): require_once(...)` stack. The upgrade itself still reports "Plugin updated successfully" (the bug is downstream of the file swap), but the critical-error snippet appears on the result page and an admin email arrives.

#### Cross-plugin sanity (catches autoloader interactions)

Run the primary path again with these plugins also active before triggering the switch: Jetpack (latest), WooPayments (latest), Yoast SEO (latest). These plugins all use either the Jetpack autoloader or Composer's ClassLoader and would surface any cross-plugin autoloader regression introduced by this PR. (None expected — this PR only adds a `require_once` of one local file.)

#### Post-upgrade sanity checks

After upgrading to this PR's build, verify the General Settings page still works:

1. Visit **WooCommerce → Settings → General**.
2. Scroll to the "Default customer location" dropdown. Confirm it renders with the four expected options ("No location by default", "Shop country/region", "Geolocate", "Geolocate (with page caching support)").
3. Change the selection and save. Confirm the saved value persists on reload. The underlying option `woocommerce_default_customer_address` stores one of `''`, `base`, `geolocation`, `geolocation_ajax` — same values as in 10.7.0.

### Testing that has already taken place:

Reproduced and validated end-to-end on a clean docker WordPress 6.9 + MariaDB 11.4 stack:

1. Vanilla 10.7.0 + this branch's `class-wc-settings-general.php` patched in place, then file-swap to 10.8.0 mid-request, trigger the settings registration code path → no fatal, `WC_Settings_General::get_settings_for_default_section()` returns 28 entries with `default: 'base'` and options keys `'', 'base', 'geolocation', 'geolocation_ajax'`.
2. Same as (1) but with Jetpack 15.8, WooPayments 10.8.0, and Yoast SEO 27.7 also active. Result identical — no fatal, settings render. The Composer ClassLoader from Yoast does NOT cover the `Automattic\WooCommerce\` namespace, so it was not silently rescuing the lookup before the fix; the fix is genuinely doing the work.
3. Negative control: with the patch removed and otherwise-identical setup, the fatal reproduces byte-for-byte against the user reports (same class FQCN, same file, same line 237).
4. Real `/wp-admin/update.php?action=upgrade-plugin` HTTP request (with admin auth + session-bound nonce) was used for the architectural-fix PR (#65338) validation in the same docker stack — confirms the iframe code path is what fires the bug and that the AJAX upgrade path on plugins.php does not.

The hotfix changes one file (1-line `require_once` plus a 9-line comment explaining the race) and ships a `patch`-significance changelog entry. No DB changes, no behavior changes visible to merchants or extensions — the constant values returned by the enum are identical to the strings the 10.7 code used.

### Regression test coverage

Per the [Field Guide: Regression Tests](https://fieldguide.automattic.com/regression-tests/) policy, an unplanned patch release should add at least one automated regression test before the fix is considered complete. Here is how that obligation is addressed for this incident:

This specific bug doesn't admit a focused PHPUnit-shaped regression test. Reproducing the autoload race requires four conditions PHPUnit's hot-loaded environment can't recreate without contrivance:

- the Jetpack autoloader's classmap must be the pre-upgrade snapshot,
- the offending class (`DefaultCustomerAddress`) must not yet be in PHP's class table,
- the post-swap consumer file must be loaded fresh from disk mid-request,
- the autoload attempt must actually fail.

In PHPUnit all four are violated by the test bootstrap: the autoloader is fully populated, the enum class is already loaded by some upstream test, and the class table is shared across the whole test run. Any "test" that contrives those conditions via reflection-evicting the classmap or grepping the source becomes a test of the FIX SHAPE rather than the BUG BEHAVIOR — useful for "did someone delete the require_once" linting, but not what the Field Guide means by "confirms that existing functionality still works while also documenting important behavior."

What does cover the behavior:

- **PHPUnit behavior tests in the architectural-fix PR (#65338)** — that PR ships two cherry-picked tests from @ayushpahwa's original #65005 that exercise the real `AssetDataRegistry` mechanism preventing this bug class:
   - `AssetDataRegistry::test_admin_hooks_are_registered_for_enqueue_asset_data` asserts the early `admin_enqueue_scripts` hook (the structural mechanism that defuses the race for any new src/ class added in an upgrade) is registered.
   - `AssetDataRegistry::test_enqueue_asset_data_is_idempotent` asserts the late `admin_print_footer_scripts` callback short-circuits once the early hook has fired, by checking that `wcSettings` is only emitted once.
   Together those guard the behavior that, when landed, makes per-file require_once preloads like the one in this PR redundant. They run against the live `AssetDataRegistry` instance and assert against real `has_action()` state plus the actual emitted inline-script payload.
- **End-to-end reproducible recipes in this PR's "How to test" section** — the docker-stack mu-plugin recipe and the JN + In-Place Upgrade Tester recipe both reproduce the bug-and-fix cycle through an actual `/wp-admin/update.php` iframe request. They aren't gated CI checks, but they are durable enough that any reviewer can re-run them to confirm the fix's behavior end-to-end.
- **Inline behavioral assertions already present** — `WC_Settings_General_Test::test_get_settings__all_settings_are_present` already asserts the `woocommerce_default_customer_address` setting is exposed with the correct type. That test would fail if a future refactor accidentally dropped the setting while attempting to rework this fix.

Net obligation: the regression-test policy is satisfied by the behavior tests landing in #65338 (which is explicitly the long-term remediation tracked alongside this incident), not by an artificial test on this hotfix. The two PRs are cross-linked.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

This PR targets `release/10.8` for inclusion in 10.8.1. Please assign the 10.8.1 milestone manually.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually and is included in the diff at `plugins/woocommerce/changelog/fix-defaultcustomeraddress-autoload-race`.

</details>



