### PR TITLE
Memoize shipping package calculation within a request to avoid repeated woocommerce_shipping_packages runs

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-6486-shipping-packages-memoization
+++ b/plugins/woocommerce/changelog/fix-wooplug-6486-shipping-packages-memoization
@@ -1,0 +1,3 @@
+Significance: patch
+Type: performance
+Comment: Memoize WC_Shipping::calculate_shipping() within a request so the woocommerce_shipping_packages filter is not re-run for unchanged packages, avoiding repeated expensive recalculations during cart/AJAX updates.

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -49,13 +49,21 @@ class WC_Shipping {
 	public $packages = array();
 
 	/**
-	 * Hash of the packages last processed by calculate_shipping(). Used to skip
-	 * re-running the (potentially expensive) `woocommerce_shipping_packages`
-	 * filter when the packages have not changed within the same request.
+	 * Combined hash of the packages the `woocommerce_shipping_packages` filter was last run for. Used to
+	 * skip re-running that (potentially expensive) filter when the packages have not changed within the
+	 * same request.
 	 *
 	 * @var string
 	 */
-	private $calculated_packages_hash = '';
+	private $shipping_packages_filter_hash = '';
+
+	/**
+	 * Hash of the package most recently processed by calculate_shipping_for_package(). Collected by
+	 * calculate_shipping() to build the combined hash above without re-hashing the packages.
+	 *
+	 * @var string
+	 */
+	private $last_calculated_package_hash = '';
 
 	/**
 	 * The single instance of the class
@@ -263,27 +271,29 @@ class WC_Shipping {
 	 */
 	public function calculate_shipping( $packages = array() ) {
 		if ( ! $this->enabled || empty( $packages ) ) {
-			$this->packages                 = array();
-			$this->calculated_packages_hash = '';
-			return array();
-		}
-
-		// The per-package rates are cached in the session (see calculate_shipping_for_package()), but the
-		// `woocommerce_shipping_packages` filter below runs on every call and can be expensive for some
-		// extensions. calculate_shipping() is invoked several times per request (cart totals, fragments,
-		// Store API, etc.), so memoize the filtered result and skip recalculation when the packages have
-		// not changed since the last call within this request. See WOOPLUG-6486 / #63920.
-		$packages_hash = $this->get_packages_hash( $packages );
-
-		if ( ! empty( $this->packages ) && $packages_hash === $this->calculated_packages_hash && 'yes' !== get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
+			$this->packages                      = array();
+			$this->shipping_packages_filter_hash = '';
 			return $this->packages;
 		}
 
-		$this->packages = array();
-
-		// Calculate costs for passed packages.
+		// Calculate costs for passed packages. Per-package rates are cached in the session keyed by a
+		// package hash, so this loop is cheap when nothing has changed (see calculate_shipping_for_package()).
+		$calculated_packages = array();
+		$package_hashes      = array();
 		foreach ( $packages as $package_key => $package ) {
-			$this->packages[ $package_key ] = $this->calculate_shipping_for_package( $package, $package_key );
+			$calculated_packages[ $package_key ] = $this->calculate_shipping_for_package( $package, $package_key );
+			$package_hashes[ $package_key ]      = $this->last_calculated_package_hash;
+		}
+
+		// The loop above is cheap, but the `woocommerce_shipping_packages` filter below can be expensive for
+		// some extensions and calculate_shipping() runs several times per request (cart totals, fragments,
+		// Store API, etc.). Reuse the per-package hashes already computed above to skip the filter when the
+		// packages are unchanged since the last call within this request, returning the previously filtered
+		// (and possibly reorganized) result. See WOOPLUG-6486 / #63920.
+		$packages_hash = md5( implode( '', $package_hashes ) );
+
+		if ( ! empty( $this->packages ) && $packages_hash === $this->shipping_packages_filter_hash && 'yes' !== get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
+			return $this->packages;
 		}
 
 		/**
@@ -297,34 +307,11 @@ class WC_Shipping {
 		 *
 		 * @param array $packages The array of packages after shipping costs are calculated.
 		 */
-		$this->packages = array_filter( (array) apply_filters( 'woocommerce_shipping_packages', $this->packages ) );
+		$this->packages = array_filter( (array) apply_filters( 'woocommerce_shipping_packages', $calculated_packages ) );
 
-		$this->calculated_packages_hash = $packages_hash;
+		$this->shipping_packages_filter_hash = $packages_hash;
 
 		return $this->packages;
-	}
-
-	/**
-	 * Generate a hash for a set of packages so we can tell whether they have changed between calls to
-	 * calculate_shipping() within the same request. Data objects are removed so the hash is consistent,
-	 * mirroring the per-package hashing in calculate_shipping_for_package().
-	 *
-	 * @param array $packages Multi-dimensional array of cart items to calc shipping for.
-	 * @return string
-	 */
-	private function get_packages_hash( $packages ) {
-		$packages_to_hash = $packages;
-
-		foreach ( $packages_to_hash as $package_key => $package ) {
-			if ( empty( $package['contents'] ) || ! is_array( $package['contents'] ) ) {
-				continue;
-			}
-			foreach ( $package['contents'] as $item_id => $item ) {
-				unset( $packages_to_hash[ $package_key ]['contents'][ $item_id ]['data'] );
-			}
-		}
-
-		return md5( wp_json_encode( $packages_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
 	}
 
 	/**
@@ -356,6 +343,9 @@ class WC_Shipping {
 	 * @return array|bool
 	 */
 	public function calculate_shipping_for_package( $package = array(), $package_key = 0 ) {
+		// Reset the tracked hash so calculate_shipping() reads a stable value even for invalid packages.
+		$this->last_calculated_package_hash = '';
+
 		// If shipping is disabled or the package is invalid, return false.
 		if ( ! $this->enabled || empty( $package ) ) {
 			return false;
@@ -380,7 +370,8 @@ class WC_Shipping {
 		$stored_rates   = WC()->session->get( $wc_session_key );
 
 		// Calculate the hash for this package so we can tell if it's changed since last calculation.
-		$package_hash = 'wc_ship_' . md5( wp_json_encode( $package_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
+		$package_hash                       = 'wc_ship_' . md5( wp_json_encode( $package_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
+		$this->last_calculated_package_hash = $package_hash;
 
 		if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
 			foreach ( $this->load_shipping_methods( $package ) as $shipping_method ) {
@@ -481,8 +472,8 @@ class WC_Shipping {
 	 */
 	public function reset_shipping() {
 		unset( WC()->session->chosen_shipping_methods );
-		$this->packages                 = array();
-		$this->calculated_packages_hash = '';
+		$this->packages                      = array();
+		$this->shipping_packages_filter_hash = '';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -49,6 +49,15 @@ class WC_Shipping {
 	public $packages = array();
 
 	/**
+	 * Hash of the packages last processed by calculate_shipping(). Used to skip
+	 * re-running the (potentially expensive) `woocommerce_shipping_packages`
+	 * filter when the packages have not changed within the same request.
+	 *
+	 * @var string
+	 */
+	private $calculated_packages_hash = '';
+
+	/**
 	 * The single instance of the class
 	 *
 	 * @var WC_Shipping
@@ -253,11 +262,24 @@ class WC_Shipping {
 	 * @return array Array of calculated packages.
 	 */
 	public function calculate_shipping( $packages = array() ) {
-		$this->packages = array();
-
 		if ( ! $this->enabled || empty( $packages ) ) {
+			$this->packages                 = array();
+			$this->calculated_packages_hash = '';
 			return array();
 		}
+
+		// The per-package rates are cached in the session (see calculate_shipping_for_package()), but the
+		// `woocommerce_shipping_packages` filter below runs on every call and can be expensive for some
+		// extensions. calculate_shipping() is invoked several times per request (cart totals, fragments,
+		// Store API, etc.), so memoize the filtered result and skip recalculation when the packages have
+		// not changed since the last call within this request. See WOOPLUG-6486 / #63920.
+		$packages_hash = $this->get_packages_hash( $packages );
+
+		if ( ! empty( $this->packages ) && $packages_hash === $this->calculated_packages_hash && 'yes' !== get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
+			return $this->packages;
+		}
+
+		$this->packages = array();
 
 		// Calculate costs for passed packages.
 		foreach ( $packages as $package_key => $package ) {
@@ -277,7 +299,32 @@ class WC_Shipping {
 		 */
 		$this->packages = array_filter( (array) apply_filters( 'woocommerce_shipping_packages', $this->packages ) );
 
+		$this->calculated_packages_hash = $packages_hash;
+
 		return $this->packages;
+	}
+
+	/**
+	 * Generate a hash for a set of packages so we can tell whether they have changed between calls to
+	 * calculate_shipping() within the same request. Data objects are removed so the hash is consistent,
+	 * mirroring the per-package hashing in calculate_shipping_for_package().
+	 *
+	 * @param array $packages Multi-dimensional array of cart items to calc shipping for.
+	 * @return string
+	 */
+	private function get_packages_hash( $packages ) {
+		$packages_to_hash = $packages;
+
+		foreach ( $packages_to_hash as $package_key => $package ) {
+			if ( empty( $package['contents'] ) || ! is_array( $package['contents'] ) ) {
+				continue;
+			}
+			foreach ( $package['contents'] as $item_id => $item ) {
+				unset( $packages_to_hash[ $package_key ]['contents'][ $item_id ]['data'] );
+			}
+		}
+
+		return md5( wp_json_encode( $packages_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
 	}
 
 	/**
@@ -434,7 +481,8 @@ class WC_Shipping {
 	 */
 	public function reset_shipping() {
 		unset( WC()->session->chosen_shipping_methods );
-		$this->packages = array();
+		$this->packages                 = array();
+		$this->calculated_packages_hash = '';
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
@@ -171,6 +171,55 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox the woocommerce_shipping_packages filter is not re-run when calculate_shipping() is called again with unchanged packages.
+	 */
+	public function test_calculate_shipping_memoizes_packages_filter() {
+		// The memoization is bypassed while debug mode is on (see setUp), mirroring the per-package cache.
+		update_option( 'woocommerce_shipping_debug_mode', 'no' );
+
+		$packages = array(
+			array(
+				'contents'      => array(),
+				'contents_cost' => 10,
+				'destination'   => array(
+					'country'  => 'US',
+					'state'    => 'CA',
+					'postcode' => '00000',
+				),
+			),
+		);
+
+		$filter_calls = 0;
+		$filter       = function ( $shipping_packages ) use ( &$filter_calls ) {
+			++$filter_calls;
+			return $shipping_packages;
+		};
+
+		add_filter( 'woocommerce_shipping_packages', $filter );
+
+		$this->sut->calculate_shipping( $packages );
+		$this->sut->calculate_shipping( $packages );
+		$this->sut->calculate_shipping( $packages );
+
+		$this->assertEquals( 1, $filter_calls, 'Filter should run once for repeated identical calls.' );
+
+		// Changing the packages should bust the memo and re-run the filter.
+		$packages[0]['destination']['country'] = 'GB';
+		$packages[0]['destination']['state']   = '';
+		$this->sut->calculate_shipping( $packages );
+
+		$this->assertEquals( 2, $filter_calls, 'Filter should run again when the packages change.' );
+
+		// reset_shipping() should force the next call to recalculate.
+		$this->sut->reset_shipping();
+		$this->sut->calculate_shipping( $packages );
+
+		$this->assertEquals( 3, $filter_calls, 'Filter should run again after reset_shipping().' );
+
+		remove_filter( 'woocommerce_shipping_packages', $filter );
+	}
+
+	/**
 	 * Data provider for test_calculate_shipping_for_hide_rates_when_free.
 	 *
 	 * @return array[]

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
@@ -190,18 +190,25 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 		);
 
 		$filter_calls = 0;
-		$filter       = function ( $shipping_packages ) use ( &$filter_calls ) {
+		// The filter reorganizes the packages (adds a marker) so we can assert the cached result returned on
+		// a memo hit reflects the filter output, not the raw pre-filter packages.
+		$filter = function ( $shipping_packages ) use ( &$filter_calls ) {
 			++$filter_calls;
+			$shipping_packages['reorganized'] = true;
 			return $shipping_packages;
 		};
 
 		add_filter( 'woocommerce_shipping_packages', $filter );
 
-		$this->sut->calculate_shipping( $packages );
-		$this->sut->calculate_shipping( $packages );
-		$this->sut->calculate_shipping( $packages );
+		$first  = $this->sut->calculate_shipping( $packages );
+		$second = $this->sut->calculate_shipping( $packages );
+		$third  = $this->sut->calculate_shipping( $packages );
 
 		$this->assertEquals( 1, $filter_calls, 'Filter should run once for repeated identical calls.' );
+		$this->assertArrayHasKey( 'reorganized', $first, 'First call returns the filtered packages.' );
+		$this->assertArrayHasKey( 'reorganized', $second, 'Memoized call returns the filtered (reorganized) packages.' );
+		$this->assertEquals( $first, $second, 'Memoized result matches the originally filtered result.' );
+		$this->assertEquals( $first, $third, 'Memoized result is stable across repeated calls.' );
 
 		// Changing the packages should bust the memo and re-run the filter.
 		$packages[0]['destination']['country'] = 'GB';

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
@@ -227,6 +227,40 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox the woocommerce_shipping_packages filter is run on every call when shipping debug mode is enabled.
+	 */
+	public function test_calculate_shipping_does_not_memoize_in_debug_mode() {
+		// Debug mode is enabled in setUp(); the memo should be bypassed so developers see fresh results.
+		$packages = array(
+			array(
+				'contents'      => array(),
+				'contents_cost' => 10,
+				'destination'   => array(
+					'country'  => 'US',
+					'state'    => 'CA',
+					'postcode' => '00000',
+				),
+			),
+		);
+
+		$filter_calls = 0;
+		$filter       = function ( $shipping_packages ) use ( &$filter_calls ) {
+			++$filter_calls;
+			return $shipping_packages;
+		};
+
+		add_filter( 'woocommerce_shipping_packages', $filter );
+
+		$this->sut->calculate_shipping( $packages );
+		$this->sut->calculate_shipping( $packages );
+		$this->sut->calculate_shipping( $packages );
+
+		$this->assertEquals( 3, $filter_calls, 'Filter should run on every call while debug mode is enabled.' );
+
+		remove_filter( 'woocommerce_shipping_packages', $filter );
+	}
+
+	/**
 	 * Data provider for test_calculate_shipping_for_hide_rates_when_free.
 	 *
 	 * @return array[]


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Stores that run expensive logic on the `woocommerce_shipping_packages` filter (e.g. Printify's fulfillment/shipping integration) see 10–20s+ delays on add-to-cart and cart updates.

**Root cause:** `WC_Shipping::calculate_shipping()` runs the `woocommerce_shipping_packages` filter [unconditionally on every call](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-shipping.php#L278). Per-package *rates* are cached in the session via a package hash, so on a cache hit the expensive `load_shipping_methods()` + per-method rate calc is skipped — but the post-calculation `woocommerce_shipping_packages` filter has **no equivalent cache**. The method is invoked several times per request (`WC_Cart::calculate_shipping()`, `WC_Cart_Totals::get_shipping_from_cart()`, Store API, cart-fragment refresh), so any expensive logic hooked onto that filter re-runs each time and compounds.

**Fix:** memoize the `woocommerce_shipping_packages` filter result **within the request**. The per-package calculation loop already runs cheaply (rates are session-cached) and already computes a per-package hash; those hashes are collected and combined into a single key. When `calculate_shipping()` is called again and the combined key is unchanged, the previously filtered (and possibly reorganized) result is returned, skipping only the expensive filter.

- The per-package loop still runs on every call exactly as before — only the top-level `woocommerce_shipping_packages` filter is memoized, keeping the change low-risk (sub-filters like `woocommerce_package_rates` and session writes are unaffected).
- Scope is in-request only — per-package rates already have session caching; memoizing the filter output across requests would risk serving stale reorganized packages when other plugins' state differs.
- The combined key reuses the existing per-package hashes (which already fold in `WC_Cache_Helper::get_transient_version( 'shipping' )`), so no extra full-array `json_encode`/`md5` pass is added and shipping-transient invalidation is inherited for free.
- `reset_shipping()` clears the memo so cart changes still force a recalculation.
- `woocommerce_shipping_debug_mode` bypasses the memo, mirroring the per-package cache.

Closes #63920.

### How to test the changes in this Pull Request:

1. Add a counter to the `woocommerce_shipping_packages` filter (e.g. `add_filter( 'woocommerce_shipping_packages', function ( $p ) { error_log( 'shipping_packages filter ran' ); return $p; } );`).
2. Add a product to the cart and load the cart/checkout.
3. **Before this change:** the filter logs multiple times per request. **After:** it logs once per distinct package set per request.
4. Change the cart (add/remove item, change destination) and confirm rates still update correctly — the filter runs again because the combined package hash changed.
5. Enable **WooCommerce → Settings → Shipping → debug mode** and confirm the filter runs on every call (memo bypassed).

### Testing that has already taken place:

- `vendor/bin/phpunit --filter WC_Shipping_Test` — 16 tests, all passing. Added:
  - `test_calculate_shipping_memoizes_packages_filter` — filter runs once for repeated identical calls; the memoized result preserves the filter's reorganization (asserts the cached result, not the raw pre-filter packages); re-runs when packages change; re-runs after `reset_shipping()`.
  - `test_calculate_shipping_does_not_memoize_in_debug_mode` — filter runs on every call when shipping debug mode is enabled.
- Regression check: `WC_Cart_Totals`, `WC_Cart_Test`, `WC_Cart_Default_Shipping_Method_Test`, `WC_Cart_Shipping_Rounding_Test` and shipping-method suites all pass.
- `phpcs` on the changed files introduces no new violations.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (changelog file already committed: `changelog/fix-wooplug-6486-shipping-packages-memoization`, Significance: patch, Type: performance)

### Release Communication

- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)