### PR TITLE
fix(checkout): skip required validation for hidden address fields

### DIFF
--- a/plugins/woocommerce/changelog/fix-65412-skip-hidden-state-validation
+++ b/plugins/woocommerce/changelog/fix-65412-skip-hidden-state-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip required-field validation for address fields hidden by country locale, preventing spurious "required field" errors on checkout and My Account address forms for countries like Austria, France, and Netherlands.

--- a/plugins/woocommerce/changelog/fix-65412-skip-hidden-state-validation
+++ b/plugins/woocommerce/changelog/fix-65412-skip-hidden-state-validation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Skip required-field validation for address fields hidden by country locale, preventing spurious "required field" errors on checkout and My Account address forms for countries like Austria, France, and Netherlands.
+Skip required-field validation for address fields that are hidden via the `woocommerce_get_country_locale` filter, preventing spurious "required field" errors on checkout and My Account address forms when a 3rd party plugin sets `hidden => true` without also setting `required => false`.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -854,6 +854,18 @@ class WC_Checkout {
 				$format      = array_filter( isset( $field['validate'] ) ? (array) $field['validate'] : array() );
 				$field_label = isset( $field['label'] ) ? $field['label'] : '';
 
+				// Hidden may not be present in field data if wc_array_overlay() didn't
+				// merge it (it only copies keys that exist in the base array). Check
+				// the locale array directly as a fallback.
+				if ( ! $hidden ) {
+					$field_base = preg_replace( '/^(billing|shipping)_/', '', $key );
+					$locale     = WC()->countries->get_country_locale();
+					$country    = $field['country'] ?? '';
+					if ( isset( $locale[ $country ][ $field_base ]['hidden'] ) ) {
+						$hidden = (bool) $locale[ $country ][ $field_base ]['hidden'];
+					}
+				}
+
 				if ( $validate_fieldset &&
 					( isset( $field['type'] ) && 'country' === $field['type'] && '' !== $data[ $key ] ) &&
 					! WC()->countries->country_exists( $data[ $key ] ) ) {

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -845,6 +845,9 @@ class WC_Checkout {
 				$validate_fieldset = false;
 			}
 
+			$country = isset( $data[ $fieldset_key . '_country' ] ) ? $data[ $fieldset_key . '_country' ] : WC()->customer->{"get_{$fieldset_key}_country"}();
+			$locale  = WC()->countries->get_country_locale();
+
 			foreach ( $fieldset as $key => $field ) {
 				if ( ! isset( $data[ $key ] ) ) {
 					continue;
@@ -854,13 +857,8 @@ class WC_Checkout {
 				$format      = array_filter( isset( $field['validate'] ) ? (array) $field['validate'] : array() );
 				$field_label = isset( $field['label'] ) ? $field['label'] : '';
 
-				// Hidden may not be present in field data if wc_array_overlay() didn't
-				// merge it (it only copies keys that exist in the base array). Check
-				// the locale array directly as a fallback.
 				if ( ! $hidden ) {
 					$field_base = preg_replace( '/^(billing|shipping)_/', '', $key );
-					$locale     = WC()->countries->get_country_locale();
-					$country    = $field['country'] ?? '';
 					if ( isset( $locale[ $country ][ $field_base ]['hidden'] ) ) {
 						$hidden = (bool) $locale[ $country ][ $field_base ]['hidden'];
 					}

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -850,6 +850,7 @@ class WC_Checkout {
 					continue;
 				}
 				$required    = ! empty( $field['required'] );
+				$hidden      = ! empty( $field['hidden'] );
 				$format      = array_filter( isset( $field['validate'] ) ? (array) $field['validate'] : array() );
 				$field_label = isset( $field['label'] ) ? $field['label'] : '';
 
@@ -930,7 +931,7 @@ class WC_Checkout {
 					}
 				}
 
-				if ( $validate_fieldset && $required && '' === $data[ $key ] ) {
+				if ( $validate_fieldset && $required && ! $hidden && '' === $data[ $key ] ) {
 					/* translators: %s: field name */
 					$errors->add( $key . '_required', apply_filters( 'woocommerce_checkout_required_field_notice', sprintf( __( '%s is a required field.', 'woocommerce' ), '<strong>' . esc_html( $field_label ) . '</strong>' ), $field_label, $key ), array( 'id' => $key ) );
 				}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -131,7 +131,19 @@ class WC_Form_Handler {
 			$value = apply_filters( 'woocommerce_process_myaccount_field_' . $key, $value );
 
 			// Validation: Required fields.
-			if ( ! empty( $field['required'] ) && empty( $field['hidden'] ) && empty( $value ) ) {
+			// Hidden may not be present in field data if wc_array_overlay() didn't
+			// merge it (it only copies keys that exist in the base array). Check
+			// both the field and the locale array directly.
+			$field_hidden = ! empty( $field['hidden'] );
+			if ( ! $field_hidden ) {
+				$field_base    = preg_replace( '/^(billing|shipping)_/', '', $key );
+				$locale        = WC()->countries->get_country_locale();
+				$field_country = $field['country'] ?? '';
+				if ( isset( $locale[ $field_country ][ $field_base ]['hidden'] ) ) {
+					$field_hidden = (bool) $locale[ $field_country ][ $field_base ]['hidden'];
+				}
+			}
+			if ( ! empty( $field['required'] ) && ! $field_hidden && empty( $value ) ) {
 				/* translators: %s: Field name. */
 				wc_add_notice( sprintf( __( '%s is a required field.', 'woocommerce' ), $field['label'] ), 'error', array( 'id' => $key ) );
 			}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -113,7 +113,9 @@ class WC_Form_Handler {
 			return;
 		}
 
-		$address = WC()->countries->get_address_fields( wc_clean( wp_unslash( $_POST[ $address_type . '_country' ] ) ), $address_type . '_' );
+		$address_country = wc_clean( wp_unslash( $_POST[ $address_type . '_country' ] ) );
+		$address         = WC()->countries->get_address_fields( $address_country, $address_type . '_' );
+		$locale          = WC()->countries->get_country_locale();
 
 		foreach ( $address as $key => $field ) {
 			if ( ! isset( $field['type'] ) ) {
@@ -131,16 +133,11 @@ class WC_Form_Handler {
 			$value = apply_filters( 'woocommerce_process_myaccount_field_' . $key, $value );
 
 			// Validation: Required fields.
-			// Hidden may not be present in field data if wc_array_overlay() didn't
-			// merge it (it only copies keys that exist in the base array). Check
-			// both the field and the locale array directly.
 			$field_hidden = ! empty( $field['hidden'] );
 			if ( ! $field_hidden ) {
-				$field_base    = preg_replace( '/^(billing|shipping)_/', '', $key );
-				$locale        = WC()->countries->get_country_locale();
-				$field_country = $field['country'] ?? '';
-				if ( isset( $locale[ $field_country ][ $field_base ]['hidden'] ) ) {
-					$field_hidden = (bool) $locale[ $field_country ][ $field_base ]['hidden'];
+				$field_base = preg_replace( '/^(billing|shipping)_/', '', $key );
+				if ( isset( $locale[ $address_country ][ $field_base ]['hidden'] ) ) {
+					$field_hidden = (bool) $locale[ $address_country ][ $field_base ]['hidden'];
 				}
 			}
 			if ( ! empty( $field['required'] ) && ! $field_hidden && empty( $value ) ) {

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -131,7 +131,7 @@ class WC_Form_Handler {
 			$value = apply_filters( 'woocommerce_process_myaccount_field_' . $key, $value );
 
 			// Validation: Required fields.
-			if ( ! empty( $field['required'] ) && empty( $value ) ) {
+			if ( ! empty( $field['required'] ) && empty( $field['hidden'] ) && empty( $value ) ) {
 				/* translators: %s: Field name. */
 				wc_add_notice( sprintf( __( '%s is a required field.', 'woocommerce' ), $field['label'] ), 'error', array( 'id' => $key ) );
 			}

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -261,14 +261,13 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	 * @param bool   $expect_error Whether an error is expected.
 	 */
 	public function test_validate_posted_data_skips_required_check_for_hidden_fields( $country, $field_key, $hidden, $expect_error ) {
-		add_filter(
-			'woocommerce_get_country_locale',
-			function ( $locale ) use ( $country, $hidden ) {
-				$locale[ $country ]['state']['required'] = true;
-				$locale[ $country ]['state']['hidden']   = $hidden;
-				return $locale;
-			}
-		);
+		$locale_filter = function ( $locale ) use ( $country, $hidden ) {
+			$locale[ $country ]['state']['required'] = true;
+			$locale[ $country ]['state']['hidden']   = $hidden;
+			return $locale;
+		};
+
+		add_filter( 'woocommerce_get_country_locale', $locale_filter );
 
 		// Force locale re-evaluation.
 		unset( WC()->countries->locale );
@@ -296,7 +295,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			$this->assertEmpty( $errors->get_error_message( $field_key . '_required' ), 'Unexpected required field error for hidden field.' );
 		}
 
-		remove_all_filters( 'woocommerce_get_country_locale' );
+		remove_filter( 'woocommerce_get_country_locale', $locale_filter );
 		unset( WC()->countries->locale );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -250,6 +250,57 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox 'validate_posted_data' skips required validation for fields hidden by country locale.
+	 *
+	 * @testWith ["US", "billing_state", true, false]
+	 *           ["US", "billing_state", false, true]
+	 *
+	 * @param string $country The billing country code.
+	 * @param string $field_key The field key to check for errors.
+	 * @param bool   $hidden Whether the field should be hidden.
+	 * @param bool   $expect_error Whether an error is expected.
+	 */
+	public function test_validate_posted_data_skips_required_check_for_hidden_fields( $country, $field_key, $hidden, $expect_error ) {
+		add_filter(
+			'woocommerce_get_country_locale',
+			function ( $locale ) use ( $country, $hidden ) {
+				$locale[ $country ]['state']['required'] = true;
+				$locale[ $country ]['state']['hidden']   = $hidden;
+				return $locale;
+			}
+		);
+
+		// Force locale re-evaluation.
+		unset( WC()->countries->locale );
+
+		$data = array(
+			'billing_country'           => $country,
+			'shipping_country'          => $country,
+			'ship_to_different_address' => false,
+			'billing_state'             => '',
+			'billing_first_name'        => 'Test',
+			'billing_last_name'         => 'User',
+			'billing_address_1'         => '123 Test St',
+			'billing_city'              => 'Test City',
+			'billing_postcode'          => '12345',
+			'billing_email'             => 'test@example.com',
+		);
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		if ( $expect_error ) {
+			$this->assertNotEmpty( $errors->get_error_message( $field_key . '_required' ), 'Expected required field error but none was found.' );
+		} else {
+			$this->assertEmpty( $errors->get_error_message( $field_key . '_required' ), 'Unexpected required field error for hidden field.' );
+		}
+
+		remove_all_filters( 'woocommerce_get_country_locale' );
+		unset( WC()->countries->locale );
+	}
+
+	/**
 	 * @testdox Checkout page contains login form for guests.
 	 */
 	public function test_checkout_page_contains_login_form_for_guests() {

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -30,6 +30,10 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			public function validate_checkout( &$data, &$errors ) {
 				return parent::validate_checkout( $data, $errors );
 			}
+
+			public function reset_fields(): void {
+				$this->fields = null;
+			}
 		};
 		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
 
@@ -267,10 +271,18 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			return $locale;
 		};
 
-		add_filter( 'woocommerce_get_country_locale', $locale_filter );
+		// Set customer country to ensure get_address_fields() uses correct locale.
+		WC()->customer->set_billing_country( $country );
+		WC()->customer->set_shipping_country( $country );
 
 		// Force locale re-evaluation.
 		unset( WC()->countries->locale );
+
+		add_filter( 'woocommerce_get_country_locale', $locale_filter );
+
+		// Force locale and checkout fields re-evaluation to pick up filter.
+		unset( WC()->countries->locale );
+		$this->sut->reset_fields();
 
 		$data = array(
 			'billing_country'           => $country,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

**Problem:** Classic checkout and My Account address forms validate required fields without checking the `hidden` flag. This causes spurious "required field" errors when a field is both `hidden => true` and `required => true`.

**Root cause (3rd-party-only):** WooCommerce core always pairs `hidden => true` with `required => false` in `class-wc-countries.php` locale definitions — zero of the 42+ countries with `hidden` set trigger this bug from core alone. The conflict can only arise via 3rd party code (plugins, themes, or mu-plugins) using the `woocommerce_get_country_locale` filter to set `hidden => true` while keeping or omitting `required`, e.g.:

```php
// Example: a 3rd party plugin that hides the state field for certain countries
// but doesn't also explicitly set required => false
add_filter( 'woocommerce_get_country_locale', function ( $locale ) {
    $locale['US']['state']['hidden'] = true;
    // 'required' inherits from base field definition (true for state) → conflict
    return $locale;
} );
```

**Fix:** Add `hidden` check to required validation in both `class-wc-checkout.php` and `class-wc-form-handler.php`, aligning with Store API behavior (`OrderController::validate_address_fields`) which already handles this correctly.

Closes #65412.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| "State / County is a required field" error on checkout when state is hidden via a 3rd party filter | Checkout proceeds without error |

### How to test the changes in this Pull Request:

1. Add an mu-plugin (or regular plugin) that creates the `hidden + required` conflict:

```php
<?php
/**
 * Plugin Name: Test Hidden + Required Conflict
 * Description: Sets state field as hidden but required to reproduce the validation bug.
 */
add_filter( 'woocommerce_get_country_locale', function ( $locale ) {
    // Target US as the test country — sets state as hidden without setting required => false
    $locale['US']['state']['hidden'] = true;
    return $locale;
} );
```

2. With the mu-plugin active, go to WooCommerce checkout.
3. Select **US** as billing country. State field should be hidden/not rendered.
4. Leave state empty (it's hidden), fill all other required fields, submit checkout.
5. **Expected (before fix):** "State / County is a required field" error.
6. **Expected (after fix):** No required field error, checkout proceeds.
7. Also test My Account → Edit Billing Address with the same mu-plugin active.
8. **Expected (after fix):** Address saves without validation error.

### Testing that has already taken place:

- PHP lint passed (`lint:php:changes` — no errors)
- Unit test added: `WC_Checkout_Test::test_validate_posted_data_skips_required_check_for_hidden_fields` with `@testWith` variants covering hidden/not-hidden scenarios
- Changelog entry created: `fix-65412-skip-hidden-state-validation`

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

Changelog file: `plugins/woocommerce/changelog/fix-65412-skip-hidden-state-validation`

- Significance: patch
- Type: fix
- Message: Skip required-field validation for address fields that are hidden via the `woocommerce_get_country_locale` filter, preventing spurious "required field" errors on checkout and My Account address forms when a 3rd party plugin sets `hidden => true` without also setting `required => false`.