### PR TITLE
POS staff server-side: store-actor POC (M1)

### DIFF
--- a/plugins/woocommerce/changelog/feature-pos-actors-poc
+++ b/plugins/woocommerce/changelog/feature-pos-actors-poc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Point of Sale store-actor model and read-only staff REST endpoint (dev-only `point_of_sale_actors` feature flag). Introduces wc_store_actors and wc_store_actor_access tables; replaces the prior WP-roles approach so POS-only staff are not wp_users.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-pos-staff.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-pos-staff.php
@@ -1,0 +1,835 @@
+<?php
+/**
+ * WooCommerce Admin POS Staff (actors) Class
+ *
+ * @package WooCommerce\Admin
+ * @since   10.9.0
+ */
+
+declare(strict_types=1);
+
+use Automattic\WooCommerce\Internal\POS\Actors\AccessProfileRegistry;
+use Automattic\WooCommerce\Internal\POS\POSController;
+use Automattic\WooCommerce\Internal\POS\Service\POSPinService;
+use Automattic\WooCommerce\Internal\StoreActors\ActorAccessRepository;
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_POS_Staff.
+ *
+ * wp-admin UI for managing store actors with POS access. Backed by the
+ * wc_store_actors and wc_store_actor_access tables (NOT wp_users). Gated
+ * behind the `point_of_sale_actors` dev feature flag.
+ *
+ * Rendered under Settings → Point of Sale → Staff. Supports:
+ *   - List active actors with display name, profile, PIN status.
+ *   - Add new actor (POS-only, with optional wp_user_id link, profile selector, optional initial PIN).
+ *   - Edit actor (display name, profile, status).
+ *   - Set / clear PIN.
+ *   - Soft-delete actor.
+ *
+ * @internal Owned by the Point of Sale staff (actors) feature.
+ * @since 10.9.0
+ */
+class WC_Admin_POS_Staff {
+
+	private const NONCE_NEW    = 'wc_pos_actors_new';
+	private const NONCE_EDIT   = 'wc_pos_actors_edit';
+	private const NONCE_DELETE = 'wc_pos_actors_delete';
+
+	private const NOTICE_TRANSIENT_PREFIX = 'wc_pos_staff_notice_';
+
+	/**
+	 * Cached notice for the current page render. Use set_notice() to write —
+	 * it can also persist the notice via transient for cross-redirect display.
+	 *
+	 * @var array{type:string,message:string}|null
+	 */
+	private static ?array $notice = null;
+
+	/**
+	 * Initialize hooks.
+	 */
+	public function __construct() {
+		add_action( 'admin_init', array( $this, 'handle_actions' ) );
+		add_action( 'admin_notices', array( $this, 'render_admin_notices' ) );
+		add_action( 'wp_ajax_wc_pos_actor_check_wp_user_role', array( $this, 'ajax_check_wp_user_role' ) );
+	}
+
+	/**
+	 * Set the form notice. When $persist is true, the notice is also stored
+	 * in a per-user transient so it survives a subsequent wp_safe_redirect.
+	 *
+	 * @param string $type    'success' or 'error'.
+	 * @param string $message Translated, plain-text message.
+	 * @param bool   $persist Persist across redirect via transient.
+	 * @return void
+	 */
+	private static function set_notice( string $type, string $message, bool $persist = false ): void {
+		self::$notice = array( 'type' => $type, 'message' => $message );
+		if ( $persist ) {
+			set_transient(
+				self::NOTICE_TRANSIENT_PREFIX . get_current_user_id(),
+				self::$notice,
+				60
+			);
+		}
+	}
+
+	/**
+	 * Read a persisted notice from the transient (if any) into the static
+	 * cache, then delete it so it only renders once.
+	 *
+	 * @return void
+	 */
+	private static function consume_persisted_notice(): void {
+		if ( null !== self::$notice ) {
+			return;
+		}
+		$key    = self::NOTICE_TRANSIENT_PREFIX . get_current_user_id();
+		$stored = get_transient( $key );
+		if ( is_array( $stored ) && isset( $stored['type'], $stored['message'] ) ) {
+			delete_transient( $key );
+			self::$notice = array(
+				'type'    => (string) $stored['type'],
+				'message' => (string) $stored['message'],
+			);
+		}
+	}
+
+	/**
+	 * admin_notices callback. Restricted to the Staff sub-section so we don't
+	 * leak notices onto other wp-admin pages.
+	 *
+	 * @return void
+	 */
+	public function render_admin_notices(): void {
+		if ( ! self::is_enabled() || ! $this->is_staff_page() ) {
+			return;
+		}
+		self::notices();
+	}
+
+	/**
+	 * AJAX handler used by the staff form to detect whether a freshly-selected
+	 * WP user is an administrator or shop_manager. The client toggles the
+	 * access-profile selector vs. the "POS Admin auto-assigned" display
+	 * based on the response.
+	 *
+	 * @return void
+	 */
+	public function ajax_check_wp_user_role(): void {
+		check_ajax_referer( 'wc_pos_actor_check_wp_user_role', '_wpnonce' );
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( array( 'message' => 'forbidden' ), 403 );
+		}
+
+		$user_id = isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0;
+		wp_send_json_success(
+			array(
+				'is_admin_or_shop_manager' => self::is_admin_or_shop_manager( $user_id ),
+			)
+		);
+	}
+
+	/**
+	 * Whether the staff actors admin UI is currently enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled(): bool {
+		return FeaturesUtil::feature_is_enabled( 'point_of_sale' )
+			&& FeaturesUtil::feature_is_enabled( POSController::FEATURE_FLAG );
+	}
+
+	/**
+	 * Output notices set by this page's POST handlers. Reads from the static
+	 * cache first; falls back to the per-user transient so notices set right
+	 * before a redirect (e.g. successful create → redirect to edit) still
+	 * display on the next request.
+	 *
+	 * @return void
+	 */
+	public static function notices(): void {
+		self::consume_persisted_notice();
+		if ( null === self::$notice ) {
+			return;
+		}
+		$class = 'error' === self::$notice['type'] ? 'notice-error' : 'notice-success';
+		printf(
+			'<div class="notice %1$s is-dismissible"><p>%2$s</p></div>',
+			esc_attr( $class ),
+			esc_html( self::$notice['message'] )
+		);
+		self::$notice = null;
+	}
+
+	/**
+	 * Page output entry point. Routes to list / new / edit views based on query args.
+	 *
+	 * @return void
+	 */
+	public static function page_output(): void {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage POS staff.', 'woocommerce' ) );
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['new-actor'] ) ) {
+			self::render_form( null );
+			return;
+		}
+
+		if ( isset( $_GET['edit-actor'] ) ) {
+			$actor_id = absint( $_GET['edit-actor'] );
+			self::render_form( $actor_id );
+			return;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		self::render_list();
+	}
+
+	/**
+	 * Render the list of actors.
+	 *
+	 * @return void
+	 */
+	private static function render_list(): void {
+		$actor_repo  = wc_get_container()->get( ActorRepository::class );
+		$access_repo = wc_get_container()->get( ActorAccessRepository::class );
+		$profiles    = wc_get_container()->get( AccessProfileRegistry::class );
+
+		$actors = $actor_repo->list_active( 200 );
+		$new_url    = add_query_arg(
+			array(
+				'page'       => 'wc-settings',
+				'tab'        => 'point-of-sale',
+				'section'    => 'staff',
+				'new-actor'  => '1',
+			),
+			admin_url( 'admin.php' )
+		);
+
+		echo '<div class="wc-pos-staff-page">';
+		echo '<h2>' . esc_html__( 'POS staff', 'woocommerce' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Manage Point of Sale staff who sign in to the POS app with a PIN. Staff are stored independently of WordPress users; any existing WordPress user can optionally be linked.', 'woocommerce' ) . '</p>';
+		echo '<p><a class="button button-primary" href="' . esc_url( $new_url ) . '">' . esc_html__( 'Add POS staff', 'woocommerce' ) . '</a></p>';
+
+		echo '<table class="wp-list-table widefat fixed striped">';
+		echo '<thead><tr>';
+		echo '<th>' . esc_html__( 'Name', 'woocommerce' ) . '</th>';
+		echo '<th>' . esc_html__( 'Profile', 'woocommerce' ) . '</th>';
+		echo '<th>' . esc_html__( 'Linked WP user', 'woocommerce' ) . '</th>';
+		echo '<th>' . esc_html__( 'PIN', 'woocommerce' ) . '</th>';
+		echo '<th>' . esc_html__( 'Status', 'woocommerce' ) . '</th>';
+		echo '<th>' . esc_html__( 'Actions', 'woocommerce' ) . '</th>';
+		echo '</tr></thead><tbody>';
+
+		if ( empty( $actors ) ) {
+			echo '<tr><td colspan="6">' . esc_html__( 'No POS staff yet.', 'woocommerce' ) . '</td></tr>';
+		} else {
+			foreach ( $actors as $actor ) {
+				$actor_id = (int) $actor['actor_id'];
+				$access   = $access_repo->get_for_actor( $actor_id );
+				$profile  = $access ? $profiles->get( (string) $access['access_profile_key'] ) : null;
+				$wp_user  = ! empty( $actor['wp_user_id'] ) ? get_userdata( (int) $actor['wp_user_id'] ) : null;
+				$has_pin  = $access && ! empty( $access['credential_hash'] );
+
+				$edit_url   = add_query_arg(
+					array(
+						'page'       => 'wc-settings',
+						'tab'        => 'point-of-sale',
+						'section'    => 'staff',
+						'edit-actor' => $actor_id,
+					),
+					admin_url( 'admin.php' )
+				);
+				$delete_url = wp_nonce_url(
+					add_query_arg(
+						array(
+							'page'         => 'wc-settings',
+							'tab'          => 'point-of-sale',
+							'section'      => 'staff',
+							'delete-actor' => $actor_id,
+						),
+						admin_url( 'admin.php' )
+					),
+					self::NONCE_DELETE,
+					'_wpnonce'
+				);
+
+				echo '<tr>';
+				echo '<td>' . esc_html( (string) $actor['display_name'] ) . '</td>';
+				echo '<td>' . esc_html( $profile ? (string) $profile['name'] : ( $access ? (string) $access['access_profile_key'] : '—' ) ) . '</td>';
+				echo '<td>' . ( $wp_user ? esc_html( $wp_user->user_login ) : '—' ) . '</td>';
+				echo '<td>' . ( $has_pin ? esc_html__( 'Set', 'woocommerce' ) : esc_html__( 'Not set', 'woocommerce' ) ) . '</td>';
+				echo '<td>' . esc_html( (string) $actor['status'] ) . '</td>';
+				echo '<td>';
+				echo '<a href="' . esc_url( $edit_url ) . '">' . esc_html__( 'Edit', 'woocommerce' ) . '</a> | ';
+				echo '<a href="' . esc_url( $delete_url ) . '" onclick="return confirm(\'' . esc_js( __( 'Delete this POS staff member?', 'woocommerce' ) ) . '\');">' . esc_html__( 'Delete', 'woocommerce' ) . '</a>';
+				echo '</td>';
+				echo '</tr>';
+			}
+		}
+
+		echo '</tbody></table>';
+		echo '</div>';
+	}
+
+	/**
+	 * Render the new/edit form. When $actor_id is null, renders the "new" form.
+	 *
+	 * @param int|null $actor_id Actor ID to edit, or null for new.
+	 * @return void
+	 */
+	private static function render_form( ?int $actor_id ): void {
+		$actor_repo  = wc_get_container()->get( ActorRepository::class );
+		$access_repo = wc_get_container()->get( ActorAccessRepository::class );
+		$profiles    = wc_get_container()->get( AccessProfileRegistry::class );
+		$pin_service = wc_get_container()->get( POSPinService::class );
+
+		$actor   = $actor_id ? $actor_repo->get_by_id( $actor_id ) : null;
+		$access  = $actor_id ? $access_repo->get_for_actor( $actor_id ) : null;
+		$has_pin = $actor_id ? $pin_service->has_pin( $actor_id ) : false;
+
+		if ( $actor_id && null === $actor ) {
+			wp_die( esc_html__( 'POS staff member not found.', 'woocommerce' ) );
+		}
+
+		$back_url = add_query_arg(
+			array(
+				'page'    => 'wc-settings',
+				'tab'     => 'point-of-sale',
+				'section' => 'staff',
+			),
+			admin_url( 'admin.php' )
+		);
+
+		$is_new = null === $actor_id;
+		$nonce  = $is_new ? self::NONCE_NEW : self::NONCE_EDIT;
+
+		echo '<div class="wc-pos-staff-page">';
+		echo '<h2>' . esc_html( $is_new ? __( 'Add POS staff', 'woocommerce' ) : __( 'Edit POS staff', 'woocommerce' ) ) . '</h2>';
+		echo '<p><a href="' . esc_url( $back_url ) . '">&larr; ' . esc_html__( 'Back to list', 'woocommerce' ) . '</a></p>';
+
+		echo '<form method="post" action="">';
+		wp_nonce_field( $nonce, '_wpnonce' );
+
+		if ( ! $is_new ) {
+			echo '<input type="hidden" name="actor_id" value="' . esc_attr( (string) $actor_id ) . '" />';
+		}
+
+		echo '<table class="form-table"><tbody>';
+
+		self::field_text( 'display_name', __( 'Display name', 'woocommerce' ), $actor['display_name'] ?? '', true );
+		self::field_text( 'first_name', __( 'First name', 'woocommerce' ), $actor['first_name'] ?? '' );
+		self::field_text( 'last_name', __( 'Last name', 'woocommerce' ), $actor['last_name'] ?? '' );
+		self::field_text( 'email', __( 'Email (optional)', 'woocommerce' ), $actor['email'] ?? '', false, 'email' );
+		self::field_user_search( (int) ( $actor['wp_user_id'] ?? 0 ) );
+
+		$linked_is_admin = self::is_admin_or_shop_manager( (int) ( $actor['wp_user_id'] ?? 0 ) );
+		$current_profile = $access['access_profile_key'] ?? AccessProfileRegistry::PROFILE_CASHIER;
+		$admin_profile   = $profiles->get( AccessProfileRegistry::PROFILE_ADMIN );
+		$admin_label     = null !== $admin_profile ? (string) $admin_profile['name'] : 'POS Admin';
+
+		// Selector row — shown when the linked user is not admin/shop_manager (or no link).
+		echo '<tr class="wc-pos-profile-selector-row" style="' . ( $linked_is_admin ? 'display:none;' : '' ) . '">';
+		echo '<th><label for="access_profile_key">' . esc_html__( 'Access profile', 'woocommerce' ) . '</label></th><td>';
+		echo '<select id="access_profile_key" name="access_profile_key">';
+		foreach ( array( AccessProfileRegistry::PROFILE_CASHIER, AccessProfileRegistry::PROFILE_MANAGER ) as $key ) {
+			$profile = $profiles->get( $key );
+			if ( null === $profile ) {
+				continue;
+			}
+			echo '<option value="' . esc_attr( $key ) . '"' . selected( $current_profile, $key, false ) . '>'
+				. esc_html( (string) $profile['name'] ) . '</option>';
+		}
+		echo '</select>';
+		echo '</td></tr>';
+
+		// Auto-assigned row — shown when the linked user is admin/shop_manager.
+		echo '<tr class="wc-pos-profile-admin-row" style="' . ( $linked_is_admin ? '' : 'display:none;' ) . '">';
+		echo '<th>' . esc_html__( 'Access profile', 'woocommerce' ) . '</th><td>';
+		echo '<strong>' . esc_html( $admin_label ) . '</strong>';
+		echo '<p class="description">' . esc_html__( 'Linked to an administrator or shop manager — POS Admin access is assigned automatically.', 'woocommerce' ) . '</p>';
+		echo '</td></tr>';
+
+		self::field_pin( $has_pin, $is_new );
+
+		if ( ! $is_new ) {
+			echo '<tr><th><label for="status">' . esc_html__( 'Status', 'woocommerce' ) . '</label></th><td>';
+			echo '<select id="status" name="status">';
+			foreach ( array( ActorRepository::STATUS_ACTIVE, ActorRepository::STATUS_INACTIVE ) as $s ) {
+				echo '<option value="' . esc_attr( $s ) . '"' . selected( $actor['status'] ?? '', $s, false ) . '>' . esc_html( $s ) . '</option>';
+			}
+			echo '</select></td></tr>';
+		}
+
+		echo '</tbody></table>';
+
+		echo '<p class="submit">';
+		submit_button( $is_new ? __( 'Create POS staff', 'woocommerce' ) : __( 'Save changes', 'woocommerce' ), 'primary', 'wc_pos_actor_submit', false );
+		if ( ! $is_new && $has_pin ) {
+			echo ' ';
+			submit_button( __( 'Remove PIN', 'woocommerce' ), 'delete', 'wc_pos_actor_remove_pin', false );
+		}
+		echo '</p>';
+		echo '</form>';
+
+		self::print_form_toggle_script();
+
+		echo '</div>';
+	}
+
+	/**
+	 * Print the inline script that listens for changes on the wp_user_id
+	 * select (wc-customer-search) and toggles between the access-profile
+	 * selector and the "POS Admin auto-assigned" notice based on the chosen
+	 * user's role. The result is fetched via a lightweight admin-ajax call
+	 * to keep the role lookup out of the page payload.
+	 *
+	 * @return void
+	 */
+	private static function print_form_toggle_script(): void {
+		$nonce = wp_create_nonce( 'wc_pos_actor_check_wp_user_role' );
+		?>
+		<script type="text/javascript">
+		(function ($) {
+			$(function () {
+				var $userSelect    = $('#wp_user_id');
+				var $selectorRow   = $('.wc-pos-profile-selector-row');
+				var $adminRow      = $('.wc-pos-profile-admin-row');
+				if (!$userSelect.length) {
+					return;
+				}
+
+				function applyState(isAdmin) {
+					if (isAdmin) {
+						$selectorRow.hide();
+						$adminRow.show();
+					} else {
+						$selectorRow.show();
+						$adminRow.hide();
+					}
+				}
+
+				$userSelect.on('change', function () {
+					var userId = parseInt($userSelect.val(), 10);
+					if (!userId) {
+						applyState(false);
+						return;
+					}
+					$.post(ajaxurl, {
+						action: 'wc_pos_actor_check_wp_user_role',
+						_wpnonce: <?php echo wp_json_encode( $nonce ); ?>,
+						user_id: userId
+					}).done(function (response) {
+						if (response && response.success) {
+							applyState(!!response.data.is_admin_or_shop_manager);
+						}
+					});
+				});
+			});
+		})(jQuery);
+		</script>
+		<?php
+	}
+
+	/**
+	 * Render the "Linked WordPress user" row as a wc-customer-search enhanced
+	 * select. WC's admin assets pick the class up and wire it to the
+	 * `woocommerce_json_search_customers` ajax endpoint with select2-style
+	 * search by name / email / login.
+	 *
+	 * @param int $current_user_id Currently linked user ID (0 when unlinked).
+	 * @return void
+	 */
+	private static function field_user_search( int $current_user_id ): void {
+		$pre_selected = '';
+		if ( $current_user_id > 0 ) {
+			$user = get_userdata( $current_user_id );
+			if ( $user ) {
+				$pre_selected = sprintf(
+					'<option value="%1$d" selected="selected">%2$s</option>',
+					$current_user_id,
+					esc_html( sprintf( '%s (#%d – %s)', $user->display_name, $user->ID, $user->user_email ) )
+				);
+			}
+		}
+
+		echo '<tr><th><label for="wp_user_id">' . esc_html__( 'Linked WordPress user (optional)', 'woocommerce' ) . '</label></th><td>';
+		echo '<select id="wp_user_id" name="wp_user_id" class="wc-customer-search" style="width:50%;" '
+			. 'data-placeholder="' . esc_attr__( 'Search by name, login, or email&hellip;', 'woocommerce' ) . '" '
+			. 'data-allow_clear="true" '
+			. 'data-action="woocommerce_json_search_customers">';
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $pre_selected is escaped above.
+		echo $pre_selected;
+		echo '</select>';
+		echo '<p class="description">' . esc_html__( 'Link this POS staff member to any existing WordPress user. Leave blank for POS-only staff with no WordPress account.', 'woocommerce' ) . '</p>';
+		echo '</td></tr>';
+	}
+
+	/**
+	 * Render the inline PIN row. Required when creating a new staff member
+	 * (a staff member without a PIN can't operate POS, so there's no value
+	 * in creating one). Optional on edit — empty means "keep current PIN".
+	 *
+	 * @param bool $has_pin Whether the staff member currently has a PIN set.
+	 * @param bool $is_new  Whether this is the create form.
+	 * @return void
+	 */
+	private static function field_pin( bool $has_pin, bool $is_new ): void {
+		$required_attr = $is_new ? ' required' : '';
+		$label         = $is_new
+			? __( '4-digit PIN', 'woocommerce' )
+			: __( '4-digit PIN', 'woocommerce' );
+
+		echo '<tr><th><label for="pin">' . esc_html( $label ) . ( $is_new ? ' <span class="description">*</span>' : '' ) . '</label></th><td>';
+		echo '<input type="text" inputmode="numeric" pattern="\\d{4}" maxlength="4" id="pin" name="pin" autocomplete="off"' . $required_attr . ' />';
+		echo '<p class="description">';
+		if ( $is_new ) {
+			esc_html_e( 'Required. Enter a 4-digit PIN the staff member will use to sign in to the POS app.', 'woocommerce' );
+		} elseif ( $has_pin ) {
+			esc_html_e( 'A PIN is currently set. Enter a new value to replace it, or leave blank to keep it.', 'woocommerce' );
+		} else {
+			esc_html_e( 'No PIN is currently set. Enter a 4-digit PIN to allow this staff member to sign in to the POS app.', 'woocommerce' );
+		}
+		echo '</p>';
+		echo '</td></tr>';
+	}
+
+	/**
+	 * Decide which access profile a staff member should be assigned.
+	 *
+	 * If linked to an administrator or shop_manager, the POS Admin profile is
+	 * forced (the form hides the selector in this case). Otherwise, the
+	 * profile key from POST is used — restricted to the two selectable keys
+	 * (cashier, manager) so a hand-crafted request can't sneak `pos_admin`
+	 * in without the role check.
+	 *
+	 * @param int $wp_user_id Linked WP user ID (0 for POS-only staff).
+	 * @return string Profile key.
+	 */
+	private static function resolve_access_profile_key( int $wp_user_id ): string {
+		if ( self::is_admin_or_shop_manager( $wp_user_id ) ) {
+			return AccessProfileRegistry::PROFILE_ADMIN;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonces are checked in action_create / action_update before this is called.
+		$submitted = isset( $_POST['access_profile_key'] ) ? sanitize_text_field( wp_unslash( $_POST['access_profile_key'] ) ) : '';
+		if ( in_array( $submitted, array( AccessProfileRegistry::PROFILE_CASHIER, AccessProfileRegistry::PROFILE_MANAGER ), true ) ) {
+			return $submitted;
+		}
+
+		// Default to cashier when nothing valid was submitted.
+		return AccessProfileRegistry::PROFILE_CASHIER;
+	}
+
+	/**
+	 * Whether the given WP user holds the administrator or shop_manager role.
+	 * Used to decide whether to auto-assign the POS Admin access profile.
+	 *
+	 * @param int $wp_user_id WordPress user ID (0 means no link).
+	 * @return bool
+	 */
+	private static function is_admin_or_shop_manager( int $wp_user_id ): bool {
+		if ( $wp_user_id <= 0 ) {
+			return false;
+		}
+		$user = get_userdata( $wp_user_id );
+		if ( ! $user ) {
+			return false;
+		}
+		$roles = (array) $user->roles;
+		return in_array( 'administrator', $roles, true ) || in_array( 'shop_manager', $roles, true );
+	}
+
+	/**
+	 * Helper to render a labeled text field row.
+	 *
+	 * @param string $name     Field name (and id).
+	 * @param string $label    Label.
+	 * @param string $value    Current value.
+	 * @param bool   $required Whether required.
+	 * @param string $type     HTML input type.
+	 * @return void
+	 */
+	private static function field_text( string $name, string $label, $value, bool $required = false, string $type = 'text' ): void {
+		printf(
+			'<tr><th><label for="%1$s">%2$s</label></th><td><input type="%3$s" id="%1$s" name="%1$s" value="%4$s"%5$s /></td></tr>',
+			esc_attr( $name ),
+			esc_html( $label ),
+			esc_attr( $type ),
+			esc_attr( (string) $value ),
+			$required ? ' required' : ''
+		);
+	}
+
+	/**
+	 * POST handler. Routes to create / update / delete / set-pin / clear-pin.
+	 *
+	 * @return void
+	 */
+	public function handle_actions(): void {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+		if ( ! $this->is_staff_page() ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		// Delete (GET with nonce).
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['delete-actor'] ) ) {
+			$this->action_delete();
+			return;
+		}
+
+		if ( 'POST' !== ( isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) : '' ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( isset( $_POST['wc_pos_actor_remove_pin'] ) ) {
+			$actor_id = isset( $_POST['actor_id'] ) ? absint( $_POST['actor_id'] ) : 0;
+			if ( $actor_id > 0 ) {
+				$this->action_remove_pin( $actor_id );
+			}
+			return;
+		}
+		if ( isset( $_POST['wc_pos_actor_submit'] ) ) {
+			$actor_id = isset( $_POST['actor_id'] ) ? absint( $_POST['actor_id'] ) : 0;
+			if ( $actor_id > 0 ) {
+				$this->action_update( $actor_id );
+			} else {
+				$this->action_create();
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * Whether the current request is on the Staff sub-section.
+	 *
+	 * @return bool
+	 */
+	private function is_staff_page(): bool {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		return isset( $_GET['page'], $_GET['tab'], $_GET['section'] )
+			&& 'wc-settings' === $_GET['page']
+			&& 'point-of-sale' === $_GET['tab']
+			&& 'staff' === $_GET['section'];
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Create handler.
+	 *
+	 * @return void
+	 */
+	private function action_create(): void {
+		check_admin_referer( self::NONCE_NEW );
+
+		$display_name = isset( $_POST['display_name'] ) ? sanitize_text_field( wp_unslash( $_POST['display_name'] ) ) : '';
+		$wp_user_id   = ! empty( $_POST['wp_user_id'] ) ? absint( $_POST['wp_user_id'] ) : 0;
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is validated by check_admin_referer above.
+		$pin = isset( $_POST['pin'] ) ? (string) wp_unslash( $_POST['pin'] ) : '';
+
+		if ( '' === $display_name ) {
+			self::$notice = array( 'type' => 'error', 'message' => __( 'Display name is required.', 'woocommerce' ) );
+			return;
+		}
+
+		$pin_service = wc_get_container()->get( POSPinService::class );
+		if ( ! $pin_service->validate_pin_format( $pin ) ) {
+			self::$notice = array( 'type' => 'error', 'message' => __( 'A 4-digit PIN is required to create a POS staff member.', 'woocommerce' ) );
+			return;
+		}
+
+		$access_profile_key = self::resolve_access_profile_key( $wp_user_id );
+		$profiles           = wc_get_container()->get( AccessProfileRegistry::class );
+		if ( ! $profiles->exists( $access_profile_key ) ) {
+			self::$notice = array( 'type' => 'error', 'message' => __( 'Unknown access profile.', 'woocommerce' ) );
+			return;
+		}
+
+		$actor_repo  = wc_get_container()->get( ActorRepository::class );
+		$access_repo = wc_get_container()->get( ActorAccessRepository::class );
+
+		$actor_id = $actor_repo->insert(
+			array(
+				'display_name'       => $display_name,
+				'first_name'         => isset( $_POST['first_name'] ) ? sanitize_text_field( wp_unslash( $_POST['first_name'] ) ) : null,
+				'last_name'          => isset( $_POST['last_name'] ) ? sanitize_text_field( wp_unslash( $_POST['last_name'] ) ) : null,
+				'email'              => isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : null,
+				'wp_user_id'         => $wp_user_id > 0 ? $wp_user_id : null,
+				'created_by_user_id' => get_current_user_id(),
+				'updated_by_user_id' => get_current_user_id(),
+			)
+		);
+		if ( 0 === $actor_id ) {
+			self::$notice = array( 'type' => 'error', 'message' => __( 'Failed to create POS staff member.', 'woocommerce' ) );
+			return;
+		}
+
+		$access_repo->insert(
+			array(
+				'actor_id'           => $actor_id,
+				'access_profile_key' => $access_profile_key,
+				'created_by_user_id' => get_current_user_id(),
+				'updated_by_user_id' => get_current_user_id(),
+			)
+		);
+
+		$result = $pin_service->set_pin( $actor_id, $pin );
+		if ( is_wp_error( $result ) ) {
+			// Atomic create: roll back the half-created staff member so the merchant
+			// can retry the whole submission with a different PIN.
+			$access_repo->delete_all_for_actor( $actor_id );
+			$actor_repo->delete( $actor_id );
+			self::set_notice( 'error', $result->get_error_message() );
+			return;
+		}
+
+		self::set_notice( 'success', __( 'POS staff member created.', 'woocommerce' ), true );
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'       => 'wc-settings',
+					'tab'        => 'point-of-sale',
+					'section'    => 'staff',
+					'edit-actor' => $actor_id,
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Update handler.
+	 *
+	 * @param int $actor_id Actor ID.
+	 * @return void
+	 */
+	private function action_update( int $actor_id ): void {
+		check_admin_referer( self::NONCE_EDIT );
+
+		$actor_repo  = wc_get_container()->get( ActorRepository::class );
+		$access_repo = wc_get_container()->get( ActorAccessRepository::class );
+		$profiles    = wc_get_container()->get( AccessProfileRegistry::class );
+
+		$existing = $actor_repo->get_by_id( $actor_id );
+		if ( null === $existing ) {
+			self::$notice = array( 'type' => 'error', 'message' => __( 'POS staff member not found.', 'woocommerce' ) );
+			return;
+		}
+
+		$wp_user_id = ! empty( $_POST['wp_user_id'] ) ? absint( $_POST['wp_user_id'] ) : 0;
+
+		$update = array(
+			'display_name'       => isset( $_POST['display_name'] ) ? sanitize_text_field( wp_unslash( $_POST['display_name'] ) ) : $existing['display_name'],
+			'first_name'         => isset( $_POST['first_name'] ) ? sanitize_text_field( wp_unslash( $_POST['first_name'] ) ) : null,
+			'last_name'          => isset( $_POST['last_name'] ) ? sanitize_text_field( wp_unslash( $_POST['last_name'] ) ) : null,
+			'email'              => isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : null,
+			'wp_user_id'         => $wp_user_id > 0 ? $wp_user_id : null,
+			'status'             => isset( $_POST['status'] ) && ActorRepository::STATUS_INACTIVE === $_POST['status'] ? ActorRepository::STATUS_INACTIVE : ActorRepository::STATUS_ACTIVE,
+			'updated_by_user_id' => get_current_user_id(),
+		);
+		$actor_repo->update( $actor_id, $update );
+
+		$access_profile_key = self::resolve_access_profile_key( $wp_user_id );
+		if ( $profiles->exists( $access_profile_key ) ) {
+			$access = $access_repo->get_for_actor( $actor_id );
+			if ( null === $access ) {
+				$access_repo->insert(
+					array(
+						'actor_id'           => $actor_id,
+						'access_profile_key' => $access_profile_key,
+						'created_by_user_id' => get_current_user_id(),
+						'updated_by_user_id' => get_current_user_id(),
+					)
+				);
+			} else {
+				$access_repo->update(
+					(int) $access['access_id'],
+					array(
+						'access_profile_key' => $access_profile_key,
+						'updated_by_user_id' => get_current_user_id(),
+					)
+				);
+			}
+		}
+
+		// Optional inline PIN — empty means "keep current PIN".
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is validated by check_admin_referer above.
+		$pin = isset( $_POST['pin'] ) ? (string) wp_unslash( $_POST['pin'] ) : '';
+		if ( '' !== $pin ) {
+			$pin_service = wc_get_container()->get( POSPinService::class );
+			$result      = $pin_service->set_pin( $actor_id, $pin );
+			if ( is_wp_error( $result ) ) {
+				self::$notice = array( 'type' => 'error', 'message' => $result->get_error_message() );
+				return;
+			}
+		}
+
+		self::$notice = array( 'type' => 'success', 'message' => __( 'POS staff member updated.', 'woocommerce' ) );
+	}
+
+	/**
+	 * Delete handler (soft-delete).
+	 *
+	 * @return void
+	 */
+	private function action_delete(): void {
+		check_admin_referer( self::NONCE_DELETE );
+
+		$actor_id = isset( $_GET['delete-actor'] ) ? absint( $_GET['delete-actor'] ) : 0;
+		if ( $actor_id <= 0 ) {
+			return;
+		}
+
+		$actor_repo = wc_get_container()->get( ActorRepository::class );
+		$actor_repo->soft_delete( $actor_id );
+
+		self::set_notice( 'success', __( 'POS staff member deleted.', 'woocommerce' ), true );
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'    => 'wc-settings',
+					'tab'     => 'point-of-sale',
+					'section' => 'staff',
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Remove the PIN from a staff member. Shares the edit-form nonce since
+	 * the "Remove PIN" button lives inside the main edit form.
+	 *
+	 * @param int $actor_id Actor ID.
+	 * @return void
+	 */
+	private function action_remove_pin( int $actor_id ): void {
+		check_admin_referer( self::NONCE_EDIT );
+
+		$pin_service = wc_get_container()->get( POSPinService::class );
+		$pin_service->delete_pin( $actor_id );
+
+		self::$notice = array( 'type' => 'success', 'message' => __( 'PIN removed.', 'woocommerce' ) );
+	}
+}
+
+return new WC_Admin_POS_Staff();

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -79,6 +79,7 @@ class WC_Admin {
 		include_once __DIR__ . '/class-wc-admin-pointers.php';
 		include_once __DIR__ . '/class-wc-admin-importers.php';
 		include_once __DIR__ . '/class-wc-admin-exporters.php';
+		include_once __DIR__ . '/class-wc-admin-pos-staff.php';
 
 		// Help Tabs.
 		/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-point-of-sale.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-point-of-sale.php
@@ -35,6 +35,47 @@ class WC_Settings_Point_Of_Sale extends WC_Settings_Page {
 	}
 
 	/**
+	 * Get own sections — adds a "Staff" sub-section when the POS staff actors
+	 * feature is enabled.
+	 *
+	 * @since 10.9.0
+	 * @return array
+	 */
+	protected function get_own_sections() {
+		$sections = array(
+			'' => __( 'General', 'woocommerce' ),
+		);
+
+		if ( class_exists( 'WC_Admin_POS_Staff' ) && WC_Admin_POS_Staff::is_enabled() ) {
+			$sections['staff'] = __( 'Staff', 'woocommerce' );
+		}
+
+		return $sections;
+	}
+
+	/**
+	 * Output the settings — routes the "Staff" sub-section through the
+	 * actor-backed admin page.
+	 *
+	 * @since 10.9.0
+	 */
+	public function output(): void {
+		global $current_section, $hide_save_button;
+
+		if (
+			'staff' === $current_section
+			&& class_exists( 'WC_Admin_POS_Staff' )
+			&& WC_Admin_POS_Staff::is_enabled()
+		) {
+			$hide_save_button = true; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			WC_Admin_POS_Staff::page_output();
+			return;
+		}
+
+		parent::output();
+	}
+
+	/**
 	 * Setting page icon.
 	 *
 	 * @var string

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1736,6 +1736,11 @@ class WC_Install {
 		$stock_notifications_table_schema = wc_get_container()->get( StockNotificationsDataStore::class )->get_database_schema();
 		$order_stats_table_schema         = self::get_order_stats_table_schema( $collate );
 
+		// Store Actors Tables Schema (gated on the point_of_sale_actors feature flag).
+		$store_actors_table_schema = $feature_controller->feature_is_enabled( 'point_of_sale_actors' )
+			? wc_get_container()->get( \Automattic\WooCommerce\Internal\StoreActors\ActorRepository::class )->get_database_schema()
+			: '';
+
 		$mysql_version = wc_get_server_database_version()['number'];
 		if ( version_compare( $mysql_version, '5.6', '>=' ) ) {
 			$datetime_default = 'DEFAULT CURRENT_TIMESTAMP';
@@ -2078,6 +2083,7 @@ CREATE TABLE {$wpdb->prefix}wc_category_lookup (
 ) $collate;
 $hpos_table_schema;
 $stock_notifications_table_schema;
+$store_actors_table_schema
 		";
 
 		return $tables;
@@ -2117,6 +2123,8 @@ $stock_notifications_table_schema;
 			"{$wpdb->prefix}wc_product_attributes_lookup",
 			"{$wpdb->prefix}wc_stock_notifications",
 			"{$wpdb->prefix}wc_stock_notificationmeta",
+			"{$wpdb->prefix}wc_store_actors",
+			"{$wpdb->prefix}wc_store_actor_access",
 
 			// WCA Tables.
 			"{$wpdb->prefix}wc_order_stats",

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -405,6 +405,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\ProductFeed\ProductFeed::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\POS\POSController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -558,6 +558,18 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_experimental'              => true,
 			),
+			'point_of_sale_actors'               => array(
+				'name'                         => __( 'Point of Sale staff', 'woocommerce' ),
+				'description'                  => __(
+					'Manage Point of Sale staff and their PINs directly in WooCommerce, without creating WordPress user accounts. Any existing WordPress user can optionally be linked. Experimental — for development and testing.',
+					'woocommerce'
+				),
+				'enabled_by_default'           => false,
+				'disable_ui'                   => false,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+				'is_experimental'              => true,
+			),
 			'fulfillments'                       => array(
 				'name'                         => __( 'Order Fulfillments', 'woocommerce' ),
 				'description'                  => __(

--- a/plugins/woocommerce/src/Internal/POS/Actors/AccessProfileRegistry.php
+++ b/plugins/woocommerce/src/Internal/POS/Actors/AccessProfileRegistry.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * AccessProfileRegistry class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS\Actors;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PHP-defined POS access profiles (replaces the role-based capability map
+ * from the prior WP-roles approach). Each profile maps every permission tag
+ * to a tri-state value: allow | deny | approval_required.
+ *
+ * Built-in profile keys are reserved under the `pos_*` prefix. Extensions can
+ * inject or override profiles/tags via the `woocommerce_pos_access_profiles`
+ * filter at boot.
+ *
+ * @internal Owned by the Point of Sale staff (actors) feature.
+ * @since 10.9.0
+ */
+class AccessProfileRegistry {
+
+	public const ACCESS_ALLOW             = 'allow';
+	public const ACCESS_DENY              = 'deny';
+	public const ACCESS_APPROVAL_REQUIRED = 'approval_required';
+
+	public const PROFILE_CASHIER = 'pos_cashier';
+	public const PROFILE_MANAGER = 'pos_manager';
+	public const PROFILE_ADMIN   = 'pos_admin';
+
+	/**
+	 * Permission tags managed by the POS context. The mobile client uses
+	 * these to gate UI actions; server-side validators consult them for
+	 * override-approval checks.
+	 */
+	public const TAG_PROCESS_SALES           = 'process_sales';
+	public const TAG_APPLY_EXISTING_COUPONS  = 'apply_existing_coupons';
+	public const TAG_VIEW_ORDERS             = 'view_orders';
+	public const TAG_CREATE_CUSTOM_DISCOUNTS = 'create_custom_discounts';
+	public const TAG_REFUND_ORDERS           = 'refund_orders';
+	public const TAG_EXIT_POS                = 'exit_pos';
+	public const TAG_VIEW_POS_SETTINGS       = 'view_pos_settings';
+	public const TAG_EDIT_POS_SETTINGS       = 'edit_pos_settings';
+	public const TAG_MANAGE_POS_STAFF        = 'manage_pos_staff';
+	public const TAG_MANAGER_APPROVAL        = 'manager_approval';
+
+	/**
+	 * Memoized profile map (after filter application).
+	 *
+	 * @var array<string, array{name: string, permissions: array<string, string>}>|null
+	 */
+	private ?array $profiles = null;
+
+	/**
+	 * Return all registered profiles, keyed by profile key.
+	 *
+	 * @return array<string, array{name: string, permissions: array<string, string>}>
+	 */
+	public function all(): array {
+		if ( null === $this->profiles ) {
+			/**
+			 * Filters the registered POS access profiles.
+			 *
+			 * Each profile is an array with `name` (string) and `permissions`
+			 * (map of tag => allow|deny|approval_required). Built-in keys use
+			 * the `pos_*` prefix and should not be removed by extensions.
+			 *
+			 * @since 10.9.0
+			 *
+			 * @param array<string, array{name: string, permissions: array<string, string>}> $profiles
+			 */
+			$this->profiles = (array) apply_filters( 'woocommerce_pos_access_profiles', $this->built_in_profiles() );
+		}
+		return $this->profiles;
+	}
+
+	/**
+	 * Return a single profile by key, or null if not registered.
+	 *
+	 * @param string $key Profile key (e.g. 'pos_cashier').
+	 * @return array{name: string, permissions: array<string, string>}|null
+	 */
+	public function get( string $key ): ?array {
+		$profiles = $this->all();
+		return $profiles[ $key ] ?? null;
+	}
+
+	/**
+	 * Return whether a profile key is registered.
+	 *
+	 * @param string $key Profile key.
+	 * @return bool
+	 */
+	public function exists( string $key ): bool {
+		return null !== $this->get( $key );
+	}
+
+	/**
+	 * Return the access value (allow|deny|approval_required) for a given
+	 * profile/tag pair. Returns 'deny' if the profile is unknown or the tag
+	 * isn't listed (fail-closed default).
+	 *
+	 * @param string $profile_key Profile key.
+	 * @param string $tag         Permission tag.
+	 * @return string
+	 */
+	public function resolve( string $profile_key, string $tag ): string {
+		$profile = $this->get( $profile_key );
+		if ( null === $profile ) {
+			return self::ACCESS_DENY;
+		}
+		return $profile['permissions'][ $tag ] ?? self::ACCESS_DENY;
+	}
+
+	/**
+	 * Built-in profiles. Extensions can wrap/extend via the
+	 * `woocommerce_pos_access_profiles` filter, but cannot replace this
+	 * default set directly.
+	 *
+	 * @return array<string, array{name: string, permissions: array<string, string>}>
+	 */
+	private function built_in_profiles(): array {
+		return array(
+			self::PROFILE_CASHIER => array(
+				'name'        => __( 'Cashier', 'woocommerce' ),
+				'permissions' => array(
+					self::TAG_PROCESS_SALES           => self::ACCESS_ALLOW,
+					self::TAG_APPLY_EXISTING_COUPONS  => self::ACCESS_ALLOW,
+					self::TAG_VIEW_ORDERS             => self::ACCESS_ALLOW,
+					self::TAG_CREATE_CUSTOM_DISCOUNTS => self::ACCESS_APPROVAL_REQUIRED,
+					self::TAG_REFUND_ORDERS           => self::ACCESS_APPROVAL_REQUIRED,
+					self::TAG_EXIT_POS                => self::ACCESS_APPROVAL_REQUIRED,
+					self::TAG_VIEW_POS_SETTINGS       => self::ACCESS_APPROVAL_REQUIRED,
+					self::TAG_EDIT_POS_SETTINGS       => self::ACCESS_DENY,
+					self::TAG_MANAGE_POS_STAFF        => self::ACCESS_DENY,
+					self::TAG_MANAGER_APPROVAL        => self::ACCESS_DENY,
+				),
+			),
+			self::PROFILE_MANAGER => array(
+				'name'        => __( 'Manager', 'woocommerce' ),
+				'permissions' => array(
+					self::TAG_PROCESS_SALES           => self::ACCESS_ALLOW,
+					self::TAG_APPLY_EXISTING_COUPONS  => self::ACCESS_ALLOW,
+					self::TAG_VIEW_ORDERS             => self::ACCESS_ALLOW,
+					self::TAG_CREATE_CUSTOM_DISCOUNTS => self::ACCESS_ALLOW,
+					self::TAG_REFUND_ORDERS           => self::ACCESS_ALLOW,
+					self::TAG_EXIT_POS                => self::ACCESS_ALLOW,
+					self::TAG_VIEW_POS_SETTINGS       => self::ACCESS_ALLOW,
+					self::TAG_EDIT_POS_SETTINGS       => self::ACCESS_APPROVAL_REQUIRED,
+					self::TAG_MANAGE_POS_STAFF        => self::ACCESS_DENY,
+					self::TAG_MANAGER_APPROVAL        => self::ACCESS_ALLOW,
+				),
+			),
+			self::PROFILE_ADMIN => array(
+				'name'        => __( 'POS Admin', 'woocommerce' ),
+				'permissions' => array(
+					self::TAG_PROCESS_SALES           => self::ACCESS_ALLOW,
+					self::TAG_APPLY_EXISTING_COUPONS  => self::ACCESS_ALLOW,
+					self::TAG_VIEW_ORDERS             => self::ACCESS_ALLOW,
+					self::TAG_CREATE_CUSTOM_DISCOUNTS => self::ACCESS_ALLOW,
+					self::TAG_REFUND_ORDERS           => self::ACCESS_ALLOW,
+					self::TAG_EXIT_POS                => self::ACCESS_ALLOW,
+					self::TAG_VIEW_POS_SETTINGS       => self::ACCESS_ALLOW,
+					self::TAG_EDIT_POS_SETTINGS       => self::ACCESS_ALLOW,
+					self::TAG_MANAGE_POS_STAFF        => self::ACCESS_ALLOW,
+					self::TAG_MANAGER_APPROVAL        => self::ACCESS_ALLOW,
+				),
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/POS/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/POS/OrderAttribution.php
@@ -1,0 +1,479 @@
+<?php
+/**
+ * OrderAttribution class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS;
+
+use Automattic\WooCommerce\Internal\POS\Actors\AccessProfileRegistry;
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Internal\StoreActors\ActorAccessRepository;
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+use WC_Abstract_Order;
+use WC_Order;
+use WC_Order_Refund;
+use WP_Error;
+use WP_REST_Request;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Server-side handling of client-asserted POS order attribution and manager
+ * overrides against the store-actor model.
+ *
+ * The mobile client adds POS context as flat scalar entries in the order's
+ * `meta_data` array on POST/PUT /wc/v3/orders and the refunds endpoint:
+ *
+ *     "meta_data": [
+ *       { "key": "_wc_pos_staff_id",            "value": 42 },
+ *       { "key": "_wc_pos_staff_name",          "value": "Alex Cashier" },
+ *       // Optional — only present when a manager authorized an override:
+ *       { "key": "_wc_pos_override_staff_id",   "value": 7 },
+ *       { "key": "_wc_pos_override_staff_name", "value": "Morgan Manager" },
+ *       { "key": "_wc_pos_override_reason",     "value": "refund_orders" }
+ *     ]
+ *
+ * Validation runs in the pre-insert filter so bogus attribution or override
+ * data rolls back the entire order request (HTTP 400, no DB row). After
+ * successful persistence, a single order note is written:
+ *
+ *   - Without override: `POS: {action} by {display_name}.`
+ *   - With override:    `POS override: {reason} granted to {actor}, approved by {approver}.`
+ *
+ * Trust model: the REST request is still authenticated as a WP user (typically
+ * the device admin / shop_manager). The actor_id meta asserts who at the
+ * terminal performed the action — the server verifies the actor exists, is
+ * active, and (for overrides) the approver's access profile grants
+ * `manager_approval`. The server does NOT block the underlying action even if
+ * the override is malformed; it records who-approved-whom for audit.
+ *
+ * @internal Owned by the Point of Sale staff (actors) feature.
+ * @since 10.9.0
+ */
+class OrderAttribution implements RegisterHooksInterface {
+
+	public const META_KEY_STAFF_ID            = '_wc_pos_staff_id';
+	public const META_KEY_STAFF_NAME          = '_wc_pos_staff_name';
+	public const META_KEY_OVERRIDE_STAFF_ID   = '_wc_pos_override_staff_id';
+	public const META_KEY_OVERRIDE_STAFF_NAME = '_wc_pos_override_staff_name';
+	public const META_KEY_OVERRIDE_REASON     = '_wc_pos_override_reason';
+	public const LOG_SOURCE                   = 'woocommerce-pos';
+
+	/**
+	 * Permission tags that may be granted via manager override. Each one
+	 * corresponds to an action a cashier-tier actor would have
+	 * `approval_required` for, and a manager-tier actor would have `allow`.
+	 *
+	 * @var string[]
+	 */
+	private const OVERRIDABLE_TAGS = array(
+		AccessProfileRegistry::TAG_REFUND_ORDERS,
+		AccessProfileRegistry::TAG_CREATE_CUSTOM_DISCOUNTS,
+		AccessProfileRegistry::TAG_EXIT_POS,
+	);
+
+	/**
+	 * @var ActorRepository
+	 */
+	private ActorRepository $actor_repo;
+
+	/**
+	 * @var ActorAccessRepository
+	 */
+	private ActorAccessRepository $access_repo;
+
+	/**
+	 * @var AccessProfileRegistry
+	 */
+	private AccessProfileRegistry $profiles;
+
+	/**
+	 * DI init.
+	 *
+	 * @internal
+	 *
+	 * @param ActorRepository       $actor_repo  Actor repository.
+	 * @param ActorAccessRepository $access_repo Actor access repository.
+	 * @param AccessProfileRegistry $profiles    Access profile registry.
+	 * @return void
+	 */
+	final public function init(
+		ActorRepository $actor_repo,
+		ActorAccessRepository $access_repo,
+		AccessProfileRegistry $profiles
+	): void {
+		$this->actor_repo  = $actor_repo;
+		$this->access_repo = $access_repo;
+		$this->profiles    = $profiles;
+	}
+
+	/**
+	 * Register the lifecycle hooks for shop_order + shop_order_refund.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter( 'woocommerce_rest_pre_insert_shop_order_object', array( $this, 'handle_pre_insert' ), 10, 3 );
+		add_filter( 'woocommerce_rest_pre_insert_shop_order_refund_object', array( $this, 'handle_pre_insert' ), 10, 3 );
+		add_action( 'woocommerce_rest_insert_shop_order_object', array( $this, 'handle_post_insert' ), 10, 3 );
+		add_action( 'woocommerce_rest_insert_shop_order_refund_object', array( $this, 'handle_post_insert' ), 10, 3 );
+	}
+
+	/**
+	 * Pre-insert validation for shop_order / shop_order_refund.
+	 *
+	 * @param WC_Abstract_Order|WP_Error $order_or_error The draft order, or an upstream error.
+	 * @param WP_REST_Request            $request        The incoming request.
+	 * @param bool                       $creating       Create vs update.
+	 * @return WC_Abstract_Order|WP_Error
+	 *
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 */
+	public function handle_pre_insert( $order_or_error, $request, $creating ) {
+		unset( $request, $creating );
+
+		if ( is_wp_error( $order_or_error ) ) {
+			return $order_or_error;
+		}
+
+		if ( ! $order_or_error instanceof WC_Abstract_Order ) {
+			return $order_or_error;
+		}
+
+		$actor_id          = $this->read_int_meta( $order_or_error, self::META_KEY_STAFF_ID );
+		$override_actor_id = $this->read_int_meta( $order_or_error, self::META_KEY_OVERRIDE_STAFF_ID );
+		$override_reason   = $this->read_string_meta( $order_or_error, self::META_KEY_OVERRIDE_REASON );
+		$has_any_pos_meta  = $actor_id > 0 || $override_actor_id > 0 || '' !== $override_reason;
+		$has_override_part = $override_actor_id > 0 || '' !== $override_reason;
+
+		if ( ! $has_any_pos_meta ) {
+			return $order_or_error;
+		}
+
+		$attribution_error = $this->validate_actor( $actor_id );
+		if ( is_wp_error( $attribution_error ) ) {
+			return $attribution_error;
+		}
+
+		if ( $has_override_part && ( $override_actor_id <= 0 || '' === $override_reason ) ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_override',
+				__( 'POS override requires both _wc_pos_override_staff_id and _wc_pos_override_reason.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( $override_actor_id > 0 ) {
+			$override_error = $this->validate_override( $override_actor_id, $override_reason, $actor_id );
+			if ( is_wp_error( $override_error ) ) {
+				return $override_error;
+			}
+		}
+
+		return $order_or_error;
+	}
+
+	/**
+	 * Post-insert: write one order note + one log line per saved order/refund.
+	 *
+	 * @param WC_Abstract_Order $order    Freshly-saved order or refund.
+	 * @param WP_REST_Request   $request  Incoming request.
+	 * @param bool              $creating Create vs update.
+	 * @return void
+	 *
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 */
+	public function handle_post_insert( $order, $request, $creating ): void {
+		unset( $request );
+
+		if ( ! $order instanceof WC_Abstract_Order ) {
+			return;
+		}
+
+		$actor_id = $this->read_int_meta( $order, self::META_KEY_STAFF_ID );
+		if ( $actor_id <= 0 ) {
+			return;
+		}
+
+		$actor = $this->actor_repo->get_by_id( $actor_id );
+		if ( null === $actor ) {
+			wc_get_logger()->warning(
+				sprintf(
+					'POS attribution skipped: actor %d not found at post-insert time (order %d).',
+					$actor_id,
+					$order->get_id()
+				),
+				array( 'source' => self::LOG_SOURCE )
+			);
+			return;
+		}
+
+		$actor_name_snapshot = $this->read_string_meta( $order, self::META_KEY_STAFF_NAME );
+		$actor_label         = '' !== $actor_name_snapshot ? $actor_name_snapshot : (string) $actor['display_name'];
+
+		$is_refund   = $order instanceof WC_Order_Refund;
+		$note_target = $is_refund ? wc_get_order( $order->get_parent_id() ) : $order;
+
+		if ( ! $note_target instanceof WC_Order ) {
+			return;
+		}
+
+		$override_actor_id = $this->read_int_meta( $order, self::META_KEY_OVERRIDE_STAFF_ID );
+		$override_reason   = $this->read_string_meta( $order, self::META_KEY_OVERRIDE_REASON );
+
+		if ( $override_actor_id > 0 && '' !== $override_reason ) {
+			$override_name = $this->read_string_meta( $order, self::META_KEY_OVERRIDE_STAFF_NAME );
+			$this->write_override_note( $note_target, $order, $actor_label, $override_actor_id, $override_name, $override_reason );
+		} else {
+			$this->write_attribution_note( $note_target, $order, $actor_label, $creating, $is_refund );
+		}
+	}
+
+	/**
+	 * Read an integer scalar from order meta. Returns 0 if absent or invalid.
+	 *
+	 * @param WC_Abstract_Order $order Order.
+	 * @param string            $key   Meta key.
+	 * @return int
+	 */
+	private function read_int_meta( WC_Abstract_Order $order, string $key ): int {
+		$value = $order->get_meta( $key, true );
+		if ( '' === $value || null === $value ) {
+			return 0;
+		}
+		if ( ! is_numeric( $value ) ) {
+			return 0;
+		}
+		return (int) $value;
+	}
+
+	/**
+	 * Read a string scalar from order meta. Returns '' if absent or invalid.
+	 *
+	 * @param WC_Abstract_Order $order Order.
+	 * @param string            $key   Meta key.
+	 * @return string
+	 */
+	private function read_string_meta( WC_Abstract_Order $order, string $key ): string {
+		$value = $order->get_meta( $key, true );
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+		return $value;
+	}
+
+	/**
+	 * Validate the asserted actor.
+	 *
+	 * @param int $actor_id Asserted actor ID.
+	 * @return true|WP_Error
+	 */
+	private function validate_actor( int $actor_id ) {
+		if ( $actor_id <= 0 ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_attribution',
+				__( 'POS attribution requires a positive _wc_pos_staff_id.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$actor = $this->actor_repo->get_by_id( $actor_id );
+		if ( null === $actor || ! empty( $actor['date_deleted_gmt'] ) ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_attribution',
+				__( 'POS attribution references an unknown staff member.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ActorRepository::STATUS_ACTIVE !== (string) $actor['status'] ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_attribution',
+				__( 'POS attribution staff member is not active.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$access = $this->access_repo->get_for_actor( $actor_id );
+		if ( null === $access || ActorAccessRepository::STATUS_ACTIVE !== (string) ( $access['status'] ?? '' ) ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_attribution',
+				__( 'POS attribution staff member has no active POS access.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate manager-override fields against the actor model + profile registry.
+	 *
+	 * @param int    $override_actor_id Approver actor ID.
+	 * @param string $override_reason   Permission tag being elevated.
+	 * @param int    $actor_id          Operator actor ID (for self-override check).
+	 * @return true|WP_Error
+	 */
+	private function validate_override( int $override_actor_id, string $override_reason, int $actor_id ) {
+		if ( ! in_array( $override_reason, self::OVERRIDABLE_TAGS, true ) ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_override',
+				__( 'POS override reason is not a supported overridable permission tag.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( $override_actor_id === $actor_id ) {
+			return new WP_Error(
+				'woocommerce_pos_self_override',
+				__( 'POS override cannot be granted by the same staff member performing the action.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$approver = $this->actor_repo->get_by_id( $override_actor_id );
+		if ( null === $approver || ! empty( $approver['date_deleted_gmt'] ) ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_override',
+				__( 'POS override references an unknown approver.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ActorRepository::STATUS_ACTIVE !== (string) $approver['status'] ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_override',
+				__( 'POS override approver is not active.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$approver_access = $this->access_repo->get_for_actor( $override_actor_id );
+		if ( null === $approver_access || ActorAccessRepository::STATUS_ACTIVE !== (string) ( $approver_access['status'] ?? '' ) ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_override',
+				__( 'POS override approver has no active POS access.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$approver_profile_key = (string) ( $approver_access['access_profile_key'] ?? '' );
+		if ( AccessProfileRegistry::ACCESS_ALLOW !== $this->profiles->resolve( $approver_profile_key, AccessProfileRegistry::TAG_MANAGER_APPROVAL ) ) {
+			return new WP_Error(
+				'woocommerce_pos_override_forbidden',
+				__( 'POS override approver is not permitted to grant approvals.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Write the simple attribution order note (no override case).
+	 *
+	 * @param WC_Order          $note_target Order to attach the note to.
+	 * @param WC_Abstract_Order $order       Order/refund being attributed.
+	 * @param string            $actor_label Display label for the actor.
+	 * @param bool              $creating    Create vs update.
+	 * @param bool              $is_refund   Whether $order is a refund.
+	 * @return void
+	 */
+	private function write_attribution_note(
+		WC_Order $note_target,
+		WC_Abstract_Order $order,
+		string $actor_label,
+		bool $creating,
+		bool $is_refund
+	): void {
+		$action_verb = $this->describe_action( $creating, $is_refund );
+
+		$note_target->add_order_note(
+			sprintf(
+				/* translators: 1: action verb (created/updated/refunded), 2: actor display name. */
+				__( 'POS: %1$s by %2$s.', 'woocommerce' ),
+				$action_verb,
+				$actor_label
+			),
+			0,
+			false
+		);
+
+		wc_get_logger()->info(
+			sprintf(
+				'POS %1$s %2$d %3$s by actor %4$s.',
+				$is_refund ? 'refund' : 'order',
+				$order->get_id(),
+				$action_verb,
+				$actor_label
+			),
+			array( 'source' => self::LOG_SOURCE )
+		);
+	}
+
+	/**
+	 * Write the combined override order note (override case).
+	 *
+	 * @param WC_Order          $note_target       Order to attach the note to.
+	 * @param WC_Abstract_Order $order             Order/refund being attributed.
+	 * @param string            $actor_label       Operator actor display label.
+	 * @param int               $override_actor_id Approver actor ID.
+	 * @param string            $override_name     Approver actor display label (snapshot).
+	 * @param string            $override_reason   Permission tag being elevated.
+	 * @return void
+	 */
+	private function write_override_note(
+		WC_Order $note_target,
+		WC_Abstract_Order $order,
+		string $actor_label,
+		int $override_actor_id,
+		string $override_name,
+		string $override_reason
+	): void {
+		if ( '' === $override_name ) {
+			$approver       = $this->actor_repo->get_by_id( $override_actor_id );
+			$override_name  = null !== $approver ? (string) $approver['display_name'] : sprintf( 'actor #%d', $override_actor_id );
+		}
+
+		$note_target->add_order_note(
+			sprintf(
+				/* translators: 1: permission tag, 2: actor display name, 3: approver display name. */
+				__( 'POS override: %1$s granted to %2$s, approved by %3$s.', 'woocommerce' ),
+				$override_reason,
+				$actor_label,
+				$override_name
+			),
+			0,
+			false
+		);
+
+		wc_get_logger()->info(
+			sprintf(
+				'POS override: %1$s on %2$s %3$d granted to %4$s, approved by %5$s (actor ID %6$d).',
+				$override_reason,
+				$order instanceof WC_Order_Refund ? 'refund' : 'order',
+				$order->get_id(),
+				$actor_label,
+				$override_name,
+				$override_actor_id
+			),
+			array( 'source' => self::LOG_SOURCE )
+		);
+	}
+
+	/**
+	 * Human-readable action verb for the attribution note + log line.
+	 *
+	 * @param bool $creating  Create vs update.
+	 * @param bool $is_refund Whether the object is a refund.
+	 * @return string
+	 */
+	private function describe_action( bool $creating, bool $is_refund ): string {
+		if ( $is_refund ) {
+			return $creating ? 'refunded' : 'refund updated';
+		}
+		return $creating ? 'created' : 'updated';
+	}
+}

--- a/plugins/woocommerce/src/Internal/POS/POSController.php
+++ b/plugins/woocommerce/src/Internal/POS/POSController.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * POSController class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS;
+
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\POS\RestApi\POSStaffController;
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Bootstraps the Point of Sale staff (actors) feature: capability grants,
+ * cascade hooks for WP user deletion, schema creation on feature-flag toggle,
+ * and REST controller registration.
+ *
+ * All wiring is gated on the `point_of_sale_actors` feature flag — when the
+ * flag is off, this controller registers nothing.
+ *
+ * @internal Owned by the Point of Sale staff (actors) feature.
+ * @since 10.9.0
+ */
+class POSController implements RegisterHooksInterface {
+
+	public const FEATURE_FLAG = 'point_of_sale_actors';
+
+	/**
+	 * @var FeaturesController
+	 */
+	private FeaturesController $features_controller;
+
+	/**
+	 * @var ActorRepository
+	 */
+	private ActorRepository $actor_repository;
+
+	/**
+	 * @var POSStaffController
+	 */
+	private POSStaffController $staff_controller;
+
+	/**
+	 * @var OrderAttribution
+	 */
+	private OrderAttribution $order_attribution;
+
+	/**
+	 * DI init.
+	 *
+	 * @internal
+	 *
+	 * @param FeaturesController  $features_controller Features controller.
+	 * @param ActorRepository     $actor_repository    Actor repository.
+	 * @param POSStaffController $staff_controller   Staff REST controller.
+	 * @param OrderAttribution    $order_attribution   Order attribution validator.
+	 * @return void
+	 */
+	final public function init(
+		FeaturesController $features_controller,
+		ActorRepository $actor_repository,
+		POSStaffController $staff_controller,
+		OrderAttribution $order_attribution
+	): void {
+		$this->features_controller = $features_controller;
+		$this->actor_repository    = $actor_repository;
+		$this->staff_controller   = $staff_controller;
+		$this->order_attribution   = $order_attribution;
+	}
+
+	/**
+	 * Register WordPress hooks.
+	 *
+	 * The feature-flag check itself triggers `__()` calls inside the
+	 * FeaturesController feature list (the flag's `name`/`description`
+	 * translate the woocommerce textdomain), so it has to run AFTER the
+	 * `init` action — otherwise WP 6.7+ logs a
+	 * `_load_textdomain_just_in_time was called incorrectly` notice which
+	 * breaks header output. We register the option-toggle handler eagerly
+	 * (no translations involved) and defer everything else to `init`.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		// Toggle handlers are safe to register eagerly — they only reference an option name.
+		// WP fires `add_option_*` on first-time creation and `update_option_*` on subsequent
+		// changes, so both are needed to catch the initial enable.
+		$option_name = 'woocommerce_feature_' . self::FEATURE_FLAG . '_enabled';
+		add_action( 'add_option_' . $option_name, array( $this, 'handle_feature_flag_added' ), 10, 2 );
+		add_action( 'update_option_' . $option_name, array( $this, 'handle_feature_flag_toggle' ), 10, 2 );
+
+		add_action( 'init', array( $this, 'register_feature_hooks' ), 0 );
+	}
+
+	/**
+	 * Register the feature-gated hooks. Runs on `init` so any translation
+	 * calls (FeaturesController feature-list lookup, etc.) happen after the
+	 * textdomain is safely loadable.
+	 *
+	 * @return void
+	 */
+	public function register_feature_hooks(): void {
+		if ( ! $this->features_controller->feature_is_enabled( self::FEATURE_FLAG ) ) {
+			return;
+		}
+
+		// Cascade: when a WP user is deleted, detach them from any linked actor.
+		add_action( 'deleted_user', array( $this, 'handle_deleted_user' ), 10, 1 );
+
+		// REST routes (M1: GET /wc/pos/v1/staff only). Auto-wires via WC's REST namespace filter.
+		$this->staff_controller->register();
+
+		// Order attribution validation + post-insert logging.
+		$this->order_attribution->register();
+	}
+
+	/**
+	 * Handle first-time creation of the feature flag option (no prior row in
+	 * wp_options). WP fires `add_option_*` rather than `update_option_*` in
+	 * this case, so we trampoline to the same install routine.
+	 *
+	 * @param string $option Option name (unused; bound by hook).
+	 * @param mixed  $value  New option value ("yes" or "no").
+	 * @return void
+	 */
+	public function handle_feature_flag_added( $option, $value ): void {
+		unset( $option );
+		if ( 'yes' === $value ) {
+			$this->run_feature_install();
+		}
+	}
+
+	/**
+	 * Handle the feature flag option change. When the flag flips from
+	 * "no" → "yes", run the install routine so the actor tables get created
+	 * via dbDelta and the POS capabilities get granted to existing roles.
+	 * Idempotent.
+	 *
+	 * @param mixed $old_value Previous option value.
+	 * @param mixed $new_value New option value.
+	 * @return void
+	 */
+	public function handle_feature_flag_toggle( $old_value, $new_value ): void {
+		if ( 'yes' !== $new_value || 'yes' === $old_value ) {
+			return;
+		}
+		$this->run_feature_install();
+	}
+
+	/**
+	 * Install routine triggered when the flag transitions to "yes": dbDelta
+	 * the schema. Idempotent — dbDelta is a no-op for unchanged tables.
+	 *
+	 * The wp-admin Staff page and the staff REST endpoint are gated on the
+	 * existing `manage_woocommerce` capability (already granted to admin
+	 * and shop_manager by default), so no new capability is registered or
+	 * granted on install.
+	 *
+	 * @return void
+	 */
+	private function run_feature_install(): void {
+		if ( class_exists( '\WC_Install' ) ) {
+			\WC_Install::create_tables();
+		}
+	}
+
+	/**
+	 * Cascade handler for WP user deletion. Detach any linked actor (set
+	 * wp_user_id NULL, status inactive). Actor rows are preserved for
+	 * historical order attribution lookups.
+	 *
+	 * @param int $user_id Deleted WordPress user ID.
+	 * @return void
+	 */
+	public function handle_deleted_user( int $user_id ): void {
+		$this->actor_repository->detach_wp_user( $user_id );
+	}
+}

--- a/plugins/woocommerce/src/Internal/POS/RestApi/POSStaffController.php
+++ b/plugins/woocommerce/src/Internal/POS/RestApi/POSStaffController.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * POSStaffController class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS\RestApi;
+
+use Automattic\WooCommerce\Internal\POS\Actors\AccessProfileRegistry;
+use Automattic\WooCommerce\Internal\POS\Service\POSPinService;
+use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use Automattic\WooCommerce\Internal\StoreActors\ActorAccessRepository;
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+use WP_REST_Request;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for the POS staff list.
+ *
+ * Exposes GET /wc/pos/v1/staff — the canonical staff list the mobile client
+ * caches and validates PIN entry against locally. Each entry includes the
+ * staff member's identity, resolved access profile + permissions, and stored
+ * PIN hash record (or null if no PIN set).
+ *
+ * The internal model uses generic "store actor" terminology (the wc_store_actors
+ * table is identity-only and may be reused by future non-POS staff features),
+ * but the public REST surface is POS-specific — hence `/staff`.
+ *
+ * Permission: `manage_woocommerce`. Only admin / shop_manager users hold this
+ * cap by default. Gating on a weaker capability would expose stored PIN
+ * hashes to roles that should not be able to brute-force them.
+ *
+ * @internal Owned by the Point of Sale staff (actors) feature.
+ * @since 10.9.0
+ */
+class POSStaffController extends RestApiControllerBase {
+
+	/**
+	 * The route namespace used in `register_rest_route()`.
+	 *
+	 * @var string
+	 */
+	protected string $route_namespace = 'wc/pos/v1';
+
+	/**
+	 * @var ActorRepository
+	 */
+	private ActorRepository $actor_repo;
+
+	/**
+	 * @var ActorAccessRepository
+	 */
+	private ActorAccessRepository $access_repo;
+
+	/**
+	 * @var AccessProfileRegistry
+	 */
+	private AccessProfileRegistry $profiles;
+
+	/**
+	 * @var POSPinService
+	 */
+	private POSPinService $pin_service;
+
+	/**
+	 * DI init.
+	 *
+	 * @internal
+	 *
+	 * @param ActorRepository       $actor_repo  Actor repository.
+	 * @param ActorAccessRepository $access_repo Actor access repository.
+	 * @param AccessProfileRegistry $profiles    Access profile registry.
+	 * @param POSPinService         $pin_service PIN service.
+	 * @return void
+	 */
+	final public function init(
+		ActorRepository $actor_repo,
+		ActorAccessRepository $access_repo,
+		AccessProfileRegistry $profiles,
+		POSPinService $pin_service
+	): void {
+		$this->actor_repo  = $actor_repo;
+		$this->access_repo = $access_repo;
+		$this->profiles    = $profiles;
+		$this->pin_service = $pin_service;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function get_rest_api_namespace(): string {
+		return 'wc/pos';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->route_namespace,
+			'/staff',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'list_staff' ),
+					'permission_callback' => fn( $request ) => $this->check_permission( $request, 'manage_woocommerce' ),
+					'args'                => array(),
+				),
+				'schema' => fn() => $this->get_staff_list_schema(),
+			)
+		);
+	}
+
+	/**
+	 * List active POS staff members. Returns a flat array (no top-level
+	 * wrapper) to match `/wc/v3/orders`, `/wc/v3/products`, etc.
+	 *
+	 * @param WP_REST_Request $request The incoming request.
+	 * @return array<int, array<string, mixed>>
+	 *
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 */
+	protected function list_staff( WP_REST_Request $request ): array {
+		unset( $request );
+
+		$actors  = $this->actor_repo->list_active();
+		$payload = array();
+
+		foreach ( $actors as $actor ) {
+			$access = $this->access_repo->get_for_actor( (int) $actor['actor_id'] );
+
+			// Skip staff members without an active POS access row.
+			if ( null === $access || ActorAccessRepository::STATUS_ACTIVE !== ( $access['status'] ?? '' ) ) {
+				continue;
+			}
+
+			$payload[] = $this->serialize_staff( $actor, $access );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Build the response shape for one staff member + access row pair.
+	 *
+	 * @param array<string, mixed> $actor  Actor row.
+	 * @param array<string, mixed> $access Access row.
+	 * @return array<string, mixed>
+	 */
+	private function serialize_staff( array $actor, array $access ): array {
+		$profile_key = (string) ( $access['access_profile_key'] ?? '' );
+		$profile     = $this->profiles->get( $profile_key );
+
+		$permissions = array();
+		if ( null !== $profile ) {
+			foreach ( $profile['permissions'] as $tag => $value ) {
+				$permissions[ (string) $tag ] = (string) $value;
+			}
+		}
+
+		return array(
+			'id'               => (int) $actor['actor_id'],
+			'uuid'             => (string) $actor['actor_uuid'],
+			'wp_user_id'       => isset( $actor['wp_user_id'] ) ? (int) $actor['wp_user_id'] : null,
+			'status'           => (string) $actor['status'],
+			'display_name'     => (string) $actor['display_name'],
+			'first_name'       => self::nullable_string( $actor['first_name'] ?? null ),
+			'last_name'        => self::nullable_string( $actor['last_name'] ?? null ),
+			'email'            => self::nullable_string( $actor['email'] ?? null ),
+			'pos_access'       => array(
+				'profile_key'  => $profile_key,
+				'profile_name' => null !== $profile ? (string) $profile['name'] : '',
+				'permissions'  => $permissions,
+				'credential'   => $this->pin_service->get_public_pin_record( (int) $actor['actor_id'] ),
+			),
+			'date_updated_gmt' => (string) $actor['date_updated_gmt'],
+		);
+	}
+
+	/**
+	 * Normalize a nullable string field — empty strings collapse to null so
+	 * the response cleanly distinguishes "not set" from a real value.
+	 *
+	 * @param mixed $value Raw value from the row.
+	 * @return string|null
+	 */
+	private static function nullable_string( $value ): ?string {
+		if ( null === $value ) {
+			return null;
+		}
+		$value = (string) $value;
+		return '' === $value ? null : $value;
+	}
+
+	/**
+	 * Schema describing the staff list payload (top-level array of staff
+	 * objects, following the `/wc/v3` convention for collection endpoints).
+	 *
+	 * Permission values use a tri-state enum: `allow`, `deny`, or
+	 * `approval_required`. The map shape (tag => state) matches WordPress'
+	 * `WP_User::$allcaps` convention.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_staff_list_schema(): array {
+		$schema             = $this->get_base_schema();
+		$schema['title']    = 'pos_staff_list';
+		$schema['type']     = 'array';
+		$schema['readonly'] = true;
+		$schema['items']    = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'               => array( 'type' => 'integer' ),
+				'uuid'             => array( 'type' => 'string' ),
+				'wp_user_id'       => array( 'type' => array( 'integer', 'null' ) ),
+				'status'           => array( 'type' => 'string' ),
+				'display_name'     => array( 'type' => 'string' ),
+				'first_name'       => array( 'type' => array( 'string', 'null' ) ),
+				'last_name'        => array( 'type' => array( 'string', 'null' ) ),
+				'email'            => array( 'type' => array( 'string', 'null' ) ),
+				'pos_access'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'profile_key'  => array( 'type' => 'string' ),
+						'profile_name' => array( 'type' => 'string' ),
+						'permissions'  => array(
+							'type'                 => 'object',
+							'description'          => __( 'Tri-state permission map keyed by permission tag. Each value is allow, deny, or approval_required.', 'woocommerce' ),
+							'additionalProperties' => array(
+								'type' => 'string',
+								'enum' => array(
+									AccessProfileRegistry::ACCESS_ALLOW,
+									AccessProfileRegistry::ACCESS_DENY,
+									AccessProfileRegistry::ACCESS_APPROVAL_REQUIRED,
+								),
+							),
+						),
+						'credential'   => array(
+							'type'       => array( 'object', 'null' ),
+							'properties' => array(
+								'algo'       => array( 'type' => 'string' ),
+								'iterations' => array( 'type' => 'integer' ),
+								'salt'       => array( 'type' => 'string' ),
+								'hash'       => array( 'type' => 'string' ),
+								'updated_at' => array( 'type' => array( 'string', 'null' ) ),
+							),
+						),
+					),
+				),
+				'date_updated_gmt' => array( 'type' => 'string' ),
+			),
+		);
+		// Collection endpoints don't have a meaningful single-object schema; drop the inherited "properties".
+		unset( $schema['properties'] );
+
+		return $schema;
+	}
+}

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * POSPinService class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS\Service;
+
+use Automattic\WooCommerce\Internal\StoreActors\ActorAccessRepository;
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stores and verifies POS PINs against the actor access table
+ * (wc_store_actor_access, context='pos', location_id=0).
+ *
+ * The PIN record is shipped to the mobile client via the staff list endpoint
+ * so the client can validate PIN entry locally. The plaintext PIN never leaves
+ * the device that set it.
+ *
+ * Hash format: PBKDF2-HMAC-SHA-256, 10k iterations, 16-byte random salt,
+ * 32-byte hash. This is native on iOS (CommonCrypto / CryptoKit) and Android
+ * (SecretKeyFactory with PBKDF2WithHmacSHA256, API 26+). Brute-forcing the
+ * 4-digit PIN space against a stolen hash takes ~100 seconds with the chosen
+ * cost factor.
+ *
+ * @internal Owned by the Point of Sale staff (actors) feature.
+ * @since 10.9.0
+ */
+class POSPinService {
+
+	public const ALGO       = 'pbkdf2-sha256';
+	public const ITERATIONS = 10000;
+	public const SALT_BYTES = 16;
+	public const HASH_BYTES = 32;
+	public const PIN_LENGTH = 4;
+
+	/**
+	 * @var ActorAccessRepository
+	 */
+	private ActorAccessRepository $access_repo;
+
+	/**
+	 * DI init.
+	 *
+	 * @param ActorAccessRepository $access_repo Repository for the actor access table.
+	 * @return void
+	 *
+	 * @internal
+	 */
+	final public function init( ActorAccessRepository $access_repo ): void {
+		$this->access_repo = $access_repo;
+	}
+
+	/**
+	 * Set or replace an actor's POS PIN. Requires an existing POS access row
+	 * for the actor — callers must create the actor + access row first.
+	 *
+	 * Enforces PIN uniqueness across all *active* POS access rows: because
+	 * staff log in to POS using only a PIN (no username), two staff sharing
+	 * the same PIN is unresolvable. The check walks active access rows and
+	 * PBKDF2-verifies the candidate PIN against each existing salted hash,
+	 * excluding the current actor so that "set the same PIN again" remains
+	 * a valid no-op rather than a collision against itself.
+	 *
+	 * @param int    $actor_id The target actor ID.
+	 * @param string $pin      The plaintext PIN. Must match PIN_LENGTH.
+	 * @return true|WP_Error
+	 */
+	public function set_pin( int $actor_id, string $pin ) {
+		if ( ! $this->validate_pin_format( $pin ) ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_pin_format',
+				__( 'PIN must be exactly 4 digits.', 'woocommerce' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		$access = $this->access_repo->get_for_actor( $actor_id );
+		if ( null === $access ) {
+			return new WP_Error(
+				'woocommerce_pos_actor_no_access',
+				__( 'Cannot set PIN — this POS staff member has no POS access assignment.', 'woocommerce' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( null !== $this->find_actor_with_pin( $pin, $actor_id ) ) {
+			return new WP_Error(
+				'woocommerce_pos_pin_in_use',
+				__( 'This PIN is already in use by another POS staff member. Choose a different PIN.', 'woocommerce' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$salt = random_bytes( self::SALT_BYTES );
+		$hash = hash_pbkdf2( 'sha256', $pin, $salt, self::ITERATIONS, self::HASH_BYTES, true );
+
+		$ok = $this->access_repo->update(
+			(int) $access['access_id'],
+			array(
+				'credential_type'       => ActorAccessRepository::CREDENTIAL_TYPE_PIN,
+				'credential_algo'       => self::ALGO,
+				'credential_iterations' => self::ITERATIONS,
+				'credential_salt'       => base64_encode( $salt ),
+				'credential_hash'       => base64_encode( $hash ),
+				'credential_updated_at' => gmdate( 'Y-m-d H:i:s' ),
+			)
+		);
+
+		if ( ! $ok ) {
+			return new WP_Error(
+				'woocommerce_pos_pin_persist_failed',
+				__( 'Failed to persist PIN.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Remove an actor's POS PIN.
+	 *
+	 * @param int $actor_id The target actor ID.
+	 * @return bool
+	 */
+	public function delete_pin( int $actor_id ): bool {
+		return $this->access_repo->clear_pos_credential( $actor_id );
+	}
+
+	/**
+	 * Check whether an actor has a POS PIN set.
+	 *
+	 * @param int $actor_id The target actor ID.
+	 * @return bool
+	 */
+	public function has_pin( int $actor_id ): bool {
+		$access = $this->access_repo->get_for_actor( $actor_id );
+		return null !== $access && ! empty( $access['credential_hash'] );
+	}
+
+	/**
+	 * Return the public PIN record for an actor, suitable for embedding in
+	 * the staff list payload sent to mobile clients. Returns null if no PIN
+	 * is set.
+	 *
+	 * @param int $actor_id The target actor ID.
+	 * @return array{algo:string,iterations:int,salt:string,hash:string,updated_at:?string}|null
+	 */
+	public function get_public_pin_record( int $actor_id ): ?array {
+		$access = $this->access_repo->get_for_actor( $actor_id );
+		if ( null === $access || empty( $access['credential_hash'] ) ) {
+			return null;
+		}
+
+		return array(
+			'algo'       => (string) ( $access['credential_algo'] ?? self::ALGO ),
+			'iterations' => (int) ( $access['credential_iterations'] ?? self::ITERATIONS ),
+			'salt'       => (string) ( $access['credential_salt'] ?? '' ),
+			'hash'       => (string) ( $access['credential_hash'] ?? '' ),
+			'updated_at' => isset( $access['credential_updated_at'] ) ? (string) $access['credential_updated_at'] : null,
+		);
+	}
+
+	/**
+	 * Verify a plaintext PIN against a stored record. Used server-side by
+	 * the wp-admin Staff page when callers re-enter the current PIN.
+	 *
+	 * @param string $pin    The plaintext PIN to verify.
+	 * @param array  $record The stored PIN record (algo, iterations, salt, hash).
+	 * @return bool
+	 */
+	public function verify_pin( string $pin, array $record ): bool {
+		if ( ! $this->validate_pin_format( $pin ) ) {
+			return false;
+		}
+
+		$algo       = (string) ( $record['algo'] ?? '' );
+		$iterations = (int) ( $record['iterations'] ?? 0 );
+		$salt_b64   = (string) ( $record['salt'] ?? '' );
+		$hash_b64   = (string) ( $record['hash'] ?? '' );
+
+		if ( self::ALGO !== $algo || $iterations <= 0 || '' === $salt_b64 || '' === $hash_b64 ) {
+			return false;
+		}
+
+		$salt          = base64_decode( $salt_b64, true );
+		$expected_hash = base64_decode( $hash_b64, true );
+		if ( false === $salt || false === $expected_hash ) {
+			return false;
+		}
+
+		$actual_hash = hash_pbkdf2( 'sha256', $pin, $salt, $iterations, self::HASH_BYTES, true );
+
+		return hash_equals( $expected_hash, $actual_hash );
+	}
+
+	/**
+	 * Find the actor ID (if any) whose stored PIN matches the candidate.
+	 *
+	 * Walks active POS access rows that carry credentials and PBKDF2-verifies
+	 * the candidate PIN against each — because each PIN is stored with a
+	 * unique random salt, a direct hash compare across rows isn't possible.
+	 * For typical POS staff list sizes (tens, not thousands), the cost is
+	 * negligible (~10 ms per verify × N).
+	 *
+	 * Used by set_pin() to enforce uniqueness, and available to callers that
+	 * need the same lookup for other reasons (e.g. future server-side PIN
+	 * login validation).
+	 *
+	 * @param string   $pin              Candidate plaintext PIN.
+	 * @param int|null $exclude_actor_id Actor ID to skip (typically the actor
+	 *                                   whose PIN is being set). null to check all.
+	 * @return int|null Matching actor ID, or null if no active staff member uses this PIN.
+	 */
+	public function find_actor_with_pin( string $pin, ?int $exclude_actor_id = null ): ?int {
+		if ( ! $this->validate_pin_format( $pin ) ) {
+			return null;
+		}
+
+		foreach ( $this->access_repo->list_active_for_context( ActorAccessRepository::CONTEXT_POS ) as $row ) {
+			$actor_id = (int) ( $row['actor_id'] ?? 0 );
+			if ( $actor_id <= 0 ) {
+				continue;
+			}
+			if ( null !== $exclude_actor_id && $actor_id === $exclude_actor_id ) {
+				continue;
+			}
+			if ( empty( $row['credential_hash'] ) ) {
+				continue;
+			}
+
+			$record = array(
+				'algo'       => (string) ( $row['credential_algo'] ?? '' ),
+				'iterations' => (int) ( $row['credential_iterations'] ?? 0 ),
+				'salt'       => (string) ( $row['credential_salt'] ?? '' ),
+				'hash'       => (string) ( $row['credential_hash'] ?? '' ),
+			);
+
+			if ( $this->verify_pin( $pin, $record ) ) {
+				return $actor_id;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Validate a PIN string against the expected wire format (4 digits).
+	 *
+	 * @param string $pin The PIN to validate.
+	 * @return bool
+	 */
+	public function validate_pin_format( string $pin ): bool {
+		return 1 === preg_match( '/^\d{' . self::PIN_LENGTH . '}$/', $pin );
+	}
+}

--- a/plugins/woocommerce/src/Internal/StoreActors/ActorAccessRepository.php
+++ b/plugins/woocommerce/src/Internal/StoreActors/ActorAccessRepository.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * ActorAccessRepository class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StoreActors;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Persistence for store actor access rows (wc_store_actor_access).
+ *
+ * Each row represents one actor's access in a given (context, location).
+ * For the POC, only context='pos', location_id=0 is written. The schema
+ * admits future contexts and location_id values without migration.
+ *
+ * @internal Owned by the Point of Sale staff (actors) feature.
+ * @since 10.9.0
+ */
+class ActorAccessRepository {
+
+	public const CONTEXT_POS    = 'pos';
+	public const LOCATION_NONE  = 0;
+	public const STATUS_ACTIVE  = 'active';
+	public const STATUS_INACTIVE = 'inactive';
+
+	public const CREDENTIAL_TYPE_PIN = 'pin';
+
+	/**
+	 * Fully-qualified table name.
+	 */
+	public function get_table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'wc_store_actor_access';
+	}
+
+	/**
+	 * Fetch the access row for an actor in a given context/location.
+	 *
+	 * @param int    $actor_id    Actor ID.
+	 * @param string $context     Context (default 'pos').
+	 * @param int    $location_id Location ID (default 0).
+	 * @return array<string, mixed>|null
+	 */
+	public function get_for_actor( int $actor_id, string $context = self::CONTEXT_POS, int $location_id = self::LOCATION_NONE ): ?array {
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM ' . $this->get_table_name()
+					. ' WHERE actor_id = %d AND context = %s AND location_id = %d LIMIT 1',
+				$actor_id,
+				$context,
+				$location_id
+			),
+			ARRAY_A
+		);
+		return $row ?: null;
+	}
+
+	/**
+	 * Fetch all access rows for an actor across contexts/locations.
+	 *
+	 * @param int $actor_id Actor ID.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function list_for_actor( int $actor_id ): array {
+		global $wpdb;
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM ' . $this->get_table_name() . ' WHERE actor_id = %d ORDER BY access_id ASC',
+				$actor_id
+			),
+			ARRAY_A
+		);
+		return $rows ?: array();
+	}
+
+	/**
+	 * List active access rows for a given context, joined-friendly format.
+	 *
+	 * Returns one row per (actor_id, context) where status = active.
+	 * The caller is expected to join against actors to filter on actor status.
+	 *
+	 * @param string $context Context.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function list_active_for_context( string $context = self::CONTEXT_POS ): array {
+		global $wpdb;
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM ' . $this->get_table_name()
+					. ' WHERE context = %s AND status = %s'
+					. ' ORDER BY access_id ASC',
+				$context,
+				self::STATUS_ACTIVE
+			),
+			ARRAY_A
+		);
+		return $rows ?: array();
+	}
+
+	/**
+	 * Insert a new access row.
+	 *
+	 * @param array<string, mixed> $data Row fields.
+	 * @return int New access_id, or 0 on failure.
+	 */
+	public function insert( array $data ): int {
+		global $wpdb;
+		$now = gmdate( 'Y-m-d H:i:s' );
+
+		$row = array(
+			'actor_id'              => (int) ( $data['actor_id'] ?? 0 ),
+			'context'               => (string) ( $data['context'] ?? self::CONTEXT_POS ),
+			'location_id'           => (int) ( $data['location_id'] ?? self::LOCATION_NONE ),
+			'access_profile_key'    => (string) ( $data['access_profile_key'] ?? '' ),
+			'status'                => $data['status'] ?? self::STATUS_ACTIVE,
+			'credential_type'       => $data['credential_type'] ?? null,
+			'credential_algo'       => $data['credential_algo'] ?? null,
+			'credential_iterations' => isset( $data['credential_iterations'] ) ? (int) $data['credential_iterations'] : null,
+			'credential_salt'       => $data['credential_salt'] ?? null,
+			'credential_hash'       => $data['credential_hash'] ?? null,
+			'credential_updated_at' => $data['credential_updated_at'] ?? null,
+			'created_by_user_id'    => isset( $data['created_by_user_id'] ) ? (int) $data['created_by_user_id'] : null,
+			'updated_by_user_id'    => isset( $data['updated_by_user_id'] ) ? (int) $data['updated_by_user_id'] : null,
+			'date_created_gmt'      => $data['date_created_gmt'] ?? $now,
+			'date_updated_gmt'      => $data['date_updated_gmt'] ?? $now,
+		);
+
+		$inserted = $wpdb->insert( $this->get_table_name(), $row );
+		if ( false === $inserted ) {
+			return 0;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Update an access row in place.
+	 *
+	 * @param int                  $access_id Access ID.
+	 * @param array<string, mixed> $data      Fields to set.
+	 * @return bool True on success.
+	 */
+	public function update( int $access_id, array $data ): bool {
+		global $wpdb;
+
+		$allowed = array(
+			'access_profile_key',
+			'status',
+			'credential_type',
+			'credential_algo',
+			'credential_iterations',
+			'credential_salt',
+			'credential_hash',
+			'credential_updated_at',
+			'updated_by_user_id',
+		);
+
+		$row = array_intersect_key( $data, array_flip( $allowed ) );
+		if ( empty( $row ) ) {
+			return false;
+		}
+
+		$row['date_updated_gmt'] = gmdate( 'Y-m-d H:i:s' );
+
+		$result = $wpdb->update(
+			$this->get_table_name(),
+			$row,
+			array( 'access_id' => $access_id )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Delete the access row for an actor in a context/location.
+	 *
+	 * @param int    $actor_id    Actor ID.
+	 * @param string $context     Context.
+	 * @param int    $location_id Location ID.
+	 * @return bool
+	 */
+	public function delete_for_actor( int $actor_id, string $context = self::CONTEXT_POS, int $location_id = self::LOCATION_NONE ): bool {
+		global $wpdb;
+		$result = $wpdb->delete(
+			$this->get_table_name(),
+			array(
+				'actor_id'    => $actor_id,
+				'context'     => $context,
+				'location_id' => $location_id,
+			)
+		);
+		return false !== $result;
+	}
+
+	/**
+	 * Delete all access rows for an actor (typically alongside actor soft-delete).
+	 *
+	 * @param int $actor_id Actor ID.
+	 * @return bool
+	 */
+	public function delete_all_for_actor( int $actor_id ): bool {
+		global $wpdb;
+		$result = $wpdb->delete(
+			$this->get_table_name(),
+			array( 'actor_id' => $actor_id )
+		);
+		return false !== $result;
+	}
+
+	/**
+	 * Clear credential material on the POS access row for an actor.
+	 *
+	 * @param int $actor_id Actor ID.
+	 * @return bool
+	 */
+	public function clear_pos_credential( int $actor_id ): bool {
+		global $wpdb;
+		$result = $wpdb->update(
+			$this->get_table_name(),
+			array(
+				'credential_type'       => null,
+				'credential_algo'       => null,
+				'credential_iterations' => null,
+				'credential_salt'       => null,
+				'credential_hash'       => null,
+				'credential_updated_at' => null,
+				'date_updated_gmt'      => gmdate( 'Y-m-d H:i:s' ),
+			),
+			array(
+				'actor_id'    => $actor_id,
+				'context'     => self::CONTEXT_POS,
+				'location_id' => self::LOCATION_NONE,
+			)
+		);
+		return false !== $result;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StoreActors/ActorRepository.php
+++ b/plugins/woocommerce/src/Internal/StoreActors/ActorRepository.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * ActorRepository class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\StoreActors;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Persistence for store actors (wc_store_actors).
+ *
+ * A store actor is any person who acts on the store — could be a WordPress user
+ * (admin, shop_manager), could be a POS-only operator with no WP account, and
+ * later could be a non-POS employee. The wp_user_id link is optional.
+ *
+ * @internal Owned by the Point of Sale staff (actors) feature.
+ * @since 10.9.0
+ */
+class ActorRepository {
+
+	public const STATUS_ACTIVE   = 'active';
+	public const STATUS_INACTIVE = 'inactive';
+
+	/**
+	 * Fully-qualified table name.
+	 *
+	 * @return string
+	 */
+	public function get_table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'wc_store_actors';
+	}
+
+	/**
+	 * Returns the CREATE TABLE statements for the store-actor identity table
+	 * and its sibling access table. WC_Install pulls this in via the container
+	 * and concatenates it into the global dbDelta schema.
+	 *
+	 * Schema is paired (actors + access) because the two tables are always
+	 * installed together; the access satellite has no meaning without an actor.
+	 *
+	 * @return string
+	 */
+	public function get_database_schema(): string {
+		global $wpdb;
+
+		$collate = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
+
+		$actors_table = $this->get_table_name();
+		$access_table = $wpdb->prefix . 'wc_store_actor_access';
+
+		return "
+CREATE TABLE $actors_table (
+  actor_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  actor_uuid char(36) NOT NULL,
+  wp_user_id bigint(20) unsigned DEFAULT NULL,
+  status varchar(20) NOT NULL DEFAULT 'active',
+  display_name varchar(200) NOT NULL,
+  first_name varchar(100) DEFAULT NULL,
+  last_name varchar(100) DEFAULT NULL,
+  email varchar(320) DEFAULT NULL,
+  created_by_user_id bigint(20) unsigned DEFAULT NULL,
+  updated_by_user_id bigint(20) unsigned DEFAULT NULL,
+  date_created_gmt datetime NOT NULL,
+  date_updated_gmt datetime NOT NULL,
+  date_deleted_gmt datetime DEFAULT NULL,
+  PRIMARY KEY  (actor_id),
+  UNIQUE KEY actor_uuid (actor_uuid),
+  KEY wp_user_id (wp_user_id),
+  KEY status (status)
+) $collate;
+CREATE TABLE $access_table (
+  access_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  actor_id bigint(20) unsigned NOT NULL,
+  context varchar(32) NOT NULL,
+  location_id bigint(20) unsigned NOT NULL DEFAULT 0,
+  access_profile_key varchar(64) NOT NULL,
+  status varchar(20) NOT NULL DEFAULT 'active',
+  credential_type varchar(32) DEFAULT NULL,
+  credential_algo varchar(50) DEFAULT NULL,
+  credential_iterations int unsigned DEFAULT NULL,
+  credential_salt varchar(255) DEFAULT NULL,
+  credential_hash varchar(255) DEFAULT NULL,
+  credential_updated_at datetime DEFAULT NULL,
+  created_by_user_id bigint(20) unsigned DEFAULT NULL,
+  updated_by_user_id bigint(20) unsigned DEFAULT NULL,
+  date_created_gmt datetime NOT NULL,
+  date_updated_gmt datetime NOT NULL,
+  PRIMARY KEY  (access_id),
+  UNIQUE KEY actor_context_location (actor_id, context, location_id),
+  KEY context_profile_status (context, access_profile_key, status),
+  KEY location_context_status (location_id, context, status)
+) $collate;
+";
+	}
+
+	/**
+	 * Fetch a single actor row by ID.
+	 *
+	 * @param int $actor_id Actor ID.
+	 * @return array<string, mixed>|null
+	 */
+	public function get_by_id( int $actor_id ): ?array {
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM ' . $this->get_table_name() . ' WHERE actor_id = %d', $actor_id ),
+			ARRAY_A
+		);
+		return $row ?: null;
+	}
+
+	/**
+	 * Fetch a single actor row by UUID.
+	 *
+	 * @param string $actor_uuid Actor UUID.
+	 * @return array<string, mixed>|null
+	 */
+	public function get_by_uuid( string $actor_uuid ): ?array {
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM ' . $this->get_table_name() . ' WHERE actor_uuid = %s', $actor_uuid ),
+			ARRAY_A
+		);
+		return $row ?: null;
+	}
+
+	/**
+	 * Fetch the actor linked to a given WP user, if any.
+	 *
+	 * @param int $wp_user_id WordPress user ID.
+	 * @return array<string, mixed>|null
+	 */
+	public function find_by_wp_user_id( int $wp_user_id ): ?array {
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM ' . $this->get_table_name() . ' WHERE wp_user_id = %d AND date_deleted_gmt IS NULL LIMIT 1',
+				$wp_user_id
+			),
+			ARRAY_A
+		);
+		return $row ?: null;
+	}
+
+	/**
+	 * List active, not-soft-deleted actors.
+	 *
+	 * @param int $limit  Limit.
+	 * @param int $offset Offset.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function list_active( int $limit = 100, int $offset = 0 ): array {
+		global $wpdb;
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM ' . $this->get_table_name()
+					. " WHERE status = %s AND date_deleted_gmt IS NULL"
+					. ' ORDER BY actor_id ASC LIMIT %d OFFSET %d',
+				self::STATUS_ACTIVE,
+				$limit,
+				$offset
+			),
+			ARRAY_A
+		);
+		return $rows ?: array();
+	}
+
+	/**
+	 * Insert a new actor.
+	 *
+	 * Caller is responsible for input sanitization. `actor_uuid` is generated
+	 * here if not supplied. Returns the new actor_id, or 0 on failure.
+	 *
+	 * @param array<string, mixed> $data Actor fields.
+	 * @return int
+	 */
+	public function insert( array $data ): int {
+		global $wpdb;
+		$now = gmdate( 'Y-m-d H:i:s' );
+
+		$row = array(
+			'actor_uuid'         => $data['actor_uuid'] ?? wp_generate_uuid4(),
+			'wp_user_id'         => isset( $data['wp_user_id'] ) ? (int) $data['wp_user_id'] : null,
+			'status'             => $data['status'] ?? self::STATUS_ACTIVE,
+			'display_name'       => (string) ( $data['display_name'] ?? '' ),
+			'first_name'         => $data['first_name'] ?? null,
+			'last_name'          => $data['last_name'] ?? null,
+			'email'              => $data['email'] ?? null,
+			'created_by_user_id' => isset( $data['created_by_user_id'] ) ? (int) $data['created_by_user_id'] : null,
+			'updated_by_user_id' => isset( $data['updated_by_user_id'] ) ? (int) $data['updated_by_user_id'] : null,
+			'date_created_gmt'   => $data['date_created_gmt'] ?? $now,
+			'date_updated_gmt'   => $data['date_updated_gmt'] ?? $now,
+		);
+
+		$inserted = $wpdb->insert( $this->get_table_name(), $row );
+		if ( false === $inserted ) {
+			return 0;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Update an actor row in place. Always refreshes date_updated_gmt.
+	 *
+	 * @param int                  $actor_id Actor ID.
+	 * @param array<string, mixed> $data     Fields to set.
+	 * @return bool True on success.
+	 */
+	public function update( int $actor_id, array $data ): bool {
+		global $wpdb;
+
+		$allowed = array(
+			'wp_user_id',
+			'status',
+			'display_name',
+			'first_name',
+			'last_name',
+			'email',
+			'updated_by_user_id',
+			'date_deleted_gmt',
+		);
+
+		$row = array_intersect_key( $data, array_flip( $allowed ) );
+		if ( empty( $row ) ) {
+			return false;
+		}
+
+		$row['date_updated_gmt'] = gmdate( 'Y-m-d H:i:s' );
+
+		$result = $wpdb->update(
+			$this->get_table_name(),
+			$row,
+			array( 'actor_id' => $actor_id )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Hard-delete an actor row by ID. Caller is responsible for removing
+	 * associated rows (e.g. wc_store_actor_access) first to avoid orphans.
+	 *
+	 * Use this for atomic-create rollback (where the actor was inserted
+	 * moments ago and the follow-up step failed). For everyday deletion
+	 * from the merchant UI, use soft_delete() so historical order
+	 * attribution can still resolve the actor's name.
+	 *
+	 * @param int $actor_id Actor ID.
+	 * @return bool True if a row was deleted.
+	 */
+	public function delete( int $actor_id ): bool {
+		global $wpdb;
+		$result = $wpdb->delete(
+			$this->get_table_name(),
+			array( 'actor_id' => $actor_id )
+		);
+		return false !== $result && $result > 0;
+	}
+
+	/**
+	 * Soft-delete an actor: set date_deleted_gmt and status=inactive.
+	 *
+	 * @param int $actor_id Actor ID.
+	 * @return bool
+	 */
+	public function soft_delete( int $actor_id ): bool {
+		return $this->update(
+			$actor_id,
+			array(
+				'status'           => self::STATUS_INACTIVE,
+				'date_deleted_gmt' => gmdate( 'Y-m-d H:i:s' ),
+			)
+		);
+	}
+
+	/**
+	 * Cascade handler for wp user deletion. Sets wp_user_id NULL and status
+	 * inactive on any actor linked to the deleted WP user.
+	 *
+	 * @param int $wp_user_id Deleted WordPress user ID.
+	 * @return int Rows affected.
+	 */
+	public function detach_wp_user( int $wp_user_id ): int {
+		global $wpdb;
+		$now    = gmdate( 'Y-m-d H:i:s' );
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE ' . $this->get_table_name()
+					. ' SET wp_user_id = NULL, status = %s, date_updated_gmt = %s'
+					. ' WHERE wp_user_id = %d',
+				self::STATUS_INACTIVE,
+				$now,
+				$wp_user_id
+			)
+		);
+		return (int) $result;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Actors/AccessProfileRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Actors/AccessProfileRegistryTest.php
@@ -1,0 +1,74 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\POS\Actors;
+
+use Automattic\WooCommerce\Internal\POS\Actors\AccessProfileRegistry;
+use WC_Unit_Test_Case;
+
+/**
+ * @since 10.9.0
+ * @group pos-actors
+ */
+class AccessProfileRegistryTest extends WC_Unit_Test_Case {
+
+	public function test_built_in_profiles_exist(): void {
+		$registry = new AccessProfileRegistry();
+		$this->assertTrue( $registry->exists( AccessProfileRegistry::PROFILE_CASHIER ) );
+		$this->assertTrue( $registry->exists( AccessProfileRegistry::PROFILE_MANAGER ) );
+		$this->assertTrue( $registry->exists( AccessProfileRegistry::PROFILE_ADMIN ) );
+	}
+
+	public function test_cashier_refund_is_approval_required(): void {
+		$registry = new AccessProfileRegistry();
+		$this->assertSame(
+			AccessProfileRegistry::ACCESS_APPROVAL_REQUIRED,
+			$registry->resolve(
+				AccessProfileRegistry::PROFILE_CASHIER,
+				AccessProfileRegistry::TAG_REFUND_ORDERS
+			)
+		);
+	}
+
+	public function test_manager_can_approve_overrides(): void {
+		$registry = new AccessProfileRegistry();
+		$this->assertSame(
+			AccessProfileRegistry::ACCESS_ALLOW,
+			$registry->resolve(
+				AccessProfileRegistry::PROFILE_MANAGER,
+				AccessProfileRegistry::TAG_MANAGER_APPROVAL
+			)
+		);
+	}
+
+	public function test_unknown_profile_resolves_to_deny(): void {
+		$registry = new AccessProfileRegistry();
+		$this->assertSame(
+			AccessProfileRegistry::ACCESS_DENY,
+			$registry->resolve( 'unknown_profile', AccessProfileRegistry::TAG_PROCESS_SALES )
+		);
+	}
+
+	public function test_filter_can_inject_a_profile(): void {
+		$callback = function ( array $profiles ): array {
+			$profiles['pos_test_role'] = array(
+				'name'        => 'Test',
+				'permissions' => array(
+					AccessProfileRegistry::TAG_PROCESS_SALES => AccessProfileRegistry::ACCESS_ALLOW,
+				),
+			);
+			return $profiles;
+		};
+
+		add_filter( 'woocommerce_pos_access_profiles', $callback );
+
+		$registry = new AccessProfileRegistry();
+		$this->assertTrue( $registry->exists( 'pos_test_role' ) );
+		$this->assertSame(
+			AccessProfileRegistry::ACCESS_ALLOW,
+			$registry->resolve( 'pos_test_role', AccessProfileRegistry::TAG_PROCESS_SALES )
+		);
+
+		remove_filter( 'woocommerce_pos_access_profiles', $callback );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/OrderAttributionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/OrderAttributionTest.php
@@ -1,0 +1,167 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\POS;
+
+use Automattic\WooCommerce\Internal\POS\Actors\AccessProfileRegistry;
+use Automattic\WooCommerce\Internal\POS\OrderAttribution;
+use Automattic\WooCommerce\Internal\StoreActors\ActorAccessRepository;
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+use Automattic\WooCommerce\Tests\Internal\StoreActors\Concerns\EnablesActorsFeature;
+use WC_Order;
+use WC_Unit_Test_Case;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * @since 10.9.0
+ * @group pos-actors
+ */
+class OrderAttributionTest extends WC_Unit_Test_Case {
+
+	use EnablesActorsFeature;
+
+	private OrderAttribution $attribution;
+	private ActorRepository $actors;
+	private ActorAccessRepository $access;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->install_actor_tables();
+		$this->attribution = wc_get_container()->get( OrderAttribution::class );
+		$this->actors      = wc_get_container()->get( ActorRepository::class );
+		$this->access      = wc_get_container()->get( ActorAccessRepository::class );
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( 'DELETE FROM ' . $this->access->get_table_name() );
+		$wpdb->query( 'DELETE FROM ' . $this->actors->get_table_name() );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	private function make_actor( string $profile_key, string $name = 'Test' ): int {
+		$id = $this->actors->insert( array( 'display_name' => $name ) );
+		$this->access->insert(
+			array(
+				'actor_id'           => $id,
+				'access_profile_key' => $profile_key,
+			)
+		);
+		return $id;
+	}
+
+	private function make_order_with_meta( array $meta ): WC_Order {
+		$order = new WC_Order();
+		foreach ( $meta as $k => $v ) {
+			$order->add_meta_data( $k, $v, true );
+		}
+		return $order;
+	}
+
+	private function invoke_pre_insert( WC_Order $order ) {
+		return $this->attribution->handle_pre_insert( $order, new WP_REST_Request(), true );
+	}
+
+	public function test_no_pos_meta_passes_through(): void {
+		$order  = new WC_Order();
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertSame( $order, $result );
+	}
+
+	public function test_unknown_actor_is_rejected(): void {
+		$order  = $this->make_order_with_meta( array( OrderAttribution::META_KEY_STAFF_ID => 999999 ) );
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'woocommerce_pos_invalid_attribution', $result->get_error_code() );
+	}
+
+	public function test_inactive_actor_is_rejected(): void {
+		$id = $this->make_actor( AccessProfileRegistry::PROFILE_CASHIER );
+		$this->actors->update( $id, array( 'status' => ActorRepository::STATUS_INACTIVE ) );
+
+		$order  = $this->make_order_with_meta( array( OrderAttribution::META_KEY_STAFF_ID => $id ) );
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	public function test_valid_attribution_passes(): void {
+		$id     = $this->make_actor( AccessProfileRegistry::PROFILE_CASHIER );
+		$order  = $this->make_order_with_meta( array( OrderAttribution::META_KEY_STAFF_ID => $id ) );
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertSame( $order, $result );
+	}
+
+	public function test_partial_override_is_rejected(): void {
+		$id    = $this->make_actor( AccessProfileRegistry::PROFILE_CASHIER );
+		$order = $this->make_order_with_meta(
+			array(
+				OrderAttribution::META_KEY_STAFF_ID          => $id,
+				OrderAttribution::META_KEY_OVERRIDE_STAFF_ID => 5,
+				// Missing override reason.
+			)
+		);
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'woocommerce_pos_invalid_override', $result->get_error_code() );
+	}
+
+	public function test_self_override_is_rejected(): void {
+		$id    = $this->make_actor( AccessProfileRegistry::PROFILE_MANAGER );
+		$order = $this->make_order_with_meta(
+			array(
+				OrderAttribution::META_KEY_STAFF_ID          => $id,
+				OrderAttribution::META_KEY_OVERRIDE_STAFF_ID => $id,
+				OrderAttribution::META_KEY_OVERRIDE_REASON   => AccessProfileRegistry::TAG_REFUND_ORDERS,
+			)
+		);
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'woocommerce_pos_self_override', $result->get_error_code() );
+	}
+
+	public function test_unsupported_override_reason_is_rejected(): void {
+		$cashier = $this->make_actor( AccessProfileRegistry::PROFILE_CASHIER, 'Alex' );
+		$manager = $this->make_actor( AccessProfileRegistry::PROFILE_MANAGER, 'Morgan' );
+
+		$order = $this->make_order_with_meta(
+			array(
+				OrderAttribution::META_KEY_STAFF_ID          => $cashier,
+				OrderAttribution::META_KEY_OVERRIDE_STAFF_ID => $manager,
+				OrderAttribution::META_KEY_OVERRIDE_REASON   => 'edit_pos_settings',
+			)
+		);
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	public function test_cashier_cannot_approve_override(): void {
+		$cashier_a = $this->make_actor( AccessProfileRegistry::PROFILE_CASHIER, 'Alex' );
+		$cashier_b = $this->make_actor( AccessProfileRegistry::PROFILE_CASHIER, 'Bobby' );
+
+		$order = $this->make_order_with_meta(
+			array(
+				OrderAttribution::META_KEY_STAFF_ID          => $cashier_a,
+				OrderAttribution::META_KEY_OVERRIDE_STAFF_ID => $cashier_b,
+				OrderAttribution::META_KEY_OVERRIDE_REASON   => AccessProfileRegistry::TAG_REFUND_ORDERS,
+			)
+		);
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'woocommerce_pos_override_forbidden', $result->get_error_code() );
+	}
+
+	public function test_manager_can_approve_cashier_override(): void {
+		$cashier = $this->make_actor( AccessProfileRegistry::PROFILE_CASHIER, 'Alex' );
+		$manager = $this->make_actor( AccessProfileRegistry::PROFILE_MANAGER, 'Morgan' );
+
+		$order = $this->make_order_with_meta(
+			array(
+				OrderAttribution::META_KEY_STAFF_ID          => $cashier,
+				OrderAttribution::META_KEY_OVERRIDE_STAFF_ID => $manager,
+				OrderAttribution::META_KEY_OVERRIDE_REASON   => AccessProfileRegistry::TAG_REFUND_ORDERS,
+			)
+		);
+		$result = $this->invoke_pre_insert( $order );
+		$this->assertSame( $order, $result );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/RestApi/POSStaffControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/RestApi/POSStaffControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\POS\RestApi;
+
+use Automattic\WooCommerce\Internal\POS\Actors\AccessProfileRegistry;
+use Automattic\WooCommerce\Internal\POS\RestApi\POSStaffController;
+use Automattic\WooCommerce\Internal\POS\Service\POSPinService;
+use Automattic\WooCommerce\Internal\StoreActors\ActorAccessRepository;
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+use Automattic\WooCommerce\Tests\Internal\StoreActors\Concerns\EnablesActorsFeature;
+use WC_REST_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * @since 10.9.0
+ * @group pos-actors
+ */
+class POSStaffControllerTest extends WC_REST_Unit_Test_Case {
+
+	use EnablesActorsFeature;
+
+	private const ROUTE = '/wc/pos/v1/staff';
+
+	private ActorRepository $actors;
+	private ActorAccessRepository $access;
+	private POSPinService $pin;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->install_actor_tables();
+		$this->actors = wc_get_container()->get( ActorRepository::class );
+		$this->access = wc_get_container()->get( ActorAccessRepository::class );
+		$this->pin    = wc_get_container()->get( POSPinService::class );
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( 'DELETE FROM ' . $this->access->get_table_name() );
+		$wpdb->query( 'DELETE FROM ' . $this->actors->get_table_name() );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		// Register the route for this test run.
+		wc_get_container()->get( POSStaffController::class )->register_routes();
+
+		// Administrator already holds manage_woocommerce by default; no extra grant needed.
+		$admin = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+	}
+
+	private function make_actor( array $actor_data = array(), array $access_data = array() ): int {
+		$id = $this->actors->insert( $actor_data + array( 'display_name' => 'Test' ) );
+		$this->access->insert(
+			$access_data + array(
+				'actor_id'           => $id,
+				'access_profile_key' => AccessProfileRegistry::PROFILE_CASHIER,
+			)
+		);
+		return $id;
+	}
+
+	public function test_get_staff_returns_flat_array_with_inlined_permissions(): void {
+		$id = $this->make_actor( array( 'display_name' => 'Alex Cashier' ) );
+		$this->pin->set_pin( $id, '1234' );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::ROUTE ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayNotHasKey( 'actors', $data );
+		$this->assertCount( 1, $data );
+
+		$staff = $data[0];
+		$this->assertSame( $id, $staff['id'] );
+		$this->assertSame( 'Alex Cashier', $staff['display_name'] );
+		$this->assertNull( $staff['wp_user_id'] );
+		$this->assertNull( $staff['email'] );
+
+		$this->assertSame( AccessProfileRegistry::PROFILE_CASHIER, $staff['pos_access']['profile_key'] );
+		$this->assertSame( 'Cashier', $staff['pos_access']['profile_name'] );
+
+		$perms = $staff['pos_access']['permissions'];
+		$this->assertIsArray( $perms );
+		$this->assertSame( AccessProfileRegistry::ACCESS_ALLOW, $perms[ AccessProfileRegistry::TAG_PROCESS_SALES ] );
+		$this->assertSame( AccessProfileRegistry::ACCESS_APPROVAL_REQUIRED, $perms[ AccessProfileRegistry::TAG_REFUND_ORDERS ] );
+		$this->assertSame( AccessProfileRegistry::ACCESS_DENY, $perms[ AccessProfileRegistry::TAG_MANAGE_POS_STAFF ] );
+
+		$cred = $staff['pos_access']['credential'];
+		$this->assertNotNull( $cred );
+		$this->assertSame( POSPinService::ALGO, $cred['algo'] );
+		$this->assertNotEmpty( $cred['hash'] );
+	}
+
+	public function test_staff_without_active_access_is_filtered_out(): void {
+		// Actor exists but with inactive access.
+		$id     = $this->actors->insert( array( 'display_name' => 'Inactive Access' ) );
+		$access = $this->access->insert(
+			array(
+				'actor_id'           => $id,
+				'access_profile_key' => AccessProfileRegistry::PROFILE_CASHIER,
+				'status'             => ActorAccessRepository::STATUS_INACTIVE,
+			)
+		);
+		$this->assertGreaterThan( 0, $access );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::ROUTE ) );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data() );
+	}
+
+	public function test_unauthenticated_caller_is_rejected(): void {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::ROUTE ) );
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	public function test_shop_manager_can_read_actors(): void {
+		// shop_manager holds manage_woocommerce by default.
+		$manager = $this->factory()->user->create( array( 'role' => 'shop_manager' ) );
+		wp_set_current_user( $manager );
+		$this->make_actor();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::ROUTE ) );
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_subscriber_is_forbidden(): void {
+		$sub = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $sub );
+		$this->make_actor();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::ROUTE ) );
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -1,0 +1,128 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\POS\Service;
+
+use Automattic\WooCommerce\Internal\POS\Service\POSPinService;
+use Automattic\WooCommerce\Internal\StoreActors\ActorAccessRepository;
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+use Automattic\WooCommerce\Tests\Internal\StoreActors\Concerns\EnablesActorsFeature;
+use WC_Unit_Test_Case;
+use WP_Error;
+
+/**
+ * @since 10.9.0
+ * @group pos-actors
+ */
+class POSPinServiceTest extends WC_Unit_Test_Case {
+
+	use EnablesActorsFeature;
+
+	private POSPinService $pin;
+	private ActorRepository $actors;
+	private ActorAccessRepository $access;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->install_actor_tables();
+		$this->pin    = wc_get_container()->get( POSPinService::class );
+		$this->actors = wc_get_container()->get( ActorRepository::class );
+		$this->access = wc_get_container()->get( ActorAccessRepository::class );
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( 'DELETE FROM ' . $this->access->get_table_name() );
+		$wpdb->query( 'DELETE FROM ' . $this->actors->get_table_name() );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	private function make_actor_with_access(): int {
+		$id = $this->actors->insert( array( 'display_name' => 'Alex' ) );
+		$this->access->insert(
+			array(
+				'actor_id'           => $id,
+				'access_profile_key' => 'pos_cashier',
+			)
+		);
+		return $id;
+	}
+
+	public function test_set_then_verify_roundtrip(): void {
+		$id = $this->make_actor_with_access();
+		$this->assertTrue( $this->pin->set_pin( $id, '1234' ) );
+
+		$record = $this->pin->get_public_pin_record( $id );
+		$this->assertNotNull( $record );
+		$this->assertSame( POSPinService::ALGO, $record['algo'] );
+		$this->assertSame( POSPinService::ITERATIONS, $record['iterations'] );
+		$this->assertTrue( $this->pin->verify_pin( '1234', $record ) );
+		$this->assertFalse( $this->pin->verify_pin( '9999', $record ) );
+	}
+
+	public function test_set_rejects_invalid_format(): void {
+		$id     = $this->make_actor_with_access();
+		$result = $this->pin->set_pin( $id, 'abcd' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertFalse( $this->pin->has_pin( $id ) );
+	}
+
+	public function test_set_requires_access_row(): void {
+		$id     = $this->actors->insert( array( 'display_name' => 'Orphan' ) );
+		$result = $this->pin->set_pin( $id, '1234' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'woocommerce_pos_actor_no_access', $result->get_error_code() );
+	}
+
+	public function test_delete_clears_credential(): void {
+		$id = $this->make_actor_with_access();
+		$this->pin->set_pin( $id, '1234' );
+		$this->assertTrue( $this->pin->has_pin( $id ) );
+
+		$this->assertTrue( $this->pin->delete_pin( $id ) );
+		$this->assertFalse( $this->pin->has_pin( $id ) );
+		$this->assertNull( $this->pin->get_public_pin_record( $id ) );
+	}
+
+	public function test_set_rejects_pin_already_in_use_by_another_active_staff(): void {
+		$alice = $this->make_actor_with_access();
+		$bob   = $this->make_actor_with_access();
+
+		$this->assertTrue( $this->pin->set_pin( $alice, '1234' ) );
+
+		$result = $this->pin->set_pin( $bob, '1234' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'woocommerce_pos_pin_in_use', $result->get_error_code() );
+		$this->assertFalse( $this->pin->has_pin( $bob ) );
+	}
+
+	public function test_set_pin_allows_reusing_own_pin_on_self_update(): void {
+		$id = $this->make_actor_with_access();
+		$this->assertTrue( $this->pin->set_pin( $id, '1234' ) );
+		// Re-setting the same PIN on the same actor must not collide with itself.
+		$this->assertTrue( $this->pin->set_pin( $id, '1234' ) );
+	}
+
+	public function test_set_pin_ignores_inactive_access_rows(): void {
+		$alice = $this->make_actor_with_access();
+		$bob   = $this->make_actor_with_access();
+		$this->pin->set_pin( $alice, '1234' );
+
+		// Mark Alice's POS access inactive.
+		$access = $this->access->get_for_actor( $alice );
+		$this->access->update( (int) $access['access_id'], array( 'status' => ActorAccessRepository::STATUS_INACTIVE ) );
+
+		// Bob can now reuse Alice's old PIN.
+		$this->assertTrue( $this->pin->set_pin( $bob, '1234' ) );
+	}
+
+	public function test_find_actor_with_pin_returns_match(): void {
+		$alice = $this->make_actor_with_access();
+		$bob   = $this->make_actor_with_access();
+		$this->pin->set_pin( $alice, '1111' );
+		$this->pin->set_pin( $bob, '2222' );
+
+		$this->assertSame( $alice, $this->pin->find_actor_with_pin( '1111' ) );
+		$this->assertSame( $bob, $this->pin->find_actor_with_pin( '2222' ) );
+		$this->assertNull( $this->pin->find_actor_with_pin( '9999' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StoreActors/ActorRepositoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StoreActors/ActorRepositoryTest.php
@@ -1,0 +1,133 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StoreActors;
+
+use Automattic\WooCommerce\Internal\StoreActors\ActorAccessRepository;
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+use Automattic\WooCommerce\Tests\Internal\StoreActors\Concerns\EnablesActorsFeature;
+use WC_Unit_Test_Case;
+
+/**
+ * @since 10.9.0
+ * @group store-actors
+ */
+class ActorRepositoryTest extends WC_Unit_Test_Case {
+
+	use EnablesActorsFeature;
+
+	private ActorRepository $actors;
+	private ActorAccessRepository $access;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->install_actor_tables();
+		$this->actors = wc_get_container()->get( ActorRepository::class );
+		$this->access = wc_get_container()->get( ActorAccessRepository::class );
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( 'DELETE FROM ' . $this->access->get_table_name() );
+		$wpdb->query( 'DELETE FROM ' . $this->actors->get_table_name() );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	public function test_insert_generates_uuid_and_returns_id(): void {
+		$id = $this->actors->insert(
+			array(
+				'display_name' => 'Alex Cashier',
+			)
+		);
+
+		$this->assertGreaterThan( 0, $id );
+		$row = $this->actors->get_by_id( $id );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'Alex Cashier', $row['display_name'] );
+		$this->assertNotEmpty( $row['actor_uuid'] );
+		$this->assertSame( ActorRepository::STATUS_ACTIVE, $row['status'] );
+		$this->assertNull( $row['wp_user_id'] );
+		$this->assertNull( $row['date_deleted_gmt'] );
+	}
+
+	public function test_find_by_wp_user_id_returns_linked_actor_only(): void {
+		$linked = $this->actors->insert(
+			array(
+				'display_name' => 'Manager',
+				'wp_user_id'   => 7,
+			)
+		);
+		$this->actors->insert( array( 'display_name' => 'POS-only cashier' ) );
+
+		$found = $this->actors->find_by_wp_user_id( 7 );
+		$this->assertNotNull( $found );
+		$this->assertSame( $linked, (int) $found['actor_id'] );
+
+		$this->assertNull( $this->actors->find_by_wp_user_id( 999 ) );
+	}
+
+	public function test_list_active_skips_soft_deleted(): void {
+		$keep = $this->actors->insert( array( 'display_name' => 'Keep' ) );
+		$drop = $this->actors->insert( array( 'display_name' => 'Drop' ) );
+		$this->actors->soft_delete( $drop );
+
+		$rows = $this->actors->list_active();
+		$ids  = array_map( static fn( $r ) => (int) $r['actor_id'], $rows );
+
+		$this->assertContains( $keep, $ids );
+		$this->assertNotContains( $drop, $ids );
+	}
+
+	public function test_soft_delete_sets_status_inactive_and_date_deleted(): void {
+		$id = $this->actors->insert( array( 'display_name' => 'Bye' ) );
+		$this->assertTrue( $this->actors->soft_delete( $id ) );
+
+		$row = $this->actors->get_by_id( $id );
+		$this->assertNotNull( $row );
+		$this->assertSame( ActorRepository::STATUS_INACTIVE, $row['status'] );
+		$this->assertNotNull( $row['date_deleted_gmt'] );
+	}
+
+	public function test_detach_wp_user_nulls_link_and_inactivates(): void {
+		$linked = $this->actors->insert(
+			array(
+				'display_name' => 'Manager',
+				'wp_user_id'   => 42,
+			)
+		);
+		$other = $this->actors->insert(
+			array(
+				'display_name' => 'Other',
+				'wp_user_id'   => 99,
+			)
+		);
+
+		$affected = $this->actors->detach_wp_user( 42 );
+		$this->assertSame( 1, $affected );
+
+		$row = $this->actors->get_by_id( $linked );
+		$this->assertNull( $row['wp_user_id'] );
+		$this->assertSame( ActorRepository::STATUS_INACTIVE, $row['status'] );
+
+		$untouched = $this->actors->get_by_id( $other );
+		$this->assertSame( 99, (int) $untouched['wp_user_id'] );
+		$this->assertSame( ActorRepository::STATUS_ACTIVE, $untouched['status'] );
+	}
+
+	public function test_update_refreshes_updated_at_and_only_writes_allowed_fields(): void {
+		$id      = $this->actors->insert( array( 'display_name' => 'Original' ) );
+		$initial = $this->actors->get_by_id( $id );
+
+		// Attempt to overwrite actor_uuid (not allowed) and display_name (allowed).
+		$this->actors->update(
+			$id,
+			array(
+				'display_name' => 'Renamed',
+				'actor_uuid'   => 'evil-uuid',
+			)
+		);
+
+		$updated = $this->actors->get_by_id( $id );
+		$this->assertSame( 'Renamed', $updated['display_name'] );
+		$this->assertSame( $initial['actor_uuid'], $updated['actor_uuid'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StoreActors/Concerns/EnablesActorsFeature.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StoreActors/Concerns/EnablesActorsFeature.php
@@ -1,0 +1,28 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\StoreActors\Concerns;
+
+use Automattic\WooCommerce\Internal\StoreActors\ActorRepository;
+
+/**
+ * Test helper trait: ensures the store-actor tables exist for the duration of
+ * the test. Calls dbDelta directly against the repository's schema so the
+ * `point_of_sale_actors` feature flag does not need to be toggled globally.
+ *
+ * @internal
+ * @since 10.9.0
+ */
+trait EnablesActorsFeature {
+
+	/**
+	 * Run dbDelta for the actor + access tables. Idempotent.
+	 *
+	 * @return void
+	 */
+	protected function install_actor_tables(): void {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		$schema = wc_get_container()->get( ActorRepository::class )->get_database_schema();
+		dbDelta( $schema );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Server-side POC for the POS staff feature, taking a different swing at the design from #65106-equivalent prior work (`feature/pos-staff-and-attribution`) based on internal feedback (pdfdoF-92E-p2#comment-10454, pdfdoF-92E-p2#comment-10456). Full design + open questions in the pdfdoF-93Q-p2.

**Approach summary** — POS staff are modeled as **store actors** in two custom tables (`wc_store_actors` + `wc_store_actor_access`), not as `wp_users`. Permissions use a tri-state map (`allow` / `deny` / `approval_required`) per permission tag. No new WP roles, no new WP capabilities — `manage_woocommerce` gates the new surface. Gated end-to-end behind a new dev-only `point_of_sale_actors` feature flag.

**What's in M1:**
- Generic identity layer (`wc_store_actors` + `wc_store_actor_access` schema, with `context`/`location_id` so future non-POS staff features and Woo locations can reuse it without rename).
- PHP-defined access profile registry (`pos_cashier` / `pos_manager` / `pos_admin`) with `woocommerce_pos_access_profiles` filter.
- `POSPinService` — PBKDF2-SHA-256 PIN storage on the access row, with cross-staff uniqueness enforcement (staff log in to POS using only a PIN, so collisions are unresolvable).
- One REST endpoint: `GET /wc/pos/v1/staff` (top-level array, permissions + PIN material inlined per staff member).
- Order/refund attribution against staff IDs (`_wc_pos_staff_id` etc.), with manager-approval override validation via the `manager_approval` permission tag.
- wp-admin Staff page under Settings → Point of Sale → Staff (list / add / edit / delete + inline PIN, `wc-customer-search` linked-user picker, admin/shop_manager → POS Admin auto-assignment, atomic create with rollback on PIN failure).
- `deleted_user` cascade nulls `wp_user_id` and inactivates linked actors.

**Out of scope (M2+):**
- Write endpoints under `/wc/pos/v1/staff` (POST/PATCH/DELETE, PIN set/clear). wp-admin handles merchant CRUD for now.
- Pagination on the staff endpoint (typically small lists; standard `wc/v3` `page`/`per_page` + `X-WP-Total` headers when added).
- `GET /wc/pos/v1/access-profiles` — M1 inlines per-staff permissions, so it isn't needed yet.
- Per-staff permission overrides; merchant-defined custom profiles; first-class Woo locations.

Closes # .

### Screenshots or screen recordings:

UI changes are limited to the new wp-admin Settings → Point of Sale → Staff section. Screenshots can be added to the P2 draft and inline here once the reviewer would find them useful — happy to record a walkthrough on request.

### How to test the changes in this Pull Request:

1. Check out the branch and ensure dependencies are fresh: `pnpm install --frozen-lockfile`.
2. In a wp-env site, enable both feature flags under WooCommerce → Settings → Advanced → Features: **Point of Sale** and the new **Point of Sale staff**. (If the actor tables don't exist immediately after toggling, run `wp-env run cli wp eval 'opcache_reset();'` and reload, or deactivate/reactivate WooCommerce once.)
3. Open **Settings → Point of Sale → Staff** and verify the list view is empty.
4. **Create a POS-only staff member**: click "Add POS staff", fill in display name + a 4-digit PIN, choose Cashier or Manager, submit. Verify the staff member appears in the list with "PIN: Set".
5. **Test PIN uniqueness**: try to create another staff member with the same PIN. Verify the form re-renders with the error "This PIN is already in use by another POS staff member. Choose a different PIN." and no half-created actor is left behind (the list view shouldn't grow).
6. **Test the admin-link auto-assignment**: edit a staff member, use the "Linked WordPress user" search to pick an administrator or shop_manager. Verify the profile selector hides and shows "POS Admin (auto-assigned)". Save; verify the access profile is `pos_admin` in the DB.
7. **Test the REST endpoint**: as an administrator, hit `GET /wp-json/wc/pos/v1/staff`. Verify the response is a top-level array with each staff member's `pos_access.permissions` (tag-keyed object) and `pos_access.credential` (algo/iterations/salt/hash) populated.
8. **Test order attribution**: create an order via `POST /wp-json/wc/v3/orders` with `meta_data: [{ key: "_wc_pos_staff_id", value: <id> }]`. Verify the order has a "POS: created by <name>." note. Try the same with an unknown/inactive staff ID — verify the request fails with HTTP 400 and the order is not created.
9. **Test override attribution**: create an order with a cashier's ID + an override pair (`_wc_pos_override_staff_id` = manager's ID, `_wc_pos_override_reason` = `refund_orders`). Verify the combined override note appears. Verify a cashier-as-approver is rejected with HTTP 400 (cashier profile doesn't grant `manager_approval = allow`).
10. **Test cascade on user deletion**: link a staff member to a non-admin WP user, then delete that WP user. Verify the actor row's `wp_user_id` becomes NULL and `status` becomes `inactive`.
11. **Test deactivation**: toggle the `point_of_sale_actors` flag off. Verify the Staff sub-section disappears and `GET /wc/pos/v1/staff` returns 404.

### Testing that has already taken place:

- 33 PHPUnit tests across `ActorRepository`, `AccessProfileRegistry`, `POSPinService`, `POSStaffController`, and `OrderAttribution` — all passing. Run: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --group pos-actors,store-actors`.
- `phpcs-changed` clean on all changed files.
- PHPStan clean on the new production code (no new baseline entries).
- Manual exercise of the wp-admin Staff page in a fresh wp-env: create/edit/delete actors, PIN set/replace/remove, linked-user search, admin auto-assignment toggle, uniqueness rejection.
- Manual `GET /wc/pos/v1/staff` and order/refund attribution flow via curl.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

Changelog entry is included in this PR at `plugins/woocommerce/changelog/feature-pos-actors-poc`.