### PR TITLE
Remove site-admin Syncpack pin

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -655,15 +655,6 @@
 			"pinVersion": "^3.2.6"
 		},
 		{
-			"dependencies": [
-				"@automattic/site-admin"
-			],
-			"packages": [
-				"**"
-			],
-			"pinVersion": "^0.0.1"
-		},
-		{
 			"label": "Only manage versions for these dependencies",
 			"dependencies": [
 				"@automattic/color-studio",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow-up from https://github.com/woocommerce/woocommerce/pull/65316#discussion_r3311178029

This PR removes the obsolete `@automattic/site-admin` version pin from `.syncpackrc`.