### PR TITLE
Enable push notifications by default

### DIFF
--- a/plugins/woocommerce/changelog/update-enable-push-notifications-by-default
+++ b/plugins/woocommerce/changelog/update-enable-push-notifications-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Enable the push notifications feature by default.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -633,7 +633,7 @@ class FeaturesController {
 					'Enable push notifications for the WooCommerce mobile apps to receive order notifications and store updates.',
 					'woocommerce'
 				),
-				'enabled_by_default'           => false,
+				'enabled_by_default'           => true,
 				'is_experimental'              => true,
 				'disable_ui'                   => true,
 				'skip_compatibility_checks'    => false,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce 10.9.0 needs push notifications enabled by default during code freeze, so this PR follows the trunk-first backport workflow and targets the `10.9.0` milestone manually.

The `push_notifications` feature definition now defaults to enabled, which makes missing `woocommerce_feature_push_notifications_enabled` options resolve to `yes` while preserving explicit opt-outs.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. On a WooCommerce test site running this branch, delete the option with `wp option delete woocommerce_feature_push_notifications_enabled`.
2. Run `wp eval 'var_dump( wc_get_container()->get( Automattic\WooCommerce\Internal\Features\FeaturesController::class )->feature_is_enabled( "push_notifications" ) );'` and confirm it prints `bool(true)`.
3. Run `wp option update woocommerce_feature_push_notifications_enabled no`, repeat the `wp eval` command, and confirm it prints `bool(false)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications are now enabled by default, allowing users to receive timely updates without requiring manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->