### PR TITLE
Fix shipping tax rates calculated for empty cart

### DIFF
--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -656,7 +656,7 @@ class WC_Tax {
 
 		// Check if cart has items before proceeding.
 		if ( ! $cart->get_cart() ) {
-			return $standard_tax_class;
+			return null;
 		}
 
 		$cart_tax_classes = $cart->get_cart_item_tax_classes_for_shipping();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`WC_Tax::get_shipping_tax_class_from_cart_items()` returned `''` (empty string) when the cart had no items, but its caller `get_shipping_tax_rates()` gates the early-return on `is_null( $tax_class )`. The empty string bypassed that null check, causing `get_shipping_tax_rates()` to proceed and return standard shipping tax class rates even for an empty cart. This fix changes the return value to `null` to match the caller's contract and ensure an empty cart correctly receives an empty rates array.

### How to test the changes in this Pull Request:

1. Install WooCommerce with at least one shipping tax class configured (WooCommerce → Settings → Tax → Shipping tax class).
2. Clear the cart so it is completely empty.
3. Call `WC_Tax::get_shipping_tax_rates()` directly (e.g., via a snippet or `wp eval`) or proceed to checkout with no items.
4. Confirm the method returns an empty array `[]` rather than the standard tax class rates.
5. Add a taxable product to the cart and repeat: confirm that shipping tax rates are now returned as expected.

### Testing that has already taken place:

Code-level analysis confirmed the return-type mismatch between `get_shipping_tax_class_from_cart_items()` (returning `''`) and the `is_null()` guard in `get_shipping_tax_rates()`. Author to confirm test suite passes before marking ready.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->

Fix `WC_Tax::get_shipping_tax_rates()` returning incorrect rates when cart is empty.

</details>