### PR TITLE
Fix SKU duplication corrupting hyphenated SKUs

### DIFF
--- a/plugins/woocommerce/changelog/fix-65378-sku-duplication-hyphen
+++ b/plugins/woocommerce/changelog/fix-65378-sku-duplication-hyphen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix SKU duplication corrupting hyphenated SKUs. Duplicating a product with SKU `SKU-123` now correctly produces `SKU-123-1` instead of `SKU-124`.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
@@ -364,7 +364,7 @@ class WC_Admin_Duplicate_Product {
 		$prefix_len = strlen( $original_sku ) + 1;
 		foreach ( $existing_skus as $existing_sku ) {
 			// Check if the SKU starts with our base and has a numeric suffix.
-			if ( strpos( $existing_sku, $original_sku . '-' ) === 0 ) {
+			if ( stripos( $existing_sku, $original_sku . '-' ) === 0 ) {
 				$suffix_str = substr( $existing_sku, $prefix_len );
 				// Only consider pure numeric suffixes.
 				if ( is_numeric( $suffix_str ) ) {
@@ -414,7 +414,7 @@ class WC_Admin_Duplicate_Product {
 		}
 
 		// Fallback: use the standard unique SKU generator which loops until it finds a unique value.
-		$product->set_sku( wc_product_generate_unique_sku( $product_id, $original_sku, 1 ) );
+		$product->set_sku( wc_product_generate_unique_sku( $product_id, $original_sku, $max_suffix + 1 ) );
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
@@ -326,7 +326,7 @@ class WC_Admin_Duplicate_Product {
 		$original_sku = $product->get_sku();
 
 		// If the product has no SKU, don't do anything.
-		if ( ! $original_sku ) {
+		if ( '' === $original_sku ) {
 			return;
 		}
 
@@ -344,7 +344,8 @@ class WC_Admin_Duplicate_Product {
 
 		// Find the maximum suffix.
 		$max_suffix = 0;
-		$prefix_len = strlen( $original_sku ) + 1; // +1 for the hyphen
+		// +1 for the hyphen separator between original SKU and suffix.
+		$prefix_len = strlen( $original_sku ) + 1;
 		foreach ( $existing_skus as $existing_sku ) {
 			// Check if the SKU starts with our base and has a numeric suffix.
 			if ( strpos( $existing_sku, $original_sku . '-' ) === 0 ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
@@ -330,6 +330,22 @@ class WC_Admin_Duplicate_Product {
 			return;
 		}
 
+		// If the source SKU is not used by any saved product, use it as-is.
+		// This preserves backward compatibility with the REST API duplicate endpoint,
+		// which lets callers set a custom SKU on the duplicate and expects that SKU
+		// to be applied directly when it is unique.
+		$source_sku_in_use = (bool) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->wc_product_meta_lookup} WHERE sku = %s",
+				$original_sku
+			)
+		);
+
+		if ( ! $source_sku_in_use ) {
+			$product->set_sku( $original_sku );
+			return;
+		}
+
 		// Query existing SKUs that match the pattern: original SKU + hyphen + number.
 		$existing_skus = $wpdb->get_col(
 			$wpdb->prepare(

--- a/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
@@ -396,8 +396,8 @@ class WC_Admin_Duplicate_Product {
 			}
 		}
 
-		// Fallback: just append -1 to original SKU if all else fails.
-		$product->set_sku( $original_sku . '-1' );
+		// Fallback: use the standard unique SKU generator which loops until it finds a unique value.
+		$product->set_sku( wc_product_generate_unique_sku( $product_id, $original_sku, 1 ) );
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
@@ -310,6 +310,10 @@ class WC_Admin_Duplicate_Product {
 	/**
 	 * Generates a unique sku for a given product.
 	 *
+	 * Appends a numeric suffix to the original SKU. For example, if the original SKU
+	 * is "SKU-123", the duplicate will get "SKU-123-1". This preserves hyphens in the
+	 * original SKU rather than treating them as suffix delimiters.
+	 *
 	 * @param WC_Product $product The product to generate a sku for.
 	 * @return void
 	 * @since 10.5.0
@@ -319,16 +323,14 @@ class WC_Admin_Duplicate_Product {
 	private function generate_unique_sku( $product ) {
 		global $wpdb;
 
-		// We want to remove the suffix from the sku so that we can find the maximum suffix using this root sku.
-		// This will allow us to find the next-highest suffix that is unique. While this does not support gap
-		// filling, this shouldn't matter for our use-case.
-		$root_sku = preg_replace( '/-[0-9]+$/', '', $product->get_sku() );
+		$original_sku = $product->get_sku();
 
-		// If the parent product has no SKU, don't do anything.
-		if ( ! $root_sku ) {
+		// If the product has no SKU, don't do anything.
+		if ( ! $original_sku ) {
 			return;
 		}
 
+		// Query existing SKUs that match the pattern: original SKU + hyphen + number.
 		$existing_skus = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT lookup.sku
@@ -336,33 +338,45 @@ class WC_Admin_Duplicate_Product {
 					INNER JOIN {$wpdb->wc_product_meta_lookup} AS lookup ON posts.ID = lookup.product_id
 					WHERE posts.post_type IN ( 'product', 'product_variation' )
 					AND lookup.sku LIKE %s",
-				$wpdb->esc_like( $root_sku ) . '%'
+				$wpdb->esc_like( $original_sku ) . '-%'
 			)
 		);
 
-		// The sku is already unique!
-		if ( empty( $existing_skus ) ) {
-			$product->set_sku( $root_sku );
-			return;
-		}
-
-		// Find the maximum suffix so we can ensure uniqueness.
+		// Find the maximum suffix.
 		$max_suffix = 0;
+		$prefix_len = strlen( $original_sku ) + 1; // +1 for the hyphen
 		foreach ( $existing_skus as $existing_sku ) {
-			// Pull a numerical suffix off the sku after the last hyphen.
-			$suffix = intval( substr( $existing_sku, strrpos( $existing_sku, '-', -1 ) + 1 ) );
-			if ( $suffix > $max_suffix ) {
-				$max_suffix = $suffix;
+			// Check if the SKU starts with our base and has a numeric suffix.
+			if ( strpos( $existing_sku, $original_sku . '-' ) === 0 ) {
+				$suffix_str = substr( $existing_sku, $prefix_len );
+				// Only consider pure numeric suffixes.
+				if ( is_numeric( $suffix_str ) ) {
+					$suffix = intval( $suffix_str );
+					if ( $suffix > $max_suffix ) {
+						$max_suffix = $suffix;
+					}
+				}
 			}
 		}
 
-		// We set a limit of SKUs to try in order to avoid infinite loops.
-		$limit      = $max_suffix + 100;
+		// Set the new SKU with the next available suffix.
+		$new_sku    = $original_sku . '-' . ( $max_suffix + 1 );
 		$product_id = $product->get_id();
 
-		while ( $max_suffix < $limit ) {
-			$new_sku = $root_sku . '-' . ( $max_suffix + 1 );
+		/**
+		 * Gives plugins an opportunity to verify SKU uniqueness themselves. Filter added to keep backwards
+		 * compatibility with `wc_product_has_unique_sku()`.
+		 * See: https://github.com/woocommerce/woocommerce/pull/62628
+		 *
+		 * @since 10.5.0
+		 *
+		 * @param bool|null $has_unique_sku Set to a boolean value to short-circuit the default SKU check.
+		 * @param int       $product_id     The ID of the current product.
+		 * @param string    $sku            The SKU to check for uniqueness.
+		 */
+		$pre_has_unique_sku = apply_filters( 'wc_product_pre_has_unique_sku', true, $product_id, $new_sku );
 
+		if ( $pre_has_unique_sku ) {
 			/**
 			 * Gives plugins an opportunity to verify SKU uniqueness themselves. Filter added to keep backwards
 			 * compatibility with `wc_product_has_unique_sku()`.
@@ -370,33 +384,20 @@ class WC_Admin_Duplicate_Product {
 			 *
 			 * @since 10.5.0
 			 *
-			 * @param bool|null $has_unique_sku Set to a boolean value to short-circuit the default SKU check.
-			 * @param int $product_id The ID of the current product.
-			 * @param string $sku The SKU to check for uniqueness.
+			 * @param bool|null $sku_found Set to a boolean value to short-circuit the default SKU check.
+			 * @param int       $product_id The ID of the current product.
+			 * @param string    $sku       The SKU to check for uniqueness.
 			 */
-			$pre_has_unique_sku = apply_filters( 'wc_product_pre_has_unique_sku', true, $product_id, $new_sku );
+			$sku_found = apply_filters( 'wc_product_has_unique_sku', false, $product_id, $new_sku );
 
-			if ( $pre_has_unique_sku ) {
-				/**
-				 * Gives plugins an opportunity to verify SKU uniqueness themselves. Filter added to keep backwards
-				 * compatibility with `wc_product_has_unique_sku()`.
-				 * See: https://github.com/woocommerce/woocommerce/pull/62628
-				 *
-				 * @since 10.5.0
-				 *
-				 * @param bool|null $sku_found Set to a boolean value to short-circuit the default SKU check.
-				 * @param int $product_id The ID of the current product.
-				 * @param string $sku The SKU to check for uniqueness.
-				 */
-				$sku_found = apply_filters( 'wc_product_has_unique_sku', false, $product_id, $new_sku );
-
-				if ( ! $sku_found ) {
-					$product->set_sku( $new_sku );
-					return;
-				}
+			if ( ! $sku_found ) {
+				$product->set_sku( $new_sku );
+				return;
 			}
-			++$max_suffix;
 		}
+
+		// Fallback: just append -1 to original SKU if all else fails.
+		$product->set_sku( $original_sku . '-1' );
 	}
 }
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-duplicate-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-duplicate-product-test.php
@@ -156,4 +156,28 @@ class WC_Admin_Duplicate_Product_Test extends WC_Unit_Test_Case {
 		$dup_c = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product4 );
 		$this->assertEquals( 'SEQ-100-3', $dup_c->get_sku() );
 	}
+
+	/**
+	 * Tests that case-insensitive SKU matching prevents collisions.
+	 *
+	 * MySQL LIKE is case-insensitive by default, so 'SKU-%' matches 'sku-1'.
+	 * The prefix check must use stripos() to match SQL behavior.
+	 */
+	public function test_duplicate_product_handles_case_insensitive_sku_conflict() {
+		// Create product with uppercase SKU.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'SKU' );
+		$product->save();
+
+		// Create a different product with lowercase variant + suffix.
+		$other = WC_Helper_Product::create_simple_product();
+		$other->set_sku( 'sku-1' );
+		$other->save();
+
+		// Duplicate the uppercase product.
+		// SQL LIKE 'SKU-%' returns 'sku-1', so max_suffix should be 1.
+		// Expected: 'SKU-2', not 'SKU-1' (which collides with 'sku-1').
+		$duplicate = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product );
+		$this->assertEquals( 'SKU-2', $duplicate->get_sku(), 'Duplicate must not collide with case-variant sku-1' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-duplicate-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-duplicate-product-test.php
@@ -110,4 +110,50 @@ class WC_Admin_Duplicate_Product_Test extends WC_Unit_Test_Case {
 
 		remove_filter( 'wc_product_has_unique_sku', array( $this, 'dont_allow_skus_with_numbers_lower_than_8' ) );
 	}
+
+	/**
+	 * Tests that duplicating a product with hyphens in the SKU correctly appends the suffix.
+	 *
+	 * For SKUs like "SKU-123", the duplicate should get "SKU-123-1", not "SKU-124".
+	 * This tests the fix for issue #65378.
+	 */
+	public function test_duplicate_product_with_hyphenated_sku_preserves_original() {
+		// Test case 1: Simple hyphen with number.
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_sku( 'SKU-123' );
+		$product1->save();
+
+		$duplicate1 = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product1 );
+		$this->assertEquals( 'SKU-123-1', $duplicate1->get_sku(), 'Duplicate of SKU-123 should be SKU-123-1' );
+
+		// Test case 2: Multiple hyphens.
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_sku( 'my-product-456' );
+		$product2->save();
+
+		$duplicate2 = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product2 );
+		$this->assertEquals( 'my-product-456-1', $duplicate2->get_sku(), 'Duplicate of my-product-456 should be my-product-456-1' );
+
+		// Test case 3: Non-numeric suffix (should still work).
+		$product3 = WC_Helper_Product::create_simple_product();
+		$product3->set_sku( 'PROD-A' );
+		$product3->save();
+
+		$duplicate3 = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product3 );
+		$this->assertEquals( 'PROD-A-1', $duplicate3->get_sku(), 'Duplicate of PROD-A should be PROD-A-1' );
+
+		// Test case 4: Sequential duplicates.
+		$product4 = WC_Helper_Product::create_simple_product();
+		$product4->set_sku( 'SEQ-100' );
+		$product4->save();
+
+		$dup_a = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product4 );
+		$this->assertEquals( 'SEQ-100-1', $dup_a->get_sku() );
+
+		$dup_b = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product4 );
+		$this->assertEquals( 'SEQ-100-2', $dup_b->get_sku() );
+
+		$dup_c = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product4 );
+		$this->assertEquals( 'SEQ-100-3', $dup_c->get_sku() );
+	}
 }


### PR DESCRIPTION
## Summary

Fix SKU duplication logic that incorrectly strips numeric segments from hyphenated SKUs. When duplicating a product with SKU `SKU-123`, the code treated `123` as an incrementable suffix, producing `SKU-124` instead of `SKU-123-1`.

Closes #65378
(For Bug Fixes) Bug introduced in PR #62628

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

## Changes

### `includes/admin/class-wc-admin-duplicate-product.php`

**Before:**
```php
$root_sku = preg_replace( '/-[0-9]+$/', '', $product->get_sku() );
// Query: LIKE $root_sku + '%'
// Then: $root_sku . '-' . ($max_suffix + 1)
```

**After:**
```php
$original_sku = $product->get_sku();
// Query: LIKE $original_sku + '-%'
// Then: $original_sku . '-' . ($max_suffix + 1)
```

**Why:** Preserves full original SKU, appends numeric suffix. No more splitting on hyphens within the original value. Fallback uses `wc_product_generate_unique_sku()` so the `wc_product_pre_has_unique_sku` / `wc_product_has_unique_sku` filters still apply.

### `tests/php/includes/admin/class-wc-admin-duplicate-product-test.php`

**Added:** `test_duplicate_product_with_hyphenated_sku_preserves_original`

Covers: simple hyphenated SKU, multiple hyphens, non-numeric suffix, sequential duplicates.

**Added:** `test_duplicate_product_handles_case_insensitive_sku_conflict`

Covers: case-insensitive SKU matching to prevent collisions when SQL LIKE returns case-variant rows.

## Testing

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

**Test 1: Hyphenated SKU duplication**
1. Create product with SKU `SKU-123`
2. Duplicate the product
3. Expected duplicate SKU: `SKU-123-1`

**Test 2: Sequential duplicates**
1. Create product with SKU `cap`
2. Duplicate twice
3. Expected: `cap-1`, `cap-2`

**Test 3: Existing trashed SKU test**
- Original test `test_duplicate_product_skips_trashed_products_with_indexed_sku` still passes

**Test 4: Case-insensitive SKU conflict**
1. Create product with SKU `SKU`
2. Create another product with SKU `sku-1`
3. Duplicate the first product
4. Expected: `SKU-2` (not `SKU-1` which collides with `sku-1`)

**Result:** All cases work as expected

### Screenshot

<img width="603" height="279" alt="image" src="https://github.com/user-attachments/assets/b32c35c2-83ce-49ad-b13a-62f91f140851"/>

### Testing that has already taken place:

- Local PHPUnit: `WC_Admin_Duplicate_Product_Test` — 4 tests, all pass
- `WC_REST_Products_Controller_Tests` (V3): 73 tests, 4 pre-existing meta-param failures (also fail on trunk)
- `ProductsControllerTest` (V4): 93 tests, 727 assertions — all pass
- PHPCS: clean on changed file
- PHPStan: 0 errors on production file
- CodeRabbit CLI: 0 findings
- Environment: macOS, Docker Desktop, wp-env, PHP 8.1, MySQL 8.0

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog Entry Details

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message 

Fix SKU duplication corrupting hyphenated SKUs. Duplicating a product with SKU `SKU-123` now correctly produces `SKU-123-1` instead of `SKU-124`.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes