### PR TITLE
Remove 'add-to-wishlist-button' from Add to Cart + Options template parts

### DIFF
--- a/plugins/woocommerce/changelog/remove-add-to-wishlist-button-from-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/remove-add-to-wishlist-button-from-add-to-cart-with-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Remove 'add-to-wishlist-button' from Add to Cart + Options template parts
+
+

--- a/plugins/woocommerce/templates/parts/external-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/external-product-add-to-cart-with-options.html
@@ -1,4 +1,3 @@
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
 <!-- /wp:group -->
-<!-- wp:woocommerce/add-to-wishlist-button /-->

--- a/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
@@ -31,4 +31,3 @@
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
 <!-- /wp:group -->
-<!-- wp:woocommerce/add-to-wishlist-button /-->

--- a/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
@@ -3,4 +3,3 @@
 <div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 <!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
 <!-- /wp:group -->
-<!-- wp:woocommerce/add-to-wishlist-button /-->

--- a/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
@@ -36,5 +36,3 @@
 	<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
 </div>
 <!-- /wp:group -->
-
-<!-- wp:woocommerce/add-to-wishlist-button /-->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/65263.

The `add-to-wishlist-button` block is still behind a feature flag, so it shouldn't be included by default in the Add to Cart + Options template parts, otherwise it renders as an invalid block in the editor.

Sidenote: I believe that even when the block is stable, we shouldn't add it to the template parts by default. That would impact any store that hasn't customized the templates, and changes in the frontend of existing stores should be avoided as much as possible IMO. Instead, I believe it should be opt-in, so if an store wants to add it, they should explicitly insert it in the template parts.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Patterns_ > _Add to Cart + Options_ and open each one of them.
2. Verify there isn't a message saying the `add-to-wishlist-button` block is not supported:

Before | After
--- | ---
<img width="1196" height="560" alt="imatge" src="https://github.com/user-attachments/assets/420d93ac-eacc-4db8-947e-3fb0305b2c97" /> | <img width="1196" height="560" alt="imatge" src="https://github.com/user-attachments/assets/38b11af5-9997-4189-8f0c-683cd4d6873d" />