### PR TITLE
Drop icon and add emoji to store_stock/store_order notifications

### DIFF
--- a/plugins/woocommerce/changelog/update-store-stock-order-pn-icon-emoji
+++ b/plugins/woocommerce/changelog/update-store-stock-order-pn-icon-emoji
@@ -1,0 +1,3 @@
+Significance: patch
+Type: update
+Comment: Drop the icon from store_stock and store_order push notifications and append a per-event emoji to the store_stock title.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
@@ -20,11 +20,6 @@ class NewOrderNotification extends Notification {
 	const TYPE = 'store_order';
 
 	/**
-	 * The icon to use in the notification.
-	 */
-	const ICON = 'https://s.wp.com/wp-content/mu-plugins/notes/images/update-payment-2x.png';
-
-	/**
 	 * An array of emojis to select from when forming the payload.
 	 */
 	const EMOJI_LIST = array( '🎉', '🎊', '🥳', '👏', '🙌' );
@@ -54,7 +49,6 @@ class NewOrderNotification extends Notification {
 
 		return array(
 			'type'        => $this->get_type(),
-			'icon'        => self::ICON,
 			// This represents the time the notification was triggered, so we can monitor age of notification at delivery.
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
@@ -28,6 +28,13 @@ class StockNotification extends Notification {
 	);
 
 	/**
+	 * Emoji appended to the notification title, one per stock event type.
+	 */
+	const EMOJI_OUT_OF_STOCK = '🚨';
+	const EMOJI_ON_BACKORDER = '🕐';
+	const EMOJI_LOW_STOCK    = '⚠️';
+
+	/**
 	 * The stock event that triggered this notification.
 	 *
 	 * @var string
@@ -274,20 +281,20 @@ class StockNotification extends Notification {
 		switch ( $this->event_type ) {
 			case self::EVENT_OUT_OF_STOCK:
 				return array(
-					'format' => 'Out of stock: %1$s',
-					'args'   => array( $product_name ),
+					'format' => 'Out of stock: %1$s %2$s',
+					'args'   => array( $product_name, self::EMOJI_OUT_OF_STOCK ),
 				);
 
 			case self::EVENT_ON_BACKORDER:
 				return array(
-					'format' => 'Backordered: %1$s',
-					'args'   => array( $product_name ),
+					'format' => 'Backordered: %1$s %2$s',
+					'args'   => array( $product_name, self::EMOJI_ON_BACKORDER ),
 				);
 
 			default:
 				return array(
-					'format' => 'Low stock: %1$s',
-					'args'   => array( $product_name ),
+					'format' => 'Low stock: %1$s %2$s',
+					'args'   => array( $product_name, self::EMOJI_LOW_STOCK ),
 				);
 		}
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
@@ -27,8 +27,6 @@ class StockNotification extends Notification {
 		self::EVENT_ON_BACKORDER,
 	);
 
-	const ICON = 'https://s.wp.com/wp-content/mu-plugins/notes/images/tos-warning-note-icon.png';
-
 	/**
 	 * The stock event that triggered this notification.
 	 *
@@ -195,7 +193,6 @@ class StockNotification extends Notification {
 
 		return array(
 			'type'        => $this->get_type(),
-			'icon'        => self::ICON,
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => $this->build_title( $product_name ),

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewOrderNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewOrderNotificationTest.php
@@ -30,7 +30,7 @@ class NewOrderNotificationTest extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'message', $payload );
 		$this->assertArrayHasKey( 'format', $payload['message'] );
 		$this->assertArrayHasKey( 'args', $payload['message'] );
-		$this->assertArrayHasKey( 'icon', $payload );
+		$this->assertArrayNotHasKey( 'icon', $payload );
 		$this->assertArrayHasKey( 'meta', $payload );
 		$this->assertArrayHasKey( 'order_id', $payload['meta'] );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/StockNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/StockNotificationTest.php
@@ -107,6 +107,21 @@ class StockNotificationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should include the event-specific emoji as the last title arg.
+	 * @dataProvider event_type_emoji_provider
+	 *
+	 * @param string $event_type     The event type constant.
+	 * @param string $expected_emoji The emoji expected for that event type.
+	 */
+	public function test_to_payload_title_args_contain_event_emoji( string $event_type, string $expected_emoji ): void {
+		$product      = WC_Helper_Product::create_simple_product();
+		$notification = new StockNotification( $product->get_id(), $event_type );
+		$payload      = $notification->to_payload();
+
+		$this->assertSame( $expected_emoji, $payload['title']['args'][1] );
+	}
+
+	/**
 	 * @testdox Should include stock quantity in the low_stock message args.
 	 */
 	public function test_to_payload_includes_stock_quantity_for_low_stock(): void {
@@ -409,6 +424,19 @@ class StockNotificationTest extends WC_Unit_Test_Case {
 			'low_stock'    => array( StockNotification::EVENT_LOW_STOCK, 'Low stock:' ),
 			'out_of_stock' => array( StockNotification::EVENT_OUT_OF_STOCK, 'Out of stock:' ),
 			'on_backorder' => array( StockNotification::EVENT_ON_BACKORDER, 'Backordered:' ),
+		);
+	}
+
+	/**
+	 * Data provider mapping event types to their expected title emoji.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function event_type_emoji_provider(): array {
+		return array(
+			'low_stock'    => array( StockNotification::EVENT_LOW_STOCK, StockNotification::EMOJI_LOW_STOCK ),
+			'out_of_stock' => array( StockNotification::EVENT_OUT_OF_STOCK, StockNotification::EMOJI_OUT_OF_STOCK ),
+			'on_backorder' => array( StockNotification::EVENT_ON_BACKORDER, StockNotification::EMOJI_ON_BACKORDER ),
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/StockNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/StockNotificationTest.php
@@ -85,7 +85,7 @@ class StockNotificationTest extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'message', $payload );
 		$this->assertArrayHasKey( 'format', $payload['message'] );
 		$this->assertArrayHasKey( 'args', $payload['message'] );
-		$this->assertArrayHasKey( 'icon', $payload );
+		$this->assertArrayNotHasKey( 'icon', $payload );
 		$this->assertArrayHasKey( 'meta', $payload );
 		$this->assertArrayHasKey( 'product_id', $payload['meta'] );
 		$this->assertArrayHasKey( 'event_type', $payload['meta'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The push notification icon is now optional on the WordPress.com side, so WooCommerce no longer needs to send a hard-coded icon. This PR drops the `icon` field (and its constants) from the `store_stock` and `store_order` push notification payloads.

It also refines the `store_stock` title with an event-specific emoji appended at the end: ⚠️ for low stock, 🚨 for out of stock, and 🕐 for backorder. The emoji is passed as a title arg (matching the existing `store_order` pattern) so it stays out of the translatable format string. This was discussed with the designer Wagner.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

2. Inspect the `store_order` payload (e.g. via `wp shell`): build a `NewOrderNotification` for an existing order and call `to_payload()`. Confirm the returned array has **no** `icon` key.
3. Inspect the `store_stock` payload for each event type: build a `StockNotification` for a product with `EVENT_LOW_STOCK`, `EVENT_OUT_OF_STOCK`, and `EVENT_ON_BACKORDER`, calling `to_payload()` each time. Confirm that:
   - There is **no** `icon` key.
   - `title.args[1]` holds the expected emoji — ⚠️ (low stock), 🚨 (out of stock), 🕐 (backorder).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Manually tested with a JN site and mobile app

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entry was added to this branch manually (`plugins/woocommerce/changelog/update-store-stock-order-pn-icon-emoji`).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
