### PR TITLE
Add the woocommerce_variable_product_taxes_influence_price filter

### DIFF
--- a/plugins/woocommerce/changelog/add-filter-for-variable-product-taxes-influence-price
+++ b/plugins/woocommerce/changelog/add-filter-for-variable-product-taxes-influence-price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the `woocommerce_variable_product_taxes_influence_price` filter.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -567,21 +567,33 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 */
 	protected function taxes_influence_price( $product ): bool {
 		if ( ! $product->is_taxable() ) {
-			return false;
+			$taxes_influence_price = false;
+		} elseif ( empty( WC_Tax::get_rates( $product->get_tax_class() ) ) ) {
+			$taxes_influence_price = false;
+		} else {
+			// Taxes influence the price regardless of VAT exempt status. Even when a
+			// customer is VAT exempt, the displayed prices differ from non-exempt
+			// prices, so they need separate cache entries and the opposite_price_hash
+			// optimization should not apply. Returning false here was causing cached
+			// non-exempt prices to be served to VAT exempt customers.
+			$taxes_influence_price = true;
 		}
 
-		if ( empty( WC_Tax::get_rates( $product->get_tax_class() ) ) ) {
-			return false;
-		}
-
-		// Taxes influence the price regardless of VAT exempt status. Even when a
-		// customer is VAT exempt, the displayed prices differ from non-exempt
-		// prices, so they need separate cache entries and the opposite_price_hash
-		// optimization should not apply. Returning false here was causing cached
-		// non-exempt prices to be served to VAT exempt customers.
-		// See: https://github.com/woocommerce/woocommerce/issues/63716
-
-		return true;
+		/**
+		 * Filters whether taxes influence the displayed price of a variable product.
+		 *
+		 * Return `true` from this filter to force separate cache entries for the two
+		 * variants. This is needed when an extension produces displayed prices that
+		 * differ from raw prices independently of the standard tax calculation, for
+		 * example when computing per-country prices for locations that have no
+		 * configured tax rates.
+		 *
+		 * @param bool       $taxes_influence_price Default decision based on product taxability and configured tax rates.
+		 * @param WC_Product $product               The variable product being evaluated.
+		 *
+		 * @since 10.9.0
+		 */
+		return (bool) apply_filters( 'woocommerce_variable_product_taxes_influence_price', $taxes_influence_price, $product );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -541,6 +541,49 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The woocommerce_variable_product_taxes_influence_price filter can override the default decision.
+	 *
+	 * @testWith [true,  true,  true,  true,  true]
+	 *           [true,  true,  true,  false, false]
+	 *           [false, true,  false, true,  true]
+	 *           [true,  false, false, true,  true]
+	 *           [false, false, false, true,  true]
+	 *           [true,  false, false, false, false]
+	 *
+	 * @param bool $taxable_product  Product is taxable or not.
+	 * @param bool $tax_has_rates    Product tax has defined rates or not.
+	 * @param bool $expected_default Value the filter callback should receive as the default decision.
+	 * @param bool $filter_returns   Value the filter callback will return.
+	 * @param bool $expected         Expected return value from taxes_influence_price.
+	 */
+	public function test_taxes_influence_price_filter_overrides_default( bool $taxable_product, bool $tax_has_rates, bool $expected_default, bool $filter_returns, bool $expected ) {
+		add_filter( 'wc_tax_enabled', '__return_true' );
+		add_filter( 'woocommerce_product_is_taxable', $taxable_product ? '__return_true' : '__return_false' );
+		add_filter( 'woocommerce_matched_rates', $tax_has_rates ? array( $this, '__return_rates' ) : '__return_empty_array' );
+
+		$received_default = null;
+		$received_product = null;
+		$filter_callback  = function ( $default_value, $product ) use ( $filter_returns, &$received_default, &$received_product ) {
+			$received_default = $default_value;
+			$received_product = $product;
+			return $filter_returns;
+		};
+		add_filter( 'woocommerce_variable_product_taxes_influence_price', $filter_callback, 10, 2 );
+
+		$product             = WC_Helper_Product::create_variation_product();
+		$extended_data_store = $this->get_data_store_with_public_taxes_influence_price();
+
+		$this->assertSame( $expected, $extended_data_store->taxes_influence_price( $product ) );
+		$this->assertSame( $expected_default, $received_default, 'Filter callback should receive the default decision.' );
+		$this->assertSame( $product->get_id(), $received_product->get_id(), 'Filter callback should receive the product being evaluated.' );
+
+		remove_filter( 'woocommerce_variable_product_taxes_influence_price', $filter_callback, 10 );
+		remove_filter( 'wc_tax_enabled', '__return_true' );
+		remove_filter( 'woocommerce_product_is_taxable', $taxable_product ? '__return_true' : '__return_false' );
+		remove_filter( 'woocommerce_matched_rates', $tax_has_rates ? array( $this, '__return_rates' ) : '__return_empty_array' );
+	}
+
+	/**
 	 * @testdox read_prices does separate caching for prices for display and not for display when they are different.
 	 *
 	 * @testWith [true]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a new `woocommerce_variable_product_taxes_influence_price` filter to `WC_Product_Variable_Data_Store_CPT::taxes_influence_price()`.

By default the method returns `true` only when the product is taxable and tax rates are configured for the customer's location; otherwise it returns `false` and the variation price cache stores a single entry shared between "for display" and "not for display" lookups (the `$opposite_price_hash` optimization in `read_price_data()`).

This default is correct for stock WooCommerce, but it breaks setups where an extension produces displayed prices that differ from raw prices independently of the standard tax calculation. The motivating case is one described in a now deleted comment in [#63716](https://github.com/woocommerce/woocommerce/issues/63716) (reproduced [here](https://github.com/woocommerce/woocommerce/pull/65394#issuecomment-4572008495)): an EU shop using dynamic caching that varies prices by country, where non-EU locations have no configured tax rates. With no rates configured, `taxes_influence_price()` returns `false`, the two cache directions collapse, and the country-specific prices stop being served correctly. The current workaround is to register a 0% tax rate for those countries just to keep the cache from collapsing.

The new filter lets such extensions force `true` (or, less commonly, force `false`) and avoid that hack.

The internal early-return chain was refactored into a single captured boolean so the filter runs once on the final decision. Behavior is unchanged when nothing hooks the filter.

Motivated by https://github.com/woocommerce/woocommerce/issues/63716#issuecomment-4547116723.

### How to test the changes in this Pull Request:

1. Configure a store with:
    - Taxes enabled, prices entered inclusive of tax, prices displayed including tax, calculate taxes based on shop address.
    - A 20% standard rate that applies to all countries.

2. Create a variable product priced 100 with at least one variation. Note its post ID and export it as a shell variable in the terminal you'll use for the wp-cli commands below - every command in steps 5–7 references it:

    ```bash
    export PRODUCT_ID=<the product>
    ```

3. Without any extra code, confirm that the variation prices on the shop / product page display as expected (i.e. 100 including tax, 83.33 excluding tax depending on the display setting).

4. Below is the filter snippet you'll toggle on and off during the rest of this test. Add it to a mu-plugin (`wp-content/mu-plugins/test-taxes-influence-price.php`, opening `<?php` tag included), but keep it COMMENTED OUT for now. A mu-plugin is required (rather than a theme `functions.php`) because the verification steps invoke wp-cli's `wp eval`, which doesn't auto-load the active theme:

    ```php
    add_filter(
        'woocommerce_variable_product_taxes_influence_price',
        function ( $default_value, $product ) {
            // Force separate cache entries for display vs. raw prices.
            return true;
        },
        10,
        2
    );
    ```

Each of the verification steps below uses the same three-command pattern. Define a shell function once to keep them readable:

```bash
inspect_cache() {
    wp transient delete wc_var_prices_$PRODUCT_ID
    wp eval "wc_get_product($PRODUCT_ID)->get_variation_prices(true);"
    wp transient get wc_var_prices_$PRODUCT_ID | jq 'keys | length'
}
```

This forces exactly one `read_price_data()` call in the "for display" direction, then prints the resulting key count. A normal product-page reload won't work here: a single front-end render calls `read_price_data()` multiple times with both `for_display` values (price-range string, variation form JSON, schema markup, etc.), which always produces 2 keys regardless of the filter and hides the cache-key pattern we're trying to observe.

> **Note:** if you're invoking wp-cli via wp-env, prepend the first two lines of the function with `wp-env run cli` and replace the last line with the following, so that `jq` works as expected: `pnpm --silent wp-env run cli wp transient get wc_var_prices_$PRODUCT_ID 2>/dev/null | jq 'keys | length'`.

5. Baseline (filter OFF, rates match current location → default returns `true`):

    Run `inspect_cache`. Expect `1` - when `taxes_influence_price()` returns `true`, the opposite-hash optimization is disabled and only the current direction's hash is written.

6. Override path (default would return `false`):

    a. Configure the standard tax rate so it does NOT apply to your current location (e.g. set its country to a different one) AND verify the tax-calculation setting matches (Shop address vs. Customer billing/shipping address) so the lookup actually misses. With no matching rates, the default `taxes_influence_price()` now returns `false`.

    b. With the filter still OFF, run `inspect_cache`. Expect `2` - `taxes_influence_price()=false` triggers the opposite-hash optimization, which writes the same computed prices under both direction hashes in one pass. This is the cache-key pattern the motivating use case wants to escape.

    c. Activate the filter (uncomment the snippet from step 4) and run `inspect_cache`. Expect `1` - forcing `true` disables the dual-write, so only the current direction's hash is stored.

7. Optional cleanup verification: comment the snippet back out and run `inspect_cache` once more. Expect `2` again (default `false` and dual-write restored).

    > **Note on observable price values:** In this minimal repro the *values* under the two keys in step 6.b are identical, because with no matching rates there is no tax to add/subtract - the optimization is harmless on its own. The filter matters in setups where another extension (e.g. a `woocommerce_variation_prices_price` callback driving per-country pricing via dynamic caching cookies) produces direction-dependent prices on top, so the dual-write must be turned off to keep the cache from serving stale data across directions.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually at `plugins/woocommerce/changelog/add-filter-for-variable-product-taxes-influence-price` (Significance: minor, Type: add).

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
