### PR TITLE
Use public @wordpress/core-data export for Taxonomy type

### DIFF
--- a/plugins/woocommerce/changelog/decouple-wp-internal-type-imports
+++ b/plugins/woocommerce/changelog/decouple-wp-internal-type-imports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Switch `Taxonomy` type imports in product collection taxonomy controls from `@wordpress/core-data/src/entity-types` to the package's public root export.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Taxonomy } from '@wordpress/core-data/src/entity-types';
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -9,6 +8,7 @@ import ProductCategoryControl from '@woocommerce/editor-components/product-categ
 import ProductTagControl from '@woocommerce/editor-components/product-tag-control';
 import ProductBrandControl from '@woocommerce/editor-components/product-brand-control';
 import type { SearchListItem } from '@woocommerce/editor-components/search-list-control/types';
+import type { Taxonomy } from '@wordpress/core-data';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/taxonomy-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/taxonomy-item.tsx
@@ -7,7 +7,7 @@ import { useState } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 import { FormTokenField } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
-import type { Taxonomy } from '@wordpress/core-data/src/entity-types';
+import type { Taxonomy } from '@wordpress/core-data';
 
 type Term = {
 	id: number;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The product collection taxonomy controls imported the `Taxonomy` TypeScript type from `@wordpress/core-data/src/entity-types`, an internal subpath of the `@wordpress/core-data` package. Reaching into `/src/` is not part of the package's stable public API.

`@wordpress/core-data` has re-exported the entire `entity-types` module from its public root entrypoint since version 7.x (via `export * from './entity-types'` in `build-types/index.d.ts`), so `Taxonomy` is available directly from the package root. This PR switches the two affected files to use the public import:

```diff
- import type { Taxonomy } from '@wordpress/core-data/src/entity-types';
+ import type { Taxonomy } from '@wordpress/core-data';
```

No runtime change. Same `Taxonomy<'edit'>` type as before (the default generic argument).

Out of scope: the same audit also flagged `import type { Style } from '@wordpress/style-engine/src/types'` in three files. Verified against `@wordpress/style-engine` v1.41.0 (the resolved version here) and v2.47.0 (latest on trunk): `Style` is not publicly re-exported from any version of the package. Long-term fix is an upstream Gutenberg PR to expose the type; in the meantime WooCommerce's internal testing against WordPress catches breakage from the internal path.

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

1. Run TypeScript type-checking for the blocks package:
   ```sh
   pnpm --filter=@woocommerce/block-library ts:check
   ```
   The two changed files (`taxonomy-controls/index.tsx`, `taxonomy-controls/taxonomy-item.tsx`) should not introduce any new errors. (Note: there are 4 pre-existing trunk errors in these files unrelated to this change.)
2. In the editor, insert a Product Collection block. Open the inspector and verify the taxonomy controls panel renders correctly:
   - The list of taxonomies is shown for collections that support filtering by taxonomy.
   - Selecting/deselecting terms inside a taxonomy control works as before.
   - The "Filter by category", "Filter by tag", and "Filter by brand" controls all open and accept input.

### Testing that has already taken place:

- Ran `pnpm --filter=@woocommerce/block-library ts:check` — no new errors introduced by this change.
- Verified `Taxonomy` resolves from `@wordpress/core-data` at compile time in the project's TypeScript configuration.
- Confirmed `@wordpress/core-data@7.19.6` (the version this monorepo resolves) re-exports `Taxonomy` from `build-types/index.d.ts` via `export * from "./entity-types"`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually at `plugins/woocommerce/changelog/decouple-wp-internal-type-imports`.