### PR TITLE
Fix guest purchases in wc_customer_bought_product when user ID is supplied

### DIFF
--- a/plugins/woocommerce/changelog/fix-customer-bought-product-guest-email
+++ b/plugins/woocommerce/changelog/fix-customer-bought-product-guest-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc_customer_bought_product() returning false for unlinked guest orders when a matching user ID is supplied.

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -449,8 +449,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 	} else {
 		// Identify the customer using the provided data. Use Customer ID to optimize performance in the following SQL
 		// queries. If an account has been deleted, use the supplied ID to ensure graceful handling.
-		$user             = null;
-		$original_user_id = $user_id;
+		$user = null;
 		if ( ! $user_id && $customer_email && is_email( $customer_email ) ) {
 			$user    = get_user_by( 'email', $customer_email );
 			$user_id = $user->ID ?? $user_id;
@@ -460,14 +459,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 			$user_id = $user->ID ?? $user_id;
 		}
 
-		// Deduplicate emails to ensure the Customer ID remains the primary performance driver in subsequent SQL queries.
 		$emails = array( $customer_email );
-		if ( $original_user_id ) {
-			$user_email = $user->user_email ?? '';
-			if ( $user_email && is_email( $user_email ) && strtolower( $user_email ) === strtolower( $customer_email ) ) {
-				$emails = array();
-			}
-		}
 		$emails = array_unique( array_filter( $emails, static fn( $email ) => $email && is_email( $email ) ) );
 
 		if ( empty( $emails ) && ! $user_id ) {

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -439,7 +439,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 		$cache_version = WC_Cache_Helper::get_transient_version( 'orders' );
 	}
 
-	$aggregation_version = 'v2'; // Update the version when modifying the aggregation implementation to ensure the cache is repopulated.
+	$aggregation_version = 'v3'; // Update the version when modifying the aggregation implementation to ensure the cache is repopulated.
 	$cache_group         = 'orders';
 	$cache_key           = 'wc_customer_bought_product_' . md5( $customer_email . '-' . $user_id . '-' . $use_lookup_tables . '-' . $aggregation_version );
 	$cache_value         = wp_cache_get( $cache_key, $cache_group );

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
@@ -330,6 +330,7 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 			$this->assertTrue( wc_customer_bought_product( 'billing@example.com', 0, $product_id_4 ) );
 
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_5 ) );
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_5 ) );
 
 			remove_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
@@ -331,6 +331,7 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_5 ) );
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_5 ) );
+			$this->assertFalse( wc_customer_bought_product( '', $customer_id_1, $product_id_5 ) );
 
 			remove_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
 		}

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -108,6 +108,7 @@ class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 			$this->assertTrue( wc_customer_bought_product( 'billing@example.com', 0, $product_id_4 ) );
 
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_5 ) );
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_5 ) );
 
 			remove_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
 		}

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -109,6 +109,7 @@ class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_5 ) );
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_5 ) );
+			$this->assertFalse( wc_customer_bought_product( '', $customer_id_1, $product_id_5 ) );
 
 			remove_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a regression in `wc_customer_bought_product()` where guest orders could be missed after a customer created an account.

After #63995, when both `$customer_email` and `$user_id` were supplied, the function removed the supplied email from the identity query if it matched the account email. That preserved the customer-ID-only fast path, but it also meant older guest orders with `customer_id = 0` were no longer considered.

This restores correctness by keeping the caller-supplied billing email in the lookup. That allows the function to find purchases made as a guest while preserving the optimized customer-ID-only path for calls that pass an empty email, such as core product review checks.


Closes #65457 .

(For Bug Fixes) Bug introduced in PR #63995.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

Here is a clean, formatted set of testing instructions you can copy and paste directly into your GitHub Pull Request description.

It organizes your steps into clear phases (Setup, Reproduction, and Verification) and provides a copy-paste ready code snippet for the reviewer to make their testing as frictionless as possible.

---

### 🛠️ Testing Instructions

**Prerequisites:** Ensure you are testing on a version of WooCommerce newer than 10.7.0 (or test directly against `trunk` before switching to this PR branch).

**Step 1: Setup & Guest Purchase**

1. Create a new test product and note its Product ID (e.g., `530`).
2. Open an incognito window and purchase this product as a **guest** (ensure you are logged out). Use a recognizable test email address (e.g., `test_guest@example.com`).
3. Go to the WordPress admin (**WooCommerce > Orders**) and change the newly created order's status to **Completed**.

**Step 2: Account Creation**
4. Register a new user account using the **exact same test email address** from Step 2.
5. Log in to the site as this newly created user.

**Step 3: Run the Test**
```
pnpm wp-env run cli wp eval "var_dump( wc_customer_bought_product( 'test_email@example.com', 5, 14 ) );"
```

**Step 4: Verify Results**

* **Without this PR (WooCommerce > 10.7.0):** Observe that the snippet incorrectly outputs `bool(false)`.
* **With this PR (or downgraded to WooCommerce 10.7.0):** Observe that the snippet correctly outputs `bool(true)`.

<!-- End testing instructions -->

