### PR TITLE
Add Plugin Upgrade Test workflow for in-place upgrade fatals

### DIFF
--- a/.github/workflows/pr-plugin-upgrade-test.yml
+++ b/.github/workflows/pr-plugin-upgrade-test.yml
@@ -1,0 +1,140 @@
+name: Plugin Upgrade Test
+on:
+    pull_request:
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - ready_for_review
+        paths:
+            - '**'
+            - '!docs/**'
+            - '!**/changelog/**'
+            - '!**/changelog.txt'
+            - '!**/readme.txt'
+            - '!.gitignore'
+            - '!.coderabbit.yml'
+            - '!CODEOWNERS'
+            - '!**/*.md'
+            - '!.husky/**'
+            - '!.cursor/**'
+            - '!.github/**'
+            - '.github/workflows/pr-plugin-upgrade-test.yml'
+            - '.github/workflows/scripts/test-plugin-update/**'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+permissions: {}
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+    build:
+        name: Build PR plugin zip
+        if: github.event.pull_request.draft == false
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  pull-package-deps: '@woocommerce/plugin-woocommerce'
+
+            - name: Build plugin zip
+              run: |
+                  cd "$GITHUB_WORKSPACE/plugins/woocommerce"
+                  # Default PLUGIN_SLUG ('woocommerce') => woocommerce.zip with an
+                  # internal woocommerce/ directory: a valid in-place upgrade target.
+                  bash bin/build-zip.sh
+
+            - name: Upload plugin zip artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: woocommerce-dev-build
+                  path: plugins/woocommerce/woocommerce.zip
+                  retention-days: 1
+
+    test:
+        name: Test upgrades to the PR build
+        needs: build
+        if: github.event.pull_request.draft == false
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        # Full build runs in the build job; this job does WP setup + downloads +
+        # 4 upgrade scenarios (incl. WooCommerce DB migrations), so allow headroom.
+        timeout-minutes: 30
+        services:
+            db:
+                image: mariadb:lts
+                env:
+                    MARIADB_ROOT_PASSWORD: wordpress
+                    MARIADB_DATABASE: wordpress
+                ports:
+                    - 3306:3306
+                options: --health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=5
+        env:
+            PLUGIN_SLUG: woocommerce
+            PLUGIN_FILE: woocommerce/woocommerce.php
+            WP_HOST: 127.0.0.1
+            WP_PORT: '8080'
+            DB_HOST: 127.0.0.1
+            DB_PORT: '3306'
+            DB_NAME: wordpress
+            DB_USER: root
+            DB_PASS: wordpress
+            ADMIN_USER: admin
+            ADMIN_PASS: password
+            ADMIN_EMAIL: admin@example.com
+            ZIPDIR: ${{ github.workspace }}/zips
+            DB_DUMP: ${{ github.workspace }}/db.sql
+            MU_PLUGIN_SRC: ${{ github.workspace }}/.github/workflows/scripts/test-plugin-update/mu-plugin.php
+            TRUNK_URL: https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip
+        steps:
+            - uses: actions/checkout@v4
+
+            # runner.temp is not available in job-level env, so derive the
+            # runner-scratch paths here and share them via $GITHUB_ENV.
+            - name: Configure scratch paths
+              run: |
+                  {
+                      echo "WP_PATH=$RUNNER_TEMP/wordpress"
+                      echo "WORKDIR=$RUNNER_TEMP/work"
+                      echo "DEV_ZIP_SRC=$RUNNER_TEMP/artifact/woocommerce.zip"
+                  } >> "$GITHUB_ENV"
+
+            - name: Setup PHP and WP-CLI
+              uses: shivammathur/setup-php@v2
+              with:
+                  # 8.3 is within WooCommerce's supported range and matches the PHP the
+                  # built zip targets; bump in step with the plugin's supported versions.
+                  php-version: '8.3'
+                  extensions: mysqli, gd, zip, mbstring, intl, exif
+                  # Keep opcache off for the CLI SAPI so php -S reads the swapped plugin
+                  # files fresh mid-request — the condition the autoload race (#65337) needs.
+                  ini-values: opcache.enable=0, opcache.enable_cli=0
+                  coverage: none
+                  tools: wp-cli
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+
+            - name: Download PR plugin zip
+              uses: actions/download-artifact@v4
+              with:
+                  name: woocommerce-dev-build
+                  path: ${{ runner.temp }}/artifact
+
+            - name: Set up WordPress
+              run: .github/workflows/scripts/test-plugin-update/setup.sh
+
+            - name: Prepare plugin zips
+              run: .github/workflows/scripts/test-plugin-update/prepare-zips.sh
+
+            - name: Test upgrades
+              run: .github/workflows/scripts/test-plugin-update/test.sh

--- a/.github/workflows/pr-plugin-upgrade-test.yml
+++ b/.github/workflows/pr-plugin-upgrade-test.yml
@@ -40,6 +40,8 @@ jobs:
             contents: read
         steps:
             - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
 
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
@@ -98,6 +100,8 @@ jobs:
             TRUNK_URL: https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip
         steps:
             - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
 
             # runner.temp is not available in job-level env, so derive the
             # runner-scratch paths here and share them via $GITHUB_ENV.

--- a/.github/workflows/scripts/test-plugin-update/mu-plugin.php
+++ b/.github/workflows/scripts/test-plugin-update/mu-plugin.php
@@ -70,3 +70,9 @@ add_filter(
 		return $value;
 	}
 );
+
+// Prevent WooCommerce's first-activation setup-wizard redirect. Activating WC sets the
+// _wc_activation_redirect transient, and OnboardingSetupWizard then 302-redirects the very
+// next admin request -- including our /wp-admin/update.php upgrade -- before the upgrade runs.
+// This filter makes WooCommerce clear the transient and skip the redirect instead.
+add_filter( 'woocommerce_prevent_automatic_wizard_redirect', '__return_true' );

--- a/.github/workflows/scripts/test-plugin-update/mu-plugin.php
+++ b/.github/workflows/scripts/test-plugin-update/mu-plugin.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Plugin Name: Plugin Upgrade Test hacks
+ * Plugin URI: https://github.com/woocommerce/woocommerce
+ * Author: WooCommerce
+ * Version: 1.0.0
+ * Text Domain: woocommerce
+ *
+ * Used only by the "Plugin Upgrade Test" CI workflow. It lets an
+ * unauthenticated request drive /wp-admin/update.php and forces WordPress to
+ * see a pending update for a target plugin pointing at a local zip, so the
+ * in-place upgrade path can be exercised without contacting wordpress.org.
+ *
+ * Ported from Jetpack's .github/files/test-plugin-update/mu-plugin.php.
+ *
+ * @package WooCommerce
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// Force user ID 1 as the logged in user.
+add_filter(
+	'determine_current_user',
+	function () {
+		return 1;
+	}
+);
+
+/**
+ * Disable the login cookie check.
+ */
+function wp_validate_auth_cookie() {
+	return true;
+}
+
+/**
+ * Disable the nonce check.
+ */
+function wp_verify_nonce() {
+	return true;
+}
+
+// Allow for forcing an "update" of a particular plugin.
+add_filter(
+	'site_transient_update_plugins',
+	function ( $value ) {
+		$plugin = get_option( 'fake_plugin_update_plugin' );
+		$url    = get_option( 'fake_plugin_update_url' );
+		if ( $plugin && $url ) {
+			if ( ! is_object( $value ) ) {
+				$value = (object) array(
+					'response'  => array(),
+					'no_update' => array(),
+				);
+			}
+			if ( ! isset( $value->response[ $plugin ] ) ) {
+				if ( isset( $value->no_update[ $plugin ] ) ) {
+					$value->response[ $plugin ] = $value->no_update[ $plugin ];
+					unset( $value->no_update[ $plugin ] );
+				} else {
+					$value->response[ $plugin ] = (object) array(
+						'plugin' => dirname( $plugin ),
+						'slug'   => dirname( $plugin ),
+					);
+				}
+			}
+			$value->response[ $plugin ]->new_version = '1000000.0.0';
+			$value->response[ $plugin ]->package     = $url;
+		}
+		return $value;
+	}
+);

--- a/.github/workflows/scripts/test-plugin-update/prepare-zips.sh
+++ b/.github/workflows/scripts/test-plugin-update/prepare-zips.sh
@@ -29,13 +29,18 @@ touch "$WORKDIR/$PLUGIN_SLUG/ci-flag.txt"
 rm -rf "${WORKDIR:?}/$PLUGIN_SLUG"
 echo "::endgroup::"
 
+# The trunk (nightly) and stable (wordpress.org) builds are external, PR-independent
+# sources. A fetch failure (nightly not published yet, network, rate-limit) is an
+# infrastructure issue, not a PR regression, so degrade it to a warning and drop that
+# source's scenarios rather than red-flagging the PR. test.sh skips a source whose zip
+# is absent, and its zero-guard still fails the job if NO source ends up available.
 echo "::group::Fetching $PLUGIN_SLUG-trunk.zip"
 if curl -L --fail --retry 2 --retry-delay "$(( 15 + RANDOM % 8 ))" --url "$TRUNK_URL" --output "$ZIPDIR/$PLUGIN_SLUG-trunk.zip"; then
 	echo "Downloaded trunk build from $TRUNK_URL"
 else
-	echo "::error::Failed to download trunk build from $TRUNK_URL (is the nightly release published?)"
-	echo "❌ Failed to download trunk build for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
-	exit 1
+	rm -f "$ZIPDIR/$PLUGIN_SLUG-trunk.zip"
+	echo "::warning::Could not download the trunk build from $TRUNK_URL (is the nightly release published?); skipping trunk scenarios."
+	echo "⚠️ Trunk source unavailable ($TRUNK_URL); trunk upgrade scenarios skipped — coverage reduced." >> "$GITHUB_STEP_SUMMARY"
 fi
 echo "::endgroup::"
 
@@ -43,29 +48,18 @@ echo "::group::Fetching $PLUGIN_SLUG-stable.zip"
 # wordpress.org rate-limits more aggressively than GitHub, hence the longer retry delay.
 # Don't use --fail on the info request: the API returns a 404 body with a valid JSON
 # response when the plugin doesn't exist, which we want to inspect rather than error on.
-if ! JSON="$( curl -L --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json" )"; then
-	echo "::error::Request to the WordPress.org API for $PLUGIN_SLUG failed."
-	echo "❌ Request to the WordPress.org API for $PLUGIN_SLUG failed" >> "$GITHUB_STEP_SUMMARY"
-	exit 1
-fi
-if jq -e --arg slug "$PLUGIN_SLUG" '.slug == $slug' <<<"$JSON" &>/dev/null; then
+STABLE_OK=
+if JSON="$( curl -L --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json" )" \
+	&& jq -e --arg slug "$PLUGIN_SLUG" '.slug == $slug' <<<"$JSON" &>/dev/null; then
 	URL="$( jq -r '.download_link // ""' <<<"$JSON" )"
-	if [[ -z "$URL" ]]; then
-		echo "::error::$PLUGIN_SLUG has no stable release download_link."
-		echo "❌ No stable release found for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
-		exit 1
-	fi
-	if curl -L --fail --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" --url "$URL" --output "$ZIPDIR/$PLUGIN_SLUG-stable.zip"; then
+	if [[ -n "$URL" ]] && curl -L --fail --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" --url "$URL" --output "$ZIPDIR/$PLUGIN_SLUG-stable.zip"; then
 		echo "Downloaded stable build from $URL"
-	else
-		echo "::error::Failed to download stable build from $URL"
-		echo "❌ Failed to download stable build for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
-		exit 1
+		STABLE_OK=1
 	fi
-else
-	echo "::error::Unexpected response from the WordPress.org API for $PLUGIN_SLUG"
-	echo "$JSON"
-	echo "❌ Unexpected response from the WordPress.org API for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
-	exit 1
+fi
+if [[ -z "$STABLE_OK" ]]; then
+	rm -f "$ZIPDIR/$PLUGIN_SLUG-stable.zip"
+	echo "::warning::Could not fetch the stable build for $PLUGIN_SLUG from wordpress.org; skipping stable scenarios."
+	echo "⚠️ Stable source unavailable (wordpress.org); stable upgrade scenarios skipped — coverage reduced." >> "$GITHUB_STEP_SUMMARY"
 fi
 echo "::endgroup::"

--- a/.github/workflows/scripts/test-plugin-update/prepare-zips.sh
+++ b/.github/workflows/scripts/test-plugin-update/prepare-zips.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Ported from Jetpack's .github/files/test-plugin-update/prepare-zips.sh ("Test
+# plugin upgrades"), simplified for WooCommerce: a single plugin, with trunk
+# pulled from the nightly GitHub release and stable from the wordpress.org API
+# (no betadownload manifest, no multi-plugin matrix).
+
+set -eo pipefail
+
+# Expected environment (set by the workflow):
+#   PLUGIN_SLUG  Plugin slug / install directory name (woocommerce).
+#   DEV_ZIP_SRC  Path to the built PR zip (internal dir: <slug>/).
+#   ZIPDIR       Output directory for the prepared upgrade-source zips.
+#   WORKDIR      Scratch directory.
+#   TRUNK_URL    URL of the latest trunk (nightly) build, e.g.
+#                https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip
+
+mkdir -p "$ZIPDIR" "$WORKDIR"
+
+echo "::group::Creating $PLUGIN_SLUG-dev.zip"
+# Unpack the PR build and add a sentinel file, so the test can prove the
+# in-place upgrade actually swapped the plugin's files.
+unzip -q "$DEV_ZIP_SRC" -d "$WORKDIR"
+[[ -d "$WORKDIR/$PLUGIN_SLUG" ]] || { echo "::error::Built zip did not contain a $PLUGIN_SLUG/ directory."; exit 1; }
+touch "$WORKDIR/$PLUGIN_SLUG/ci-flag.txt"
+( cd "$WORKDIR" && zip -qr "$ZIPDIR/$PLUGIN_SLUG-dev.zip" "$PLUGIN_SLUG" )
+rm -rf "${WORKDIR:?}/$PLUGIN_SLUG"
+echo "::endgroup::"
+
+echo "::group::Fetching $PLUGIN_SLUG-trunk.zip"
+if curl -L --fail --retry 2 --retry-delay "$(( 15 + RANDOM % 8 ))" --url "$TRUNK_URL" --output "$ZIPDIR/$PLUGIN_SLUG-trunk.zip"; then
+	echo "Downloaded trunk build from $TRUNK_URL"
+else
+	echo "::error::Failed to download trunk build from $TRUNK_URL (is the nightly release published?)"
+	echo "❌ Failed to download trunk build for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
+	exit 1
+fi
+echo "::endgroup::"
+
+echo "::group::Fetching $PLUGIN_SLUG-stable.zip"
+# wordpress.org rate-limits more aggressively than GitHub, hence the longer retry delay.
+# Don't use --fail on the info request: the API returns a 404 body with a valid JSON
+# response when the plugin doesn't exist, which we want to inspect rather than error on.
+if ! JSON="$( curl -L --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json" )"; then
+	echo "::error::Request to the WordPress.org API for $PLUGIN_SLUG failed."
+	echo "❌ Request to the WordPress.org API for $PLUGIN_SLUG failed" >> "$GITHUB_STEP_SUMMARY"
+	exit 1
+fi
+if jq -e --arg slug "$PLUGIN_SLUG" '.slug == $slug' <<<"$JSON" &>/dev/null; then
+	URL="$( jq -r '.download_link // ""' <<<"$JSON" )"
+	if [[ -z "$URL" ]]; then
+		echo "::error::$PLUGIN_SLUG has no stable release download_link."
+		echo "❌ No stable release found for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
+		exit 1
+	fi
+	if curl -L --fail --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" --url "$URL" --output "$ZIPDIR/$PLUGIN_SLUG-stable.zip"; then
+		echo "Downloaded stable build from $URL"
+	else
+		echo "::error::Failed to download stable build from $URL"
+		echo "❌ Failed to download stable build for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
+		exit 1
+	fi
+else
+	echo "::error::Unexpected response from the WordPress.org API for $PLUGIN_SLUG"
+	echo "$JSON"
+	echo "❌ Unexpected response from the WordPress.org API for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
+	exit 1
+fi
+echo "::endgroup::"

--- a/.github/workflows/scripts/test-plugin-update/prepare-zips.sh
+++ b/.github/workflows/scripts/test-plugin-update/prepare-zips.sh
@@ -18,12 +18,14 @@ set -eo pipefail
 mkdir -p "$ZIPDIR" "$WORKDIR"
 
 echo "::group::Creating $PLUGIN_SLUG-dev.zip"
-# Unpack the PR build and add a sentinel file, so the test can prove the
-# in-place upgrade actually swapped the plugin's files.
-unzip -q "$DEV_ZIP_SRC" -d "$WORKDIR"
-[[ -d "$WORKDIR/$PLUGIN_SLUG" ]] || { echo "::error::Built zip did not contain a $PLUGIN_SLUG/ directory."; exit 1; }
+# Add a sentinel file to the PR build so the test can prove the in-place upgrade
+# actually swapped the plugin's files. zip can append a single entry to the copied
+# archive, so there's no need to unpack and repack the whole plugin.
+unzip -l "$DEV_ZIP_SRC" | grep -qE " $PLUGIN_SLUG/" || { echo "::error::Built zip did not contain a $PLUGIN_SLUG/ directory."; exit 1; }
+cp "$DEV_ZIP_SRC" "$ZIPDIR/$PLUGIN_SLUG-dev.zip"
+mkdir -p "$WORKDIR/$PLUGIN_SLUG"
 touch "$WORKDIR/$PLUGIN_SLUG/ci-flag.txt"
-( cd "$WORKDIR" && zip -qr "$ZIPDIR/$PLUGIN_SLUG-dev.zip" "$PLUGIN_SLUG" )
+( cd "$WORKDIR" && zip -q "$ZIPDIR/$PLUGIN_SLUG-dev.zip" "$PLUGIN_SLUG/ci-flag.txt" )
 rm -rf "${WORKDIR:?}/$PLUGIN_SLUG"
 echo "::endgroup::"
 

--- a/.github/workflows/scripts/test-plugin-update/prepare-zips.sh
+++ b/.github/workflows/scripts/test-plugin-update/prepare-zips.sh
@@ -35,7 +35,7 @@ echo "::endgroup::"
 # source's scenarios rather than red-flagging the PR. test.sh skips a source whose zip
 # is absent, and its zero-guard still fails the job if NO source ends up available.
 echo "::group::Fetching $PLUGIN_SLUG-trunk.zip"
-if curl -L --fail --retry 2 --retry-delay "$(( 15 + RANDOM % 8 ))" --url "$TRUNK_URL" --output "$ZIPDIR/$PLUGIN_SLUG-trunk.zip"; then
+if curl -L --fail --connect-timeout 15 --max-time 180 --retry 2 --retry-delay "$(( 15 + RANDOM % 8 ))" --url "$TRUNK_URL" --output "$ZIPDIR/$PLUGIN_SLUG-trunk.zip"; then
 	echo "Downloaded trunk build from $TRUNK_URL"
 else
 	rm -f "$ZIPDIR/$PLUGIN_SLUG-trunk.zip"
@@ -49,10 +49,10 @@ echo "::group::Fetching $PLUGIN_SLUG-stable.zip"
 # Don't use --fail on the info request: the API returns a 404 body with a valid JSON
 # response when the plugin doesn't exist, which we want to inspect rather than error on.
 STABLE_OK=
-if JSON="$( curl -L --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json" )" \
+if JSON="$( curl -L --connect-timeout 15 --max-time 60 --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json" )" \
 	&& jq -e --arg slug "$PLUGIN_SLUG" '.slug == $slug' <<<"$JSON" &>/dev/null; then
 	URL="$( jq -r '.download_link // ""' <<<"$JSON" )"
-	if [[ -n "$URL" ]] && curl -L --fail --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" --url "$URL" --output "$ZIPDIR/$PLUGIN_SLUG-stable.zip"; then
+	if [[ -n "$URL" ]] && curl -L --fail --connect-timeout 15 --max-time 180 --retry 2 --retry-delay "$(( 30 + RANDOM % 8 ))" --url "$URL" --output "$ZIPDIR/$PLUGIN_SLUG-stable.zip"; then
 		echo "Downloaded stable build from $URL"
 		STABLE_OK=1
 	fi

--- a/.github/workflows/scripts/test-plugin-update/setup.sh
+++ b/.github/workflows/scripts/test-plugin-update/setup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Ported from Jetpack's .github/files/test-plugin-update/setup.sh ("Test plugin
+# upgrades"), adapted for WooCommerce: WordPress is installed on the runner and
+# served via php -S, rather than the jetpack-wordpress-dev Apache container.
+
+set -eo pipefail
+
+# Expected environment (set by the workflow):
+#   WP_PATH       Absolute path to the WordPress install / web root.
+#   WP_HOST       Host the site is served from (e.g. 127.0.0.1).
+#   WP_PORT       Port the site is served from (e.g. 8080).
+#   DB_HOST       MariaDB host (the service container, e.g. 127.0.0.1).
+#   DB_PORT       MariaDB port (e.g. 3306).
+#   DB_NAME       Database name (pre-created by the service container).
+#   DB_USER       Database user.
+#   DB_PASS       Database password.
+#   ADMIN_USER    WordPress admin username.
+#   ADMIN_PASS    WordPress admin password.
+#   ADMIN_EMAIL   WordPress admin email.
+#   MU_PLUGIN_SRC Path to the fake-update mu-plugin to install.
+#   DB_DUMP       Path to write the clean-state database dump to.
+#
+# The database is created by the MariaDB service container (MARIADB_DATABASE)
+# and the workflow only starts steps once the service is healthy, so there is
+# no need for a mysql client on the runner.
+
+WP_URL="http://$WP_HOST:$WP_PORT"
+
+echo "::group::Install WordPress"
+mkdir -p "$WP_PATH"
+cd "$WP_PATH"
+wp core download
+wp config create \
+	--dbname="$DB_NAME" \
+	--dbuser="$DB_USER" \
+	--dbpass="$DB_PASS" \
+	--dbhost="$DB_HOST:$DB_PORT" \
+	--skip-check
+# Log to debug.log (not the screen) so the test can grep it, allow in-place
+# upgrades without FTP creds, and avoid loopback cron stalling php -S.
+wp config set WP_DEBUG true --raw --type=constant
+wp config set WP_DEBUG_LOG true --raw --type=constant
+wp config set WP_DEBUG_DISPLAY false --raw --type=constant
+wp config set FS_METHOD 'direct' --type=constant
+wp config set DISABLE_WP_CRON true --raw --type=constant
+# Disable WP's fatal-error handler (recovery mode). Otherwise a plugin that fatals
+# on load gets "paused" — especially under the mu-plugin's forced-admin context —
+# which would mask the fatal from the post-upgrade page-load smoke. We want fatals
+# to surface (logged + HTTP 500), not be silently recovered.
+wp config set WP_DISABLE_FATAL_ERROR_HANDLER true --raw --type=constant
+wp core install \
+	--url="$WP_URL" \
+	--title="Plugin Upgrade Test" \
+	--admin_user="$ADMIN_USER" \
+	--admin_password="$ADMIN_PASS" \
+	--admin_email="$ADMIN_EMAIL" \
+	--skip-email
+rm -f "$WP_PATH/index.html"
+mkdir -p "$WP_PATH/wp-content/mu-plugins"
+cp "$MU_PLUGIN_SRC" "$WP_PATH/wp-content/mu-plugins/plugin-upgrade-test.php"
+echo "::endgroup::"
+
+echo "::group::Verify debug.log wiring"
+# Positive control: prove WordPress actually writes to the exact log file test.sh
+# greps. Without this, a misconfigured WP_DEBUG_LOG would route fatals elsewhere
+# and every run would pass silently.
+: > "$WP_PATH/wp-content/debug.log" 2>/dev/null || true
+wp eval 'error_log( "ci-debug-log-wiring-check" );'
+if ! grep -q 'ci-debug-log-wiring-check' "$WP_PATH/wp-content/debug.log" 2>/dev/null; then
+	echo "::error::WP_DEBUG_LOG is not routing to wp-content/debug.log; fatal detection would silently pass."
+	exit 1
+fi
+: > "$WP_PATH/wp-content/debug.log"
+echo "debug.log wiring verified."
+echo "::endgroup::"
+
+echo "::group::Backing up database"
+wp db export "$DB_DUMP"
+echo "::endgroup::"

--- a/.github/workflows/scripts/test-plugin-update/test.sh
+++ b/.github/workflows/scripts/test-plugin-update/test.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+
+# Ported from Jetpack's .github/files/test-plugin-update/test.sh ("Test plugin
+# upgrades"), adapted for WooCommerce: no Jetpack connection mocking, php -S
+# instead of an Apache container, and a stronger set of assertions.
+
+set -eo pipefail
+
+# Expected environment (set by the workflow):
+#   PLUGIN_SLUG  Plugin slug / install directory name (woocommerce).
+#   PLUGIN_FILE  Plugin entry file, relative to the plugins dir (woocommerce/woocommerce.php).
+#   WP_PATH      Absolute path to the WordPress install / web root.
+#   WP_HOST      Host the built-in server binds to (e.g. 127.0.0.1).
+#   WP_PORT      Port the built-in server binds to (e.g. 8080).
+#   ZIPDIR       Directory holding woocommerce-{stable,trunk,dev}.zip.
+#   DB_DUMP      Clean-state database dump to restore before each scenario.
+
+WP=( wp --path="$WP_PATH" )
+DEBUG_LOG="$WP_PATH/wp-content/debug.log"
+SERVER_LOG="$GITHUB_WORKSPACE/php-server.log"
+BASE_URL="http://$WP_HOST:$WP_PORT"
+FATAL_RE='PHP (Fatal error|Parse error)|Uncaught (Error|Exception|TypeError|ValueError)'
+EXIT=0
+FINISHED=false
+SERVER_PID=
+SCENARIOS_RUN=0
+BASELINE_SKIPPED=0
+
+# A skipped scenario (missing zip, or a fatal in the baseline build itself) only
+# warns — we don't red-flag a PR for a broken wp.org/nightly source. Total skip
+# (zero scenarios actually upgraded) IS a failure, enforced by the zero-guard at
+# the end. Partial skip is therefore an accepted, surfaced-but-non-fatal state.
+
+# shellcheck disable=SC2329  # Invoked indirectly via the EXIT trap below.
+function onexit {
+	if [[ -n "$SERVER_PID" ]]; then
+		kill "$SERVER_PID" &>/dev/null || true
+	fi
+	if ! "$FINISHED"; then
+		echo "💣 The testing script exited unexpectedly." >> "$GITHUB_STEP_SUMMARY"
+	fi
+}
+trap onexit EXIT
+
+# Record a failure. Converts only our intentional "\n" separators to real newlines
+# and prints the rest literally (no %b escape processing of arbitrary fatal text).
+# A real newline is used because this lands in the Markdown step summary; %0A only
+# renders as a newline inside ::workflow:: commands.
+function failed {
+	printf '%s\n' "❌ ${1//\\n/$'\n'}" >> "$GITHUB_STEP_SUMMARY"
+	FAILED=1
+	EXIT=1
+}
+
+# Truncate (creating if absent) the debug log.
+function reset_log {
+	: > "$DEBUG_LOG"
+}
+
+# Echo any logged PHP fatal/parse error or uncaught throwable in the given log
+# (default: the WP debug log), empty if clean. Uncaught Errors (the #65337 class)
+# are logged by PHP as "PHP Fatal error:  Uncaught Error: ...".
+function log_fatal {
+	grep -iE "$FATAL_RE" "${1:-$DEBUG_LOG}" 2>/dev/null || true
+}
+
+# --- Detector self-test -------------------------------------------------------
+# Prove the fatal-detection chain works before trusting any green result. If the
+# grep pattern or log path ever drifts, this fails loudly instead of silently
+# passing every PR. (setup.sh separately proves WordPress writes to this log.)
+echo "::group::Detector self-test"
+# Generate a REAL uncaught PHP fatal (same shape as the #65337 missing-class error)
+# and confirm log_fatal matches PHP's actual log format. This guards against grep
+# pattern drift AND PHP log-format drift — not just a synthetic string we know matches.
+SELFTEST_LOG="$( mktemp )"
+php -d log_errors=1 -d error_log="$SELFTEST_LOG" -d display_errors=0 -r 'CiDetectorSelfTestMissingClass::go();' || true
+if [[ -z "$( log_fatal "$SELFTEST_LOG" )" ]]; then
+	echo "::error::Detector self-test failed — the pattern did not match a real PHP fatal."
+	cat "$SELFTEST_LOG" || true
+	echo "❌ Detector self-test failed; aborting (cannot reliably detect fatals)." >> "$GITHUB_STEP_SUMMARY"
+	FINISHED=true  # Suppress the trap's "exited unexpectedly" message on this deliberate abort.
+	exit 1
+fi
+rm -f "$SELFTEST_LOG"
+echo "Detector self-test passed."
+echo "::endgroup::"
+
+# --- Web server ---------------------------------------------------------------
+echo "::group::Starting PHP built-in web server"
+# PHP_CLI_SERVER_WORKERS lets the server handle the sub-requests the upgrade
+# flow may make without stalling on its single thread.
+PHP_CLI_SERVER_WORKERS=4 php -S "$WP_HOST:$WP_PORT" -t "$WP_PATH" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+# version.php executes (returns HTTP 200, no DB needed) once PHP is serving.
+for (( i=1; i<=15; i++ )); do
+	curl -sf -o /dev/null "$BASE_URL/wp-includes/version.php" && break
+	[[ $i -eq 15 ]] && { echo "::error::Web server failed to start."; cat "$SERVER_LOG"; exit 1; }
+	sleep 1
+done
+echo "Web server ready (pid $SERVER_PID)."
+echo "::endgroup::"
+
+# --- Scenarios ----------------------------------------------------------------
+for FROM in stable trunk; do
+	for HOW in web cli; do
+		[[ -e "$ZIPDIR/$PLUGIN_SLUG-$FROM.zip" ]] || { echo "No $FROM zip, skipping $FROM/$HOW."; continue; }
+
+		FAILED=
+		printf '\n\e[1mTest upgrade of %s from %s via %s\e[0m\n' "$PLUGIN_SLUG" "$FROM" "$HOW"
+
+		echo "::group::Restoring database from backup"
+		if ! "${WP[@]}" db import "$DB_DUMP"; then
+			failed "Database restore failed for $FROM/$HOW!"
+		fi
+		echo "::endgroup::"
+		if [[ -n "$FAILED" ]]; then continue; fi
+
+		echo "::group::Installing baseline $PLUGIN_SLUG $FROM"
+		reset_log
+		if ! "${WP[@]}" plugin install --activate --force "$ZIPDIR/$PLUGIN_SLUG-$FROM.zip"; then
+			failed "Baseline install/activate failed for $PLUGIN_SLUG $FROM!"
+		fi
+		echo '== Debug log =='
+		cat "$DEBUG_LOG"
+		BASELINE_FATAL="$( log_fatal )"
+		# Remove the sentinel so its reappearance after the upgrade proves the swap.
+		rm -f "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG/ci-flag.txt"
+		echo "::endgroup::"
+		if [[ -n "$FAILED" ]]; then
+			rm -rf "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG"
+			continue
+		fi
+		# A fatal in the baseline (the previous release / nightly itself, before any
+		# upgrade) is an environment/source problem, not a regression in this PR.
+		# Surface it as a warning and skip, rather than red-flagging an innocent PR.
+		if [[ -n "$BASELINE_FATAL" ]]; then
+			echo "::warning::Baseline $FROM build logged a fatal before upgrade — not attributing to this PR.%0A$BASELINE_FATAL"
+			echo "⚠️ Baseline $FROM build fataled before upgrade (environment/source issue, not this PR); skipped $FROM/$HOW." >> "$GITHUB_STEP_SUMMARY"
+			BASELINE_SKIPPED=$(( BASELINE_SKIPPED + 1 ))
+			"${WP[@]}" plugin uninstall "$PLUGIN_SLUG" 2>/dev/null || rm -rf "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG"
+			continue
+		fi
+
+		# Count only scenarios that reach the upgrade with a clean baseline, so an
+		# all-baseline-skipped run trips the zero-guard (red) instead of going green.
+		SCENARIOS_RUN=$(( SCENARIOS_RUN + 1 ))
+
+		echo "::group::Upgrading $PLUGIN_SLUG via $HOW"
+		"${WP[@]}" --quiet option set fake_plugin_update_plugin "$PLUGIN_FILE" || true
+		"${WP[@]}" --quiet option set fake_plugin_update_url "$ZIPDIR/$PLUGIN_SLUG-dev.zip" || true
+		reset_log
+		SERVER_FATAL=
+		if [[ "$HOW" == 'cli' ]]; then
+			if ! "${WP[@]}" plugin upgrade "$PLUGIN_SLUG" 2>&1 | tee "$GITHUB_WORKSPACE/out.txt"; then
+				failed "CLI upgrade of $PLUGIN_SLUG from $FROM exited with a non-zero status"
+			fi
+		else
+			# The /wp-admin/update.php iframe flow is what reproduces the same-request
+			# autoload race (#65337). curl returns 0 even on HTTP 5xx, so assert on the
+			# status code and scan the body for WP's critical-error markers explicitly.
+			SERVER_LOG_PRE="$( wc -c < "$SERVER_LOG" 2>/dev/null || echo 0 )"
+			HTTP_CODE="$( curl -s --get --connect-timeout 10 --max-time 300 \
+				--output "$GITHUB_WORKSPACE/out.txt" --write-out '%{http_code}' \
+				--url "$BASE_URL/wp-admin/update.php?action=upgrade-plugin&_wpnonce=bogus" \
+				--data "plugin=$PLUGIN_FILE" || true )"
+			echo "HTTP $HTTP_CODE"
+			cat "$GITHUB_WORKSPACE/out.txt" || true
+			echo
+			if [[ "$HTTP_CODE" != 2* && "$HTTP_CODE" != 3* ]]; then
+				failed "Web upgrade of $PLUGIN_SLUG from $FROM returned HTTP $HTTP_CODE"
+			fi
+			if grep -qiE 'There has been a critical error|Installation failed|Update failed' "$GITHUB_WORKSPACE/out.txt"; then
+				failed "Web upgrade of $PLUGIN_SLUG from $FROM reported an error in the response body"
+			fi
+			# WordPress routes error_log() to debug.log, so a mid-upgrade fatal lands there;
+			# but a fatal raised before WP sets that up would go to php -S's stderr instead.
+			# Scan the new tail of the server log too, so neither sink can hide a fatal.
+			SERVER_FATAL="$( tail -c "+$(( SERVER_LOG_PRE + 1 ))" "$SERVER_LOG" 2>/dev/null | grep -iE "$FATAL_RE" || true )"
+		fi
+		echo '== Debug log =='
+		cat "$DEBUG_LOG"
+		echo "::endgroup::"
+
+		UP_FATAL="$( log_fatal )"
+		if [[ -n "$UP_FATAL$SERVER_FATAL" ]]; then
+			failed "Mid-upgrade fatal for $PLUGIN_SLUG ($HOW update from $FROM)!\n${UP_FATAL}${SERVER_FATAL}"
+			echo "::error::Mid-upgrade fatal for $PLUGIN_SLUG ($HOW from $FROM)."
+		elif [[ ! -e "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG/ci-flag.txt" ]]; then
+			failed "Plugin $PLUGIN_SLUG ($HOW update from $FROM) does not appear to have been updated (sentinel missing)."
+		fi
+
+		# Post-upgrade smoke: even when the upgrade request logged no fatal, confirm the
+		# site still serves (catches WSOD / broken bootstrap with no logged fatal). Follow
+		# redirects (-L) so WooCommerce's first-load onboarding redirect lands on a real
+		# rendered page rather than passing on the bare 30x.
+		if [[ -z "$FAILED" ]]; then
+			echo "::group::Post-upgrade page-load smoke"
+			reset_log
+			SERVER_LOG_PRE="$( wc -c < "$SERVER_LOG" 2>/dev/null || echo 0 )"
+			HOME_CODE="$( curl -sL --connect-timeout 10 --max-time 60 -o /dev/null --write-out '%{http_code}' "$BASE_URL/" || true )"
+			ADMIN_CODE="$( curl -sL --connect-timeout 10 --max-time 60 -o /dev/null --write-out '%{http_code}' "$BASE_URL/wp-admin/" || true )"
+			echo "home=$HOME_CODE admin=$ADMIN_CODE"
+			cat "$DEBUG_LOG"
+			SMOKE_FATAL="$( log_fatal )$( tail -c "+$(( SERVER_LOG_PRE + 1 ))" "$SERVER_LOG" 2>/dev/null | grep -iE "$FATAL_RE" || true )"
+			if [[ "$HOME_CODE" != 2* ]]; then
+				failed "Home page returned HTTP $HOME_CODE after $HOW upgrade from $FROM"
+			fi
+			if [[ "$ADMIN_CODE" != 2* ]]; then
+				failed "wp-admin returned HTTP $ADMIN_CODE after $HOW upgrade from $FROM"
+			fi
+			if [[ -n "$SMOKE_FATAL" ]]; then
+				failed "Post-upgrade page load fataled ($HOW from $FROM)!\n$SMOKE_FATAL"
+			fi
+			echo "::endgroup::"
+		fi
+
+		echo "::group::Deactivating $PLUGIN_SLUG"
+		reset_log
+		if ! "${WP[@]}" plugin deactivate "$PLUGIN_SLUG"; then
+			failed "Plugin deactivate failed after $PLUGIN_SLUG $HOW update from $FROM!"
+		fi
+		echo '== Debug log =='
+		cat "$DEBUG_LOG"
+		if [[ -n "$( log_fatal )" ]]; then
+			failed "Fatal on deactivate for $PLUGIN_SLUG ($HOW from $FROM)!"
+		fi
+		echo "::endgroup::"
+
+		echo "::group::Uninstalling $PLUGIN_SLUG"
+		reset_log
+		if ! "${WP[@]}" plugin uninstall "$PLUGIN_SLUG"; then
+			failed "Plugin uninstall failed after $PLUGIN_SLUG $HOW update from $FROM!"
+			rm -rf "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG"
+		fi
+		echo '== Debug log =='
+		cat "$DEBUG_LOG"
+		if [[ -n "$( log_fatal )" ]]; then
+			failed "Fatal on uninstall for $PLUGIN_SLUG ($HOW from $FROM)!"
+		fi
+		echo "::endgroup::"
+
+		"${WP[@]}" --quiet option delete fake_plugin_update_plugin || true
+		"${WP[@]}" --quiet option delete fake_plugin_update_url || true
+
+		if [[ -z "$FAILED" ]]; then
+			echo "✅ Upgrade of $PLUGIN_SLUG from $FROM via $HOW succeeded!" >> "$GITHUB_STEP_SUMMARY"
+		fi
+	done
+done
+
+# Guard against a silent green where no scenario actually exercised an upgrade —
+# either every source zip was missing, or every baseline fataled before upgrade.
+if [[ "$SCENARIOS_RUN" -eq 0 ]]; then
+	echo "::error::No upgrade scenarios ran — every source zip was missing or every baseline fataled before upgrade."
+	echo "❌ No upgrade scenarios actually ran (missing source zips, or all baselines fataled)." >> "$GITHUB_STEP_SUMMARY"
+	EXIT=1
+elif [[ "$BASELINE_SKIPPED" -gt 0 ]]; then
+	# Surface partial coverage loss prominently: the run is green but did not test
+	# every source. A baseline fatal is an environment/source issue, not this PR's
+	# fault, so it doesn't fail the job — but the reduced coverage must be visible.
+	echo "::warning::Coverage reduced — $BASELINE_SKIPPED scenario(s) skipped on a baseline fatal; those upgrade paths were NOT tested."
+	echo "⚠️ Coverage reduced: $BASELINE_SKIPPED scenario(s) skipped because the baseline build fataled before upgrade. Those upgrade paths were NOT exercised this run." >> "$GITHUB_STEP_SUMMARY"
+fi
+
+FINISHED=true
+exit $EXIT

--- a/.github/workflows/scripts/test-plugin-update/test.sh
+++ b/.github/workflows/scripts/test-plugin-update/test.sh
@@ -103,7 +103,7 @@ echo "::endgroup::"
 # --- Scenarios ----------------------------------------------------------------
 for FROM in stable trunk; do
 	for HOW in web cli; do
-		[[ -e "$ZIPDIR/$PLUGIN_SLUG-$FROM.zip" ]] || { echo "No $FROM zip, skipping $FROM/$HOW."; continue; }
+		[[ -e "$ZIPDIR/$PLUGIN_SLUG-$FROM.zip" ]] || { echo "::warning::No $FROM source zip present; skipping $FROM/$HOW."; continue; }
 
 		FAILED=
 		printf '\n\e[1mTest upgrade of %s from %s via %s\e[0m\n' "$PLUGIN_SLUG" "$FROM" "$HOW"
@@ -118,7 +118,14 @@ for FROM in stable trunk; do
 		echo "::group::Installing baseline $PLUGIN_SLUG $FROM"
 		reset_log
 		if ! "${WP[@]}" plugin install --activate --force "$ZIPDIR/$PLUGIN_SLUG-$FROM.zip"; then
-			failed "Baseline install/activate failed for $PLUGIN_SLUG $FROM!"
+			# The baseline is a published build, not this PR, so a failed install/activate
+			# is an environment/source problem. Warn and skip rather than failing the PR.
+			echo "::warning::Baseline $FROM build failed to install/activate — skipping $FROM/$HOW (not attributed to this PR)."
+			echo "⚠️ Baseline $FROM build failed to install/activate (environment/source issue, not this PR); skipped $FROM/$HOW." >> "$GITHUB_STEP_SUMMARY"
+			BASELINE_SKIPPED=$(( BASELINE_SKIPPED + 1 ))
+			rm -rf "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG"
+			echo "::endgroup::"
+			continue
 		fi
 		echo '== Debug log =='
 		cat "$DEBUG_LOG"
@@ -126,10 +133,6 @@ for FROM in stable trunk; do
 		# Remove the sentinel so its reappearance after the upgrade proves the swap.
 		rm -f "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG/ci-flag.txt"
 		echo "::endgroup::"
-		if [[ -n "$FAILED" ]]; then
-			rm -rf "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG"
-			continue
-		fi
 		# A fatal in the baseline (the previous release / nightly itself, before any
 		# upgrade) is an environment/source problem, not a regression in this PR.
 		# Surface it as a warning and skip, rather than red-flagging an innocent PR.


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WooCommerce 10.8.0 shipped a fatal that only surfaced **during the in-place upgrade** from 10.7.x (the `DefaultCustomerAddress` autoload race introduced in [#64091](<https://github.com/woocommerce/woocommerce/issues/64091>), fixed in [#65337](<https://github.com/woocommerce/woocommerce/issues/65337>)). No CI check exercises the upgrade path — unit tests run against an already-booted, fully-autoloaded environment — so this whole class of bug was invisible until users hit it.

This adds a `pull_request` check, **Plugin Upgrade Test**, ported from Jetpack's "Test plugin upgrades". It:

* builds the PR's `woocommerce` plugin zip (reusing `setup-woocommerce-monorepo` + `bin/build-zip.sh`),
* installs the previous version — **stable** from the [wordpress.org](<http://wordpress.org>) API and **trunk** from the nightly release,
* upgrades to the PR build through WordPress's real update machinery, both `wp plugin upgrade` (CLI) and a request to `/wp-admin/update.php?action=upgrade-plugin` (the web/iframe path), and
* fails the job if a PHP fatal lands in `debug.log` or the server log.

The **web path** is the one that reproduces the same-request autoloader race [#65337](<https://github.com/woocommerce/woocommerce/issues/65337>) fixed: it boots WordPress on the old code, swaps plugin files mid-request, then runs the new code in the same request (the upgrade iframe footer). It would have caught [#64091](<https://github.com/woocommerce/woocommerce/issues/64091>) before release.

Security: runs on `pull_request` (not `pull_request_target`), with no secrets and `contents: read`, so building and running the PR's own plugin code stays sandboxed on an ephemeral runner. A CI-only fake-update mu-plugin (auth/nonce bypass) is copied only into the runner's WordPress install and is excluded from the shipped zip by `.distignore`.

Adds the workflow plus three bash scripts and the mu-plugin under `.github/workflows/scripts/test-plugin-update/`.

See woocommerce/woocommerce#52311 — this workflow detects the failure class; it does not prevent it. Deliberately not "Closes", because 52311 asks for files to be removable without triggering fatals, and that needs either a stub-on-deletion convention or an autoloader change. Detection is the half that stops one shipping unnoticed.

Proof it earns its keep: on 2026-07-29 an in-place update from 10.9.4 to 11.0.0-rc.2 was found to fatal on the update screen (issue woocommerce/woocommerce#67135, fixed by PR woocommerce/woocommerce#67136). That is the second instance of this failure class in consecutive releases — the first was `Admin\API\Settings` in 10.9, fixed by PR woocommerce/woocommerce#66081. This workflow would have caught both at PR time. Its own upgrade test is currently the only place either was recorded.

### How to test the changes in this Pull Request:

1. Confirm the **Plugin Upgrade Test** check runs on this PR and passes (current trunk is fixed): it builds the zip, then runs four scenarios — stable→dev and trunk→dev, each via web and CLI — and reports each in the job summary.
2. (Optional regression proof) On a throwaway branch, revert [#65337](<https://github.com/woocommerce/woocommerce/issues/65337>) to reintroduce the fatal, push, and confirm the **web** scenarios go red with `PHP Fatal error: ... DefaultCustomerAddress ... not found` in the summary. Discard the branch afterward.

### Testing that has already taken place:

* Static validation: `actionlint`, `shellcheck`, `bash -n`, and `php -l` all clean.
* Local end-to-end verification on a throwaway WordPress + MariaDB using the real `mu-plugin.php` and the real detection logic: the fake-update mechanism drives a genuine `Plugin_Upgrader` upgrade from a local zip (files swapped, sentinel present), the clean path goes green, and a `Uncaught Error: Class ... not found` raised during the `update.php` request is caught via both `debug.log` and the php -S server log (job red). The detector self-test and the `debug.log` wiring self-test both pass.
* Reviewed across multiple rounds (correctness, security, adversarial, reliability, testing, project-standards) plus an independent Codex pass, which confirmed by reading the bundled WordPress upgrader source that the web path exercises the real same-request upgrade flow.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Comment</summary>

#### Comment

CI-only change under `.github/` — no shippable plugin code is modified, so no package changelog entry is required.

</details>