### PR TITLE
Fix Add to Cart Button not working on Products (Beta) block

### DIFF
--- a/plugins/woocommerce/changelog/fix-products-beta-add-to-cart-button
+++ b/plugins/woocommerce/changelog/fix-products-beta-add-to-cart-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Add to Cart Button not working on Products (Beta) block

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
@@ -97,6 +97,47 @@ test.describe( `${ blockData.name } Block `, () => {
 		await expect( advancedFilterOption ).toBeVisible();
 		await expect( inheritQueryFromTemplateOption ).toBeVisible();
 	} );
+
+	test( 'product button should add product to the cart when inheriting query from template', async ( {
+		admin,
+		editor,
+		page,
+		frontendUtils,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+		await editor.setContent( '' );
+		await insertProductsQuery( editor );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await frontendUtils.goToShop();
+
+		const addToCartButton = page.getByRole( 'button', { name: 'Add to cart: “Single”' } );
+		await addToCartButton.click();
+		await expect( addToCartButton ).toHaveText( '1 in cart' );
+		const cartLink = page.getByRole( 'link', { name: 'View cart' } );
+		await expect( cartLink ).toBeVisible();
+	} );
+
+	test( 'product button should add product to the cart when not inheriting query from template', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await insertProductsQuery( editor, { inherit: false } );
+		await editor.publishAndVisitPost();
+
+		const addToCartButton = page.getByRole( 'button', { name: 'Add to cart: “Single”' } );
+		await addToCartButton.click();
+		await expect( addToCartButton ).toHaveText( '1 in cart' );
+		const cartLink = page.getByRole( 'link', { name: 'View cart' } );
+		await expect( cartLink ).toBeVisible();
+	} );
 } );
 
 for ( const {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
@@ -116,7 +116,9 @@ test.describe( `${ blockData.name } Block `, () => {
 		} );
 		await frontendUtils.goToShop();
 
-		const addToCartButton = page.getByRole( 'button', { name: 'Add to cart: “Single”' } );
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart: “Single”',
+		} );
 		await addToCartButton.click();
 		await expect( addToCartButton ).toHaveText( '1 in cart' );
 		const cartLink = page.getByRole( 'link', { name: 'View cart' } );
@@ -132,7 +134,9 @@ test.describe( `${ blockData.name } Block `, () => {
 		await insertProductsQuery( editor, { inherit: false } );
 		await editor.publishAndVisitPost();
 
-		const addToCartButton = page.getByRole( 'button', { name: 'Add to cart: “Single”' } );
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart: “Single”',
+		} );
 		await addToCartButton.click();
 		await expect( addToCartButton ).toHaveText( '1 in cart' );
 		const cartLink = page.getByRole( 'link', { name: 'View cart' } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/products/utils.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/products/utils.ts
@@ -38,13 +38,18 @@ export const productQueryInnerBlocksTemplate = [
 	{ name: 'core/query-no-results' },
 ];
 
-export const insertProductsQuery = async ( editor: Editor ) => {
+export const insertProductsQuery = async (
+	editor: Editor,
+	options: {
+		inherit?: boolean;
+	} = {}
+) => {
 	await editor.insertBlock( {
 		name: 'core/query',
 		attributes: {
 			namespace: 'woocommerce/product-query',
 			query: {
-				inherit: true,
+				inherit: options.inherit ?? true,
 			},
 		},
 		innerBlocks: productQueryInnerBlocksTemplate,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -82,6 +82,12 @@ class ProductQuery extends AbstractBlock {
 			10,
 			2
 		);
+		add_filter(
+			'render_block_core/post-template',
+			array( $this, 'add_iapi_context' ),
+			10,
+			2
+		);
 		add_filter( 'rest_product_query', array( $this, 'update_rest_query' ), 10, 2 );
 		add_filter( 'rest_product_collection_params', array( $this, 'extend_rest_query_allowed_params' ), 10, 1 );
 	}
@@ -164,6 +170,86 @@ class ProductQuery extends AbstractBlock {
 		}
 
 		return $block_content;
+	}
+
+	/**
+	 * Add product interactivity directives to each loop item in Products (Beta).
+	 *
+	 * @internal
+	 *
+	 * @param string $block_content Rendered block HTML.
+	 * @param array  $block         Parsed block data.
+	 * @return string
+	 */
+	public function add_iapi_context( string $block_content, array $block ): string {
+		$namespace = $block['attrs']['__woocommerceNamespace'] ?? '';
+		if ( 'woocommerce/product-query/product-template' !== $namespace ) {
+			return $block_content;
+		}
+
+		$processor = new \WP_HTML_Tag_Processor( $block_content );
+
+		while (
+			$processor->next_tag(
+				array(
+					'tag_name'   => 'LI',
+					'class_name' => 'wp-block-post',
+				)
+			)
+		) {
+			$class_attribute = $processor->get_attribute( 'class' );
+			$product_id      = $this->get_product_id_from_class_attribute( is_string( $class_attribute ) ? $class_attribute : '' );
+
+			if ( ! $product_id || 'product' !== get_post_type( $product_id ) ) {
+				continue;
+			}
+
+			wc_interactivity_api_load_product( 'I acknowledge that using experimental APIs means my theme or plugin will inevitably break in the next version of WooCommerce', $product_id );
+
+			$product_context = array(
+				'productId'   => $product_id,
+				'variationId' => null,
+			);
+
+			$processor->set_attribute( 'data-wp-interactive', 'woocommerce/products' );
+			$processor->set_attribute(
+				'data-wp-context',
+				'woocommerce/products::' . wp_json_encode( $product_context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP )
+			);
+			$processor->set_attribute( 'data-wp-key', 'product-item-' . $product_id );
+		}
+
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Extract a post ID from the `post-{id}` class WordPress adds to loop items.
+	 *
+	 * @internal
+	 *
+	 * @param string $class_attribute The element class attribute.
+	 * @return int|null
+	 */
+	private function get_product_id_from_class_attribute( $class_attribute ): ?int {
+		if ( '' === $class_attribute ) {
+			return null;
+		}
+
+		$classes = explode( ' ', $class_attribute );
+
+		foreach ( $classes as $class ) {
+			if ( ! str_starts_with( $class, 'post-' ) ) {
+				continue;
+			}
+
+			$product_id = (int) substr( $class, 5 );
+
+			if ( $product_id > 0 ) {
+				return $product_id;
+			}
+		}
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The _Add to Cart Button_ block was refactored recently and it required some extra context. That was handled correctly in the _Product Catalog_ and _Add to Cart + Options_ blocks, but not in the deprecated _Products (Beta)_ block. This PR fixes it by passing the necessary directives.

Closes WOOPLUG-6791.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/63662.

Discussion about the milestone in p1780566388567389-slack-C02SGH7JBGS.

### How to test the changes in this Pull Request:

1. Create a post or page and insert the _Products (Beta)_ block.

```HTML
<!-- wp:query {"queryId":2,"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","outofstock","onbackorder"]},"displayLayout":{"type":"flex","columns":3},"namespace":"woocommerce/product-query"} -->
<div class="wp-block-query">
	<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
		<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
		<!-- wp:post-title {"textAlign":"center","level":3,"fontSize":"medium","isLink":true,"__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
		<!-- wp:woocommerce/product-price {"textAlign":"center","fontSize":"small","isDescendentOfQueryLoop":true} /-->
		<!-- wp:woocommerce/product-button {"textAlign":"center","fontSize":"small","isDescendentOfQueryLoop":true} /-->
	<!-- /wp:post-template -->
	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
		<!-- wp:query-pagination-previous /-->
		<!-- wp:query-pagination-numbers /-->
		<!-- wp:query-pagination-next /-->
	<!-- /wp:query-pagination -->
	<!-- wp:query-no-results -->
		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
		<p></p>
		<!-- /wp:paragraph -->
	<!-- /wp:query-no-results -->
</div>
<!-- /wp:query -->
```

2. Go to the frontend.
3. Try adding one product to the cart. Verify the button changes to "1 in cart" and the product has been successfully added to the cart.
4. Repeat the process in the Product Catalog template.