### PR TITLE
Remove product pre-publish modal feature flag

### DIFF
--- a/packages/js/product-editor/changelog/remove-product-pre-publish-modal-flag
+++ b/packages/js/product-editor/changelog/remove-product-pre-publish-modal-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove the disabled product pre-publish modal feature flag.

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -33,7 +33,6 @@ import { SaveDraftButton } from './save-draft-button';
 import { LoadingState } from './loading-state';
 import { Tabs } from '../tabs';
 import { HEADER_PINNED_ITEMS_SCOPE, TRACKS_SOURCE } from '../../constants';
-import { useShowPrepublishChecks } from '../../hooks/use-show-prepublish-checks';
 import { HeaderProps, Image } from './types';
 
 const PublishButton = lazy( () =>
@@ -76,8 +75,6 @@ export function Header( {
 	const editedProductName = product?.name;
 	const catalogVisibility = product?.catalog_visibility;
 	const productStatus = product?.status;
-
-	const { showPrepublishChecks } = useShowPrepublishChecks();
 
 	const sidebarWidth = useAdminSidebarWidth();
 
@@ -254,7 +251,6 @@ export function Header( {
 					<Suspense fallback={ null }>
 						<PublishButton
 							productType={ productType }
-							isPrePublishPanelVisible={ showPrepublishChecks }
 							isMenuButton
 							visibleTab={ selectedTab }
 						/>

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -1,23 +1,19 @@
 /**
  * External dependencies
  */
-import type { MouseEvent } from 'react';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { type Product } from '@woocommerce/data';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
-import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
-import { wooProductEditorUiStore } from '../../../store/product-editor-ui';
 import { useErrorHandler } from '../../../hooks/use-error-handler';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { useFeedbackBar } from '../../../hooks/use-feedback-bar';
-import { TRACKS_SOURCE } from '../../../constants';
 import { usePublish } from '../hooks/use-publish';
 import { PublishButtonMenu } from './publish-button-menu';
 import { showSuccessNotice } from './utils';
@@ -26,16 +22,14 @@ import type { PublishButtonProps } from './types';
 export function PublishButton( {
 	productType = 'product',
 	isMenuButton,
-	isPrePublishPanelVisible = true,
 	visibleTab = 'general',
 	...props
 }: PublishButtonProps ) {
 	const { createErrorNotice } = useDispatch( 'core/notices' );
 	const { maybeShowFeedbackBar } = useFeedbackBar();
-	const { openPrepublishPanel } = useDispatch( wooProductEditorUiStore );
 	const { getProductErrorMessageAndProps } = useErrorHandler();
 
-	const [ editedStatus, , prevStatus ] = useEntityProp< Product[ 'status' ] >(
+	const [ , , prevStatus ] = useEntityProp< Product[ 'status' ] >(
 		'postType',
 		productType,
 		'status'
@@ -77,39 +71,6 @@ export function PublishButton( {
 				<PublishButtonMenu
 					{ ...menuProps }
 					postType={ productType }
-					visibleTab={ visibleTab }
-				/>
-			);
-		}
-
-		if (
-			editedStatus !== 'publish' &&
-			editedStatus !== 'future' &&
-			window.wcAdminFeatures[ 'product-pre-publish-modal' ] &&
-			isPrePublishPanelVisible
-		) {
-			function handlePrePublishButtonClick(
-				event: MouseEvent< HTMLButtonElement >
-			) {
-				if ( publishButtonProps[ 'aria-disabled' ] ) {
-					event.preventDefault();
-					return;
-				}
-
-				recordEvent( 'product_prepublish_panel', {
-					source: TRACKS_SOURCE,
-					action: 'view',
-				} );
-				openPrepublishPanel();
-			}
-
-			return (
-				<PublishButtonMenu
-					{ ...publishButtonProps }
-					postType={ productType }
-					controls={ undefined }
-					onClick={ handlePrePublishButtonClick }
-					renderMenu={ renderPublishButtonMenu }
 					visibleTab={ visibleTab }
 				/>
 			);

--- a/packages/js/product-editor/src/components/header/publish-button/types.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/types.ts
@@ -1,7 +1,6 @@
 export type PublishButtonProps = {
 	productType?: string;
 	isMenuButton?: boolean;
-	isPrePublishPanelVisible?: boolean;
 	visibleTab?: string | null;
 	disabled?: boolean;
 	onClick?: ( event: React.MouseEvent< HTMLElement > ) => void;

--- a/plugins/woocommerce/changelog/remove-product-pre-publish-modal-flag
+++ b/plugins/woocommerce/changelog/remove-product-pre-publish-modal-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove the disabled product pre-publish modal feature flag.

--- a/plugins/woocommerce/client/admin/client/typings/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/typings/global.d.ts
@@ -65,7 +65,6 @@ declare global {
 			'payment-gateway-suggestions': boolean;
 			'pattern-toolkit-full-composability': boolean;
 			printful: boolean;
-			'product-pre-publish-modal': boolean;
 			'product-custom-fields': boolean;
 			'remote-inbox-notifications': boolean;
 			'remote-free-extensions': boolean;

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -24,7 +24,6 @@
 		"onboarding": true,
 		"onboarding-tasks": true,
 		"pattern-toolkit-full-composability": true,
-		"product-pre-publish-modal": false,
 		"product-custom-fields": true,
 		"products-catalog-api": false,
 		"remote-inbox-notifications": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -25,7 +25,6 @@
 		"onboarding-tasks": true,
 		"pattern-toolkit-full-composability": true,
 		"payment-gateway-suggestions": true,
-		"product-pre-publish-modal": false,
 		"product-custom-fields": true,
 		"products-catalog-api": true,
 		"printful": true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Follow-up to https://github.com/woocommerce/woocommerce/pull/65333.

Part of https://github.com/woocommerce/woocommerce/issues/65384.

PR #65333 deprecates Product Editor v2 and its extension APIs ahead of removal in WooCommerce 11.0. The `product-pre-publish-modal` feature flag was already disabled, so this PR removes the flag from admin configuration and typings, and removes the unreachable pre-publish panel branch from the product editor publish button.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Checkout this branch.
2. Confirm there are no remaining references to `product-pre-publish-modal` in `packages/` or `plugins/`.
3. Open a product in the product block editor.
4. Confirm the publish button continues to show the standard publish menu behavior and does not open the pre-publish side panel.

<!-- End testing instructions -->



### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove product pre-publish modal feature flag.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entries were created manually for WooCommerce Core and `@woocommerce/product-editor`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
