### PR TITLE
Add Flat Config export to @woocommerce/eslint-plugin

### DIFF
--- a/packages/js/eslint-plugin/README.md
+++ b/packages/js/eslint-plugin/README.md
@@ -34,6 +34,23 @@ Refer to the [ESLint documentation on Shareable Configs](http://eslint.org/docs/
 
 The `recommended` preset will include rules governing an ES2015+ environment, and includes rules from the [`@wordpress/eslint-plugin/recommended`](https://github.com/WordPress/gutenberg/tree/trunk/packages/eslint-plugin) project.
 
+### Flat Config (ESLint v9+)
+
+ESLint v9 and v10 use the new [Flat Config](https://eslint.org/docs/latest/use/configure/configuration-files) format. The plugin exposes a `flat/recommended` array that you can spread into your `eslint.config.js`:
+
+```js
+// eslint.config.js
+const wc = require( '@woocommerce/eslint-plugin' );
+
+module.exports = [ ...wc.configs[ 'flat/recommended' ] ];
+```
+
+The flat-config export is built on top of the same `recommended` preset, so the rules, parser, plugins, settings, and test-file overrides all stay in sync automatically. Legacy `.eslintrc.js` consumers (ESLint v8) should continue to use the `extends: 'plugin:@woocommerce/eslint-plugin/recommended'` syntax shown above.
+
+#### ESLint v9 / v10 caveats
+
+The `flat/recommended` export resolves the legacy `extends` chain through `FlatCompat` from `@eslint/eslintrc`, so the config loads cleanly under ESLint v9+ and can be spread into your `eslint.config.js` without the `TypeError: ... is not iterable` reported in [#65458](https://github.com/woocommerce/woocommerce/issues/65458). A handful of the underlying plugins in this preset (`@typescript-eslint@5.x`, `eslint-plugin-jest@27.x`, `eslint-plugin-testing-library@5.x`) predate ESLint v9 and may throw runtime errors such as `context.getScope is not a function` when their rules run under v9. Bumping those plugin dependencies to v9-compatible majors is tracked separately; in the meantime you can silence individual failing rules with a `rules: { ... }` override in your own `eslint.config.js`.
+
 If you want to use prettier in your code editor, you'll need to create a `.prettierrc.js` file at the root of your project with the following:
 
 ```js

--- a/packages/js/eslint-plugin/changelog/add-flat-config-support
+++ b/packages/js/eslint-plugin/changelog/add-flat-config-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Flat Config export (`configs['flat/recommended']`) for ESLint v9/v10 compatibility. #65458

--- a/packages/js/eslint-plugin/configs/flat/__tests__/recommended.js
+++ b/packages/js/eslint-plugin/configs/flat/__tests__/recommended.js
@@ -1,0 +1,41 @@
+/**
+ * Tests for the Flat Config export of @woocommerce/eslint-plugin.
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/65458
+ */
+
+'use strict';
+
+const flatRecommended = require( '../recommended' );
+const legacyRecommended = require( '../../recommended' );
+
+describe( 'Flat Config export', () => {
+	test( 'exports an array suitable for spreading into a flat config', () => {
+		expect( Array.isArray( flatRecommended ) ).toBe( true );
+		expect( flatRecommended.length ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'each entry is a flat-config object (no eslintrc-only `extends` key)', () => {
+		flatRecommended.forEach( ( entry ) => {
+			expect( typeof entry ).toBe( 'object' );
+			expect( entry ).not.toBeNull();
+			// eslintrc-style `extends` is illegal in flat config; FlatCompat
+			// resolves it into the entry's `rules` / `plugins` / etc.
+			expect( entry ).not.toHaveProperty( 'extends' );
+		} );
+	} );
+
+	test( 'still ships the legacy eslintrc config object unchanged', () => {
+		// Regression guard: the 73 monorepo consumers depend on this shape.
+		expect( Array.isArray( legacyRecommended ) ).toBe( false );
+		expect( typeof legacyRecommended ).toBe( 'object' );
+		expect( Array.isArray( legacyRecommended.extends ) ).toBe( true );
+	} );
+
+	test( 'the issue reproducer can spread the export without throwing', () => {
+		// This is the exact pattern from issue #65458, translated to use
+		// the new key. Before the fix this throws "TypeError: ... is not
+		// iterable" because `configs.recommended` is a plain object.
+		expect( () => [ ...flatRecommended ] ).not.toThrow();
+	} );
+} );

--- a/packages/js/eslint-plugin/configs/flat/recommended.js
+++ b/packages/js/eslint-plugin/configs/flat/recommended.js
@@ -1,0 +1,28 @@
+/**
+ * Flat Config export for `@woocommerce/eslint-plugin`.
+ *
+ * This export provides a flat-config-compatible array of ESLint config objects
+ * for use with ESLint v9+ and the new Flat Config format (eslint.config.js).
+ *
+ * Example usage in eslint.config.js:
+ *
+ *   const wc = require( '@woocommerce/eslint-plugin' );
+ *   module.exports = [ ...wc.configs[ 'flat/recommended' ] ];
+ *
+ * Legacy consumers (ESLint v8 and earlier) should continue to use
+ * `extends: 'plugin:@woocommerce/eslint-plugin/recommended'` in their .eslintrc.js.
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/65458
+ * @see https://eslint.org/docs/latest/use/migrate-to-10.0.0
+ * @since 2.4.0
+ */
+
+'use strict';
+
+const { FlatCompat } = require( '@eslint/eslintrc' );
+
+const compat = new FlatCompat( { baseDirectory: __dirname } );
+
+module.exports = [
+	...compat.extends( 'plugin:@woocommerce/eslint-plugin/recommended' ),
+];

--- a/packages/js/eslint-plugin/configs/recommended.js
+++ b/packages/js/eslint-plugin/configs/recommended.js
@@ -11,7 +11,18 @@ module.exports = {
 		'jest/globals': true,
 		jest: true,
 	},
-	plugins: [ '@wordpress', '@typescript-eslint' ],
+	plugins: [
+		'@wordpress',
+		'@typescript-eslint',
+		// Additional plugin namespaces referenced by rules below. Listing
+		// them explicitly keeps flat-config (ESLint v9+) translation working:
+		// FlatCompat only registers the plugins that are declared here, while
+		// legacy eslintrc resolves plugin namespaces on demand from rule
+		// references. Both plugins ship transitively via
+		// @wordpress/eslint-plugin@14.x.
+		'import',
+		'jest',
+	],
 	rules: {
 		radix: 'error',
 		yoda: [ 'error', 'never' ],

--- a/packages/js/eslint-plugin/index.js
+++ b/packages/js/eslint-plugin/index.js
@@ -1,8 +1,32 @@
-module.exports = {
-	configs: {
-		recommended: require( './configs/recommended' ),
-	},
+/**
+ * Lazy plugin exports.
+ *
+ * The `flat/recommended` config is loaded on demand (via a getter) so that
+ * loading this module from inside its own FlatCompat chain does not create a
+ * circular require loop. The rule is loaded eagerly because it has no
+ * dependencies and is cheap to keep ready.
+ */
+
+const plugin = {
+	configs: {},
 	rules: {
 		'dependency-group': require( './rules/dependency-group' ),
 	},
 };
+
+Object.defineProperties( plugin.configs, {
+	recommended: {
+		enumerable: true,
+		get() {
+			return require( './configs/recommended' );
+		},
+	},
+	'flat/recommended': {
+		enumerable: true,
+		get() {
+			return require( './configs/flat/recommended' );
+		},
+	},
+} );
+
+module.exports = plugin;

--- a/packages/js/eslint-plugin/package.json
+++ b/packages/js/eslint-plugin/package.json
@@ -29,6 +29,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
+		"@eslint/eslintrc": "^3.0.0",
 		"@typescript-eslint/eslint-plugin": "^5.62.0",
 		"@typescript-eslint/parser": "^5.62.0",
 		"@wordpress/eslint-plugin": "14.7.0",
@@ -45,7 +46,8 @@
 		"lint": "pnpm --if-present '/^lint:lang:.*$/'",
 		"lint:fix": "pnpm --if-present '/^lint:fix:lang:.*$/'",
 		"lint:fix:lang:js": "eslint ./rules ./configs --fix",
-		"lint:lang:js": "eslint ./rules ./configs"
+		"lint:lang:js": "eslint ./rules ./configs",
+		"test": "jest"
 	},
 	"devDependencies": {
 		"@babel/core": "7.25.7",

--- a/packages/js/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/js/eslint-plugin/rules/__tests__/dependency-group.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+const { RuleTester } = require( 'eslint' );
 
 /**
  * Internal dependencies
  */
-import rule from '../dependency-group';
+const rule = require( '../dependency-group' );
 
 const ruleTester = new RuleTester( {
 	parserOptions: {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #65458.

`@woocommerce/eslint-plugin@2.3.0` exports `configs.recommended` as a legacy eslintrc object, so consumers on ESLint v9/v10 who try to spread it into a `eslint.config.js` array hit `TypeError: ... is not iterable`. The fix adds a sibling `configs['flat/recommended']` array built on top of the same `recommended` preset through `FlatCompat` from `@eslint/eslintrc`. `index.js` now exposes both configs via lazy property getters so loading the package from inside its own `FlatCompat` chain does not create a circular require loop. `recommended.js` lists the `import` and `jest` plugin namespaces explicitly so the FlatCompat translation registers them; both ship transitively via `@wordpress/eslint-plugin@14.x` and the change is a no-op for the 73 existing eslintrc consumers in this monorepo.

Reproduction from the issue, before the fix:

```js
// eslint.config.js
const wc = require( '@woocommerce/eslint-plugin' );
module.exports = [ ...wc.configs.recommended ]; // TypeError: ... is not iterable
```

After the fix the same intent works via the new key:

```js
const wc = require( '@woocommerce/eslint-plugin' );
module.exports = [ ...wc.configs[ 'flat/recommended' ] ];
```

### Screenshots or screen recordings:

N/A — developer tooling change, no UI.

### How to test the changes in this Pull Request:

1. From the repo root, run `pnpm install`.
2. Run the package tests and self-lint:
   ```
   pnpm --filter @woocommerce/eslint-plugin test
   pnpm --filter @woocommerce/eslint-plugin lint:lang:js
   ```
   Expect: 2 test suites / 6 tests pass, and 0 lint errors (3 pre-existing `import/no-extraneous-dependencies` warnings about the TypeScript resolver remain unchanged).
3. In a scratch directory, install ESLint v9 and the package locally, then create:
   ```js
   // eslint.config.js
   const wc = require( '@woocommerce/eslint-plugin' );
   module.exports = [ ...wc.configs[ 'flat/recommended' ] ];
   ```
   Confirm the file loads without `TypeError` and `npx eslint` resolves the config (full rule execution may surface v8-era plugin errors such as `context.getScope is not a function` from `@typescript-eslint@5.x`; those are documented in the README caveats and out of scope for this PR).
4. Verify the legacy path still works: in any package that extends `plugin:@woocommerce/eslint-plugin/recommended` in `.eslintrc.js`, the lint output is unchanged.

### Testing that has already taken place:

- `pnpm --filter @woocommerce/eslint-plugin test` — 6/6 pass (2 suites: existing `dependency-group` rule tests + new `flat/recommended` shape tests covering array shape, absence of eslintrc-only `extends` keys, legacy object unchanged regression guard, and the issue reproducer spreading without throwing).
- `pnpm --filter @woocommerce/eslint-plugin lint:lang:js` — 0 errors.
- Smoke test in a clean consumer directory with `eslint@^9` and the package linked via `file:` — the spread `[ ...wc.configs[ 'flat/recommended' ] ]` no longer throws, returns a 37-element flat config array, and `npx eslint fixture.js` loads the config successfully.
- `coderabbit review --agent` — 0 findings.

### Milestone

-   [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entry lives in the per-package jetpack-changelogger file at `packages/js/eslint-plugin/changelog/add-flat-config-support` (`Significance: minor`, `Type: add`) and will be released with the next `@woocommerce/eslint-plugin` npm publish. The auto-generated `plugins/woocommerce/changelog/` entry is not applicable because this PR only touches a JS package and ships through the package's own release pipeline.

### Release Communication

-   [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

Consumers migrating to ESLint v9/v10 Flat Config can now spread `configs['flat/recommended']` into their `eslint.config.js`. The legacy `extends: 'plugin:@woocommerce/eslint-plugin/recommended'` path is unchanged.