### PR TITLE
Fix trunk CI broken pipe when reading the head commit message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            MESSAGE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
+            MESSAGE=$(head -1 <<< "$HEAD_COMMIT_MESSAGE")
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             MESSAGE="$PR_TITLE"
           else
@@ -355,7 +355,7 @@ jobs:
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           INPUT_TRIGGER: ${{ inputs.trigger }}
         run: |
-          COMMIT_MESSAGE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
+          COMMIT_MESSAGE=$(head -1 <<< "$HEAD_COMMIT_MESSAGE")
 
           if [[ -n "${INPUT_TRIGGER}" ]]; then
               CHECKS_TYPE="${INPUT_TRIGGER}"
@@ -411,7 +411,7 @@ jobs:
             REPORT_TITLE="$PR_TITLE"
             REF_NAME="$GITHUB_HEAD_REF"
           elif [[ "${{ github.event_name }}" == "push" ]]; then
-            REPORT_TITLE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
+            REPORT_TITLE=$(head -1 <<< "$HEAD_COMMIT_MESSAGE")
           else
             REPORT_TITLE="$EVENT_NAME"
           fi


### PR DESCRIPTION
### Changes proposed in this Pull Request

Trunk CI went red right after #65111 merged: ~70 jobs failed at the **Determine BuildKite Analytics Message** step (the actual tests were *skipped*, not failing). [Failing run.](https://github.com/woocommerce/woocommerce/actions/runs/26643108216)

**Root cause — a broken pipe, not a test failure.** That step uses `shell: bash`, which GitHub invokes as `bash --noprofile --norc -eo pipefail {0}` (note `-o pipefail`). On `push` events it takes the first line of the commit message with:

```bash
MESSAGE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
```

`#65111` was a squash of a long stack, so its commit message is ~300 KB — well over the 64 KB pipe buffer. `head -1` reads the first line and closes the pipe while `echo` is still writing, so `echo` gets `EPIPE` and prints `echo: write error: Broken pipe`. Under `pipefail` the pipeline returns non-zero and `set -e` fails the step — so every test job running this step is marked failed and its tests skipped, cascading into ~70 red jobs plus the roll-up.

This is why **all checks were green on the PR**: `pull_request` events take the `MESSAGE="$PR_TITLE"` branch (no pipe). The bug only triggers on push-to-trunk *with a large commit message*.

**Fix.** Read the first line with a here-string instead of an `echo`-pipe:

```bash
MESSAGE=$(head -1 <<< "$HEAD_COMMIT_MESSAGE")
```

A here-string feeds `head` from a buffer with no concurrent writer process, so it cannot trigger `SIGPIPE`/`EPIPE` regardless of `pipefail`, while keeping `head -1` semantics identical. The same fragile pattern appears in two sibling steps (the **Slack report** and **test-report dispatch**); those run on the default shell (no `pipefail`) so today they only logged a harmless "Broken pipe" to stderr — but they're fixed here too for consistency and to stay safe if `pipefail` is ever enabled.

### How to test the changes in this Pull Request

CI-only change. To see the mechanism locally (needs bash 5.x to observe the *old* failure):

```bash
big=$(printf 'filler %d\n' $(seq 1 8000)); msg="First line (#65111)
$big"
# Old form — fails under pipefail with a large message:
bash -c 'set -eo pipefail; m=$(echo "$1" | head -1); echo "ok: $m"' _ "$msg"
# New form — always passes, prints "ok: First line (#65111)":
bash -c 'set -eo pipefail; m=$(head -1 <<< "$1"); echo "ok: $m"' _ "$msg"
```

After merge, the trunk `push` run will exercise the fixed step directly.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment below.)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

CI workflow-only change under `.github/`. The changelog-validation path filter in `ci.yml` excludes `.github/**`, so no changelog fragment is required.

</details>
