### PR TITLE
Fix admin order items subtotal subtracting fee tax for fixed end-prices

### DIFF
--- a/plugins/woocommerce/changelog/fix-line-item-subtotal-display
+++ b/plugins/woocommerce/changelog/fix-line-item-subtotal-display
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix the order admin Items Subtotal incorrectly subtracting fee and shipping tax for stores with fixed end-prices.
+Fix the order admin Items Subtotal incorrectly subtracting fee tax for stores with fixed end-prices.

--- a/plugins/woocommerce/changelog/fix-line-item-subtotal-display
+++ b/plugins/woocommerce/changelog/fix-line-item-subtotal-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the order admin Items Subtotal incorrectly subtracting fee and shipping tax for stores with fixed end-prices.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -2152,8 +2152,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * For stores with fixed end-prices (prices entered including tax with the
 	 * woocommerce_adjust_non_base_location_prices adjustment disabled), the
 	 * line-item subtotal tax is removed so the displayed subtotal matches the
-	 * ex-tax cart display. Only line-item taxes are subtracted, not the fee or
-	 * shipping taxes that get_cart_tax() would also include.
+	 * ex-tax cart display. Only line-item taxes are subtracted, not the fee tax
+	 * that get_cart_tax() would also include.
 	 *
 	 * @return float
 	 */

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -2150,15 +2150,26 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Get the items subtotal amount to display in the admin order screen.
 	 *
 	 * For stores with fixed end-prices (prices entered including tax with the
-	 * woocommerce_adjust_non_base_location_prices adjustment disabled), the cart
-	 * tax is removed so the displayed subtotal matches the ex-tax cart display.
+	 * woocommerce_adjust_non_base_location_prices adjustment disabled), the
+	 * line-item subtotal tax is removed so the displayed subtotal matches the
+	 * ex-tax cart display. Only line-item taxes are subtracted, not the fee or
+	 * shipping taxes that get_cart_tax() would also include.
 	 *
 	 * @return float
 	 */
 	public function get_subtotal_amount_to_display() {
-		return $this->has_fixed_end_prices()
-			? (float) $this->get_subtotal() - (float) $this->get_cart_tax()
-			: (float) $this->get_subtotal();
+		if ( ! $this->has_fixed_end_prices() ) {
+			return (float) $this->get_subtotal();
+		}
+
+		$subtotal_tax = 0;
+		foreach ( $this->get_items() as $item ) {
+			if ( $item instanceof WC_Order_Item_Product ) {
+				$subtotal_tax += self::round_line_tax( (float) $item->get_subtotal_tax(), false );
+			}
+		}
+
+		return (float) $this->get_subtotal() - wc_round_tax_total( $subtotal_tax );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -2333,6 +2333,43 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_subtotal_amount_to_display() excludes fee tax from the items subtotal in fixed end-price mode.
+	 */
+	public function test_get_subtotal_amount_to_display_excludes_fee_tax_in_fixed_price_mode(): void {
+		$context = $this->create_manual_order_tax_context();
+		add_filter( 'woocommerce_adjust_non_base_location_prices', '__return_false' );
+		$order = $this->create_manual_order_for_tax_context( $context, '24' );
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_props(
+			array(
+				'name'       => 'Handling',
+				'tax_status' => ProductTaxStatus::TAXABLE,
+				'tax_class'  => $context['tax_class_slug'],
+				'total'      => 10,
+			)
+		);
+		$order->add_item( $fee );
+
+		try {
+			$order->calculate_totals();
+
+			$line_item = current( $order->get_items() );
+
+			// The €24 tax-inclusive item carries €1.98 tax, so the ex-tax items subtotal is €22.02.
+			// The €0.90 taxable-fee tax (also part of get_cart_tax()) must not be subtracted from it.
+			$this->assertEquals( 22.02, round( (float) $order->get_subtotal_amount_to_display(), 2 ), 'Displayed items subtotal must exclude fee tax' );
+			$this->assertEquals(
+				round( (float) $order->get_item_subtotal_to_display( $line_item ), 2 ),
+				round( (float) $order->get_subtotal_amount_to_display(), 2 ),
+				'Displayed items subtotal must match the per-item displayed subtotal'
+			);
+		} finally {
+			$this->cleanup_manual_order_tax_context( $context, $order );
+		}
+	}
+
+	/**
 	 * Creates tax rates and a product for manual order tax tests.
 	 *
 	 * @param string $prices_include_tax Whether prices include tax.

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -2356,6 +2356,10 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 
 			$line_item = current( $order->get_items() );
 
+			// Guard the precondition: the fee must be taxed, otherwise get_cart_tax()
+			// would equal the item tax and the buggy code would also yield €22.02.
+			$this->assertEquals( 0.90, round( (float) $fee->get_total_tax(), 2 ), 'Test setup must include taxable fee tax' );
+
 			// The €24 tax-inclusive item carries €1.98 tax, so the ex-tax items subtotal is €22.02.
 			// The €0.90 taxable-fee tax (also part of get_cart_tax()) must not be subtracted from it.
 			$this->assertEquals( 22.02, round( (float) $order->get_subtotal_amount_to_display(), 2 ), 'Displayed items subtotal must exclude fee tax' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up bug fix to #63744.

That PR added `WC_Abstract_Order::get_subtotal_amount_to_display()` to render the ex-tax "Items Subtotal" on the admin order screen for stores with **fixed end-prices** (prices entered including tax with `woocommerce_adjust_non_base_location_prices` disabled). It computed the value as:

```php
$this->get_subtotal() - $this->get_cart_tax()
```

The two operands have **mismatched scopes**:

- `get_subtotal()` covers **line items only** (`get_items()` defaults to `'line_item'`).
- `get_cart_tax()` aggregates **line item *and* fee/shipping taxes** - `update_taxes()` sums taxes over `get_items( array( 'line_item', 'fee' ) )` (plus shipping) into `cart_tax`.

So when a taxable **fee** (or shipping) is present, its tax was incorrectly subtracted from the items-only subtotal. The displayed "Items Subtotal" came out too low and no longer matched the sum of the per-line displayed prices (the per-line `get_item_subtotal_to_display()` correctly uses each item's own `get_subtotal_tax()`).

This PR reworks `get_subtotal_amount_to_display()` to subtract only the **line-item subtotal taxes**, mirroring the existing `get_subtotal_to_display()` pattern. Fee and shipping taxes are excluded, and the displayed total again matches the per-item display.

`includes/abstracts/abstract-wc-order.php`

- `get_subtotal_amount_to_display()`: sum line-item subtotal taxes (guarded by `instanceof WC_Order_Item_Product`) instead of using `get_cart_tax()`.

`tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php`

- Add `test_get_subtotal_amount_to_display_excludes_fee_tax_in_fixed_price_mode` asserting the displayed subtotal excludes fee tax and matches the per-item displayed subtotal.

Bug introduced in PR #63744.

### How to test the changes in this Pull Request:

This reuses the tax scenario from #63744 and adds a taxable fee, which is the condition that triggers the bug.

1. In **WooCommerce → Settings → Tax**, set **Prices entered with tax** to **Yes**. Set the store base country to **Belgium** and add tax rates: **Belgium 6%** and **Netherlands 9%** (same class).
2. Add `add_filter( 'woocommerce_adjust_non_base_location_prices', '__return_false' );` (e.g. via a mu-plugin).
3. Create a product priced at **€24.00**.
4. Create an order in the backend, set the **billing country to Netherlands**, and add the **€24.00** product.
5. Add a **fee** to the order of **€10.00**, taxable (same tax class).
6. Click **Recalculate**.

Verify:

- The line item **Price** column shows **€22.02** (ex-tax), and the **Items Subtotal** row now matches it at **€22.02**. Order **Total** is **€34.90** (€24.00 item incl. tax + €10.00 fee + €0.90 fee tax).
- Without this fix, the **Items Subtotal** instead shows **€21.12** - the €0.90 fee tax wrongly subtracted from the items subtotal - while the line "Price" still shows €22.02.
- Click **Recalculate** again - totals stay identical.

Alternative check: use a **negative** taxable fee of **−€10.00** (a manual discount) instead of a positive fee. The **Items Subtotal** should show **€22.02**; before the fix it showed **€22.85**.

Regression guard (no fee): remove the fee and confirm the **Items Subtotal** is still **€22.02**, i.e. this change does not affect orders without taxable fees/shipping.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix admin order Items Subtotal incorrectly subtracting fee and shipping tax for stores with fixed end-prices.
