### PR TITLE
[Performance] Optimize \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery query generation

### DIFF
--- a/plugins/woocommerce/changelog/update-47865-orders-table-query-build
+++ b/plugins/woocommerce/changelog/update-47865-orders-table-query-build
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Optimized SQL generation in \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery by removing 'group by' and 'limit' clauses when they are not required.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -899,6 +899,15 @@ class OrdersTableQuery {
 		$groupby = $groupby ? ( 'GROUP BY ' . $groupby ) : '';
 		$orderby = $orderby ? ( 'ORDER BY ' . $orderby ) : '';
 
+		// Performance note: simplify the query to allow the query optimizer to select a more efficient execution plan. As of
+		// version 10.9, this logic is implemented here as alternative changes above are getting flagged by regression analysis.
+		if ( '' === $join && "{$orders_table}.id" === $fields ) {
+			$groupby = '';
+		}
+		if ( 'LIMIT 0, ' . self::MYSQL_MAX_UNSIGNED_BIGINT === $limits ) {
+			$limits = '';
+		}
+
 		$this->sql = "SELECT $fields FROM $orders_table $join WHERE $where $groupby $orderby $limits";
 
 		if ( ! $this->suppress_filters ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #47865, WOOPLUG-2225.

Refactors `\Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery` to omit `GROUP BY` when no join is present. Impact is low in terms of timing, but skips unnecessary CPU work for larger data sets.

Affected areas: coupon usage validation, orders listing under `My account` (store) and `Orders` (admin), filtering orders by date in `Orders` (admin).

Benchmarks (timings only, as it directly reflects offloaded CPU; 76K orders):
```  
  ┌───────────┬─────────────────┬──────────────┬───────────┐
  │ Scenario  │     Variant     │ MariaDB 11.8 │ MySQL 5.7 │                                                                                                                                                   
  ├───────────┼─────────────────┼──────────────┼───────────┤
  │ Unlimited │ A (GROUP BY)    │ 20.5ms       │ 695ms     │                                                                                                                                                   
  ├───────────┼─────────────────┼──────────────┼───────────┤                                                                                                                                                 
  │ Unlimited │ B (no GROUP BY) │ 18.4ms       │ 691ms     │                                                                                                                                                   
  ├───────────┼─────────────────┼──────────────┼───────────┤                                                                                                                                                   
  │ Paginated │ A (GROUP BY)    │ 0.20ms       │ 2.5ms     │                                                                                                                                                 
  ├───────────┼─────────────────┼──────────────┼───────────┤                                                                                                                                                   
  │ Paginated │ B (no GROUP BY) │ 0.17ms       │ 2.3ms     │
  └───────────┴─────────────────┴──────────────┴───────────┘
```

### How to test the changes in this Pull Request:

- Navigate to `My account -> Orders` in the store: smoke test the page is loading, and orders are rendered
- Navigate to `WooCommerce -> Orders` in admin: smoke test the page is loading, and orders are rendered
- (optional) on those pages, verify the target SQL has no grouping