### PR TITLE
Replace PanelBody with ToolsPanel in Linked Product control

### DIFF
--- a/plugins/woocommerce/changelog/fix-59464-use-toolspanel-in-linked-product-control
+++ b/plugins/woocommerce/changelog/fix-59464-use-toolspanel-in-linked-product-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace PanelBody with ToolsPanel in Linked Product control for Product Collection block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/linked-product-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/linked-product-control.tsx
@@ -10,16 +10,18 @@ import type { WooCommerceBlockLocation } from '@woocommerce/blocks/product-templ
 import { type ProductResponseItem, isEmpty } from '@woocommerce/types';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
-	PanelBody,
-	PanelRow,
 	Button,
 	Flex,
 	FlexItem,
 	Dropdown,
 	RadioControl,
+	Spinner,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalText as Text,
-	Spinner,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
 /**
@@ -231,9 +233,25 @@ const LinkedProductControl = ( {
 	);
 
 	return (
-		<PanelBody title={ __( 'Linked Product', 'woocommerce' ) }>
-			{ showRadioControl && (
-				<PanelRow>
+		<ToolsPanel
+			label={ __( 'Linked Product', 'woocommerce' ) }
+			resetAll={ () =>
+				handleRadioControlChange(
+					PRODUCT_REFERENCE_TYPE.CURRENT_PRODUCT
+				)
+			}
+		>
+			<ToolsPanelItem
+				label={ __( 'Linked Product', 'woocommerce' ) }
+				hasValue={ () => ! isEmpty( productReference ) }
+				onDeselect={ () =>
+					handleRadioControlChange(
+						PRODUCT_REFERENCE_TYPE.CURRENT_PRODUCT
+					)
+				}
+				isShownByDefault
+			>
+				{ showRadioControl && (
 					<RadioControl
 						className="wc-block-product-collection-product-reference-radio"
 						label={ __( 'Products to show', 'woocommerce' ) }
@@ -254,10 +272,8 @@ const LinkedProductControl = ( {
 						] }
 						onChange={ handleRadioControlChange }
 					/>
-				</PanelRow>
-			) }
-			{ showSpecificProductSelector && (
-				<PanelRow>
+				) }
+				{ showSpecificProductSelector && (
 					<Dropdown
 						className="wc-block-product-collection-linked-product-control"
 						contentClassName="wc-block-product-collection-linked-product__popover-content"
@@ -280,9 +296,9 @@ const LinkedProductControl = ( {
 						open={ isDropdownOpen }
 						onToggle={ () => setIsDropdownOpen( ! isDropdownOpen ) }
 					/>
-				</PanelRow>
-			) }
-		</PanelBody>
+				) }
+			</ToolsPanelItem>
+		</ToolsPanel>
 	);
 };
 


### PR DESCRIPTION
## Still working on the PR

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR removes `PanelBody` and replaces it with `ToolsPanel` and `ToolsPanelItem` in the Linked Product inspector control within the Product Collection block.

Part of #59464 

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="354" height="172" alt="Screenshot 2026-06-10 at 12 48 25 PM" src="https://github.com/user-attachments/assets/3d20df23-abf7-49b6-8464-1c533d836afe" /> | <img width="424" height="197" alt="Screenshot 2026-06-10 at 12 45 15 PM" src="https://github.com/user-attachments/assets/e5583ed6-5792-4302-8c25-d9aed17a67c2" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create or open a product page in the block editor.
2. Add a Product Collection block and select the "Related Products" collection type.
3. In the block, click on any product via the "Select product" button to set a specific product reference.
4. Open the **List View**, select the **Related Products** block, and find the **Linked Product** panel in the Inspector Controls sidebar.
5. Verify the panel renders correctly.
6. Open the panel menu (⋮ icon) and click **Reset all** and verify the control resets.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
