### PR TITLE
Push notifications: extract auth trait and fix @since tags

### DIFF
--- a/plugins/woocommerce/changelog/64351-followup-authorize-trait
+++ b/plugins/woocommerce/changelog/64351-followup-authorize-trait
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Extract shared authorize_as_authenticated logic from the push notifications REST controllers into a new AuthorizesPushNotificationRequests trait.

--- a/plugins/woocommerce/changelog/64487-followup-since-tags
+++ b/plugins/woocommerce/changelog/64487-followup-since-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Correct @since tags on push notification preference filtering methods introduced in 10.9.0.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestController.php
@@ -6,8 +6,8 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Controllers;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
+use Automattic\WooCommerce\Internal\PushNotifications\Traits\AuthorizesPushNotificationRequests;
 use Automattic\WooCommerce\Internal\PushNotifications\Traits\ConvertsExceptionsToWpError;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
 use Exception;
@@ -24,6 +24,7 @@ use WP_REST_Server;
  * @since 10.8.0
  */
 class NotificationPreferencesRestController extends RestApiControllerBase {
+	use AuthorizesPushNotificationRequests;
 	use ConvertsExceptionsToWpError;
 
 	/**
@@ -48,28 +49,16 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 	private NotificationPreferencesService $preferences_service;
 
 	/**
-	 * The push notifications module enablement gate.
-	 *
-	 * @var PushNotifications
-	 */
-	private PushNotifications $push_notifications;
-
-	/**
 	 * Initialize injected dependencies.
 	 *
 	 * @internal
 	 *
 	 * @param NotificationPreferencesService $preferences_service The preferences service.
-	 * @param PushNotifications              $push_notifications  The push notifications module.
 	 *
 	 * @since 10.8.0
 	 */
-	final public function init(
-		NotificationPreferencesService $preferences_service,
-		PushNotifications $push_notifications
-	): void {
+	final public function init( NotificationPreferencesService $preferences_service ): void {
 		$this->preferences_service = $preferences_service;
-		$this->push_notifications  = $push_notifications;
 	}
 
 	/**
@@ -152,37 +141,6 @@ class NotificationPreferencesRestController extends RestApiControllerBase {
 		}
 
 		return new WP_REST_Response( $merged, WP_Http::OK );
-	}
-
-	/**
-	 * Checks user is authenticated and authorized to access this endpoint.
-	 *
-	 * @since 10.8.0
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
-	 * @return bool|WP_Error
-	 */
-	public function authorize_as_authenticated( WP_REST_Request $request ) {
-		if ( ! get_current_user_id() ) {
-			return new WP_Error(
-				'woocommerce_rest_cannot_view',
-				__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		if ( ! $this->push_notifications->should_be_enabled() ) {
-			return false;
-		}
-
-		$has_valid_role = array_reduce(
-			PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED,
-			fn ( $carry, $role ) => $this->check_permission( $request, $role ) === true ? true : $carry,
-			false
-		);
-
-		return $has_valid_role ? true : false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataS
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenNotFoundException;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Internal\PushNotifications\Traits\AuthorizesPushNotificationRequests;
 use Automattic\WooCommerce\Internal\PushNotifications\Traits\ConvertsExceptionsToWpError;
 use Automattic\WooCommerce\Internal\PushNotifications\Validators\PushTokenValidator;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
@@ -29,6 +30,7 @@ use WP_Http;
  * @since 10.6.0
  */
 class PushTokenRestController extends RestApiControllerBase {
+	use AuthorizesPushNotificationRequests;
 	use ConvertsExceptionsToWpError;
 
 	/**
@@ -291,41 +293,6 @@ class PushTokenRestController extends RestApiControllerBase {
 				),
 			)
 		);
-	}
-
-	/**
-	 * Checks user is authenticated and authorized to access this endpoint.
-	 *
-	 * @since 10.6.0
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
-	 * @return bool|WP_Error
-	 */
-	public function authorize_as_authenticated( WP_REST_Request $request ) {
-		if ( ! get_current_user_id() ) {
-			return new WP_Error(
-				'woocommerce_rest_cannot_view',
-				__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		if ( ! wc_get_container()->get( PushNotifications::class )->should_be_enabled() ) {
-			return false;
-		}
-
-		$has_valid_role = array_reduce(
-			PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED,
-			fn ( $carry, $role ) => $this->check_permission( $request, $role ) === true ? true : $carry,
-			false
-		);
-
-		if ( ! $has_valid_role ) {
-			return false;
-		}
-
-		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
@@ -196,7 +196,7 @@ abstract class Notification {
 	 * @param mixed $pref_value The user's stored preference value, or null.
 	 * @return bool True if this notification should be sent to that user.
 	 *
-	 * @since 10.8.0
+	 * @since 10.9.0
 	 */
 	public function should_send_to_user( $pref_value ): bool {
 		if ( null === $pref_value ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -197,7 +197,7 @@ class NotificationProcessor {
 	 *
 	 * @return PushToken[] The tokens whose owner wants the notification.
 	 *
-	 * @since 10.8.0
+	 * @since 10.9.0
 	 */
 	private function filter_tokens_by_preferences( array $tokens, Notification $notification ): array {
 		$type           = $notification->get_type();

--- a/plugins/woocommerce/src/Internal/PushNotifications/Traits/AuthorizesPushNotificationRequests.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Traits/AuthorizesPushNotificationRequests.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Traits;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * Shared "is this caller an authenticated push-notifications user?" check for
+ * REST controllers in the PushNotifications module.
+ *
+ * Implementing classes must extend {@see \Automattic\WooCommerce\Internal\RestApiControllerBase}
+ * so that `check_permission()` is available.
+ */
+trait AuthorizesPushNotificationRequests {
+	/**
+	 * Checks the user is authenticated, the push notifications module is
+	 * enabled, and the user holds at least one role allowed to interact with
+	 * push notifications.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 * @return bool|WP_Error
+	 */
+	public function authorize_as_authenticated( WP_REST_Request $request ) {
+		if ( ! get_current_user_id() ) {
+			return new WP_Error(
+				'woocommerce_rest_cannot_view',
+				__( 'Sorry, you are not allowed to do that.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		if ( ! wc_get_container()->get( PushNotifications::class )->should_be_enabled() ) {
+			return false;
+		}
+
+		$has_valid_role = array_reduce(
+			PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED,
+			fn ( $carry, $role ) => $this->check_permission( $request, $role ) === true ? true : $carry,
+			false
+		);
+
+		return $has_valid_role ? true : false;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Two internal follow-ups to review feedback on the push notifications module. No user-facing behavior changes.

**1. Extract `authorize_as_authenticated` into a shared trait** (`88358e3274`)
The permission callback was duplicated almost verbatim in `NotificationPreferencesRestController` and `PushTokenRestController`. This moves it into a new `AuthorizesPushNotificationRequests` trait (mirroring the existing `ConvertsExceptionsToWpError` trait), looks up `PushNotifications` via the container in one place, and drops the now-unused DI of `PushNotifications` from `NotificationPreferencesRestController`. Addresses @hannahtinkler's suggestion: https://github.com/woocommerce/woocommerce/pull/64351#discussion_r3218483918

**2. Correct `@since` tags on preference-filter methods** (`47d3b69c9c`)
`Notification::should_send_to_user()` and `NotificationProcessor::filter_tokens_by_preferences()` were tagged `@since 10.8.0`, but PR #64487 merged after the bump to `10.9.0-dev`, so they should be `@since 10.9.0`. Addresses @albarin's comment: https://github.com/woocommerce/woocommerce/pull/64487#issuecomment-4448627834

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the affected unit tests and confirm they pass:
   `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "PushTokenRestControllerTest|NotificationPreferencesRestControllerTest|NotificationTest|NotificationProcessorTest"`
2. With push notifications enabled and Jetpack connected, hit `GET /wp-json/wc-push-notifications/preferences` as a shop manager/administrator and confirm a `200` with the preferences payload.
3. As a logged-out user (or a subscriber), hit the same endpoint and confirm a `401`/`rest_authorization_required` response — confirming the trait's auth logic is unchanged.
4. Repeat 2–3 against `POST /wp-json/wc-push-notifications/push-tokens` to confirm `PushTokenRestController` still authorizes identically after switching to the trait.


<!-- End testing instructions -->

### Testing that has already taken place:

- Smoke testing push token registration and changing push preferences

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entries were added manually in the branch: `64351-followup-authorize-trait` (trait extraction) and `64487-followup-since-tags` (@since correction), both `Significance: patch`, `Type: dev`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>