### PR TITLE
Skip saving checkout shipping totals to customer meta

### DIFF
--- a/plugins/woocommerce/changelog/65544-65104-stale-user-meta
+++ b/plugins/woocommerce/changelog/65544-65104-stale-user-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixes checkout flow to not save shipping_method in customer meta

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1229,6 +1229,12 @@ class WC_Checkout {
 				$customer->set_display_name( $customer->get_first_name() . ' ' . $customer->get_last_name() );
 			}
 
+			$shipping_fields = array(
+				'shipping_method' => true,
+				'shipping_total'  => true,
+				'shipping_tax'    => true,
+			);
+
 			foreach ( $data as $key => $value ) {
 				// Use setters where available.
 				if ( is_callable( array( $customer, "set_{$key}" ) ) ) {
@@ -1236,7 +1242,9 @@ class WC_Checkout {
 
 					// Store custom fields prefixed with either shipping_ or billing_.
 				} elseif ( 0 === stripos( $key, 'billing_' ) || 0 === stripos( $key, 'shipping_' ) ) {
-					$customer->update_meta_data( $key, $value );
+					if ( ! isset( $shipping_fields[ $key ] ) ) {
+						$customer->update_meta_data( $key, $value );
+					}
 				}
 			}
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -21,6 +21,17 @@ class WC_Checkout {
 	use CogsAwareTrait;
 
 	/**
+	 * Checkout/order-level shipping fields that should not be persisted as generic meta.
+	 *
+	 * @var string[]
+	 */
+	private const SHIPPING_FIELDS_EXCLUDED_FROM_META = array(
+		'shipping_method',
+		'shipping_total',
+		'shipping_tax',
+	);
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var WC_Checkout|null
@@ -420,19 +431,15 @@ class WC_Checkout {
 				'billing'  => true,
 			);
 
-			$shipping_fields = array(
-				'shipping_method' => true,
-				'shipping_total'  => true,
-				'shipping_tax'    => true,
-			);
 			foreach ( $data as $key => $value ) {
 				if ( is_callable( array( $order, "set_{$key}" ) ) ) {
 					$order->{"set_{$key}"}( $value );
 					// Store custom fields prefixed with either shipping_ or billing_. This is for backwards compatibility with 2.6.x.
-				} elseif ( isset( $fields_prefix[ current( explode( '_', $key ) ) ] ) ) {
-					if ( ! isset( $shipping_fields[ $key ] ) ) {
-						$order->update_meta_data( '_' . $key, $value );
-					}
+				} elseif (
+					isset( $fields_prefix[ current( explode( '_', $key ) ) ] )
+					&& ! in_array( $key, self::SHIPPING_FIELDS_EXCLUDED_FROM_META, true )
+				) {
+					$order->update_meta_data( '_' . $key, $value );
 				}
 			}
 
@@ -1229,22 +1236,17 @@ class WC_Checkout {
 				$customer->set_display_name( $customer->get_first_name() . ' ' . $customer->get_last_name() );
 			}
 
-			$shipping_fields = array(
-				'shipping_method' => true,
-				'shipping_total'  => true,
-				'shipping_tax'    => true,
-			);
-
 			foreach ( $data as $key => $value ) {
 				// Use setters where available.
 				if ( is_callable( array( $customer, "set_{$key}" ) ) ) {
 					$customer->{"set_{$key}"}( $value );
 
 					// Store custom fields prefixed with either shipping_ or billing_.
-				} elseif ( 0 === stripos( $key, 'billing_' ) || 0 === stripos( $key, 'shipping_' ) ) {
-					if ( ! isset( $shipping_fields[ $key ] ) ) {
-						$customer->update_meta_data( $key, $value );
-					}
+				} elseif (
+					( 0 === stripos( $key, 'billing_' ) || 0 === stripos( $key, 'shipping_' ) )
+					&& ! in_array( $key, self::SHIPPING_FIELDS_EXCLUDED_FROM_META, true )
+				) {
+					$customer->update_meta_data( $key, $value );
 				}
 			}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/checkout/checkout.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/checkout/checkout.php
@@ -364,4 +364,53 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 			'The customer-chosen value for an "Any" variation attribute must be persisted on the order line item.'
 		);
 	}
+
+	/**
+	 * @testdox Should not save checkout shipping fields as customer meta.
+	 *
+	 * @throws ReflectionException When unable to reflect the checkout method.
+	 */
+	public function test_process_customer_does_not_save_checkout_shipping_fields_as_customer_meta(): void {
+		$user_id = wp_create_user( 'checkout-shipping-fields-customer', 'password', 'checkout-shipping-fields-customer@example.com' );
+		$this->assertNotWPError( $user_id );
+		wp_set_current_user( $user_id );
+
+		$process_customer = new ReflectionMethod( WC_Checkout::class, 'process_customer' );
+		$process_customer->setAccessible( true );
+		$process_customer->invoke(
+			WC_Checkout::instance(),
+			array(
+				'billing_first_name' => 'Jane',
+				'billing_last_name'  => 'Customer',
+				'billing_email'      => 'checkout-shipping-fields-customer@example.com',
+				'shipping_address_1' => '123 Test Street',
+				'shipping_method'    => array( 'flat_rate:1' ),
+				'shipping_total'     => '5.00',
+				'shipping_tax'       => '0.50',
+			)
+		);
+
+		$this->assertSame(
+			'123 Test Street',
+			get_user_meta( $user_id, 'shipping_address_1', true ),
+			'Regular shipping address fields should still be saved as customer meta.'
+		);
+		$this->assertSame(
+			'',
+			get_user_meta( $user_id, 'shipping_method', true ),
+			'The selected checkout shipping method should not be saved as customer meta.'
+		);
+		$this->assertSame(
+			'',
+			get_user_meta( $user_id, 'shipping_total', true ),
+			'Checkout shipping totals should not be saved as customer meta.'
+		);
+		$this->assertSame(
+			'',
+			get_user_meta( $user_id, 'shipping_tax', true ),
+			'Checkout shipping taxes should not be saved as customer meta.'
+		);
+
+		wp_set_current_user( 0 );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/checkout/checkout.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/checkout/checkout.php
@@ -384,6 +384,7 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 				'billing_last_name'  => 'Customer',
 				'billing_email'      => 'checkout-shipping-fields-customer@example.com',
 				'shipping_address_1' => '123 Test Street',
+				'shipping_custom'    => 'custom shipping value',
 				'shipping_method'    => array( 'flat_rate:1' ),
 				'shipping_total'     => '5.00',
 				'shipping_tax'       => '0.50',
@@ -394,6 +395,11 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 			'123 Test Street',
 			get_user_meta( $user_id, 'shipping_address_1', true ),
 			'Regular shipping address fields should still be saved as customer meta.'
+		);
+		$this->assertSame(
+			'custom shipping value',
+			get_user_meta( $user_id, 'shipping_custom', true ),
+			'Custom shipping fields should still be saved as customer meta.'
 		);
 		$this->assertSame(
 			'',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds an exclusion for checkout shipping data to prevent them from being saved to customer meta.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #65104  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

```bash
pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --testdox --filter WC_Tests_Checkout
```

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixes checkout flow to not save shipping_method in customer meta

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
