### PR TITLE
Remove no longer needed render_block_with_context() util

### DIFF
--- a/plugins/woocommerce/changelog/remove-render_block_with_context_util
+++ b/plugins/woocommerce/changelog/remove-render_block_with_context_util
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Remove no longer needed render_block_with_context() util
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItem.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItem.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
-use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils as AddToCartWithOptionsUtils;
 use WP_Block;
 
 /**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItem.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItem.php
@@ -61,15 +61,17 @@ class GroupedProductItem extends AbstractBlock {
 
 		add_filter( 'render_block_context', array( $this, 'set_is_descendant_of_grouped_product_selector_context' ), 10, 2 );
 
-		// Render the inner blocks of the Post Template block with `dynamic` set to `false` to prevent calling
-		// `render_callback` and ensure that no wrapper markup is included.
-		$block_content = AddToCartWithOptionsUtils::render_block_with_context(
-			$block,
+		// Create new block with custom context.
+		$new_block = new WP_Block(
+			$block->parsed_block,
 			array(
 				'postType' => 'product',
 				'postId'   => $post->ID,
-			),
+			)
 		);
+
+		// Render with dynamic set to false to prevent calling render_callback.
+		$block_content = $new_block->render( array( 'dynamic' => false ) );
 
 		remove_filter( 'render_block_context', array( $this, 'set_is_descendant_of_grouped_product_selector_context' ) );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -226,6 +226,31 @@ class Utils {
 	}
 
 	/**
+	 * Renders a new block with custom context.
+	 *
+	 * @deprecated This method is deprecated and should not be used in new code.
+	 *
+	 * @param WP_Block $block The block instance.
+	 * @param array    $context The context for the new block.
+	 * @return string Rendered block content
+	 */
+	public static function render_block_with_context( $block, $context ) {
+		wc_deprecated_function( 'Utils::render_block_with_context', '11.0.0' );
+
+		// Get an instance of the current block.
+		$block_instance = $block->parsed_block;
+
+		// Create new block with custom context.
+		$new_block = new WP_Block(
+			$block_instance,
+			$context
+		);
+
+		// Render with dynamic set to false to prevent calling render_callback.
+		return $new_block->render( array( 'dynamic' => false ) );
+	}
+
+	/**
 	 * Check if min and max purchase quantity are the same for a product.
 	 *
 	 * @param \WC_Product $product The product to check.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -227,27 +227,6 @@ class Utils {
 	}
 
 	/**
-	 * Renders a new block with custom context
-	 *
-	 * @param WP_Block $block The block instance.
-	 * @param array    $context The context for the new block.
-	 * @return string Rendered block content
-	 */
-	public static function render_block_with_context( $block, $context ) {
-		// Get an instance of the current block.
-		$block_instance = $block->parsed_block;
-
-		// Create new block with custom context.
-		$new_block = new WP_Block(
-			$block_instance,
-			$context
-		);
-
-		// Render with dynamic set to false to prevent calling render_callback.
-		return $new_block->render( array( 'dynamic' => false ) );
-	}
-
-	/**
 	 * Check if min and max purchase quantity are the same for a product.
 	 *
 	 * @param \WC_Product $product The product to check.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -226,31 +226,6 @@ class Utils {
 	}
 
 	/**
-	 * Renders a new block with custom context.
-	 *
-	 * @deprecated This method is deprecated and should not be used in new code.
-	 *
-	 * @param WP_Block $block The block instance.
-	 * @param array    $context The context for the new block.
-	 * @return string Rendered block content
-	 */
-	public static function render_block_with_context( $block, $context ) {
-		wc_deprecated_function( 'Utils::render_block_with_context', '11.0.0' );
-
-		// Get an instance of the current block.
-		$block_instance = $block->parsed_block;
-
-		// Create new block with custom context.
-		$new_block = new WP_Block(
-			$block_instance,
-			$context
-		);
-
-		// Render with dynamic set to false to prevent calling render_callback.
-		return $new_block->render( array( 'dynamic' => false ) );
-	}
-
-	/**
 	 * Check if min and max purchase quantity are the same for a product.
 	 *
 	 * @param \WC_Product $product The product to check.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Enums\ProductType;
-use WP_Block;
 
 /**
  * Utility methods used for the Add to Cart + Options block.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Small PR getting rid of the `render_block_with_context()` util. Until now it was used by the Variation Selector and Grouped Product Template blocks, but with the recent changes in Variation Selector is now only used by the latter, so it doesn't make sense having it as a util. The `AddToCartWithOptions/Utils` class is marked as internal, so it's safe to remove it.

### How to test the changes in this Pull Request:

This PR doesn't introduce any user-facing changes, so testing is about making sure there are no regressions.

1. Go to the frontend of a grouped product, making sure the template uses the _Add to Cart + Options_ block.
2. Smoke test the block by changing quantities and adding the product to cart.
3. Verify everything works as expected.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
