### PR TITLE
Fix shipping cache invalidation from package metadata

### DIFF
--- a/plugins/woocommerce/changelog/65541-fix-checkout-shipping-cache-homeboy
+++ b/plugins/woocommerce/changelog/65541-fix-checkout-shipping-cache-homeboy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent calculated package totals from invalidating cached shipping rates.
+Prevent non-rate package metadata from invalidating cached shipping rates.

--- a/plugins/woocommerce/changelog/65541-fix-checkout-shipping-cache-homeboy
+++ b/plugins/woocommerce/changelog/65541-fix-checkout-shipping-cache-homeboy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent calculated package totals from invalidating cached shipping rates.

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -413,19 +413,17 @@ class WC_Shipping {
 	/**
 	 * Generate the shipping-rate cache hash for a package.
 	 *
-	 * @param array $package Package of cart items.
+	 * @param array $package_to_hash Package of cart items.
 	 * @return string
 	 */
-	private function get_package_hash( array $package ): string {
-		$package_to_hash = $package;
-
+	private function get_package_hash( array $package_to_hash ): string {
 		/**
 		 * Filters package fields that should not affect the shipping-rate cache hash.
 		 *
 		 * @since 11.0.0
 		 *
 		 * @param array $ignored_fields Package field names ignored while generating the cache hash.
-		 * @param array $package Package of cart items.
+		 * @param array $package        Package of cart items.
 		 */
 		$ignored_fields = apply_filters(
 			'woocommerce_shipping_package_hash_ignored_fields',
@@ -437,7 +435,7 @@ class WC_Shipping {
 				'rates',
 				'package_index',
 			),
-			$package
+			$package_to_hash
 		);
 
 		foreach ( array_unique( array_filter( (array) $ignored_fields, 'is_string' ) ) as $field ) {
@@ -445,10 +443,8 @@ class WC_Shipping {
 		}
 
 		// Remove data objects so hashes are consistent.
-		if ( isset( $package_to_hash['contents'] ) && is_array( $package_to_hash['contents'] ) ) {
-			foreach ( $package_to_hash['contents'] as $item_id => $item ) {
-				unset( $package_to_hash['contents'][ $item_id ]['data'] );
-			}
+		foreach ( (array) ( $package_to_hash['contents'] ?? array() ) as $item_id => $item ) {
+			unset( $package_to_hash['contents'][ $item_id ]['data'] );
 		}
 
 		return 'wc_ship_' . md5( wp_json_encode( $package_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -320,20 +320,12 @@ class WC_Shipping {
 		// local pickup rates here however since those are not shipped.
 		$is_shippable = $this->is_package_shippable( $package );
 
-		// Check if we need to recalculate shipping for this package.
-		$package_to_hash = $package;
-
-		// Remove data objects so hashes are consistent.
-		foreach ( $package_to_hash['contents'] as $item_id => $item ) {
-			unset( $package_to_hash['contents'][ $item_id ]['data'] );
-		}
-
 		// Get rates stored in the WC session data for this package.
 		$wc_session_key = 'shipping_for_package_' . $package_key;
 		$stored_rates   = WC()->session->get( $wc_session_key );
 
 		// Calculate the hash for this package so we can tell if it's changed since last calculation.
-		$package_hash = 'wc_ship_' . md5( wp_json_encode( $package_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
+		$package_hash = $this->get_package_hash( $package );
 
 		if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
 			foreach ( $this->load_shipping_methods( $package ) as $shipping_method ) {
@@ -416,6 +408,50 @@ class WC_Shipping {
 		}
 
 		return $package;
+	}
+
+	/**
+	 * Generate the shipping-rate cache hash for a package.
+	 *
+	 * @param array $package Package of cart items.
+	 * @return string
+	 */
+	private function get_package_hash( array $package ): string {
+		$package_to_hash = $package;
+
+		/**
+		 * Filters package fields that should not affect the shipping-rate cache hash.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param array $ignored_fields Package field names ignored while generating the cache hash.
+		 * @param array $package Package of cart items.
+		 */
+		$ignored_fields = apply_filters(
+			'woocommerce_shipping_package_hash_ignored_fields',
+			array(
+				'subtotal',
+				'total',
+				'package_id',
+				'package_name',
+				'rates',
+				'package_index',
+			),
+			$package
+		);
+
+		foreach ( array_unique( array_filter( (array) $ignored_fields, 'is_string' ) ) as $field ) {
+			unset( $package_to_hash[ $field ] );
+		}
+
+		// Remove data objects so hashes are consistent.
+		if ( isset( $package_to_hash['contents'] ) && is_array( $package_to_hash['contents'] ) ) {
+			foreach ( $package_to_hash['contents'] as $item_id => $item ) {
+				unset( $package_to_hash['contents'][ $item_id ]['data'] );
+			}
+		}
+
+		return 'wc_ship_' . md5( wp_json_encode( $package_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
@@ -129,6 +129,117 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox ignored package fields do not invalidate cached shipping rates
+	 *
+	 * @dataProvider provide_ignored_package_hash_fields
+	 *
+	 * @param string $field Package field to mutate.
+	 * @param mixed  $value Mutated field value.
+	 */
+	public function test_calculate_shipping_for_package_ignores_non_rate_fields_in_package_hash( string $field, $value ) {
+		update_option( 'woocommerce_shipping_debug_mode', 'no' );
+		WC()->session->__unset( 'shipping_for_package_0' );
+
+		$filter_calls = 0;
+		$filter       = $this->get_package_rates_counter( $filter_calls );
+		$package      = $this->get_package_hash_test_package();
+
+		add_filter( 'woocommerce_package_rates', $filter, 10 );
+
+		$this->sut->calculate_shipping_for_package( $package );
+
+		$package[ $field ] = $value;
+
+		$this->sut->calculate_shipping_for_package( $package );
+
+		$this->assertSame( 1, $filter_calls );
+
+		remove_filter( 'woocommerce_package_rates', $filter, 10 );
+	}
+
+	/**
+	 * @testdox material package fields invalidate cached shipping rates
+	 *
+	 * @dataProvider provide_material_package_hash_fields
+	 *
+	 * @param callable $mutate_package Package mutation callback.
+	 */
+	public function test_calculate_shipping_for_package_invalidates_cache_for_material_package_changes( callable $mutate_package ) {
+		update_option( 'woocommerce_shipping_debug_mode', 'no' );
+		WC()->session->__unset( 'shipping_for_package_0' );
+
+		$filter_calls = 0;
+		$filter       = $this->get_package_rates_counter( $filter_calls );
+		$package      = $this->get_package_hash_test_package();
+
+		add_filter( 'woocommerce_package_rates', $filter, 10 );
+
+		$this->sut->calculate_shipping_for_package( $package );
+
+		$mutate_package( $package );
+
+		$this->sut->calculate_shipping_for_package( $package );
+
+		$this->assertSame( 2, $filter_calls );
+
+		remove_filter( 'woocommerce_package_rates', $filter, 10 );
+	}
+
+	/**
+	 * @testdox unknown package fields invalidate cached shipping rates by default
+	 */
+	public function test_calculate_shipping_for_package_invalidates_cache_for_unknown_package_fields_by_default() {
+		update_option( 'woocommerce_shipping_debug_mode', 'no' );
+		WC()->session->__unset( 'shipping_for_package_0' );
+
+		$filter_calls = 0;
+		$filter       = $this->get_package_rates_counter( $filter_calls );
+		$package      = $this->get_package_hash_test_package();
+
+		add_filter( 'woocommerce_package_rates', $filter, 10 );
+
+		$this->sut->calculate_shipping_for_package( $package );
+
+		$package['custom_extension_key'] = 'changed';
+
+		$this->sut->calculate_shipping_for_package( $package );
+
+		$this->assertSame( 2, $filter_calls );
+
+		remove_filter( 'woocommerce_package_rates', $filter, 10 );
+	}
+
+	/**
+	 * @testdox extensions can ignore package fields for the shipping-rate cache hash
+	 */
+	public function test_calculate_shipping_for_package_allows_extensions_to_ignore_package_hash_fields() {
+		update_option( 'woocommerce_shipping_debug_mode', 'no' );
+		WC()->session->__unset( 'shipping_for_package_0' );
+
+		$filter_calls          = 0;
+		$filter                = $this->get_package_rates_counter( $filter_calls );
+		$ignored_fields_filter = function ( array $ignored_fields ): array {
+			$ignored_fields[] = 'custom_extension_key';
+			return $ignored_fields;
+		};
+		$package               = $this->get_package_hash_test_package();
+
+		add_filter( 'woocommerce_package_rates', $filter, 10 );
+		add_filter( 'woocommerce_shipping_package_hash_ignored_fields', $ignored_fields_filter );
+
+		$this->sut->calculate_shipping_for_package( $package );
+
+		$package['custom_extension_key'] = 'changed';
+
+		$this->sut->calculate_shipping_for_package( $package );
+
+		$this->assertSame( 1, $filter_calls );
+
+		remove_filter( 'woocommerce_shipping_package_hash_ignored_fields', $ignored_fields_filter );
+		remove_filter( 'woocommerce_package_rates', $filter, 10 );
+	}
+
+	/**
 	 * Data provider for test_package_rates_filter_error_handling.
 	 *
 	 * @return array[]
@@ -167,6 +278,92 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 				},
 				'Filter handles arithmetic operations on rate costs safely',
 			),
+		);
+	}
+
+	/**
+	 * Data provider for ignored package hash fields.
+	 *
+	 * @return array[]
+	 */
+	public function provide_ignored_package_hash_fields(): array {
+		return array(
+			'subtotal'      => array( 'subtotal', 20 ),
+			'total'         => array( 'total', 20 ),
+			'package_id'    => array( 'package_id', 'package-1-changed' ),
+			'package_name'  => array( 'package_name', 'Package 1 Changed' ),
+			'rates'         => array( 'rates', array( 'prefilled_rate' => new WC_Shipping_Rate( 'prefilled_rate', 'Prefilled Rate', '7.00' ) ) ),
+			'package_index' => array( 'package_index', 2 ),
+		);
+	}
+
+	/**
+	 * Data provider for material package hash fields.
+	 *
+	 * @return array[]
+	 */
+	public function provide_material_package_hash_fields(): array {
+		return array(
+			'destination postcode' => array(
+				function ( array &$package ): void {
+					$package['destination']['postcode'] = '11111';
+				},
+			),
+			'contents cost'        => array(
+				function ( array &$package ): void {
+					$package['contents_cost'] = 20;
+				},
+			),
+			'cart contents'        => array(
+				function ( array &$package ): void {
+					$package['contents']['test_item']['quantity'] = 2;
+				},
+			),
+		);
+	}
+
+	/**
+	 * Get a package rates filter that counts recalculations.
+	 *
+	 * @param int $filter_calls Filter call count.
+	 * @return callable
+	 */
+	private function get_package_rates_counter( int &$filter_calls ): callable {
+		return function ( $rates ) use ( &$filter_calls ) {
+			++$filter_calls;
+			return $rates;
+		};
+	}
+
+	/**
+	 * Get a package for shipping hash tests.
+	 *
+	 * @return array
+	 */
+	private function get_package_hash_test_package(): array {
+		return array(
+			'contents'       => array(
+				'test_item' => array(
+					'quantity'          => 1,
+					'line_subtotal'     => 10,
+					'line_subtotal_tax' => 0,
+					'line_total'        => 10,
+					'line_tax'          => 0,
+					'data'              => new WC_Product_Simple(),
+				),
+			),
+			'contents_cost'  => 10,
+			'destination'    => array(
+				'country'  => 'US',
+				'state'    => 'CA',
+				'postcode' => '00000',
+			),
+			'package_id'     => 'package-1',
+			'package_name'   => 'Package 1',
+			'package_index'  => 1,
+			'subtotal'       => 10,
+			'total'          => 10,
+			'rates'          => array(),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
@@ -342,7 +342,7 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 	 */
 	private function get_package_hash_test_package(): array {
 		return array(
-			'contents'       => array(
+			'contents'      => array(
 				'test_item' => array(
 					'quantity'          => 1,
 					'line_subtotal'     => 10,
@@ -352,18 +352,18 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 					'data'              => new WC_Product_Simple(),
 				),
 			),
-			'contents_cost'  => 10,
-			'destination'    => array(
+			'contents_cost' => 10,
+			'destination'   => array(
 				'country'  => 'US',
 				'state'    => 'CA',
 				'postcode' => '00000',
 			),
-			'package_id'     => 'package-1',
-			'package_name'   => 'Package 1',
-			'package_index'  => 1,
-			'subtotal'       => 10,
-			'total'          => 10,
-			'rates'          => array(),
+			'package_id'    => 'package-1',
+			'package_name'  => 'Package 1',
+			'package_index' => 1,
+			'subtotal'      => 10,
+			'total'         => 10,
+			'rates'         => array(),
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

- Move shipping package cache hash generation into a private `WC_Shipping::get_package_hash()` helper.
- Exclude known non-rate package metadata from the hash: `subtotal`, `total`, `package_id`, `package_name`, `rates`, and `package_index`.
- Add `woocommerce_shipping_package_hash_ignored_fields` so extensions can declare their own package metadata keys as non-rate-affecting.
- Keep unknown package fields conservative by default: unknown/custom fields still invalidate cached shipping rates unless explicitly ignored by the new filter.
- Expand regression coverage for ignored fields, material package changes, unknown package keys, and the filter extension path.

Fixes #26569, #49259

#### Evidence

The broadened runtime proof uses the merged `checkout-shipping-cache` Homeboy rig workload from `chubes4/homeboy-rigs#348`.

Reduced proof configuration:
- `WC_SHIPPING_CACHE_CART_ITEMS=12`
- `WC_SHIPPING_CACHE_PACKAGES=3`
- `WC_SHIPPING_CACHE_WARM_RUNS=1`
- `WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS=1`
- `WC_SHIPPING_CACHE_REHASH_RUNS=1`

Trunk proof:
- Run ID: `ca104517-e3ec-4357-8ff2-a30dff4f499b`
- `subtotal_churn_rate_calculation_calls=48`
- `total_field_churn_rate_calculation_calls=48`
- `package_id_churn_rate_calculation_calls=48`
- `package_name_churn_rate_calculation_calls=48`
- `package_index_churn_rate_calculation_calls=48`
- `rates_churn_rate_calculation_calls=16`
- `destination_postcode_rehash_rate_calculation_calls=48`
- `contents_cost_rehash_rate_calculation_calls=48`
- `unknown_package_key_rehash_rate_calculation_calls=48`

Candidate proof:
- Run ID: `acae45c6-8c3d-44fa-ac8e-369ca9101b42`
- `subtotal_churn_rate_calculation_calls=0`
- `total_field_churn_rate_calculation_calls=0`
- `package_id_churn_rate_calculation_calls=0`
- `package_name_churn_rate_calculation_calls=0`
- `package_index_churn_rate_calculation_calls=0`
- `rates_churn_rate_calculation_calls=0`
- `destination_postcode_rehash_rate_calculation_calls=48`
- `contents_cost_rehash_rate_calculation_calls=48`
- `unknown_package_key_rehash_rate_calculation_calls=48`

The candidate removes recalculations caused by known non-rate package metadata while preserving recalculation for material shipping inputs and unknown package keys.

### Screenshots or screen recordings:

Not applicable. This is a server-side shipping-rate cache fix with no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In a test store with WooCommerce active, configure at least one shipping method for a shipping zone.
2. Add shippable products to the cart and calculate shipping rates for a package.
3. Change only non-rate package metadata such as `subtotal`, `total`, `package_id`, `package_name`, `rates`, or `package_index` while leaving package contents, destination, and shipping inputs unchanged.
4. Confirm WooCommerce reuses the cached shipping rates instead of recalculating them.
5. Change material package data such as destination, contents cost, or cart contents and confirm WooCommerce recalculates shipping rates.
6. Add a custom package key and confirm it invalidates cached rates by default.
7. Add that custom key to `woocommerce_shipping_package_hash_ignored_fields` and confirm changes to that key no longer invalidate cached rates.

<!-- End testing instructions -->

### Testing that has already taken place:

- `php -l plugins/woocommerce/includes/class-wc-shipping.php`
- `php -l plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php`
- `git diff --check`
- Homeboy/WP Codebox `checkout-shipping-cache` trunk and candidate proofs listed above.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Prevent non-rate package metadata from invalidating cached shipping rates.

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the shipping package cache hash invalidation path, broadening the implementation after review feedback, drafting regression tests, preparing Homeboy rig evidence, and updating the PR text; Chris remains responsible for review and testing.
