### PR TITLE
[Performance] Optimize Jetpack connection status retrieval on admin pages

### DIFF
--- a/plugins/woocommerce/changelog/performance-64471-jetpack-connection-status
+++ b/plugins/woocommerce/changelog/performance-64471-jetpack-connection-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Optimized JetPack connection status retrieval on admin pages.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -37960,12 +37960,6 @@ parameters:
 			path: src/Admin/API/Leaderboards.php
 
 		-
-			message: '#^Call to method get_query_params\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\WP_REST_Request\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Leaderboards.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Leaderboards\:\:get_allowed_items\(\) has invalid return type Automattic\\WooCommerce\\Admin\\API\\WP_Error\.$#'
 			identifier: class.notFound
 			count: 1

--- a/plugins/woocommerce/src/Admin/API/Leaderboards.php
+++ b/plugins/woocommerce/src/Admin/API/Leaderboards.php
@@ -455,8 +455,6 @@ class Leaderboards extends \WC_REST_Data_Controller {
 		$response->header( 'X-WP-Total', count( $data ) );
 		$response->header( 'X-WP-TotalPages', 1 );
 
-		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-
 		return $response;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -346,7 +346,6 @@ class Loader {
 		 */
 		$preload_data_endpoints = apply_filters( 'woocommerce_component_settings_preload_endpoints', array() );
 
-		$preload_data_endpoints['jetpackStatus'] = '/jetpack/v4/connection';
 		if ( ! empty( $preload_data_endpoints ) ) {
 			$preload_data = array_reduce(
 				array_values( $preload_data_endpoints ),
@@ -421,10 +420,16 @@ class Loader {
 		/* phpcs:ignore */
 		$settings['variationTitleAttributesSeparator'] = apply_filters( 'woocommerce_product_variation_title_attributes_separator', ' - ', new \WC_Product() );
 
+		// Performance note: refer back to https://github.com/woocommerce/woocommerce/pull/41092: unconditionally loading /jetpack/v4/connection.
+		// As automattic/jetpack-connection package is a direct dependency, we can return the Jetpack connection status via its public API.
+		$settings['dataEndpoints'] = $settings['dataEndpoints'] ?? array();
+		try {
+			$settings['dataEndpoints']['jetpackStatus'] = \Automattic\Jetpack\Connection\REST_Connector::connection_status( false );
+		} catch ( \Throwable $e ) {
+			$settings['dataEndpoints']['jetpackStatus'] = array();
+		}
+
 		if ( ! empty( $preload_data_endpoints ) ) {
-			$settings['dataEndpoints'] = isset( $settings['dataEndpoints'] )
-				? $settings['dataEndpoints']
-				: array();
 			foreach ( $preload_data_endpoints as $key => $endpoint ) {
 				// Handle error case: rest_do_request() doesn't guarantee success.
 				if ( empty( $preload_data[ $endpoint ] ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -144,7 +144,7 @@ class Settings {
 
 		//phpcs:ignore
 		$preload_data_endpoints = apply_filters( 'woocommerce_component_settings_preload_endpoints', array() );
-		$preload_data_endpoints['jetpackStatus'] = '/jetpack/v4/connection';
+
 		if ( ! empty( $preload_data_endpoints ) ) {
 			$preload_data = array_reduce(
 				array_values( $preload_data_endpoints ),
@@ -223,10 +223,17 @@ class Settings {
 		$settings['variationTitleAttributesSeparator'] = apply_filters( 'woocommerce_product_variation_title_attributes_separator', ' - ', new \WC_Product() );
 
 		$settings = $this->add_settings_ui_schema( $settings );
+
+		// Performance note: refer back to https://github.com/woocommerce/woocommerce/pull/41092: unconditionally loading /jetpack/v4/connection.
+		// As automattic/jetpack-connection package is a direct dependency, we can return the Jetpack connection status via its public API.
+		$settings['dataEndpoints'] = $settings['dataEndpoints'] ?? array();
+		try {
+			$settings['dataEndpoints']['jetpackStatus'] = \Automattic\Jetpack\Connection\REST_Connector::connection_status( false );
+		} catch ( \Throwable $e ) {
+			$settings['dataEndpoints']['jetpackStatus'] = array();
+		}
+
 		if ( ! empty( $preload_data_endpoints ) ) {
-			$settings['dataEndpoints'] = isset( $settings['dataEndpoints'] )
-				? $settings['dataEndpoints']
-				: array();
 			foreach ( $preload_data_endpoints as $key => $endpoint ) {
 				// Handle error case: rest_do_request() doesn't guarantee success.
 				if ( empty( $preload_data[ $endpoint ] ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #64471, WOOPLUG-6624.

On admin pages, replace preloading `/jetpack/v4/connection` with `rest_preload_api_request` in favour of directly fetching Jetpack connection status with `automattic/jetpack-connection` package public APIs.

Additionally evaluated:
- conditionally fetching the status data: regression analysis flagged issues with this approach
- optimizing data fetch from `\Automattic\WooCommerce\Internal\Admin\Analytics::add_preload_endpoints`: not feasible

On multiple admin pages, this is the single `rest_preload_api_request` call, which initializes REST mid of the request. If a store has multiple extensions that provide REST APIs, routes population increases the overhead further, as in the original report.

Note: I'm skipping benchmarking here, as the timing impact depends heavily on the specific extensions.

### How to test the changes in this Pull Request:

- Switch to trunk
- Navigate to the admin area
- Visit multiple pages (Dashboard, WooCommerce Products/Orders/Settings) and use your browser's console to confirm that `wcSettings.admin.dataEndpoints` has an entry `jetpackStatus`
- Switch to this branch
- Navigate to the admin area
- Visit multiple pages (Dashboard, WooCommerce Products/Orders/Settings) and use your browser's console to confirm that `wcSettings.admin.dataEndpoints` has an entry `jetpackStatus`