### PR TITLE
Fix non-visual attribute term responses

### DIFF
--- a/docs/apis/store-api/resources-endpoints/product-attribute-terms.md
+++ b/docs/apis/store-api/resources-endpoints/product-attribute-terms.md
@@ -5,15 +5,16 @@ GET /products/attributes/:id/terms
 GET /products/attributes/:id/terms?orderby=slug
 ```
 
-| Attribute | Type    | Required | Description                                                                                                   |
-| :-------- | :------ | :------: |:--------------------------------------------------------------------------------------------------------------|
-| `id`      | integer |   Yes    | The ID of the attribute to retrieve terms for.                                                                |
-| `order`   | string  |    no    | Order ascending or descending. Allowed values: `asc`, `desc`                                                  |
-| `orderby` | string  |    no    | Sort collection by object attribute. Allowed values: `id`, `name`, `name_num`, `slug`, `count`, `menu_order`. |
+| Attribute               | Type    | Required | Description                                                                                                   |
+| :---------------------- | :------ | :------: | :------------------------------------------------------------------------------------------------------------ |
+| `id`                    | integer |   Yes    | The ID of the attribute to retrieve terms for.                                                                |
+| `order`                 | string  |    no    | Order ascending or descending. Allowed values: `asc`, `desc`                                                  |
+| `orderby`               | string  |    no    | Sort collection by object attribute. Allowed values: `id`, `name`, `name_num`, `slug`, `count`, `menu_order`. |
+| `__experimental_visual` | boolean |    no    | If true, include experimental visual swatch data for `wc-visual` attribute terms.                             |
 
 ## Visual response fields
 
-The following fields are included only for `wc-visual` attribute terms.
+The following fields are included only when `__experimental_visual=true` is passed for `wc-visual` attribute terms.
 Other attribute types keep the default term response without `__experimentalVisual`.
 
 | Attribute                    | Type   | Description                                                                                                    |
@@ -23,7 +24,7 @@ Other attribute types keep the default term response without `__experimentalVisu
 | `__experimentalVisual.value` | string | Visual swatch value. Returns a hex color for `color`, an image URL for `image`, or an empty string for `none`. |
 
 ```sh
-curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"
+curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms?__experimental_visual=true"
 ```
 
 **Example response for visual attribute terms:**

--- a/docs/apis/store-api/resources-endpoints/product-attribute-terms.md
+++ b/docs/apis/store-api/resources-endpoints/product-attribute-terms.md
@@ -56,3 +56,18 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"
 	}
 ]
 ```
+
+**Example response for non-visual attribute terms:**
+
+```json
+[
+	{
+		"id": 12,
+		"name": "Large",
+		"slug": "large",
+		"description": "",
+		"parent": 0,
+		"count": 7
+	}
+]
+```

--- a/docs/apis/store-api/resources-endpoints/product-attribute-terms.md
+++ b/docs/apis/store-api/resources-endpoints/product-attribute-terms.md
@@ -11,11 +11,22 @@ GET /products/attributes/:id/terms?orderby=slug
 | `order`   | string  |    no    | Order ascending or descending. Allowed values: `asc`, `desc`                                                  |
 | `orderby` | string  |    no    | Sort collection by object attribute. Allowed values: `id`, `name`, `name_num`, `slug`, `count`, `menu_order`. |
 
+## Visual response fields
+
+The following fields are included only for `wc-visual` attribute terms.
+Other attribute types keep the default term response without `__experimentalVisual`.
+
+| Attribute                    | Type   | Description                                                                                                    |
+| :--------------------------- | :----- | :------------------------------------------------------------------------------------------------------------- |
+| `__experimentalVisual`       | object | Experimental visual swatch data for `wc-visual` attribute terms.                                               |
+| `__experimentalVisual.type`  | string | Visual swatch type. Allowed values: `color`, `image`, `none`.                                                  |
+| `__experimentalVisual.value` | string | Visual swatch value. Returns a hex color for `color`, an image URL for `image`, or an empty string for `none`. |
+
 ```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"
 ```
 
-**Example response:**
+**Example response for visual attribute terms:**
 
 ```json
 [
@@ -23,13 +34,25 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"
 		"id": 22,
 		"name": "Blue",
 		"slug": "blue",
-		"count": 5
+		"description": "",
+		"parent": 0,
+		"count": 5,
+		"__experimentalVisual": {
+			"type": "color",
+			"value": "#1e73be"
+		}
 	},
 	{
 		"id": 48,
 		"name": "Burgundy",
 		"slug": "burgundy",
-		"count": 1
+		"description": "",
+		"parent": 0,
+		"count": 1,
+		"__experimentalVisual": {
+			"type": "image",
+			"value": "https://example-store.com/wp-content/uploads/2026/06/burgundy-swatch.jpg"
+		}
 	}
 ]
 ```

--- a/plugins/woocommerce/changelog/fix-nonvisual-attribute-term-response
+++ b/plugins/woocommerce/changelog/fix-nonvisual-attribute-term-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve existing Store API responses for non-visual attribute terms.

--- a/plugins/woocommerce/changelog/fix-nonvisual-attribute-term-response
+++ b/plugins/woocommerce/changelog/fix-nonvisual-attribute-term-response
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Preserve existing Store API responses for non-visual attribute terms.
+Keep Store API visual attribute term data opt-in with `__experimental_visual`.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -96,7 +96,11 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 		resourceName: 'products/attributes/terms',
 		resourceValues: [ attribute?.id || 0 ],
 		shouldSelect: !! attribute?.id && termIds.length > 0,
-		query: { include: termIds, hide_empty: false, __experimental_visual: true },
+		query: {
+			include: termIds,
+			hide_empty: false,
+			__experimental_visual: true,
+		},
 	} );
 	const visualByTermId = useMemo( () => {
 		return attributeTerms.reduce< Record< number, VisualAttributeTerm > >(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -96,7 +96,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 		resourceName: 'products/attributes/terms',
 		resourceValues: [ attribute?.id || 0 ],
 		shouldSelect: !! attribute?.id && termIds.length > 0,
-		query: { include: termIds, hide_empty: false },
+		query: { include: termIds, hide_empty: false, __experimental_visual: true },
 	} );
 	const visualByTermId = useMemo( () => {
 		return attributeTerms.reduce< Record< number, VisualAttributeTerm > >(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -65,7 +65,11 @@ const Edit = ( props: EditProps ) => {
 			resourceName: 'products/attributes/terms',
 			resourceValues: [ attributeObject?.id || 0 ],
 			shouldSelect: !! attributeObject?.id,
-			query: { orderby: 'menu_order', hide_empty: hideEmpty },
+			query: {
+				orderby: 'menu_order',
+				hide_empty: hideEmpty,
+				__experimental_visual: true,
+			},
 		} );
 
 	const { data: filteredCounts, isLoading: isFilterCountsLoading } =

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\ProductAttributeTermSchema;
 
@@ -74,7 +75,46 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 		$params['orderby']['enum'][] = 'menu_order';
 		$params['orderby']['enum'][] = 'name_num';
 		$params['orderby']['enum'][] = 'id';
+		$params['__experimental_visual'] = array(
+			'description'       => __( 'If true, include experimental visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'default'           => false,
+			'sanitize_callback' => 'wc_string_to_bool',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 		return $params;
+	}
+
+	/**
+	 * Prepare a single item for response.
+	 *
+	 * @param mixed            $item Item to format to schema.
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @return \WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, \WP_REST_Request $request ) {
+		$response = parent::prepare_item_for_response( $item, $request );
+
+		if (
+			! wc_string_to_bool( $request['__experimental_visual'] ) ||
+			! ( $item instanceof \WP_Term ) ||
+			! VisualAttributeTermMeta::is_visual_attribute_taxonomy( $item->taxonomy )
+		) {
+			return $response;
+		}
+
+		$data = $response->get_data();
+
+		$data[ ProductAttributeTermSchema::VISUAL_PROPERTY_NAME ] = VisualAttributeTermMeta::get_term_visual(
+			(int) $item->term_id
+		);
+
+		$response->set_data( $data );
+
+		return $response;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -71,10 +71,10 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                      = parent::get_collection_params();
-		$params['orderby']['enum'][] = 'menu_order';
-		$params['orderby']['enum'][] = 'name_num';
-		$params['orderby']['enum'][] = 'id';
+		$params                          = parent::get_collection_params();
+		$params['orderby']['enum'][]     = 'menu_order';
+		$params['orderby']['enum'][]     = 'name_num';
+		$params['orderby']['enum'][]     = 'id';
 		$params['__experimental_visual'] = array(
 			'description'       => __( 'If true, include experimental visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
 			'type'              => 'boolean',

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductAttributeTermSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductAttributeTermSchema.php
@@ -52,9 +52,9 @@ class ProductAttributeTermSchema extends TermSchema {
 	public function get_item_response( $term ) {
 		$response = parent::get_item_response( $term );
 
-		$response[ self::VISUAL_PROPERTY_NAME ] = VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy )
-			? VisualAttributeTermMeta::get_term_visual( (int) $term->term_id )
-			: null;
+		if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
+			$response[ self::VISUAL_PROPERTY_NAME ] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
+		}
 
 		return $response;
 	}
@@ -67,7 +67,7 @@ class ProductAttributeTermSchema extends TermSchema {
 	private function get_visual_property_schema(): array {
 		return array(
 			'description' => __( 'Experimental visual swatch data for wc-visual attribute terms.', 'woocommerce' ),
-			'type'        => array( 'object', 'null' ),
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
 			'properties'  => array(

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductAttributeTermSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductAttributeTermSchema.php
@@ -44,22 +44,6 @@ class ProductAttributeTermSchema extends TermSchema {
 	}
 
 	/**
-	 * Convert a product attribute term object into an object suitable for the response.
-	 *
-	 * @param \WP_Term $term Term object.
-	 * @return array
-	 */
-	public function get_item_response( $term ) {
-		$response = parent::get_item_response( $term );
-
-		if ( VisualAttributeTermMeta::is_visual_attribute_taxonomy( $term->taxonomy ) ) {
-			$response[ self::VISUAL_PROPERTY_NAME ] = VisualAttributeTermMeta::get_term_visual( (int) $term->term_id );
-		}
-
-		return $response;
-	}
-
-	/**
 	 * Get the visual data property schema.
 	 *
 	 * @return array

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
@@ -81,6 +81,7 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$this->assertArrayHasKey( 'slug', $data[0] );
 		$this->assertArrayHasKey( 'description', $data[0] );
 		$this->assertArrayHasKey( 'count', $data[0] );
+		$this->assertArrayNotHasKey( '__experimentalVisual', $data[0] );
 	}
 
 	/**
@@ -111,6 +112,7 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$this->assertArrayHasKey( 'order', $params );
 		$this->assertArrayHasKey( 'orderby', $params );
 		$this->assertArrayHasKey( 'hide_empty', $params );
+		$this->assertArrayHasKey( '__experimental_visual', $params );
 	}
 
 	/**
@@ -120,7 +122,9 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$routes     = new \Automattic\WooCommerce\StoreApi\RoutesController( new \Automattic\WooCommerce\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-attribute-terms' );
 		$schema     = $controller->get_item_schema();
-		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'red', 'pa_color' ), new \WP_REST_Request() );
+		$request    = new \WP_REST_Request();
+		$request->set_param( '__experimental_visual', true );
+		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'red', 'pa_color' ), $request );
 		$data       = $response->get_data();
 		$validate   = new ValidateSchema( $schema );
 
@@ -145,7 +149,10 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$term = get_term_by( 'name', 'red', 'pa_color' );
 		update_term_meta( $term->term_id, 'color', '#00ff00' );
 
-		$response = $controller->prepare_item_for_response( $term, new \WP_REST_Request() );
+		$request = new \WP_REST_Request();
+		$request->set_param( '__experimental_visual', true );
+
+		$response = $controller->prepare_item_for_response( $term, $request );
 		$data     = $response->get_data();
 
 		$validate = new ValidateSchema( $schema );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
@@ -97,6 +97,7 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$this->assertEquals( 'small-slug', $data['slug'] );
 		$this->assertEquals( 'Description of small', $data['description'] );
 		$this->assertEquals( 0, $data['count'] );
+		$this->assertArrayNotHasKey( '__experimentalVisual', $data );
 	}
 
 	/**
@@ -119,12 +120,15 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$routes     = new \Automattic\WooCommerce\StoreApi\RoutesController( new \Automattic\WooCommerce\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-attribute-terms' );
 		$schema     = $controller->get_item_schema();
-		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'small', 'pa_size' ), new \WP_REST_Request() );
+		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'red', 'pa_color' ), new \WP_REST_Request() );
 		$data       = $response->get_data();
 		$validate   = new ValidateSchema( $schema );
 
 		$this->assertArrayHasKey( '__experimentalVisual', $data );
-		$this->assertNull( $data['__experimentalVisual'] );
+		$this->assertSame( 'none', $data['__experimentalVisual']['type'] );
+		$this->assertSame( '', $data['__experimentalVisual']['value'] );
+
+		$data['__experimentalVisual'] = (object) $data['__experimentalVisual'];
 
 		$diff = $validate->get_diff_from_object( $data );
 		$this->assertEmpty( $diff, print_r( $diff, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductAttributeTerms.php
@@ -124,9 +124,9 @@ class ProductAttributeTerms extends ControllerTestCase {
 		$schema     = $controller->get_item_schema();
 		$request    = new \WP_REST_Request();
 		$request->set_param( '__experimental_visual', true );
-		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'red', 'pa_color' ), $request );
-		$data       = $response->get_data();
-		$validate   = new ValidateSchema( $schema );
+		$response = $controller->prepare_item_for_response( get_term_by( 'name', 'red', 'pa_color' ), $request );
+		$data     = $response->get_data();
+		$validate = new ValidateSchema( $schema );
 
 		$this->assertArrayHasKey( '__experimentalVisual', $data );
 		$this->assertSame( 'none', $data['__experimentalVisual']['type'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Store API product attribute terms should preserve the existing response shape for non-visual attributes. This keeps `__experimentalVisual` scoped to `wc-visual` terms, updates tests for that behavior, and documents the visual-only response field.

Bug introduced in PR #65347.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

The easiest way is testing the Product Filters block in the Site Editor:

1. Add an attribute filter block for a regular, non-visual attribute.
2. Confirm the terms request does not include `__experimental_visual=true`.
3. Confirm the terms response does not include `__experimentalVisual`.
4. Add an attribute filter block for a `wc-visual` attribute.
5. Confirm the terms request includes `__experimental_visual=true`.
6. Confirm the terms response includes `__experimentalVisual` with `type` and `value`.

<img width="1537" height="943" alt="image" src="https://github.com/user-attachments/assets/dc9872cb-3643-4ae3-961e-792952011b1e" />

<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Manual changelog added: `plugins/woocommerce/changelog/fix-nonvisual-attribute-term-response`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

