### PR TITLE
fix(logging): prevent fatal error in get_log_directory_size when log directory does not exist

### DIFF
--- a/plugins/woocommerce/changelog/65390-fix-log-dir-size-fatal
+++ b/plugins/woocommerce/changelog/65390-fix-log-dir-size-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error on System Status page when log directory does not exist (e.g. when logging is disabled).

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -58174,12 +58174,6 @@ parameters:
 			path: src/Internal/Admin/Logging/FileV2/FileController.php
 
 		-
-			message: '#^Parameter \#1 \$directory of class RecursiveDirectoryIterator constructor expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Logging/FileV2/FileController.php
-
-		-
 			message: '#^Parameter \#1 \$fp of function feof expects resource, resource\|false given\.$#'
 			identifier: argument.type
 			count: 1
@@ -58187,12 +58181,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$fp of function fgets expects resource, resource\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Logging/FileV2/FileController.php
-
-		-
-			message: '#^Parameter \#1 \$path of function wp_is_writable expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Logging/FileV2/FileController.php

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -658,6 +658,10 @@ class FileController {
 		$bytes = 0;
 		$path  = realpath( Settings::get_log_directory( false ) );
 
+		if ( empty( $path ) ) {
+			return 0;
+		}
+
 		if ( wp_is_writable( $path ) ) {
 			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ), \RecursiveIteratorIterator::CATCH_GET_CHILD );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -411,6 +411,22 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_log_directory_size returns 0 when log directory does not exist.
+	 */
+	public function test_get_log_directory_size_missing_directory(): void {
+		$missing  = wp_upload_dir()['basedir'] . '/wc-logs-nonexistent/';
+		$callback = function () use ( $missing ) {
+			return $missing;
+		};
+		add_filter( 'woocommerce_log_directory', $callback );
+
+		$result = $this->sut->get_log_directory_size();
+		$this->assertSame( 0, $result );
+
+		remove_filter( 'woocommerce_log_directory', $callback );
+	}
+
+	/**
 	 * @testdox The get_log_directory_size method should return an accurate size of the directory in bytes.
 	 */
 	public function test_get_log_directory_size(): void {


### PR DESCRIPTION
## Summary

Fixes a fatal `ValueError` on the WooCommerce System Status page when logging is disabled and the log directory does not exist.

Fixes #65390

## Changes

### `plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php`

**Before:**
```php
public function get_log_directory_size(): int {
    $bytes = 0;
    $path  = realpath( Settings::get_log_directory( false ) );

    if ( wp_is_writable( $path ) ) {
```

**After:**
```php
public function get_log_directory_size(): int {
    $bytes = 0;
    $path  = realpath( Settings::get_log_directory( false ) );

    if ( empty( $path ) ) {
        return 0;
    }

    if ( wp_is_writable( $path ) ) {
```

**Why:** When logging is disabled, the log directory may never be created. `realpath()` returns `false` for non-existent paths, and passing that to `wp_is_writable()` triggers a `ValueError: Path must not be empty` in PHP. The guard clause returns 0 bytes early since a non-existent directory has no size.

## Testing

**Test 1: Logging disabled**
1. Go to WooCommerce → Status → Logs → Settings
2. Uncheck "Enable logging" and save
3. Navigate to WooCommerce → Status (system status tab)
4. Page loads without fatal error

**Test 2: Logging enabled (regression check)**
1. Enable logging (default state)
2. Navigate to WooCommerce → Status
3. Log directory size displays correctly

### Submission Review Guidelines

- [x] This PR follows [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)
- [x] This PR does not contain any breaking changes

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->