### PR TITLE
Fix notoptions bloat from variable product cache priming

### DIFF
--- a/plugins/woocommerce/changelog/fix-variable-product-notoptions-prime
+++ b/plugins/woocommerce/changelog/fix-variable-product-notoptions-prime
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid priming transient option caches for variable products when a persistent object cache is active, which prevents unbounded growth of the notoptions cache.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -128,16 +128,25 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @since 3.0.0
 	 */
 	protected function read_product_data( &$product ) {
-		// Prime caches to reduce future queries.
-		$product_id = $product->get_id();
-		wp_prime_option_caches(
-			array(
-				'_transient_wc_var_prices_' . $product_id,
-				'_transient_timeout_wc_var_prices_' . $product_id,
-				'_transient_wc_product_children_' . $product_id,
-				'_transient_timeout_wc_product_children_' . $product_id,
-			)
-		);
+		// Only prime the transient option caches when there is no persistent object
+		// cache. When one is active, get_transient() reads these values from the
+		// 'transient' cache group and never from wp_options, so priming the option
+		// names cannot help. Instead each missing name is recorded in core's
+		// 'notoptions' cache, and because the options never exist the entries are
+		// never cleared, so notoptions grows by four per variable product across the
+		// catalog. WC_Order::needs_processing() stopped using transients for the same
+		// reason in 10.8.0.
+		if ( ! wp_using_ext_object_cache() ) {
+			$product_id = $product->get_id();
+			wp_prime_option_caches(
+				array(
+					'_transient_wc_var_prices_' . $product_id,
+					'_transient_timeout_wc_var_prices_' . $product_id,
+					'_transient_wc_product_children_' . $product_id,
+					'_transient_timeout_wc_product_children_' . $product_id,
+				)
+			);
+		}
 
 		parent::read_product_data( $product );
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -783,4 +783,45 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		}
 		$product->delete();
 	}
+
+	/**
+	 * @testdox read_product_data does not record variable product transient names in the notoptions cache when a persistent object cache is in use.
+	 */
+	public function test_read_product_data_does_not_prime_transients_with_object_cache() {
+		$product    = WC_Helper_Product::create_variation_product();
+		$product_id = $product->get_id();
+
+		$option_names = array(
+			'_transient_wc_var_prices_' . $product_id,
+			'_transient_timeout_wc_var_prices_' . $product_id,
+			'_transient_wc_product_children_' . $product_id,
+			'_transient_timeout_wc_product_children_' . $product_id,
+		);
+
+		// Simulate a persistent object cache and start from a clean notoptions cache.
+		$previous = wp_using_ext_object_cache( true );
+		wp_cache_delete( 'notoptions', 'options' );
+
+		// Force a fresh read so read_product_data() runs.
+		$data_store = new WC_Product_Variable_Data_Store_CPT();
+		$fresh      = new WC_Product_Variable();
+		$fresh->set_id( $product_id );
+		$data_store->read( $fresh );
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+
+		// Restore the flag before asserting so a failed assertion cannot leak into other tests.
+		wp_using_ext_object_cache( $previous );
+
+		$notoptions = is_array( $notoptions ) ? $notoptions : array();
+		foreach ( $option_names as $option_name ) {
+			$this->assertArrayNotHasKey(
+				$option_name,
+				$notoptions,
+				'Variable product transient option names must not be added to notoptions when a persistent object cache is active.'
+			);
+		}
+
+		$product->delete();
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -800,18 +800,22 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		// Simulate a persistent object cache and start from a clean notoptions cache.
 		$previous = wp_using_ext_object_cache( true );
-		wp_cache_delete( 'notoptions', 'options' );
 
-		// Force a fresh read so read_product_data() runs.
-		$data_store = new WC_Product_Variable_Data_Store_CPT();
-		$fresh      = new WC_Product_Variable();
-		$fresh->set_id( $product_id );
-		$data_store->read( $fresh );
+		try {
+			wp_cache_delete( 'notoptions', 'options' );
 
-		$notoptions = wp_cache_get( 'notoptions', 'options' );
+			// Force a fresh read so read_product_data() runs.
+			$data_store = new WC_Product_Variable_Data_Store_CPT();
+			$fresh      = new WC_Product_Variable();
+			$fresh->set_id( $product_id );
+			$data_store->read( $fresh );
 
-		// Restore the flag before asserting so a failed assertion cannot leak into other tests.
-		wp_using_ext_object_cache( $previous );
+			$notoptions = wp_cache_get( 'notoptions', 'options' );
+		} finally {
+			// Always restore. Cast to bool because wp_using_ext_object_cache( null ) is a
+			// no-op, which would otherwise leak the simulated true state into later tests.
+			wp_using_ext_object_cache( (bool) $previous );
+		}
 
 		$notoptions = is_array( $notoptions ) ? $notoptions : array();
 		foreach ( $option_names as $option_name ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`WC_Product_Variable_Data_Store_CPT::read_product_data()` calls `wp_prime_option_caches()` with the option names for the `wc_var_prices` and `wc_product_children` transients on every variable product read. On a site with a persistent object cache, those transients are stored in the `transient` cache group rather than as `wp_options` rows, so `get_transient()` never reads them from the options table. The prime cannot find them, and per the behaviour of `wp_prime_option_caches()` each missing name is recorded in core's `notoptions` cache. Because the corresponding options never exist, those entries are never cleared, so the `notoptions` cache grows by four entries per variable product (value and timeout for each of the two transients) across the whole catalog.

On installs that keep the object cache in a sharded backend (for example Redis split across nodes), `notoptions` is a single key on one node that is read on every request. As it grows, its retrieval cost rises and concentrates on that one node.

This is the same `wp_prime_option_caches` with transient names pattern that was removed from `WC_Order::needs_processing()` in 10.8.0. The now deprecated `prime_needs_processing_transients()` is the order side sibling of this code. The variable product data store was not changed at that time.

Worth flagging for future review: the order side instance was the more dangerous shape. It added one `notoptions` entry per order id, so on a high volume store it grew without bound over time rather than being capped by catalog size. This variable product instance is bounded at roughly four times the variable product count, but it is the same root cause. Any other `wp_prime_option_caches()` caller that passes `_transient_*` or `_site_transient_*` names is unsafe under a persistent object cache for the same reason, since those names are never real options in that configuration, and is worth auditing.

The fix guards the prime with `! wp_using_ext_object_cache()`, which is the condition WordPress itself uses in `get_transient()` and `set_transient()` to choose between the options table and the object cache. Sites without a persistent object cache keep the existing query batching. Sites with one no longer pollute `notoptions`.

Closes #65438.

(For Bug Fixes) Bug introduced in PR #64088.

### How to test the changes in this Pull Request:

1. Set up a site with a persistent object cache (for example Redis with a drop-in at `wp-content/object-cache.php`).
2. Record the current notoptions size: `wp eval 'echo count( (array) wp_cache_get( "notoptions", "options" ) );'`
3. Load several distinct variable products: `wp eval 'foreach ( array( A, B, C ) as $id ) { wc_get_product( $id ); }'` using real variable product IDs.
4. Re-run the count from step 2. Before this change it grows by four per distinct variable product, with names `_transient_wc_var_prices_<id>`, `_transient_timeout_wc_var_prices_<id>`, `_transient_wc_product_children_<id>` and `_transient_timeout_wc_product_children_<id>`. After this change it does not grow.
5. On a site with no persistent object cache, confirm the prime still runs and that variation price ranges and child IDs still resolve correctly.

### Testing that has already taken place:

Reproduced on a production store running a sharded Redis object cache. The `notoptions` cache held tens of thousands of `_transient_wc_var_prices_*` and `_transient_wc_product_children_*` entries that do not exist in `wp_options`, at roughly four times the number of variable products in the catalog. A stack trace confirmed the entries originate from `read_product_data()` calling `wp_prime_option_caches()`, and the same names are absent from `wp_options`. With the guard in place the entries stop being written and the count holds at the genuine missing option baseline.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Avoid priming transient option caches for variable products when a persistent object cache is active, which prevents unbounded growth of the notoptions cache.