### PR TITLE
Product gallery videos #2: Add product media gallery REST support

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -1064,6 +1064,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @param bool            $creating If is creating a new object.
+	 * @throws WC_REST_Exception If product media gallery data is invalid.
 	 *
 	 * @return WP_Error|WC_Data
 	 */

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Enums\CatalogVisibility;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareRestControllerTrait;
+use Automattic\WooCommerce\Internal\ProductGallery\ProductMediaGallery;
 use Automattic\WooCommerce\Utilities\I18nUtil;
 use Automattic\WooCommerce\Utilities\MetaDataUtil;
 
@@ -210,6 +211,136 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		}
 
 		return $images;
+	}
+
+	/**
+	 * Get the media gallery for a product.
+	 *
+	 * @param WC_Product|WC_Product_Variation $product Product instance.
+	 *
+	 * @return array
+	 */
+	protected function get_media_gallery( $product ) {
+		$media_gallery = ProductMediaGallery::get_product_media_gallery_items(
+			$product,
+			array(
+				'context'         => 'edit',
+				'feature_enabled' => ProductMediaGallery::is_feature_enabled(),
+			)
+		);
+
+		if ( empty( $media_gallery ) ) {
+			return array();
+		}
+
+		ProductMediaGallery::prime_attachment_caches( $media_gallery, true );
+
+		$items = array();
+
+		foreach ( array_values( $media_gallery ) as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			if ( 'attachment' !== ( $item['source_type'] ?? '' ) || empty( $item['id'] ) ) {
+				continue;
+			}
+
+			$attachment_data = $this->get_media_gallery_attachment_data( (int) $item['id'], $item['media_type'] ?? '' );
+
+			if ( empty( $attachment_data ) ) {
+				continue;
+			}
+
+			$item = array_merge( $item, $attachment_data );
+
+			if ( 'video' === ( $item['media_type'] ?? '' ) ) {
+				$poster_id = ProductMediaGallery::get_video_poster_id( $item );
+
+				if ( $poster_id ) {
+					$item['poster_id'] = $poster_id;
+					$item              = array_merge( $item, $this->get_media_gallery_poster_data( $poster_id ) );
+				}
+			}
+
+			$item['position'] = count( $items );
+			$items[]          = $item;
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Get attachment response data for a media gallery item.
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $media_type    Media type.
+	 *
+	 * @return array
+	 */
+	protected function get_media_gallery_attachment_data( $attachment_id, $media_type ) {
+		$attachment_post = get_post( $attachment_id );
+
+		if ( is_null( $attachment_post ) ) {
+			return array();
+		}
+
+		$attachment_url = wp_get_attachment_url( $attachment_id );
+		$data           = array(
+			'date_created'      => wc_rest_prepare_date_response( $attachment_post->post_date, false ),
+			'date_created_gmt'  => wc_rest_prepare_date_response( $attachment_post->post_date_gmt ),
+			'date_modified'     => wc_rest_prepare_date_response( $attachment_post->post_modified, false ),
+			'date_modified_gmt' => wc_rest_prepare_date_response( $attachment_post->post_modified_gmt ),
+			'mime_type'         => get_post_mime_type( $attachment_id ),
+			'name'              => get_the_title( $attachment_id ),
+		);
+
+		if ( $attachment_url ) {
+			$data['src'] = $attachment_url;
+		}
+
+		if ( 'image' === $media_type ) {
+			$thumbnail = wp_get_attachment_image_src( $attachment_id, 'woocommerce_thumbnail' );
+
+			$data['alt']    = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+			$data['srcset'] = (string) wp_get_attachment_image_srcset( $attachment_id, 'full' );
+			$data['sizes']  = (string) wp_get_attachment_image_sizes( $attachment_id, 'full' );
+
+			if ( is_array( $thumbnail ) ) {
+				$data['thumbnail'] = current( $thumbnail );
+			} elseif ( $attachment_url ) {
+				$data['thumbnail'] = $attachment_url;
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get poster response data for a media gallery video item.
+	 *
+	 * @param int $poster_id Poster attachment ID.
+	 *
+	 * @return array
+	 */
+	protected function get_media_gallery_poster_data( $poster_id ) {
+		$poster_url = wp_get_attachment_image_src( $poster_id, 'full' );
+		$poster_url = is_array( $poster_url ) ? current( $poster_url ) : wp_get_attachment_url( $poster_id );
+		$data       = array();
+
+		if ( $poster_url ) {
+			$data['poster'] = $poster_url;
+		}
+
+		$thumbnail = wp_get_attachment_image_src( $poster_id, 'woocommerce_thumbnail' );
+
+		if ( is_array( $thumbnail ) ) {
+			$data['thumbnail'] = current( $thumbnail );
+		} elseif ( $poster_url ) {
+			$data['thumbnail'] = $poster_url;
+		}
+
+		return $data;
 	}
 
 	/**
@@ -723,10 +854,211 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	}
 
 	/**
+	 * Set product media gallery.
+	 *
+	 * @param WC_Product $product       Product instance.
+	 * @param array      $media_gallery Media gallery data.
+	 *
+	 * @throws WC_REST_Exception REST API exceptions.
+	 * @return WC_Product
+	 */
+	protected function set_product_media_gallery( $product, $media_gallery ) {
+		$this->validate_product_media_gallery( $media_gallery );
+
+		$media_gallery = ProductMediaGallery::normalize_media_gallery_items( $media_gallery, true );
+		$media_gallery = $this->sync_product_images_from_media_gallery( $product, $media_gallery );
+
+		$stored_media_gallery = ProductMediaGallery::has_videos( $media_gallery ) ? $media_gallery : array();
+
+		$product->set_media_gallery( $stored_media_gallery );
+
+		return $product;
+	}
+
+	/**
+	 * Sync stored media gallery data after an update through the images request field.
+	 *
+	 * @param WC_Product $product Product instance.
+	 *
+	 * @return WC_Product
+	 */
+	protected function sync_media_gallery_from_images_request( $product ) {
+		if ( ! method_exists( $product, 'set_media_gallery' ) ) {
+			return $product;
+		}
+
+		if ( ! ProductMediaGallery::is_feature_enabled() ) {
+			$product->set_media_gallery( array() );
+			return $product;
+		}
+
+		return $this->sync_media_gallery_from_images_update( $product );
+	}
+
+	/**
+	 * Sync stored media gallery data after an update through product image props.
+	 *
+	 * @param WC_Product $product Product instance.
+	 *
+	 * @return WC_Product
+	 */
+	protected function sync_media_gallery_from_images_update( $product ) {
+		if ( ! method_exists( $product, 'get_media_gallery' ) || ! method_exists( $product, 'set_media_gallery' ) ) {
+			return $product;
+		}
+
+		$media_gallery = $product->get_media_gallery( 'edit' );
+
+		if ( empty( $media_gallery ) ) {
+			return $product;
+		}
+
+		$image_media_items    = ProductMediaGallery::get_product_image_media_items( $product, true, 'edit' );
+		$updated_media_items  = array();
+		$images_inserted      = false;
+		$has_preserved_videos = false;
+
+		foreach ( $media_gallery as $media_item ) {
+			if ( ! is_array( $media_item ) || empty( $media_item['media_type'] ) ) {
+				continue;
+			}
+
+			if ( 'image' === $media_item['media_type'] ) {
+				if ( ! $images_inserted ) {
+					$updated_media_items = array_merge( $updated_media_items, $image_media_items );
+					$images_inserted     = true;
+				}
+				continue;
+			}
+
+			if ( 'video' === $media_item['media_type'] ) {
+				$updated_media_items[] = $media_item;
+				$has_preserved_videos  = true;
+			}
+		}
+
+		if ( ! $has_preserved_videos ) {
+			$product->set_media_gallery( array() );
+			return $product;
+		}
+
+		if ( ! $images_inserted ) {
+			$updated_media_items = array_merge( $image_media_items, $updated_media_items );
+		}
+
+		$product->set_media_gallery( ProductMediaGallery::maybe_prepend_product_image( $product, $updated_media_items, 'edit' ) );
+
+		return $product;
+	}
+
+	/**
+	 * Validate product media gallery items.
+	 *
+	 * @param mixed $media_gallery Media gallery data.
+	 *
+	 * @throws WC_REST_Exception REST API exceptions.
+	 * @return void
+	 */
+	protected function validate_product_media_gallery( $media_gallery ) {
+		if ( ! is_array( $media_gallery ) ) {
+			throw new WC_REST_Exception( 'woocommerce_product_media_gallery_invalid', esc_html__( 'Media gallery must be an array.', 'woocommerce' ), 400 );
+		}
+
+		if ( empty( $media_gallery ) ) {
+			return;
+		}
+
+		foreach ( $media_gallery as $item ) {
+			$this->validate_product_media_gallery_item( $item );
+		}
+	}
+
+	/**
+	 * Validate a product media gallery item.
+	 *
+	 * @param mixed $item Media gallery item.
+	 *
+	 * @throws WC_REST_Exception REST API exceptions.
+	 * @return void
+	 */
+	protected function validate_product_media_gallery_item( $item ) {
+		if ( ! is_array( $item ) ) {
+			throw new WC_REST_Exception( 'woocommerce_product_media_gallery_invalid_item', esc_html__( 'Media gallery items must be objects.', 'woocommerce' ), 400 );
+		}
+
+		$media_type = isset( $item['media_type'] ) ? sanitize_key( $item['media_type'] ) : '';
+
+		if ( ! in_array( $media_type, array( 'image', 'video' ), true ) ) {
+			throw new WC_REST_Exception( 'woocommerce_product_media_gallery_invalid_media_type', esc_html__( 'Media gallery items must be images or videos.', 'woocommerce' ), 400 );
+		}
+
+		$source_type = isset( $item['source_type'] ) ? sanitize_key( $item['source_type'] ) : 'attachment';
+
+		if ( 'attachment' !== $source_type ) {
+			throw new WC_REST_Exception( 'woocommerce_product_media_gallery_invalid_source_type', esc_html__( 'Only attachment media gallery items are currently supported.', 'woocommerce' ), 400 );
+		}
+
+		$attachment_id = isset( $item['id'] ) ? absint( $item['id'] ) : 0;
+
+		if ( ! $attachment_id ) {
+			throw new WC_REST_Exception( 'woocommerce_product_media_gallery_invalid_attachment_id', esc_html__( 'Media gallery attachment ID is required.', 'woocommerce' ), 400 );
+		}
+
+		if ( 'image' === $media_type && ! wp_attachment_is_image( $attachment_id ) ) {
+			/* translators: %s: attachment id */
+			throw new WC_REST_Exception( 'woocommerce_product_media_gallery_invalid_image_id', sprintf( esc_html__( '#%s is an invalid image ID.', 'woocommerce' ), esc_html( (string) $attachment_id ) ), 400 );
+		}
+
+		if ( 'video' === $media_type ) {
+			$mime_type = get_post_mime_type( $attachment_id );
+
+			if ( ! is_string( $mime_type ) || 0 !== strpos( $mime_type, 'video/' ) ) {
+				/* translators: %s: attachment id */
+				throw new WC_REST_Exception( 'woocommerce_product_media_gallery_invalid_video_id', sprintf( esc_html__( '#%s is an invalid video ID.', 'woocommerce' ), esc_html( (string) $attachment_id ) ), 400 );
+			}
+
+			$poster_id = isset( $item['poster_id'] ) ? absint( $item['poster_id'] ) : 0;
+
+			if ( $poster_id && ! wp_attachment_is_image( $poster_id ) ) {
+				/* translators: %s: attachment id */
+				throw new WC_REST_Exception( 'woocommerce_product_media_gallery_invalid_poster_id', sprintf( esc_html__( '#%s is an invalid poster image ID.', 'woocommerce' ), esc_html( (string) $poster_id ) ), 400 );
+			}
+		}
+	}
+
+	/**
+	 * Sync product image props from the mixed media gallery.
+	 *
+	 * @param WC_Product $product       Product instance.
+	 * @param array      $media_gallery Normalized media gallery items.
+	 *
+	 * @return array Canonical media gallery items.
+	 */
+	protected function sync_product_images_from_media_gallery( $product, $media_gallery ) {
+		$image_ids      = ProductMediaGallery::get_image_ids( $media_gallery );
+		$cover_image_id = ! empty( $image_ids ) ? absint( array_shift( $image_ids ) ) : 0;
+
+		if ( $cover_image_id ) {
+			wc_product_attach_featured_image( $cover_image_id, $product, false );
+		} else {
+			$product->set_image_id( $cover_image_id );
+		}
+
+		$product->set_gallery_image_ids( $image_ids );
+
+		if ( $cover_image_id ) {
+			return ProductMediaGallery::maybe_prepend_product_image( $product, $media_gallery, 'edit' );
+		}
+
+		return array_values( $media_gallery );
+	}
+
+	/**
 	 * Prepare a single product for create or update.
 	 *
 	 * @param  WP_REST_Request $request Request object.
 	 * @param  bool            $creating If is creating a new object.
+	 * @throws WC_REST_Exception If product media gallery data is invalid.
 	 * @return WP_Error|WC_Data
 	 */
 	protected function prepare_object_for_database( $request, $creating = false ) {
@@ -1132,6 +1464,19 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		// Check for featured/gallery images, upload it and set it.
 		if ( isset( $request['images'] ) ) {
 			$product = $this->set_product_images( $product, $request['images'] );
+
+			if ( ! isset( $request['media_gallery'] ) ) {
+				$product = $this->sync_media_gallery_from_images_request( $product );
+			}
+		}
+
+		// Check for mixed media gallery and set it.
+		if ( isset( $request['media_gallery'] ) ) {
+			if ( ! ProductMediaGallery::is_feature_enabled() ) {
+				throw new WC_REST_Exception( 'woocommerce_product_media_gallery_feature_disabled', esc_html__( 'Product gallery videos are not enabled.', 'woocommerce' ), 400 );
+			}
+
+			$product = $this->set_product_media_gallery( $product, $request['media_gallery'] );
 		}
 
 		// Allow set meta_data.
@@ -1168,6 +1513,141 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		 * @param bool            $creating If is creating a new object.
 		 */
 		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}_object", $product, $request, $creating );
+	}
+
+	/**
+	 * Get the Product media gallery schema.
+	 *
+	 * @return array
+	 */
+	protected function get_media_gallery_schema() {
+		return array(
+			'description' => __( 'List of media gallery items.', 'woocommerce' ),
+			'type'        => 'array',
+			'context'     => array( 'view', 'edit' ),
+			'items'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'media_type'        => array(
+						'description' => __( 'Media type.', 'woocommerce' ),
+						'type'        => 'string',
+						'enum'        => array( 'image', 'video' ),
+						'context'     => array( 'view', 'edit' ),
+					),
+					'source_type'       => array(
+						'description' => __( 'Media source type.', 'woocommerce' ),
+						'type'        => 'string',
+						'default'     => 'attachment',
+						'enum'        => array( 'attachment' ),
+						'context'     => array( 'view', 'edit' ),
+					),
+					'id'                => array(
+						'description' => __( 'Media attachment ID.', 'woocommerce' ),
+						'type'        => 'integer',
+						'context'     => array( 'view', 'edit' ),
+					),
+					'poster_id'         => array(
+						'description' => __( 'Video poster attachment ID.', 'woocommerce' ),
+						'type'        => 'integer',
+						'context'     => array( 'view', 'edit' ),
+					),
+					'settings'          => array(
+						'description' => __( 'Video loading settings.', 'woocommerce' ),
+						'type'        => 'object',
+						'context'     => array( 'view', 'edit' ),
+						'properties'  => array(
+							'preload' => array(
+								'description' => __( 'Video preload behavior.', 'woocommerce' ),
+								'type'        => 'string',
+								'enum'        => array( 'auto', 'metadata', 'none' ),
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+					'src'               => array(
+						'description' => __( 'Media URL.', 'woocommerce' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'poster'            => array(
+						'description' => __( 'Video poster URL.', 'woocommerce' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'thumbnail'         => array(
+						'description' => __( 'Media thumbnail URL.', 'woocommerce' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'mime_type'         => array(
+						'description' => __( 'Media MIME type.', 'woocommerce' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'name'              => array(
+						'description' => __( 'Media name.', 'woocommerce' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'alt'               => array(
+						'description' => __( 'Image alternative text.', 'woocommerce' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'srcset'            => array(
+						'description' => __( 'Image srcset.', 'woocommerce' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'sizes'             => array(
+						'description' => __( 'Image sizes.', 'woocommerce' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'date_created'      => array(
+						'description' => __( "The date the media was created, in the site's timezone.", 'woocommerce' ),
+						'type'        => 'date-time',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'date_created_gmt'  => array(
+						'description' => __( 'The date the media was created, as GMT.', 'woocommerce' ),
+						'type'        => 'date-time',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'date_modified'     => array(
+						'description' => __( "The date the media was last modified, in the site's timezone.", 'woocommerce' ),
+						'type'        => 'date-time',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'date_modified_gmt' => array(
+						'description' => __( 'The date the media was last modified, as GMT.', 'woocommerce' ),
+						'type'        => 'date-time',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'position'          => array(
+						'description' => __( 'Media position in the gallery.', 'woocommerce' ),
+						'type'        => 'integer',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+				),
+			),
+		);
 	}
 
 	/**
@@ -1852,6 +2332,10 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			$schema = $this->add_cogs_related_product_schema( $schema, false );
 		}
 
+		if ( ProductMediaGallery::is_feature_enabled() ) {
+			$schema['properties']['media_gallery'] = $this->get_media_gallery_schema();
+		}
+
 		return $this->add_additional_fields_schema( $schema );
 	}
 
@@ -2068,6 +2552,10 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 			if ( in_array( 'global_unique_id', $fields, true ) ) {
 				$data['global_unique_id'] = $product->get_global_unique_id( $context );
+			}
+
+			if ( ProductMediaGallery::is_feature_enabled() && in_array( 'media_gallery', $fields, true ) ) {
+				$data['media_gallery'] = $this->get_media_gallery( $product );
 			}
 
 			$post_type_obj = get_post_type_object( $this->post_type );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -997,6 +997,7 @@ class Controller extends WC_REST_Products_V2_Controller {
 	 *
 	 * @param  WP_REST_Request $request Request object.
 	 * @param  bool            $creating If is creating a new object.
+	 * @throws WC_REST_Exception If product media gallery data is invalid.
 	 * @return WP_Error|WC_Data
 	 */
 	protected function prepare_object_for_database( $request, $creating = false ) {

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -8,6 +8,7 @@
 
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\ProductGallery\ProductMediaGallery;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 // phpcs:ignore Squiz.Commenting.FileComment.Missing
@@ -32,6 +33,14 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 				'role' => 'administrator',
 			)
 		);
+	}
+
+	/**
+	 * Tear down test case.
+	 */
+	public function tearDown(): void {
+		delete_option( ProductMediaGallery::ENABLE_OPTION_NAME );
+		parent::tearDown();
 	}
 
 	/**
@@ -330,6 +339,449 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 'Test API Update', $data['button_text'] );
 		$this->assertEquals( 'http://automattic.com', $data['external_url'] );
+	}
+
+	/**
+	 * Test product images are projected to the media gallery on get.
+	 *
+	 * @testdox Should project product images to media gallery responses.
+	 */
+	public function test_get_product_projects_images_to_media_gallery() {
+		wp_set_current_user( $this->user );
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'yes' );
+
+		$product           = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$image_id          = $this->create_product_media_attachment( 'Main product image' );
+		$gallery_image_ids = array(
+			$this->create_product_media_attachment( 'Gallery image 1' ),
+			$this->create_product_media_attachment( 'Gallery image 2' ),
+		);
+
+		$product->set_image_id( $image_id );
+		$product->set_gallery_image_ids( $gallery_image_ids );
+		$product->save();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $image_id,
+					'position'    => 0,
+				),
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $gallery_image_ids[0],
+					'position'    => 1,
+				),
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $gallery_image_ids[1],
+					'position'    => 2,
+				),
+			),
+			$this->get_media_gallery_identity_fields( $data['media_gallery'] )
+		);
+
+		$product->delete( true );
+		wp_delete_attachment( $image_id, true );
+		wp_delete_attachment( $gallery_image_ids[0], true );
+		wp_delete_attachment( $gallery_image_ids[1], true );
+	}
+
+	/**
+	 * Test updating a product media gallery persists mixed media and syncs product images.
+	 *
+	 * @testdox Should persist media gallery and sync product images.
+	 */
+	public function test_update_product_media_gallery_persists_and_syncs_product_images() {
+		wp_set_current_user( $this->user );
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'yes' );
+
+		$product   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$poster_id = $this->create_product_media_attachment( 'Video poster' );
+		$image_id  = $this->create_product_media_attachment( 'Gallery image' );
+		$video_id  = $this->create_product_media_attachment( 'Product video', 'video/mp4' );
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
+		$request->set_body_params(
+			array(
+				'media_gallery' => array(
+					array(
+						'media_type'  => 'video',
+						'source_type' => 'attachment',
+						'id'          => $video_id,
+						'poster_id'   => $poster_id,
+						'settings'    => array(
+							'preload' => 'metadata',
+						),
+					),
+					array(
+						'media_type'  => 'image',
+						'source_type' => 'attachment',
+						'id'          => $image_id,
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 'image', $data['media_gallery'][0]['media_type'] );
+		$this->assertSame( $image_id, $data['media_gallery'][0]['id'] );
+		$this->assertSame( 'video', $data['media_gallery'][1]['media_type'] );
+		$this->assertSame( $video_id, $data['media_gallery'][1]['id'] );
+		$this->assertSame( $poster_id, $data['media_gallery'][1]['poster_id'] );
+
+		$updated_product = wc_get_product( $product->get_id() );
+
+		$this->assertInstanceOf( WC_Product::class, $updated_product );
+		$this->assertSame( $image_id, (int) $updated_product->get_image_id() );
+		$this->assertSame( $product->get_id(), (int) get_post( $image_id )->post_parent );
+		$this->assertSame( array(), $updated_product->get_gallery_image_ids() );
+		$this->assertEquals(
+			array(
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $image_id,
+				),
+				array(
+					'media_type'  => 'video',
+					'source_type' => 'attachment',
+					'id'          => $video_id,
+					'poster_id'   => $poster_id,
+					'settings'    => array(
+						'preload' => 'metadata',
+					),
+				),
+			),
+			$updated_product->get_media_gallery( 'edit' )
+		);
+
+		$product->delete( true );
+		wp_delete_attachment( $poster_id, true );
+		wp_delete_attachment( $image_id, true );
+		wp_delete_attachment( $video_id, true );
+	}
+
+	/**
+	 * Test updating product images preserves stored video gallery data.
+	 *
+	 * @testdox Should preserve stored videos when product images are updated.
+	 */
+	public function test_update_product_images_preserves_stored_video_media_gallery_items() {
+		wp_set_current_user( $this->user );
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'yes' );
+
+		$product      = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$old_image_id = $this->create_product_media_attachment( 'Old gallery image' );
+		$poster_id    = $this->create_product_media_attachment( 'Old video poster' );
+		$video_id     = $this->create_product_media_attachment( 'Old product video', 'video/mp4' );
+		$new_image_id = $this->create_product_media_attachment( 'New product image' );
+
+		$product->set_media_gallery(
+			array(
+				array(
+					'media_type'  => 'video',
+					'source_type' => 'attachment',
+					'id'          => $video_id,
+					'poster_id'   => $poster_id,
+				),
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $old_image_id,
+				),
+			)
+		);
+		$product->save();
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
+		$request->set_body_params(
+			array(
+				'images' => array(
+					array(
+						'id'       => $new_image_id,
+						'position' => 0,
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $new_image_id,
+					'position'    => 0,
+				),
+				array(
+					'media_type'  => 'video',
+					'source_type' => 'attachment',
+					'id'          => $video_id,
+					'position'    => 1,
+				),
+			),
+			$this->get_media_gallery_identity_fields( $data['media_gallery'] )
+		);
+
+		$updated_product = wc_get_product( $product->get_id() );
+
+		$this->assertInstanceOf( WC_Product::class, $updated_product );
+		$this->assertEquals(
+			array(
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $new_image_id,
+				),
+				array(
+					'media_type'  => 'video',
+					'source_type' => 'attachment',
+					'id'          => $video_id,
+					'poster_id'   => $poster_id,
+				),
+			),
+			$updated_product->get_media_gallery( 'edit' )
+		);
+		$this->assertSame( $new_image_id, (int) $updated_product->get_image_id() );
+		$this->assertSame( array(), $updated_product->get_gallery_image_ids() );
+
+		$product->delete( true );
+		wp_delete_attachment( $old_image_id, true );
+		wp_delete_attachment( $poster_id, true );
+		wp_delete_attachment( $video_id, true );
+		wp_delete_attachment( $new_image_id, true );
+	}
+
+	/**
+	 * Test updating product images clears stored video gallery data when the feature is disabled.
+	 *
+	 * @testdox Should clear stored videos when product images are updated while product gallery videos are disabled.
+	 */
+	public function test_update_product_images_clears_stored_video_media_gallery_items_when_feature_disabled() {
+		wp_set_current_user( $this->user );
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'no' );
+
+		$product      = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$old_image_id = $this->create_product_media_attachment( 'Old gallery image' );
+		$poster_id    = $this->create_product_media_attachment( 'Old video poster' );
+		$video_id     = $this->create_product_media_attachment( 'Old product video', 'video/mp4' );
+		$new_image_id = $this->create_product_media_attachment( 'New product image' );
+
+		$product->set_media_gallery(
+			array(
+				array(
+					'media_type'  => 'video',
+					'source_type' => 'attachment',
+					'id'          => $video_id,
+					'poster_id'   => $poster_id,
+				),
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $old_image_id,
+				),
+			)
+		);
+		$product->save();
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
+		$request->set_body_params(
+			array(
+				'images' => array(
+					array(
+						'id'       => $new_image_id,
+						'position' => 0,
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$updated_product = wc_get_product( $product->get_id() );
+
+		$this->assertInstanceOf( WC_Product::class, $updated_product );
+		$this->assertSame( $new_image_id, (int) $updated_product->get_image_id() );
+		$this->assertSame( array(), $updated_product->get_gallery_image_ids() );
+		$this->assertSame( array(), $updated_product->get_media_gallery( 'edit' ) );
+
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'yes' );
+
+		$get_response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
+		$get_data     = $get_response->get_data();
+
+		$this->assertEquals( 200, $get_response->get_status() );
+		$this->assertSame(
+			array(
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $new_image_id,
+					'position'    => 0,
+				),
+			),
+			$this->get_media_gallery_identity_fields( $get_data['media_gallery'] )
+		);
+
+		$product->delete( true );
+		wp_delete_attachment( $old_image_id, true );
+		wp_delete_attachment( $poster_id, true );
+		wp_delete_attachment( $video_id, true );
+		wp_delete_attachment( $new_image_id, true );
+	}
+
+	/**
+	 * Test media gallery attachment media types must match their requested media type.
+	 *
+	 * @testdox Should reject media gallery items with mismatched attachment media types.
+	 */
+	public function test_update_product_media_gallery_rejects_mismatched_attachment_media_types() {
+		wp_set_current_user( $this->user );
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'yes' );
+
+		$product  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$image_id = $this->create_product_media_attachment( 'Gallery image' );
+		$video_id = $this->create_product_media_attachment( 'Product video', 'video/mp4' );
+
+		$requests = array(
+			array(
+				'item' => array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $video_id,
+				),
+				'code' => 'woocommerce_product_media_gallery_invalid_image_id',
+			),
+			array(
+				'item' => array(
+					'media_type'  => 'video',
+					'source_type' => 'attachment',
+					'id'          => $image_id,
+				),
+				'code' => 'woocommerce_product_media_gallery_invalid_video_id',
+			),
+			array(
+				'item' => array(
+					'media_type'  => 'video',
+					'source_type' => 'attachment',
+					'id'          => $video_id,
+					'poster_id'   => $video_id,
+				),
+				'code' => 'woocommerce_product_media_gallery_invalid_poster_id',
+			),
+		);
+
+		foreach ( $requests as $request_data ) {
+			$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
+			$request->set_body_params(
+				array(
+					'media_gallery' => array( $request_data['item'] ),
+				)
+			);
+			$response = $this->server->dispatch( $request );
+			$data     = $response->get_data();
+
+			$this->assertEquals( 400, $response->get_status() );
+			$this->assertSame( $request_data['code'], $data['code'] );
+		}
+
+		$product->delete( true );
+		wp_delete_attachment( $image_id, true );
+		wp_delete_attachment( $video_id, true );
+	}
+
+	/**
+	 * Test external video embeds are not accepted yet.
+	 *
+	 * @testdox Should reject embed-backed media gallery items.
+	 */
+	public function test_update_product_media_gallery_rejects_embeds() {
+		wp_set_current_user( $this->user );
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'yes' );
+
+		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
+
+		$request->set_body_params(
+			array(
+				'media_gallery' => array(
+					array(
+						'media_type'  => 'video',
+						'source_type' => 'embed',
+						'url'         => 'https://www.youtube.com/watch?v=abc123',
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertSame( array(), wc_get_product( $product->get_id() )->get_media_gallery( 'edit' ) );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * Test external video embeds are not exposed by the REST media gallery yet.
+	 *
+	 * @testdox Should omit embed-backed media gallery items from responses.
+	 */
+	public function test_get_product_media_gallery_omits_embeds() {
+		wp_set_current_user( $this->user );
+		update_option( ProductMediaGallery::ENABLE_OPTION_NAME, 'yes' );
+
+		$product  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$image_id = $this->create_product_media_attachment( 'Gallery image' );
+
+		$product->set_media_gallery(
+			array(
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $image_id,
+				),
+				array(
+					'media_type'  => 'video',
+					'source_type' => 'embed',
+					'url'         => 'https://www.youtube.com/watch?v=abc123',
+				),
+			)
+		);
+		$product->save();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				array(
+					'media_type'  => 'image',
+					'source_type' => 'attachment',
+					'id'          => $image_id,
+					'position'    => 0,
+				),
+			),
+			$this->get_media_gallery_identity_fields( $data['media_gallery'] )
+		);
+
+		$product->delete( true );
+		wp_delete_attachment( $image_id, true );
 	}
 
 	/**
@@ -915,6 +1367,49 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		foreach ( $response_products as $response_product ) {
 			$this->assertContains( $response_product['id'], $expected_product_ids );
 		}
+	}
+
+	/**
+	 * Create a product media attachment.
+	 *
+	 * @param string $title     Attachment title.
+	 * @param string $mime_type Attachment MIME type.
+	 *
+	 * @return int
+	 */
+	private function create_product_media_attachment( $title, $mime_type = 'image/jpeg' ) {
+		$file_extension = 'video/mp4' === $mime_type ? 'mp4' : 'jpg';
+
+		return wp_insert_attachment(
+			array(
+				'post_title'     => $title,
+				'post_type'      => 'attachment',
+				'post_mime_type' => $mime_type,
+			),
+			sanitize_title( $title ) . '.' . $file_extension
+		);
+	}
+
+	/**
+	 * Get the media gallery identity fields from a REST response.
+	 *
+	 * @param array $media_gallery Media gallery response items.
+	 *
+	 * @return array
+	 */
+	private function get_media_gallery_identity_fields( $media_gallery ) {
+		$items = array();
+
+		foreach ( $media_gallery as $item ) {
+			$items[] = array(
+				'media_type'  => $item['media_type'],
+				'source_type' => $item['source_type'],
+				'id'          => $item['id'],
+				'position'    => $item['position'],
+			);
+		}
+
+		return $items;
 	}
 
 	/**


### PR DESCRIPTION
> [!NOTE]  
> The whole flow can be tested in scope of #65135.

### Changes proposed in this Pull Request:

Split from main PR #65135. Stacked on #65396.

Adds REST API support for product media galleries. This exposes media gallery data in product responses, validates attachment-backed media gallery updates, and keeps legacy product image fields in sync.

Areas touched:

- REST API product schema/read handling.
- REST API media gallery update validation.
- Legacy images sync behavior.
- Focused REST API tests.

### How to test the changes in this Pull Request:

> [!NOTE]  
> The whole flow can be tested in scope of #65135.

Use a WooCommerce test site with the Product gallery videos feature flag enabled at `WooCommerce > Settings > Advanced > Features > Product gallery videos (Beta)`, and authenticate as a user that can manage products. Prepare one product, two image attachment IDs, one uploaded video attachment ID, and optionally one poster image attachment ID.

1. Send a `PUT` request to `/wp-json/wc/v3/products/<product_id>` with a mixed media gallery payload:

```json
{
	"media_gallery": [
		{
			"media_type": "image",
			"source_type": "attachment",
			"id": 123
		},
		{
			"media_type": "video",
			"source_type": "attachment",
			"id": 456,
			"poster_id": 789
		},
		{
			"media_type": "image",
			"source_type": "attachment",
			"id": 321
		}
	]
}
```

2. Confirm the response includes `media_gallery` with the image, video, and image items in the submitted order.

3. Confirm the response `images` field contains only image attachments from the media gallery. The video should not appear in `images`.

4. Send a second `PUT` request to `/wp-json/wc/v3/products/<product_id>` using the existing `images` field only:

```json
{
	"images": [
		{
			"id": 321
		},
		{
			"id": 123
		}
	]
}
```

5. Confirm the response updates the image items but preserves the previously stored video item in `media_gallery`.

6. Optional validation check: send a `media_gallery` item with an invalid `source_type`, an image item pointing at a video attachment, or a video item pointing at an image attachment. Confirm the request returns a `400` response.

### Testing that has already taken place:

Code is split unchanged from #65135. Focused REST media gallery PHPUnit, PHPStan, and lint checks were run on the main branch before splitting.

### Changelog entry

Included in #65396.


