### PR TITLE
Prevent email preview dummy order from being persisted

### DIFF
--- a/plugins/woocommerce/changelog/stomail-8111-prevent-preview-overwriting-real-order
+++ b/plugins/woocommerce/changelog/stomail-8111-prevent-preview-overwriting-real-order
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Prevent the email preview from overwriting or reading from an existing order whose id collides with the preview dummy order id.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -372,8 +372,9 @@ class EmailPreview {
 		$variation            = $this->get_dummy_product_variation();
 		$downloadable_product = $this->get_dummy_downloadable_product();
 
+		// PreviewOrder keeps its id at 0 so it can never read from or write to a
+		// real order. It surfaces a display number via get_order_number() instead.
 		$order = new PreviewOrder();
-		$order->set_id( 12345 );
 
 		// Create and add product items manually without saving to database.
 		// Use add_item() instead of add_product() to avoid immediate database writes.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -372,7 +372,7 @@ class EmailPreview {
 		$variation            = $this->get_dummy_product_variation();
 		$downloadable_product = $this->get_dummy_downloadable_product();
 
-		$order = new WC_Order();
+		$order = new PreviewOrder();
 		$order->set_id( 12345 );
 
 		// Create and add product items manually without saving to database.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/PreviewOrder.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/PreviewOrder.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Non-persistent WC_Order used for email preview.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\EmailPreview;
+
+use WC_Order;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Order subclass for the email preview. Its writes are no-ops and its
+ * items/meta caches start empty, so it can't accidentally touch a real order
+ * in the database.
+ *
+ * The preview gives its dummy order a hard-coded id of 12345. If a store has
+ * a real order with that id, $order->save() (called directly or via
+ * update_status, payment_complete, etc.) would overwrite that real row, and
+ * $order->get_items() / get_meta() would lazy-load the real order's data
+ * into the dummy.
+ *
+ * Other reads still go through the data store (get_total_refunded etc.) and
+ * return 0/empty against the non-existent row, which keeps the rendering code
+ * unchanged.
+ */
+class PreviewOrder extends WC_Order {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int|object|WC_Order $order Order to read. Defaults to 0 (a new, empty order).
+	 */
+	public function __construct( $order = 0 ) {
+		parent::__construct( $order );
+
+		// Pre-populate so get_items() / get_meta() never lazy-read from a real row.
+		foreach ( $this->item_types_to_group as $group ) {
+			$this->items[ $group ] = array();
+		}
+		$this->meta_data = array();
+	}
+
+	/**
+	 * Block save(). Replaces the parent's data-store write path with a no-op.
+	 *
+	 * @return int The order id (unchanged).
+	 */
+	public function save() {
+		wc_get_logger()->warning(
+			'Email preview order save() blocked to prevent overwriting a real order.',
+			array( 'source' => 'email-preview' )
+		);
+		return $this->get_id();
+	}
+
+	/**
+	 * Block save_meta_data(). Extensions sometimes call update_meta_data()
+	 * followed by save_meta_data() directly, bypassing save().
+	 */
+	public function save_meta_data(): void {
+		// Intentionally empty.
+	}
+
+	/**
+	 * Block delete(). A preview order has no row to delete; allowing the call
+	 * would target a real order with the same id.
+	 *
+	 * @param bool $force_delete Should the order be deleted permanently.
+	 * @return bool Always false.
+	 */
+	public function delete( $force_delete = false ) {
+		return false;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/PreviewOrder.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/PreviewOrder.php
@@ -12,21 +12,31 @@ use WC_Order;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Order subclass for the email preview. Its writes are no-ops and its
- * items/meta caches start empty, so it can't accidentally touch a real order
- * in the database.
+ * WC_Order subclass for the email preview.
  *
- * The preview gives its dummy order a hard-coded id of 12345. If a store has
- * a real order with that id, $order->save() (called directly or via
- * update_status, payment_complete, etc.) would overwrite that real row, and
- * $order->get_items() / get_meta() would lazy-load the real order's data
- * into the dummy.
+ * The preview needs an order to render, but it must never read from or write
+ * to a real order in the database. The key to that is the id: order methods
+ * that touch the database key off get_id() and resolve to nothing when it is
+ * 0 (add_order_note(), remove_order_items(), get_refunds(), the refund totals,
+ * item/meta reads, etc.). So this order keeps id 0 and exposes the preview's
+ * display number through get_order_number() instead.
  *
- * Other reads still go through the data store (get_total_refunded etc.) and
- * return 0/empty against the non-existent row, which keeps the rendering code
- * unchanged.
+ * Two cases aren't safe at id 0 and are handled explicitly:
+ * - save() and its siblings would insert a new row, so they are no-ops.
+ * - get_customer_order_notes() passes the id to get_comments(), which treats
+ *   0 as "no filter" and would return every order note on the site, so it is
+ *   overridden to return nothing.
+ *
+ * The item/meta caches are pre-filled as empty too, as a guard against any
+ * future read path that doesn't check the id first.
  */
 class PreviewOrder extends WC_Order {
+
+	/**
+	 * The order number shown in the preview. Not a real order id, so it can't
+	 * collide with a row in the database.
+	 */
+	const PREVIEW_ORDER_NUMBER = '12345';
 
 	/**
 	 * Constructor.
@@ -36,7 +46,6 @@ class PreviewOrder extends WC_Order {
 	public function __construct( $order = 0 ) {
 		parent::__construct( $order );
 
-		// Pre-populate so get_items() / get_meta() never lazy-read from a real row.
 		foreach ( $this->item_types_to_group as $group ) {
 			$this->items[ $group ] = array();
 		}
@@ -44,13 +53,25 @@ class PreviewOrder extends WC_Order {
 	}
 
 	/**
-	 * Block save(). Replaces the parent's data-store write path with a no-op.
+	 * Get the order number to display.
+	 *
+	 * The real id stays 0, so this provides a representative number for the
+	 * preview without tying the order to a database row.
+	 *
+	 * @return string
+	 */
+	public function get_order_number() {
+		return self::PREVIEW_ORDER_NUMBER;
+	}
+
+	/**
+	 * Block save(). A preview order should never be written to the database.
 	 *
 	 * @return int The order id (unchanged).
 	 */
 	public function save() {
 		wc_get_logger()->warning(
-			'Email preview order save() blocked to prevent overwriting a real order.',
+			'Email preview order save() blocked to prevent writing to the database.',
 			array( 'source' => 'email-preview' )
 		);
 		return $this->get_id();
@@ -65,13 +86,22 @@ class PreviewOrder extends WC_Order {
 	}
 
 	/**
-	 * Block delete(). A preview order has no row to delete; allowing the call
-	 * would target a real order with the same id.
+	 * Block delete(). A preview order has no row to delete.
 	 *
 	 * @param bool $force_delete Should the order be deleted permanently.
 	 * @return bool Always false.
 	 */
 	public function delete( $force_delete = false ) {
 		return false;
+	}
+
+	/**
+	 * A preview order has no customer notes. The parent passes the id straight
+	 * to get_comments(), which treats id 0 as "return every order note".
+	 *
+	 * @return array
+	 */
+	public function get_customer_order_notes() {
+		return array();
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -408,4 +408,35 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 0, $order->get_id(), 'PreviewOrder must not be assigned a real database id on save().' );
 	}
+
+	/**
+	 * @testdox PreviewOrder keeps its id at 0 but still shows a representative order number.
+	 */
+	public function test_preview_order_displays_number_without_a_real_id(): void {
+		$order = new PreviewOrder();
+
+		$this->assertSame( 0, $order->get_id(), 'PreviewOrder must not carry a real order id.' );
+		$this->assertSame( '12345', $order->get_order_number(), 'PreviewOrder must expose a display order number.' );
+	}
+
+	/**
+	 * @testdox PreviewOrder database methods that key off the order id are inert.
+	 */
+	public function test_preview_order_database_methods_are_inert(): void {
+		$real_order = WC_Helper_Order::create_order();
+		$real_order->add_order_note( 'Customer note', 1 );
+		$real_order->save();
+		wc_create_refund(
+			array(
+				'order_id' => $real_order->get_id(),
+				'amount'   => 5,
+			)
+		);
+
+		$order = new PreviewOrder();
+
+		$this->assertSame( 0, $order->add_order_note( 'Preview note' ), 'add_order_note() must not write a note.' );
+		$this->assertSame( array(), $order->get_refunds(), 'get_refunds() must not read refunds from the database.' );
+		$this->assertSame( array(), $order->get_customer_order_notes(), 'get_customer_order_notes() must not read notes from the database.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -4,7 +4,9 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\Admin\EmailPreview;
 
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\PreviewOrder;
 use WC_Emails;
+use WC_Helper_Order;
 use WC_Product;
 use WC_Unit_Test_Case;
 
@@ -330,5 +332,80 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 		update_option( $additional_key, $additional_value );
 		delete_transient( $heading_key );
 		delete_transient( $additional_key );
+	}
+
+	/**
+	 * @testdox Calling save() on the preview dummy order must not overwrite a real order whose id matches the dummy's.
+	 */
+	public function test_dummy_order_save_does_not_overwrite_real_order(): void {
+		$real_order = WC_Helper_Order::create_order();
+		$real_id    = $real_order->get_id();
+		$real_order->set_billing_first_name( 'Real' );
+		$real_order->set_billing_last_name( 'Customer' );
+		$real_order->set_total( 999 );
+		$real_order->save();
+
+		$snapshot = array(
+			'first_name' => $real_order->get_billing_first_name(),
+			'last_name'  => $real_order->get_billing_last_name(),
+			'total'      => $real_order->get_total(),
+			'status'     => $real_order->get_status(),
+		);
+
+		$listener = function ( $order ) use ( $real_id ) {
+			$order->set_id( $real_id );
+			$order->set_billing_first_name( 'Pwned' );
+			$order->set_billing_last_name( 'Pwned' );
+			$order->set_total( 1 );
+			$order->save();
+			return $order;
+		};
+		add_filter( 'woocommerce_email_preview_dummy_order', $listener );
+
+		$this->sut->render();
+
+		remove_filter( 'woocommerce_email_preview_dummy_order', $listener );
+
+		$reloaded = wc_get_order( $real_id );
+		$this->assertSame( $snapshot['first_name'], $reloaded->get_billing_first_name(), 'Billing first name must be unchanged.' );
+		$this->assertSame( $snapshot['last_name'], $reloaded->get_billing_last_name(), 'Billing last name must be unchanged.' );
+		$this->assertSame( $snapshot['total'], $reloaded->get_total(), 'Order total must be unchanged.' );
+		$this->assertSame( $snapshot['status'], $reloaded->get_status(), 'Order status must be unchanged.' );
+	}
+
+	/**
+	 * @testdox Reading meta on the preview dummy order must not leak real order meta from the database.
+	 */
+	public function test_dummy_order_does_not_leak_real_order_meta(): void {
+		$real_order = WC_Helper_Order::create_order();
+		$real_id    = $real_order->get_id();
+		$real_order->update_meta_data( '_secret_value', 'do-not-leak' );
+		$real_order->save();
+
+		$captured = 'sentinel';
+		$listener = function ( $order ) use ( $real_id, &$captured ) {
+			$order->set_id( $real_id );
+			$captured = $order->get_meta( '_secret_value' );
+			return $order;
+		};
+		add_filter( 'woocommerce_email_preview_dummy_order', $listener );
+
+		$content = $this->sut->render();
+
+		remove_filter( 'woocommerce_email_preview_dummy_order', $listener );
+
+		$this->assertSame( '', $captured, 'Preview dummy must not lazy-load meta from the orders table.' );
+		$this->assertStringNotContainsString( 'do-not-leak', $content, 'Real order meta must not appear in the rendered preview.' );
+	}
+
+	/**
+	 * @testdox PreviewOrder save() is a no-op and does not insert a row when id is unset.
+	 */
+	public function test_preview_order_save_is_noop(): void {
+		$order = new PreviewOrder();
+		$order->set_billing_first_name( 'Phantom' );
+		$order->save();
+
+		$this->assertSame( 0, $order->get_id(), 'PreviewOrder must not be assigned a real database id on save().' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The email settings preview builds a dummy `WC_Order` with a hard-coded id (`12345`) and exposes it through the email-render hooks. Any extension that calls `$order->save()` on that dummy object writes through to the orders table and overwrites the real row at id 12345 with placeholder data. The same id collision may also cause a read leak - `$order->get_items()` and `$order->get_meta()` lazy-load the real order's items into the dummy on first access.

This PR introduces `PreviewOrder`, a `WC_Order` subclass whose `save()`, `save_meta_data()` and `delete()` are no-ops, and whose constructor pre-populates `$items` and `$meta_data` so the lazy-read paths never fire. `save()` also logs a warning so we have telemetry on extensions that misbehave during preview. `EmailPreview::get_dummy_order()` now instantiates `PreviewOrder` instead of `WC_Order` and there should be no other behavior changes to the email preview itself.

Related [STOMAIL-8111: Prevent email preview dummy orders from mutating real orders](https://linear.app/a8c/issue/STOMAIL-8111/prevent-email-preview-dummy-orders-from-mutating-real-orders).

### Screenshots or screen recordings:

N/A


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a real order with id `12345` in your test store. A simplest way to do so is to bump the table auto-increment and then create an order through wp-admin.

   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp db query "ALTER TABLE wp_wc_orders AUTO_INCREMENT = 12345; ALTER TABLE wp_posts AUTO_INCREMENT = 12345;"```

   Then create an order in WooCommerce → Orders → Add new.

2. Add the sample plugin below into `wp-content/mu-plugins/wc-email-preview-simulate-persisted-dummy-order.php`. It simulates an extension that calls save() on the dummy order during preview rendering.

```php
<?php
/** Plugin Name: WC Email Preview Simulate Persisted Dummy Order */
add_filter( 'woocommerce_email_preview_dummy_order', function ( $order ) {
    $order->save();
    return $order;
} );
```

3. Open an email preview, e.g. WooCommerce → Settings → Emails → New order. Optionally send a test email too.
4. Reload order 12345 in WooCommerce → Orders.

  - Expected (with this PR): the order is unchanged. Optionally, inspect `wp-content/debug.log` and confirm it contains the "Email preview order save() blocked…" warning.
  - Without this PR (trunk): the order's billing details and items are overwritten with the dummy object data.


### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
