### PR TITLE
Fix setting options core data locks

### DIFF
--- a/packages/js/data/changelog/dev-setting-options-core-data-locks
+++ b/packages/js/data/changelog/dev-setting-options-core-data-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Setting options: register the core-data store in tests.

--- a/packages/js/data/src/setting-options/actions.ts
+++ b/packages/js/data/src/setting-options/actions.ts
@@ -37,17 +37,13 @@ type CurriedSelectors< T > = {
 };
 
 type Resolvers = typeof import('./resolvers');
-type StoreLock = {
-	readonly __storeLock: unique symbol;
-};
-type CoreDataLockDispatch = {
-	__unstableAcquireStoreLock: (
-		storeName: string,
-		path: string[],
-		options: { exclusive: boolean }
-	) => Promise< StoreLock >;
-	__unstableReleaseStoreLock: ( lock: StoreLock ) => Promise< void >;
-};
+type CoreDataActions = ReturnType<
+	ReturnType< typeof coreDataStore.instantiate >[ 'getActions' ]
+>;
+type CoreDataLockDispatch = Pick<
+	CoreDataActions,
+	'__unstableAcquireStoreLock' | '__unstableReleaseStoreLock'
+>;
 
 export type ThunkArgs = {
 	select: CurriedSelectors< Selectors >;

--- a/packages/js/data/src/setting-options/actions.ts
+++ b/packages/js/data/src/setting-options/actions.ts
@@ -3,10 +3,6 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import type { createRegistry } from '@wordpress/data';
-import type {
-	ActionCreatorsOf,
-	CurriedSelectorsOf,
-} from '@wordpress/data/build-types/types';
 import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
@@ -24,9 +20,10 @@ import type {
 	SettingsState,
 } from './types';
 import { NAMESPACE } from '../constants';
-import { store, STORE_NAME } from './';
+import { STORE_NAME } from './';
 
 type WPDataRegistry = ReturnType< typeof createRegistry >;
+type Selectors = typeof import('./selectors');
 
 type CurriedState< F > = F extends (
 	state: SettingsState,
@@ -35,10 +32,23 @@ type CurriedState< F > = F extends (
 	? ( ...args: P ) => R
 	: F;
 
+type CurriedSelectors< T > = {
+	[ K in keyof T ]: CurriedState< T[ K ] >;
+};
+
 type Resolvers = typeof import('./resolvers');
+type StoreLock = unknown;
+type StoreLockDispatch = {
+	__unstableAcquireStoreLock: (
+		storeName: string,
+		path: string[],
+		options: { exclusive: boolean }
+	) => Promise< StoreLock >;
+	__unstableReleaseStoreLock: ( lock: StoreLock ) => Promise< void >;
+};
 
 export type ThunkArgs = {
-	select: CurriedSelectorsOf< typeof store >;
+	select: CurriedSelectors< Selectors >;
 	resolveSelect: CurriedState< Resolvers >;
 	dispatch: ActionDispatchersForThunk;
 	registry: WPDataRegistry;
@@ -413,27 +423,31 @@ export const saveEditedSetting =
 		return saveSettingRequest( groupId, settingId, value, dispatch );
 	};
 
-type CoreDataActions = ActionCreatorsOf< typeof coreDataStore >;
+const getCoreDataLockDispatch = (
+	registry: WPDataRegistry
+): StoreLockDispatch =>
+	registry.dispatch( coreDataStore ) as unknown as StoreLockDispatch;
+
 type UnstableAcquireStoreLockParams = Parameters<
-	CoreDataActions[ '__unstableAcquireStoreLock' ]
+	StoreLockDispatch[ '__unstableAcquireStoreLock' ]
 >;
 type UnstableReleaseStoreLockParams = Parameters<
-	CoreDataActions[ '__unstableReleaseStoreLock' ]
+	StoreLockDispatch[ '__unstableReleaseStoreLock' ]
 >;
 
 export const __unstableAcquireStoreLock =
 	( ...args: UnstableAcquireStoreLockParams ) =>
 	( { registry }: ThunkArgs ) =>
-		registry
-			.dispatch( coreDataStore )
-			.__unstableAcquireStoreLock( ...args );
+		getCoreDataLockDispatch( registry ).__unstableAcquireStoreLock(
+			...args
+		);
 
 export const __unstableReleaseStoreLock =
 	( ...args: UnstableReleaseStoreLockParams ) =>
 	( { registry }: ThunkArgs ) =>
-		registry
-			.dispatch( coreDataStore )
-			.__unstableReleaseStoreLock( ...args );
+		getCoreDataLockDispatch( registry ).__unstableReleaseStoreLock(
+			...args
+		);
 
 // Return type of all action creators
 export type Actions = ReturnType<
@@ -460,7 +474,7 @@ export type ActionDispatchersForThunk = {
 	saveEditedSettingsGroup: typeof saveEditedSettingsGroup;
 	saveSetting: typeof saveSetting;
 	saveSettingsGroup: typeof saveSettingsGroup;
-	__unstableAcquireStoreLock: typeof __unstableAcquireStoreLock;
-	__unstableReleaseStoreLock: typeof __unstableReleaseStoreLock;
+	__unstableAcquireStoreLock: StoreLockDispatch[ '__unstableAcquireStoreLock' ];
+	__unstableReleaseStoreLock: StoreLockDispatch[ '__unstableReleaseStoreLock' ];
 	< T = Record< string, unknown > >( args: T ): void;
 };

--- a/packages/js/data/src/setting-options/actions.ts
+++ b/packages/js/data/src/setting-options/actions.ts
@@ -37,17 +37,17 @@ type CurriedSelectors< T > = {
 };
 
 type Resolvers = typeof import('./resolvers');
-type StoreActions< StoreDescriptor > = StoreDescriptor extends {
-	instantiate: ( ...args: never[] ) => infer StoreInstance;
-}
-	? StoreInstance extends { getActions: () => infer Actions }
-		? Actions
-		: never
-	: never;
-type CoreDataLockDispatch = Pick<
-	StoreActions< typeof coreDataStore >,
-	'__unstableAcquireStoreLock' | '__unstableReleaseStoreLock'
->;
+type StoreLock = {
+	readonly __storeLock: unique symbol;
+};
+type CoreDataLockDispatch = {
+	__unstableAcquireStoreLock: (
+		storeName: string,
+		path: string[],
+		options: { exclusive: boolean }
+	) => Promise< StoreLock >;
+	__unstableReleaseStoreLock: ( lock: StoreLock ) => Promise< void >;
+};
 
 export type ThunkArgs = {
 	select: CurriedSelectors< Selectors >;

--- a/packages/js/data/src/setting-options/actions.ts
+++ b/packages/js/data/src/setting-options/actions.ts
@@ -37,15 +37,17 @@ type CurriedSelectors< T > = {
 };
 
 type Resolvers = typeof import('./resolvers');
-type StoreLock = unknown;
-type StoreLockDispatch = {
-	__unstableAcquireStoreLock: (
-		storeName: string,
-		path: string[],
-		options: { exclusive: boolean }
-	) => Promise< StoreLock >;
-	__unstableReleaseStoreLock: ( lock: StoreLock ) => Promise< void >;
-};
+type StoreActions< StoreDescriptor > = StoreDescriptor extends {
+	instantiate: ( ...args: never[] ) => infer StoreInstance;
+}
+	? StoreInstance extends { getActions: () => infer Actions }
+		? Actions
+		: never
+	: never;
+type CoreDataLockDispatch = Pick<
+	StoreActions< typeof coreDataStore >,
+	'__unstableAcquireStoreLock' | '__unstableReleaseStoreLock'
+>;
 
 export type ThunkArgs = {
 	select: CurriedSelectors< Selectors >;
@@ -425,14 +427,14 @@ export const saveEditedSetting =
 
 const getCoreDataLockDispatch = (
 	registry: WPDataRegistry
-): StoreLockDispatch =>
-	registry.dispatch( coreDataStore ) as unknown as StoreLockDispatch;
+): CoreDataLockDispatch =>
+	registry.dispatch( coreDataStore ) as CoreDataLockDispatch;
 
 type UnstableAcquireStoreLockParams = Parameters<
-	StoreLockDispatch[ '__unstableAcquireStoreLock' ]
+	CoreDataLockDispatch[ '__unstableAcquireStoreLock' ]
 >;
 type UnstableReleaseStoreLockParams = Parameters<
-	StoreLockDispatch[ '__unstableReleaseStoreLock' ]
+	CoreDataLockDispatch[ '__unstableReleaseStoreLock' ]
 >;
 
 export const __unstableAcquireStoreLock =
@@ -474,7 +476,7 @@ export type ActionDispatchersForThunk = {
 	saveEditedSettingsGroup: typeof saveEditedSettingsGroup;
 	saveSetting: typeof saveSetting;
 	saveSettingsGroup: typeof saveSettingsGroup;
-	__unstableAcquireStoreLock: StoreLockDispatch[ '__unstableAcquireStoreLock' ];
-	__unstableReleaseStoreLock: StoreLockDispatch[ '__unstableReleaseStoreLock' ];
+	__unstableAcquireStoreLock: CoreDataLockDispatch[ '__unstableAcquireStoreLock' ];
+	__unstableReleaseStoreLock: CoreDataLockDispatch[ '__unstableReleaseStoreLock' ];
 	< T = Record< string, unknown > >( args: T ): void;
 };

--- a/packages/js/data/src/setting-options/actions.ts
+++ b/packages/js/data/src/setting-options/actions.ts
@@ -3,11 +3,11 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import type { createRegistry } from '@wordpress/data';
-import type { CurriedSelectorsOf } from '@wordpress/data/build-types/types';
-import type CreateLocksActions from '@wordpress/core-data/build-types/locks/actions';
-// @ts-expect-error WP core data doesn't explicitly export the actions
-// eslint-disable-next-line @woocommerce/dependency-group
-import createLocksActions from '@wordpress/core-data/build/locks/actions';
+import type {
+	ActionCreatorsOf,
+	CurriedSelectorsOf,
+} from '@wordpress/data/build-types/types';
+import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -413,13 +413,27 @@ export const saveEditedSetting =
 		return saveSettingRequest( groupId, settingId, value, dispatch );
 	};
 
-const lockActions = createLocksActions() as ReturnType<
-	typeof CreateLocksActions
+type CoreDataActions = ActionCreatorsOf< typeof coreDataStore >;
+type UnstableAcquireStoreLockParams = Parameters<
+	CoreDataActions[ '__unstableAcquireStoreLock' ]
 >;
+type UnstableReleaseStoreLockParams = Parameters<
+	CoreDataActions[ '__unstableReleaseStoreLock' ]
+>;
+
 export const __unstableAcquireStoreLock =
-	lockActions.__unstableAcquireStoreLock;
+	( ...args: UnstableAcquireStoreLockParams ) =>
+	( { registry }: ThunkArgs ) =>
+		registry
+			.dispatch( coreDataStore )
+			.__unstableAcquireStoreLock( ...args );
+
 export const __unstableReleaseStoreLock =
-	lockActions.__unstableReleaseStoreLock;
+	( ...args: UnstableReleaseStoreLockParams ) =>
+	( { registry }: ThunkArgs ) =>
+		registry
+			.dispatch( coreDataStore )
+			.__unstableReleaseStoreLock( ...args );
 
 // Return type of all action creators
 export type Actions = ReturnType<
@@ -446,5 +460,7 @@ export type ActionDispatchersForThunk = {
 	saveEditedSettingsGroup: typeof saveEditedSettingsGroup;
 	saveSetting: typeof saveSetting;
 	saveSettingsGroup: typeof saveSettingsGroup;
+	__unstableAcquireStoreLock: typeof __unstableAcquireStoreLock;
+	__unstableReleaseStoreLock: typeof __unstableReleaseStoreLock;
 	< T = Record< string, unknown > >( args: T ): void;
-} & ReturnType< typeof CreateLocksActions >;
+};

--- a/packages/js/data/src/setting-options/test/utils.ts
+++ b/packages/js/data/src/setting-options/test/utils.ts
@@ -3,6 +3,7 @@
  */
 import { createRegistry } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
+import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -13,15 +14,13 @@ import * as actions from '../actions';
 import reducer from '../reducer';
 import type { SettingsState } from '../types';
 import { Setting, SettingsGroup } from '../types';
-// @ts-expect-error WP core data doesn't explicitly export the actions
-// eslint-disable-next-line @woocommerce/dependency-group
-import createLocksActions from '@wordpress/core-data/build/locks/actions';
 
 /**
  * Creates a fresh registry and store for testing.
  */
 export const createTestRegistryAndStore = () => {
 	const registry = createRegistry();
+	registry.register( coreDataStore );
 
 	// Create initial state matching the reducer's initial state
 	const initialState: SettingsState = {
@@ -37,10 +36,7 @@ export const createTestRegistryAndStore = () => {
 
 	const store = registry.registerStore( STORE_NAME, {
 		reducer,
-		actions: {
-			...actions,
-			...createLocksActions(),
-		},
+		actions,
 		controls,
 		selectors,
 		initialState, // Pass initial state to ensure fresh state each time


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While working on https://github.com/woocommerce/woocommerce/pull/65308, I noticed an improvement that could already be merged in trunk.

With this PR, the setting store can be locked using the `core-data` without importing private functions. 

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Ensure that the CI is green.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

A manual changelog entry was added in `packages/js/data/changelog/dev-setting-options-core-data-locks`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>