### PR TITLE
Restore milestone section in draft PR skill

### DIFF
--- a/.ai/skills/woocommerce-git-draft-pr/SKILL.md
+++ b/.ai/skills/woocommerce-git-draft-pr/SKILL.md
@@ -30,7 +30,7 @@ From the dynamic context above (read full diffs only if the stat summary is ambi
 - **Significance**: Patch (most common), Minor (new features), Major (breaking — rare)
 - **Bug fix?** Look for issue refs in commits/branch name (e.g., `#12345`, `fix/issue-12345`)
 - **UI changes?** Changes in `client/`, `templates/`, CSS/SCSS, JSX/TSX
-- **Plugin-affecting?** Code shipped to users = yes. CI/CD, workflows, tooling, docs = no. This drives changelog, milestone, and PR body complexity — non-plugin PRs use a simplified body (see Step 3).
+- **Plugin-affecting?** Code shipped to users = yes. CI/CD, workflows, tooling, docs = no. This drives changelog, testing, and PR body complexity — non-plugin PRs use a simplified body (see Step 3).
 
 ### 2. Gather Context
 
@@ -58,8 +58,9 @@ Use a simplified body with only these sections:
 
 - **Submission Review Guidelines**: Keep as-is from template.
 - **Changes proposed**: 2-3 sentences. Lead with WHY, then WHAT.
+- **Milestone**: Keep the section and check auto-assign `[x]` unless a milestone will be assigned manually. Keep the surrounding template comments, including `<!-- milestone-target-selection -->` and `<!-- /milestone-target-selection -->`.
 
-Skip Screenshots, Testing instructions, Testing done, Milestone, and Changelog sections entirely.
+Skip Screenshots, Testing instructions, Testing done, and Changelog sections entirely.
 
 #### Plugin-affecting changes
 
@@ -70,7 +71,7 @@ Use the full template:
 - **Screenshots**: Remove section if no UI changes. For UI changes, use Chrome DevTools MCP to capture screenshots if available; otherwise remind user to add them before marking ready.
 - **Testing instructions**: Concrete numbered steps with expected outcomes derived from the diff. Each step must be actionable — don't reference links that won't exist yet.
 - **Testing done**: Fill with what's verifiable from the session (commits, test runs, lint runs). If nothing is verifiable, write "Author to fill in before marking ready."
-- **Milestone**: Check auto-assign `[x]` if plugin-affecting. Keep the surrounding template comments, including `<!-- milestone-target-selection -->` and `<!-- /milestone-target-selection -->`.
+- **Milestone**: Check auto-assign `[x]` unless a milestone will be assigned manually. Keep the surrounding template comments, including `<!-- milestone-target-selection -->` and `<!-- /milestone-target-selection -->`.
 - **Changelog**: If changelogs already in diff → "does not require" (created manually). Otherwise → "Automatically create" `[x]` with Significance, Type, and a user-facing Message. Keep the template comments in this section, including inline comments after headings such as `#### Message <!-- Add a changelog message here -->`.
 
 Do not strip HTML comments (`<!-- -->`) from retained template sections. They support PR automation and GitHub tests. Remove only unfilled placeholder lines that are actual visible placeholders (e.g., `Closes # .`, `Bug introduced in PR # .`).
@@ -95,5 +96,5 @@ Output the PR URL. If UI changes need screenshots, remind the user.
 
 - No Co-Authored-By lines or self-attribution
 - Never commit code — pushing is fine
-- Preserve the PR template section headings and HTML comments exactly in retained sections (for plugin-affecting PRs)
+- Preserve the PR template section headings and HTML comments exactly in retained sections; the Milestone section is required for all PRs unless a milestone is assigned manually
 - Changelog checkboxes must match CI automation format

--- a/plugins/woocommerce/changelog/restore-draft-pr-milestone-section
+++ b/plugins/woocommerce/changelog/restore-draft-pr-milestone-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: This updates agent PR creation instructions only and does not affect shipped WooCommerce code.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The draft PR skill was omitting the Milestone section for non-plugin changes, which left agent-created PRs without the checkbox required by the milestone workflow. This updates the skill so generated PR bodies keep the milestone automation markers and check the auto-assign option unless a milestone will be assigned manually.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
