### PR TITLE
add(order-list): add country column and billing country filter

### DIFF
--- a/plugins/woocommerce/changelog/fix-65309-country-column-filter
+++ b/plugins/woocommerce/changelog/fix-65309-country-column-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add "Country" column and billing country filter to the admin order list table. Column is hidden by default (enable via Screen Options). Filter uses a dropdown of all countries. Column is sortable.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -125,6 +125,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		$show_columns['order_status']     = __( 'Status', 'woocommerce' );
 		$show_columns['billing_address']  = __( 'Billing', 'woocommerce' );
 		$show_columns['shipping_address'] = __( 'Ship to', 'woocommerce' );
+		$show_columns['billing_country']  = __( 'Country', 'woocommerce' );
 		$show_columns['order_total']      = __( 'Total', 'woocommerce' );
 		$show_columns['wc_actions']       = __( 'Actions', 'woocommerce' );
 
@@ -217,6 +218,13 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 */
 	protected function render_shipping_address_column() {
 		$this->orders_list_table->render_shipping_address_column( $this->object );
+	}
+
+	/**
+	 * Render column: billing_country.
+	 */
+	protected function render_billing_country_column() {
+		$this->orders_list_table->render_billing_country_column( $this->object );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -598,6 +598,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	protected function render_filters() {
 		$this->orders_list_table->created_via_filter();
 		$this->orders_list_table->customers_filter();
+		$this->orders_list_table->billing_country_filter();
 	}
 
 	/**
@@ -649,6 +650,18 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 					'value'   => $created_via,
 					'compare' => 'IN',
 				),
+			);
+			// @codingStandardsIgnoreEnd
+		}
+
+		// Filter the orders by billing country.
+		if ( ! empty( $_GET['_billing_country'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// @codingStandardsIgnoreStart
+			$query_vars['meta_query']   = $query_vars['meta_query'] ?? array();
+			$query_vars['meta_query'][] = array(
+				'key'     => '_billing_country',
+				'value'   => sanitize_text_field( wp_unslash( $_GET['_billing_country'] ) ),
+				'compare' => '=',
 			);
 			// @codingStandardsIgnoreEnd
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -614,6 +614,18 @@ class ListTable extends WP_List_Table {
 			return;
 		}
 
+		/**
+		 * Fires when a valid billing country filter value has been read from the request, before
+		 * it is added to the order query args. Extensions can use this to map custom request
+		 * values to additional query args (e.g. supporting comma-separated country lists).
+		 *
+		 * @since 10.5.0
+		 *
+		 * @param string                $country   The validated ISO country code.
+		 * @param ListTable             $list_table The current list table instance.
+		 */
+		do_action( 'woocommerce_order_list_table_set_billing_country_args', $country, $this );
+
 		$this->order_query_args['billing_country'] = $country;
 		$this->has_filter                          = true;
 	}
@@ -1027,7 +1039,19 @@ class ListTable extends WP_List_Table {
 	public function billing_country_filter() {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$current_country = isset( $_GET['_billing_country'] ) ? sanitize_text_field( wp_unslash( $_GET['_billing_country'] ) ) : '';
-		$countries       = WC()->countries->get_countries();
+
+		/**
+		 * Filters the list of countries available in the billing country filter dropdown on the order list table.
+		 *
+		 * This filter enables extensions to add, remove, or reorder the countries shown in the
+		 * billing country filter without modifying the underlying template. It also lets extensions
+		 * align the dropdown options with any custom address field schemas they register.
+		 *
+		 * @since 10.5.0
+		 *
+		 * @param array $countries Associative array of country code => country name.
+		 */
+		$countries = apply_filters( 'woocommerce_order_list_table_billing_country_filter', WC()->countries->get_countries() );
 		?>
 		<select name="_billing_country" id="filter-by-billing-country">
 			<option value=""><?php esc_html_e( 'All countries', 'woocommerce' ); ?></option>

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -608,6 +608,12 @@ class ListTable extends WP_List_Table {
 			return;
 		}
 
+		// Validate against the list of valid countries to prevent URL injection of invalid codes.
+		$countries = WC()->countries->get_countries();
+		if ( ! isset( $countries[ $country ] ) ) {
+			return;
+		}
+
 		$this->order_query_args['billing_country'] = $country;
 		$this->has_filter                          = true;
 	}
@@ -1084,9 +1090,9 @@ class ListTable extends WP_List_Table {
 		return apply_filters(
 			'woocommerce_' . $this->order_type . '_list_table_sortable_columns',
 			array(
-				'order_number' => 'ID',
-				'order_date'   => 'date',
-				'order_total'  => 'order_total',
+				'order_number'    => 'ID',
+				'order_date'      => 'date',
+				'order_total'     => 'order_total',
 				'billing_country' => 'billing_country',
 			)
 		);
@@ -1348,11 +1354,14 @@ class ListTable extends WP_List_Table {
 
 		if ( $country_code ) {
 			$countries = WC()->countries->get_countries();
-			$name      = $countries[ $country_code ] ?? $country_code;
-			echo esc_html( $name );
-		} else {
-			echo '&ndash;';
+
+			if ( isset( $countries[ $country_code ] ) ) {
+				echo esc_html( $countries[ $country_code ] );
+				return;
+			}
 		}
+
+		echo '&ndash;';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -115,6 +115,7 @@ class ListTable extends WP_List_Table {
 		add_action( 'admin_footer', array( $this, 'enqueue_scripts' ) );
 		add_action( 'woocommerce_order_list_table_restrict_manage_orders', array( $this, 'created_via_filter' ) );
 		add_action( 'woocommerce_order_list_table_restrict_manage_orders', array( $this, 'customers_filter' ) );
+		add_action( 'woocommerce_order_list_table_restrict_manage_orders', array( $this, 'billing_country_filter' ) );
 
 		$this->items_per_page();
 		set_screen_options();
@@ -406,6 +407,7 @@ class ListTable extends WP_List_Table {
 		$this->set_customer_args();
 		$this->set_search_args();
 		$this->set_created_via_args();
+		$this->set_billing_country_args();
 
 		/**
 		 * Provides an opportunity to modify the query arguments used in the (Custom Order Table-powered) order list
@@ -593,6 +595,21 @@ class ListTable extends WP_List_Table {
 		$this->order_query_args['created_via'] = array_map( 'trim', explode( ',', $created_via ) );
 
 		$this->has_filter = true;
+	}
+
+	/**
+	 * Implements filtering of orders by billing country.
+	 */
+	private function set_billing_country_args(): void {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$country = sanitize_text_field( wp_unslash( $_GET['_billing_country'] ?? '' ) );
+
+		if ( empty( $country ) ) {
+			return;
+		}
+
+		$this->order_query_args['billing_country'] = $country;
+		$this->has_filter                          = true;
 	}
 
 	/**
@@ -997,6 +1014,32 @@ class ListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Render the billing country filter dropdown.
+	 *
+	 * @return void
+	 */
+	public function billing_country_filter() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$current_country = isset( $_GET['_billing_country'] ) ? sanitize_text_field( wp_unslash( $_GET['_billing_country'] ) ) : '';
+		$countries       = WC()->countries->get_countries();
+		?>
+		<select name="_billing_country" id="filter-by-billing-country">
+			<option value=""><?php esc_html_e( 'All countries', 'woocommerce' ); ?></option>
+			<?php
+			foreach ( $countries as $code => $name ) {
+				printf(
+					'<option value="%s"%s>%s</option>',
+					esc_attr( $code ),
+					selected( $code, $current_country, false ),
+					esc_html( $name )
+				);
+			}
+			?>
+		</select>
+		<?php
+	}
+
+	/**
 	 * Get list columns.
 	 *
 	 * @return array
@@ -1018,6 +1061,7 @@ class ListTable extends WP_List_Table {
 				'order_status'     => esc_html__( 'Status', 'woocommerce' ),
 				'billing_address'  => esc_html__( 'Billing', 'woocommerce' ),
 				'shipping_address' => esc_html__( 'Ship to', 'woocommerce' ),
+				'billing_country'  => esc_html__( 'Country', 'woocommerce' ),
 				'order_total'      => esc_html__( 'Total', 'woocommerce' ),
 				'wc_actions'       => esc_html__( 'Actions', 'woocommerce' ),
 			)
@@ -1043,6 +1087,7 @@ class ListTable extends WP_List_Table {
 				'order_number' => 'ID',
 				'order_date'   => 'date',
 				'order_total'  => 'order_total',
+				'billing_country' => 'billing_country',
 			)
 		);
 	}
@@ -1062,6 +1107,7 @@ class ListTable extends WP_List_Table {
 				array(
 					'billing_address',
 					'shipping_address',
+					'billing_country',
 					'wc_actions',
 				)
 			);
@@ -1285,6 +1331,25 @@ class ListTable extends WP_List_Table {
 				/* translators: %s: shipping method */
 				echo '<span class="description">' . sprintf( esc_html__( 'via %s', 'woocommerce' ), esc_html( $order->get_shipping_method() ) ) . '</span>';
 			}
+		} else {
+			echo '&ndash;';
+		}
+	}
+
+	/**
+	 * Renders order billing country.
+	 *
+	 * @param WC_Order $order The order object for the current row.
+	 *
+	 * @return void
+	 */
+	public function render_billing_country_column( WC_Order $order ): void {
+		$country_code = $order->get_billing_country();
+
+		if ( $country_code ) {
+			$countries = WC()->countries->get_countries();
+			$name      = $countries[ $country_code ] ?? $country_code;
+			echo esc_html( $name );
 		} else {
 			echo '&ndash;';
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
@@ -232,4 +232,54 @@ class ListTableTest extends \WC_Unit_Test_Case {
 
 		$this->assertCount( 2, $filtered_items ); // Both orders should be shown.
 	}
+
+	/**
+	 * @testdox When filtering by billing_country, only orders with that specific value should be shown.
+	 */
+	public function test_filtering_by_billing_country_shows_only_matching_orders(): void {
+		$order1 = \WC_Helper_Order::create_order();
+		$order1->set_billing_country( 'US' );
+		$order1->save();
+
+		$order2 = \WC_Helper_Order::create_order();
+		$order2->set_billing_country( 'GB' );
+		$order2->save();
+
+		$_GET['_billing_country'] = 'US';
+
+		$this->sut->prepare_items();
+
+		$get_items      = function () {
+			return $this->items;
+		};
+		$filtered_items = $get_items->call( $this->sut );
+
+		$this->assertCount( 1, $filtered_items );
+		$this->assertEquals( 'US', $filtered_items[0]->get_billing_country() );
+		$this->assertEquals( $order1->get_id(), $filtered_items[0]->get_id() );
+	}
+
+	/**
+	 * @testdox When the billing_country filter is empty, all orders should be shown.
+	 */
+	public function test_filtering_by_billing_country_shows_all_orders_when_no_filter(): void {
+		$order1 = \WC_Helper_Order::create_order();
+		$order1->set_billing_country( 'US' );
+		$order1->save();
+
+		$order2 = \WC_Helper_Order::create_order();
+		$order2->set_billing_country( 'GB' );
+		$order2->save();
+
+		unset( $_GET['_billing_country'] );
+
+		$this->sut->prepare_items();
+
+		$get_items      = function () {
+			return $this->items;
+		};
+		$filtered_items = $get_items->call( $this->sut );
+
+		$this->assertCount( 2, $filtered_items );
+	}
 }


### PR DESCRIPTION
## Summary

Adds a "Country" column and billing country filter dropdown to the admin order list table, giving merchants direct visibility into order billing countries without relying on analytics (which are unreliable per #63699).

Fixes #65309

## Changes

### `plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php`

**New column:** `billing_country` added to `get_columns()`, `get_sortable_columns()`, and `default_hidden_columns()`. Hidden by default — enable via Screen Options.

**After:**
```php
'billing_country'  => esc_html__( 'Country', 'woocommerce' ),
```

**New filter method:** `billing_country_filter()` renders a `<select>` dropdown populated from `WC()->countries->get_countries()`, filtering orders by `_billing_country` GET param. Now wrapped in `apply_filters( 'woocommerce_order_list_table_billing_country_filter', ... )` for extensibility.

**New query method:** `set_billing_country_args()` reads the filter value and sets `$this->order_query_args['billing_country']` — handled natively by `OrdersTableQuery::process_addresses_table_query_args()` via `wc_order_addresses` JOIN. Now fires `do_action( 'woocommerce_order_list_table_set_billing_country_args', $country, $this )` for extensions.

**New render method:** `render_billing_country_column()` resolves ISO code to full country name via `WC()->countries->get_countries()`, falls back to `–` if empty.

### `plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php`

**Column added** to `define_columns()`. **Render method** delegates to HPOS `ListTable::render_billing_country_column()`.

### `plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php`

**Unit tests added** for the billing country filter:
- `test_filtering_by_billing_country_shows_only_matching_orders()`
- `test_filtering_by_billing_country_shows_all_orders_when_no_filter()`

## Testing

1. WP Admin → WooCommerce → Orders → Screen Options → check "Country"
2. Verify column shows billing country names, `–` for empty
3. Use "All countries" dropdown → select country → Filter
4. Click column header to sort ASC/DESC
5. Test with HPOS enabled and disabled (legacy storage)

## Screenshots

| Before | After |
| ------ | ----- |
| Orders table without country column, no country filter in toolbar | Orders table with Country column (hidden by default, enabled via Screen Options) and billing country dropdown filter in toolbar |

![image](https://github.com/user-attachments/assets/0d56c1e0-a8d0-4e03-becb-27a75c18872c)

## How to test the changes in this Pull Request

1. Enable the "Country" column: WP Admin → WooCommerce → Orders → Screen Options → check "Country" → Apply
2. Verify the column appears with full country names (e.g. "United States", "United Kingdom") and `–` for orders without billing country
3. Click the "Country" column header to sort orders by country (ASC/DESC)
4. Use the "All countries" dropdown filter in the toolbar above the table:
   - Select a country (e.g. "United States")
   - Click "Filter"
   - Verify only orders with that billing country are shown
   - Select "All countries" to clear the filter
5. Test with both HPOS enabled and HPOS disabled (legacy CPT storage)
6. Run unit tests: `pnpm test:php:env -- --filter ListTableTest`

## Testing that has already taken place

- Manual testing in local wp-env with WooCommerce Core trunk
- Verified column appears and is sortable
- Verified filter dropdown works and filters orders correctly
- Tested with HPOS enabled (orders table) and HPOS disabled (legacy CPT)
- Existing tests pass (`created_via` filter tests as regression check)
- New unit tests added for billing_country filter behavior
- PHP lint (phpcs) and PHPStan pass on changed files

## Milestone

- [x] Auto-assign to next version

## Changelog entry

**Significance**: minor
**Type**: add
**Message**: Add "Country" column and billing country filter to admin order list table. Column is hidden by default (enable via Screen Options). Filter uses a dropdown of all countries. Column is sortable.

## Release Communication

- [x] Feature Highlight (user-facing changes)
- [ ] Developer Advisory (developer-facing changes)

---

**Submission Review Guidelines** (checklist):

- [x] Followed WooCommerce Contributing Guidelines & WordPress Coding Standards
- [x] Checked for duplicate open PRs
- [x] Reviewed code for security best practices