### PR TITLE
Fix order totals only filling half width on edit order screen (on mobile)

### DIFF
--- a/plugins/woocommerce/changelog/63967-fix-order-totals-mobile-width
+++ b/plugins/woocommerce/changelog/63967-fix-order-totals-mobile-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order totals only filling half the width on the admin order screen at mobile widths.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2252,6 +2252,19 @@ ul.wc_coupon_list_block {
 		}
 	}
 
+	// Stack the coupons/totals columns full width once the admin sidebar hides.
+	@media screen and (max-width: 782px) {
+		.wc-used-coupons,
+		.wc-order-totals {
+			float: none;
+			width: 100%;
+		}
+
+		.wc-used-coupons {
+			margin-bottom: 12px;
+		}
+	}
+
 	.refund-actions {
 		margin-top: 5px;
 		padding-top: 12px;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On the admin order screen (order items metabox), the order totals section is set to 50% because the width is shared with the list of coupons applied to the order. While this works well on desktop, it makes for a worse experience on mobile, with this important information crammed in the right half and possibly wrapping awkwardly.

This PR collapses the coupons and totals to full width below the 782px breakpoint.

Closes #63967.

### Screenshots or screen recordings:

Mobile (< 782px):

| Before | After |
| ------ | ----- |
| <img width="424" height="413" alt="Screenshot 2026-06-02 at 14 11 13" src="https://github.com/user-attachments/assets/9494eb63-e9fe-488a-918f-aced1396aeec" /> | <img width="482" height="378" alt="Screenshot 2026-06-02 at 14 36 03" src="https://github.com/user-attachments/assets/6d6c4bd7-254c-4ca1-a13e-0f650d508c63" /> |

Desktop (unchanged):

<img width="1100" height="348" alt="Screenshot 2026-06-02 at 14 28 36" src="https://github.com/user-attachments/assets/db4541a5-10cc-4f94-b2e5-26e5d9131c33" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Coupons** and create a coupon.
1. Go to **WooCommerce > Orders** and create a couple of orders, one with no coupons applied and the other with at least one coupon. Make sure to add some items and/or taxes to the order so totals are populated.
1. Open both orders for editing and confirm that in both cases the totals look unchanged (compared to `trunk`, see screenshot above).
1. Now, narrow the browser window below 782 px (or use your browser's devtools device emulation) and scroll to the order totals.
1. Confirm that the totals (and coupons) now extend the full width making the totals (in particular) a more readable. See screenshots above for an example.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.