### PR TITLE
Add JSON output to HPOS status CLI command

### DIFF
--- a/plugins/woocommerce/changelog/65545-65303-hpos-status-json
+++ b/plugins/woocommerce/changelog/65545-65303-hpos-status-json
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds JSON format for the `wp wc hpos status` command

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1039,6 +1039,11 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 *   - json
 	 * ---
 	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wc hpos status
+	 *     wp wc hpos status --format=json
+	 *
 	 * @since 8.6.0
 	 *
 	 * @param array $args       Positional arguments passed to the command.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1056,8 +1056,19 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 		);
 
 		if ( 'json' === ( $assoc_args['format'] ?? 'text' ) ) {
+			$encoded_status = wp_json_encode( $status );
+			if ( false === $encoded_status ) {
+				$error_message = sprintf(
+					/* translators: %s is the JSON encoding error message. */
+					__( 'Failed to encode HPOS status as JSON: %s', 'woocommerce' ),
+					json_last_error_msg()
+				);
+				fwrite( STDERR, $error_message . PHP_EOL ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI error output.
+				exit( 1 );
+			}
+
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WP CLI JSON output.
-			echo wp_json_encode( $status ) . PHP_EOL;
+			echo $encoded_status . PHP_EOL;
 			return;
 		}
 

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1028,6 +1028,17 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	/**
 	 * Displays a summary of HPOS situation on this site.
 	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: text
+	 * options:
+	 *   - text
+	 *   - json
+	 * ---
+	 *
 	 * @since 8.6.0
 	 *
 	 * @param array $args       Positional arguments passed to the command.
@@ -1035,23 +1046,35 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 */
 	public function status( array $args = array(), array $assoc_args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- for backwards compat.
 		$legacy_handler = wc_get_container()->get( LegacyDataHandler::class );
+		$status         = array(
+			'hpos_enabled'               => $this->controller->custom_orders_table_usage_is_enabled(),
+			'compatibility_mode_enabled' => $this->synchronizer->data_sync_is_enabled(),
+			'unsynced_orders'            => $this->synchronizer->get_current_orders_pending_sync_count(),
+			'orders_subject_to_cleanup'  => ( $this->synchronizer->custom_orders_table_is_authoritative() && ! $this->synchronizer->data_sync_is_enabled() )
+				? $legacy_handler->count_orders_for_cleanup()
+				: 0,
+		);
+
+		if ( 'json' === ( $assoc_args['format'] ?? 'text' ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WP CLI JSON output.
+			echo wp_json_encode( $status ) . PHP_EOL;
+			return;
+		}
 
 		// translators: %s is either 'yes' or 'no'.
-		WP_CLI::log( sprintf( __( 'HPOS enabled?: %s', 'woocommerce' ), wc_bool_to_string( $this->controller->custom_orders_table_usage_is_enabled() ) ) );
+		WP_CLI::log( sprintf( __( 'HPOS enabled?: %s', 'woocommerce' ), wc_bool_to_string( $status['hpos_enabled'] ) ) );
 
 		// translators: %s is either 'yes' or 'no'.
-		WP_CLI::log( sprintf( __( 'Compatibility mode enabled?: %s', 'woocommerce' ), wc_bool_to_string( $this->synchronizer->data_sync_is_enabled() ) ) );
+		WP_CLI::log( sprintf( __( 'Compatibility mode enabled?: %s', 'woocommerce' ), wc_bool_to_string( $status['compatibility_mode_enabled'] ) ) );
 
 		// translators: %d is an order count.
-		WP_CLI::log( sprintf( __( 'Unsynced orders: %d', 'woocommerce' ), $this->synchronizer->get_current_orders_pending_sync_count() ) );
+		WP_CLI::log( sprintf( __( 'Unsynced orders: %d', 'woocommerce' ), $status['unsynced_orders'] ) );
 
 		WP_CLI::log(
 			sprintf(
 				/* translators: %d is an order count. */
 				__( 'Orders subject to cleanup: %d', 'woocommerce' ),
-				( $this->synchronizer->custom_orders_table_is_authoritative() && ! $this->synchronizer->data_sync_is_enabled() )
-				? $legacy_handler->count_orders_for_cleanup()
-				: 0
+				$status['orders_subject_to_cleanup']
 			)
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/CLIRunnerTest.php
+++ b/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/CLIRunnerTest.php
@@ -1,0 +1,51 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Database\Migrations\CustomOrderTable;
+
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\CLIRunner;
+
+/**
+ * Tests for the HPOS CLI runner.
+ */
+class CLIRunnerTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var CLIRunner
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = wc_get_container()->get( CLIRunner::class );
+	}
+
+	/**
+	 * @testdox Should support JSON output for HPOS status.
+	 */
+	public function test_status_supports_json_output(): void {
+		ob_start();
+		$this->sut->status( array(), array( 'format' => 'json' ) );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'HPOS enabled?: ', $output );
+
+		$status = json_decode( trim( $output ), true );
+
+		$this->assertIsArray( $status, 'JSON status output should decode into an array.' );
+		$this->assertArrayHasKey( 'hpos_enabled', $status );
+		$this->assertArrayHasKey( 'compatibility_mode_enabled', $status );
+		$this->assertArrayHasKey( 'unsynced_orders', $status );
+		$this->assertArrayHasKey( 'orders_subject_to_cleanup', $status );
+		$this->assertIsBool( $status['hpos_enabled'] );
+		$this->assertIsBool( $status['compatibility_mode_enabled'] );
+		$this->assertIsInt( $status['unsynced_orders'] );
+		$this->assertIsInt( $status['orders_subject_to_cleanup'] );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a JSON format to the `wp wc hpos status` command

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #65303   .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

```bash
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter CLIRunnerTest --testdox
```

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds JSON format for the `wp wc hpos status` command

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
