### PR TITLE
Accessibility: Add proper ARIA roles and scope attributes to cart table headers

### DIFF
--- a/plugins/woocommerce/changelog/accessibility-cart-table-headers
+++ b/plugins/woocommerce/changelog/accessibility-cart-table-headers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Add proper ARIA roles and scope attributes to cart table headers for screen reader accessibility (WCAG 1.3.1)
+
+

--- a/plugins/woocommerce/changelog/accessibility-cart-table-headers
+++ b/plugins/woocommerce/changelog/accessibility-cart-table-headers
@@ -1,5 +1,4 @@
 Significance: patch
 Type: tweak
-Comment: Add proper ARIA roles and scope attributes to cart table headers for screen reader accessibility (WCAG 1.3.1)
 
-
+Add proper ARIA roles and scope attributes to cart table headers for screen reader accessibility (WCAG 1.3.1)

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -271,7 +271,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 						</a>
 					) }
 				</td>
-				<td className="wc-block-cart-item__product">
+				<th scope="row" className="wc-block-cart-item__product">
 					<div className="wc-block-cart-item__wrap">
 						<ProductName
 							disabled={
@@ -418,7 +418,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 							</div>
 						) }
 					</div>
-				</td>
+				</th>
 				<td className="wc-block-cart-item__total">
 					<div className="wc-block-cart-item__total-price-and-sale-badge-wrapper">
 						<ProductPrice

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -271,7 +271,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 						</a>
 					) }
 				</td>
-				<th scope="row" className="wc-block-cart-item__product">
+				<td role="rowheader" className="wc-block-cart-item__product">
 					<div className="wc-block-cart-item__wrap">
 						<ProductName
 							disabled={
@@ -418,7 +418,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 							</div>
 						) }
 					</div>
-				</th>
+				</td>
 				<td className="wc-block-cart-item__total">
 					<div className="wc-block-cart-item__total-price-and-sale-badge-wrapper">
 						<ProductPrice

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
@@ -92,13 +92,22 @@ const CartLineItemsTable = ( {
 			</caption>
 			<thead>
 				<tr className="wc-block-cart-items__header">
-					<th className="wc-block-cart-items__header-image">
+					<th
+						scope="col"
+						className="wc-block-cart-items__header-image"
+					>
 						<span>{ __( 'Product', 'woocommerce' ) }</span>
 					</th>
-					<th className="wc-block-cart-items__header-product">
+					<th
+						scope="col"
+						className="wc-block-cart-items__header-product"
+					>
 						<span>{ __( 'Details', 'woocommerce' ) }</span>
 					</th>
-					<th className="wc-block-cart-items__header-total">
+					<th
+						scope="col"
+						className="wc-block-cart-items__header-total"
+					>
 						<span>{ __( 'Total', 'woocommerce' ) }</span>
 					</th>
 				</tr>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/block.js
@@ -212,9 +212,7 @@ describe( 'Testing cart', () => {
 
 		await waitFor( () =>
 			expect(
-				document.querySelector(
-					'.wc-block-cart-item__total'
-				)
+				document.querySelector( '.wc-block-cart-item__total' )
 			).toHaveTextContent( '16€' )
 		);
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/block.js
@@ -211,9 +211,11 @@ describe( 'Testing cart', () => {
 		render( <CartBlock /> );
 
 		await waitFor( () =>
-			expect( screen.getAllByRole( 'cell' )[ 1 ] ).toHaveTextContent(
-				'16€'
-			)
+			expect(
+				document.querySelector(
+					'.wc-block-cart-item__total'
+				)
+			).toHaveTextContent( '16€' )
 		);
 	} );
 

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.8.0
+ * @version 11.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -130,7 +130,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_backorder_notification', '<p class="backorder_notification">' . esc_html__( 'Available on backorder', 'woocommerce' ) . '</p>', $product_id ) );
 						}
 						?>
-						</th>
+						</td>
 
 						<td class="product-price" data-title="<?php esc_attr_e( 'Price', 'woocommerce' ); ?>">
 							<?php

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -107,7 +107,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 						?>
 						</td>
 
-						<td role="rowheader" class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
+						<th scope="row" class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
 						<?php
 						if ( ! $product_permalink ) {
 							echo wp_kses_post( $product_name . '&nbsp;' );
@@ -130,7 +130,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_backorder_notification', '<p class="backorder_notification">' . esc_html__( 'Available on backorder', 'woocommerce' ) . '</p>', $product_id ) );
 						}
 						?>
-						</td>
+						</th>
 
 						<td class="product-price" data-title="<?php esc_attr_e( 'Price', 'woocommerce' ); ?>">
 							<?php

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -25,8 +25,8 @@ do_action( 'woocommerce_before_cart' ); ?>
 	<table class="shop_table shop_table_responsive cart woocommerce-cart-form__contents" cellspacing="0">
 		<thead>
 			<tr>
-				<th class="product-remove"><span class="screen-reader-text"><?php esc_html_e( 'Remove item', 'woocommerce' ); ?></span></th>
-				<th class="product-thumbnail"><span class="screen-reader-text"><?php esc_html_e( 'Thumbnail image', 'woocommerce' ); ?></span></th>
+				<th scope="col" class="product-remove"><span class="screen-reader-text"><?php esc_html_e( 'Remove item', 'woocommerce' ); ?></span></th>
+				<th scope="col" class="product-thumbnail"><span class="screen-reader-text"><?php esc_html_e( 'Thumbnail image', 'woocommerce' ); ?></span></th>
 				<th scope="col" class="product-name"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
 				<th scope="col" class="product-price"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
 				<th scope="col" class="product-quantity"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></th>
@@ -107,7 +107,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 						?>
 						</td>
 
-						<td scope="row" role="rowheader" class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
+						<td role="rowheader" class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
 						<?php
 						if ( ! $product_permalink ) {
 							echo wp_kses_post( $product_name . '&nbsp;' );
@@ -130,7 +130,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_backorder_notification', '<p class="backorder_notification">' . esc_html__( 'Available on backorder', 'woocommerce' ) . '</p>', $product_id ) );
 						}
 						?>
-						</td>
+						</th>
 
 						<td class="product-price" data-title="<?php esc_attr_e( 'Price', 'woocommerce' ); ?>">
 							<?php

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -107,7 +107,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 						?>
 						</td>
 
-						<th scope="row" class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
+						<td role="rowheader" class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
 						<?php
 						if ( ! $product_permalink ) {
 							echo wp_kses_post( $product_name . '&nbsp;' );
@@ -130,7 +130,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_backorder_notification', '<p class="backorder_notification">' . esc_html__( 'Available on backorder', 'woocommerce' ) . '</p>', $product_id ) );
 						}
 						?>
-						</th>
+						</td>
 
 						<td class="product-price" data-title="<?php esc_attr_e( 'Price', 'woocommerce' ); ?>">
 							<?php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes WCAG 1.3.1 accessibility issue on the cart page where table headers were not properly indicated to screen readers.

**Old cart** (`templates/cart/cart.php`):
- Added `scope="col"` to `<th>` elements that were missing it (Remove item, Thumbnail image columns)
- Fixed invalid `<td scope="row" role="rowheader">` to `<td role="rowheader">` (the `scope` attribute is only valid on `<th>`)

**Block cart** (`cart-line-items-table/index.tsx` + `cart-line-item-row.tsx`):
- Added `scope="col"` to all column header `<th>` elements
- Changed product column from `<th scope="row">` to `<td role="rowheader">` to preserve accessibility without breaking CSS selectors

These changes affect both the cart block and mini cart (which share the same components).

Closes #60720.

### Screenshots or screen recordings:

Not applicable — no visual changes.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. **Old cart**: Run `pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp post update 6 --post_content='[woocommerce_cart]' --user=admin` to set the cart page to the shortcode, then visit `/cart` with a product in the cart. Inspect the table HTML — verify all `<th>` elements in `<thead>` have `scope="col"` and the product name cell has `role="rowheader"`.
2. **Block cart**: Create a page with the Cart block, then visit `/cart` with a product in the cart. Inspect the table — verify `<th>` elements have `scope="col"` and the product column uses `<td role="rowheader">`.
3. **Screen reader test**: Use VoiceOver (macOS) or NVDA (Windows) to navigate the cart table. Verify that row headers (product names) are announced when moving between cells in a row.

### Testing that has already taken place:

- PHP lint: passed
- JS lint: passed (0 errors)
- JS unit tests: 5/5 passed
- Branch-level lint: passed

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Tweak

#### Message

Add proper ARIA roles and scope attributes to cart table headers for screen reader accessibility (WCAG 1.3.1).

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
