### PR TITLE
Prevent order item meta updates to reserved keys via admin

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5971-order-item-meta
+++ b/plugins/woocommerce/changelog/wooplug-5971-order-item-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Order editing: skip reserved internal meta keys when saving order items, so they cannot be added via the "Add meta" button and stored as invisible meta.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -8,6 +8,7 @@
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable;
+use Automattic\WooCommerce\Internal\Utilities\OrderItemMetaUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -235,23 +236,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * @return string
 	 */
 	public static function get_order_preview_item_html( $order ) {
-		$hidden_order_itemmeta = apply_filters(
-			'woocommerce_hidden_order_itemmeta',
-			array(
-				'_qty',
-				'_tax_class',
-				'_product_id',
-				'_variation_id',
-				'_line_subtotal',
-				'_line_subtotal_tax',
-				'_line_total',
-				'_line_tax',
-				'method_id',
-				'cost',
-				'_reduced_stock',
-				'_restock_refunded_items',
-			)
-		);
+		$hidden_order_itemmeta = OrderItemMetaUtil::get_hidden_keys();
 
 		$line_items = apply_filters( 'woocommerce_admin_order_preview_line_items', $order->get_items(), $order );
 		$columns    = apply_filters(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -10,23 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$hidden_order_itemmeta = apply_filters(
-	'woocommerce_hidden_order_itemmeta',
-	array(
-		'_qty',
-		'_tax_class',
-		'_product_id',
-		'_variation_id',
-		'_line_subtotal',
-		'_line_subtotal_tax',
-		'_line_total',
-		'_line_tax',
-		'method_id',
-		'cost',
-		'_reduced_stock',
-		'_restock_refunded_items',
-	)
-);
+$hidden_order_itemmeta = \Automattic\WooCommerce\Internal\Utilities\OrderItemMetaUtil::get_hidden_keys();
 ?><div class="view">
 	<?php
 	$meta_data = $item->get_all_formatted_meta_data( '' );

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -8,6 +8,7 @@
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
+use Automattic\WooCommerce\Internal\Utilities\OrderItemMetaUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -362,9 +363,16 @@ function wc_save_order_items( $order_id, $items ) {
 			}
 
 			if ( isset( $items['meta_key'][ $item_id ], $items['meta_value'][ $item_id ] ) ) {
+				$reserved_meta_keys = OrderItemMetaUtil::get_reserved_keys( $item );
+
 				foreach ( $items['meta_key'][ $item_id ] as $meta_id => $meta_key ) {
 					$meta_key   = substr( wp_unslash( $meta_key ), 0, 255 );
 					$meta_value = isset( $items['meta_value'][ $item_id ][ $meta_id ] ) ? wp_unslash( $items['meta_value'][ $item_id ][ $meta_id ] ) : '';
+
+					// Skip reserved keys, which cannot be added or edited as custom meta.
+					if ( in_array( $meta_key, $reserved_meta_keys, true ) ) {
+						continue;
+					}
 
 					if ( '' === $meta_key && '' === $meta_value ) {
 						if ( ! strstr( $meta_id, 'new-' ) ) {
@@ -428,8 +436,15 @@ function wc_save_order_items( $order_id, $items ) {
 			);
 
 			if ( isset( $items['meta_key'][ $item_id ], $items['meta_value'][ $item_id ] ) ) {
+				$reserved_meta_keys = OrderItemMetaUtil::get_reserved_keys( $item );
+
 				foreach ( $items['meta_key'][ $item_id ] as $meta_id => $meta_key ) {
 					$meta_value = isset( $items['meta_value'][ $item_id ][ $meta_id ] ) ? wp_unslash( $items['meta_value'][ $item_id ][ $meta_id ] ) : '';
+
+					// Skip reserved keys, which cannot be added or edited as custom meta.
+					if ( in_array( $meta_key, $reserved_meta_keys, true ) ) {
+						continue;
+					}
 
 					if ( '' === $meta_key && '' === $meta_value ) {
 						if ( ! strstr( $meta_id, 'new-' ) ) {

--- a/plugins/woocommerce/src/Internal/Utilities/OrderItemMetaUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/OrderItemMetaUtil.php
@@ -1,0 +1,62 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+use WC_Order_Item;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Helpers for the order item meta keys WooCommerce manages internally.
+ *
+ * @since 11.0.0
+ */
+final class OrderItemMetaUtil {
+
+	/**
+	 * Get the order item meta keys hidden from the admin order screen.
+	 *
+	 * @return string[]
+	 */
+	public static function get_hidden_keys(): array {
+		/**
+		 * Filters the order item meta keys hidden from the admin order screen.
+		 *
+		 * @since 2.2.0
+		 * @param string[] $hidden_keys Hidden order item meta keys.
+		 */
+		return apply_filters(
+			'woocommerce_hidden_order_itemmeta',
+			array(
+				'_qty',
+				'_tax_class',
+				'_product_id',
+				'_variation_id',
+				'_line_subtotal',
+				'_line_subtotal_tax',
+				'_line_total',
+				'_line_tax',
+				'method_id',
+				'cost',
+				'_reduced_stock',
+				'_restock_refunded_items',
+			)
+		);
+	}
+
+	/**
+	 * Get the meta keys that cannot be added or edited as custom meta on an order item.
+	 *
+	 * Combines the hidden keys with the item's own internal meta keys, which back core item data.
+	 *
+	 * @param WC_Order_Item $item Order item to check.
+	 * @return string[]
+	 */
+	public static function get_reserved_keys( WC_Order_Item $item ): array {
+		// @phpstan-ignore-next-line method.notFound Proxied via WC_Data_Store::__call() on the order item data store.
+		$internal_meta_keys = (array) $item->get_data_store()->get_internal_meta_keys();
+
+		return array_values( array_unique( array_merge( self::get_hidden_keys(), $internal_meta_keys ) ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -535,4 +535,50 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$order_item = new WC_Order_Item_Product( $order_item_id );
 		$this->assertEquals( 4, $order_item->get_meta( '_reduced_stock', true ), 'Reduced stock meta should be updated to new quantity' );
 	}
+
+	/**
+	 * @testdox wc_save_order_items() should skip reserved meta keys while still saving valid custom meta.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/62328
+	 */
+	public function test_wc_save_order_items_skips_reserved_meta_keys() {
+		$order               = WC_Helper_Order::create_order();
+		$order_item          = current( $order->get_items() );
+		$item_id             = $order_item->get_id();
+		$original_product_id = $order_item->get_product_id();
+
+		// new-0 = internal key, new-1 = hidden key, new-2 = valid custom meta.
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		$items = array(
+			'order_item_id'        => array( $item_id ),
+			'order_item_name'      => array( $item_id => $order_item->get_name() ),
+			'order_item_qty'       => array( $item_id => $order_item->get_quantity() ),
+			'order_item_tax_class' => array( $item_id => $order_item->get_tax_class() ),
+			'line_total'           => array( $item_id => $order_item->get_total() ),
+			'line_subtotal'        => array( $item_id => $order_item->get_subtotal() ),
+			'meta_key'             => array(
+				$item_id => array(
+					'new-0' => '_product_id',
+					'new-1' => '_reduced_stock',
+					'new-2' => 'custom_meta',
+				),
+			),
+			'meta_value'           => array(
+				$item_id => array(
+					'new-0' => '99999',
+					'new-1' => '5',
+					'new-2' => 'hello world',
+				),
+			),
+		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+
+		wc_save_order_items( $order->get_id(), $items );
+
+		$saved_item = new WC_Order_Item_Product( $item_id );
+
+		$this->assertEquals( 'hello world', $saved_item->get_meta( 'custom_meta', true ), 'Valid custom meta should still be saved' );
+		$this->assertEquals( $original_product_id, $saved_item->get_product_id(), 'Reserved internal key should not overwrite core item data' );
+		$this->assertFalse( $saved_item->meta_exists( '_reduced_stock' ), 'Reserved hidden key should not be stored as item meta' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The order item "Add meta" button in the order edit screen (items metabox) allows admins to enter internal meta keys (e.g. `_product_id`, `_qty`), which either freeze the order page or are silently stored but then hidden at display time, resulting in unremovable meta.

This PR ensures that `wc_save_order_items()` skips any reserved keys (based on item type) but allows other valid keys/metadata to be persisted.

Closes woocommerce/woocommerce#62328.

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Orders** and create an order with at least one product line item.
2. Click the edit (pencil) icon on the line item, then **Add meta**. Add two rows: `_product_id` with a value that doesn't match a product (e.g. `99999`), and `gift_message` with `hello`. Click **Save**.
3. Confirm the order saves normally, the items form doesn't freeze and your new meta is correctly stored but `_product_id`  didn't change in the meta.<br>You can use the following WP-CLI command to verify the order item meta:

   ```sh
   wp db query "SELECT oi.order_item_id, oi.order_item_type, oi.order_item_name, im.meta_key, im.meta_value
   LEFT JOIN $(wp db prefix)woocommerce_order_itemmeta im ON oi.order_item_id = im.order_item_id
   FROM $(wp db prefix)woocommerce_order_items oi WHERE oi.order_id = <ORDER_ID> ORDER BY oi.order_item_id, im.meta_key;"
   ```
4. Click the edit (pencil) icon on the line item once again, then **Add meta**. Use `_product_id` as key with a value that does match an existing product on your store. Click **Save**. Confirm operation is successful but no product detail changes in your order.
5. Edit the item again, click **Add meta** and add `_qty` with any value. Confirm that the operation doesn't hang and that no duplicate `_qty` row is added to item meta (use the query above to verify).
6. (Optional) Repeat the steps above on `trunk` and confirm that using an invalid `_product_id` results in a fatal, a valid one *partially overwrites* the order item (you might see a new SKU/image being displayed) and that `_qty` results in duplicate meta entries.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.