### PR TITLE
feat(product-feed): add query provider for pull integrations (#65389)

### DIFF
--- a/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryInterface.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryInterface.php
@@ -35,9 +35,16 @@ interface ProductQueryInterface {
 	 * @param int   $page Page number (1-based).
 	 * @param int   $limit Products per page.
 	 * @return array {
-	 *     @type array $products        Array of mapped product data arrays.
-	 *     @type int   $total           Total matching products (before pagination).
-	 *     @type int   $max_num_pages   Total pages available.
+	 *     @type array $products        Mapped product data that passed validation
+	 *                                  (post-validation). Use count($products) for the
+	 *                                  number actually returned on this page.
+	 *     @type int   $total           Pre-validation total: count of products matched
+	 *                                  by the underlying query, before the validator
+	 *                                  filter. Use this for total catalog size and to
+	 *                                  compute pagination. May be greater than
+	 *                                  count($products) when invalid entries are dropped.
+	 *     @type int   $max_num_pages   Total pages available, based on the pre-validation
+	 *                                  $total and the requested $limit.
 	 * }
 	 */
 	public function query_products( array $args, int $page, int $limit ): array;

--- a/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryInterface.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryInterface.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Product Query Interface.
+ *
+ * @package Automattic\WooCommerce\Internal\ProductFeed
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\ProductFeed\Feed;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Interface for querying mapped product data without file delivery concerns.
+ *
+ * Enables pull/query consumers (e.g., UCP, live APIs) to retrieve product data
+ * using the same mapping and validation pipeline as push-feed integrations,
+ * without depending on CSV or file delivery semantics.
+ *
+ * @since 10.10.0
+ */
+interface ProductQueryInterface {
+	/**
+	 * Query mapped products with pagination.
+	 *
+	 * Returns an array containing mapped product data that passed validation,
+	 * along with pagination metadata.
+	 *
+	 * @since 10.10.0
+	 *
+	 * @param array $args Additional query arguments to merge with integration defaults.
+	 * @param int   $page Page number (1-based).
+	 * @param int   $limit Products per page.
+	 * @return array {
+	 *     @type array $products        Array of mapped product data arrays.
+	 *     @type int   $total           Total matching products (before pagination).
+	 *     @type int   $max_num_pages   Total pages available.
+	 * }
+	 */
+	public function query_products( array $args, int $page, int $limit ): array;
+
+	/**
+	 * Get a single mapped product by ID.
+	 *
+	 * Honors the integration's query args (status, type, tax_query) so excluded
+	 * products (e.g., draft, pos-hidden) are not returned.
+	 *
+	 * @since 10.10.0
+	 *
+	 * @param int $product_id Product ID.
+	 * @return array|null Mapped product data, or null if not found or excluded.
+	 */
+	public function get_product( int $product_id ): ?array;
+
+	/**
+	 * Get the total count of products matching the current query configuration.
+	 *
+	 * @since 10.10.0
+	 *
+	 * @param array $args Additional query arguments to merge with integration defaults.
+	 * @return int Total matching product count.
+	 */
+	public function get_total_count( array $args = array() ): int;
+}

--- a/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryService.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryService.php
@@ -148,10 +148,11 @@ class ProductQueryService implements ProductQueryInterface {
 			array_merge(
 				$this->query_args,
 				array(
-					'include' => array( $product_id ),
-					'limit'   => 1,
-					'page'    => 1,
-					'return'  => 'objects',
+					'include'  => array( $product_id ),
+					'limit'    => 1,
+					'page'     => 1,
+					'paginate' => true,
+					'return'   => 'objects',
 				)
 			)
 		);

--- a/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryService.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryService.php
@@ -90,6 +90,10 @@ class ProductQueryService implements ProductQueryInterface {
 	 * }
 	 */
 	public function query_products( array $args, int $page, int $limit ): array {
+		// Coerce pagination inputs to valid values so the loader never receives page<1 or limit<1.
+		$page  = max( 1, $page );
+		$limit = max( 1, $limit );
+
 		/**
 		 * Result is always stdClass when paginate=true.
 		 *

--- a/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryService.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryService.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Product Query Service class.
+ *
+ * @package Automattic\WooCommerce\Internal\ProductFeed
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\ProductFeed\Feed;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Service for querying mapped product data without file delivery concerns.
+ *
+ * Composes the same product loading, mapping, and validation pipeline used by
+ * ProductWalker, but returns data directly instead of pushing to a feed file.
+ * This enables pull/query consumers (e.g., UCP, live APIs) to reuse the
+ * integration's product shaping logic without CSV or file dependencies.
+ *
+ * @since 10.10.0
+ */
+class ProductQueryService implements ProductQueryInterface {
+
+	/**
+	 * The product loader.
+	 *
+	 * @var ProductLoader
+	 */
+	private ProductLoader $product_loader;
+
+	/**
+	 * The product mapper.
+	 *
+	 * @var ProductMapperInterface
+	 */
+	private ProductMapperInterface $mapper;
+
+	/**
+	 * The feed validator.
+	 *
+	 * @var FeedValidatorInterface
+	 */
+	private FeedValidatorInterface $validator;
+
+	/**
+	 * The base query arguments from the integration.
+	 *
+	 * @var array
+	 */
+	private array $query_args;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 10.10.0
+	 *
+	 * @param ProductMapperInterface $mapper         The product mapper.
+	 * @param FeedValidatorInterface $validator       The feed validator.
+	 * @param ProductLoader          $product_loader  The product loader.
+	 * @param array                  $query_args      Base query arguments from the integration.
+	 */
+	public function __construct(
+		ProductMapperInterface $mapper,
+		FeedValidatorInterface $validator,
+		ProductLoader $product_loader,
+		array $query_args
+	) {
+		$this->mapper         = $mapper;
+		$this->validator      = $validator;
+		$this->product_loader = $product_loader;
+		$this->query_args     = $query_args;
+	}
+
+	/**
+	 * Query mapped products with pagination.
+	 *
+	 * @since 10.10.0
+	 *
+	 * @param array $args  Additional query arguments to merge with integration defaults.
+	 * @param int   $page  Page number (1-based).
+	 * @param int   $limit Products per page.
+	 * @return array {
+	 *     @type array $products        Array of mapped product data arrays.
+	 *     @type int   $total           Total matching products (before pagination).
+	 *     @type int   $max_num_pages   Total pages available.
+	 * }
+	 */
+	public function query_products( array $args, int $page, int $limit ): array {
+		/**
+		 * Result is always stdClass when paginate=true.
+		 *
+		 * @var \stdClass $result
+		 */
+		$result = $this->product_loader->get_products(
+			array_merge(
+				$this->query_args,
+				$args,
+				array(
+					'page'     => $page,
+					'limit'    => $limit,
+					'paginate' => true,
+				)
+			)
+		);
+
+		$entries = array();
+		foreach ( $result->products as $product ) {
+			$mapped_data = $this->mapper->map_product( $product );
+
+			if ( ! empty( $this->validator->validate_entry( $mapped_data, $product ) ) ) {
+				continue;
+			}
+
+			$entries[] = $mapped_data;
+		}
+
+		return array(
+			'products'      => $entries,
+			'total'         => $result->total ?? 0,
+			'max_num_pages' => $result->max_num_pages ?? 0,
+		);
+	}
+
+	/**
+	 * Get a single mapped product by ID.
+	 *
+	 * Loads the product through the ProductLoader with the integration's query
+	 * args, so status, type, and tax_query filters are applied. This prevents
+	 * returning draft, disallowed-type, or pos-hidden products that the
+	 * integration excludes.
+	 *
+	 * @since 10.10.0
+	 *
+	 * @param int $product_id Product ID.
+	 * @return array|null Mapped product data, or null if not found or excluded.
+	 */
+	public function get_product( int $product_id ): ?array {
+		/**
+		 * Result is always stdClass when paginate=true.
+		 *
+		 * @var \stdClass $result
+		 */
+		$result = $this->product_loader->get_products(
+			array_merge(
+				$this->query_args,
+				array(
+					'include' => array( $product_id ),
+					'limit'   => 1,
+					'page'    => 1,
+					'return'  => 'objects',
+				)
+			)
+		);
+
+		if ( empty( $result->products ) ) {
+			return null;
+		}
+
+		$product     = $result->products[0];
+		$mapped_data = $this->mapper->map_product( $product );
+
+		if ( ! empty( $this->validator->validate_entry( $mapped_data, $product ) ) ) {
+			return null;
+		}
+
+		return $mapped_data;
+	}
+
+	/**
+	 * Get the total count of products matching the current query configuration.
+	 *
+	 * @since 10.10.0
+	 *
+	 * @param array $args Additional query arguments to merge with integration defaults.
+	 * @return int Total matching product count.
+	 */
+	public function get_total_count( array $args = array() ): int {
+		/**
+		 * Result is always stdClass when paginate=true.
+		 *
+		 * @var \stdClass $result
+		 */
+		$result = $this->product_loader->get_products(
+			array_merge(
+				$this->query_args,
+				$args,
+				array(
+					'limit'    => 1,
+					'page'     => 1,
+					'paginate' => true,
+				)
+			)
+		);
+
+		return (int) ( $result->total ?? 0 );
+	}
+}

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/IntegrationInterface.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/IntegrationInterface.php
@@ -12,6 +12,7 @@ namespace Automattic\WooCommerce\Internal\ProductFeed\Integrations;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedValidatorInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductMapperInterface;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductQueryInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -87,4 +88,18 @@ interface IntegrationInterface {
 	 * @return FeedValidatorInterface The feed validator.
 	 */
 	public function get_feed_validator(): FeedValidatorInterface;
+
+	/**
+	 * Create a query provider for pull/query consumers.
+	 *
+	 * Returns a ProductQueryInterface implementation that allows consumers to
+	 * query mapped product data without depending on file delivery semantics.
+	 * Useful for live query integrations (e.g., UCP) that need paginated or
+	 * individual product lookups.
+	 *
+	 * @since 10.10.0
+	 *
+	 * @return ProductQueryInterface|null The query provider, or null if not supported.
+	 */
+	public function create_query_provider(): ?ProductQueryInterface;
 }

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSIntegration.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSIntegration.php
@@ -151,6 +151,22 @@ class POSIntegration implements IntegrationInterface {
 			$this
 		);
 
+		// Defensive: third-party filters could return non-array values. Fall back to the
+		// integration defaults so ProductQueryService never receives a malformed payload.
+		if ( ! is_array( $query_args ) ) {
+			wc_get_logger()->warning(
+				'Invalid query args returned from woocommerce_product_feed_args filter. Expected array.',
+				array( 'source' => 'product-feed-pos-integration' )
+			);
+			$query_args = array_merge(
+				array(
+					'status' => array( 'publish' ),
+					'return' => 'objects',
+				),
+				$this->get_product_feed_query_args()
+			);
+		}
+
 		return new ProductQueryService(
 			$this->get_product_mapper(),
 			$this->get_feed_validator(),

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSIntegration.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSIntegration.php
@@ -12,6 +12,9 @@ namespace Automattic\WooCommerce\Internal\ProductFeed\Integrations\POSCatalog;
 use Automattic\WooCommerce\Container;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedValidatorInterface;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductLoader;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductQueryInterface;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductQueryService;
 use Automattic\WooCommerce\Internal\ProductFeed\Integrations\IntegrationInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Storage\JsonFileFeed;
 
@@ -119,5 +122,40 @@ class POSIntegration implements IntegrationInterface {
 	 */
 	public function get_feed_validator(): FeedValidatorInterface {
 		return $this->container->get( FeedValidator::class );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function create_query_provider(): ProductQueryInterface {
+		$query_args = array_merge(
+			array(
+				'status' => array( 'publish' ),
+				'return' => 'objects',
+			),
+			$this->get_product_feed_query_args()
+		);
+
+		/**
+		 * Filters the product query arguments.
+		 *
+		 * @since 10.10.0
+		 *
+		 * @param array                $query_args  The arguments to pass to wc_get_products().
+		 * @param IntegrationInterface $integration The integration that the query belongs to.
+		 * @return array
+		 */
+		$query_args = apply_filters(
+			'woocommerce_product_feed_args',
+			$query_args,
+			$this
+		);
+
+		return new ProductQueryService(
+			$this->get_product_mapper(),
+			$this->get_feed_validator(),
+			$this->container->get( ProductLoader::class ),
+			$query_args
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductQueryServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductQueryServiceTest.php
@@ -1,0 +1,381 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\ProductFeed\Feed;
+
+use WC_Helper_Product;
+use WC_Product;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductLoader;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductMapperInterface;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedValidatorInterface;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductQueryService;
+
+/**
+ * ProductQueryServiceTest class.
+ */
+class ProductQueryServiceTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		remove_all_filters( 'woocommerce_product_feed_args' );
+	}
+
+	/**
+	 * Clean up test fixtures.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'woocommerce_product_feed_args' );
+		wc_get_container()->reset_all_replacements();
+	}
+
+	/**
+	 * Data provider for query_products pagination tests.
+	 *
+	 * @return array Test scenarios.
+	 */
+	public function provider_query_products(): array {
+		return array(
+			'No results'               => array(
+				'number_of_products' => 0,
+				'batch_size'         => 10,
+				'page'               => 1,
+			),
+			'Single page'              => array(
+				'number_of_products' => 5,
+				'batch_size'         => 10,
+				'page'               => 1,
+			),
+			'Multiple pages'           => array(
+				'number_of_products' => 25,
+				'batch_size'         => 10,
+				'page'               => 2,
+			),
+			'Page beyond last'         => array(
+				'number_of_products' => 5,
+				'batch_size'         => 10,
+				'page'               => 3,
+			),
+		);
+	}
+
+	/**
+	 * Test query_products with varying pagination.
+	 *
+	 * @param int $number_of_products The number of products to create.
+	 * @param int $batch_size         The batch size (limit).
+	 * @param int $page               The page number.
+	 *
+	 * @dataProvider provider_query_products
+	 */
+	public function test_query_products( int $number_of_products, int $batch_size, int $page ): void {
+		// Arrange: Create products.
+		$products = array();
+		for ( $i = 0; $i < $number_of_products; $i++ ) {
+			$products[] = WC_Helper_Product::create_simple_product();
+		}
+
+		// Set up mocks.
+		$mock_loader    = $this->createMock( ProductLoader::class );
+		$mock_mapper    = $this->createMock( ProductMapperInterface::class );
+		$mock_validator = $this->createMock( FeedValidatorInterface::class );
+		$query_args     = array(
+			'status' => array( 'publish' ),
+		);
+
+		// Mock the loader to return paginated results.
+		$start_index = ( $page - 1 ) * $batch_size;
+		$page_slice  = array_slice( $products, $start_index, $batch_size );
+
+		$mock_loader->method( 'get_products' )
+			->willReturn(
+				(object) array(
+					'products'      => $page_slice,
+					'total'         => $number_of_products,
+					'max_num_pages' => max( 1, (int) ceil( $number_of_products / $batch_size ) ),
+				)
+			);
+
+		// Mapper returns simple array per product.
+		$mock_mapper->method( 'map_product' )
+			->willReturnCallback(
+				function ( WC_Product $product ) {
+					return array(
+						'id'   => $product->get_id(),
+						'name' => $product->get_name(),
+					);
+				}
+			);
+
+		// Validator passes everything.
+		$mock_validator->method( 'validate_entry' )
+			->willReturn( array() );
+
+		// Act.
+		$service = new ProductQueryService( $mock_mapper, $mock_validator, $mock_loader, $query_args );
+		$result  = $service->query_products( array(), $page, $batch_size );
+
+		// Assert.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'products', $result );
+		$this->assertArrayHasKey( 'total', $result );
+		$this->assertArrayHasKey( 'max_num_pages', $result );
+		$this->assertSame( $number_of_products, $result['total'] );
+		$this->assertCount( count( $page_slice ), $result['products'] );
+	}
+
+	/**
+	 * Test query_products filters out invalid entries.
+	 */
+	public function test_query_products_validates_entries(): void {
+		// Arrange: Create 3 products.
+		$products = array(
+			WC_Helper_Product::create_simple_product(),
+			WC_Helper_Product::create_simple_product(),
+			WC_Helper_Product::create_simple_product(),
+		);
+
+		$mock_loader    = $this->createMock( ProductLoader::class );
+		$mock_mapper    = $this->createMock( ProductMapperInterface::class );
+		$mock_validator = $this->createMock( FeedValidatorInterface::class );
+
+		$mock_loader->method( 'get_products' )
+			->willReturn(
+				(object) array(
+					'products'      => $products,
+					'total'         => 3,
+					'max_num_pages' => 1,
+				)
+			);
+
+		$mock_mapper->method( 'map_product' )
+			->willReturnCallback(
+				function ( WC_Product $product ) {
+					return array( 'id' => $product->get_id() );
+				}
+			);
+
+		// Second product fails validation.
+		$call_count = 0;
+		$mock_validator->method( 'validate_entry' )
+			->willReturnCallback(
+				function () use ( &$call_count ) {
+					$call_count++;
+					return ( 2 === $call_count ) ? array( 'missing_field' ) : array();
+				}
+			);
+
+		// Act.
+		$service = new ProductQueryService( $mock_mapper, $mock_validator, $mock_loader, array() );
+		$result  = $service->query_products( array(), 1, 10 );
+
+		// Assert: 3 products queried, 1 filtered -> 2 returned.
+		$this->assertCount( 2, $result['products'] );
+		$this->assertSame( 3, $result['total'] );
+	}
+
+	/**
+	 * Test query_products merges additional args.
+	 */
+	public function test_query_products_merges_args(): void {
+		$mock_loader    = $this->createMock( ProductLoader::class );
+		$mock_mapper    = $this->createMock( ProductMapperInterface::class );
+		$mock_validator = $this->createMock( FeedValidatorInterface::class );
+
+		$base_args = array( 'type' => array( 'simple' ) );
+
+		$mock_loader->expects( $this->once() )
+			->method( 'get_products' )
+			->with(
+				$this->callback(
+					function ( $args ) {
+						$this->assertArrayHasKey( 'type', $args );
+						$this->assertSame( array( 'simple' ), $args['type'] );
+						$this->assertArrayHasKey( 'category', $args );
+						$this->assertSame( array( 'shirts' ), $args['category'] );
+						$this->assertSame( 2, $args['page'] );
+						$this->assertSame( 25, $args['limit'] );
+						$this->assertTrue( $args['paginate'] );
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				(object) array(
+					'products'      => array(),
+					'total'         => 0,
+					'max_num_pages' => 0,
+				)
+			);
+
+		$mock_validator->method( 'validate_entry' )->willReturn( array() );
+
+		$service = new ProductQueryService( $mock_mapper, $mock_validator, $mock_loader, $base_args );
+		$service->query_products( array( 'category' => array( 'shirts' ) ), 2, 25 );
+	}
+
+	/**
+	 * Test get_product returns mapped data for valid product.
+	 */
+	public function test_get_product_returns_mapped_data(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$mock_loader    = $this->createMock( ProductLoader::class );
+		$mock_mapper    = $this->createMock( ProductMapperInterface::class );
+		$mock_validator = $this->createMock( FeedValidatorInterface::class );
+		$query_args     = array( 'status' => array( 'publish' ) );
+
+		$mock_loader->method( 'get_products' )
+			->willReturn(
+				(object) array(
+					'products' => array( $product ),
+					'total'    => 1,
+				)
+			);
+
+		$mock_mapper->method( 'map_product' )
+			->willReturn( array( 'id' => $product->get_id(), 'name' => 'Test Product' ) );
+
+		$mock_validator->method( 'validate_entry' )->willReturn( array() );
+
+		$service = new ProductQueryService( $mock_mapper, $mock_validator, $mock_loader, $query_args );
+		$result  = $service->get_product( $product->get_id() );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertSame( $product->get_id(), $result['id'] );
+	}
+
+	/**
+	 * Test get_product passes query_args to loader.
+	 */
+	public function test_get_product_passes_query_args_to_loader(): void {
+		$mock_loader    = $this->createMock( ProductLoader::class );
+		$mock_mapper    = $this->createMock( ProductMapperInterface::class );
+		$mock_validator = $this->createMock( FeedValidatorInterface::class );
+		$query_args     = array(
+			'status' => array( 'publish' ),
+			'type'   => array( 'simple' ),
+		);
+
+		$mock_loader->expects( $this->once() )
+			->method( 'get_products' )
+			->with(
+				$this->callback(
+					function ( $args ) {
+						$this->assertSame( array( 'publish' ), $args['status'] );
+						$this->assertSame( array( 'simple' ), $args['type'] );
+						$this->assertSame( array( 42 ), $args['include'] );
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				(object) array( 'products' => array() )
+			);
+
+		$service = new ProductQueryService( $mock_mapper, $mock_validator, $mock_loader, $query_args );
+		$result  = $service->get_product( 42 );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test get_product returns null when validation fails.
+	 */
+	public function test_get_product_returns_null_when_validation_fails(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$mock_loader    = $this->createMock( ProductLoader::class );
+		$mock_mapper    = $this->createMock( ProductMapperInterface::class );
+		$mock_validator = $this->createMock( FeedValidatorInterface::class );
+
+		$mock_loader->method( 'get_products' )
+			->willReturn(
+				(object) array( 'products' => array( $product ) )
+			);
+
+		$mock_mapper->method( 'map_product' )
+			->willReturn( array( 'id' => $product->get_id() ) );
+
+		$mock_validator->method( 'validate_entry' )
+			->willReturn( array( 'invalid_sku' ) );
+
+		$service = new ProductQueryService( $mock_mapper, $mock_validator, $mock_loader, array() );
+		$result  = $service->get_product( $product->get_id() );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test get_total_count returns correct count.
+	 */
+	public function test_get_total_count(): void {
+		$mock_loader    = $this->createMock( ProductLoader::class );
+		$mock_mapper    = $this->createMock( ProductMapperInterface::class );
+		$mock_validator = $this->createMock( FeedValidatorInterface::class );
+		$base_args      = array( 'type' => array( 'simple' ) );
+
+		$mock_loader->expects( $this->once() )
+			->method( 'get_products' )
+			->with(
+				$this->callback(
+					function ( $args ) {
+						$this->assertSame( 1, $args['limit'] );
+						$this->assertTrue( $args['paginate'] );
+						$this->assertArrayHasKey( 'type', $args );
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				(object) array(
+					'total'         => 42,
+					'max_num_pages' => 42,
+					'products'      => array(),
+				)
+			);
+
+		$service = new ProductQueryService( $mock_mapper, $mock_validator, $mock_loader, $base_args );
+		$result  = $service->get_total_count( array() );
+
+		$this->assertSame( 42, $result );
+	}
+
+	/**
+	 * Test get_total_count merges additional args.
+	 */
+	public function test_get_total_count_merges_args(): void {
+		$mock_loader    = $this->createMock( ProductLoader::class );
+		$mock_mapper    = $this->createMock( ProductMapperInterface::class );
+		$mock_validator = $this->createMock( FeedValidatorInterface::class );
+		$base_args      = array( 'type' => array( 'simple' ) );
+
+		$mock_loader->expects( $this->once() )
+			->method( 'get_products' )
+			->with(
+				$this->callback(
+					function ( $args ) use ( $base_args ) {
+						$this->assertSame( $base_args['type'], $args['type'] );
+						$this->assertArrayHasKey( 'category', $args );
+						$this->assertSame( array( 'shirts' ), $args['category'] );
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				(object) array(
+					'total'    => 10,
+					'products' => array(),
+				)
+			);
+
+		$service = new ProductQueryService( $mock_mapper, $mock_validator, $mock_loader, $base_args );
+		$result  = $service->get_total_count( array( 'category' => array( 'shirts' ) ) );
+
+		$this->assertSame( 10, $result );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductQueryServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductQueryServiceTest.php
@@ -16,14 +16,6 @@ use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductQueryService;
 class ProductQueryServiceTest extends \WC_Unit_Test_Case {
 
 	/**
-	 * Set up test fixtures.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-		remove_all_filters( 'woocommerce_product_feed_args' );
-	}
-
-	/**
 	 * Clean up test fixtures.
 	 */
 	public function tearDown(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductQueryServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductQueryServiceTest.php
@@ -269,6 +269,10 @@ class ProductQueryServiceTest extends \WC_Unit_Test_Case {
 						$this->assertSame( array( 'publish' ), $args['status'] );
 						$this->assertSame( array( 'simple' ), $args['type'] );
 						$this->assertSame( array( 42 ), $args['include'] );
+						$this->assertArrayHasKey( 'paginate', $args );
+						$this->assertTrue( $args['paginate'] );
+						$this->assertSame( 1, $args['limit'] );
+						$this->assertSame( 1, $args['page'] );
 						return true;
 					}
 				)


### PR DESCRIPTION
## Summary

Add `ProductQueryInterface` and `ProductQueryService` to the ProductFeed framework so pull/query consumers (UCP, live APIs) can reuse the same product mapping and validation pipeline without file delivery dependencies. The existing push-feed architecture forced UCP to duplicate mapping logic in `woocommerce-ai`. This change decouples product shaping from file output.

Fixes #65389

## Changes

### New: ProductQueryInterface
[`src/Internal/ProductFeed/Feed/ProductQueryInterface.php`](plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryInterface.php)

```php
interface ProductQueryInterface {
    public function query_products( array $args, int $page, int $limit ): array;
    public function get_product( int $product_id ): ?array;
    public function get_total_count( array $args = array() ): int;
}
```

### New: ProductQueryService
[`src/Internal/ProductFeed/Feed/ProductQueryService.php`](plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductQueryService.php)

Composes `ProductLoader`, `ProductMapperInterface`, and `FeedValidatorInterface` to provide paginated queries, single-product lookups, and total counts. No file I/O. Mirrors the same load → map → validate pipeline as `ProductWalker` but returns data directly.

### Modified: IntegrationInterface
[`src/Internal/ProductFeed/Integrations/IntegrationInterface.php`](plugins/woocommerce/src/Internal/ProductFeed/Integrations/IntegrationInterface.php)

Added `create_query_provider(): ?ProductQueryInterface` — nullable return ensures backward compatibility with existing integrations.

### Modified: POSIntegration
[`src/Internal/ProductFeed/Integrations/POSCatalog/POSIntegration.php`](plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSIntegration.php)

Implements `create_query_provider()` returning a `ProductQueryService` wired to POS mapper, validator, loader, and query args. Honors the `woocommerce_product_feed_args` filter for consistency.

### New: ProductQueryServiceTest
[`tests/php/src/Internal/ProductFeed/Feed/ProductQueryServiceTest.php`](plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductQueryServiceTest.php)

11 tests covering pagination, validation filtering, arg merging, null returns for missing/invalid products, and total count queries.

## Testing

All existing ProductFeed tests pass (44 tests, 562 assertions) — zero regressions.

```
pnpm test:php:env -- --filter ProductFeed        # 44 tests ✅
pnpm test:php:env -- --filter ProductQueryService # 11 tests ✅
pnpm lint:php:changes                             # clean ✅
composer exec -- phpstan analyse <files>          # no errors ✅
```

Manual test for UCP-style consumption:

```php
$query = $integration->create_query_provider();
$result = $query->query_products( array(), 1, 10 );
// Returns: ['products' => [...], 'total' => N, 'max_num_pages' => N]

$single = $query->get_product( 123 );
// Returns: mapped product array or null
```