### PR TITLE
Fix exception info leak, null dereferences, and duplicate date query key

### DIFF
--- a/plugins/woocommerce/changelog/65368-fix-null-safety-and-security-bugs
+++ b/plugins/woocommerce/changelog/65368-fix-null-safety-and-security-bugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix exception message info leak to non-admin API callers, null dereferences on missing parent product and order, and duplicate date query key in OrdersTableQuery.

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -521,8 +521,10 @@ function wc_get_low_stock_amount( WC_Product $product ) {
 	$low_stock_amount = $product->get_low_stock_amount();
 
 	if ( '' === $low_stock_amount && $product->is_type( ProductType::VARIATION ) ) {
-		$product          = wc_get_product( $product->get_parent_id() );
-		$low_stock_amount = $product->get_low_stock_amount();
+		$parent = wc_get_product( $product->get_parent_id() );
+		if ( $parent ) {
+			$low_stock_amount = $parent->get_low_stock_amount();
+		}
 	}
 
 	if ( '' === $low_stock_amount ) {

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -35752,12 +35752,6 @@ parameters:
 			path: includes/wc-stock-functions.php
 
 		-
-			message: '#^Cannot call method get_low_stock_amount\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/wc-stock-functions.php
-
-		-
 			message: '#^Cannot call method get_stock_quantity\(\) on WC_Product\|false\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -69735,24 +69729,6 @@ parameters:
 		-
 			message: '#^Call to static method get_order_item\(\) on an unknown class Automattic\\WooCommerce\\Internal\\WC_Order_Factory\.$#'
 			identifier: class.notFound
-			count: 1
-			path: src/Internal/RestockRefundedItemsAdjuster.php
-
-		-
-			message: '#^Cannot call method get_qty_refunded_for_item\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/RestockRefundedItemsAdjuster.php
-
-		-
-			message: '#^Cannot call method get_refunds\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/RestockRefundedItemsAdjuster.php
-
-		-
-			message: '#^Cannot call method get_version\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
-			identifier: method.nonObject
 			count: 1
 			path: src/Internal/RestockRefundedItemsAdjuster.php
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -544,7 +544,7 @@ class OrdersTableQuery {
 
 		// Add top-level date parameters to the date_query.
 		$tl_query = array();
-		foreach ( array( 'hour', 'minute', 'second', 'year', 'monthnum', 'week', 'day', 'year' ) as $tl_key ) {
+		foreach ( array( 'hour', 'minute', 'second', 'year', 'monthnum', 'week', 'day' ) as $tl_key ) {
 			if ( $this->arg_isset( $tl_key ) ) {
 				$tl_query[ $tl_key ] = $this->args[ $tl_key ];
 				unset( $this->args[ $tl_key ] );

--- a/plugins/woocommerce/src/Internal/RestApiControllerBase.php
+++ b/plugins/woocommerce/src/Internal/RestApiControllerBase.php
@@ -156,7 +156,6 @@ abstract class RestApiControllerBase implements RegisterHooksInterface {
 			$data['exception_message'] = $exception->getMessage();
 			$data['exception_trace']   = (array) $exception->getTrace();
 		}
-		$data['exception_message'] = $exception->getMessage();
 
 		return new WP_Error( 'woocommerce_rest_internal_error', __( 'Internal server error', 'woocommerce' ), $data );
 	}

--- a/plugins/woocommerce/src/Internal/RestockRefundedItemsAdjuster.php
+++ b/plugins/woocommerce/src/Internal/RestockRefundedItemsAdjuster.php
@@ -41,7 +41,7 @@ class RestockRefundedItemsAdjuster {
 	 */
 	public function initialize_restock_refunded_items( $order_id, $items ) {
 		$order = wc_get_order( $order_id );
-		if ( ! $order ) {
+		if ( ! $order instanceof \WC_Order ) {
 			return;
 		}
 		$order_version = $order->get_version();

--- a/plugins/woocommerce/src/Internal/RestockRefundedItemsAdjuster.php
+++ b/plugins/woocommerce/src/Internal/RestockRefundedItemsAdjuster.php
@@ -40,7 +40,10 @@ class RestockRefundedItemsAdjuster {
 	 * @param array $items Order items to save.
 	 */
 	public function initialize_restock_refunded_items( $order_id, $items ) {
-		$order         = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return;
+		}
 		$order_version = $order->get_version();
 
 		if ( version_compare( $order_version, '5.5', '>=' ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Four PHP bugs fixed: (1) a duplicate assignment in `RestApiControllerBase::internal_wp_error()` overwrote the permission-gated block, leaking exception messages to any API caller regardless of role; (2) `wc_get_low_stock_amount()` called `->get_low_stock_amount()` on the return value of `wc_get_product()` without a null check — fatal when a variation's parent product has been deleted; (3) `RestockRefundedItemsAdjuster::initialize_restock_refunded_items()` called `->get_version()` on the return value of `wc_get_order()` without checking for failure; (4) `OrdersTableQuery`'s date-parameter loop contained a duplicate `'year'` entry, causing a redundant no-op iteration.

### How to test the changes in this Pull Request:

1. **Exception info leak** — As a non-admin user (e.g. `subscriber` role), trigger a WooCommerce REST API endpoint that results in a 500 internal error. Inspect the JSON response body: `exception_message` should not be present. As an admin, repeat — `exception_message`, `exception_class`, and `exception_trace` should all be present.
2. **Null dereference on deleted parent product** — Create a variable product with a variation. Set `manage_stock` on the variation to inherit from parent, then hard-delete the parent product row from the database. Trigger a stock change event (e.g. place an order containing the variation). Confirm no fatal error occurs and low stock amount falls back to the site setting.
3. **Null dereference in RestockRefundedItemsAdjuster** — Fire the `woocommerce_order_item_saved` action with a non-existent order ID (e.g. `do_action('woocommerce_order_item_saved', 999999, [])`). Confirm no fatal PHP error is logged.
4. **Duplicate date query key** — Call `wc_get_orders(['year' => 2024])`. Confirm results are identical before and after. The fix is a correctness/quality improvement with no observable behavior change under normal conditions.

### Testing that has already taken place:

Code review and static analysis. PHP/Composer not available in the local environment; author to confirm test suite passes before marking ready.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->

Fix exception message info leak to non-admin API callers, null dereferences on missing parent product and order, and duplicate date query key in OrdersTableQuery.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)