### PR TITLE
Fix conditional visibility for additional checkout fields across locations

### DIFF
--- a/plugins/woocommerce/changelog/fix-65416-conditional-additional-fields
+++ b/plugins/woocommerce/changelog/fix-65416-conditional-additional-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow additional checkout fields to be referenced from JSON Schema conditional visibility rules across locations (contact, order, address).

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/test/use-schema-parser.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/test/use-schema-parser.tsx
@@ -100,14 +100,19 @@ describe( 'useSchemaParser', () => {
 			},
 		};
 
-		// Mock checkout data
+		// Mock checkout data — includes fields from all locations
 		mockCheckoutData = {
 			prefersCollection: false,
 			shouldCreateAccount: true,
 			orderNotes: 'Please deliver after 6 PM',
 			additionalFields: {
+				// Contact-level field
 				'namespace/contact_field': 'value1',
+				// Order-level field
 				'namespace/order_field': 'value2',
+				// Address-level field (e.g., VAT number shown conditionally)
+				'namespace/vat_number': 'IT123456789',
+				'namespace/customer_type': 'business',
 			},
 			customerId: 123,
 		};
@@ -304,10 +309,11 @@ describe( 'useSchemaParser', () => {
 			expect( checkout ).toHaveProperty( 'payment_method' );
 			expect( checkout.payment_method ).toBe( 'stripe' );
 
+			// All additional fields available for cross-location conditions
 			expect( checkout ).toHaveProperty( 'additional_fields' );
-			expect( checkout.additional_fields ).toEqual( {
-				'namespace/order_field': 'value2',
-			} );
+			expect( checkout.additional_fields ).toEqual(
+				mockCheckoutData.additionalFields
+			);
 		} );
 
 		it( 'should transform customer data correctly', () => {
@@ -337,11 +343,11 @@ describe( 'useSchemaParser', () => {
 			expect( customer ).toHaveProperty( 'address' );
 			expect( customer.address ).toEqual( mockCartData.billingAddress );
 
+			// All additional fields available for cross-location conditions
 			expect( customer ).toHaveProperty( 'additional_fields' );
-			// Additional fields should be filtered to only include contact form keys
-			expect( customer.additional_fields ).toEqual( {
-				'namespace/contact_field': 'value1',
-			} );
+			expect( customer.additional_fields ).toEqual(
+				mockCheckoutData.additionalFields
+			);
 		} );
 	} );
 
@@ -412,23 +418,24 @@ describe( 'useSchemaParser', () => {
 		} );
 	} );
 
-	describe( 'additional fields filtering', () => {
-		it( 'should filter additional fields for contact form keys', () => {
+	describe( 'cross-location additional fields', () => {
+		it( 'should expose all additional fields in customer for billing form type', () => {
 			const { result } = renderHook(
 				( { formType } ) => useSchemaParser( formType ),
 				{
-					initialProps: { formType: 'contact' as FormType },
+					initialProps: { formType: 'billing' as FormType },
 					wrapper,
 				}
 			);
 
 			const { customer } = result.current.data!;
-			expect( customer.additional_fields ).toEqual( {
-				'namespace/contact_field': 'value1',
-			} );
+			// All additional fields available, not filtered by location
+			expect( customer.additional_fields ).toEqual(
+				mockCheckoutData.additionalFields
+			);
 		} );
 
-		it( 'should filter additional fields for order form keys', () => {
+		it( 'should expose all additional fields in checkout for order form type', () => {
 			const { result } = renderHook(
 				( { formType } ) => useSchemaParser( formType ),
 				{
@@ -438,9 +445,26 @@ describe( 'useSchemaParser', () => {
 			);
 
 			const { checkout } = result.current.data!;
-			expect( checkout.additional_fields ).toEqual( {
-				'namespace/order_field': 'value2',
-			} );
+			// All additional fields available, not filtered by location
+			expect( checkout.additional_fields ).toEqual(
+				mockCheckoutData.additionalFields
+			);
+		} );
+
+		it( 'should expose all additional fields in customer for contact form type', () => {
+			const { result } = renderHook(
+				( { formType } ) => useSchemaParser( formType ),
+				{
+					initialProps: { formType: 'contact' as FormType },
+					wrapper,
+				}
+			);
+
+			const { customer } = result.current.data!;
+			// All additional fields available, not filtered by location
+			expect( customer.additional_fields ).toEqual(
+				mockCheckoutData.additionalFields
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/test/use-schema-parser.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/test/use-schema-parser.tsx
@@ -466,5 +466,24 @@ describe( 'useSchemaParser', () => {
 				mockCheckoutData.additionalFields
 			);
 		} );
+
+		it( 'should preserve original key format in additional_fields (snakeCaseKeys is shallow)', () => {
+			const { result } = renderHook(
+				( { formType } ) => useSchemaParser( formType ),
+				{
+					initialProps: { formType: 'billing' as FormType },
+					wrapper,
+				}
+			);
+
+			const { customer } = result.current.data!;
+			// Inner keys preserved as-is (snakeCaseKeys is shallow, only transforms top-level)
+			expect( customer.additional_fields ).toHaveProperty(
+				'namespace/contact_field'
+			);
+			expect( customer.additional_fields ).toHaveProperty(
+				'namespace/vat_number'
+			);
+		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-schema-parser.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-schema-parser.ts
@@ -5,15 +5,9 @@ import { useRef, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { snakeCaseKeys } from '@woocommerce/base-utils';
 import type {
-	OrderFormValues,
 	AddressFormValues,
 	FormType,
-	ContactFormValues,
 } from '@woocommerce/settings';
-import {
-	ORDER_FORM_KEYS,
-	CONTACT_FORM_KEYS,
-} from '@woocommerce/block-settings';
 import fastDeepEqual from 'fast-deep-equal/es6';
 import {
 	cartStore,
@@ -106,38 +100,14 @@ const useDocumentObject = < T extends FormType | 'global' >(
 			checkout: {
 				createAccount: shouldCreateAccount,
 				customerNote: orderNotes,
-				additionalFields: Object.entries( additionalFields ).reduce(
-					( acc, [ key, value ] ) => {
-						if (
-							ORDER_FORM_KEYS.includes(
-								key as keyof OrderFormValues
-							)
-						) {
-							acc[ key as keyof OrderFormValues ] = value;
-						}
-						return acc;
-					},
-					{} as OrderFormValues
-				),
+				additionalFields: additionalFields,
 				paymentMethod: activePaymentMethod,
 			},
 			customer: {
 				id: customerId,
 				billingAddress,
 				shippingAddress,
-				additionalFields: Object.entries( additionalFields ).reduce(
-					( acc, [ key, value ] ) => {
-						if (
-							CONTACT_FORM_KEYS.includes(
-								key as keyof ContactFormValues
-							)
-						) {
-							acc[ key as keyof ContactFormValues ] = value;
-						}
-						return acc;
-					},
-					{} as ContactFormValues
-				),
+				additionalFields: additionalFields,
 				...( formType === 'billing' || formType === 'shipping'
 					? {
 							address:
@@ -223,7 +193,7 @@ export interface DocumentObject< T extends FormType | 'global' > {
 				create_account: boolean;
 				customer_note: string;
 				payment_method: string;
-				additional_fields: OrderFormValues;
+				additional_fields: Record< string, string | boolean >;
 		  }
 		| Record< string, never >;
 	customer:
@@ -231,7 +201,7 @@ export interface DocumentObject< T extends FormType | 'global' > {
 				id: number;
 				billing_address: AddressFormValues;
 				shipping_address: AddressFormValues;
-				additional_fields: ContactFormValues;
+				additional_fields: Record< string, string | boolean >;
 				address: T extends 'billing'
 					? AddressFormValues
 					: T extends 'shipping'


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `useSchemaParser` hook in the block-based checkout previously filtered additional fields by registration location when building the `DocumentObject` used by the JSON Schema conditional visibility system. Address-level fields were excluded from the document, so conditions on them (e.g. "show VAT field when customer type is business") could not be evaluated in contact/order blocks.

This PR removes the location-based filter and exposes the full `additionalFields` object in both the `checkout` and `customer` branches of the `DocumentObject`. The `DocumentObject` interface is updated to use `Record<string, string | boolean>` so it can hold fields from any location.

Closes #65416

### Screenshots or screen recordings:

CLI/no UI change — behavior is exercised by JSON Schema conditional rules on additional fields; no visual diff.

| Before | After |
| ------ | ----- |
| Address-level additional fields (`location: 'address'`) excluded from `DocumentObject.additional_fields` in checkout and customer contexts. | All additional fields exposed in both `checkout.additional_fields` and `customer.additional_fields`, regardless of registration location. |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add the following PHP snippet to a must-use plugin or your active theme's `functions.php`:

   ```php
   add_action( 'woocommerce_blocks_loaded', function () {
       if ( ! function_exists( 'woocommerce_register_additional_checkout_field' ) ) {
           return;
       }
       woocommerce_register_additional_checkout_field( array(
           'id'       => 'namespace/customer-type',
           'label'    => 'Customer Type',
           'location' => 'address',
           'type'     => 'select',
           'options'  => array(
               array( 'value' => 'private',  'label' => 'Private' ),
               array( 'value' => 'business', 'label' => 'Business' ),
           ),
       ) );
       woocommerce_register_additional_checkout_field( array(
           'id'       => 'namespace/vat-number',
           'label'    => 'VAT Number',
           'location' => 'address',
           'type'     => 'text',
           'required' => false,
           'hidden'   => array(
               'customer' => array(
                   'additional_fields' => array(
                       'namespace/customer-type' => array(
                           'not' => array( 'eq' => 'business' ),
                       ),
                   ),
               ),
           ),
       ) );
   } );
   ```

2. With the block-based checkout active, add any product to the cart and open `/checkout`.
3. Verify the "VAT Number" field is **hidden** by default in the address block.
4. Select **Business** in the "Customer Type" field — verify "VAT Number" **appears**.
5. Select **Private** — verify "VAT Number" **hides again**.
6. Repeat with `location: 'contact'` for the controlling field and `location: 'address'` for the conditional field to confirm the cross-location case works in both directions.
7. Run the existing test suite to confirm no regression:
   ```bash
   pnpm --filter=@woocommerce/block-library test:js -- --testPathPattern="use-schema-parser"
   ```
   All tests (including the new `cross-location additional fields` describe block) should pass.

### Testing that has already taken place:

- Unit tests in `plugins/woocommerce/client/blocks/assets/js/base/hooks/test/use-schema-parser.tsx` were extended with 4 new test cases covering billing/order/contact form types and shallow `snakeCaseKeys` key-format preservation. All 14 tests pass against `checkout-document-schema.json` via AJV.
- CodeRabbit review passed with no actionable issues on the PR's changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs created from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Allow additional checkout fields to be referenced from JSON Schema conditional visibility rules across locations (contact, order, address).

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

No release communication required — this restores existing conditional visibility behavior, not a new user-facing feature or breaking API change.