### PR TITLE
Batch-prime post caches in analytics Reports include_extended_info

### DIFF
--- a/plugins/woocommerce/changelog/65468-performance-prime-analytics-extended-info
+++ b/plugins/woocommerce/changelog/65468-performance-prime-analytics-extended-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Batch-prime post caches up front in the analytics Products and Variations Reports data stores so per-row hydration in `include_extended_info()` reads from cache instead of issuing one query per row.

--- a/plugins/woocommerce/changelog/65468-performance-prime-analytics-extended-info
+++ b/plugins/woocommerce/changelog/65468-performance-prime-analytics-extended-info
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-Reduce per-row queries in the analytics Products and Variations reports.
+Improve the performance of the analytics Products and Variations reports by batch-priming product caches.

--- a/plugins/woocommerce/changelog/65468-performance-prime-analytics-extended-info
+++ b/plugins/woocommerce/changelog/65468-performance-prime-analytics-extended-info
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-Batch-prime post caches up front in the analytics Products and Variations Reports data stores so per-row hydration in `include_extended_info()` reads from cache instead of issuing one query per row.
+Reduce per-row queries in the analytics Products and Variations reports.

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -291,6 +291,27 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 	}
 
 	/**
+	 * Batch-prime post + meta caches for a list of IDs, plus their `_thumbnail_id` attachments.
+	 *
+	 * @param array $ids Post IDs to prime.
+	 * @return void
+	 */
+	protected static function prime_object_caches( array $ids ): void {
+		$ids = array_unique( array_filter( array_map( 'intval', $ids ) ) );
+		if ( empty( $ids ) ) {
+			return;
+		}
+		_prime_post_caches( $ids );
+
+		$image_ids = array_filter(
+			array_map( static fn( $id ) => (int) get_post_meta( $id, '_thumbnail_id', true ), $ids )
+		);
+		if ( ! empty( $image_ids ) ) {
+			_prime_post_caches( array_unique( $image_ids ) );
+		}
+	}
+
+	/**
 	 * Whether or not the report should use the caching layer.
 	 *
 	 * Provides an opportunity for plugins to prevent reports from using cache.

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
@@ -250,6 +250,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		global $wpdb;
 		$product_names = array();
 
+		if ( $query_args['extended_info'] ) {
+			self::prime_object_caches( array_column( $products_data, 'product_id' ) );
+		}
+
 		foreach ( $products_data as $key => $product_data ) {
 			$extended_info = new \ArrayObject();
 			if ( $query_args['extended_info'] ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php
@@ -242,6 +242,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param array $query_args Query parameters.
 	 */
 	protected function include_extended_info( &$products_data, $query_args ) {
+		if ( $query_args['extended_info'] ) {
+			self::prime_object_caches(
+				array_merge(
+					array_column( $products_data, 'product_id' ),
+					array_column( $products_data, 'variation_id' )
+				)
+			);
+		}
+
 		foreach ( $products_data as $key => $product_data ) {
 			$extended_info = new \ArrayObject();
 			if ( $query_args['extended_info'] ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds a `Reports\DataStore::prime_object_caches( array $ids )` helper and calls it from the Products and Variations analytics report data stores at the start of `include_extended_info()`. The helper batches post + thumbnail-attachment priming, so per-row `wc_get_product()` / `$product->get_image()` calls read from cache instead of issuing a `wp_postmeta` lookup per row (and an extra `wp_posts` lookup per thumbnail).

Closes # .

### How to test the changes in this Pull Request:

**Setup**

1. Add this mu-plugin to expose the server-side query count in REST response headers. Save as `wp-content/mu-plugins/query-count-header.php`:

   ```php
   <?php
   /**
    * Plugin Name: Query Count Header
    * Description: Adds X-WC-Query-Count response header on REST requests for performance testing.
    */
   add_filter(
       'rest_post_dispatch',
       function ( $response ) {
           global $wpdb;
           $response->header( 'X-WC-Query-Count', (string) $wpdb->num_queries );
           return $response;
       },
       999
   );
   ```
2. The store needs **completed orders** so the analytics screens have data. Include at least one variable-product order to exercise the Variations path.

**Testing steps (repeat this for each endpoint listed below):**

**Endpoints to test** (replace `YOUR-STORE` with your test domain; tweak `after` / `before` to cover dates with orders):

| Endpoint URL | Notes |
| --- | --- |
| `https://YOUR-STORE/wp-json/wc-analytics/leaderboards?per_page=20` | Verified by author: **91 → 75** (saved 16) |
| `https://YOUR-STORE/wp-json/wc-analytics/reports/products?extended_info=true` | Verified by author: **76 → 59** (saved 17) |
| `https://YOUR-STORE/wp-json/wc-analytics/reports/variations?extended_info=true&per_page=20&after=2025-01-01T00:00:00&before=2026-12-31T00:00:00` | Verified by author: **67 → 59** (saved 8) |

1. On `trunk`, make a GET request to the URL and note the `X-WC-Query-Count` response header. 
2. Switch to this branch, run the same request, compare, expect a drop of in the number of queries per request.
4. **Regression check:** the JSON body should be identical between `trunk` and branch.

### Testing that has already taken place:

- **Live on author's store**, measured via `X-WC-Query-Count` response header:
  - `/wc-analytics/leaderboards`: **91 → 75** (saved **16**)
  - `/wc-analytics/reports/products` with `extended_info=true`: **108 → 91** (saved **17**)
  - `/wc-analytics/reports/variations` with `extended_info=true`: **67 → 59** (saved **8**)
- PHPStan + phpcs are clean across all changes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [x] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Improve the performance of the analytics Products and Variations reports by batch-priming product caches.

</details>
