### PR TITLE
Fix: skip EmailLogger order note for unloaded (preview) order objects

### DIFF
--- a/plugins/woocommerce/src/Internal/Email/EmailLogger.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailLogger.php
@@ -150,7 +150,7 @@ class EmailLogger implements RegisterHooksInterface {
 	 * @return void
 	 */
 	private function maybe_add_order_note( $wc_object, string $email_id, WC_Email $email, bool $success, ?string $error_reason ): void {
-		if ( ! $wc_object instanceof WC_Order ) {
+		if ( ! $wc_object instanceof WC_Order || ! $wc_object->get_object_read() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
@@ -500,6 +500,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 
 		$order = $this->createMock( \WC_Order::class );
 		$order->method( 'get_id' )->willReturn( 42 );
+		$order->method( 'get_object_read' )->willReturn( true );
 		$order->expects( $this->never() )->method( 'add_order_note' );
 
 		$email = $this->create_mock_email( 'customer_processing_order', 'customer@example.com', $order );
@@ -514,6 +515,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 
 		$order = $this->createMock( \WC_Order::class );
 		$order->method( 'get_id' )->willReturn( 42 );
+		$order->method( 'get_object_read' )->willReturn( true );
 		$order->expects( $this->never() )->method( 'add_order_note' );
 
 		$email = $this->create_mock_email( 'customer_processing_order', 'customer@example.com', $order );

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
@@ -375,6 +375,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 	public function test_order_note_added_on_successful_send_for_order(): void {
 		$order = $this->createMock( \WC_Order::class );
 		$order->method( 'get_id' )->willReturn( 42 );
+		$order->method( 'get_object_read' )->willReturn( true );
 		$order->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -394,6 +395,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 	public function test_order_note_added_on_failed_send_for_order(): void {
 		$order = $this->createMock( \WC_Order::class );
 		$order->method( 'get_id' )->willReturn( 42 );
+		$order->method( 'get_object_read' )->willReturn( true );
 		$order->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -416,6 +418,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 	public function test_order_note_failure_includes_error_reason(): void {
 		$order = $this->createMock( \WC_Order::class );
 		$order->method( 'get_id' )->willReturn( 42 );
+		$order->method( 'get_object_read' )->willReturn( true );
 		$order->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -438,6 +441,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 	public function test_order_note_failure_redacts_email_addresses_in_reason(): void {
 		$order = $this->createMock( \WC_Order::class );
 		$order->method( 'get_id' )->willReturn( 42 );
+		$order->method( 'get_object_read' )->willReturn( true );
 		$order->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -470,6 +474,22 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 		$this->sut->handle_woocommerce_email_sent( true, 'some_product_email', $email );
 
 		$this->assertLogged( 'info', 'some_product_email' );
+	}
+
+	/**
+	 * @testdox No order note is added when the order object has not been read from the datastore (e.g. a preview dummy).
+	 */
+	public function test_no_order_note_for_unloaded_order_object(): void {
+		$order = $this->createMock( \WC_Order::class );
+		$order->method( 'get_id' )->willReturn( 12345 );
+		$order->method( 'get_object_read' )->willReturn( false );
+		$order->expects( $this->never() )->method( 'add_order_note' );
+
+		$email = $this->create_mock_email( 'customer_processing_order', 'customer@example.com', $order );
+		$this->sut->handle_woocommerce_email_sent( true, 'customer_processing_order', $email );
+
+		// Logger entry should still be written even though no note is added.
+		$this->assertLogged( 'info', 'customer_processing_order' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

Follow-up to #65247 based on a side-effect spotted by @mahangu in [this comment](https://github.com/woocommerce/woocommerce/pull/65247#issuecomment-4560756065).

**The bug:** `EmailPreview` builds its dummy order with `new WC_Order()` + `set_id( 12345 )` — no datastore read, so `get_object_read()` is `false`. The `maybe_add_order_note()` guard in #65247 only checked `instanceof WC_Order`, which the dummy passes. `add_order_note()` then called `wp_insert_comment()` with `comment_post_ID = 12345`, and because WordPress does not verify the post exists, three "Email … sent." notes appeared on whatever real order held that ID after each test-send click.

**The fix:** One additional condition on the early return:

```php
// Before
if ( ! $wc_object instanceof WC_Order ) {

// After
if ( ! $wc_object instanceof WC_Order || ! $wc_object->get_object_read() ) {
```

`WC_Data::set_object_read( true )` is called inside both `WC_Order_Data_Store_CPT::read()` and `OrdersTableDataStore::read()` — i.e. only when an order is actually hydrated from the database. Preview dummies, in-memory objects, and any other `WC_Order` that has never been persisted will have `get_object_read() === false` and are silently skipped.

The WooCommerce logger entry is unaffected — it is written before `maybe_add_order_note()` is called.

### How to test

1. Ensure a customer-facing email is enabled (WooCommerce → Settings → Emails → Processing order).
2. Go to WooCommerce → Settings → Emails → Processing order → **Send test**.
3. **Expected:** no order note is added to any order on the site.
4. Place a real order as a customer so the Processing order email fires.
5. Open that order in WooCommerce → Orders.
6. **Expected:** a private order note "Email 'Processing order' sent." appears (order note behaviour from #65247 is preserved).

### Testing that has already taken place

Unit tests updated — `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter EmailLoggerTest` covers:
- Four existing order-note tests updated to stub `get_object_read()` returning `true` (real-order path).
- New `test_no_order_note_for_unloaded_order_object`: order with `get_object_read() === false` never calls `add_order_note()`, logger entry still written.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [x] This Pull Request does not require a changelog entry. (Bug fix for unreleased feature in #65247 — covered by that PR's changelog.)