### PR TITLE
Add WooPayments onboarding business details regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ CLAUDE.local.md
 
 # Docusaurus
 .docusaurus
+
+.mcp.json

--- a/plugins/woocommerce/changelog/add-woopayments-onboarding-regression-tests
+++ b/plugins/woocommerce/changelog/add-woopayments-onboarding-regression-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add WooPayments onboarding business details regression tests.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/business-details-flow.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/business-details-flow.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useOnboardingContext } from '../../../data/onboarding-context';
+import { useStepperContext } from '../components/stepper';
+import { BusinessVerificationContextProvider } from '../data/business-verification-context';
+import { OnboardingForm } from '../components/form';
+import BusinessDetails from '../sections/business-details';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '../../../data/onboarding-context', () => ( {
+	useOnboardingContext: jest.fn(),
+} ) );
+
+jest.mock( '../components/stepper', () => ( {
+	useStepperContext: jest.fn(),
+} ) );
+
+jest.mock( '~/settings-payments/utils', () => ( {
+	recordPaymentsOnboardingEvent: jest.fn(),
+} ) );
+
+const mockApiFetch = apiFetch as jest.Mock;
+const mockUseOnboardingContext = useOnboardingContext as jest.Mock;
+const mockUseStepperContext = useStepperContext as jest.Mock;
+const mockNextStep = jest.fn();
+
+const fields = {
+	available_countries: {
+		GB: 'United Kingdom (UK)',
+		US: 'United States (US)',
+	},
+	business_types: [
+		{
+			key: 'US',
+			name: 'United States (US)',
+			types: [
+				{
+					key: 'individual',
+					name: 'Individual',
+					description: '',
+					structures: [],
+				},
+				{
+					key: 'company',
+					name: 'Company',
+					description: '',
+					structures: [
+						{
+							key: 'llc',
+							name: 'Limited liability company',
+						},
+					],
+				},
+			],
+		},
+		{
+			key: 'GB',
+			name: 'United Kingdom (UK)',
+			types: [
+				{
+					key: 'individual',
+					name: 'Individual',
+					description: '',
+					structures: [],
+				},
+			],
+		},
+	],
+	mccs_display_tree: [
+		{
+			id: 'food-and-drink',
+			type: 'category',
+			title: 'Food and drink',
+			items: [
+				{
+					id: '5812',
+					type: 'mcc',
+					title: 'Restaurants',
+					mcc: 5812,
+					keywords: [ 'food' ],
+				},
+			],
+		},
+	],
+	industry_to_mcc: {},
+	location: 'US',
+};
+
+const createCurrentStep = () => ( {
+	id: 'business_verification',
+	status: 'not_started',
+	actions: {
+		save: {
+			href: '/wc/v3/payments/onboarding/business-verification',
+		},
+	},
+	context: {
+		fields,
+		self_assessment: {},
+		sub_steps: {
+			business: { status: 'not_started' },
+			embedded: { status: 'not_started' },
+		},
+	},
+} );
+
+const renderBusinessDetailsForm = (
+	initialData: Record< string, string | undefined > = {}
+) => {
+	return render(
+		<BusinessVerificationContextProvider
+			initialData={ {
+				country: 'US',
+				...initialData,
+			} }
+		>
+			<OnboardingForm>
+				<BusinessDetails />
+			</OnboardingForm>
+		</BusinessVerificationContextProvider>
+	);
+};
+
+describe( 'Business details onboarding flow', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockApiFetch.mockResolvedValue( {} );
+		mockUseOnboardingContext.mockReturnValue( {
+			currentStep: createCurrentStep(),
+			sessionEntryPoint: 'settings',
+		} );
+		mockUseStepperContext.mockReturnValue( {
+			nextStep: mockNextStep,
+		} );
+	} );
+
+	it( 'opens the business type options using the real business details form', () => {
+		renderBusinessDetailsForm();
+
+		fireEvent.click(
+			screen.getByRole( 'combobox', {
+				name: 'What type of legal entity is your business?',
+			} )
+		);
+
+		expect(
+			screen.getByRole( 'option', { name: /Company/ } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'option', { name: /Individual/ } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'selects a business type with keyboard commands and renders dependent fields', async () => {
+		renderBusinessDetailsForm( {
+			business_type: 'company',
+		} );
+
+		expect(
+			screen.getByRole( 'combobox', {
+				name: 'What category of legal entity identify your business?',
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'combobox', {
+				name: /What type of goods or services does your business sell?/,
+			} )
+		).not.toBeInTheDocument();
+
+		const businessTypeSelect = screen.getByRole( 'combobox', {
+			name: 'What type of legal entity is your business?',
+		} );
+
+		fireEvent.keyDown( businessTypeSelect, { key: 'ArrowDown' } );
+		fireEvent.keyDown( businessTypeSelect, { key: 'ArrowDown' } );
+		fireEvent.keyDown( businessTypeSelect, { key: 'Enter' } );
+
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'combobox', {
+					name: /What type of goods or services does your business sell?/,
+				} )
+			).toBeInTheDocument();
+		} );
+
+		expect(
+			screen.queryByRole( 'combobox', {
+				name: 'What category of legal entity identify your business?',
+			} )
+		).not.toBeInTheDocument();
+
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		const savePayload = mockApiFetch.mock.calls.at( -1 )?.[ 0 ].data;
+
+		expect( savePayload ).toEqual( {
+			self_assessment: {
+				business_type: 'individual',
+				'company.structure': undefined,
+			},
+			source: 'settings',
+		} );
+	} );
+
+	it( 'resets dependent business details when the country changes', async () => {
+		renderBusinessDetailsForm( {
+			business_type: 'company',
+			'company.structure': 'llc',
+		} );
+
+		expect(
+			screen.getByRole( 'combobox', {
+				name: 'What category of legal entity identify your business?',
+			} )
+		).toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole( 'combobox', {
+				name: 'Where is your business located?',
+			} )
+		);
+		fireEvent.click(
+			screen.getByRole( 'option', { name: 'United Kingdom (UK)' } )
+		);
+
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'combobox', {
+					name: 'What type of legal entity is your business?',
+				} )
+			).toHaveTextContent( 'Select an option' );
+		} );
+
+		expect(
+			screen.queryByRole( 'combobox', {
+				name: 'What category of legal entity identify your business?',
+			} )
+		).not.toBeInTheDocument();
+
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		const savePayload = mockApiFetch.mock.calls.at( -1 )?.[ 0 ].data;
+
+		expect( savePayload ).toEqual( {
+			self_assessment: {
+				country: 'GB',
+				business_type: undefined,
+			},
+			source: 'settings',
+		} );
+	} );
+
+	it( 'marks the business sub-step complete when required details are present', async () => {
+		renderBusinessDetailsForm( {
+			business_type: 'individual',
+			mcc: '5812',
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		await waitFor( () => expect( mockNextStep ).toHaveBeenCalled() );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			url: '/wc/v3/payments/onboarding/business-verification',
+			method: 'POST',
+			data: {
+				sub_steps: {
+					business: { status: 'completed' },
+					embedded: { status: 'not_started' },
+				},
+			},
+		} );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds higher-level Jest/React Testing Library regression coverage for the WooPayments onboarding business details flow.

The previous business verification tests mock the form and business details section, so regressions in the real country/business type/business structure/MCC field wiring could be missed. These tests render the real business details form with mocked onboarding/stepper contexts and verify:

- the business type dropdown opens with realistic onboarding field data;
- keyboard selection of business type updates dependent fields;
- changing country resets dependent business details;
- completing required business details marks the business sub-step complete.

Also ignores local `.mcp.json` files.

### Screenshots or screen recordings:

N/A. Tests only.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run:
   ```sh
   cd plugins/woocommerce/client/admin
   pnpm test:js -- client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test
   ```
3. Confirm the business verification test suite passes.

### Testing that has already taken place:

- Ran the business verification Jest tests:
  - `cd plugins/woocommerce/client/admin && pnpm test:js -- client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test`
- Ran ESLint for the new test file:
  - `cd plugins/woocommerce/client/admin && pnpm exec eslint client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/business-details-flow.test.tsx --ext=js,ts,tsx`

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

Manual changelog entry added: `plugins/woocommerce/changelog/add-woopayments-onboarding-regression-tests`.

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)
