### PR TITLE
Retry wp-env startup on Docker pull failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,35 @@ jobs:
       - name: 'Start Test Environment'
         id: 'prepare-test-environment'
         if: ${{ matrix.testEnv.shouldCreate }}
-        run: pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cleanup_test_environment() {
+            if [ "${{ matrix.testEnv.start }}" = "env:start:blocks" ]; then
+              pnpm --filter="@woocommerce/block-library" env:stop || true
+            else
+              pnpm --filter="${{ matrix.projectName }}" env:stop || true
+            fi
+          }
+
+          max_attempts=2
+          attempt=1
+
+          until pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}; do
+            exit_code=$?
+
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "::error::Unable to start the test environment after $attempt attempts."
+              exit "$exit_code"
+            fi
+
+            delay=$(( attempt * 30 ))
+            echo "::warning::Unable to start the test environment on attempt $attempt. Cleaning up and retrying in ${delay}s."
+            cleanup_test_environment
+            sleep "$delay"
+            attempt=$(( attempt + 1 ))
+          done
 
       - name: 'Determine BuildKite Analytics Message'
         env:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The CI test environment can fail before tests run when `wp-env start` hits a transient Docker Hub image manifest lookup failure, for example while pulling `mariadb:lts` or `phpmyadmin:latest`. This wraps the test environment start command in a small retry loop with cleanup and backoff so those external Docker registry hiccups do not fail otherwise valid test jobs.

Example jobs:

- [Core API tests](https://github.com/woocommerce/woocommerce/actions/runs/26625901241/job/78462855169)
- [Blocks e2e tests 4/10](https://github.com/woocommerce/woocommerce/actions/runs/26625901241/job/78462855247)
- [Blocks e2e tests 2/10](https://github.com/woocommerce/woocommerce/actions/runs/26625901241/job/78462855277)

This is based on agent investigation with 95% confidence of the cause and fix.