### PR TITLE
Fix checkout address helpers for collapsed forms

### DIFF
--- a/packages/js/e2e-utils-playwright/changelog/fix-checkout-address-fill-idempotent
+++ b/packages/js/e2e-utils-playwright/changelog/fix-checkout-address-fill-idempotent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Make checkout address field helpers open collapsed address forms before filling fields.

--- a/packages/js/e2e-utils-playwright/src/checkout.ts
+++ b/packages/js/e2e-utils-playwright/src/checkout.ts
@@ -16,6 +16,9 @@ const addressLabels: Record< AddressType, string > = {
 	billing: 'Billing address',
 };
 
+const addressFieldVisibilityTimeout = 20_000;
+const addressFieldProbeTimeout = 1000;
+
 /**
  * Sets a field value based on its element type (select or input).
  *
@@ -30,6 +33,48 @@ async function setDynamicFieldType( field: Locator, value: string ) {
 	} else {
 		await field.fill( value );
 	}
+}
+
+/**
+ * Ensures address fields are editable before filling them.
+ *
+ * Checkout address forms may be rendered either expanded, or collapsed behind
+ * an edit button when an existing customer already has an address. This helper
+ * accepts both valid states so tests do not need to click edit buttons manually.
+ *
+ * @param page - Playwright page object
+ * @param type - The address type ('shipping' or 'billing')
+ */
+async function ensureAddressFieldsEditable( page: Page, type: AddressType ) {
+	const label = addressLabels[ type ];
+	const addressGroup = page.getByRole( 'group', { name: label } );
+	const firstNameField = addressGroup.getByLabel( 'First name' );
+
+	await addressGroup.waitFor( {
+		state: 'visible',
+		timeout: addressFieldVisibilityTimeout,
+	} );
+
+	try {
+		await firstNameField.waitFor( {
+			state: 'visible',
+			timeout: addressFieldProbeTimeout,
+		} );
+		return;
+	} catch {
+		const editButton = page.getByRole( 'button', {
+			name: `Edit ${ label.toLowerCase() }`,
+		} );
+
+		if ( await editButton.isVisible() ) {
+			await editButton.click();
+		}
+	}
+
+	await firstNameField.waitFor( {
+		state: 'visible',
+		timeout: addressFieldVisibilityTimeout,
+	} );
 }
 
 /**
@@ -66,6 +111,8 @@ async function fillCheckoutBlocks(
 	} = details;
 
 	const label = addressLabels[ type ];
+
+	await ensureAddressFieldsEditable( page, type );
 
 	await page
 		.getByRole( 'group', { name: label } )
@@ -192,6 +239,8 @@ async function fillCheckoutBlocks(
 /**
  * Convenience function to fill Shipping Address fields.
  *
+ * Opens a collapsed shipping address form automatically before filling fields.
+ *
  * @param page            - Playwright page object
  * @param shippingDetails - See CheckoutDetails type for available fields
  */
@@ -204,6 +253,8 @@ export async function fillShippingCheckoutBlocks(
 
 /**
  * Convenience function to fill Billing Address fields.
+ *
+ * Opens a collapsed billing address form automatically before filling fields.
  *
  * @param page           - Playwright page object
  * @param billingDetails - See CheckoutDetails type for available fields

--- a/plugins/woocommerce/changelog/fix-checkout-address-fill-idempotent
+++ b/plugins/woocommerce/changelog/fix-checkout-address-fill-idempotent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Use idempotent checkout address helpers in checkout e2e tests.

--- a/plugins/woocommerce/tests/e2e-pw/tests/checkout/checkout.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/checkout/checkout.spec.ts
@@ -445,9 +445,6 @@ checkoutPages.forEach( ( { name, slug } ) => {
 					.locator( '#shipping_postcode' )
 					.fill( shippingAddress.zip );
 			} else {
-				await page
-					.getByRole( 'button', { name: 'Edit shipping address' } )
-					.click();
 				await fillShippingCheckoutBlocks( page, shippingAddress );
 			}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Checkout e2e tests can encounter either an already-expanded address form or a form collapsed behind an edit button, depending on customer state. The shared checkout address helpers now ensure the requested address form is editable before filling fields, clicking the relevant edit button only when needed. The affected checkout spec now relies on that idempotent helper instead of clicking `Edit shipping address` directly.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable — e2e helper/test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/e2e-utils-playwright lint && pnpm --filter=@woocommerce/e2e-utils-playwright lint:lang:types && pnpm --filter=@woocommerce/e2e-utils-playwright build`.
2. Run `pnpm --filter=@woocommerce/e2e-utils-playwright test`.
3. Run `cd plugins/woocommerce && pnpm exec eslint tests/e2e-pw/tests/checkout/checkout.spec.ts`.
4. Run the targeted checkout e2e test in the default environment, for example:
   ```sh
   cd plugins/woocommerce
   bash ./tests/e2e-pw/run-tests-with-env.sh default \
     --project=e2e \
     tests/e2e-pw/tests/checkout/checkout.spec.ts \
     -g "customer can login at checkout and place the order with a different shipping address blocks checkout" \
     --workers=1 \
     --retries=0
   ```
5. Run the same targeted checkout e2e test with HPOS disabled, for example:
   ```sh
   cd plugins/woocommerce
   bash ./tests/e2e-pw/run-tests-with-env.sh default-hpos-disabled \
     --project=e2e-hpos-disabled \
     tests/e2e-pw/tests/checkout/checkout.spec.ts \
     -g "customer can login at checkout and place the order with a different shipping address blocks checkout" \
     --workers=1 \
     --retries=0
   ```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm --filter=@woocommerce/e2e-utils-playwright lint`
- `pnpm --filter=@woocommerce/e2e-utils-playwright lint:lang:types`
- `pnpm --filter=@woocommerce/e2e-utils-playwright build`
- `pnpm --filter=@woocommerce/e2e-utils-playwright test`
- `cd plugins/woocommerce && pnpm exec eslint tests/e2e-pw/tests/checkout/checkout.spec.ts`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- Local targeted checkout e2e against wp-env on `WP_ENV_TESTS_PORT=8096` / `BASE_URL=http://localhost:8096`:
  - HPOS enabled/default: passed with `--repeat-each=2`
  - HPOS disabled: passed with `--repeat-each=2`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Manual changelog entries are included for `@woocommerce/e2e-utils-playwright` and `@woocommerce/plugin-woocommerce`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

