### PR TITLE
Add compatibility shim for removed product block editor registry

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-block-editor-block-registry-compat
+++ b/plugins/woocommerce/changelog/fix-product-block-editor-block-registry-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a compatibility shim for the removed product block editor block registry to avoid third-party extension fatals.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * WooCommerce Product Editor Block Registration compatibility shim.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+/**
+ * Removed product block editor block registry.
+ *
+ * @deprecated 10.9.0 Product editor extension APIs were deprecated. The product block editor was removed in 11.0.0 with no replacement.
+ */
+class BlockRegistry {
+	/**
+	 * Whether the removal warning has already been logged for the current request.
+	 *
+	 * @var bool
+	 */
+	private static $removal_warning_logged = false;
+
+	/**
+	 * Constructor.
+	 */
+	protected function __construct() {}
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return BlockRegistry
+	 */
+	public static function get_instance(): BlockRegistry {
+		self::maybe_log_removal_warning();
+
+		return new self();
+	}
+
+	/**
+	 * Register product related block categories.
+	 *
+	 * @param array $block_categories Array of categories for block types.
+	 * @param mixed $editor_context   The current block editor context.
+	 *
+	 * @return array
+	 */
+	public static function register_categories( $block_categories, $editor_context ): array {
+		unset( $editor_context );
+
+		self::maybe_log_removal_warning();
+
+		return $block_categories;
+	}
+
+	/**
+	 * Check if a block is registered.
+	 *
+	 * @param string $block_name Block name.
+	 *
+	 * @return bool
+	 */
+	public static function is_registered( $block_name ): bool {
+		unset( $block_name );
+
+		self::maybe_log_removal_warning();
+
+		return false;
+	}
+
+	/**
+	 * Unregister a block.
+	 *
+	 * @param string $block_name Block name.
+	 */
+	public static function unregister( $block_name ): void {
+		unset( $block_name );
+
+		self::maybe_log_removal_warning();
+	}
+
+	/**
+	 * Register a block type from metadata stored in the block.json file.
+	 *
+	 * @param string $file_or_folder Path to the JSON file with metadata definition for the block or
+	 *                               path to the folder where the `block.json` file is located.
+	 *
+	 * @return false
+	 */
+	public static function register_block_type_from_metadata( $file_or_folder ) {
+		unset( $file_or_folder );
+
+		self::maybe_log_removal_warning();
+
+		return false;
+	}
+
+	/**
+	 * Log a warning about the removed compatibility class.
+	 */
+	private static function maybe_log_removal_warning(): void {
+		if ( self::$removal_warning_logged || ! function_exists( 'wc_get_logger' ) ) {
+			return;
+		}
+
+		self::$removal_warning_logged = true;
+
+		wc_get_logger()->warning(
+			'Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry is a temporary compatibility shim and will be removed soon. Product editor extension APIs were deprecated in WooCommerce 10.9.0, and the product block editor was removed in WooCommerce 11.0.0 with no replacement.',
+			array( 'source' => 'product-block-editor' )
+		);
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -3,8 +3,6 @@
  * WooCommerce Product Editor Block Registration compatibility shim.
  */
 
-declare( strict_types = 1 );
-
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
 /**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -12,6 +12,38 @@ namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
  */
 class BlockRegistry {
 	/**
+	 * Version that product editor APIs were deprecated in.
+	 */
+	const DEPRECATED_SINCE = '10.9.0';
+
+	/**
+	 * Generic blocks directory.
+	 */
+	const GENERIC_BLOCKS_DIR = '';
+
+	/**
+	 * Product fields blocks directory.
+	 */
+	const PRODUCT_FIELDS_BLOCKS_DIR = '';
+
+	/**
+	 * Array of all available generic blocks.
+	 */
+	const GENERIC_BLOCKS = array();
+
+	/**
+	 * Array of all available product fields blocks.
+	 */
+	const PRODUCT_FIELDS_BLOCKS = array();
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var BlockRegistry|null
+	 */
+	private static $instance = null;
+
+	/**
 	 * Whether the removal warning has already been logged for the current request.
 	 *
 	 * @var bool
@@ -29,9 +61,16 @@ class BlockRegistry {
 	 * @return BlockRegistry
 	 */
 	public static function get_instance(): BlockRegistry {
+		$instance = self::$instance;
+
+		if ( null === $instance ) {
+			$instance       = new self();
+			self::$instance = $instance;
+		}
+
 		self::maybe_log_removal_warning();
 
-		return new self();
+		return $instance;
 	}
 
 	/**
@@ -40,9 +79,9 @@ class BlockRegistry {
 	 * @param array $block_categories Array of categories for block types.
 	 * @param mixed $editor_context   The current block editor context.
 	 *
-	 * @return array
+	 * @return array[]
 	 */
-	public static function register_categories( $block_categories, $editor_context ): array {
+	public function register_categories( $block_categories, $editor_context ) {
 		unset( $editor_context );
 
 		self::maybe_log_removal_warning();
@@ -57,7 +96,7 @@ class BlockRegistry {
 	 *
 	 * @return bool
 	 */
-	public static function is_registered( $block_name ): bool {
+	public function is_registered( $block_name ): bool {
 		unset( $block_name );
 
 		self::maybe_log_removal_warning();
@@ -69,8 +108,9 @@ class BlockRegistry {
 	 * Unregister a block.
 	 *
 	 * @param string $block_name Block name.
+	 * @return void
 	 */
-	public static function unregister( $block_name ): void {
+	public function unregister( $block_name ) {
 		unset( $block_name );
 
 		self::maybe_log_removal_warning();
@@ -84,7 +124,7 @@ class BlockRegistry {
 	 *
 	 * @return false
 	 */
-	public static function register_block_type_from_metadata( $file_or_folder ) {
+	public function register_block_type_from_metadata( $file_or_folder ) {
 		unset( $file_or_folder );
 
 		self::maybe_log_removal_warning();

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
@@ -3,8 +3,6 @@
  * WooCommerce Product Editor Product Template compatibility shim.
  */
 
-declare( strict_types = 1 );
-
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
 /**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * WooCommerce Product Editor Product Template compatibility shim.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+/**
+ * Removed product editor product template value object.
+ *
+ * @deprecated 10.9.0 Product editor extension APIs were deprecated. The product block editor was removed in 11.0.0 with no replacement.
+ */
+class ProductTemplate {
+	/**
+	 * Whether the removal warning has already been logged for the current request.
+	 *
+	 * @var bool
+	 */
+	private static $removal_warning_logged = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $data Template data.
+	 */
+	public function __construct( array $data ) {
+		unset( $data );
+
+		self::maybe_log_removal_warning();
+	}
+
+	/**
+	 * Get the template ID.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		self::maybe_log_removal_warning();
+
+		return '';
+	}
+
+	/**
+	 * Get the template title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		self::maybe_log_removal_warning();
+
+		return '';
+	}
+
+	/**
+	 * Get the layout template ID.
+	 *
+	 * @return string|null
+	 */
+	public function get_layout_template_id() {
+		self::maybe_log_removal_warning();
+
+		return null;
+	}
+
+	/**
+	 * Set the layout template ID.
+	 *
+	 * @param string $layout_template_id The layout template ID.
+	 * @return void
+	 */
+	public function set_layout_template_id( string $layout_template_id ) {
+		unset( $layout_template_id );
+
+		self::maybe_log_removal_warning();
+	}
+
+	/**
+	 * Get the product data.
+	 *
+	 * @return array
+	 */
+	public function get_product_data() {
+		self::maybe_log_removal_warning();
+
+		return array();
+	}
+
+	/**
+	 * Get the template description.
+	 *
+	 * @return string|null
+	 */
+	public function get_description() {
+		self::maybe_log_removal_warning();
+
+		return null;
+	}
+
+	/**
+	 * Set the template description.
+	 *
+	 * @param string $description The template description.
+	 * @return void
+	 */
+	public function set_description( string $description ) {
+		unset( $description );
+
+		self::maybe_log_removal_warning();
+	}
+
+	/**
+	 * Get the template icon.
+	 *
+	 * @return string|null
+	 */
+	public function get_icon() {
+		self::maybe_log_removal_warning();
+
+		return null;
+	}
+
+	/**
+	 * Set the template icon.
+	 *
+	 * @param string $icon The icon name or an external image URL.
+	 * @return void
+	 */
+	public function set_icon( string $icon ) {
+		unset( $icon );
+
+		self::maybe_log_removal_warning();
+	}
+
+	/**
+	 * Get the template order.
+	 *
+	 * @return int
+	 */
+	public function get_order() {
+		self::maybe_log_removal_warning();
+
+		return 999;
+	}
+
+	/**
+	 * Get the selectable attribute.
+	 *
+	 * @return bool
+	 */
+	public function get_is_selectable_by_user() {
+		self::maybe_log_removal_warning();
+
+		return false;
+	}
+
+	/**
+	 * Set the template order.
+	 *
+	 * @param int $order The template order.
+	 * @return void
+	 */
+	public function set_order( int $order ) {
+		unset( $order );
+
+		self::maybe_log_removal_warning();
+	}
+
+	/**
+	 * Get the product template as JSON-like data.
+	 *
+	 * @return array
+	 */
+	public function to_json() {
+		self::maybe_log_removal_warning();
+
+		return array();
+	}
+
+	/**
+	 * Log a warning about the removed compatibility class.
+	 */
+	private static function maybe_log_removal_warning(): void {
+		if ( self::$removal_warning_logged || ! function_exists( 'wc_get_logger' ) ) {
+			return;
+		}
+
+		self::$removal_warning_logged = true;
+
+		wc_get_logger()->warning(
+			'Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplate is a temporary compatibility shim and will be removed soon. Product editor extension APIs were deprecated in WooCommerce 10.9.0, and the product block editor was removed in WooCommerce 11.0.0 with no replacement.',
+			array( 'source' => 'product-block-editor' )
+		);
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/GroupInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/GroupInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * WooCommerce Product Editor group interface compatibility shim.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates;
+
+/**
+ * Removed product editor group container interface.
+ *
+ * @deprecated 10.9.0 Product editor extension APIs were deprecated. The product block editor was removed in 11.0.0 with no replacement.
+ */
+interface GroupInterface {}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/GroupInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/GroupInterface.php
@@ -3,8 +3,6 @@
  * WooCommerce Product Editor group interface compatibility shim.
  */
 
-declare( strict_types = 1 );
-
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates;
 
 /**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductFormTemplateInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductFormTemplateInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * WooCommerce Product Editor product form template interface compatibility shim.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates;
+
+/**
+ * Removed product editor product form template interface.
+ *
+ * @deprecated 10.9.0 Product editor extension APIs were deprecated. The product block editor was removed in 11.0.0 with no replacement.
+ */
+interface ProductFormTemplateInterface {}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductFormTemplateInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductFormTemplateInterface.php
@@ -3,8 +3,6 @@
  * WooCommerce Product Editor product form template interface compatibility shim.
  */
 
-declare( strict_types = 1 );
-
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates;
 
 /**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SectionInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SectionInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * WooCommerce Product Editor section interface compatibility shim.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates;
+
+/**
+ * Removed product editor section container interface.
+ *
+ * @deprecated 10.9.0 Product editor extension APIs were deprecated. The product block editor was removed in 11.0.0 with no replacement.
+ */
+interface SectionInterface {}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SectionInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SectionInterface.php
@@ -3,8 +3,6 @@
  * WooCommerce Product Editor section interface compatibility shim.
  */
 
-declare( strict_types = 1 );
-
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates;
 
 /**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SubsectionInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SubsectionInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * WooCommerce Product Editor subsection interface compatibility shim.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates;
+
+/**
+ * Removed product editor subsection container interface.
+ *
+ * @deprecated 10.9.0 Product editor extension APIs were deprecated. The product block editor was removed in 11.0.0 with no replacement.
+ */
+interface SubsectionInterface {}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SubsectionInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SubsectionInterface.php
@@ -3,8 +3,6 @@
  * WooCommerce Product Editor subsection interface compatibility shim.
  */
 
-declare( strict_types = 1 );
-
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates;
 
 /**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/README.md
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/README.md
@@ -1,0 +1,7 @@
+# Product Block Editor compatibility shims
+
+This folder contains temporary compatibility shims for PHP classes and interfaces that were part of the removed Product Block Editor.
+
+The Product Editor extension APIs were deprecated in WooCommerce 10.9.0, and the Product Block Editor was removed in WooCommerce 11.0.0 with no replacement. These classes remain only to avoid fatal errors in extensions or custom code that still reference the old PHP symbols during the transition period.
+
+Do not add new Product Block Editor behavior here. Any code in this folder should be limited to compatibility with the removed APIs, should avoid reintroducing the removed editor, and may be removed in a future WooCommerce version.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With #65500, we removed the Product Editor codebase. Unfortunately, there are some public APIs that can't be removed, otherwise there is [the risk of fatal errors](https://github.com/woocommerce/woocommerce/actions/runs/27004058888?pr=65500). This PR adds a compatibility shim.

### Screenshots or screen recordings:

Not applicable. This is a backend compatibility change.

### How to test the changes in this Pull Request:

1. Checkout https://github.com/woocommerce/woocommerce/pull/65500
2. Install https://wordpress.org/plugins/google-listings-and-ads plugin.
3. Visit the WooCommerce Home
4. See fatal.
5. Checkout this branch.
6. Visit the WooCommerce Home.
7. Ensure that it works as expected.


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
