### PR TITLE
Fix TypeError when cached variation parent ID is returned as a string

### DIFF
--- a/plugins/woocommerce/changelog/65496-wooplug-6699-variation-parent-int-cast
+++ b/plugins/woocommerce/changelog/65496-wooplug-6699-variation-parent-int-cast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal TypeError in ProductVersionStringInvalidator when a persistent object cache returns the cached variation parent ID as a string.

--- a/plugins/woocommerce/src/Internal/Caches/ProductVersionStringInvalidator.php
+++ b/plugins/woocommerce/src/Internal/Caches/ProductVersionStringInvalidator.php
@@ -523,7 +523,9 @@ class ProductVersionStringInvalidator {
 		$cached    = wp_cache_get( $cache_key, 'woocommerce' );
 
 		if ( false !== $cached ) {
-			return $cached ? $cached : null;
+			// Cast to int: persistent object cache backends (e.g. Redis) can return scalars as strings,
+			// which would violate this method's ?int return type.
+			return $cached ? (int) $cached : null;
 		}
 
 		if ( $this->is_using_cpt_data_store() ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/ProductVersionStringInvalidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/ProductVersionStringInvalidatorTest.php
@@ -976,4 +976,22 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 		$products_list_after = $this->version_generator->get_version( 'list_products', false );
 		$this->assertNotNull( $products_list_after, 'Products list version string should NOT be deleted when variation is deleted' );
 	}
+
+	/**
+	 * @testdox Invalidating a variation does not fatal and invalidates the parent when the object cache returns the cached parent ID as a string.
+	 */
+	public function test_string_cached_parent_id_is_normalized_and_parent_invalidated(): void {
+		$variation_id = 472;
+		$parent_id    = 462;
+
+		wp_cache_set( "wc_variation_parent_{$variation_id}", (string) $parent_id, 'woocommerce' );
+		$this->version_generator->generate_version( "product_{$parent_id}" );
+
+		$this->sut->handle_woocommerce_updated_product_attribute_summary( $variation_id );
+
+		$this->assertNull(
+			$this->version_generator->get_version( "product_{$parent_id}", false ),
+			'Parent should be invalidated, proving the string parent ID was cast to int'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`ProductVersionStringInvalidator::get_variation_parent_id()` returns `?int`, but on a cache hit it returned `wp_cache_get()`'s value unchanged. Persistent object caches (e.g. Redis) return cached scalars as strings, so the method returned a `string` against its `?int` return type and threw a fatal `TypeError` — breaking variation deletes, attribute syncs, and other cache-invalidation paths on affected stores.

This casts the cached value to `int` before returning, so a cache hit satisfies the `?int` contract regardless of object-cache backend. Adds a regression test.

Closes #64874 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

The default in-memory object cache preserves types, so the persistent-cache condition (a cached scalar returned as a string) is reproduced directly by seeding a string into the cache key — no Redis or product setup required. The same command is used in both steps below; only the checked-out branch differs (wp-env: prefix with `pnpm wp-env run cli`):

```bash
wp eval '
wp_cache_set( "wc_variation_parent_123", "456", "woocommerce" );
( new \Automattic\WooCommerce\Internal\Caches\ProductVersionStringInvalidator() )
    ->handle_woocommerce_updated_product_attribute_summary( 123 );
echo "OK\n";
'
```

(No product or variation is needed — `get_variation_parent_id()` returns on the cache hit before any DB lookup, so the seeded value is what's returned.)

1. **Reproduce on `trunk`:** check out `trunk` and run the command above. It fatals with `TypeError: ...get_variation_parent_id(): Return value must be of type ?int, string returned`.

2. **Verify the fix on this branch:** check out this branch and run the same command. It now prints `OK` (no fatal).

3. Run the unit tests; all pass, including the added regression test:

    ```bash
    pnpm test:php:env -- --filter ProductVersionStringInvalidatorTest
    ```

<!-- End testing instructions -->

### Testing that has already taken place:

-   Reproduced the original `TypeError` and verified the fix (red → green) with the WP-CLI repro above, on PHP 8.1 / wp-env.
-   Reproduced the full production scenario against a real Redis Object Cache 2.8.0 backend (phpredis/predis, non-igbinary serializer): confirmed a stored `int` is returned as a `string` across requests, that the variation invalidation chain (`woocommerce_attribute_updated` → `invalidate_products_with_attribute()` → `invalidate_variation_and_parent()` → `get_variation_parent_id()`) fatals before the fix and succeeds after it.
-   `ProductVersionStringInvalidatorTest` passes (46 tests). `phpcs` (changed files) and PHPStan on the modified file are clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->

Fix fatal TypeError in ProductVersionStringInvalidator when a persistent object cache returns the cached variation parent ID as a string.

</details>