### PR TITLE
Fix incorrect use of dl tag in cart item data (accessibility)

### DIFF
--- a/plugins/woocommerce/changelog/61076-fix-cart-item-data-dl-a11y
+++ b/plugins/woocommerce/changelog/61076-fix-cart-item-data-dl-a11y
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Accessibility: Replace the semantic dl/dt/dd markup in the cart item data template with non-semantic elements so screen readers no longer announce cart item meta (e.g. variations, vendor) as a definition list.

--- a/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
@@ -248,10 +248,12 @@ a.remove {
 }
 
 dl.variation,
+.variation,
 .wc-item-meta {
 	list-style: none outside;
 
 	dt,
+	.variation-label,
 	.wc-item-meta-label {
 		float: left;
 		clear: both;
@@ -259,7 +261,8 @@ dl.variation,
 		list-style: none outside;
 	}
 
-	dd {
+	dd,
+	.variation-value {
 		margin: 0;
 	}
 
@@ -800,7 +803,8 @@ table.variations {
 		display: block;
 	}
 
-	dl.variation {
+	dl.variation,
+	.variation {
 		margin-top: 0;
 
 		p,
@@ -1033,7 +1037,8 @@ table.variations {
 		padding: 1rem 0.5rem;
 	}
 
-	dl.variation {
+	dl.variation,
+	.variation {
 		margin: 0;
 
 		p {

--- a/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
@@ -251,10 +251,12 @@ a.remove {
 }
 
 dl.variation,
+.variation,
 .wc-item-meta {
 	list-style: none outside;
 
 	dt,
+	.variation-label,
 	.wc-item-meta-label {
 		float: left;
 		clear: both;
@@ -263,7 +265,8 @@ dl.variation,
 		list-style: none outside;
 	}
 
-	dd {
+	dd,
+	.variation-value {
 		margin: 0;
 	}
 
@@ -745,7 +748,8 @@ table.variations {
 		display: block;
 	}
 
-	dl.variation {
+	dl.variation,
+	.variation {
 		margin-top: 0;
 
 		p,
@@ -970,7 +974,8 @@ table.variations {
 		padding: 1em 0.5em;
 	}
 
-	dl.variation {
+	dl.variation,
+	.variation {
 		margin: 0;
 
 		p {

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -411,10 +411,12 @@ a.remove {
 }
 
 dl.variation,
+.variation,
 .wc-item-meta {
 	list-style: none outside;
 
 	dt,
+	.variation-label,
 	.wc-item-meta-label {
 		float: left;
 		clear: both;
@@ -424,7 +426,8 @@ dl.variation,
 		font-weight: 400;
 	}
 
-	dd {
+	dd,
+	.variation-value {
 		margin: 0;
 	}
 
@@ -1652,7 +1655,8 @@ a.reset_variations {
 		padding: 1rem 0.5em;
 	}
 
-	dl.variation {
+	dl.variation,
+	.variation {
 		margin: 0;
 
 		p {
@@ -1660,7 +1664,9 @@ a.reset_variations {
 		}
 
 		dt,
-		dd {
+		dd,
+		.variation-label,
+		.variation-value {
 			font-family: $headings;
 
 			p {

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -361,10 +361,12 @@ a.remove {
 }
 
 dl.variation,
+.variation,
 .wc-item-meta {
 	list-style: none outside;
 
 	dt,
+	.variation-label,
 	.wc-item-meta-label {
 		float: left;
 		clear: both;
@@ -374,7 +376,8 @@ dl.variation,
 		font-weight: 400;
 	}
 
-	dd {
+	dd,
+	.variation-value {
 		margin: 0;
 	}
 
@@ -1125,11 +1128,14 @@ a.reset_variations {
 		display: block;
 	}
 
-	dl.variation {
+	dl.variation,
+	.variation {
 		margin-top: 1rem;
 
 		dt,
 		dd,
+		.variation-label,
+		.variation-value,
 		p {
 			font-family: $headings;
 			font-size: 1.4rem;
@@ -1631,7 +1637,8 @@ a.reset_variations {
 		padding: 1rem 0.5em;
 	}
 
-	dl.variation {
+	dl.variation,
+	.variation {
 		margin: 0;
 
 		p {
@@ -1639,7 +1646,9 @@ a.reset_variations {
 		}
 
 		dt,
-		dd {
+		dd,
+		.variation-label,
+		.variation-value {
 			font-family: $headings;
 
 			p {

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -1023,10 +1023,12 @@ p.demo_store,
 
 	td.product-name {
 		dl.variation,
+		.variation,
 		.wc-item-meta {
 			list-style: none outside;
 
 			dt,
+			.variation-label,
 			.wc-item-meta-label {
 				float: left;
 				clear: both;
@@ -1035,7 +1037,8 @@ p.demo_store,
 				list-style: none outside;
 			}
 
-			dd {
+			dd,
+			.variation-value {
 				margin: 0;
 			}
 

--- a/plugins/woocommerce/templates/cart/cart-item-data.php
+++ b/plugins/woocommerce/templates/cart/cart-item-data.php
@@ -17,8 +17,13 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+/*
+ * Non-semantic markup is used intentionally: this data is not a list of terms and definitions,
+ * so the previously used <dl>/<dt>/<dd> tags were announced incorrectly by screen readers.
+ * See https://github.com/woocommerce/woocommerce/issues/61076.
+ */
 ?>
-<?php // Non-semantic markup is used intentionally: this data is not a list of terms and definitions, so the previously used <dl>/<dt>/<dd> tags were announced incorrectly by screen readers. See https://github.com/woocommerce/woocommerce/issues/61076. ?>
 <div class="variation">
 	<?php foreach ( $item_data as $data ) : ?>
 		<div class="<?php echo sanitize_html_class( 'variation-' . $data['key'] ); ?> variation-label"><?php echo wp_kses_post( $data['key'] ); ?>:</div>

--- a/plugins/woocommerce/templates/cart/cart-item-data.php
+++ b/plugins/woocommerce/templates/cart/cart-item-data.php
@@ -12,15 +12,16 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     2.4.0
+ * @version     11.0.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<dl class="variation">
+<?php // Non-semantic markup is used intentionally: this data is not a list of terms and definitions, so the previously used <dl>/<dt>/<dd> tags were announced incorrectly by screen readers. See https://github.com/woocommerce/woocommerce/issues/61076. ?>
+<div class="variation">
 	<?php foreach ( $item_data as $data ) : ?>
-		<dt class="<?php echo sanitize_html_class( 'variation-' . $data['key'] ); ?>"><?php echo wp_kses_post( $data['key'] ); ?>:</dt>
-		<dd class="<?php echo sanitize_html_class( 'variation-' . $data['key'] ); ?>"><?php echo wp_kses_post( wpautop( $data['display'] ) ); ?></dd>
+		<div class="<?php echo sanitize_html_class( 'variation-' . $data['key'] ); ?> variation-label"><?php echo wp_kses_post( $data['key'] ); ?>:</div>
+		<div class="<?php echo sanitize_html_class( 'variation-' . $data['key'] ); ?> variation-value"><?php echo wp_kses_post( wpautop( $data['display'] ) ); ?></div>
 	<?php endforeach; ?>
-</dl>
+</div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`cart/cart-item-data.php` rendered cart item meta in a `<dl>`/`<dt>`/`<dd>` definition list, which screen readers announce as a term/definition list even though the content isn't. Per the issue discussion, `role="presentation"` isn't viable, so this switches to non-semantic `<div>`s (matching the Cart/Checkout block). Existing `variation`/`variation-{key}` classes are kept, `variation-label`/`variation-value` added, and the bundled stylesheets updated to style the new markup alongside the old selectors.

Closes #61076.

(For Bug Fixes) Bug introduced in PR # — long-standing markup, present since woo 2.1.0.

### How to test the changes in this Pull Request:

1. On a classic theme (e.g. Storefront), add a variable product (or any product with vendor/extension cart item data) to the cart.
2. Confirm the cart and mini-cart item meta still renders correctly, with no visual regression on the bundled themes.
3. Confirm the markup uses `<div class="variation">` instead of `<dl>`/`<dt>`/`<dd>`, and a screen reader no longer announces it as a definition list.

### Testing that has already taken place:

`php -l` and `phpcs` pass on the template; all five SCSS files compile and emit the new selectors.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

> Changelog entry added manually in `plugins/woocommerce/changelog/61076-fix-cart-item-data-dl-a11y`.
