### PR TITLE
Rename Products (Beta) block to Products (Deprecated)

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-query-fixes
+++ b/plugins/woocommerce/changelog/fix-product-query-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Rename Products (Beta) block to Products (Deprecated)

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/inspector-controls/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/inspector-controls/upgrade-notice.tsx
@@ -9,7 +9,7 @@ import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-d
 export const UpgradeNotice = ( props: { upgradeBlock: () => void } ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Upgrade all Products (Beta) blocks on this page to <strongText /> for more features!',
+			'Upgrade all Products blocks on this page to <strongText /> for more features!',
 			'woocommerce'
 		),
 		{

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/utils.tsx
@@ -99,6 +99,10 @@ export function useAllowedControls(
 		[ attributes ]
 	);
 
+	if ( ! Array.isArray( controls ) ) {
+		return [];
+	}
+
 	if ( ! isSiteEditorPage() ) {
 		return controls.filter( ( control ) => control !== 'wooInherit' );
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/variations/product-query.tsx
@@ -45,7 +45,7 @@ const registerProductsBlock = ( attributes: QueryBlockAttributes ) => {
 		),
 		name: PRODUCT_QUERY_VARIATION_NAME,
 		/* translators: "Products" is the name of the block. */
-		title: __( 'Products (Beta)', 'woocommerce' ),
+		title: __( 'Products (Deprecated)', 'woocommerce' ),
 		isActive: ( blockAttributes ) =>
 			blockAttributes.namespace === PRODUCT_QUERY_VARIATION_NAME,
 		icon: (

--- a/plugins/woocommerce/client/blocks/assets/js/shared/hocs/with-product-data-context.js
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/hocs/with-product-data-context.js
@@ -11,7 +11,7 @@ const getProductById = ( products, id ) =>
 	products.find( ( product ) => product.id === id );
 
 const getProductId = ( isDescendentOfQueryLoop, productId, postId ) => {
-	// Keep for backwards compatibility of Products (Beta) block.
+	// Keep for backwards compatibility of Products (Deprecated) block.
 	if ( isDescendentOfQueryLoop ) {
 		return postId;
 	}

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
@@ -46,16 +46,16 @@ The compatibility is built around the entire page. The classic Single Product Pa
 The following table shows where the hooks are injected into the page.
 
 
-| Hook                                      | Block Name                                                                                                                                             | Position |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| woocommerce_before_main_content           | First block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs) | before   |
-| woocommerce_after_main_content            | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)  | after    |
-| woocommerce_sidebar                       | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)  | after    |
-| woocommerce_before_single_product         | First block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs) | before   |
-| woocommerce_before_single_product_summary | First block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs) | before |
-| woocommerce_single_product_summary        | First `core/post-excerpt` or `woocommerce/product-summary` block                                                                                                                         | before   |
-| woocommerce_after_single_product          | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)  | after    |
-| woocommerce_product_meta_start            | Product Meta                                                                                                                                           | before   |
-| woocommerce_product_meta_end              | Product Meta                                                                                                                                           | after    |
-| woocommerce_share                         | Product Details                                                                                                                                        | before   |
-| woocommerce_after_single_product_summary  | Product Details                                                                                                                                        | before   |
+| Hook                                     | Block Name                                                                                                                                             | Position|
+|------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| woocommerce_before_main_content          | First block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)| before  |
+| woocommerce_after_main_content           | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs) | after   |
+| woocommerce_sidebar                      | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs) | after   |
+| woocommerce_before_single_product        | First block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)| before  |
+| woocommerce_before_single_product_summary| First block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)| before  |
+| woocommerce_single_product_summary       | First `core/post-excerpt` or `woocommerce/product-summary` block                                                                                       | before  |
+| woocommerce_after_single_product         | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs) | after   |
+| woocommerce_product_meta_start           | Product Meta                                                                                                                                           | before  |
+| woocommerce_product_meta_end             | Product Meta                                                                                                                                           | after   |
+| woocommerce_share                        | Product Details                                                                                                                                        | before  |
+| woocommerce_after_single_product_summary | Product Details                                                                                                                                        | before  |

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
@@ -20,7 +20,7 @@ Furthermore, it is possible to disable the compatibility layer via the hook: [`w
 
 ## Archive Product Templates - [ArchiveProductTemplatesCompatibility](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/Templates/ArchiveProductTemplatesCompatibility.php)
 
-The compatibility is built around the Product Collection and Products (Beta) blocks because the loop is the main element of archive templates and hooks are placed inside and around the loop. The Compatibility Layer injects custom attributes for the Product Collection and Products (Beta) blocks that **inherit query from the template** and their inner blocks.
+The compatibility is built around the Product Collection block because the loop is the main element of archive templates and hooks are placed inside and around the loop. The Compatibility Layer injects custom attributes for the Product Collection block that **inherit query from the template** and their inner blocks.
 
 The following table shows where the hooks are injected into the page.
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -48,7 +48,7 @@ test.describe( 'Product Collection', () => {
 		await expect( pageObject.addToCartButtons ).toHaveCount( 9 );
 	} );
 
-	test( 'Can be migrated to from Products (Beta) block', async ( {
+	test( 'Can be migrated to from Products (Deprecated) block', async ( {
 		page,
 		editor,
 		admin,
@@ -63,7 +63,7 @@ test.describe( 'Product Collection', () => {
 		} );
 
 		await expect(
-			editor.canvas.getByLabel( 'Block: Products (Beta)' )
+			editor.canvas.getByLabel( 'Block: Products (Deprecated)' )
 		).toBeVisible();
 
 		await editor.canvas
@@ -76,7 +76,7 @@ test.describe( 'Product Collection', () => {
 			.click();
 
 		await expect(
-			editor.canvas.getByLabel( 'Block: Products (Beta)' )
+			editor.canvas.getByLabel( 'Block: Products (Deprecated)' )
 		).toBeHidden();
 		await expect(
 			editor.canvas.getByLabel( 'Block: Product Collection' ).first()

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -77,7 +77,7 @@ class ProductQuery extends AbstractBlock {
 			2
 		);
 		add_filter(
-			'render_block',
+			'render_block_core/query',
 			array( $this, 'enqueue_styles' ),
 			10,
 			2
@@ -159,7 +159,7 @@ class ProductQuery extends AbstractBlock {
 	 * @return string The block content.
 	 */
 	public function enqueue_styles( string $block_content, array $block ) {
-		if ( 'core/query' === $block['blockName'] && self::is_woocommerce_variation( $block ) ) {
+		if ( self::is_woocommerce_variation( $block ) ) {
 			wp_enqueue_style( 'wc-blocks-style-product-query' );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR includes several fixes/tweaks to the Products block:

* Rename it from Products (Beta) to Products (Deprecated). I belive the word 'Beta' makes it feels it's going to become stable at some point in the future, while marking it as 'Deprecated' is clearer that the block should not be used.
* Update a hook to use `render_block_core/query` instead of `render_block`. Not a big deal, but should be slightly better performance-wise.
* Add an extra protection in case `allowedControls` is not an array. I believe that's what was causing the JS issue described in pdCMQf-2on-p2. I didn't investigate it further as I think we should move towards removing most of the editor components from that block.

### How to test the changes in this Pull Request:

1. Create a post or page and insert the Products block:

```HTML
<!-- wp:query {"queryId":2,"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","outofstock","onbackorder"]},"displayLayout":{"type":"flex","columns":3},"namespace":"woocommerce/product-query"} -->
<div class="wp-block-query">
	<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
		<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
		<!-- wp:post-title {"textAlign":"center","level":3,"fontSize":"medium","isLink":true,"__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
		<!-- wp:woocommerce/product-price {"textAlign":"center","fontSize":"small","isDescendentOfQueryLoop":true} /-->
		<!-- wp:woocommerce/product-button {"textAlign":"center","fontSize":"small","isDescendentOfQueryLoop":true} /-->
	<!-- /wp:post-template -->
	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
		<!-- wp:query-pagination-previous /-->
		<!-- wp:query-pagination-numbers /-->
		<!-- wp:query-pagination-next /-->
	<!-- /wp:query-pagination -->
	<!-- wp:query-no-results -->
		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
		<p></p>
		<!-- /wp:paragraph -->
	<!-- /wp:query-no-results -->
</div>
<!-- /wp:query -->
```

2. Select it and verify its name is `Products (Deprecated)` instead of `Products (Beta)`.

Before | After
--- | ---
<img width="411" height="391" alt="imatge" src="https://github.com/user-attachments/assets/7472b4c0-baeb-44eb-86b8-8c5ab01b26ea" /> | <img width="411" height="391" alt="imatge" src="https://github.com/user-attachments/assets/ed1bd804-41ae-495a-b653-d86ec3fab126" />

3. Smoke test the block to make sure there are no regressions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->