### PR TITLE
Fix null dereferences from unchecked WordPress API return values

### DIFF
--- a/plugins/woocommerce/changelog/65370-fix-null-safety-round-2
+++ b/plugins/woocommerce/changelog/65370-fix-null-safety-round-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal errors from unchecked return values of wc_get_order(), wc_get_product(), get_term(), and get_user_by() in OrdersTableDataStore, structured data, product permalink builder, and Orders list table.

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -268,9 +268,8 @@ class WC_Structured_Data {
 								break;
 							}
 						}
-						$date_on_sale_to        = isset( $variation_id )
-							? wc_get_product( $variation_id )->get_date_on_sale_to()
-							: null;
+						$variation_product = isset( $variation_id ) ? wc_get_product( $variation_id ) : null;
+						$date_on_sale_to   = $variation_product ? $variation_product->get_date_on_sale_to() : null;
 						$sale_price_valid_until = $date_on_sale_to
 							? gmdate( 'Y-m-d', $date_on_sale_to->getTimestamp() )
 							: null;

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -325,6 +325,10 @@ function wc_product_post_type_link( $permalink, $post ) {
 				foreach ( $ancestors as $ancestor ) {
 					$ancestor_object = get_term( $ancestor, 'product_cat' );
 
+					if ( ! $ancestor_object instanceof WP_Term ) {
+						continue;
+					}
+
 					/**
 					 * Filter whether to use only the top-level parent category in the product permalink.
 					 *

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -979,13 +979,15 @@ class ListTable extends WP_List_Table {
 			$user_id = absint( $_GET['_customer_user'] );
 			$user    = get_user_by( 'id', $user_id );
 
-			$user_string = sprintf(
-				/* translators: 1: user display name 2: user ID 3: user email */
-				esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
-				$user->display_name,
-				absint( $user->ID ),
-				$user->user_email
-			);
+			if ( $user ) {
+				$user_string = sprintf(
+					/* translators: 1: user display name 2: user ID 3: user email */
+					esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
+					$user->display_name,
+					absint( $user->ID ),
+					$user->user_email
+				);
+			}
 		}
 
 		// Note: use of htmlspecialchars (below) is to prevent XSS when rendered by selectWoo.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -871,7 +871,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	public function get_download_permissions_granted( $order ) {
 		$order_id = is_int( $order ) ? $order : $order->get_id();
 		$order    = wc_get_order( $order_id );
-		return $order->get_download_permissions_granted();
+		return $order ? $order->get_download_permissions_granted() : false;
 	}
 
 	/**
@@ -898,7 +898,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	public function get_recorded_sales( $order ) {
 		$order_id = is_int( $order ) ? $order : $order->get_id();
 		$order    = wc_get_order( $order_id );
-		return $order->get_recorded_sales();
+		return $order ? $order->get_recorded_sales() : false;
 	}
 
 	/**
@@ -952,7 +952,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	public function get_email_sent( $order ) {
 		$order_id = is_int( $order ) ? $order : $order->get_id();
 		$order    = wc_get_order( $order_id );
-		return $order->get_new_order_email_sent();
+		return $order ? $order->get_new_order_email_sent() : false;
 	}
 
 	/**
@@ -1004,7 +1004,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	public function get_stock_reduced( $order ) {
 		$order_id = is_int( $order ) ? $order : $order->get_id();
 		$order    = wc_get_order( $order_id );
-		return $order->get_order_stock_reduced();
+		return $order ? $order->get_order_stock_reduced() : false;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`wc_get_order()`, `wc_get_product()`, `get_term()`, and `get_user_by()` all return `false`/`null`/`WP_Error` on failure, but four code paths were calling methods or accessing properties on the return value without checking first. This caused fatal errors in edge cases: deleted orders, deleted variation parents, orphaned taxonomy terms, and invalid customer user IDs. This PR adds guards at each site — `OrdersTableDataStore` (four getter methods), `class-wc-structured-data` (sale price schema), `wc-product-functions` (permalink builder), and the HPOS Orders `ListTable` (customer filter).

### How to test the changes in this Pull Request:

1. **OrdersTableDataStore getters** — call `WC()->order_factory->get_order(0)->get_data_store()->get_download_permissions_granted(999999)` (non-existent order ID). Confirm it returns `false` rather than a fatal "Call to a member function on bool" error. Repeat for `get_recorded_sales`, `get_email_sent`, `get_stock_reduced`.
2. **Structured data** — create a variable product with a sale price set on a variation, then hard-delete the variation's post row directly in the database. Visit the parent product page. Confirm the JSON-LD structured data renders without a fatal PHP error.
3. **Product permalink** — create a product assigned to a category whose parent term has been deleted directly from `wp_terms` (orphaned child). Navigate to the product permalink. Confirm no fatal error and the permalink resolves gracefully.
4. **Orders list table** — go to WooCommerce > Orders and append `?_customer_user=999999` to the URL (a non-existent user ID). Confirm the page renders without a fatal PHP error.

### Testing that has already taken place:

Code review and static analysis. Author to confirm test suite passes before marking ready.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->

Fix fatal errors from unchecked return values of wc_get_order(), wc_get_product(), get_term(), and get_user_by() in OrdersTableDataStore, structured data, product permalink builder, and Orders list table.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)