### PR TITLE
feat(myaccount): EU withdrawal button feature (Issue #65443)

### DIFF
--- a/plugins/woocommerce/changelog/65443-eu-withdrawal-button
+++ b/plugins/woocommerce/changelog/65443-eu-withdrawal-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Comment: Add native support for the EU mandatory right of withdrawal function (Directive 2023/2673). Introduces new My Account endpoints for withdrawal requests, a two-step confirmation flow, customer/admin email notifications, and an admin meta box to manage requests.

--- a/plugins/woocommerce/changelog/65443-fix-eu-withdrawal-bugs
+++ b/plugins/woocommerce/changelog/65443-fix-eu-withdrawal-bugs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix EU withdrawal flow: show acknowledgment after submit, use order number in admin meta box, limit eligibility to completed orders, replace generic order note with proper withdrawal emails (admin + customer), and notify customer when admin approves or rejects a request.

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -123,6 +123,8 @@ class WC_Emails {
 				'woocommerce_new_customer_note',
 				'woocommerce_created_customer',
 				'woocommerce_payment_gateway_enabled',
+				'woocommerce_withdrawal_request_submitted',
+				'woocommerce_withdrawal_request_updated',
 			)
 		);
 
@@ -301,6 +303,7 @@ class WC_Emails {
 			'WC_Email_Admin_Payment_Gateway_Enabled' => __DIR__ . '/emails/class-wc-email-admin-payment-gateway-enabled.php',
 			'WC_Email_Customer_Withdrawal_Request'   => __DIR__ . '/emails/class-wc-email-customer-withdrawal-request.php',
 			'WC_Email_New_Withdrawal_Request'        => __DIR__ . '/emails/class-wc-email-new-withdrawal-request.php',
+			'WC_Email_Customer_Withdrawal_Status'    => __DIR__ . '/emails/class-wc-email-customer-withdrawal-status.php',
 		);
 		if ( FeaturesUtil::feature_is_enabled( 'point_of_sale' ) ) {
 			$emails['WC_Email_Customer_POS_Completed_Order'] = __DIR__ . '/emails/class-wc-email-customer-pos-completed-order.php';

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -181,7 +181,8 @@ class WC_Emails {
 		 * @param array  $args Email args.
 		 */
 		if ( apply_filters( 'woocommerce_allow_send_queued_transactional_email', true, $filter, $args ) ) {
-			self::instance(); // Init self so emails exist.
+			self::instance();
+			// Init self so emails exist.
 
 			// Ensure gateways are loaded in case they need to insert data into the emails.
 			WC()->payment_gateways();
@@ -204,7 +205,8 @@ class WC_Emails {
 	public static function send_transactional_email( $args = array() ) {
 		try {
 			$args = func_get_args();
-			self::instance(); // Init self so emails exist.
+			self::instance();
+			// Init self so emails exist.
 
 			/**
 			 * Action hook for email template classes to trigger the sending of an email.
@@ -297,6 +299,8 @@ class WC_Emails {
 			'WC_Email_Customer_Reset_Password'       => __DIR__ . '/emails/class-wc-email-customer-reset-password.php',
 			'WC_Email_Customer_New_Account'          => __DIR__ . '/emails/class-wc-email-customer-new-account.php',
 			'WC_Email_Admin_Payment_Gateway_Enabled' => __DIR__ . '/emails/class-wc-email-admin-payment-gateway-enabled.php',
+			'WC_Email_Customer_Withdrawal_Request'   => __DIR__ . '/emails/class-wc-email-customer-withdrawal-request.php',
+			'WC_Email_New_Withdrawal_Request'        => __DIR__ . '/emails/class-wc-email-new-withdrawal-request.php',
 		);
 		if ( FeaturesUtil::feature_is_enabled( 'point_of_sale' ) ) {
 			$emails['WC_Email_Customer_POS_Completed_Order'] = __DIR__ . '/emails/class-wc-email-customer-pos-completed-order.php';
@@ -668,14 +672,16 @@ class WC_Emails {
 
 				foreach ( $fields as $field ) {
 					if ( isset( $field['label'], $field['value'] ) && $field['value'] ) {
-						echo wp_kses_post( $field['label'] . ': ' . $field['value'] ) . "\n"; // WPCS: XSS ok.
+						echo wp_kses_post( $field['label'] . ': ' . $field['value'] ) . "\n";
+						// WPCS: XSS ok.
 					}
 				}
 			} else {
 
 				foreach ( $fields as $field ) {
 					if ( isset( $field['label'], $field['value'] ) && $field['value'] ) {
-						echo '<p><strong>' . wp_kses_post( $field['label'] ) . ':</strong> ' . wp_kses_post( $field['value'] ) . '</p>'; // WPCS: XSS ok.
+						echo '<p><strong>' . wp_kses_post( $field['label'] ) . ':</strong> ' . wp_kses_post( $field['value'] ) . '</p>';
+						// WPCS: XSS ok.
 					}
 				}
 			}

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -101,6 +101,8 @@ class WC_Query {
 			'add-payment-method'         => get_option( 'woocommerce_myaccount_add_payment_method_endpoint', 'add-payment-method' ),
 			'delete-payment-method'      => get_option( 'woocommerce_myaccount_delete_payment_method_endpoint', 'delete-payment-method' ),
 			'set-default-payment-method' => get_option( 'woocommerce_myaccount_set_default_payment_method_endpoint', 'set-default-payment-method' ),
+			'withdrawals'                => get_option( 'woocommerce_myaccount_withdrawals_endpoint', 'withdrawals' ),
+			'request-withdrawal'         => get_option( 'woocommerce_myaccount_request_withdrawal_endpoint', 'request-withdrawal' ),
 		);
 	}
 
@@ -151,6 +153,17 @@ class WC_Query {
 				break;
 			case 'add-payment-method':
 				$title = __( 'Add payment method', 'woocommerce' );
+				break;
+			case 'withdrawals':
+				if ( ! empty( $wp->query_vars['withdrawals'] ) ) {
+					/* translators: %d: page number */
+					$title = sprintf( __( 'Withdrawals (page %d)', 'woocommerce' ), intval( $wp->query_vars['withdrawals'] ) );
+				} else {
+					$title = __( 'Withdrawals', 'woocommerce' );
+				}
+				break;
+			case 'request-withdrawal':
+				$title = __( 'Request withdrawal', 'woocommerce' );
 				break;
 			case 'lost-password':
 				if ( in_array( $action, array( 'rp', 'resetpass', 'newaccount' ), true ) ) {
@@ -788,7 +801,8 @@ class WC_Query {
 		 * Kicks in when prices excluding tax are displayed including tax.
 		 */
 		if ( wc_tax_enabled() && 'incl' === get_option( 'woocommerce_tax_display_shop' ) && ! wc_prices_include_tax() ) {
-			$tax_class = apply_filters( 'woocommerce_price_filter_widget_tax_class', '' ); // Uses standard tax class.
+			$tax_class = apply_filters( 'woocommerce_price_filter_widget_tax_class', '' );
+			// Uses standard tax class.
 			$tax_rates = WC_Tax::get_rates( $tax_class );
 
 			if ( $tax_rates ) {
@@ -1058,7 +1072,8 @@ class WC_Query {
 						}
 
 						$query_type                                    = ! empty( $_GET[ 'query_type_' . $attribute ] ) && in_array( $_GET[ 'query_type_' . $attribute ], array( 'and', 'or' ), true ) ? wc_clean( wp_unslash( $_GET[ 'query_type_' . $attribute ] ) ) : '';
-						self::$chosen_attributes[ $taxonomy ]['terms'] = array_map( 'sanitize_title', $filter_terms ); // Ensures correct encoding.
+						self::$chosen_attributes[ $taxonomy ]['terms'] = array_map( 'sanitize_title', $filter_terms );
+						// Ensures correct encoding.
 						self::$chosen_attributes[ $taxonomy ]['query_type'] = $query_type ? $query_type : apply_filters( 'woocommerce_layered_nav_default_query_type', 'and' );
 					}
 				}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -408,6 +408,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Orders\WithdrawalController::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-withdrawal-request.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-withdrawal-request.php
@@ -43,13 +43,14 @@ if ( ! class_exists( 'WC_Email_Customer_Withdrawal_Request', false ) ) :
 			$this->template_html  = 'emails/customer-withdrawal-request.php';
 			$this->template_plain = 'emails/plain/customer-withdrawal-request.php';
 			$this->placeholders   = array(
-				'{order_date}'   => '',
-				'{order_number}' => '',
-				'{site_title}'   => '',
+				'{order_date}'           => '',
+				'{order_number}'         => '',
+				'{site_title}'           => '',
+				'{request_date_created}' => '',
 			);
 
 			// Triggers for this email.
-			add_action( 'woocommerce_customer_withdrawal_request_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_withdrawal_request_submitted_notification', array( $this, 'trigger' ), 10, 2 );
 
 			// Call parent constructor.
 			parent::__construct();
@@ -71,18 +72,47 @@ if ( ! class_exists( 'WC_Email_Customer_Withdrawal_Request', false ) ) :
 				return;
 			}
 
-			$this->object                         = $order;
-			$this->request_id                     = $request_id;
-			$this->recipient                      = $order->get_billing_email();
-			$this->placeholders['{order_date}']   = wc_format_datetime( $order->get_date_created() );
-			$this->placeholders['{order_number}'] = $order->get_order_number();
-			$this->placeholders['{site_title}']   = $this->get_blogname();
+			$this->object                                 = $order;
+			$this->request_id                             = $request_id;
+			$this->recipient                              = $order->get_billing_email();
+			$this->placeholders['{order_date}']           = wc_format_datetime( $order->get_date_created() );
+			$this->placeholders['{order_number}']         = $order->get_order_number();
+			$this->placeholders['{site_title}']           = $this->get_blogname();
+			$this->placeholders['{request_date_created}'] = $this->get_request_date_created( $order, $request_id );
 
-			if ( $this->is_enabled() && $this->get_recipient() ) {
-				$this->send_notification();
-			}
+			$this->send_notification();
 
 			$this->restore_locale();
+		}
+
+		/**
+		 * Get the date the withdrawal request was created from the order meta.
+		 *
+		 * @param WC_Order $order      Order object.
+		 * @param string   $request_id Withdrawal request ID.
+		 * @return string Formatted date or empty string.
+		 */
+		private function get_request_date_created( $order, $request_id ) {
+			if ( ! is_a( $order, 'WC_Order' ) || '' === $request_id ) {
+				return '';
+			}
+			$requests = $order->get_meta( '_withdrawal_requests', true );
+			if ( ! is_array( $requests ) ) {
+				return '';
+			}
+			foreach ( $requests as $request ) {
+				if ( isset( $request['request_id'] ) && $request['request_id'] === $request_id && ! empty( $request['date_created'] ) ) {
+					$date = $request['date_created'];
+					if ( ! $date instanceof WC_DateTime ) {
+						$date = wc_string_to_datetime( (string) $date );
+						if ( false === $date ) {
+							return '';
+						}
+					}
+					return wc_format_datetime( $date );
+				}
+			}
+			return '';
 		}
 
 		/**
@@ -114,13 +144,14 @@ if ( ! class_exists( 'WC_Email_Customer_Withdrawal_Request', false ) ) :
 			return wc_get_template_html(
 				$this->template_html,
 				array(
-					'order'              => $this->object,
-					'request_id'         => $this->request_id,
-					'email_heading'      => $this->get_heading(),
-					'additional_content' => $this->get_additional_content(),
-					'sent_to_admin'      => false,
-					'plain_text'         => false,
-					'email'              => $this,
+					'order'                => $this->object,
+					'request_id'           => $this->request_id,
+					'request_date_created' => $this->placeholders['{request_date_created}'],
+					'email_heading'        => $this->get_heading(),
+					'additional_content'   => $this->get_additional_content(),
+					'sent_to_admin'        => false,
+					'plain_text'           => false,
+					'email'                => $this,
 				)
 			);
 		}
@@ -134,13 +165,14 @@ if ( ! class_exists( 'WC_Email_Customer_Withdrawal_Request', false ) ) :
 			return wc_get_template_html(
 				$this->template_plain,
 				array(
-					'order'              => $this->object,
-					'request_id'         => $this->request_id,
-					'email_heading'      => $this->get_heading(),
-					'additional_content' => $this->get_additional_content(),
-					'sent_to_admin'      => false,
-					'plain_text'         => true,
-					'email'              => $this,
+					'order'                => $this->object,
+					'request_id'           => $this->request_id,
+					'request_date_created' => $this->placeholders['{request_date_created}'],
+					'email_heading'        => $this->get_heading(),
+					'additional_content'   => $this->get_additional_content(),
+					'sent_to_admin'        => false,
+					'plain_text'           => true,
+					'email'                => $this,
 				)
 			);
 		}

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-withdrawal-request.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-withdrawal-request.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Class WC_Email_Customer_Withdrawal_Request file.
+ *
+ * @package WooCommerce\Emails
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	// Exit if accessed directly.
+	exit;
+}
+
+if ( ! class_exists( 'WC_Email_Customer_Withdrawal_Request', false ) ) :
+
+	/**
+	 * Customer Withdrawal Request Email.
+	 *
+	 * Sent to the customer when they submit a withdrawal request, acknowledging
+	 * receipt as required by EU Directive 2023/2673.
+	 *
+	 * @class   WC_Email_Customer_Withdrawal_Request
+	 * @version 10.9.0
+	 * @package WooCommerce\Classes\Emails
+	 * @extends WC_Email
+	 */
+	class WC_Email_Customer_Withdrawal_Request extends WC_Email {
+
+		/**
+		 * The withdrawal request ID.
+		 *
+		 * @var string
+		 */
+		public $request_id = '';
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_withdrawal_request';
+			$this->customer_email = true;
+			$this->title          = __( 'Withdrawal request received', 'woocommerce' );
+			$this->email_group    = 'order-updates';
+			$this->template_html  = 'emails/customer-withdrawal-request.php';
+			$this->template_plain = 'emails/plain/customer-withdrawal-request.php';
+			$this->placeholders   = array(
+				'{order_date}'   => '',
+				'{order_number}' => '',
+				'{site_title}'   => '',
+			);
+
+			// Triggers for this email.
+			add_action( 'woocommerce_customer_withdrawal_request_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor.
+			parent::__construct();
+
+			$this->description = __( 'Withdrawal request acknowledgment emails are sent to customers when they submit a withdrawal request.', 'woocommerce' );
+		}
+
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int    $order_id   The order ID.
+		 * @param string $request_id The withdrawal request ID.
+		 */
+		public function trigger( $order_id, $request_id = '' ) {
+			$this->setup_locale();
+
+			$order = wc_get_order( $order_id );
+			if ( ! is_a( $order, 'WC_Order' ) ) {
+				return;
+			}
+
+			$this->object                         = $order;
+			$this->request_id                     = $request_id;
+			$this->recipient                      = $order->get_billing_email();
+			$this->placeholders['{order_date}']   = wc_format_datetime( $order->get_date_created() );
+			$this->placeholders['{order_number}'] = $order->get_order_number();
+			$this->placeholders['{site_title}']   = $this->get_blogname();
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send_notification();
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get email subject.
+		 *
+		 * @since  10.9.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'Your withdrawal request has been received', 'woocommerce' );
+		}
+
+		/**
+		 * Get email heading.
+		 *
+		 * @since  10.9.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Withdrawal request received', 'woocommerce' );
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html,
+				array(
+					'order'              => $this->object,
+					'request_id'         => $this->request_id,
+					'email_heading'      => $this->get_heading(),
+					'additional_content' => $this->get_additional_content(),
+					'sent_to_admin'      => false,
+					'plain_text'         => false,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain,
+				array(
+					'order'              => $this->object,
+					'request_id'         => $this->request_id,
+					'email_heading'      => $this->get_heading(),
+					'additional_content' => $this->get_additional_content(),
+					'sent_to_admin'      => false,
+					'plain_text'         => true,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Default content to show below main email content.
+		 *
+		 * @since 10.9.0
+		 * @return string
+		 */
+		public function get_default_additional_content() {
+			return __( 'Thank you for your patience. The merchant will review your request and contact you about the next steps.', 'woocommerce' );
+		}
+	}
+
+endif;
+
+return new WC_Email_Customer_Withdrawal_Request();

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-withdrawal-status.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-withdrawal-status.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Class WC_Email_Customer_Withdrawal_Status file.
+ *
+ * @package WooCommerce\Emails
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	// Exit if accessed directly.
+	exit;
+}
+
+if ( ! class_exists( 'WC_Email_Customer_Withdrawal_Status', false ) ) :
+
+	/**
+	 * Customer Withdrawal Status Email.
+	 *
+	 * Sent to the customer when a store admin approves or rejects their withdrawal
+	 * request, as required by EU Directive 2023/2673.
+	 *
+	 * @class   WC_Email_Customer_Withdrawal_Status
+	 * @version 10.9.0
+	 * @package WooCommerce\Classes\Emails
+	 * @extends WC_Email
+	 */
+	class WC_Email_Customer_Withdrawal_Status extends WC_Email {
+
+		/**
+		 * The withdrawal request ID.
+		 *
+		 * @var string
+		 */
+		public $request_id = '';
+
+		/**
+		 * The new status: 'approved' or 'rejected'.
+		 *
+		 * @var string
+		 */
+		public $new_status = '';
+
+		/**
+		 * Admin notes attached to the update.
+		 *
+		 * @var string
+		 */
+		public $admin_notes = '';
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_withdrawal_status';
+			$this->customer_email = true;
+			$this->title          = __( 'Withdrawal request update', 'woocommerce' );
+			$this->email_group    = 'order-updates';
+			$this->template_html  = 'emails/customer-withdrawal-status.php';
+			$this->template_plain = 'emails/plain/customer-withdrawal-status.php';
+			$this->placeholders   = array(
+				'{order_date}'     => '',
+				'{order_number}'   => '',
+				'{site_title}'     => '',
+				'{request_status}' => '',
+			);
+
+			// Triggers for this email.
+			add_action( 'woocommerce_withdrawal_request_updated_notification', array( $this, 'trigger' ), 10, 4 );
+
+			// Call parent constructor.
+			parent::__construct();
+
+			$this->description = __( 'Withdrawal request status emails are sent to customers when the store admin approves or rejects their withdrawal request.', 'woocommerce' );
+		}
+
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int    $order_id    The order ID.
+		 * @param string $request_id  The withdrawal request ID.
+		 * @param string $new_status  The new status (approved or rejected).
+		 * @param string $admin_notes Admin notes attached to the update.
+		 */
+		public function trigger( $order_id, $request_id = '', $new_status = '', $admin_notes = '' ) {
+			$this->setup_locale();
+
+			$order = wc_get_order( $order_id );
+			if ( ! is_a( $order, 'WC_Order' ) ) {
+				return;
+			}
+
+			$this->object                           = $order;
+			$this->request_id                       = $request_id;
+			$this->new_status                       = $new_status;
+			$this->admin_notes                      = $admin_notes;
+			$this->recipient                        = $order->get_billing_email();
+			$this->placeholders['{order_date}']     = wc_format_datetime( $order->get_date_created() );
+			$this->placeholders['{order_number}']   = $order->get_order_number();
+			$this->placeholders['{site_title}']     = $this->get_blogname();
+			$this->placeholders['{request_status}'] = $this->get_status_label( $new_status );
+
+			$this->send_notification();
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get human-readable status label.
+		 *
+		 * @param string $status Status slug.
+		 * @return string
+		 */
+		private function get_status_label( $status ) {
+			$labels = array(
+				'approved' => __( 'Approved', 'woocommerce' ),
+				'rejected' => __( 'Rejected', 'woocommerce' ),
+			);
+			return $labels[ $status ] ?? ucfirst( $status );
+		}
+
+		/**
+		 * Get email subject.
+		 *
+		 * @since  10.9.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'Your withdrawal request for order {order_number} has been {request_status}', 'woocommerce' );
+		}
+
+		/**
+		 * Get email heading.
+		 *
+		 * @since  10.9.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Withdrawal request update', 'woocommerce' );
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html,
+				array(
+					'order'              => $this->object,
+					'request_id'         => $this->request_id,
+					'new_status'         => $this->new_status,
+					'admin_notes'        => $this->admin_notes,
+					'email_heading'      => $this->get_heading(),
+					'additional_content' => $this->get_additional_content(),
+					'sent_to_admin'      => false,
+					'plain_text'         => false,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain,
+				array(
+					'order'              => $this->object,
+					'request_id'         => $this->request_id,
+					'new_status'         => $this->new_status,
+					'admin_notes'        => $this->admin_notes,
+					'email_heading'      => $this->get_heading(),
+					'additional_content' => $this->get_additional_content(),
+					'sent_to_admin'      => false,
+					'plain_text'         => true,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Default content to show below main email content.
+		 *
+		 * @since 10.9.0
+		 * @return string
+		 */
+		public function get_default_additional_content() {
+			return __( 'If you have any questions about this decision, please contact the store directly.', 'woocommerce' );
+		}
+	}
+
+endif;
+
+return new WC_Email_Customer_Withdrawal_Status();

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-withdrawal-request.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-withdrawal-request.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'WC_Email_New_Withdrawal_Request', false ) ) :
 			);
 
 			// Triggers for this email.
-			add_action( 'woocommerce_new_withdrawal_request_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_withdrawal_request_submitted_notification', array( $this, 'trigger' ), 10, 2 );
 
 			// Call parent constructor.
 			parent::__construct();
@@ -80,9 +80,7 @@ if ( ! class_exists( 'WC_Email_New_Withdrawal_Request', false ) ) :
 			$this->placeholders['{site_title}']           = $this->get_blogname();
 			$this->placeholders['{request_date_created}'] = $this->get_request_date_created( $order, $request_id );
 
-			if ( $this->is_enabled() && $this->get_recipient() ) {
-				$this->send_notification();
-			}
+			$this->send_notification();
 
 			$this->restore_locale();
 		}
@@ -107,6 +105,9 @@ if ( ! class_exists( 'WC_Email_New_Withdrawal_Request', false ) ) :
 					$date = $request['date_created'];
 					if ( ! $date instanceof WC_DateTime ) {
 						$date = wc_string_to_datetime( (string) $date );
+						if ( false === $date ) {
+							return '';
+						}
 					}
 					return wc_format_datetime( $date );
 				}

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-withdrawal-request.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-withdrawal-request.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Class WC_Email_New_Withdrawal_Request file.
+ *
+ * @package WooCommerce\Emails
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	// Exit if accessed directly.
+	exit;
+}
+
+if ( ! class_exists( 'WC_Email_New_Withdrawal_Request', false ) ) :
+
+	/**
+	 * New Withdrawal Request Email.
+	 *
+	 * Sent to the admin/mail forwarding address when a customer submits a
+	 * withdrawal request.
+	 *
+	 * @class   WC_Email_New_Withdrawal_Request
+	 * @version 10.9.0
+	 * @package WooCommerce\Classes\Emails
+	 * @extends WC_Email
+	 */
+	class WC_Email_New_Withdrawal_Request extends WC_Email {
+
+		/**
+		 * The withdrawal request ID.
+		 *
+		 * @var string
+		 */
+		public $request_id = '';
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'new_withdrawal_request';
+			$this->customer_email = false;
+			$this->title          = __( 'New withdrawal request', 'woocommerce' );
+			$this->email_group    = 'admin-notifications';
+			$this->template_html  = 'emails/admin-withdrawal-request.php';
+			$this->template_plain = 'emails/plain/admin-withdrawal-request.php';
+			$this->placeholders   = array(
+				'{order_date}'           => '',
+				'{order_number}'         => '',
+				'{site_title}'           => '',
+				'{request_date_created}' => '',
+			);
+
+			// Triggers for this email.
+			add_action( 'woocommerce_new_withdrawal_request_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor.
+			parent::__construct();
+
+			$this->description = __( 'Admin notification emails are sent to the store admin when a customer submits a withdrawal request.', 'woocommerce' );
+		}
+
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int    $order_id   The order ID.
+		 * @param string $request_id The withdrawal request ID.
+		 */
+		public function trigger( $order_id, $request_id = '' ) {
+			$this->setup_locale();
+
+			$order = wc_get_order( $order_id );
+			if ( ! is_a( $order, 'WC_Order' ) ) {
+				return;
+			}
+
+			$this->object                                 = $order;
+			$this->request_id                             = $request_id;
+			$this->recipient                              = $this->get_option( 'recipient', get_option( 'admin_email' ) );
+			$this->placeholders['{order_date}']           = wc_format_datetime( $order->get_date_created() );
+			$this->placeholders['{order_number}']         = $order->get_order_number();
+			$this->placeholders['{site_title}']           = $this->get_blogname();
+			$this->placeholders['{request_date_created}'] = $this->get_request_date_created( $order, $request_id );
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send_notification();
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get the date the withdrawal request was created from the order meta.
+		 *
+		 * @param WC_Order $order      Order object.
+		 * @param string   $request_id Withdrawal request ID.
+		 * @return string Formatted date or empty string.
+		 */
+		private function get_request_date_created( $order, $request_id ) {
+			if ( ! is_a( $order, 'WC_Order' ) || '' === $request_id ) {
+				return '';
+			}
+			$requests = $order->get_meta( '_withdrawal_requests', true );
+			if ( ! is_array( $requests ) ) {
+				return '';
+			}
+			foreach ( $requests as $request ) {
+				if ( isset( $request['request_id'] ) && $request['request_id'] === $request_id && ! empty( $request['date_created'] ) ) {
+					$date = $request['date_created'];
+					if ( ! $date instanceof WC_DateTime ) {
+						$date = wc_string_to_datetime( (string) $date );
+					}
+					return wc_format_datetime( $date );
+				}
+			}
+			return '';
+		}
+
+		/**
+		 * Get email subject.
+		 *
+		 * @since  10.9.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'New withdrawal request for order {order_number} — {site_title}', 'woocommerce' );
+		}
+
+		/**
+		 * Get email heading.
+		 *
+		 * @since  10.9.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'New withdrawal request', 'woocommerce' );
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html,
+				array(
+					'order'                => $this->object,
+					'request_id'           => $this->request_id,
+					'request_date_created' => $this->placeholders['{request_date_created}'],
+					'email_heading'        => $this->get_heading(),
+					'additional_content'   => $this->get_additional_content(),
+					'sent_to_admin'        => true,
+					'plain_text'           => false,
+					'email'                => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain,
+				array(
+					'order'                => $this->object,
+					'request_id'           => $this->request_id,
+					'request_date_created' => $this->placeholders['{request_date_created}'],
+					'email_heading'        => $this->get_heading(),
+					'additional_content'   => $this->get_additional_content(),
+					'sent_to_admin'        => true,
+					'plain_text'           => true,
+					'email'                => $this,
+				)
+			);
+		}
+
+		/**
+		 * Default content to show below main email content.
+		 *
+		 * @since 10.9.0
+		 * @return string
+		 */
+		public function get_default_additional_content() {
+			return __( 'You can manage this withdrawal request from the order edit screen.', 'woocommerce' );
+		}
+	}
+
+endif;
+
+return new WC_Email_New_Withdrawal_Request();

--- a/plugins/woocommerce/includes/wc-account-functions.php
+++ b/plugins/woocommerce/includes/wc-account-functions.php
@@ -31,7 +31,8 @@ function wc_lostpassword_url( $default_url = '' ) {
 	}
 
 	// Don't redirect to the woocommerce endpoint on global network admin lost passwords.
-	if ( is_multisite() && isset( $_GET['redirect_to'] ) && false !== strpos( wp_unslash( $_GET['redirect_to'] ), network_admin_url() ) ) { // WPCS: input var ok, sanitization ok, CSRF ok.
+	if ( is_multisite() && isset( $_GET['redirect_to'] ) && false !== strpos( wp_unslash( $_GET['redirect_to'] ), network_admin_url() ) ) {
+		// WPCS: input var ok, sanitization ok, CSRF ok.
 		return $default_url;
 	}
 
@@ -101,6 +102,7 @@ function wc_get_account_menu_items() {
 		'payment-methods' => get_option( 'woocommerce_myaccount_payment_methods_endpoint', 'payment-methods' ),
 		'edit-account'    => get_option( 'woocommerce_myaccount_edit_account_endpoint', 'edit-account' ),
 		'customer-logout' => get_option( 'woocommerce_logout_endpoint', 'customer-logout' ),
+		'withdrawals'     => get_option( 'woocommerce_myaccount_withdrawals_endpoint', 'withdrawals' ),
 	);
 
 	$items = array(
@@ -111,6 +113,7 @@ function wc_get_account_menu_items() {
 		'payment-methods' => __( 'Payment methods', 'woocommerce' ),
 		'edit-account'    => __( 'Account details', 'woocommerce' ),
 		'customer-logout' => __( 'Log out', 'woocommerce' ),
+		'withdrawals'     => __( 'Withdrawals', 'woocommerce' ),
 	);
 
 	// Remove missing endpoints.
@@ -150,9 +153,11 @@ function wc_is_current_account_menu_item( $endpoint ) {
 
 	$current = isset( $wp->query_vars[ $endpoint ] );
 	if ( 'dashboard' === $endpoint && ( isset( $wp->query_vars['page'] ) || empty( $wp->query_vars ) ) ) {
-		$current = true; // Dashboard is not an endpoint, so needs a custom check.
+		$current = true;
+		// Dashboard is not an endpoint, so needs a custom check.
 	} elseif ( 'orders' === $endpoint && isset( $wp->query_vars['view-order'] ) ) {
-		$current = true; // When looking at individual order, highlight Orders list item (to signify where in the menu the user currently is).
+		$current = true;
+		// When looking at individual order, highlight Orders list item (to signify where in the menu the user currently is).
 	} elseif ( 'payment-methods' === $endpoint && isset( $wp->query_vars['add-payment-method'] ) ) {
 		$current = true;
 	}
@@ -339,6 +344,23 @@ function wc_get_account_orders_actions( $order ) {
 	$statuses_for_cancel = apply_filters( 'woocommerce_valid_order_statuses_for_cancel', array( OrderStatus::PENDING, OrderStatus::FAILED ), $order );
 	if ( ! in_array( $order->get_status(), $statuses_for_cancel, true ) ) {
 		unset( $actions['cancel'] );
+	}
+
+	// Add EU withdrawal action (Directive 2023/2673).
+	if ( class_exists( '\\Automattic\\WooCommerce\\Internal\\Orders\\WithdrawalController' ) ) {
+		$withdrawal_controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Orders\WithdrawalController::class );
+		if ( $withdrawal_controller->is_order_eligible_for_withdrawal( $order ) ) {
+			$withdrawal_url      = wp_nonce_url(
+				wc_get_endpoint_url( 'request-withdrawal', $order->get_id(), wc_get_page_permalink( 'myaccount' ) ),
+				'woocommerce-view_withdrawal_' . $order->get_id()
+			);
+			$actions['withdraw'] = array(
+				'url'        => $withdrawal_url,
+				'name'       => __( 'Withdraw', 'woocommerce' ),
+				/* translators: %s: order number */
+				'aria-label' => sprintf( __( 'Withdraw from order %s', 'woocommerce' ), $order->get_order_number() ),
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-account-functions.php
+++ b/plugins/woocommerce/includes/wc-account-functions.php
@@ -108,12 +108,12 @@ function wc_get_account_menu_items() {
 	$items = array(
 		'dashboard'       => __( 'Dashboard', 'woocommerce' ),
 		'orders'          => __( 'Orders', 'woocommerce' ),
+		'withdrawals'     => __( 'Withdrawals', 'woocommerce' ),
 		'downloads'       => __( 'Downloads', 'woocommerce' ),
 		'edit-address'    => _n( 'Address', 'Addresses', ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) ? 2 : 1, 'woocommerce' ),
 		'payment-methods' => __( 'Payment methods', 'woocommerce' ),
 		'edit-account'    => __( 'Account details', 'woocommerce' ),
 		'customer-logout' => __( 'Log out', 'woocommerce' ),
-		'withdrawals'     => __( 'Withdrawals', 'woocommerce' ),
 	);
 
 	// Remove missing endpoints.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -240,7 +240,8 @@ add_action( 'woocommerce_after_shop_loop', 'woocommerce_reset_loop', 999 );
  * @return mixed
  */
 function wc_get_loop_prop( $prop, $default = '' ) {
-	wc_setup_loop(); // Ensure shop loop is setup.
+	wc_setup_loop();
+	// Ensure shop loop is setup.
 
 	return isset( $GLOBALS['woocommerce_loop'], $GLOBALS['woocommerce_loop'][ $prop ] ) ? $GLOBALS['woocommerce_loop'][ $prop ] : $default;
 }
@@ -443,7 +444,8 @@ function wc_get_default_products_per_row() {
 		update_option( 'woocommerce_catalog_columns', $columns );
 	}
 
-	if ( has_filter( 'loop_shop_columns' ) ) { // Legacy filter handling.
+	if ( has_filter( 'loop_shop_columns' ) ) {
+		// Legacy filter handling.
 		$columns = apply_filters( 'loop_shop_columns', $columns );
 	}
 
@@ -492,7 +494,8 @@ function wc_reset_product_grid_settings() {
 		update_option( 'woocommerce_catalog_columns', absint( $product_grid['default_columns'] ) );
 	}
 
-	wp_cache_flush(); // Flush any caches which could impact settings or templates.
+	wp_cache_flush();
+	// Flush any caches which could impact settings or templates.
 }
 add_action( 'after_switch_theme', 'wc_reset_product_grid_settings' );
 
@@ -1464,8 +1467,9 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 				array_filter(
 					array(
 						'button',
-						wc_wp_theme_get_element_class_name( 'button' ), // escaped in the template.
-						'product_type_' . $product->get_type(),
+						wc_wp_theme_get_element_class_name( 'button' ),
+						// escaped in the template.
+																						'product_type_' . $product->get_type(),
 						$product->is_purchasable() && $product->is_in_stock() ? 'add_to_cart_button' : '',
 						$product->supports( 'ajax_add_to_cart' ) && $product->is_purchasable() && $product->is_in_stock() ? 'ajax_add_to_cart' : '',
 					)
@@ -3733,7 +3737,8 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 		$class                 = $args['class'];
 		$required              = (bool) $args['required'];
 		$show_option_none      = (bool) $args['show_option_none'];
-		$show_option_none_text = $args['show_option_none'] ? $args['show_option_none'] : __( 'Choose an option', 'woocommerce' ); // We'll do our best to hide the placeholder, but we'll need to show something when resetting options.
+		$show_option_none_text = $args['show_option_none'] ? $args['show_option_none'] : __( 'Choose an option', 'woocommerce' );
+		// We'll do our best to hide the placeholder, but we'll need to show something when resetting options.
 
 		if ( empty( $options ) && ! empty( $product ) && ! empty( $attribute ) ) {
 			$attributes = $product->get_variation_attributes();
@@ -3915,6 +3920,40 @@ if ( ! function_exists( 'woocommerce_account_add_payment_method' ) ) {
 	 */
 	function woocommerce_account_add_payment_method() {
 		WC_Shortcode_My_Account::add_payment_method();
+	}
+}
+
+if ( ! function_exists( 'woocommerce_account_withdrawals' ) ) {
+
+	/**
+	 * My Account > Withdrawals list template.
+	 *
+	 * @param int $current_page Current page number.
+	 * @return void
+	 */
+	function woocommerce_account_withdrawals( $current_page ) {
+		$container        = wc_get_container();
+		$controller_class = \Automattic\WooCommerce\Internal\Orders\WithdrawalController::class;
+		if ( $container->has( $controller_class ) ) {
+			$container->get( $controller_class )->output_withdrawals( max( 1, absint( $current_page ) ) );
+		}
+	}
+}
+
+if ( ! function_exists( 'woocommerce_account_request_withdrawal' ) ) {
+
+	/**
+	 * My Account > Request withdrawal template.
+	 *
+	 * @param int $order_id Order ID.
+	 * @return void
+	 */
+	function woocommerce_account_request_withdrawal( $order_id ) {
+		$container        = wc_get_container();
+		$controller_class = \Automattic\WooCommerce\Internal\Orders\WithdrawalController::class;
+		if ( $container->has( $controller_class ) ) {
+			$container->get( $controller_class )->output_request_withdrawal( absint( $order_id ) );
+		}
 	}
 }
 

--- a/plugins/woocommerce/includes/wc-template-hooks.php
+++ b/plugins/woocommerce/includes/wc-template-hooks.php
@@ -311,6 +311,8 @@ add_action( 'woocommerce_account_edit-address_endpoint', 'woocommerce_account_ed
 add_action( 'woocommerce_account_payment-methods_endpoint', 'woocommerce_account_payment_methods' );
 add_action( 'woocommerce_account_add-payment-method_endpoint', 'woocommerce_account_add_payment_method' );
 add_action( 'woocommerce_account_edit-account_endpoint', 'woocommerce_account_edit_account' );
+add_action( 'woocommerce_account_withdrawals_endpoint', 'woocommerce_account_withdrawals' );
+add_action( 'woocommerce_account_request-withdrawal_endpoint', 'woocommerce_account_request_withdrawal' );
 add_action( 'woocommerce_register_form', 'wc_registration_privacy_policy_text', 20 );
 
 /**

--- a/plugins/woocommerce/src/Internal/Orders/WithdrawalController.php
+++ b/plugins/woocommerce/src/Internal/Orders/WithdrawalController.php
@@ -42,10 +42,6 @@ class WithdrawalController implements RegisterHooksInterface {
 	 * @return void
 	 */
 	public function register() {
-		// Endpoint content handlers.
-		add_action( 'woocommerce_account_withdrawals_endpoint', array( $this, 'output_withdrawals' ) );
-		add_action( 'woocommerce_account_request-withdrawal_endpoint', array( $this, 'output_request_withdrawal' ) );
-
 		// Form submission handler.
 		add_action( 'template_redirect', array( $this, 'handle_withdrawal_request' ) );
 
@@ -130,7 +126,13 @@ class WithdrawalController implements RegisterHooksInterface {
 			?>
 			<div class="withdrawal-request" style="margin-bottom:1em;padding-bottom:1em;border-bottom:1px solid #ddd;">
 				<p>
-					<strong><?php esc_html_e( 'Request', 'woocommerce' ); ?> #<?php echo esc_html( $request['request_id'] ?? '' ); ?></strong><br>
+					<strong>
+						<?php
+						/* translators: %s: order number */
+						printf( esc_html__( 'Withdrawal request for Order #%s', 'woocommerce' ), esc_html( $order->get_order_number() ) );
+						?>
+					</strong>
+					<code style="display:block;margin-top:4px;font-size:11px;color:#666;"><?php echo esc_html( $request['request_id'] ?? '' ); ?></code><br>
 					<?php echo esc_html( $date ); ?><br>
 					<span class="withdrawal-status" style="display:inline-block;padding:2px 8px;border-radius:3px;background:#f0f0f1;">
 						<?php echo esc_html( $status_label ); ?>
@@ -224,6 +226,16 @@ class WithdrawalController implements RegisterHooksInterface {
 		$requests = $this->get_withdrawal_requests( $order );
 		if ( ! isset( $requests[ $request_index ] ) ) {
 			wp_send_json_error( __( 'Withdrawal request not found.', 'woocommerce' ) );
+		}
+
+		// Race condition guard: only update if the indexed request is still pending
+		// and matches the request_id supplied in the form.
+		if (
+			! isset( $requests[ $request_index ]['request_id'] ) ||
+			$requests[ $request_index ]['request_id'] !== $raw_request_id ||
+			'pending' !== ( $requests[ $request_index ]['status'] ?? '' )
+		) {
+			wp_send_json_error( __( 'This withdrawal request has already been processed.', 'woocommerce' ) );
 		}
 
 		$new_status                                 = 'approve' === $request_action ? 'approved' : 'rejected';
@@ -336,14 +348,13 @@ class WithdrawalController implements RegisterHooksInterface {
 		$requests = $this->get_withdrawal_requests( $order );
 
 		$withdrawal_data = array(
-			'request_id'                  => $request_id,
-			'date_created'                => time(),
-			'status'                      => 'pending',
-			'reason'                      => $reason,
-			'items'                       => array(),
+			'request_id'   => $request_id,
+			'date_created' => time(),
+			'status'       => 'pending',
+			'reason'       => $reason,
+			'items'        => array(),
 			// Full withdrawal by default.
-							'admin_notes' => '',
-			'ip_address'                  => wc_get_ip_address(),
+			'admin_notes'  => '',
 		);
 
 		$requests[] = $withdrawal_data;
@@ -360,9 +371,9 @@ class WithdrawalController implements RegisterHooksInterface {
 		 */
 		do_action( 'woocommerce_withdrawal_request_submitted', $order->get_id(), $request_id );
 
-		// Add customer-visible order note.
+		// Add admin-only order note (customer notification sent via dedicated email class).
 		/* translators: %s: withdrawal request ID */
-		$order->add_order_note( sprintf( __( 'Withdrawal request #%s submitted by customer.', 'woocommerce' ), $request_id ), true );
+		$order->add_order_note( sprintf( __( 'Withdrawal request #%s submitted by customer.', 'woocommerce' ), $request_id ) );
 		$order->save();
 
 		// Redirect to acknowledgment page.
@@ -387,12 +398,20 @@ class WithdrawalController implements RegisterHooksInterface {
 	public function output_withdrawals( $current_page ) {
 		$current_page = max( 1, absint( $current_page ) );
 
+		// Only fetch orders that already have at least one withdrawal request, so pagination
+		// surfaces older withdrawal history (not just the most recent N orders).
 		$customer_orders = wc_get_orders(
 			array(
-				'customer' => get_current_user_id(),
-				'limit'    => 10,
-				'page'     => $current_page,
-				'return'   => 'ids',
+				'customer'   => get_current_user_id(),
+				'limit'      => 10,
+				'page'       => $current_page,
+				'return'     => 'ids',
+				'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					array(
+						'key'     => self::WITHDRAWAL_REQUESTS_META_KEY,
+						'compare' => 'EXISTS',
+					),
+				),
 			)
 		);
 
@@ -447,17 +466,12 @@ class WithdrawalController implements RegisterHooksInterface {
 			return;
 		}
 
-		if ( ! $this->is_order_eligible_for_withdrawal( $order ) ) {
-			wc_add_notice( __( 'This order is not eligible for withdrawal.', 'woocommerce' ), 'error' );
-			return;
-		}
-
 		$submitted  = ! empty( $_GET['submitted'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$request_id = ! empty( $_GET['request_id'] ) ? sanitize_text_field( wp_unslash( $_GET['request_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$step       = ! empty( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( $submitted && $request_id ) {
-			// Acknowledgment screen.
+			// Acknowledgment screen — bypass eligibility gate (request already exists).
 			$requests     = $this->get_withdrawal_requests( $order );
 			$request_data = null;
 			foreach ( $requests as $r ) {
@@ -474,6 +488,11 @@ class WithdrawalController implements RegisterHooksInterface {
 				exit;
 			}
 
+			// Clear session data before rendering so a theme override that drops the cleanup still works.
+			if ( function_exists( 'WC' ) && WC()->session ) {
+				WC()->session->set( 'woocommerce_withdrawal_request_data', null );
+			}
+
 			wc_get_template(
 				'myaccount/form-request-withdrawal-submitted.php',
 				array(
@@ -482,6 +501,11 @@ class WithdrawalController implements RegisterHooksInterface {
 					'request_data' => $request_data,
 				)
 			);
+			return;
+		}
+
+		if ( ! $this->is_order_eligible_for_withdrawal( $order ) ) {
+			wc_add_notice( __( 'This order is not eligible for withdrawal.', 'woocommerce' ), 'error' );
 			return;
 		}
 
@@ -552,6 +576,8 @@ class WithdrawalController implements RegisterHooksInterface {
 		 */
 		$window_days = apply_filters( 'woocommerce_withdrawal_window_days', self::DEFAULT_WITHDRAWAL_WINDOW_DAYS );
 
+		// Withdrawal window starts on the order completion date (delivery/service fulfillment).
+		// Fall back to creation date only if completion is missing (rare, e.g. legacy orders).
 		$date_object = $order->get_date_completed() ? $order->get_date_completed() : $order->get_date_created();
 		if ( ! $date_object ) {
 			return false;
@@ -563,10 +589,11 @@ class WithdrawalController implements RegisterHooksInterface {
 			return false;
 		}
 
-		// Must not already have a pending withdrawal request.
+		// Block if any withdrawal request already exists for this order (pending, approved, or rejected).
+		// Per EU Directive 2023/2673, only one withdrawal request per contract.
 		$requests = $this->get_withdrawal_requests( $order );
 		foreach ( $requests as $request ) {
-			if ( 'pending' === $request['status'] ) {
+			if ( ! empty( $request['status'] ) ) {
 				return false;
 			}
 		}
@@ -596,8 +623,6 @@ class WithdrawalController implements RegisterHooksInterface {
 		return apply_filters(
 			'woocommerce_valid_order_statuses_for_withdrawal',
 			array(
-				'processing',
-				'on-hold',
 				'completed',
 			)
 		);

--- a/plugins/woocommerce/src/Internal/Orders/WithdrawalController.php
+++ b/plugins/woocommerce/src/Internal/Orders/WithdrawalController.php
@@ -1,0 +1,682 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Orders;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use WC_Order;
+use WC_Rate_Limiter;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Controller for EU withdrawal (right of withdrawal) functionality.
+ *
+ * Handles the withdrawal request lifecycle: form display, submission processing,
+ * data persistence, and email notifications. Integrates with the My Account
+ * page via existing endpoint/template architecture.
+ *
+ * @since 10.9.0
+ */
+class WithdrawalController implements RegisterHooksInterface {
+
+	/**
+	 * Meta key used to store withdrawal requests on orders.
+	 *
+	 * @var string
+	 */
+	private const WITHDRAWAL_REQUESTS_META_KEY = '_withdrawal_requests';
+
+	/**
+	 * Default withdrawal window in days (14 days per EU Consumer Rights Directive).
+	 * Merchants can customize this via the `woocommerce_withdrawal_window_days` filter.
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_WITHDRAWAL_WINDOW_DAYS = 14;
+
+	/**
+	 * Register hooks for the withdrawal controller.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		// Endpoint content handlers.
+		add_action( 'woocommerce_account_withdrawals_endpoint', array( $this, 'output_withdrawals' ) );
+		add_action( 'woocommerce_account_request-withdrawal_endpoint', array( $this, 'output_request_withdrawal' ) );
+
+		// Form submission handler.
+		add_action( 'template_redirect', array( $this, 'handle_withdrawal_request' ) );
+
+		// Enqueue styles.
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+		// Admin meta box.
+		add_action( 'add_meta_boxes', array( $this, 'add_withdrawal_meta_box' ) );
+		add_action( 'wp_ajax_woocommerce_update_withdrawal_request', array( $this, 'ajax_update_withdrawal_request' ) );
+
+		// Rewrite flushing on plugin update.
+		add_action( 'woocommerce_updated', array( __CLASS__, 'maybe_flush_rewrite_rules' ) );
+	}
+
+	/**
+	 * Enqueue styles for withdrawal endpoints.
+	 *
+	 * @return void
+	 */
+	public function enqueue_scripts() {
+		if ( ! is_account_page() ) {
+			return;
+		}
+
+		$endpoint = $this->get_current_endpoint();
+		if ( ! in_array( $endpoint, array( 'withdrawals', 'request-withdrawal' ), true ) ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'woocommerce-withdrawal',
+			plugins_url( 'assets/css/withdrawal.css', WC_PLUGIN_FILE ),
+			array(),
+			\WC_VERSION
+		);
+	}
+
+	/**
+	 * Add withdrawal management meta box to order edit screen.
+	 *
+	 * @return void
+	 */
+	public function add_withdrawal_meta_box() {
+		$screen = OrderUtil::get_order_admin_screen();
+		if ( ! $screen ) {
+			return;
+		}
+
+		add_meta_box(
+			'woocommerce-order-withdrawal',
+			__( 'Withdrawal Requests', 'woocommerce' ),
+			array( $this, 'render_withdrawal_meta_box' ),
+			$screen,
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the withdrawal management meta box.
+	 *
+	 * @param \WP_Post|WC_Order $post_or_order Post or order object.
+	 * @return void
+	 */
+	public function render_withdrawal_meta_box( $post_or_order ) {
+		$order = ( $post_or_order instanceof WC_Order ) ? $post_or_order : wc_get_order( $post_or_order->ID );
+		if ( ! $order ) {
+			echo '<p>' . esc_html__( 'Order not found.', 'woocommerce' ) . '</p>';
+			return;
+		}
+
+		$requests = $this->get_withdrawal_requests( $order );
+
+		if ( empty( $requests ) ) {
+			echo '<p>' . esc_html__( 'No withdrawal requests for this order.', 'woocommerce' ) . '</p>';
+			return;
+		}
+
+		foreach ( $requests as $index => $request ) {
+			$status_label = $this->get_status_label( $request['status'] ?? 'pending' );
+			$date         = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $request['date_created'] ?? 0 );
+			?>
+			<div class="withdrawal-request" style="margin-bottom:1em;padding-bottom:1em;border-bottom:1px solid #ddd;">
+				<p>
+					<strong><?php esc_html_e( 'Request', 'woocommerce' ); ?> #<?php echo esc_html( $request['request_id'] ?? '' ); ?></strong><br>
+					<?php echo esc_html( $date ); ?><br>
+					<span class="withdrawal-status" style="display:inline-block;padding:2px 8px;border-radius:3px;background:#f0f0f1;">
+						<?php echo esc_html( $status_label ); ?>
+					</span>
+				</p>
+
+				<?php if ( ! empty( $request['reason'] ) ) : ?>
+					<p><strong><?php esc_html_e( 'Reason', 'woocommerce' ); ?>:</strong><br>
+					<?php echo esc_html( $request['reason'] ); ?></p>
+				<?php endif; ?>
+
+				<?php if ( 'pending' === $request['status'] ) : ?>
+					<p>
+						<button type="button" class="button button-small withdrawal-action" data-action="approve" data-index="<?php echo esc_attr( (string) $index ); ?>" data-request-id="<?php echo esc_attr( $request['request_id'] ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update_withdrawal_' . $request['request_id'] ) ); ?>">
+							<?php esc_html_e( 'Approve', 'woocommerce' ); ?>
+						</button>
+						<button type="button" class="button button-small withdrawal-action" data-action="reject" data-index="<?php echo esc_attr( (string) $index ); ?>" data-request-id="<?php echo esc_attr( $request['request_id'] ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update_withdrawal_' . $request['request_id'] ) ); ?>">
+							<?php esc_html_e( 'Reject', 'woocommerce' ); ?>
+						</button>
+					</p>
+					<p>
+						<label for="withdrawal_admin_notes_<?php echo esc_attr( $index ); ?>">
+							<?php esc_html_e( 'Admin notes:', 'woocommerce' ); ?>
+						</label><br>
+						<textarea id="withdrawal_admin_notes_<?php echo esc_attr( $index ); ?>" class="withdrawal-admin-notes" rows="2" style="width:100%;"><?php echo esc_textarea( $request['admin_notes'] ?? '' ); ?></textarea>
+					</p>
+				<?php elseif ( ! empty( $request['admin_notes'] ) ) : ?>
+					<p><strong><?php esc_html_e( 'Admin notes', 'woocommerce' ); ?>:</strong><br>
+					<?php echo esc_html( $request['admin_notes'] ); ?></p>
+				<?php endif; ?>
+			</div>
+			<?php
+		}
+
+		wc_enqueue_js(
+			"
+			jQuery( '.withdrawal-action' ).on( 'click', function() {
+				var button = jQuery( this );
+				var data = {
+					action: 'woocommerce_update_withdrawal_request',
+					request_action: button.data( 'action' ),
+					request_index: button.data( 'index' ),
+					request_id: button.data( 'request-id' ),
+					order_id: " . absint( $order->get_id() ) . ",
+					admin_notes: button.closest( '.withdrawal-request' ).find( '.withdrawal-admin-notes' ).val(),
+					_wpnonce: button.data( 'nonce' )
+				};
+
+				button.prop( 'disabled', true ).text( '" . esc_js( __( 'Processing…', 'woocommerce' ) ) . "' );
+
+				jQuery.post( '" . esc_js( admin_url( 'admin-ajax.php' ) ) . "', data, function( response ) {
+					if ( response.success ) {
+						location.reload();
+					} else {
+						alert( response.data || '" . esc_js( __( 'Error updating withdrawal request.', 'woocommerce' ) ) . "' );
+						button.prop( 'disabled', false ).text( button.data( 'action' ) === 'approve' ? '" . esc_js( __( 'Approve', 'woocommerce' ) ) . "' : '" . esc_js( __( 'Reject', 'woocommerce' ) ) . "' );
+					}
+				} );
+			} );
+			"
+		);
+	}
+
+	/**
+	 * AJAX handler for updating withdrawal request status (approve/reject).
+	 *
+	 * @return void
+	 */
+	public function ajax_update_withdrawal_request() {
+		$raw_request_id = isset( $_POST['request_id'] ) ? sanitize_text_field( wp_unslash( $_POST['request_id'] ) ) : '';
+		check_ajax_referer( 'update_withdrawal_' . $raw_request_id, '_wpnonce' );
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( __( 'Insufficient permissions.', 'woocommerce' ) );
+		}
+
+		$order_id       = absint( $_POST['order_id'] ?? 0 );
+		$request_index  = absint( $_POST['request_index'] ?? 0 );
+		$request_action = sanitize_text_field( wp_unslash( $_POST['request_action'] ?? '' ) );
+		$admin_notes    = sanitize_textarea_field( wp_unslash( $_POST['admin_notes'] ?? '' ) );
+
+		if ( ! in_array( $request_action, array( 'approve', 'reject' ), true ) ) {
+			wp_send_json_error( __( 'Invalid action.', 'woocommerce' ) );
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			wp_send_json_error( __( 'Order not found.', 'woocommerce' ) );
+		}
+
+		$requests = $this->get_withdrawal_requests( $order );
+		if ( ! isset( $requests[ $request_index ] ) ) {
+			wp_send_json_error( __( 'Withdrawal request not found.', 'woocommerce' ) );
+		}
+
+		$new_status                                 = 'approve' === $request_action ? 'approved' : 'rejected';
+		$requests[ $request_index ]['status']       = $new_status;
+		$requests[ $request_index ]['admin_notes']  = $admin_notes;
+		$requests[ $request_index ]['date_updated'] = time();
+
+		$this->save_withdrawal_requests( $order, $requests );
+
+		$action_label = 'approve' === $request_action ? __( 'approved', 'woocommerce' ) : __( 'rejected', 'woocommerce' );
+		/* translators: %1$s: request ID, %2$s: action (approved/rejected) */
+		$order->add_order_note( sprintf( __( 'Withdrawal request #%1$s %2$s.', 'woocommerce' ), $requests[ $request_index ]['request_id'], $action_label ) );
+
+		/**
+		 * Fires when a withdrawal request status is updated (approved/rejected).
+		 *
+		 * @since 10.9.0
+		 * @param int    $order_id   Order ID.
+		 * @param string $request_id Withdrawal request ID.
+		 * @param string $new_status New status (approved/rejected).
+		 * @param string $admin_notes Admin notes attached to the update.
+		 */
+		do_action( 'woocommerce_withdrawal_request_updated', $order->get_id(), $requests[ $request_index ]['request_id'], $new_status, $admin_notes );
+
+		wp_send_json_success();
+	}
+
+	/**
+	 * Handle withdrawal request form submission.
+	 *
+	 * @return void
+	 */
+	public function handle_withdrawal_request() {
+		if ( ! is_account_page() ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['action'] ) || 'request_withdrawal' !== $_POST['action'] ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'woocommerce-request_withdrawal' ) ) {
+			wc_add_notice( __( 'Session expired. Please try again.', 'woocommerce' ), 'error' );
+			return;
+		}
+
+		$order_id = absint( $_POST['order_id'] ?? 0 );
+		$order    = wc_get_order( $order_id );
+
+		if ( ! $order ) {
+			wc_add_notice( __( 'Order not found.', 'woocommerce' ), 'error' );
+			return;
+		}
+
+		// Verify order ownership.
+		if ( ! current_user_can( 'view_order', $order_id ) ) {
+			wc_add_notice( __( 'You do not have permission to withdraw from this order.', 'woocommerce' ), 'error' );
+			return;
+		}
+
+		// Verify order is eligible for withdrawal.
+		if ( ! $this->is_order_eligible_for_withdrawal( $order ) ) {
+			wc_add_notice( __( 'This order is not eligible for withdrawal.', 'woocommerce' ), 'error' );
+			return;
+		}
+
+		// Rate limiting.
+		if ( WC_Rate_Limiter::retried_too_soon( 'woocommerce_withdrawal_' . $order_id ) ) {
+			wc_add_notice( __( 'You have already submitted a withdrawal request for this order. Please wait before trying again.', 'woocommerce' ), 'error' );
+			return;
+		}
+
+		$step = sanitize_text_field( wp_unslash( $_POST['step'] ?? '' ) );
+
+		if ( 'confirm' !== $step ) {
+			// Step 1: Persist form data in session, redirect to confirmation step.
+			$reason = isset( $_POST['withdrawal_reason'] ) ? sanitize_textarea_field( wp_unslash( $_POST['withdrawal_reason'] ) ) : '';
+
+			if ( function_exists( 'WC' ) && WC()->session ) {
+				WC()->session->set(
+					'woocommerce_withdrawal_request_data',
+					array(
+						'order_id'     => $order_id,
+						'reason'       => $reason,
+						'date_created' => time(),
+					)
+				);
+			}
+
+			$redirect_url = wc_get_endpoint_url( 'request-withdrawal', $order_id, wc_get_page_permalink( 'myaccount' ) );
+			$redirect_url = add_query_arg( 'step', 'confirm', $redirect_url );
+			wp_safe_redirect( $redirect_url );
+			exit;
+		}
+
+		// Step 2: Process the actual withdrawal submission.
+		$session_data = ( function_exists( 'WC' ) && WC()->session ) ? WC()->session->get( 'woocommerce_withdrawal_request_data' ) : null;
+		$reason       = '';
+
+		if ( is_array( $session_data ) && isset( $session_data['order_id'] ) && (int) $session_data['order_id'] === $order_id ) {
+			$reason = isset( $session_data['reason'] ) ? (string) $session_data['reason'] : '';
+		} else {
+			// Fallback to POST (e.g., when session is unavailable).
+			$reason = isset( $_POST['withdrawal_reason'] ) ? sanitize_textarea_field( wp_unslash( $_POST['withdrawal_reason'] ) ) : '';
+		}
+
+		// Generate a unique request ID.
+		$request_id = wp_generate_uuid4();
+
+		$requests = $this->get_withdrawal_requests( $order );
+
+		$withdrawal_data = array(
+			'request_id'                  => $request_id,
+			'date_created'                => time(),
+			'status'                      => 'pending',
+			'reason'                      => $reason,
+			'items'                       => array(),
+			// Full withdrawal by default.
+							'admin_notes' => '',
+			'ip_address'                  => wc_get_ip_address(),
+		);
+
+		$requests[] = $withdrawal_data;
+		$this->save_withdrawal_requests( $order, $requests );
+
+		/**
+		 * Fires after a withdrawal request has been saved to the order.
+		 *
+		 * Used by email classes to send notifications to the customer and store admin.
+		 *
+		 * @since 10.9.0
+		 * @param int    $order_id   Order ID.
+		 * @param string $request_id Withdrawal request ID.
+		 */
+		do_action( 'woocommerce_withdrawal_request_submitted', $order->get_id(), $request_id );
+
+		// Add customer-visible order note.
+		/* translators: %s: withdrawal request ID */
+		$order->add_order_note( sprintf( __( 'Withdrawal request #%s submitted by customer.', 'woocommerce' ), $request_id ), true );
+		$order->save();
+
+		// Redirect to acknowledgment page.
+		$redirect_url = wc_get_endpoint_url( 'request-withdrawal', $order_id, wc_get_page_permalink( 'myaccount' ) );
+		$redirect_url = add_query_arg(
+			array(
+				'submitted'  => '1',
+				'request_id' => $request_id,
+			),
+			$redirect_url
+		);
+		wp_safe_redirect( $redirect_url );
+		exit;
+	}
+
+	/**
+	 * Output the withdrawals list page content.
+	 *
+	 * @param int $current_page Current page number for pagination.
+	 * @return void
+	 */
+	public function output_withdrawals( $current_page ) {
+		$current_page = max( 1, absint( $current_page ) );
+
+		$customer_orders = wc_get_orders(
+			array(
+				'customer' => get_current_user_id(),
+				'limit'    => 10,
+				'page'     => $current_page,
+				'return'   => 'ids',
+			)
+		);
+
+		$withdrawal_orders = array();
+		foreach ( $customer_orders as $oid ) {
+			$order = wc_get_order( $oid );
+			if ( ! $order ) {
+				continue;
+			}
+			$requests = $this->get_withdrawal_requests( $order );
+			if ( ! empty( $requests ) ) {
+				$withdrawal_orders[ $oid ] = array(
+					'order'    => $order,
+					'requests' => $requests,
+				);
+			}
+		}
+
+		wc_get_template(
+			'myaccount/withdrawals.php',
+			array(
+				'withdrawal_orders' => $withdrawal_orders,
+			)
+		);
+	}
+
+	/**
+	 * Output the request withdrawal form page.
+	 *
+	 * @param int $order_id Order ID from the endpoint query var.
+	 * @return void
+	 */
+	public function output_request_withdrawal( $order_id ) {
+		$order_id = absint( $order_id );
+
+		if ( ! $order_id ) {
+			// No specific order — show an order selection form.
+			$eligible_orders = $this->get_eligible_orders_for_current_user();
+			wc_get_template(
+				'myaccount/form-request-withdrawal.php',
+				array(
+					'eligible_orders' => $eligible_orders,
+					'order'           => null,
+				)
+			);
+			return;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order || ! current_user_can( 'view_order', $order_id ) ) {
+			wc_add_notice( __( 'Order not found.', 'woocommerce' ), 'error' );
+			return;
+		}
+
+		if ( ! $this->is_order_eligible_for_withdrawal( $order ) ) {
+			wc_add_notice( __( 'This order is not eligible for withdrawal.', 'woocommerce' ), 'error' );
+			return;
+		}
+
+		$submitted  = ! empty( $_GET['submitted'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$request_id = ! empty( $_GET['request_id'] ) ? sanitize_text_field( wp_unslash( $_GET['request_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$step       = ! empty( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( $submitted && $request_id ) {
+			// Acknowledgment screen.
+			$requests     = $this->get_withdrawal_requests( $order );
+			$request_data = null;
+			foreach ( $requests as $r ) {
+				if ( isset( $r['request_id'] ) && $r['request_id'] === $request_id ) {
+					$request_data = $r;
+					break;
+				}
+			}
+
+			// Authorization: only the order owner (or an admin) may see the acknowledgment.
+			if ( ! $request_data || ( (int) $order->get_user_id() !== get_current_user_id() && ! current_user_can( 'manage_woocommerce' ) ) ) {
+				wc_add_notice( __( 'You are not allowed to view this withdrawal request.', 'woocommerce' ), 'error' );
+				wp_safe_redirect( wc_get_page_permalink( 'myaccount' ) );
+				exit;
+			}
+
+			wc_get_template(
+				'myaccount/form-request-withdrawal-submitted.php',
+				array(
+					'order'        => $order,
+					'request_id'   => $request_id,
+					'request_data' => $request_data,
+				)
+			);
+			return;
+		}
+
+		if ( 'confirm' === $step ) {
+			// Confirmation step.
+			wc_get_template(
+				'myaccount/form-request-withdrawal-confirm.php',
+				array(
+					'order' => $order,
+				)
+			);
+			return;
+		}
+
+		// Initial form.
+		wc_get_template(
+			'myaccount/form-request-withdrawal.php',
+			array(
+				'eligible_orders' => array( $order ),
+				'order'           => $order,
+			)
+		);
+	}
+
+	/**
+	 * Get eligible orders for withdrawal for the current customer.
+	 *
+	 * @return WC_Order[]
+	 */
+	private function get_eligible_orders_for_current_user() {
+		$customer_orders = wc_get_orders(
+			array(
+				'customer' => get_current_user_id(),
+				'limit'    => -1,
+				'status'   => $this->get_withdrawable_order_statuses(),
+				'return'   => 'ids',
+			)
+		);
+
+		$eligible = array();
+		foreach ( $customer_orders as $oid ) {
+			$order = wc_get_order( $oid );
+			if ( $order && $this->is_order_eligible_for_withdrawal( $order ) ) {
+				$eligible[] = $order;
+			}
+		}
+
+		return $eligible;
+	}
+
+	/**
+	 * Check if an order is eligible for withdrawal.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return bool
+	 */
+	public function is_order_eligible_for_withdrawal( WC_Order $order ): bool {
+		// Must have a valid withdrawable status.
+		if ( ! $order->has_status( $this->get_withdrawable_order_statuses() ) ) {
+			return false;
+		}
+
+		/**
+		 * Filters the withdrawal window in days.
+		 *
+		 * @since 10.9.0
+		 * @param int $window_days Withdrawal window in days.
+		 */
+		$window_days = apply_filters( 'woocommerce_withdrawal_window_days', self::DEFAULT_WITHDRAWAL_WINDOW_DAYS );
+
+		$date_object = $order->get_date_completed() ? $order->get_date_completed() : $order->get_date_created();
+		if ( ! $date_object ) {
+			return false;
+		}
+		$completed_date = $date_object->getTimestamp();
+		$deadline       = strtotime( '+' . $window_days . ' days', $completed_date );
+
+		if ( time() > $deadline ) {
+			return false;
+		}
+
+		// Must not already have a pending withdrawal request.
+		$requests = $this->get_withdrawal_requests( $order );
+		foreach ( $requests as $request ) {
+			if ( 'pending' === $request['status'] ) {
+				return false;
+			}
+		}
+
+		/**
+		 * Filter whether an order is eligible for withdrawal.
+		 *
+		 * @since 10.9.0
+		 * @param bool     $eligible Whether the order is eligible.
+		 * @param WC_Order $order    The order object.
+		 */
+		return apply_filters( 'woocommerce_order_is_eligible_for_withdrawal', true, $order );
+	}
+
+	/**
+	 * Get order statuses where withdrawal is allowed.
+	 *
+	 * @return array
+	 */
+	public function get_withdrawable_order_statuses(): array {
+		/**
+		 * Filter the order statuses that allow withdrawal.
+		 *
+		 * @since 10.9.0
+		 * @param array $statuses Order statuses.
+		 */
+		return apply_filters(
+			'woocommerce_valid_order_statuses_for_withdrawal',
+			array(
+				'processing',
+				'on-hold',
+				'completed',
+			)
+		);
+	}
+
+	/**
+	 * Get withdrawal requests stored on an order.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return array
+	 */
+	public function get_withdrawal_requests( WC_Order $order ): array {
+		$requests = $order->get_meta( self::WITHDRAWAL_REQUESTS_META_KEY, true );
+		return is_array( $requests ) ? $requests : array();
+	}
+
+	/**
+	 * Save withdrawal requests to an order.
+	 *
+	 * @param WC_Order $order    Order object.
+	 * @param array    $requests Withdrawal requests array.
+	 * @return void
+	 */
+	public function save_withdrawal_requests( WC_Order $order, array $requests ): void {
+		$order->update_meta_data( self::WITHDRAWAL_REQUESTS_META_KEY, $requests );
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Flush rewrite rules when the plugin is updated.
+	 *
+	 * @return void
+	 */
+	public static function maybe_flush_rewrite_rules() {
+		if ( ! did_action( 'woocommerce_updated' ) ) {
+			return;
+		}
+
+		$version_option  = 'woocommerce_withdrawal_endpoints_version';
+		$current_version = get_option( $version_option, '' );
+
+		if ( \WC_VERSION !== $current_version ) {
+			update_option( $version_option, \WC_VERSION );
+			flush_rewrite_rules();
+		}
+	}
+
+	/**
+	 * Get the current My Account endpoint.
+	 *
+	 * @return string
+	 */
+	private function get_current_endpoint(): string {
+		global $wp_query;
+		if ( ! isset( $wp_query->query_vars ) ) {
+			return '';
+		}
+
+		foreach ( array( 'withdrawals', 'request-withdrawal' ) as $endpoint ) {
+			if ( isset( $wp_query->query_vars[ $endpoint ] ) ) {
+				return $endpoint;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get a human-readable label for a withdrawal status.
+	 *
+	 * @param string $status Status key.
+	 * @return string
+	 */
+	private function get_status_label( string $status ): string {
+		$labels = array(
+			'pending'  => __( 'Pending', 'woocommerce' ),
+			'approved' => __( 'Approved', 'woocommerce' ),
+			'rejected' => __( 'Rejected', 'woocommerce' ),
+		);
+		return $labels[ $status ] ?? ucfirst( $status );
+	}
+}

--- a/plugins/woocommerce/templates/emails/admin-withdrawal-request.php
+++ b/plugins/woocommerce/templates/emails/admin-withdrawal-request.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Admin new withdrawal request email
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-withdrawal-request.php.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails
+ * @version 10.9.0
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+/**
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+
+<?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
+<p><?php esc_html_e( 'A customer has submitted a new withdrawal request for the following order:', 'woocommerce' ); ?></p>
+
+<table class="td" cellspacing="0" cellpadding="6" style="width:100%;margin-bottom:30px;" border="1">
+	<tr>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Order number', 'woocommerce' ); ?></th>
+		<td class="td" style="text-align:left;"><?php echo esc_html( $order->get_order_number() ); ?></td>
+	</tr>
+	<tr>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Withdrawal reference', 'woocommerce' ); ?></th>
+		<td class="td" style="text-align:left;"><code><?php echo esc_html( $request_id ); ?></code></td>
+	</tr>
+	<tr>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Date of request', 'woocommerce' ); ?></th>
+		<td class="td" style="text-align:left;"><?php echo '' !== $request_date_created ? esc_html( $request_date_created ) : esc_html( wc_format_datetime( new WC_DateTime() ) ); ?></td>
+	</tr>
+	<tr>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Customer', 'woocommerce' ); ?></th>
+		<td class="td" style="text-align:left;">
+			<?php echo esc_html( $order->get_formatted_billing_full_name() ); ?>
+			(<a href="mailto:<?php echo esc_attr( $order->get_billing_email() ); ?>"><?php echo esc_html( $order->get_billing_email() ); ?></a>)
+		</td>
+	</tr>
+</table>
+
+<p>
+	<a href="<?php echo esc_url( admin_url( 'post.php?post=' . absint( $order->get_id() ) . '&action=edit' ) ); ?>" class="button">
+		<?php esc_html_e( 'Review and process', 'woocommerce' ); ?>
+	</a>
+</p>
+
+<?php echo $email_improvements_enabled ? '</div>' : ''; ?>
+
+<?php
+/**
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+if ( $additional_content ) {
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
+}
+
+/**
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/customer-withdrawal-request.php
+++ b/plugins/woocommerce/templates/emails/customer-withdrawal-request.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Customer withdrawal request email
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-withdrawal-request.php.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails
+ * @version 10.9.0
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+/**
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+
+<?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
+<p>
+<?php
+if ( ! empty( $order->get_billing_first_name() ) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) );
+} else {
+	printf( esc_html__( 'Hi,', 'woocommerce' ) );
+}
+?>
+</p>
+<p><?php esc_html_e( 'We have received your withdrawal request. Here is a summary:', 'woocommerce' ); ?></p>
+
+<table class="td" cellspacing="0" cellpadding="6" style="width:100%;margin-bottom:30px;" border="1">
+	<tr>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Order number', 'woocommerce' ); ?></th>
+		<td class="td" style="text-align:left;"><?php echo esc_html( $order->get_order_number() ); ?></td>
+	</tr>
+	<tr>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Withdrawal reference', 'woocommerce' ); ?></th>
+		<td class="td" style="text-align:left;"><code><?php echo esc_html( $request_id ); ?></code></td>
+	</tr>
+	<tr>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Date of request', 'woocommerce' ); ?></th>
+		<td class="td" style="text-align:left;"><?php echo esc_html( current_time( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) ); ?></td>
+	</tr>
+	<tr>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Status', 'woocommerce' ); ?></th>
+		<td class="td" style="text-align:left;"><?php esc_html_e( 'Pending review', 'woocommerce' ); ?></td>
+	</tr>
+</table>
+
+<?php echo $email_improvements_enabled ? '</div>' : ''; ?>
+
+<?php
+/**
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Show user-defined additional content.
+ */
+if ( $additional_content ) {
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
+}
+
+/**
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/customer-withdrawal-request.php
+++ b/plugins/woocommerce/templates/emails/customer-withdrawal-request.php
@@ -46,7 +46,7 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 	</tr>
 	<tr>
 		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Date of request', 'woocommerce' ); ?></th>
-		<td class="td" style="text-align:left;"><?php echo esc_html( current_time( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) ); ?></td>
+		<td class="td" style="text-align:left;"><?php echo '' !== $request_date_created ? esc_html( $request_date_created ) : esc_html__( 'N/A', 'woocommerce' ); ?></td>
 	</tr>
 	<tr>
 		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Status', 'woocommerce' ); ?></th>

--- a/plugins/woocommerce/templates/emails/customer-withdrawal-status.php
+++ b/plugins/woocommerce/templates/emails/customer-withdrawal-status.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Admin new withdrawal request email
+ * Customer withdrawal status email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-withdrawal-request.php.
+ * Sent to the customer when their withdrawal request has been approved or rejected.
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
@@ -17,13 +17,39 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
+$status_label = 'approved' === $new_status
+	? __( 'approved', 'woocommerce' )
+	: __( 'rejected', 'woocommerce' );
+
 /**
  * @hooked WC_Emails::email_header() Output the email header
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<p><?php esc_html_e( 'A customer has submitted a new withdrawal request for the following order:', 'woocommerce' ); ?></p>
+<p>
+<?php
+if ( ! empty( $order->get_billing_first_name() ) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) );
+} else {
+	printf( esc_html__( 'Hi,', 'woocommerce' ) );
+}
+?>
+</p>
+<p>
+<?php
+/* translators: 1: order number, 2: status (approved/rejected) */
+printf( esc_html__( 'Your withdrawal request for order %1$s has been %2$s by the store.', 'woocommerce' ), esc_html( $order->get_order_number() ), esc_html( $status_label ) );
+?>
+</p>
+
+<?php if ( ! empty( $admin_notes ) ) : ?>
+	<p><strong><?php esc_html_e( 'Notes from the store', 'woocommerce' ); ?>:</strong></p>
+	<blockquote style="margin:0 0 20px;padding:10px 15px;border-left:3px solid #ddd;color:#555;">
+		<?php echo esc_html( $admin_notes ); ?>
+	</blockquote>
+<?php endif; ?>
 
 <table class="td" cellspacing="0" cellpadding="6" style="width:100%;margin-bottom:30px;" border="1">
 	<tr>
@@ -35,29 +61,20 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		<td class="td" style="text-align:left;"><code><?php echo esc_html( $request_id ); ?></code></td>
 	</tr>
 	<tr>
-		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Date of request', 'woocommerce' ); ?></th>
-		<td class="td" style="text-align:left;"><?php echo '' !== $request_date_created ? esc_html( $request_date_created ) : esc_html( wc_format_datetime( new WC_DateTime() ) ); ?></td>
-	</tr>
-	<tr>
-		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Customer', 'woocommerce' ); ?></th>
+		<th class="td" scope="row" style="text-align:left;"><?php esc_html_e( 'Status', 'woocommerce' ); ?></th>
 		<td class="td" style="text-align:left;">
-			<?php echo esc_html( $order->get_formatted_billing_full_name() ); ?>
-			(<a href="mailto:<?php echo esc_attr( $order->get_billing_email() ); ?>"><?php echo esc_html( $order->get_billing_email() ); ?></a>)
+			<strong><?php echo esc_html( $status_label ); ?></strong>
 		</td>
 	</tr>
 </table>
-
-<p>
-	<a href="<?php echo esc_url( $order->get_edit_order_url() ); ?>" class="button">
-		<?php esc_html_e( 'Review and process', 'woocommerce' ); ?>
-	</a>
-</p>
 
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 
 <?php
 /**
  * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
  */
 do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
@@ -72,6 +89,9 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
+/**
+ * Show user-defined additional content.
+ */
 if ( $additional_content ) {
 	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );

--- a/plugins/woocommerce/templates/emails/plain/admin-withdrawal-request.php
+++ b/plugins/woocommerce/templates/emails/plain/admin-withdrawal-request.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Admin new withdrawal request email (plain text)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-withdrawal-request.php.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Plain
+ * @version 10.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+echo esc_html__( 'A customer has submitted a new withdrawal request for the following order:', 'woocommerce' ) . "\n\n";
+
+echo esc_html__( 'Order number', 'woocommerce' ) . ': ' . esc_html( $order->get_order_number() ) . "\n";
+echo esc_html__( 'Withdrawal reference', 'woocommerce' ) . ': ' . esc_html( $request_id ) . "\n";
+echo esc_html__( 'Date of request', 'woocommerce' ) . ': ' . esc_html( ! empty( $request_date_created ) ? $request_date_created : wc_format_datetime( new WC_DateTime() ) ) . "\n";
+echo esc_html__( 'Customer', 'woocommerce' ) . ': ' . esc_html( $order->get_formatted_billing_full_name() ) . ' (' . esc_html( $order->get_billing_email() ) . ")\n\n";
+
+/* translators: %s: admin edit order URL */
+echo sprintf( esc_html__( 'Review and process: %s', 'woocommerce' ), esc_url( admin_url( 'post.php?post=' . absint( $order->get_id() ) . '&action=edit' ) ) ) . "\n\n";
+
+/**
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+echo "\n----------------------------------------\n\n";
+
+/**
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+if ( $additional_content ) {
+	echo "\n\n----------------------------------------\n\n";
+	echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+}

--- a/plugins/woocommerce/templates/emails/plain/customer-withdrawal-request.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-withdrawal-request.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Customer withdrawal request email (plain text)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-withdrawal-request.php.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Plain
+ * @version 10.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/* translators: %s: Customer first name */
+$first_name = $order->get_billing_first_name();
+if ( '' === $first_name ) {
+	echo esc_html__( 'Hi,', 'woocommerce' ) . "\n\n";
+} else {
+	/* translators: %s: Customer first name */
+	echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $first_name ) ) . "\n\n";
+}
+echo esc_html__( 'We have received your withdrawal request. Here is a summary:', 'woocommerce' ) . "\n\n";
+
+echo esc_html__( 'Order number', 'woocommerce' ) . ': ' . esc_html( $order->get_order_number() ) . "\n";
+echo esc_html__( 'Withdrawal reference', 'woocommerce' ) . ': ' . esc_html( $request_id ) . "\n";
+echo esc_html__( 'Date of request', 'woocommerce' ) . ': ' . esc_html( current_time( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) ) . "\n";
+echo esc_html__( 'Status', 'woocommerce' ) . ': ' . esc_html__( 'Pending review', 'woocommerce' ) . "\n\n";
+
+/**
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+echo "\n----------------------------------------\n\n";
+
+/**
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+echo "\n\n----------------------------------------\n\n";
+
+if ( $additional_content ) {
+	echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+	echo "\n\n----------------------------------------\n\n";
+}

--- a/plugins/woocommerce/templates/emails/plain/customer-withdrawal-status.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-withdrawal-status.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Customer withdrawal status email (plain text)
+ *
+ * @package WooCommerce\Templates\Emails\Plain
+ * @version 10.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$status_label = 'approved' === $new_status
+	? __( 'approved', 'woocommerce' )
+	: __( 'rejected', 'woocommerce' );
+
+echo '= ' . esc_html( $email_heading ) . " =\n\n";
+
+if ( ! empty( $order->get_billing_first_name() ) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ) . "\n\n", esc_html( $order->get_billing_first_name() ) );
+}
+
+/* translators: 1: order number, 2: status (approved/rejected) */
+printf( esc_html__( 'Your withdrawal request for order %1$s has been %2$s by the store.', 'woocommerce' ) . "\n\n", esc_html( $order->get_order_number() ), esc_html( $status_label ) );
+
+if ( ! empty( $admin_notes ) ) {
+	echo esc_html__( 'Notes from the store', 'woocommerce' ) . ":\n";
+	echo wp_strip_all_tags( $admin_notes ) . "\n\n";
+}
+
+echo "----------------------------------------\n\n";
+
+echo esc_html__( 'Order number', 'woocommerce' ) . ': ' . esc_html( $order->get_order_number() ) . "\n";
+echo esc_html__( 'Withdrawal reference', 'woocommerce' ) . ': ' . esc_html( $request_id ) . "\n";
+echo esc_html__( 'Status', 'woocommerce' ) . ': ' . esc_html( $status_label ) . "\n";
+
+echo "\n----------------------------------------\n\n";
+
+/**
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+if ( $additional_content ) {
+	echo "\n" . wp_strip_all_tags( $additional_content ) . "\n";
+}
+
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/plugins/woocommerce/templates/myaccount/form-request-withdrawal-confirm.php
+++ b/plugins/woocommerce/templates/myaccount/form-request-withdrawal-confirm.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Withdrawal request form - Step 2: confirmation.
+ *
+ * Final review and submit of the withdrawal request. Required by
+ * EU Directive 2023/2673 to ensure the consumer can review and confirm
+ * their withdrawal before it is submitted.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-request-withdrawal-confirm.php.
+ *
+ * @package WooCommerce\Templates
+ * @version 10.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( empty( $order ) || ! ( $order instanceof WC_Order ) ) {
+	echo '<p>' . esc_html__( 'Invalid order.', 'woocommerce' ) . '</p>';
+	return;
+}
+?>
+
+<div class="woocommerce-withdrawal-confirm">
+	<h2><?php esc_html_e( 'Confirm your withdrawal', 'woocommerce' ); ?></h2>
+	<p>
+		<?php
+		esc_html_e(
+			'Please review the information below and confirm your withdrawal request. By submitting, you are exercising your statutory right of withdrawal from this contract.',
+			'woocommerce'
+		);
+		?>
+	</p>
+
+	<table class="woocommerce-table shop_table">
+		<tbody>
+			<tr>
+				<th><?php esc_html_e( 'Order number', 'woocommerce' ); ?></th>
+				<td><?php echo esc_html( $order->get_order_number() ); ?></td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Order date', 'woocommerce' ); ?></th>
+				<td>
+					<?php
+					$date = $order->get_date_completed() ? $order->get_date_completed() : $order->get_date_created();
+					echo esc_html( wc_format_datetime( $date ) );
+					?>
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Order total', 'woocommerce' ); ?></th>
+				<td><?php echo wp_kses_post( $order->get_formatted_order_total() ); ?></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<form method="post" class="woocommerce-form withdrawal-confirm-form">
+		<?php wp_nonce_field( 'woocommerce-request_withdrawal', '_wpnonce' ); ?>
+		<input type="hidden" name="action" value="request_withdrawal" />
+		<input type="hidden" name="order_id" value="<?php echo esc_attr( (string) $order->get_id() ); ?>" />
+		<input type="hidden" name="step" value="confirm" />
+		<?php
+		$reason = '';
+		if ( function_exists( 'WC' ) && WC()->session ) {
+			$data = WC()->session->get( 'woocommerce_withdrawal_request_data', array() );
+			if ( isset( $data['reason'] ) ) {
+				$candidate = (string) $data['reason'];
+				$candidate = trim( wp_strip_all_tags( $candidate ) );
+				$candidate = preg_replace( '/\s+/', ' ', $candidate );
+				if ( is_string( $candidate ) && strlen( $candidate ) > 1000 ) {
+					$candidate = substr( $candidate, 0, 1000 );
+				}
+				$reason = $candidate;
+			}
+		}
+		?>
+		<input type="hidden" name="withdrawal_reason" value="<?php echo esc_attr( $reason ); ?>" />
+
+		<p>
+			<label>
+				<input type="checkbox" name="withdrawal_confirm" value="1" required />
+				<?php esc_html_e( 'I confirm that I wish to withdraw from this contract.', 'woocommerce' ); ?>
+			</label>
+		</p>
+
+		<p>
+			<button type="submit" class="button alt" name="woocommerce_request_withdrawal_confirm">
+				<?php esc_html_e( 'Submit withdrawal request', 'woocommerce' ); ?>
+			</button>
+			<a class="button" href="<?php echo esc_url( wc_get_endpoint_url( 'request-withdrawal', $order->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>">
+				<?php esc_html_e( 'Cancel', 'woocommerce' ); ?>
+			</a>
+		</p>
+	</form>
+</div>

--- a/plugins/woocommerce/templates/myaccount/form-request-withdrawal-submitted.php
+++ b/plugins/woocommerce/templates/myaccount/form-request-withdrawal-submitted.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Withdrawal request submitted acknowledgment.
+ *
+ * Shown after a successful withdrawal request submission. Records the
+ * date and time of the withdrawal as required by EU Directive 2023/2673.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-request-withdrawal-submitted.php.
+ *
+ * @package WooCommerce\Templates
+ * @version 10.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// Clear session data after rendering.
+if ( function_exists( 'WC' ) && WC()->session ) {
+	WC()->session->set( 'woocommerce_withdrawal_request_data', null );
+}
+
+$date_created = isset( $request_data['date_created'] ) ? (int) $request_data['date_created'] : time();
+$request_id   = isset( $request_id ) && is_string( $request_id ) ? $request_id : '';
+$order_number = ( is_object( $order ) && method_exists( $order, 'get_order_number' ) ) ? $order->get_order_number() : '';
+?>
+<div class="woocommerce-withdrawal-submitted">
+	<h2><?php esc_html_e( 'Withdrawal request received', 'woocommerce' ); ?></h2>
+	<p>
+		<?php
+		esc_html_e(
+			'Your withdrawal request has been successfully submitted. The merchant has been notified and will process your request. You will receive a separate confirmation email shortly.',
+			'woocommerce'
+		);
+		?>
+	</p>
+
+	<table class="woocommerce-table shop_table">
+		<tbody>
+			<tr>
+				<th><?php esc_html_e( 'Request reference', 'woocommerce' ); ?></th>
+				<td><code><?php echo '' !== $request_id ? esc_html( $request_id ) : esc_html__( 'N/A', 'woocommerce' ); ?></code></td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Date and time of withdrawal', 'woocommerce' ); ?></th>
+				<td>
+					<?php
+					if ( $date_created > 0 ) {
+						echo esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $date_created ) );
+					} else {
+						echo esc_html__( 'N/A', 'woocommerce' );
+					}
+					?>
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Order number', 'woocommerce' ); ?></th>
+				<td><?php echo '' !== $order_number ? esc_html( $order_number ) : esc_html__( 'N/A', 'woocommerce' ); ?></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>
+		<a class="button" href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>">
+			<?php esc_html_e( 'Back to account', 'woocommerce' ); ?>
+		</a>
+		<a class="button" href="<?php echo esc_url( wc_get_endpoint_url( 'withdrawals', '', wc_get_page_permalink( 'myaccount' ) ) ); ?>">
+			<?php esc_html_e( 'View all withdrawals', 'woocommerce' ); ?>
+		</a>
+	</p>
+</div>

--- a/plugins/woocommerce/templates/myaccount/form-request-withdrawal-submitted.php
+++ b/plugins/woocommerce/templates/myaccount/form-request-withdrawal-submitted.php
@@ -13,12 +13,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-// Clear session data after rendering.
-if ( function_exists( 'WC' ) && WC()->session ) {
-	WC()->session->set( 'woocommerce_withdrawal_request_data', null );
-}
-
-$date_created = isset( $request_data['date_created'] ) ? (int) $request_data['date_created'] : time();
+$date_created = isset( $request_data['date_created'] ) ? (int) $request_data['date_created'] : 0;
 $request_id   = isset( $request_id ) && is_string( $request_id ) ? $request_id : '';
 $order_number = ( is_object( $order ) && method_exists( $order, 'get_order_number' ) ) ? $order->get_order_number() : '';
 ?>

--- a/plugins/woocommerce/templates/myaccount/form-request-withdrawal.php
+++ b/plugins/woocommerce/templates/myaccount/form-request-withdrawal.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Withdrawal request form - Step 1: select order and review.
+ *
+ * Shows eligible orders for withdrawal OR the order review form for a specific order.
+ * This is the entry point of the two-step confirmation process required by
+ * EU Directive 2023/2673.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-request-withdrawal.php.
+ *
+ * @package WooCommerce\Templates
+ * @version 10.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+
+<div class="woocommerce-withdrawal-request-form">
+	<h2><?php esc_html_e( 'Withdraw from contract', 'woocommerce' ); ?></h2>
+	<p>
+		<?php
+		esc_html_e(
+			'You have the right to withdraw from this contract within 14 days without giving any reason. To exercise your right of withdrawal, please use the form below.',
+			'woocommerce'
+		);
+		?>
+	</p>
+
+	<?php if ( empty( $eligible_orders ) ) : ?>
+		<p><?php esc_html_e( 'You currently have no orders eligible for withdrawal.', 'woocommerce' ); ?></p>
+		<p>
+			<a class="button" href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>">
+				<?php esc_html_e( 'Back to account', 'woocommerce' ); ?>
+			</a>
+		</p>
+	<?php elseif ( $order ) : ?>
+		<p><strong><?php esc_html_e( 'Order details', 'woocommerce' ); ?></strong></p>
+		<table class="woocommerce-table shop_table">
+			<tbody>
+				<tr>
+					<th><?php esc_html_e( 'Order number', 'woocommerce' ); ?></th>
+					<td><?php echo esc_html( $order->get_order_number() ); ?></td>
+				</tr>
+				<tr>
+					<th><?php esc_html_e( 'Order date', 'woocommerce' ); ?></th>
+					<td>
+						<?php
+						$completed = $order->get_date_completed() ? $order->get_date_completed() : $order->get_date_created();
+						echo esc_html( wc_format_datetime( $completed ) );
+						?>
+					</td>
+				</tr>
+				<tr>
+					<th><?php esc_html_e( 'Order total', 'woocommerce' ); ?></th>
+					<td><?php echo wp_kses_post( $order->get_formatted_order_total() ); ?></td>
+				</tr>
+			</tbody>
+		</table>
+
+		<form method="post" class="woocommerce-form withdrawal-form">
+			<?php wp_nonce_field( 'woocommerce-request_withdrawal', '_wpnonce' ); ?>
+			<input type="hidden" name="action" value="request_withdrawal" />
+			<input type="hidden" name="order_id" value="<?php echo esc_attr( (string) $order->get_id() ); ?>" />
+			<input type="hidden" name="step" value="" />
+
+			<p>
+				<label for="withdrawal_reason"><?php esc_html_e( 'Reason for withdrawal (optional)', 'woocommerce' ); ?></label>
+				<textarea
+					id="withdrawal_reason"
+					name="withdrawal_reason"
+					rows="4"
+					style="width:100%;"
+					placeholder="<?php esc_attr_e( 'You may optionally provide a reason for your withdrawal. This is not required.', 'woocommerce' ); ?>"
+				></textarea>
+			</p>
+
+			<p>
+				<button type="submit" class="button alt" name="woocommerce_request_withdrawal_submit">
+					<?php esc_html_e( 'Continue', 'woocommerce' ); ?>
+				</button>
+			</p>
+		</form>
+	<?php else : ?>
+		<p><?php esc_html_e( 'Please select an order to withdraw from:', 'woocommerce' ); ?></p>
+		<table class="woocommerce-orders-table shop_table shop_table_responsive">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Order', 'woocommerce' ); ?></th>
+					<th><?php esc_html_e( 'Date', 'woocommerce' ); ?></th>
+					<th><?php esc_html_e( 'Total', 'woocommerce' ); ?></th>
+					<th><?php esc_html_e( 'Action', 'woocommerce' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $eligible_orders as $eligible_order ) : ?>
+					<tr>
+						<td><?php echo esc_html( $eligible_order->get_order_number() ); ?></td>
+						<td>
+							<?php
+							$date = $eligible_order->get_date_completed() ? $eligible_order->get_date_completed() : $eligible_order->get_date_created();
+							echo esc_html( wc_format_datetime( $date ) );
+							?>
+						</td>
+						<td><?php echo wp_kses_post( $eligible_order->get_formatted_order_total() ); ?></td>
+						<td>
+							<a class="button" href="<?php echo esc_url( wc_get_endpoint_url( 'request-withdrawal', $eligible_order->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>">
+								<?php esc_html_e( 'Select', 'woocommerce' ); ?>
+							</a>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
+</div>

--- a/plugins/woocommerce/templates/myaccount/form-request-withdrawal.php
+++ b/plugins/woocommerce/templates/myaccount/form-request-withdrawal.php
@@ -34,6 +34,15 @@ defined( 'ABSPATH' ) || exit;
 			</a>
 		</p>
 	<?php elseif ( $order ) : ?>
+		<?php
+		$preserved_reason = '';
+		if ( function_exists( 'WC' ) && WC()->session ) {
+			$session_data = WC()->session->get( 'woocommerce_withdrawal_request_data', array() );
+			if ( is_array( $session_data ) && isset( $session_data['order_id'] ) && (int) $session_data['order_id'] === $order->get_id() && ! empty( $session_data['reason'] ) ) {
+				$preserved_reason = (string) $session_data['reason'];
+			}
+		}
+		?>
 		<p><strong><?php esc_html_e( 'Order details', 'woocommerce' ); ?></strong></p>
 		<table class="woocommerce-table shop_table">
 			<tbody>
@@ -71,7 +80,7 @@ defined( 'ABSPATH' ) || exit;
 					rows="4"
 					style="width:100%;"
 					placeholder="<?php esc_attr_e( 'You may optionally provide a reason for your withdrawal. This is not required.', 'woocommerce' ); ?>"
-				></textarea>
+				><?php echo esc_textarea( $preserved_reason ); ?></textarea>
 			</p>
 
 			<p>
@@ -94,15 +103,15 @@ defined( 'ABSPATH' ) || exit;
 			<tbody>
 				<?php foreach ( $eligible_orders as $eligible_order ) : ?>
 					<tr>
-						<td><?php echo esc_html( $eligible_order->get_order_number() ); ?></td>
-						<td>
+						<td data-title="<?php esc_attr_e( 'Order', 'woocommerce' ); ?>"><?php echo esc_html( $eligible_order->get_order_number() ); ?></td>
+						<td data-title="<?php esc_attr_e( 'Date', 'woocommerce' ); ?>">
 							<?php
 							$date = $eligible_order->get_date_completed() ? $eligible_order->get_date_completed() : $eligible_order->get_date_created();
 							echo esc_html( wc_format_datetime( $date ) );
 							?>
 						</td>
-						<td><?php echo wp_kses_post( $eligible_order->get_formatted_order_total() ); ?></td>
-						<td>
+						<td data-title="<?php esc_attr_e( 'Total', 'woocommerce' ); ?>"><?php echo wp_kses_post( $eligible_order->get_formatted_order_total() ); ?></td>
+						<td data-title="<?php esc_attr_e( 'Action', 'woocommerce' ); ?>">
 							<a class="button" href="<?php echo esc_url( wc_get_endpoint_url( 'request-withdrawal', $eligible_order->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>">
 								<?php esc_html_e( 'Select', 'woocommerce' ); ?>
 							</a>

--- a/plugins/woocommerce/templates/myaccount/withdrawals.php
+++ b/plugins/woocommerce/templates/myaccount/withdrawals.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Withdrawals list.
+ *
+ * Lists all customer orders that have withdrawal requests.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/withdrawals.php.
+ *
+ * @package WooCommerce\Templates
+ * @version 10.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+
+<h2><?php esc_html_e( 'My withdrawals', 'woocommerce' ); ?></h2>
+
+<?php if ( empty( $withdrawal_orders ) ) : ?>
+	<p><?php esc_html_e( 'You have not submitted any withdrawal requests yet.', 'woocommerce' ); ?></p>
+<?php else : ?>
+	<table class="woocommerce-orders-table woocommerce-MyAccount-withdrawals shop_table shop_table_responsive my_account_withdrawals">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Order', 'woocommerce' ); ?></th>
+				<th><?php esc_html_e( 'Date submitted', 'woocommerce' ); ?></th>
+				<th><?php esc_html_e( 'Reference', 'woocommerce' ); ?></th>
+				<th><?php esc_html_e( 'Status', 'woocommerce' ); ?></th>
+				<th><?php esc_html_e( 'Action', 'woocommerce' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php foreach ( $withdrawal_orders as $data ) : ?>
+				<?php
+				$order    = $data['order'];
+				$requests = $data['requests'];
+				$view_url = $order->get_view_order_url();
+				?>
+				<?php foreach ( $requests as $request ) : ?>
+					<tr>
+						<td>
+							<a href="<?php echo esc_url( $view_url ); ?>">
+								<?php echo esc_html( $order->get_order_number() ); ?>
+							</a>
+						</td>
+						<td>
+							<?php
+							$ts = isset( $request['date_created'] ) ? (int) $request['date_created'] : 0;
+							echo esc_html( $ts ? date_i18n( get_option( 'date_format' ), $ts ) : '—' );
+							?>
+						</td>
+						<td><code><?php echo esc_html( $request['request_id'] ?? '' ); ?></code></td>
+						<td>
+							<?php
+							$status = $request['status'] ?? 'pending';
+							$labels = array(
+								'pending'  => __( 'Pending', 'woocommerce' ),
+								'approved' => __( 'Approved', 'woocommerce' ),
+								'rejected' => __( 'Rejected', 'woocommerce' ),
+							);
+							echo esc_html( $labels[ $status ] ?? ucfirst( $status ) );
+							?>
+						</td>
+						<td>
+							<a class="button" href="<?php echo esc_url( $view_url ); ?>">
+								<?php esc_html_e( 'View order', 'woocommerce' ); ?>
+							</a>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			<?php endforeach; ?>
+		</tbody>
+	</table>
+<?php endif; ?>


### PR DESCRIPTION
## Summary

Implements EU Directive 2023/2673 mandatory electronic withdrawal function. Adds a two-step withdrawal flow in My Account: (1) review order eligibility and reason, (2) confirm submission. Withdrawal requests stored as order meta. Admin can view/manage requests via order edit screen. Customer and admin email notifications sent on submission.

Fixes #65443

## Changes

### New: WithdrawalController (`src/Internal/Orders/WithdrawalController.php`)

Central controller handling form routing, order eligibility check, session-based two-step flow, order meta persistence, and template dispatch.

**Why:** Single source of truth for all withdrawal logic. PSR-4, DI-compatible.

### New: Email classes (`includes/emails/class-wc-email-*.php`)

Two email classes: customer acknowledgment and admin notification. Both support `{request_date_created}` placeholder populated from order meta.

**Why:** Admins need immediate notification; customers need confirmation with reference ID.

### New: My Account templates (`templates/myaccount/form-request-withdrawal*.php`)

Three-step template flow: initial review → confirmation → acknowledgment. Uses WooCommerce template override pattern.

**Why:** EU Directive requires consumer review and explicit confirmation before submission.

### New: Withdrawals list (`templates/myaccount/withdrawals.php`)

Paginated list of past withdrawal requests per order in My Account.

**Why:** Consumer needs visibility into submitted requests.

### Modified: Endpoint registration

Added `withdrawals` and `request-withdrawal` query vars. Registered template hooks in `wc-template-hooks.php`. Added "Withdraw" action on eligible orders in `wc-account-functions.php`.

**Why:** Standard WooCommerce endpoint pattern for My Account pages.

## Testing

**Test 1: Eligibility check**
1. Place an order, mark it completed/delivered
2. Go to My Account → Orders
3. Verify "Withdraw" action visible on eligible orders

Result: Action appears on completed orders not previously withdrawn.

**Test 2: Two-step submission flow**
1. Click "Withdraw" on an eligible order
2. Step 1: Enter reason, click Continue
3. Step 2: Review details, check confirmation box, Submit
4. Verify acknowledgment screen with reference ID

Result: Request submitted, order meta updated, confirmation email sent.

**Test 3: Admin notification**
1. Submit withdrawal request
2. Check admin email inbox

Result: Admin receives notification with order number, reference ID, and direct link to order edit screen.

**Test 4: Withdrawals list**
1. After submission, go to My Account → Withdrawals
2. Verify past requests listed with status

Result: Submitted request appears in list with pending status.

## Screenshots
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/c567e6f5-9c86-410e-870a-22eecff7066d" />
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/e4b57cd2-9337-4fe6-839b-8f3784f08814" />
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/e660c4d2-395a-4da7-b5ba-f2bfcb17fbf6" />
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/8b3ee63c-d990-4705-8386-cb6845b4e9fb" />
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/17bd65cb-99c2-4df8-afee-a6bd76e4fde2" />
<img width="1916" height="822" alt="image" src="https://github.com/user-attachments/assets/29d4f2da-657f-4f44-b652-78efcfaefbda" />


