### PR TITLE
Fix duplicate processors accumulating in wc_pending_batch_processes

### DIFF
--- a/plugins/woocommerce/changelog/fix-batch-processing-duplicate-enqueue
+++ b/plugins/woocommerce/changelog/fix-batch-processing-duplicate-enqueue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix BatchProcessingController::enqueue_processor() appending duplicate entries to the wc_pending_batch_processes option.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -100,8 +100,9 @@ class BatchProcessingController {
 
 		// De-duplicate defensively. Historically this method compared the class name against array_keys() rather
 		// than the stored values, so the same processor was appended on every call and bloated the option. Collapsing
-		// here also heals stores already carrying duplicate entries on their next enqueue.
-		$deduplicated_updates = array_values( array_unique( $pending_updates ) );
+		// here also heals stores already carrying duplicate entries on their next enqueue. Filtering to strings keeps
+		// array_unique() from fataling on (and silently strips) any non-string values a corrupted option may contain.
+		$deduplicated_updates = array_values( array_unique( array_filter( $pending_updates, 'is_string' ) ) );
 		if ( ! in_array( $processor_class_name, $deduplicated_updates, true ) ) {
 			$deduplicated_updates[] = $processor_class_name;
 		}

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -99,10 +99,18 @@ class BatchProcessingController {
 		$pending_updates = $this->get_enqueued_processors();
 
 		// De-duplicate defensively. Historically this method compared the class name against array_keys() rather
-		// than the stored values, so the same processor was appended on every call and bloated the option. Collapsing
-		// here also heals stores already carrying duplicate entries on their next enqueue. Filtering to strings keeps
-		// array_unique() from fataling on (and silently strips) any non-string values a corrupted option may contain.
-		$deduplicated_updates = array_values( array_unique( array_filter( $pending_updates, 'is_string' ) ) );
+		// than the stored values, so the same processor was appended on every call and bloated the option. Building
+		// the unique list in a single pass heals stores already carrying duplicates on their next enqueue while
+		// keeping only one entry per class name in memory (so the cleanup stays bounded even when the stored list
+		// ballooned to thousands of entries), and skips any non-string values a corrupted option may hold.
+		$deduplicated_updates = array();
+		$seen                 = array();
+		foreach ( $pending_updates as $value ) {
+			if ( is_string( $value ) && ! isset( $seen[ $value ] ) ) {
+				$seen[ $value ]         = true;
+				$deduplicated_updates[] = $value;
+			}
+		}
 		if ( ! in_array( $processor_class_name, $deduplicated_updates, true ) ) {
 			$deduplicated_updates[] = $processor_class_name;
 		}

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -97,10 +97,18 @@ class BatchProcessingController {
 	 */
 	public function enqueue_processor( string $processor_class_name ): void {
 		$pending_updates = $this->get_enqueued_processors();
-		if ( ! in_array( $processor_class_name, array_keys( $pending_updates ), true ) ) {
-			$pending_updates[] = $processor_class_name;
-			$this->set_enqueued_processors( $pending_updates );
+
+		// De-duplicate defensively. Historically this method compared the class name against array_keys() rather
+		// than the stored values, so the same processor was appended on every call and bloated the option. Collapsing
+		// here also heals stores already carrying duplicate entries on their next enqueue.
+		$deduplicated_updates = array_values( array_unique( $pending_updates ) );
+		if ( ! in_array( $processor_class_name, $deduplicated_updates, true ) ) {
+			$deduplicated_updates[] = $processor_class_name;
 		}
+		if ( $deduplicated_updates !== $pending_updates ) {
+			$this->set_enqueued_processors( $deduplicated_updates );
+		}
+
 		$this->schedule_watchdog_action( false, true );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -146,6 +146,24 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Enqueuing collapses a heavily bloated list of thousands of duplicates to a single entry.
+	 */
+	public function test_enqueue_processor_collapses_heavily_bloated_list(): void {
+		$processor = get_class( $this->test_process );
+
+		// Mirror the reported production case (thousands of identical entries).
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array_fill( 0, 3000, $processor ),
+			false
+		);
+
+		$this->sut->enqueue_processor( $processor );
+
+		$this->assertSame( array( $processor ), $this->sut->get_enqueued_processors(), 'A heavily bloated list must collapse to a single entry.' );
+	}
+
+	/**
 	 * @testdox 'remove_processor' dequeues and unschedules a processor, but the watchdog is kept alive if more processors are still enqueued.
 	 */
 	public function test_remove_processor_when_others_are_still_enqueued() {

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -63,6 +63,7 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$enqueued = $this->sut->get_enqueued_processors();
 		$this->assertCount( 1, $enqueued, 'Repeated enqueues of the same processor must not create duplicates.' );
 		$this->assertContains( $processor, $enqueued, 'The enqueued processor should still be present.' );
+		$this->assertCount( 1, get_option( BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME ), 'The persisted option must not contain duplicates.' );
 	}
 
 	/**
@@ -81,7 +82,67 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$this->sut->enqueue_processor( $processor );
 
 		$this->assertCount( 1, $this->sut->get_enqueued_processors(), 'Existing duplicates should collapse to a single entry.' );
-		$this->assertCount( 1, get_option( BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME ), 'The de-duplicated list should be persisted.' );
+		$persisted = get_option( BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME );
+		$this->assertCount( 1, $persisted, 'The de-duplicated list should be persisted.' );
+		$this->assertContains( $processor, $persisted, 'The persisted list should still contain the processor.' );
+	}
+
+	/**
+	 * @testdox Enqueuing a processor collapses duplicates of other processors without dropping them.
+	 */
+	public function test_enqueue_processor_collapses_duplicates_without_dropping_others(): void {
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array( 'Processor\\A', 'Processor\\A', 'Processor\\A', 'Processor\\B' ),
+			false
+		);
+
+		$this->sut->enqueue_processor( 'Processor\\C' );
+
+		$this->assertSame(
+			array( 'Processor\\A', 'Processor\\B', 'Processor\\C' ),
+			$this->sut->get_enqueued_processors(),
+			'Collapsing duplicates must preserve other processors and append the new one, in order.'
+		);
+	}
+
+	/**
+	 * @testdox Re-enqueuing an already-present processor on a clean list does not rewrite the option.
+	 */
+	public function test_enqueue_processor_skips_write_when_unchanged(): void {
+		$processor = get_class( $this->test_process );
+		$this->sut->enqueue_processor( $processor );
+
+		$writes = 0;
+		add_filter(
+			'pre_update_option_' . BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			function ( $value ) use ( &$writes ) {
+				++$writes;
+				return $value;
+			}
+		);
+
+		$this->sut->enqueue_processor( $processor );
+
+		$this->assertSame( 0, $writes, 'A no-op enqueue must not trigger an option write.' );
+	}
+
+	/**
+	 * @testdox Enqueuing strips non-string values from a corrupted option without fataling.
+	 */
+	public function test_enqueue_processor_strips_non_string_values(): void {
+		$processor = get_class( $this->test_process );
+
+		// A corrupted option containing non-string values would otherwise make array_unique() fatal.
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array( $processor, new \stdClass(), array( 'corrupt' ), 12345 ),
+			false
+		);
+
+		$this->sut->enqueue_processor( $processor );
+
+		$this->assertSame( array( $processor ), $this->sut->get_enqueued_processors(), 'Non-string values must be stripped, leaving only valid processor names.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -51,6 +51,40 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Enqueuing the same processor repeatedly keeps a single entry.
+	 */
+	public function test_enqueue_processor_is_idempotent(): void {
+		$processor = get_class( $this->test_process );
+
+		$this->sut->enqueue_processor( $processor );
+		$this->sut->enqueue_processor( $processor );
+		$this->sut->enqueue_processor( $processor );
+
+		$enqueued = $this->sut->get_enqueued_processors();
+		$this->assertCount( 1, $enqueued, 'Repeated enqueues of the same processor must not create duplicates.' );
+		$this->assertContains( $processor, $enqueued, 'The enqueued processor should still be present.' );
+	}
+
+	/**
+	 * @testdox Enqueuing collapses a pre-existing list bloated with duplicates and persists the cleanup.
+	 */
+	public function test_enqueue_processor_collapses_preexisting_duplicates(): void {
+		$processor = get_class( $this->test_process );
+
+		// Simulate an option bloated by the historical duplicate bug.
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array_fill( 0, 5, $processor ),
+			false
+		);
+
+		$this->sut->enqueue_processor( $processor );
+
+		$this->assertCount( 1, $this->sut->get_enqueued_processors(), 'Existing duplicates should collapse to a single entry.' );
+		$this->assertCount( 1, get_option( BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME ), 'The de-duplicated list should be persisted.' );
+	}
+
+	/**
 	 * @testdox 'remove_processor' dequeues and unschedules a processor, but the watchdog is kept alive if more processors are still enqueued.
 	 */
 	public function test_remove_processor_when_others_are_still_enqueued() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

`BatchProcessingController::enqueue_processor()` is meant to keep a unique list of pending processors in the `wc_pending_batch_processes` option, but its duplicate check compared the class name against `array_keys( $pending_updates )` — the numeric list indices — instead of the stored class-name values. A strict `in_array()` of a string against integer keys is always false, so the same processor was appended on every call. On stores running HPOS background sync in continuous mode, `DataSynchronizer::handle_continuous_background_sync()` enqueues the processor on the `shutdown` hook on every request, so the option grew by one duplicate per page load (a real store accumulated 2,858 identical `DataSynchronizer` entries, driving options-table writes and Action Scheduler lookup churn).

This fixes the check to compare against the stored values, and de-duplicates the list outside the membership gate so stores already carrying duplicate entries self-heal on their next enqueue (no migration required). `get_enqueued_processors()` stays a pure read.

Closes #63786.

(For Bug Fixes) Bug introduced in PR #33233.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start from a clean queue: `wp option delete wc_pending_batch_processes`.
2. In `wp shell`, enqueue the same processor three times:
   ```php
   $c = wc_get_container()->get( Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController::class );
   $c->enqueue_processor( Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class );
   $c->enqueue_processor( Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class );
   $c->enqueue_processor( Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class );
   ```
3. Run `wp option get wc_pending_batch_processes --format=json` and confirm it contains the processor exactly **once** (before this fix it would contain three copies).
4. Self-heal check: seed duplicates with `wp option update wc_pending_batch_processes '["Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\DataSynchronizer","Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\DataSynchronizer","Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\DataSynchronizer"]' --format=json`, enqueue the processor once more (step 2), then re-run step 3 — the option should collapse to a single entry.
5. Run the unit tests: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter BatchProcessingControllerTests`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- Added two regression tests (TDD): confirmed they fail against `trunk` (3 and 6 entries) and pass after the fix.
- `BatchProcessingControllerTests` full class: 9 tests, 40 assertions, all passing in the wp-env container (PHPUnit 9.6, PHP 8.1).
- PHPStan: no errors on `BatchProcessingController.php` (project config).
- `phpcs`/branch-lint not run locally (codesniffer tooling not installed in this checkout); deferred to CI. Diff manually reviewed against WordPress Coding Standards.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

The changelog entry was added manually in this branch (`plugins/woocommerce/changelog/fix-batch-processing-duplicate-enqueue`), so neither automation box below is checked.

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix BatchProcessingController::enqueue_processor() appending duplicate entries to the wc_pending_batch_processes option.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)