### PR TITLE
Fix fatal errors from unchecked null returns in cart, coupon, and download functions

### DIFF
--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1162,6 +1162,10 @@ class WC_Cart extends WC_Legacy_Cart {
 				$missing_attributes = array();
 				$parent_data        = wc_get_product( $product_data->get_parent_id() );
 
+				if ( ! $parent_data ) {
+					throw new Exception( __( 'Sorry, this product cannot be added to the cart.', 'woocommerce' ) );
+				}
+
 				$variation_attributes = $product_data->get_variation_attributes();
 				// Filter out 'any' variations, which are empty, as they need to be explicitly specified while adding to cart.
 				$variation_attributes = array_filter( $variation_attributes );

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -1253,8 +1253,10 @@ class WC_Coupon extends WC_Legacy_Coupon {
 
 						if ( count( $intersect ) > 0 ) {
 							foreach ( $intersect as $cat_id ) {
-								$cat          = get_term( $cat_id, 'product_cat' );
-								$categories[] = $cat->name;
+								$cat = get_term( $cat_id, 'product_cat' );
+								if ( $cat instanceof WP_Term ) {
+									$categories[] = $cat->name;
+								}
 							}
 						}
 					}

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -432,6 +432,9 @@ function wc_orders_count( $status, string $type = '' ) {
 function wc_downloadable_file_permission( $download_id, $product, $order, $qty = 1, $item = null ) {
 	if ( is_numeric( $product ) ) {
 		$product = wc_get_product( $product );
+		if ( ! $product ) {
+			return false;
+		}
 	}
 	$download = new WC_Customer_Download();
 	$download->set_download_id( $download_id );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Three functions that accept numeric IDs and resolve them to objects were missing null-safety guards, causing fatal errors when the underlying object no longer exists:

- **`wc_downloadable_file_permission()`** (`wc-order-functions.php`): when a numeric `$product` argument was passed, `wc_get_product()` could return `false`, which was then used without a check — `$product->get_id()` would fatal. Added early `return false` when the product cannot be resolved.
- **Coupon excluded-category validation** (`class-wc-coupon.php`): `get_term()` can return `WP_Error` or `null` for a deleted/invalid term, but `$cat->name` was accessed unconditionally. Added an `instanceof WP_Term` guard so deleted categories are silently skipped rather than causing a fatal.
- **`add_to_cart()` variation validation** (`class-wc-cart.php`): `wc_get_product()` on the variation's parent ID could return `false` (e.g., after the parent product is trashed), but `$parent_data->get_attributes()` was called immediately. Added an early exception to surface a user-friendly error and stop execution cleanly.

### How to test the changes in this Pull Request:

**wc_downloadable_file_permission():**
1. Create a downloadable product and a completed order containing it.
2. Delete the product from the database directly (or use `wp post delete <id> --force`).
3. Trigger `wc_downloadable_file_permission( $download_id, $deleted_product_id, $order )`.
4. Confirm it returns `false` rather than fataling.

**Coupon excluded-category validation:**
1. Create a coupon with an excluded product category.
2. Delete that product category from WooCommerce → Products → Categories.
3. Add a product to the cart and apply the coupon.
4. Confirm no fatal error occurs and the coupon applies or declines gracefully.

**add_to_cart() variation parent check:**
1. Create a variable product with a variation.
2. Trash or delete the parent product while leaving the variation post in the database.
3. Attempt to add the variation to the cart (e.g., via `WC()->cart->add_to_cart( $variation_id, 1, $variation_id )`).
4. Confirm a user-friendly error notice is shown rather than a fatal error.

### Testing that has already taken place:

Code-level analysis confirmed the missing null guards and the resulting fatal-error paths. Author to confirm test suite passes before marking ready.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->

Fix fatal errors when product, variation parent, or category term objects are not found in `wc_downloadable_file_permission()`, coupon category validation, and `WC_Cart::add_to_cart()`.

</details>