### PR TITLE
security: add allowed_classes => false to unserialize() in LookupDataStore

### DIFF
--- a/plugins/woocommerce/changelog/65426-security-unserialize-allowed-classes
+++ b/plugins/woocommerce/changelog/65426-security-unserialize-allowed-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Security hardening: pass allowed_classes => false to unserialize() in LookupDataStore to prevent PHP Object Injection via crafted cached data.

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -923,7 +923,7 @@ class LookupDataStore {
 		}
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
-		$temp = unserialize( $temp );
+		$temp = unserialize( $temp, array( 'allowed_classes' => false ) );
 		if ( false === $temp ) {
 			throw new \WC_Data_Exception( 0, 'The product attributes metadata row is not properly serialized' );
 		}


### PR DESCRIPTION
## Description

This PR passes `allowed_classes => false` to the `unserialize()` call in `LookupDataStore` to harden against PHP Object Injection attacks.

The cached value being unserialized holds plain array/scalar data (product attribute values), not class instances, so restricting deserialization to no classes is safe and correct.

## Changes

- `LookupDataStore.php`: add `['allowed_classes' => false]` to `unserialize()`

## Testing instructions

### Manual testing

1. Set up a WooCommerce store with products that have attributes (e.g. size, colour).
2. Ensure the product attributes lookup table is populated (`wp_wc_product_attributes_lookup`).
3. Navigate to a shop/category page that uses attribute filtering.
4. Verify that attribute filters appear and work correctly (no errors, no broken filters).
5. Add a product to cart and verify checkout works normally.

### Automated testing

No new tests added (this is a one-line defensive hardening change with no behaviour change for valid data). The existing `LookupDataStoreTest` suite covers the affected code paths.