### PR TITLE
Visual attribute refactor and cleanup

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/visual-attribute-terms.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/visual-attribute-terms.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import type { CSSProperties } from 'react';
+
+export type VisualAttributeTerm = {
+	type: 'color' | 'image' | 'none';
+	value: string;
+};
+
+const getEscapedUrl = ( url: string ) => url.split( "'" ).join( '%27' );
+
+export const isVisualAttributeTermEmpty = ( visual?: VisualAttributeTerm ) =>
+	! visual || visual.type === 'none' || ! visual.value;
+
+export const getVisualAttributeTermStyle = (
+	visual?: VisualAttributeTerm
+): CSSProperties | undefined => {
+	if ( ! visual || visual.type === 'none' || ! visual.value ) {
+		return undefined;
+	}
+
+	if ( visual.type === 'image' ) {
+		return {
+			backgroundImage: `url('${ getEscapedUrl( visual.value ) }')`,
+		};
+	}
+
+	return {
+		backgroundColor: visual.value,
+	};
+};
+
+export const getVisualAttributeTermStyleString = (
+	visual?: VisualAttributeTerm
+): string => {
+	if ( ! visual || visual.type === 'none' || ! visual.value ) {
+		return '';
+	}
+
+	if ( visual.type === 'image' ) {
+		return `background-image: url('${ getEscapedUrl( visual.value ) }');`;
+	}
+
+	return `background-color: ${ visual.value }`;
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/constants.ts
@@ -4,6 +4,11 @@
 import type { TemplateArray } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
+
 export const ATTRIBUTE_ITEM_TEMPLATE: TemplateArray = [
 	[
 		'woocommerce/add-to-cart-with-options-variation-selector-attribute',
@@ -66,8 +71,8 @@ export const DEFAULT_ATTRIBUTES = [
 	},
 ] as const;
 
-export const EMPTY_TERM_COLORS: Record< string, string > = {
-	'-1': '#0000ff',
-	'-2': '#e10000',
-	'-3': '#009b00',
+export const EMPTY_TERM_VISUALS: Record< string, VisualAttributeTerm > = {
+	'-1': { type: 'color', value: '#0000ff' },
+	'-2': { type: 'color', value: '#e10000' },
+	'-3': { type: 'color', value: '#009b00' },
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -93,7 +93,8 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 			attribute.terms.length > 0
 		) {
 			items = attribute.terms.map( ( term ) => {
-				const visual = term.visual || EMPTY_TERM_VISUALS[ term.id ];
+				const visual =
+					term.__experimentalVisual || EMPTY_TERM_VISUALS[ term.id ];
 
 				return {
 					id: `${ attribute.taxonomy }-${ term.slug }`,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -36,11 +36,12 @@ import {
 /**
  * Internal dependencies
  */
-import { DEFAULT_ATTRIBUTES, EMPTY_TERM_COLORS } from './constants';
+import { DEFAULT_ATTRIBUTES, EMPTY_TERM_VISUALS } from './constants';
 import type {
 	SelectableItem,
 	SelectableItemsContext,
 } from '../../../../types/type-defs/selectable-items';
+import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
 
 const INNER_CHIPS = 'woocommerce/product-filter-chips';
 
@@ -81,14 +82,16 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 	const { data: attribute } =
 		useCustomDataContext< ProductResponseAttributeItem >( 'attribute' );
 
-	const termVisuals = getSetting<
-		Record< string, { color?: string; image?: string } >
-	>( 'variationSelectorTermVisuals', {} );
+	const termVisuals = getSetting< Record< string, VisualAttributeTerm > >(
+		'variationSelectorTermVisuals',
+		{}
+	);
 
 	const selectableContext = useMemo( () => {
 		let items: SelectableItem< {
 			label: string;
 			ariaLabel: string;
+			visual?: VisualAttributeTerm;
 		} >[] = [];
 		if (
 			attribute &&
@@ -96,23 +99,15 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 			attribute.terms.length > 0
 		) {
 			items = attribute.terms.map( ( term ) => {
-				let color: string | undefined;
-				let image: string | undefined;
-
-				if ( term.id in termVisuals ) {
-					color = termVisuals[ term.id ]?.color || '';
-					image = termVisuals[ term.id ]?.image || '';
-				} else if ( term.id in EMPTY_TERM_COLORS ) {
-					color = EMPTY_TERM_COLORS[ term.id ];
-				}
+				const visual =
+					termVisuals[ term.id ] || EMPTY_TERM_VISUALS[ term.id ];
 
 				return {
 					id: `${ attribute.taxonomy }-${ term.slug }`,
 					label: term.name,
 					value: term.slug,
 					ariaLabel: term.name,
-					...( color ? { color } : {} ),
-					...( image ? { image } : {} ),
+					...( visual ? { visual } : {} ),
 				};
 			} );
 		}
@@ -125,6 +120,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 		} satisfies SelectableItemsContext< {
 			label: string;
 			ariaLabel: string;
+			visual?: VisualAttributeTerm;
 		} >;
 	}, [ attribute, termVisuals ] );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -20,7 +20,6 @@ import {
 import { isProductResponseItem } from '@woocommerce/entities';
 import type { ProductResponseAttributeItem } from '@woocommerce/types';
 import { __ } from '@wordpress/i18n';
-import { getSetting } from '@woocommerce/settings';
 import {
 	DisplayStyleSwitcher,
 	resetDisplayStyleBlock,
@@ -82,11 +81,6 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 	const { data: attribute } =
 		useCustomDataContext< ProductResponseAttributeItem >( 'attribute' );
 
-	const termVisuals = getSetting< Record< string, VisualAttributeTerm > >(
-		'variationSelectorTermVisuals',
-		{}
-	);
-
 	const selectableContext = useMemo( () => {
 		let items: SelectableItem< {
 			label: string;
@@ -99,8 +93,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 			attribute.terms.length > 0
 		) {
 			items = attribute.terms.map( ( term ) => {
-				const visual =
-					termVisuals[ term.id ] || EMPTY_TERM_VISUALS[ term.id ];
+				const visual = term.visual || EMPTY_TERM_VISUALS[ term.id ];
 
 				return {
 					id: `${ attribute.taxonomy }-${ term.slug }`,
@@ -122,7 +115,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 			ariaLabel: string;
 			visual?: VisualAttributeTerm;
 		} >;
-	}, [ attribute, termVisuals ] );
+	}, [ attribute ] );
 
 	const blockPreviewProps = useBlockPreview( {
 		blocks,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -25,14 +25,14 @@ import type {
 	Context as AddToCartWithOptionsStoreContext,
 } from '../frontend';
 import type { SelectableItem } from '../../../types/type-defs/selectable-items';
+import type { VisualAttributeTerm } from '../../../base/utils/visual-attribute-terms';
 
 type VariationOptionItem = {
 	id: string;
 	label: string;
 	value: string;
 	ariaLabel?: string;
-	color?: string;
-	image?: string;
+	visual?: VisualAttributeTerm;
 };
 
 type Context = AddToCartWithOptionsStoreContext & {
@@ -44,7 +44,7 @@ type Context = AddToCartWithOptionsStoreContext & {
 };
 
 type ToggleContext = Context & {
-	item?: SelectableItem;
+	item?: SelectableItem< { visual?: VisualAttributeTerm } >;
 };
 
 const universalLock =
@@ -183,12 +183,16 @@ export type VariableProductAddToCartWithOptionsStore =
 	AddToCartWithOptionsStore & {
 		state: {
 			selectedAttributes: SelectedAttributes[];
-			selectableItems: readonly SelectableItem[];
+			selectableItems: readonly SelectableItem< {
+				visual?: VisualAttributeTerm;
+			} >[];
 		};
 		actions: {
 			setAttribute: ( attribute: string, value: string ) => void;
 			removeAttribute: ( attribute: string ) => void;
-			toggle: ( item?: SelectableItem ) => void;
+			toggle: (
+				item?: SelectableItem< { visual?: VisualAttributeTerm } >
+			) => void;
 			autoselectAttributes: ( args: {
 				includedAttributes?: string[];
 				excludedAttributes?: string[];
@@ -213,7 +217,9 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 				}
 				return context.selectedAttributes || [];
 			},
-			get selectableItems(): readonly SelectableItem[] {
+			get selectableItems(): readonly SelectableItem< {
+				visual?: VisualAttributeTerm;
+			} >[] {
 				const context = getContext< Context >();
 				if ( ! context ) {
 					return [];
@@ -250,8 +256,9 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 						selected,
 						disabled,
 						hidden: hideInvalid && disabled,
-						...( row.color !== undefined && { color: row.color } ),
-						...( row.image !== undefined && { image: row.image } ),
+						...( row.visual !== undefined && {
+							visual: row.visual,
+						} ),
 					};
 				} );
 			},
@@ -299,7 +306,11 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					selectedAttributes.splice( index, 1 );
 				}
 			},
-			toggle( itemArg?: SelectableItem | Event ) {
+			toggle(
+				itemArg?:
+					| SelectableItem< { visual?: VisualAttributeTerm } >
+					| Event
+			) {
 				const context = getContext< ToggleContext >();
 				const item =
 					itemArg && ! ( itemArg instanceof Event )

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -102,8 +102,8 @@ const Edit = ( props: EditProps ) => {
 					value: term.id.toString(),
 					selected: index === 0,
 					...( showCounts && { count: term.count } ),
-					...( term.visual && {
-						visual: term.visual,
+					...( term.__experimentalVisual && {
+						visual: term.__experimentalVisual,
 					} ),
 				} ) );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -32,13 +32,13 @@ import { getAllowedBlocks } from '../../utils/get-allowed-blocks';
 import { EXCLUDED_BLOCKS } from '../../constants';
 import { FilterOptionItem, FilterItemFields } from '../../types';
 import type { SelectableItemsContext } from '../../../../types/type-defs/selectable-items';
+import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
 import { InitialDisabled } from '../../components/initial-disabled';
 import { Notice } from '../../components/notice';
 import { sortFilterOptions } from '../../utils/sort-filter-options';
 
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
-const EMPTY_TERM_VISUALS: Record< string, { color?: string; image?: string } > =
-	{};
+const EMPTY_TERM_VISUALS: Record< string, VisualAttributeTerm > = {};
 
 const Edit = ( props: EditProps ) => {
 	const { attributes: blockAttributes } = props;
@@ -54,9 +54,10 @@ const Edit = ( props: EditProps ) => {
 	} = blockAttributes;
 
 	const attributeObject = getAttributeFromId( attributeId );
-	const termVisuals = getSetting<
-		Record< string, { color?: string; image?: string } >
-	>( 'productFilterTermVisuals', EMPTY_TERM_VISUALS );
+	const termVisuals = getSetting< Record< string, VisualAttributeTerm > >(
+		'productFilterTermVisuals',
+		EMPTY_TERM_VISUALS
+	);
 
 	const [ attributeOptions, setAttributeOptions ] = useState<
 		FilterOptionItem[]
@@ -108,8 +109,7 @@ const Edit = ( props: EditProps ) => {
 					selected: index === 0,
 					...( showCounts && { count: term.count } ),
 					...( term.id in termVisuals && {
-						color: termVisuals[ term.id ]?.color || '',
-						image: termVisuals[ term.id ]?.image || '',
+						visual: termVisuals[ term.id ],
 					} ),
 				} ) );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -32,13 +32,11 @@ import { getAllowedBlocks } from '../../utils/get-allowed-blocks';
 import { EXCLUDED_BLOCKS } from '../../constants';
 import { FilterOptionItem, FilterItemFields } from '../../types';
 import type { SelectableItemsContext } from '../../../../types/type-defs/selectable-items';
-import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
 import { InitialDisabled } from '../../components/initial-disabled';
 import { Notice } from '../../components/notice';
 import { sortFilterOptions } from '../../utils/sort-filter-options';
 
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
-const EMPTY_TERM_VISUALS: Record< string, VisualAttributeTerm > = {};
 
 const Edit = ( props: EditProps ) => {
 	const { attributes: blockAttributes } = props;
@@ -54,10 +52,6 @@ const Edit = ( props: EditProps ) => {
 	} = blockAttributes;
 
 	const attributeObject = getAttributeFromId( attributeId );
-	const termVisuals = getSetting< Record< string, VisualAttributeTerm > >(
-		'productFilterTermVisuals',
-		EMPTY_TERM_VISUALS
-	);
 
 	const [ attributeOptions, setAttributeOptions ] = useState<
 		FilterOptionItem[]
@@ -108,8 +102,8 @@ const Edit = ( props: EditProps ) => {
 					value: term.id.toString(),
 					selected: index === 0,
 					...( showCounts && { count: term.count } ),
-					...( term.id in termVisuals && {
-						visual: termVisuals[ term.id ],
+					...( term.visual && {
+						visual: term.visual,
 					} ),
 				} ) );
 
@@ -128,7 +122,6 @@ const Edit = ( props: EditProps ) => {
 		isTermsLoading,
 		isFilterCountsLoading,
 		attributeObject,
-		termVisuals,
 	] );
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -26,21 +26,10 @@ import './style.scss';
 import './editor.scss';
 import { EditProps } from './types';
 import { getColorClasses, getColorVars } from './utils';
-
-const getSwatchStyle = ( item: { color?: string; image?: string } ) => {
-	if ( item.image ) {
-		const escapedImage = item.image.split( "'" ).join( '%27' );
-		return {
-			backgroundImage: `url('${ escapedImage }')`,
-		};
-	} else if ( item.color ) {
-		return {
-			backgroundColor: item.color,
-		};
-	}
-
-	return undefined;
-};
+import {
+	getVisualAttributeTermStyle,
+	isVisualAttributeTermEmpty,
+} from '../../../../base/utils/visual-attribute-terms';
 
 const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 	const {
@@ -137,19 +126,19 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 											/>
 										</span>
 										<span className="wc-block-product-filter-checkbox-list__text-wrapper">
-											{ ( item.color !== undefined ||
-												item.image !== undefined ) && (
+											{ item.visual !== undefined && (
 												<span
 													className={ clsx(
 														'wc-block-product-filter-checkbox-list__color-swatch',
 														{
 															'is-empty':
-																! item.color &&
-																! item.image,
+																isVisualAttributeTermEmpty(
+																	item.visual
+																),
 														}
 													) }
-													style={ getSwatchStyle(
-														item
+													style={ getVisualAttributeTermStyle(
+														item.visual
 													) }
 													aria-hidden="true"
 												/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/frontend.ts
@@ -10,10 +10,14 @@ import type {
 	SelectableItem,
 	SelectableItemsParentStore,
 } from '../../../../types/type-defs/selectable-items';
+import {
+	getVisualAttributeTermStyleString,
+	isVisualAttributeTermEmpty,
+} from '../../../../base/utils/visual-attribute-terms';
+import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
 
 type CheckboxListItem = SelectableItem< {
-	color?: string;
-	image?: string;
+	visual?: VisualAttributeTerm;
 	index?: number;
 } >;
 
@@ -41,7 +45,7 @@ type CheckboxListStore = {
 function getParentStore( storeNamespace?: string ) {
 	if ( ! storeNamespace ) return undefined;
 	return store<
-		SelectableItemsParentStore< { color?: string; image?: string } >
+		SelectableItemsParentStore< { visual?: VisualAttributeTerm } >
 	>( storeNamespace );
 }
 
@@ -56,19 +60,6 @@ function normalizeDisplayLimit( displayLimit: number ): number {
 function getCurrentItem(): CheckboxListItem | undefined {
 	const context = getContext< { item?: CheckboxListItem } >();
 	return context.item;
-}
-
-function getSwatchStyle( item?: CheckboxListItem ): string {
-	if ( item?.image ) {
-		const escapedImage = item.image.split( "'" ).join( '%27' );
-		return `background-image: url('${ escapedImage }');`;
-	}
-
-	if ( item?.color ) {
-		return `background-color: ${ item.color }`;
-	}
-
-	return '';
 }
 
 const { state }: CheckboxListStore = store< CheckboxListStore >(
@@ -100,11 +91,11 @@ const { state }: CheckboxListStore = store< CheckboxListStore >(
 			},
 			get colorSwatchStyle(): string {
 				const item = getCurrentItem();
-				return getSwatchStyle( item );
+				return getVisualAttributeTermStyleString( item?.visual );
 			},
 			get isColorSwatchEmpty(): boolean {
 				const item = getCurrentItem();
-				return ! item?.color && ! item?.image;
+				return isVisualAttributeTermEmpty( item?.visual );
 			},
 		},
 		actions: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/types.ts
@@ -7,6 +7,7 @@ import { BlockEditProps } from '@wordpress/blocks';
  * Internal dependencies
  */
 import type { SelectableItemsBlockContext } from '../../../../types/type-defs/selectable-items';
+import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
 
 export type Color = {
 	slug?: string;
@@ -30,8 +31,7 @@ export type BlockAttributes = {
 export type EditProps = BlockEditProps< BlockAttributes > & {
 	context: SelectableItemsBlockContext< {
 		count?: number;
-		color?: string;
-		image?: string;
+		visual?: VisualAttributeTerm;
 		depth?: number;
 	} >;
 	optionElementBorder: Color;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -25,21 +25,10 @@ import {
 import { EditProps } from './types';
 import './editor.scss';
 import { getColorClasses, getColorVars } from './utils';
-
-const getSwatchStyle = ( item: { color?: string; image?: string } ) => {
-	if ( item.image ) {
-		const escapedImage = item.image.split( "'" ).join( '%27' );
-		return {
-			backgroundImage: `url('${ escapedImage }')`,
-		};
-	} else if ( item.color ) {
-		return {
-			backgroundColor: item.color,
-		};
-	}
-
-	return undefined;
-};
+import {
+	getVisualAttributeTermStyle,
+	isVisualAttributeTermEmpty,
+} from '../../../../base/utils/visual-attribute-terms';
 
 const Edit = ( props: EditProps ): JSX.Element => {
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
@@ -72,9 +61,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 	const { isLoading = false, items = [] } =
 		context?.[ 'woocommerce/selectableItems' ] ?? {};
 
-	const hasVisualSwatches = items.some(
-		( item ) => 'color' in item || 'image' in item
-	);
+	const hasVisualSwatches = items.some( ( item ) => 'visual' in item );
 
 	const globalColors = getSetting< { background?: string; text?: string } >(
 		'globalStylesColors',
@@ -144,11 +131,14 @@ const Edit = ( props: EditProps ): JSX.Element => {
 												'wc-block-product-filter-chips__swatch',
 												{
 													'wc-block-product-filter-chips__swatch--no-color':
-														! item.color &&
-														! item.image,
+														isVisualAttributeTermEmpty(
+															item.visual
+														),
 												}
 											) }
-											style={ getSwatchStyle( item ) }
+											style={ getVisualAttributeTermStyle(
+												item.visual
+											) }
 											aria-hidden="true"
 										/>
 										<span className="wc-block-product-filter-chips__text">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/frontend.ts
@@ -10,11 +10,15 @@ import type {
 	SelectableItem,
 	SelectableItemsParentStore,
 } from '../../../../types/type-defs/selectable-items';
+import {
+	getVisualAttributeTermStyleString,
+	isVisualAttributeTermEmpty,
+} from '../../../../base/utils/visual-attribute-terms';
+import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
 import { getClosestColor } from '../../utils/get-closest-color';
 
 type ChipsItem = SelectableItem< {
-	color?: string;
-	image?: string;
+	visual?: VisualAttributeTerm;
 	index?: number;
 } >;
 
@@ -46,7 +50,7 @@ type ChipsStore = {
 function getParentStore( storeNamespace?: string ) {
 	if ( ! storeNamespace ) return undefined;
 	return store<
-		SelectableItemsParentStore< { color?: string; image?: string } >
+		SelectableItemsParentStore< { visual?: VisualAttributeTerm } >
 	>( storeNamespace );
 }
 
@@ -88,19 +92,6 @@ function initChipColors( element: HTMLElement ): void {
 	}
 }
 
-function getSwatchStyle( item?: ChipsItem ): string {
-	if ( item?.image ) {
-		const escapedImage = item.image.split( "'" ).join( '%27' );
-		return `background-image: url('${ escapedImage }');`;
-	}
-
-	if ( item?.color ) {
-		return `background-color: ${ item.color }`;
-	}
-
-	return '';
-}
-
 const { state }: ChipsStore = store< ChipsStore >(
 	'woocommerce/product-filter-chips',
 	{
@@ -125,11 +116,11 @@ const { state }: ChipsStore = store< ChipsStore >(
 			},
 			get swatchHidden(): boolean {
 				const item = getCurrentItem();
-				return ! item?.color && ! item?.image;
+				return isVisualAttributeTermEmpty( item?.visual );
 			},
 			get swatchStyle(): string {
 				const item = getCurrentItem();
-				return getSwatchStyle( item );
+				return getVisualAttributeTermStyleString( item?.visual );
 			},
 		},
 		actions: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/types.ts
@@ -7,6 +7,7 @@ import { BlockEditProps } from '@wordpress/blocks';
  * Internal dependencies
  */
 import type { SelectableItemsBlockContext } from '../../../../types/type-defs/selectable-items';
+import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
 
 export type Color = {
 	slug?: string;
@@ -35,8 +36,7 @@ export type EditProps = BlockEditProps< BlockAttributes > & {
 	style: Record< string, string >;
 	context: SelectableItemsBlockContext< {
 		count?: number;
-		color?: string;
-		image?: string;
+		visual?: VisualAttributeTerm;
 	} >;
 	chipText: Color;
 	setChipText: ( value: string ) => void;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
@@ -7,6 +7,7 @@ import type { BlockEditProps } from '@wordpress/blocks';
  * Internal dependencies
  */
 import type { SelectableItem } from '../../types/type-defs/selectable-items';
+import type { VisualAttributeTerm } from '../../base/utils/visual-attribute-terms';
 
 // ----------------------------------------
 // Filter-specific item fields
@@ -18,8 +19,7 @@ export type FilterItemFields = {
 	depth?: number;
 	menuOrder?: number;
 	attributeQueryType?: 'and' | 'or';
-	color?: string;
-	image?: string;
+	visual?: VisualAttributeTerm;
 };
 
 export type FilterOptionItem = SelectableItem< FilterItemFields >;

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/attributes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/attributes.ts
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import type { VisualAttributeTerm } from '../../base/utils/visual-attribute-terms';
+
 export interface AttributeSetting {
 	attribute_id: string;
 	attribute_name: string;
@@ -38,6 +43,7 @@ export interface AttributeTerm {
 	name: string;
 	parent: number;
 	slug: string;
+	visual?: VisualAttributeTerm;
 }
 
 export interface AttributeMetadata {

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/attributes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/attributes.ts
@@ -43,7 +43,8 @@ export interface AttributeTerm {
 	name: string;
 	parent: number;
 	slug: string;
-	visual?: VisualAttributeTerm;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	__experimentalVisual?: VisualAttributeTerm;
 }
 
 export interface AttributeMetadata {

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-response.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-response.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import type { VisualAttributeTerm } from '../../base/utils/visual-attribute-terms';
 import type { CurrencyResponse } from './currency';
 
 export interface ProductResponseItemPrices extends CurrencyResponse {
@@ -36,6 +37,7 @@ export interface ProductResponseTermItem {
 	name: string;
 	slug: string;
 	link?: string;
+	visual?: VisualAttributeTerm;
 }
 
 export interface ProductResponseAttributeItem {

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-response.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-response.ts
@@ -37,7 +37,8 @@ export interface ProductResponseTermItem {
 	name: string;
 	slug: string;
 	link?: string;
-	visual?: VisualAttributeTerm;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	__experimentalVisual?: VisualAttributeTerm;
 }
 
 export interface ProductResponseAttributeItem {

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/inner-block-protocols.md
@@ -128,14 +128,17 @@ export type FilterItemFields = {
 	depth?: number;
 	menuOrder?: number;
 	attributeQueryType?: 'and' | 'or';
-	color?: string;
+	visual?: {
+		type: 'color' | 'image' | 'none';
+		value: string;
+	};
 };
 ```
 
 | Consumer | Optional fields read | Fallback |
 | --- | --- | --- |
-| `checkbox-list` | `count`, `color`, `depth`, `filterType === 'rating'` | Text label, no count, no swatch, no indent |
-| `chips` | `count`, `color` | Text label, no count, no swatch |
+| `checkbox-list` | `count`, `visual`, `depth`, `filterType === 'rating'` | Text label, no count, no swatch, no indent |
+| `chips` | `count`, `visual` | Text label, no count, no swatch |
 
 Checkbox-list and chips mirror parent items into child `state.items`, adding local `index` for show-more and setting `hidden` when an item should be hidden. Their templates bind overflow visibility with `context.item.hidden`.
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -329,29 +329,6 @@ class WC_Admin_Taxonomies {
 	}
 
 	/**
-	 * Check if the current taxonomy should show visual swatch controls.
-	 *
-	 * @param string $taxonomy Taxonomy slug.
-	 * @return bool
-	 *
-	 * @internal
-	 */
-	private function is_visual_product_attribute_taxonomy( $taxonomy ) {
-		if ( ! taxonomy_is_product_attribute( $taxonomy ) ) {
-			return false;
-		}
-
-		if ( ! array_key_exists( 'wc-visual', wc_get_attribute_types() ) ) {
-			return false;
-		}
-
-		$attribute_id = wc_attribute_taxonomy_id_by_name( $taxonomy );
-		$attribute    = $attribute_id ? wc_get_attribute( $attribute_id ) : null;
-
-		return $attribute && 'wc-visual' === $attribute->type;
-	}
-
-	/**
 	 * Add custom fields for product attribute terms.
 	 *
 	 * @param string $taxonomy Taxonomy slug.
@@ -360,7 +337,7 @@ class WC_Admin_Taxonomies {
 	 * @internal
 	 */
 	public function add_product_attribute_term_fields( $taxonomy ) {
-		if ( ! $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
+		if ( ! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {
 			return;
 		}
 		?>
@@ -408,7 +385,7 @@ class WC_Admin_Taxonomies {
 	 * @internal
 	 */
 	public function edit_product_attribute_term_fields( $term ) {
-		if ( ! $this->is_visual_product_attribute_taxonomy( $term->taxonomy ) ) {
+		if ( ! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
 			return;
 		}
 
@@ -483,7 +460,7 @@ class WC_Admin_Taxonomies {
 		$is_attribute_term_screen = 0 === strpos( $screen->id, 'edit-pa_' );
 		$taxonomy                 = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( $is_attribute_term_screen && $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
+		if ( $is_attribute_term_screen && VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {
 			wp_enqueue_media();
 			WCAdminAssets::register_script( 'wp-admin-scripts', 'visual-attribute-color-picker', true, array( 'wp-components' ) );
 		}
@@ -516,7 +493,7 @@ class WC_Admin_Taxonomies {
 	 * @internal
 	 */
 	public function save_product_attribute_term_fields( $term_id, $tt_id = '', $taxonomy = '' ) {
-		if ( ! $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
+		if ( ! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {
 			return;
 		}
 
@@ -579,7 +556,7 @@ class WC_Admin_Taxonomies {
 	 * @internal
 	 */
 	public function add_term_visual_column( $columns, $taxonomy ) {
-		if ( ! $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
+		if ( ! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {
 			return $columns;
 		}
 
@@ -616,7 +593,7 @@ class WC_Admin_Taxonomies {
 			return $content;
 		}
 
-		if ( ! $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
+		if ( ! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {
 			return $content;
 		}
 
@@ -800,7 +777,7 @@ class WC_Admin_Taxonomies {
 	 */
 	public function scripts_at_visual_attribute_screen_footer() {
 		$taxonomy = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! $this->is_visual_product_attribute_taxonomy( $taxonomy ) ) {
+		if ( ! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 use Automattic\WooCommerce\Internal\AssignDefaultCategory;
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 
 /**
  * WC_Admin_Taxonomies class.
@@ -522,7 +523,7 @@ class WC_Admin_Taxonomies {
 		$color_value = isset( $_POST['term_color'] ) ? sanitize_hex_color( wp_unslash( $_POST['term_color'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$image_id    = isset( $_POST['term_image'] ) ? absint( wp_unslash( $_POST['term_image'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
-		wc_save_visual_attribute_term_meta( (int) $term_id, $color_value ?? '', $image_id );
+		VisualAttributeTermMeta::save_term_visual( (int) $term_id, $color_value ?? '', $image_id );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController;
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use Automattic\WooCommerce\Internal\Orders\CouponsController;
 use Automattic\WooCommerce\Internal\Orders\TaxesController;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
@@ -790,7 +791,7 @@ class WC_AJAX {
 						$color_value = isset( $_POST['term_color'] ) ? sanitize_hex_color( wp_unslash( $_POST['term_color'] ) ) : '';
 						$image_id    = isset( $_POST['term_image'] ) ? absint( wp_unslash( $_POST['term_image'] ) ) : 0;
 
-						wc_save_visual_attribute_term_meta( (int) $result['term_id'], $color_value ?? '', $image_id );
+						VisualAttributeTermMeta::save_term_visual( (int) $result['term_id'], $color_value ?? '', $image_id );
 					}
 
 					$term = get_term_by( 'id', $result['term_id'], $taxonomy );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -742,29 +742,6 @@ class WC_AJAX {
 	}
 
 	/**
-	 * Check if a product attribute taxonomy supports visual term colors.
-	 *
-	 * @param string $taxonomy Taxonomy slug.
-	 * @return bool
-	 *
-	 * @internal
-	 */
-	private static function is_visual_product_attribute_taxonomy( $taxonomy ) {
-		if ( ! taxonomy_exists( $taxonomy ) || ! taxonomy_is_product_attribute( $taxonomy ) ) {
-			return false;
-		}
-
-		if ( ! array_key_exists( 'wc-visual', wc_get_attribute_types() ) ) {
-			return false;
-		}
-
-		$attribute_id = wc_attribute_taxonomy_id_by_name( $taxonomy );
-		$attribute    = $attribute_id ? wc_get_attribute( $attribute_id ) : null;
-
-		return $attribute && 'wc-visual' === $attribute->type;
-	}
-
-	/**
 	 * Add a new attribute via ajax function.
 	 *
 	 * @return void
@@ -787,7 +764,7 @@ class WC_AJAX {
 						)
 					);
 				} else {
-					if ( self::is_visual_product_attribute_taxonomy( $taxonomy ) && ( isset( $_POST['term_color'] ) || isset( $_POST['term_image'] ) ) ) {
+					if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) && ( isset( $_POST['term_color'] ) || isset( $_POST['term_image'] ) ) ) {
 						$color_value = isset( $_POST['term_color'] ) ? sanitize_hex_color( wp_unslash( $_POST['term_color'] ) ) : '';
 						$image_id    = isset( $_POST['term_image'] ) ? absint( wp_unslash( $_POST['term_image'] ) ) : 0;
 

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -798,19 +799,5 @@ function wc_attribute_taxonomy_slug( $attribute_name ) {
  * @return void
  */
 function wc_save_visual_attribute_term_meta( int $term_id, string $color = '', int $image_id = 0 ): void {
-	if ( $image_id && wp_attachment_is_image( $image_id ) ) {
-		update_term_meta( $term_id, 'image', absint( $image_id ) );
-		delete_term_meta( $term_id, 'color' );
-		return;
-	}
-
-	$sanitized_color = sanitize_hex_color( $color );
-	if ( $sanitized_color ) {
-		update_term_meta( $term_id, 'color', $sanitized_color );
-		delete_term_meta( $term_id, 'image' );
-		return;
-	}
-
-	delete_term_meta( $term_id, 'color' );
-	delete_term_meta( $term_id, 'image' );
+	VisualAttributeTermMeta::save_term_visual( $term_id, $color, $image_id );
 }

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\WooCommerce\Enums\ProductType;
-use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -782,22 +781,4 @@ function wc_attribute_taxonomy_slug( $attribute_name ) {
 	wp_cache_set( $cache_key, $attribute_slug, 'woocommerce-attributes' );
 
 	return $attribute_slug;
-}
-
-/**
- * Save visual attribute term meta (color or image).
- *
- * Color and image are mutually exclusive. When a color is saved, any image meta is removed,
- * and when an image is saved, any color meta is removed.
- *
- * @internal This function is only used internally and should not be used directly.
- *
- * @since 10.9.0
- * @param int    $term_id  Term ID.
- * @param string $color    Hex color value.
- * @param int    $image_id Attachment ID for the term image.
- * @return void
- */
-function wc_save_visual_attribute_term_meta( int $term_id, string $color = '', int $image_id = 0 ): void {
-	VisualAttributeTermMeta::save_term_visual( $term_id, $color, $image_id );
 }

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -53464,12 +53464,6 @@ parameters:
 			path: src/Blocks/BlockTypes/ProductFilterAttribute.php
 
 		-
-			message: '#^Parameter \#2 \$array of function array_map expects array, array\<int, WP_Term\>\|WP_Error given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/BlockTypes/ProductFilterAttribute.php
-
-		-
 			message: '#^Parameter \$block of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\ProductFilterAttribute\:\:get_attribute_counts\(\) has invalid type Automattic\\WooCommerce\\Blocks\\BlockTypes\\WP_Block\.$#'
 			identifier: class.notFound
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use WP_Block;
 
 /**
@@ -31,64 +32,8 @@ class VariationSelectorAttribute extends AbstractBlock {
 		parent::enqueue_data( $attributes );
 
 		if ( is_admin() ) {
-			$this->asset_data_registry->add( 'variationSelectorTermVisuals', $this->get_visual_attribute_term_visuals() );
+			$this->asset_data_registry->add( 'variationSelectorTermVisuals', VisualAttributeTermMeta::get_attribute_term_visuals() );
 		}
-	}
-
-	/**
-	 * Get visual values for wc-visual attribute terms.
-	 *
-	 * @param string|null $attribute_name Optional product attribute taxonomy name (e.g. `pa_color`). When omitted, values for every wc-visual attribute are loaded.
-	 * @return array<int, array{color?: string, image?: string}> Map of term ID to color/image values.
-	 */
-	private function get_visual_attribute_term_visuals( ?string $attribute_name = null ): array {
-		$visuals    = array();
-		$attributes = wc_get_attribute_taxonomies();
-
-		foreach ( $attributes as $attribute ) {
-			if ( 'wc-visual' !== $attribute->attribute_type ) {
-				continue;
-			}
-			if ( $attribute_name && 'pa_' . $attribute->attribute_name !== $attribute_name ) {
-				continue;
-			}
-
-			$terms = get_terms(
-				array(
-					'taxonomy'   => 'pa_' . $attribute->attribute_name,
-					'hide_empty' => false,
-				)
-			);
-
-			if ( is_wp_error( $terms ) ) {
-				continue;
-			}
-
-			foreach ( $terms as $term ) {
-				$image_id = absint( get_term_meta( $term->term_id, 'image', true ) );
-
-				if ( $image_id && wp_attachment_is_image( $image_id ) ) {
-					$image = wp_get_attachment_image_url( $image_id, 'thumbnail' );
-
-					if ( $image ) {
-						$visuals[ $term->term_id ] = array(
-							'image' => $image,
-						);
-						continue;
-					}
-				}
-
-				$color = sanitize_hex_color( get_term_meta( $term->term_id, 'color', true ) );
-
-				if ( $color ) {
-					$visuals[ $term->term_id ] = array(
-						'color' => $color,
-					);
-				}
-			}
-		}
-
-		return $visuals;
 	}
 
 	/**
@@ -326,7 +271,7 @@ class VariationSelectorAttribute extends AbstractBlock {
 	private function build_variation_selectable_items( string $attribute_name, string $attribute_slug, array $attribute_terms, ?string $default_selected ): array {
 		$id_prefix    = sanitize_title( $attribute_slug );
 		$items        = array();
-		$term_visuals = $this->get_visual_attribute_term_visuals( $attribute_name );
+		$term_visuals = VisualAttributeTermMeta::get_attribute_term_visuals( $attribute_name );
 
 		foreach ( $attribute_terms as $attribute_term ) {
 			if ( ! is_array( $attribute_term ) || ! isset( $attribute_term['value'], $attribute_term['label'] ) ) {
@@ -343,8 +288,7 @@ class VariationSelectorAttribute extends AbstractBlock {
 			);
 
 			if ( isset( $attribute_term['term_id'], $term_visuals[ $attribute_term['term_id'] ] ) ) {
-				$item['color'] = $term_visuals[ $attribute_term['term_id'] ]['color'] ?? '';
-				$item['image'] = $term_visuals[ $attribute_term['term_id'] ]['image'] ?? '';
+				$item['visual'] = $term_visuals[ $attribute_term['term_id'] ];
 			}
 
 			$items[] = $item;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -257,7 +257,9 @@ class VariationSelectorAttribute extends AbstractBlock {
 	private function build_variation_selectable_items( string $attribute_name, string $attribute_slug, array $attribute_terms, ?string $default_selected ): array {
 		$id_prefix    = sanitize_title( $attribute_slug );
 		$items        = array();
-		$term_visuals = VisualAttributeTermMeta::get_term_visuals( wp_list_pluck( $attribute_terms, 'term_id' ) );
+		$term_visuals = VisualAttributeTermMeta::is_visual_attribute_taxonomy( $attribute_name )
+			? VisualAttributeTermMeta::get_term_visuals( wp_list_pluck( $attribute_terms, 'term_id' ) )
+			: array();
 
 		foreach ( $attribute_terms as $attribute_term ) {
 			if ( ! is_array( $attribute_term ) || ! isset( $attribute_term['value'], $attribute_term['label'] ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -23,20 +23,6 @@ class VariationSelectorAttribute extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options-variation-selector-attribute';
 
 	/**
-	 * Extra data passed through from server to client for block.
-	 *
-	 * @param array $attributes Any attributes that currently are available from the block.
-	 * @return void
-	 */
-	protected function enqueue_data( array $attributes = array() ) {
-		parent::enqueue_data( $attributes );
-
-		if ( is_admin() ) {
-			$this->asset_data_registry->add( 'variationSelectorTermVisuals', VisualAttributeTermMeta::get_attribute_term_visuals() );
-		}
-	}
-
-	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.
@@ -271,7 +257,7 @@ class VariationSelectorAttribute extends AbstractBlock {
 	private function build_variation_selectable_items( string $attribute_name, string $attribute_slug, array $attribute_terms, ?string $default_selected ): array {
 		$id_prefix    = sanitize_title( $attribute_slug );
 		$items        = array();
-		$term_visuals = VisualAttributeTermMeta::get_attribute_term_visuals( $attribute_name );
+		$term_visuals = VisualAttributeTermMeta::get_term_visuals( wp_list_pluck( $attribute_terms, 'term_id' ) );
 
 		foreach ( $attribute_terms as $attribute_term ) {
 			if ( ! is_array( $attribute_term ) || ! isset( $attribute_term['value'], $attribute_term['label'] ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -46,7 +46,6 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		if ( is_admin() ) {
 			$this->asset_data_registry->add( 'defaultProductFilterAttribute', $this->get_default_product_attribute() );
-			$this->asset_data_registry->add( 'productFilterTermVisuals', VisualAttributeTermMeta::get_attribute_term_visuals() );
 		}
 	}
 
@@ -176,6 +175,10 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		$attribute_terms = get_terms( $args );
 
+		if ( is_wp_error( $attribute_terms ) ) {
+			$attribute_terms = array();
+		}
+
 		$filter_param_key = 'filter_' . str_replace( 'pa_', '', $product_attribute->slug );
 		$filter_params    = $block->context['filterParams'] ?? array();
 		$selected_terms   = array();
@@ -197,7 +200,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 			$visual_values       = array();
 
 			if ( $is_visual_attribute ) {
-				$visual_values = VisualAttributeTermMeta::get_attribute_term_visuals( $product_attribute->slug );
+				$visual_values = VisualAttributeTermMeta::get_term_visuals( wp_list_pluck( $attribute_terms, 'term_id' ) );
 			}
 
 			$attribute_options = array_map(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\ProductCollection\Utils as ProductCollectionUtils;
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use Automattic\WooCommerce\Internal\ProductFilters\FilterDataProvider;
 use Automattic\WooCommerce\Internal\ProductFilters\QueryClauses;
 
@@ -18,13 +19,6 @@ final class ProductFilterAttribute extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'product-filter-attribute';
-
-	/**
-	 * Cached map of term ID to visual values for wc-visual attribute terms.
-	 *
-	 * @var array<int, array{color?: string, image?: string}>|null
-	 */
-	private $term_visuals = null;
 
 	/**
 	 * Initialize this block type.
@@ -52,66 +46,8 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		if ( is_admin() ) {
 			$this->asset_data_registry->add( 'defaultProductFilterAttribute', $this->get_default_product_attribute() );
-			$this->asset_data_registry->add( 'productFilterTermVisuals', $this->get_visual_attribute_term_visuals() );
+			$this->asset_data_registry->add( 'productFilterTermVisuals', VisualAttributeTermMeta::get_attribute_term_visuals() );
 		}
-	}
-
-	/**
-	 * Get visual values for all wc-visual attribute terms.
-	 *
-	 * @return array<int, array{color?: string, image?: string}> Map of term ID to color/image values.
-	 */
-	private function get_visual_attribute_term_visuals(): array {
-		if ( null !== $this->term_visuals ) {
-			return $this->term_visuals;
-		}
-
-		$visuals    = array();
-		$attributes = wc_get_attribute_taxonomies();
-
-		foreach ( $attributes as $attribute ) {
-			if ( 'wc-visual' !== $attribute->attribute_type ) {
-				continue;
-			}
-
-			$terms = get_terms(
-				array(
-					'taxonomy'   => 'pa_' . $attribute->attribute_name,
-					'hide_empty' => false,
-				)
-			);
-
-			if ( is_wp_error( $terms ) ) {
-				continue;
-			}
-
-			foreach ( $terms as $term ) {
-				$image_id = absint( get_term_meta( $term->term_id, 'image', true ) );
-
-				if ( $image_id && wp_attachment_is_image( $image_id ) ) {
-					$image = wp_get_attachment_image_url( $image_id, 'thumbnail' );
-
-					if ( $image ) {
-						$visuals[ $term->term_id ] = array(
-							'image' => $image,
-						);
-						continue;
-					}
-				}
-
-				$color = sanitize_hex_color( get_term_meta( $term->term_id, 'color', true ) );
-
-				if ( $color ) {
-					$visuals[ $term->term_id ] = array(
-						'color' => $color,
-					);
-				}
-			}
-		}
-
-		$this->term_visuals = $visuals;
-
-		return $this->term_visuals;
 	}
 
 	/**
@@ -124,8 +60,6 @@ final class ProductFilterAttribute extends AbstractBlock {
 			delete_transient( 'wc_block_product_filter_attribute_default_attribute' );
 		}
 	}
-
-
 
 	/**
 	 * Prepare the active filter items.
@@ -263,7 +197,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 			$visual_values       = array();
 
 			if ( $is_visual_attribute ) {
-				$visual_values = $this->get_visual_attribute_term_visuals();
+				$visual_values = VisualAttributeTermMeta::get_attribute_term_visuals( $product_attribute->slug );
 			}
 
 			$attribute_options = array_map(
@@ -287,8 +221,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 					}
 
 					if ( $is_visual_attribute ) {
-						$item['color'] = $visual_values[ $term['term_id'] ]['color'] ?? '';
-						$item['image'] = $visual_values[ $term['term_id'] ]['image'] ?? '';
+						$item['visual'] = $visual_values[ $term['term_id'] ] ?? VisualAttributeTermMeta::get_empty_visual();
 					}
 
 					return $item;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -258,10 +258,16 @@ final class ProductFilterAttribute extends AbstractBlock {
 		);
 
 		if ( ! empty( $attribute_counts ) ) {
-			$show_counts       = $block_attributes['showCounts'] ?? false;
-			$visual_values     = $this->get_visual_attribute_term_visuals();
+			$show_counts         = $block_attributes['showCounts'] ?? false;
+			$is_visual_attribute = 'wc-visual' === $product_attribute->type;
+			$visual_values       = array();
+
+			if ( $is_visual_attribute ) {
+				$visual_values = $this->get_visual_attribute_term_visuals();
+			}
+
 			$attribute_options = array_map(
-				function ( $term ) use ( $block_attributes, $attribute_counts, $selected_terms, $product_attribute, $show_counts, $visual_values ) {
+				function ( $term ) use ( $block_attributes, $attribute_counts, $selected_terms, $product_attribute, $show_counts, $is_visual_attribute, $visual_values ) {
 					$term          = (array) $term;
 					$term['count'] = $attribute_counts[ $term['term_id'] ] ?? 0;
 
@@ -280,7 +286,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 						$item['count'] = $term['count'];
 					}
 
-					if ( 'wc-visual' === $product_attribute->type ) {
+					if ( $is_visual_attribute ) {
 						$item['color'] = $visual_values[ $term['term_id'] ]['color'] ?? '';
 						$item['image'] = $visual_values[ $term['term_id'] ]['image'] ?? '';
 					}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -196,7 +196,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		if ( ! empty( $attribute_counts ) ) {
 			$show_counts         = $block_attributes['showCounts'] ?? false;
-			$is_visual_attribute = 'wc-visual' === $product_attribute->type;
+			$is_visual_attribute = VisualAttributeTermMeta::is_visual_attribute_taxonomy( $product_attribute->slug );
 			$visual_values       = array();
 
 			if ( $is_visual_attribute ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -3,6 +3,8 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
+
 /**
  * Product Filter: Checkbox List Block.
  */
@@ -85,7 +87,7 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 
 		$first_item          = reset( $items );
 		$show_counts         = is_array( $first_item ) && array_key_exists( 'count', $first_item );
-		$has_visual_swatches = is_array( $first_item ) && ( array_key_exists( 'color', $first_item ) || array_key_exists( 'image', $first_item ) );
+		$has_visual_swatches = is_array( $first_item ) && array_key_exists( 'visual', $first_item );
 
 		ob_start();
 		?>
@@ -249,17 +251,9 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 	 * @return string
 	 */
 	private function get_item_swatch_style( array $item ): string {
-		$image = isset( $item['image'] ) ? esc_url_raw( (string) $item['image'] ) : '';
-		if ( $image ) {
-			return sprintf( "background-image:url('%s')", str_replace( "'", '%27', $image ) );
-		}
+		$visual = isset( $item['visual'] ) && is_array( $item['visual'] ) ? $item['visual'] : array();
 
-		$color = isset( $item['color'] ) ? sanitize_hex_color( (string) $item['color'] ) : '';
-		if ( $color ) {
-			return sprintf( 'background-color:%s', $color );
-		}
-
-		return '';
+		return VisualAttributeTermMeta::get_swatch_style( $visual );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -87,7 +87,7 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 
 		$first_item          = reset( $items );
 		$show_counts         = is_array( $first_item ) && array_key_exists( 'count', $first_item );
-		$has_visual_swatches = is_array( $first_item ) && array_key_exists( 'visual', $first_item );
+		$has_visual_swatches = self::has_visual_swatches( $items );
 
 		ob_start();
 		?>
@@ -242,6 +242,22 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Check whether any item has visual swatch data.
+	 *
+	 * @param array $items Selectable items.
+	 * @return bool
+	 */
+	private static function has_visual_swatches( array $items ): bool {
+		foreach ( $items as $item ) {
+			if ( is_array( $item ) && array_key_exists( 'visual', $item ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -3,6 +3,8 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
+
 /**
  * Product Filter: Chips Block.
  */
@@ -94,7 +96,7 @@ final class ProductFilterChips extends AbstractBlock {
 
 		$first_item          = reset( $items );
 		$show_counts         = is_array( $first_item ) && array_key_exists( 'count', $first_item );
-		$has_visual_swatches = is_array( $first_item ) && ( array_key_exists( 'color', $first_item ) || array_key_exists( 'image', $first_item ) );
+		$has_visual_swatches = is_array( $first_item ) && array_key_exists( 'visual', $first_item );
 		$button_role         = 'single' === $block_context['selectionMode'] ? 'radio' : 'checkbox';
 
 		if ( $has_visual_swatches && is_string( $classes ) && ! str_contains( $classes, 'is-style-swatch' ) ) {
@@ -226,16 +228,8 @@ final class ProductFilterChips extends AbstractBlock {
 	 * @return string
 	 */
 	private function get_item_swatch_style( array $item ): string {
-		$image = isset( $item['image'] ) ? esc_url_raw( (string) $item['image'] ) : '';
-		if ( $image ) {
-			return sprintf( "background-image:url('%s')", str_replace( "'", '%27', $image ) );
-		}
+		$visual = isset( $item['visual'] ) && is_array( $item['visual'] ) ? $item['visual'] : array();
 
-		$color = isset( $item['color'] ) ? sanitize_hex_color( (string) $item['color'] ) : '';
-		if ( $color ) {
-			return sprintf( 'background-color:%s', $color );
-		}
-
-		return '';
+		return VisualAttributeTermMeta::get_swatch_style( $visual );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -96,7 +96,7 @@ final class ProductFilterChips extends AbstractBlock {
 
 		$first_item          = reset( $items );
 		$show_counts         = is_array( $first_item ) && array_key_exists( 'count', $first_item );
-		$has_visual_swatches = is_array( $first_item ) && array_key_exists( 'visual', $first_item );
+		$has_visual_swatches = self::has_visual_swatches( $items );
 		$button_role         = 'single' === $block_context['selectionMode'] ? 'radio' : 'checkbox';
 
 		if ( $has_visual_swatches && is_string( $classes ) && ! str_contains( $classes, 'is-style-swatch' ) ) {
@@ -219,6 +219,22 @@ final class ProductFilterChips extends AbstractBlock {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Check whether any item has visual swatch data.
+	 *
+	 * @param array $items Selectable items.
+	 * @return bool
+	 */
+	private static function has_visual_swatches( array $items ): bool {
+		foreach ( $items as $item ) {
+			if ( is_array( $item ) && array_key_exists( 'visual', $item ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermMeta.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermMeta.php
@@ -83,50 +83,47 @@ class VisualAttributeTermMeta {
 	}
 
 	/**
-	 * Get normalized visual values for wc-visual attribute terms.
+	 * Get normalized visual values for the given terms.
 	 *
-	 * @param string|null $attribute_name Optional product attribute taxonomy name, e.g. `pa_color`.
-	 * @param string      $image_size Image size for image visual URLs.
+	 * @param array  $term_ids Term IDs.
+	 * @param string $image_size Image size for image visual URLs.
 	 * @return array<int, array{type: string, value: string}> Map of term ID to visual values.
 	 *
 	 * @since 10.9.0
 	 */
-	public static function get_attribute_term_visuals( ?string $attribute_name = null, string $image_size = 'thumbnail' ): array {
-		$visuals        = array();
-		$attribute_slug = $attribute_name ? wc_attribute_taxonomy_slug( $attribute_name ) : null;
+	public static function get_term_visuals( array $term_ids, string $image_size = 'thumbnail' ): array {
+		$visuals  = array();
+		$term_ids = array_unique( array_filter( array_map( 'absint', $term_ids ) ) );
 
-		$attributes = wc_get_attribute_taxonomies();
-
-		foreach ( $attributes as $attribute ) {
-			if ( 'wc-visual' !== $attribute->attribute_type ) {
-				continue;
-			}
-
-			if ( $attribute_slug && $attribute_slug !== $attribute->attribute_name ) {
-				continue;
-			}
-
-			$terms = get_terms(
-				array(
-					'taxonomy'   => wc_attribute_taxonomy_name( $attribute->attribute_name ),
-					'hide_empty' => false,
-				)
-			);
-
-			if ( is_wp_error( $terms ) ) {
-				continue;
-			}
-
-			foreach ( $terms as $term ) {
-				if ( ! $term instanceof \WP_Term ) {
-					continue;
-				}
-
-				$visuals[ $term->term_id ] = self::get_term_visual( (int) $term->term_id, $image_size );
-			}
+		foreach ( $term_ids as $term_id ) {
+			$visuals[ $term_id ] = self::get_term_visual( $term_id, $image_size );
 		}
 
 		return $visuals;
+	}
+
+	/**
+	 * Check whether a taxonomy is a wc-visual product attribute taxonomy.
+	 *
+	 * @param string $taxonomy Taxonomy name.
+	 * @return bool
+	 *
+	 * @since 10.9.0
+	 */
+	public static function is_visual_attribute_taxonomy( string $taxonomy ): bool {
+		static $visual_attribute_taxonomies = null;
+
+		if ( null === $visual_attribute_taxonomies ) {
+			$visual_attribute_taxonomies = array();
+
+			foreach ( wc_get_attribute_taxonomies() as $attribute ) {
+				if ( 'wc-visual' === $attribute->attribute_type ) {
+					$visual_attribute_taxonomies[ wc_attribute_taxonomy_name( $attribute->attribute_name ) ] = true;
+				}
+			}
+		}
+
+		return isset( $visual_attribute_taxonomies[ $taxonomy ] );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermMeta.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermMeta.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Visual attribute term meta utilities.
+ *
+ * @package WooCommerce\Classes
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\ProductAttributes;
+
+/**
+ * Utilities for wc-visual attribute term metadata.
+ *
+ * @internal
+ *
+ * @since 10.9.0
+ */
+class VisualAttributeTermMeta {
+
+	/**
+	 * Color visual type.
+	 */
+	public const TYPE_COLOR = 'color';
+
+	/**
+	 * Image visual type.
+	 */
+	public const TYPE_IMAGE = 'image';
+
+	/**
+	 * Empty visual type.
+	 */
+	public const TYPE_NONE = 'none';
+
+	/**
+	 * Get an empty visual term value.
+	 *
+	 * @return array{type: string, value: string}
+	 *
+	 * @since 10.9.0
+	 */
+	public static function get_empty_visual(): array {
+		return array(
+			'type'  => self::TYPE_NONE,
+			'value' => '',
+		);
+	}
+
+	/**
+	 * Get the normalized visual value for a term.
+	 *
+	 * @param int    $term_id Term ID.
+	 * @param string $image_size Image size for image visual URLs.
+	 * @return array{type: string, value: string}
+	 *
+	 * @since 10.9.0
+	 */
+	public static function get_term_visual( int $term_id, string $image_size = 'thumbnail' ): array {
+		$image_id = absint( get_term_meta( $term_id, 'image', true ) );
+
+		if ( $image_id && wp_attachment_is_image( $image_id ) ) {
+			$image_url = wp_get_attachment_image_url( $image_id, $image_size );
+
+			if ( $image_url ) {
+				return array(
+					'type'  => self::TYPE_IMAGE,
+					'value' => $image_url,
+				);
+			}
+		}
+
+		$color = sanitize_hex_color( get_term_meta( $term_id, 'color', true ) );
+
+		if ( $color ) {
+			return array(
+				'type'  => self::TYPE_COLOR,
+				'value' => $color,
+			);
+		}
+
+		return self::get_empty_visual();
+	}
+
+	/**
+	 * Get normalized visual values for wc-visual attribute terms.
+	 *
+	 * @param string|null $attribute_name Optional product attribute taxonomy name, e.g. `pa_color`.
+	 * @param string      $image_size Image size for image visual URLs.
+	 * @return array<int, array{type: string, value: string}> Map of term ID to visual values.
+	 *
+	 * @since 10.9.0
+	 */
+	public static function get_attribute_term_visuals( ?string $attribute_name = null, string $image_size = 'thumbnail' ): array {
+		$visuals        = array();
+		$attribute_slug = $attribute_name ? wc_attribute_taxonomy_slug( $attribute_name ) : null;
+
+		$attributes = wc_get_attribute_taxonomies();
+
+		foreach ( $attributes as $attribute ) {
+			if ( 'wc-visual' !== $attribute->attribute_type ) {
+				continue;
+			}
+
+			if ( $attribute_slug && $attribute_slug !== $attribute->attribute_name ) {
+				continue;
+			}
+
+			$terms = get_terms(
+				array(
+					'taxonomy'   => wc_attribute_taxonomy_name( $attribute->attribute_name ),
+					'hide_empty' => false,
+				)
+			);
+
+			if ( is_wp_error( $terms ) ) {
+				continue;
+			}
+
+			foreach ( $terms as $term ) {
+				if ( ! $term instanceof \WP_Term ) {
+					continue;
+				}
+
+				$visuals[ $term->term_id ] = self::get_term_visual( (int) $term->term_id, $image_size );
+			}
+		}
+
+		return $visuals;
+	}
+
+	/**
+	 * Save mutually exclusive visual attribute term meta.
+	 *
+	 * @param int    $term_id Term ID.
+	 * @param string $color Hex color value.
+	 * @param int    $image_id Attachment ID for the term image.
+	 * @return void
+	 *
+	 * @since 10.9.0
+	 */
+	public static function save_term_visual( int $term_id, string $color = '', int $image_id = 0 ): void {
+		if ( $image_id && wp_attachment_is_image( $image_id ) ) {
+			update_term_meta( $term_id, 'image', absint( $image_id ) );
+			delete_term_meta( $term_id, 'color' );
+			return;
+		}
+
+		$sanitized_color = sanitize_hex_color( $color );
+		if ( $sanitized_color ) {
+			update_term_meta( $term_id, 'color', $sanitized_color );
+			delete_term_meta( $term_id, 'image' );
+			return;
+		}
+
+		delete_term_meta( $term_id, 'color' );
+		delete_term_meta( $term_id, 'image' );
+	}
+
+	/**
+	 * Build an inline swatch style from a normalized visual value.
+	 *
+	 * @param array{type?: string, value?: string} $visual Normalized visual value.
+	 * @return string
+	 *
+	 * @since 10.9.0
+	 */
+	public static function get_swatch_style( array $visual ): string {
+		$type  = isset( $visual['type'] ) ? (string) $visual['type'] : self::TYPE_NONE;
+		$value = isset( $visual['value'] ) ? (string) $visual['value'] : '';
+
+		if ( self::TYPE_IMAGE === $type ) {
+			$image = esc_url_raw( $value );
+
+			if ( $image ) {
+				return sprintf( "background-image:url('%s')", str_replace( "'", '%27', $image ) );
+			}
+		}
+
+		if ( self::TYPE_COLOR === $type ) {
+			$color = sanitize_hex_color( $value );
+
+			if ( $color ) {
+				return sprintf( 'background-color:%s', $color );
+			}
+		}
+
+		return '';
+	}
+}

--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermMeta.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermMeta.php
@@ -111,9 +111,12 @@ class VisualAttributeTermMeta {
 	 * @since 10.9.0
 	 */
 	public static function is_visual_attribute_taxonomy( string $taxonomy ): bool {
-		static $visual_attribute_taxonomies = null;
+		static $visual_attribute_taxonomies = array();
+		static $cache_prefix                = '';
 
-		if ( null === $visual_attribute_taxonomies ) {
+		$current_cache_prefix = \WC_Cache_Helper::get_cache_prefix( 'woocommerce-attributes' );
+		if ( $cache_prefix !== $current_cache_prefix ) {
+			$cache_prefix                = $current_cache_prefix;
 			$visual_attribute_taxonomies = array();
 
 			foreach ( wc_get_attribute_taxonomies() as $attribute ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ProductAttributeTermSchema;
 
 /**
  * ProductAttributeTerms class.
@@ -13,6 +14,13 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	 * @var string
 	 */
 	const IDENTIFIER = 'product-attribute-terms';
+
+	/**
+	 * The routes schema.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = ProductAttributeTermSchema::IDENTIFIER;
 
 	/**
 	 * Get the path of this REST route.

--- a/plugins/woocommerce/src/StoreApi/SchemaController.php
+++ b/plugins/woocommerce/src/StoreApi/SchemaController.php
@@ -51,6 +51,7 @@ class SchemaController {
 				Schemas\V1\OrderSchema::IDENTIFIER         => Schemas\V1\OrderSchema::class,
 				Schemas\V1\ProductSchema::IDENTIFIER       => Schemas\V1\ProductSchema::class,
 				Schemas\V1\ProductAttributeSchema::IDENTIFIER => Schemas\V1\ProductAttributeSchema::class,
+				Schemas\V1\ProductAttributeTermSchema::IDENTIFIER => Schemas\V1\ProductAttributeTermSchema::class,
 				Schemas\V1\ProductCategorySchema::IDENTIFIER => Schemas\V1\ProductCategorySchema::class,
 				Schemas\V1\ProductBrandSchema::IDENTIFIER  => Schemas\V1\ProductBrandSchema::class,
 				Schemas\V1\ProductCollectionDataSchema::IDENTIFIER => Schemas\V1\ProductCollectionDataSchema::class,

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductAttributeTermSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductAttributeTermSchema.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductAttributeTermSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductAttributeTermSchema.php
@@ -1,0 +1,66 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
+
+/**
+ * ProductAttributeTermSchema class.
+ */
+class ProductAttributeTermSchema extends TermSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'product-attribute-term';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'product-attribute-term';
+
+	/**
+	 * Term properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		$schema = parent::get_properties();
+
+		$schema['__experimentalVisual'] = array(
+			'description' => __( 'Experimental visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
+			'type'        => 'object',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+			'properties'  => array(
+				'type'  => array(
+					'type' => 'string',
+					'enum' => array( VisualAttributeTermMeta::TYPE_COLOR, VisualAttributeTermMeta::TYPE_IMAGE, VisualAttributeTermMeta::TYPE_NONE ),
+				),
+				'value' => array(
+					'type' => 'string',
+				),
+			),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Convert a product attribute term object into an object suitable for the response.
+	 *
+	 * @param \WP_Term $term Term object.
+	 * @return array
+	 */
+	public function get_item_response( $term ) {
+		$response = parent::get_item_response( $term );
+
+		if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
+			$response['__experimentalVisual'] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
+		}
+
+		return $response;
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -329,32 +329,32 @@ class ProductSchema extends AbstractSchema {
 							'items'       => [
 								'type'       => 'object',
 								'properties' => [
-									'id'      => [
+									'id'                   => [
 										'description' => __( 'The term ID, or 0 if the attribute is not a global attribute.', 'woocommerce' ),
 										'type'        => 'integer',
 										'context'     => [ 'view', 'edit', 'embed' ],
 										'readonly'    => true,
 									],
-									'name'    => [
+									'name'                 => [
 										'description' => __( 'The term name.', 'woocommerce' ),
 										'type'        => 'string',
 										'context'     => [ 'view', 'edit', 'embed' ],
 										'readonly'    => true,
 									],
-									'slug'    => [
+									'slug'                 => [
 										'description' => __( 'The term slug.', 'woocommerce' ),
 										'type'        => 'string',
 										'context'     => [ 'view', 'edit', 'embed' ],
 										'readonly'    => true,
 									],
-									'default' => [
+									'default'              => [
 										'description' => __( 'If this is a default attribute', 'woocommerce' ),
 										'type'        => 'boolean',
 										'context'     => [ 'view', 'edit', 'embed' ],
 										'readonly'    => true,
 									],
-									'visual'  => [
-										'description' => __( 'Visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
+									'__experimentalVisual' => [
+										'description' => __( 'Experimental visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
 										'type'        => 'object',
 										'context'     => [ 'view', 'edit', 'embed' ],
 										'readonly'    => true,
@@ -910,7 +910,7 @@ class ProductSchema extends AbstractSchema {
 		$value = (array) $this->prepare_product_attribute_value( $term->name, $term->term_id, $term->slug );
 
 		if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
-			$value['visual'] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
+			$value['__experimentalVisual'] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
 		}
 
 		return (object) $value;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
@@ -351,6 +352,21 @@ class ProductSchema extends AbstractSchema {
 										'type'        => 'boolean',
 										'context'     => [ 'view', 'edit', 'embed' ],
 										'readonly'    => true,
+									],
+									'visual'  => [
+										'description' => __( 'Visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
+										'type'        => 'object',
+										'context'     => [ 'view', 'edit', 'embed' ],
+										'readonly'    => true,
+										'properties'  => [
+											'type'  => [
+												'type' => 'string',
+												'enum' => [ VisualAttributeTermMeta::TYPE_COLOR, VisualAttributeTermMeta::TYPE_IMAGE, VisualAttributeTermMeta::TYPE_NONE ],
+											],
+											'value' => [
+												'type' => 'string',
+											],
+										],
 									],
 								],
 							],
@@ -891,7 +907,13 @@ class ProductSchema extends AbstractSchema {
 	 * @return object
 	 */
 	protected function prepare_product_attribute_taxonomy_value( \WP_Term $term ) {
-		return $this->prepare_product_attribute_value( $term->name, $term->term_id, $term->slug );
+		$value = (array) $this->prepare_product_attribute_value( $term->name, $term->term_id, $term->slug );
+
+		if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
+			$value['visual'] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
+		}
+
+		return (object) $value;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/TermSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/TermSchema.php
@@ -28,44 +28,44 @@ class TermSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id'          => array(
+			'id'                   => array(
 				'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'name'        => array(
+			'name'                 => array(
 				'description' => __( 'Term name.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'slug'        => array(
+			'slug'                 => array(
 				'description' => __( 'String based identifier for the term.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'description' => array(
+			'description'          => array(
 				'description' => __( 'Term description.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'parent'      => array(
+			'parent'               => array(
 				'description' => __( 'Parent term ID, if applicable.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'count'       => array(
+			'count'                => array(
 				'description' => __( 'Number of objects (posts of any type) assigned to the term.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'visual'      => array(
-				'description' => __( 'Visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
+			'__experimentalVisual' => array(
+				'description' => __( 'Experimental visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
 				'type'        => 'object',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -99,7 +99,7 @@ class TermSchema extends AbstractSchema {
 		];
 
 		if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
-			$response['visual'] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
+			$response['__experimentalVisual'] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
 		}
 
 		return $response;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/TermSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/TermSchema.php
@@ -1,6 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
+
 /**
  * TermSchema class.
  */
@@ -62,6 +64,21 @@ class TermSchema extends AbstractSchema {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
+			'visual'      => array(
+				'description' => __( 'Visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
+				'type'        => 'object',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'properties'  => array(
+					'type'  => array(
+						'type' => 'string',
+						'enum' => array( VisualAttributeTermMeta::TYPE_COLOR, VisualAttributeTermMeta::TYPE_IMAGE, VisualAttributeTermMeta::TYPE_NONE ),
+					),
+					'value' => array(
+						'type' => 'string',
+					),
+				),
+			),
 		];
 	}
 
@@ -72,7 +89,7 @@ class TermSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $term ) {
-		return [
+		$response = [
 			'id'          => (int) $term->term_id,
 			'name'        => $this->prepare_html_response( $term->name ),
 			'slug'        => $term->slug,
@@ -80,5 +97,11 @@ class TermSchema extends AbstractSchema {
 			'parent'      => (int) $term->parent,
 			'count'       => (int) $term->count,
 		];
+
+		if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
+			$response['visual'] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
+		}
+
+		return $response;
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/TermSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/TermSchema.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
-use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
-
 /**
  * TermSchema class.
  */
@@ -28,56 +26,41 @@ class TermSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id'                   => array(
+			'id'          => array(
 				'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'name'                 => array(
+			'name'        => array(
 				'description' => __( 'Term name.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'slug'                 => array(
+			'slug'        => array(
 				'description' => __( 'String based identifier for the term.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'description'          => array(
+			'description' => array(
 				'description' => __( 'Term description.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'parent'               => array(
+			'parent'      => array(
 				'description' => __( 'Parent term ID, if applicable.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'count'                => array(
+			'count'       => array(
 				'description' => __( 'Number of objects (posts of any type) assigned to the term.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-			),
-			'__experimentalVisual' => array(
-				'description' => __( 'Experimental visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
-				'type'        => 'object',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'properties'  => array(
-					'type'  => array(
-						'type' => 'string',
-						'enum' => array( VisualAttributeTermMeta::TYPE_COLOR, VisualAttributeTermMeta::TYPE_IMAGE, VisualAttributeTermMeta::TYPE_NONE ),
-					),
-					'value' => array(
-						'type' => 'string',
-					),
-				),
 			),
 		];
 	}
@@ -89,7 +72,7 @@ class TermSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $term ) {
-		$response = [
+		return [
 			'id'          => (int) $term->term_id,
 			'name'        => $this->prepare_html_response( $term->name ),
 			'slug'        => $term->slug,
@@ -97,11 +80,5 @@ class TermSchema extends AbstractSchema {
 			'parent'      => (int) $term->parent,
 			'count'       => (int) $term->count,
 		];
-
-		if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
-			$response['__experimentalVisual'] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
-		}
-
-		return $response;
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -297,7 +297,7 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 	 *
 	 * @testdox Should save visual attribute term color or image meta exclusively.
 	 */
-	public function test_wc_save_visual_attribute_term_meta(): void {
+	public function test_visual_attribute_term_meta_saves_exclusive_values(): void {
 		$term_name = 'visual-meta-test-' . wp_rand();
 		$term      = wp_insert_term( $term_name, 'product_cat' );
 		$term_id   = is_array( $term ) ? (int) $term['term_id'] : 0;
@@ -320,7 +320,7 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			update_term_meta( $term_id, 'image', $image_id );
 			update_term_meta( $term_id, 'color', '#112233' );
 
-			wc_save_visual_attribute_term_meta( $term_id, '#aabbcc', 0 );
+			VisualAttributeTermMeta::save_term_visual( $term_id, '#aabbcc', 0 );
 
 			$this->assertSame( '#aabbcc', get_term_meta( $term_id, 'color', true ), 'Color meta should be saved.' );
 			$this->assertSame( '', get_term_meta( $term_id, 'image', true ), 'Image meta should be removed when color is saved.' );
@@ -333,7 +333,7 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 				'Canonical visual meta should expose saved colors as a typed value.'
 			);
 
-			wc_save_visual_attribute_term_meta( $term_id, '', $image_id );
+			VisualAttributeTermMeta::save_term_visual( $term_id, '', $image_id );
 
 			$this->assertSame( (string) $image_id, get_term_meta( $term_id, 'image', true ), 'Image meta should be saved.' );
 			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Color meta should be removed when image is saved.' );
@@ -341,7 +341,7 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			$this->assertSame( VisualAttributeTermMeta::TYPE_IMAGE, $saved_image_visual['type'], 'Canonical visual meta should expose saved images as a typed value.' );
 			$this->assertStringContainsString( 'visual-attribute-term-image.jpg', $saved_image_visual['value'], 'Canonical image values should use the image URL.' );
 
-			wc_save_visual_attribute_term_meta( $term_id, '', 999999 );
+			VisualAttributeTermMeta::save_term_visual( $term_id, '', 999999 );
 
 			$this->assertSame( '', get_term_meta( $term_id, 'image', true ), 'Invalid image IDs should be ignored.' );
 			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Invalid image IDs should clear existing visual meta.' );
@@ -350,7 +350,7 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			update_term_meta( $term_id, 'color', '#112233' );
 			update_term_meta( $term_id, 'image', $image_id );
 
-			wc_save_visual_attribute_term_meta( $term_id, '#ff00aa', $image_id );
+			VisualAttributeTermMeta::save_term_visual( $term_id, '#ff00aa', $image_id );
 
 			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Color meta should be removed when image takes precedence.' );
 			$this->assertSame( (string) $image_id, get_term_meta( $term_id, 'image', true ), 'Image should take precedence when both values are provided.' );

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -7,7 +7,6 @@
 
 declare( strict_types=1 );
 
-use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use PHPUnit\Framework\MockObject\Matcher\InvokedRecorder;
 
@@ -289,79 +288,6 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			$this->assertTrue( $features['wc-visual-attribute']['disable_ui'], 'The visual attribute feature setting should be hidden for classic themes.' );
 		} finally {
 			switch_theme( $original_theme );
-		}
-	}
-
-	/**
-	 * Test saving visual attribute term meta with mutual exclusivity.
-	 *
-	 * @testdox Should save visual attribute term color or image meta exclusively.
-	 */
-	public function test_visual_attribute_term_meta_saves_exclusive_values(): void {
-		$term_name = 'visual-meta-test-' . wp_rand();
-		$term      = wp_insert_term( $term_name, 'product_cat' );
-		$term_id   = is_array( $term ) ? (int) $term['term_id'] : 0;
-		$image_id  = 0;
-
-		$this->assertNotEmpty( $term_id, 'A test term should be created.' );
-
-		try {
-			$image_id = wp_insert_attachment(
-				array(
-					'post_title'     => 'Visual attribute term image',
-					'post_type'      => 'attachment',
-					'post_mime_type' => 'image/jpeg',
-				)
-			);
-			$this->assertIsInt( $image_id, 'The image should be created.' );
-
-			update_post_meta( $image_id, '_wp_attached_file', 'visual-attribute-term-image.jpg' );
-
-			update_term_meta( $term_id, 'image', $image_id );
-			update_term_meta( $term_id, 'color', '#112233' );
-
-			VisualAttributeTermMeta::save_term_visual( $term_id, '#aabbcc', 0 );
-
-			$this->assertSame( '#aabbcc', get_term_meta( $term_id, 'color', true ), 'Color meta should be saved.' );
-			$this->assertSame( '', get_term_meta( $term_id, 'image', true ), 'Image meta should be removed when color is saved.' );
-			$this->assertSame(
-				array(
-					'type'  => VisualAttributeTermMeta::TYPE_COLOR,
-					'value' => '#aabbcc',
-				),
-				VisualAttributeTermMeta::get_term_visual( $term_id ),
-				'Canonical visual meta should expose saved colors as a typed value.'
-			);
-
-			VisualAttributeTermMeta::save_term_visual( $term_id, '', $image_id );
-
-			$this->assertSame( (string) $image_id, get_term_meta( $term_id, 'image', true ), 'Image meta should be saved.' );
-			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Color meta should be removed when image is saved.' );
-			$saved_image_visual = VisualAttributeTermMeta::get_term_visual( $term_id );
-			$this->assertSame( VisualAttributeTermMeta::TYPE_IMAGE, $saved_image_visual['type'], 'Canonical visual meta should expose saved images as a typed value.' );
-			$this->assertStringContainsString( 'visual-attribute-term-image.jpg', $saved_image_visual['value'], 'Canonical image values should use the image URL.' );
-
-			VisualAttributeTermMeta::save_term_visual( $term_id, '', 999999 );
-
-			$this->assertSame( '', get_term_meta( $term_id, 'image', true ), 'Invalid image IDs should be ignored.' );
-			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Invalid image IDs should clear existing visual meta.' );
-			$this->assertSame( VisualAttributeTermMeta::get_empty_visual(), VisualAttributeTermMeta::get_term_visual( $term_id ), 'Canonical visual meta should expose invalid image IDs as empty values.' );
-
-			update_term_meta( $term_id, 'color', '#112233' );
-			update_term_meta( $term_id, 'image', $image_id );
-
-			VisualAttributeTermMeta::save_term_visual( $term_id, '#ff00aa', $image_id );
-
-			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Color meta should be removed when image takes precedence.' );
-			$this->assertSame( (string) $image_id, get_term_meta( $term_id, 'image', true ), 'Image should take precedence when both values are provided.' );
-		} finally {
-			if ( $term_id ) {
-				wp_delete_term( $term_id, 'product_cat' );
-			}
-
-			if ( $image_id ) {
-				wp_delete_attachment( $image_id, true );
-			}
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -7,6 +7,7 @@
 
 declare( strict_types=1 );
 
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use PHPUnit\Framework\MockObject\Matcher\InvokedRecorder;
 
@@ -323,16 +324,28 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 
 			$this->assertSame( '#aabbcc', get_term_meta( $term_id, 'color', true ), 'Color meta should be saved.' );
 			$this->assertSame( '', get_term_meta( $term_id, 'image', true ), 'Image meta should be removed when color is saved.' );
+			$this->assertSame(
+				array(
+					'type'  => VisualAttributeTermMeta::TYPE_COLOR,
+					'value' => '#aabbcc',
+				),
+				VisualAttributeTermMeta::get_term_visual( $term_id ),
+				'Canonical visual meta should expose saved colors as a typed value.'
+			);
 
 			wc_save_visual_attribute_term_meta( $term_id, '', $image_id );
 
 			$this->assertSame( (string) $image_id, get_term_meta( $term_id, 'image', true ), 'Image meta should be saved.' );
 			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Color meta should be removed when image is saved.' );
+			$saved_image_visual = VisualAttributeTermMeta::get_term_visual( $term_id );
+			$this->assertSame( VisualAttributeTermMeta::TYPE_IMAGE, $saved_image_visual['type'], 'Canonical visual meta should expose saved images as a typed value.' );
+			$this->assertStringContainsString( 'visual-attribute-term-image.jpg', $saved_image_visual['value'], 'Canonical image values should use the image URL.' );
 
 			wc_save_visual_attribute_term_meta( $term_id, '', 999999 );
 
 			$this->assertSame( '', get_term_meta( $term_id, 'image', true ), 'Invalid image IDs should be ignored.' );
 			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Invalid image IDs should clear existing visual meta.' );
+			$this->assertSame( VisualAttributeTermMeta::get_empty_visual(), VisualAttributeTermMeta::get_term_visual( $term_id ), 'Canonical visual meta should expose invalid image IDs as empty values.' );
 
 			update_term_meta( $term_id, 'color', '#112233' );
 			update_term_meta( $term_id, 'image', $image_id );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/VariationSelectorAttribute.php
@@ -147,6 +147,22 @@ class VariationSelectorAttribute extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that non-visual attribute terms do not render swatch markup.
+	 *
+	 * @testdox VariationSelectorAttribute does not render swatches for non-visual attributes.
+	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute::build_variation_selectable_items
+	 */
+	public function test_does_not_render_swatches_for_non_visual_attribute(): void {
+		$variable_product = $this->create_variable_product_with_variations();
+		$inner_blocks     = $this->get_attribute_name_block_markup() . $this->get_chips_block_markup();
+
+		$markup = $this->render_variation_selector_attribute( $variable_product, $inner_blocks );
+
+		$this->assertStringNotContainsString( 'is-style-swatch', $markup, 'Chips wrapper should not use swatch style for non-visual attributes.' );
+		$this->assertStringNotContainsString( 'wc-block-product-filter-chips__swatch', $markup, 'Swatch elements should not be rendered for non-visual attributes.' );
+	}
+
+	/**
 	 * Tests that wc-visual attribute terms render chips with swatch markup and classes.
 	 *
 	 * @testdox VariationSelectorAttribute renders wc-visual attribute options with swatch classes and colors.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
@@ -128,7 +128,7 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$this->assertArrayNotHasKey( '__experimentalVisual', $data );
 
 		$diff = $validate->get_diff_from_object( $data );
-		$this->assertEmpty( $diff, print_r( $diff, true ) );
+		$this->assertEmpty( $diff, print_r( $diff, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 	}
 
 	/**
@@ -153,6 +153,6 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$data['__experimentalVisual'] = (object) $data['__experimentalVisual'];
 
 		$diff = $validate->get_diff_from_object( $data );
-		$this->assertEmpty( $diff, print_r( $diff, true ) );
+		$this->assertEmpty( $diff, print_r( $diff, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
@@ -19,6 +19,7 @@ class ProductAttributeTerms extends ControllerTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+		global $wpdb;
 
 		$fixtures = new FixtureData();
 
@@ -26,6 +27,42 @@ class ProductAttributeTerms extends ControllerTestCase {
 			$fixtures->get_product_attribute( 'color', array( 'red', 'green', 'blue' ) ),
 			$fixtures->get_product_attribute( 'size', array( 'small', 'medium', 'large' ) ),
 		);
+
+		$wpdb->update(
+			$wpdb->prefix . 'woocommerce_attribute_taxonomies',
+			array( 'attribute_type' => 'wc-visual' ),
+			array( 'attribute_id' => $this->attributes[0]['attribute_id'] ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		delete_transient( 'wc_attribute_taxonomies' );
+		\WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
+	}
+
+	/**
+	 * Cleanup test product data. Called after every test.
+	 */
+	protected function tearDown(): void {
+		global $wpdb;
+
+		if ( isset( $this->attributes[0]['attribute_id'] ) ) {
+			$wpdb->update(
+				$wpdb->prefix . 'woocommerce_attribute_taxonomies',
+				array( 'attribute_type' => 'select' ),
+				array( 'attribute_id' => $this->attributes[0]['attribute_id'] ),
+				array( '%s' ),
+				array( '%d' )
+			);
+
+			$term = get_term_by( 'name', 'red', $this->attributes[0]['attribute_taxonomy'] );
+			delete_term_meta( $term->term_id, 'color' );
+
+			delete_transient( 'wc_attribute_taxonomies' );
+			\WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
+		}
+
+		parent::tearDown();
 	}
 
 	/**
@@ -83,9 +120,39 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$controller = $routes->get( 'product-attribute-terms' );
 		$schema     = $controller->get_item_schema();
 		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'small', 'pa_size' ), new \WP_REST_Request() );
-		$validate   = new ValidateSchema( $schema );
+		$data       = $response->get_data();
 
-		$diff = $validate->get_diff_from_object( $response->get_data() );
+		// In non wc-visual attributes, the __experimentalVisual property is expected not to be present.
+		unset( $schema['properties']['__experimentalVisual'] );
+		$validate = new ValidateSchema( $schema );
+		$this->assertArrayNotHasKey( '__experimentalVisual', $data );
+
+		$diff = $validate->get_diff_from_object( $data );
+		$this->assertEmpty( $diff, print_r( $diff, true ) );
+	}
+
+	/**
+	 * Test visual attribute terms include experimental visual data.
+	 */
+	public function test_prepare_item_includes_visual_data_for_wc_visual_attributes() {
+		$routes     = new \Automattic\WooCommerce\StoreApi\RoutesController( new \Automattic\WooCommerce\StoreApi\SchemaController( $this->mock_extend ) );
+		$controller = $routes->get( 'product-attribute-terms' );
+		$schema     = $controller->get_item_schema();
+
+		$term = get_term_by( 'name', 'red', 'pa_color' );
+		update_term_meta( $term->term_id, 'color', '#00ff00' );
+
+		$response = $controller->prepare_item_for_response( $term, new \WP_REST_Request() );
+		$data     = $response->get_data();
+
+		$validate = new ValidateSchema( $schema );
+		$this->assertArrayHasKey( '__experimentalVisual', $data );
+		$this->assertSame( 'color', $data['__experimentalVisual']['type'] );
+		$this->assertSame( '#00ff00', $data['__experimentalVisual']['value'] );
+
+		$data['__experimentalVisual'] = (object) $data['__experimentalVisual'];
+
+		$diff = $validate->get_diff_from_object( $data );
 		$this->assertEmpty( $diff, print_r( $diff, true ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermMetaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermMetaTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Visual attribute term meta tests.
+ *
+ * @package WooCommerce\Tests\Internal\ProductAttributes
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\ProductAttributes;
+
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the visual attribute term meta utility.
+ */
+class VisualAttributeTermMetaTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Should save visual attribute term color or image meta exclusively.
+	 */
+	public function test_saves_exclusive_values(): void {
+		$term_name = 'visual-meta-test-' . wp_rand();
+		$term      = wp_insert_term( $term_name, 'product_cat' );
+		$term_id   = is_array( $term ) ? (int) $term['term_id'] : 0;
+		$image_id  = 0;
+
+		$this->assertNotEmpty( $term_id, 'A test term should be created.' );
+
+		try {
+			$image_id = wp_insert_attachment(
+				array(
+					'post_title'     => 'Visual attribute term image',
+					'post_type'      => 'attachment',
+					'post_mime_type' => 'image/jpeg',
+				)
+			);
+			$this->assertIsInt( $image_id, 'The image should be created.' );
+
+			update_post_meta( $image_id, '_wp_attached_file', 'visual-attribute-term-image.jpg' );
+
+			update_term_meta( $term_id, 'image', $image_id );
+			update_term_meta( $term_id, 'color', '#112233' );
+
+			VisualAttributeTermMeta::save_term_visual( $term_id, '#aabbcc', 0 );
+
+			$this->assertSame( '#aabbcc', get_term_meta( $term_id, 'color', true ), 'Color meta should be saved.' );
+			$this->assertSame( '', get_term_meta( $term_id, 'image', true ), 'Image meta should be removed when color is saved.' );
+			$this->assertSame(
+				array(
+					'type'  => VisualAttributeTermMeta::TYPE_COLOR,
+					'value' => '#aabbcc',
+				),
+				VisualAttributeTermMeta::get_term_visual( $term_id ),
+				'Canonical visual meta should expose saved colors as a typed value.'
+			);
+
+			VisualAttributeTermMeta::save_term_visual( $term_id, '', $image_id );
+
+			$this->assertSame( (string) $image_id, get_term_meta( $term_id, 'image', true ), 'Image meta should be saved.' );
+			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Color meta should be removed when image is saved.' );
+			$saved_image_visual = VisualAttributeTermMeta::get_term_visual( $term_id );
+			$this->assertSame( VisualAttributeTermMeta::TYPE_IMAGE, $saved_image_visual['type'], 'Canonical visual meta should expose saved images as a typed value.' );
+			$this->assertStringContainsString( 'visual-attribute-term-image.jpg', $saved_image_visual['value'], 'Canonical image values should use the image URL.' );
+
+			VisualAttributeTermMeta::save_term_visual( $term_id, '', 999999 );
+
+			$this->assertSame( '', get_term_meta( $term_id, 'image', true ), 'Invalid image IDs should be ignored.' );
+			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Invalid image IDs should clear existing visual meta.' );
+			$this->assertSame( VisualAttributeTermMeta::get_empty_visual(), VisualAttributeTermMeta::get_term_visual( $term_id ), 'Canonical visual meta should expose invalid image IDs as empty values.' );
+
+			update_term_meta( $term_id, 'color', '#112233' );
+			update_term_meta( $term_id, 'image', $image_id );
+
+			VisualAttributeTermMeta::save_term_visual( $term_id, '#ff00aa', $image_id );
+
+			$this->assertSame( '', get_term_meta( $term_id, 'color', true ), 'Color meta should be removed when image takes precedence.' );
+			$this->assertSame( (string) $image_id, get_term_meta( $term_id, 'image', true ), 'Image should take precedence when both values are provided.' );
+		} finally {
+			if ( $term_id ) {
+				wp_delete_term( $term_id, 'product_cat' );
+			}
+
+			if ( $image_id ) {
+				wp_delete_attachment( $image_id, true );
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR contains some cleanup for not only image but visual and inner blocks like Chips and List. I also fixes some design flaw I made initially.

 - Avoid loading visual term data for non-visual attributes.
 - Centralize visual term logic in VisualAttributeTermMeta.
     - Normalizes term visual data.
     - Handles image-vs-color priority.
     - Builds swatch inline styles.
     - Saves mutually-exclusive image / color term meta.
 - Remove wc_save_visual_attribute_term_meta() global helper and use Internal helper above which gives us more space to change.
 - Replace first-item swatch detection by scaning all selectable items.
 - Stop preloading all visual attribute terms in editor which hurts performance.
 - Load visual data only for terms already needed by render/API paths.
 - Add Store API visual data for visual attributes only.
     - Field: __experimentalVisual.
     - Shape: { type: 'color' | 'image' | 'none', value: string }.
     - Only on wc-visual attribute terms.