### PR TITLE
Fix BatchProcessingController dedup check appending duplicate processors

### DIFF
--- a/plugins/woocommerce/changelog/65522-wooplug-6555-batchprocessing-dedup
+++ b/plugins/woocommerce/changelog/65522-wooplug-6555-batchprocessing-dedup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix BatchProcessingController enqueue dedup check so processors are no longer stored repeatedly in the wc_pending_batch_processes option.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -97,7 +97,7 @@ class BatchProcessingController {
 	 */
 	public function enqueue_processor( string $processor_class_name ): void {
 		$pending_updates = $this->get_enqueued_processors();
-		if ( ! in_array( $processor_class_name, array_keys( $pending_updates ), true ) ) {
+		if ( ! in_array( $processor_class_name, $pending_updates, true ) ) {
 			$pending_updates[] = $processor_class_name;
 			$this->set_enqueued_processors( $pending_updates );
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -51,6 +51,22 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Enqueuing the same processor more than once does not create duplicate entries.
+	 */
+	public function test_enqueue_processor_deduplicates_repeated_enqueues() {
+		$processor = get_class( $this->test_process );
+
+		$this->sut->enqueue_processor( $processor );
+		$this->sut->enqueue_processor( $processor );
+
+		$this->assertCount(
+			1,
+			$this->sut->get_enqueued_processors(),
+			'Enqueuing the same processor twice should not create duplicate entries'
+		);
+	}
+
+	/**
 	 * @testdox 'remove_processor' dequeues and unschedules a processor, but the watchdog is kept alive if more processors are still enqueued.
 	 */
 	public function test_remove_processor_when_others_are_still_enqueued() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`BatchProcessingController::enqueue_processor()` deduplicated with `array_keys( $pending_updates )`, but `$pending_updates` is a list of class-name strings, so `array_keys()` returns integer indices, the strict `in_array()` never matches, and a duplicate is appended to the `wc_pending_batch_processes` option on every call. Removing `array_keys()` compares against the values (like `is_enqueued()`), so each processor is stored once.

Closes #64175 .

### How to test the changes in this Pull Request:

1. Enqueue the same processor a few times and check the option (wp-env: prefix with `pnpm wp-env run cli`):

    ```bash
    wp eval '
    $c = wc_get_container()->get( \Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController::class );
    $c->force_clear_all_processes();
    $p = \Automattic\WooCommerce\Internal\Logging\OrderLogsDeletionProcessor::class;
    $c->enqueue_processor( $p ); $c->enqueue_processor( $p ); $c->enqueue_processor( $p );
    echo count( get_option( "wc_pending_batch_processes" ) ) . "\n";
    $c->force_clear_all_processes();
    '
    ```

    `trunk` prints `3` (duplicates); this branch prints `1`.

2. `pnpm test:php:env -- --filter BatchProcessingControllerTests` should all pass.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->

Fix BatchProcessingController enqueue dedup check so processors are no longer stored repeatedly in the wc_pending_batch_processes option.

</details>