### PR TITLE
Fix missing return, unit case mismatch, and undefined key in cart display

### DIFF
--- a/plugins/woocommerce/changelog/65372-fix-formatting-and-cart-bugs
+++ b/plugins/woocommerce/changelog/65372-fix-formatting-and-cart-bugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing return value in wc_get_filename_from_url(), silent unit conversion failures in wc_get_dimension()/wc_get_weight() from unlowercased $from_unit, and undefined array key warning in cart tax display for unknown country codes.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -345,7 +345,7 @@ function wc_cart_totals_order_total_html() {
 		if ( ! empty( $tax_string_array ) ) {
 			$taxable_address = WC()->customer->get_taxable_address();
 			if ( WC()->customer->is_customer_outside_base() && ! WC()->customer->has_calculated_shipping() ) {
-				$country = WC()->countries->estimated_for_prefix( $taxable_address[0] ) . WC()->countries->countries[ $taxable_address[0] ];
+				$country = WC()->countries->estimated_for_prefix( $taxable_address[0] ) . ( WC()->countries->countries[ $taxable_address[0] ] ?? '' );
 				/* translators: 1: tax amount 2: country name */
 				$tax_text = wp_kses_post( sprintf( __( '(includes %1$s estimated for %2$s)', 'woocommerce' ), implode( ', ', $tax_string_array ), $country ) );
 			} else {

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -99,6 +99,7 @@ function wc_get_filename_from_url( $file_url ) {
 	if ( isset( $parts['path'] ) ) {
 		return basename( $parts['path'] );
 	}
+	return '';
 }
 
 /**
@@ -121,6 +122,8 @@ function wc_get_dimension( $dimension, $to_unit, $from_unit = '' ) {
 
 	if ( empty( $from_unit ) ) {
 		$from_unit = strtolower( get_option( 'woocommerce_dimension_unit' ) );
+	} else {
+		$from_unit = strtolower( $from_unit );
 	}
 
 	// Unify all units to cm first.
@@ -181,6 +184,8 @@ function wc_get_weight( $weight, $to_unit, $from_unit = '' ) {
 
 	if ( empty( $from_unit ) ) {
 		$from_unit = strtolower( get_option( 'woocommerce_weight_unit' ) );
+	} else {
+		$from_unit = strtolower( $from_unit );
 	}
 
 	// Unify all units to kg first.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Three bugs in PHP utility functions: `wc_get_filename_from_url()` had no `return` statement in its fallback path, violating its declared `string` return type and causing callers in the product data store, REST API controllers, and CSV importer to receive `null` instead of `''`; `wc_get_dimension()` and `wc_get_weight()` lowercased `$to_unit` but not `$from_unit` when explicitly passed, causing silent unit conversion failures for mixed-case input; `wc_get_cart_totals_tax_total_html()` accessed `WC()->countries->countries[ $taxable_address[0] ]` without a key guard, producing a PHP undefined-key warning when the customer address resolves to an unrecognised country code.

### How to test the changes in this Pull Request:

1. **Missing return** — call `wc_get_filename_from_url( 'http://example.com' )` (URL with no path). Before: returns `null`. After: returns `''`.
2. **Dimension case normalization** — call `wc_get_dimension( 10, 'cm', 'IN' )` (uppercase `$from_unit`). Before: switch doesn't match `'IN'`, value is returned unconverted. After: correctly converts ~25.4.
3. **Weight case normalization** — call `wc_get_weight( 10, 'kg', 'LBS' )`. Before: unconverted. After: returns ~4.54.
4. **Cart countries guard** — add a filter via `woocommerce_customer_taxable_address` returning an address with a nonexistent country code (e.g. `'XX'`). Load the cart page with a taxable product. Before: PHP undefined-key warning in error log. After: renders cleanly with empty country string.

### Testing that has already taken place:

Code review and static analysis. Author to confirm test suite passes before marking ready.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->

Fix missing return value in wc_get_filename_from_url(), silent unit conversion failures in wc_get_dimension()/wc_get_weight() from unlowercased $from_unit, and undefined array key warning in cart tax display for unknown country codes.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)