### PR TITLE
Limit layered nav count cache growth

### DIFF
--- a/plugins/woocommerce/changelog/65552-fix-layered-nav-count-cache-bound
+++ b/plugins/woocommerce/changelog/65552-fix-layered-nav-count-cache-bound
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Limit layered navigation count cache growth for product attributes and brands.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-brand-nav.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-brand-nav.php
@@ -2,6 +2,8 @@
 
 declare( strict_types = 1);
 
+use Automattic\WooCommerce\Internal\ProductAttributesLookup\Filterer;
+
 /**
  * Layered Navigation Widget for brands WC 2.6 version
  *
@@ -542,6 +544,7 @@ class WC_Widget_Brand_Nav extends WC_Widget {
 			$counts                       = array_map( 'absint', wp_list_pluck( $results, 'term_count', 'term_count_id' ) );
 			$cached_counts[ $query_hash ] = $counts;
 			if ( true === $cache ) {
+				$cached_counts = Filterer::limit_layered_nav_count_cache_entries( $cached_counts, $query_hash );
 				set_transient( 'wc_layered_nav_counts_' . sanitize_title( $taxonomy ), $cached_counts, HOUR_IN_SECONDS );
 			}
 		}

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-brand-nav.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-brand-nav.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1);
+declare( strict_types = 1 );
 
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\Filterer;
 

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php
@@ -211,10 +211,50 @@ class Filterer {
 			$counts                       = array_map( 'absint', wp_list_pluck( $results, 'term_count', 'term_count_id' ) );
 			$cached_counts[ $query_hash ] = $counts;
 			if ( true === $cache ) {
+				$cached_counts = self::limit_layered_nav_count_cache_entries( $cached_counts, $query_hash );
 				set_transient( 'wc_layered_nav_counts_' . sanitize_title( $taxonomy ), $cached_counts, DAY_IN_SECONDS );
 			}
 		}
 		return array_map( 'absint', (array) $cached_counts[ $query_hash ] );
+	}
+
+	/**
+	 * Limit the number of query result entries stored in a layered nav count transient.
+	 *
+	 * The layered nav count cache stores many query hashes inside a single transient per taxonomy.
+	 * Without a cap, bot or faceted-search enumeration can grow that single option without bound.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param array  $cached_counts Cached count entries keyed by query hash.
+	 * @param string $current_hash  Hash for the query that was just added or read.
+	 * @return array Bounded cached count entries.
+	 */
+	public static function limit_layered_nav_count_cache_entries( array $cached_counts, string $current_hash ): array {
+		/**
+		 * Maximum number of query result entries to store in each layered nav count transient.
+		 *
+		 * Set to 0 to disable the cap.
+		 *
+		 * @hook woocommerce_layered_nav_count_cache_max_entries
+		 * @since 10.9.0
+		 *
+		 * @param int $max_entries Maximum number of cached query result entries. Default 1000.
+		 * @return int
+		 */
+		$max_entries = (int) apply_filters( 'woocommerce_layered_nav_count_cache_max_entries', 1000 );
+
+		if ( $max_entries < 1 || count( $cached_counts ) <= $max_entries ) {
+			return $cached_counts;
+		}
+
+		if ( isset( $cached_counts[ $current_hash ] ) ) {
+			$current_counts = $cached_counts[ $current_hash ];
+			unset( $cached_counts[ $current_hash ] );
+			$cached_counts[ $current_hash ] = $current_counts;
+		}
+
+		return array_slice( $cached_counts, -$max_entries, null, true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\ProductAttributesLookup;
 use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\AttributesHelper;
+use Automattic\WooCommerce\Internal\ProductAttributesLookup\Filterer;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
@@ -55,6 +56,8 @@ class FiltererTest extends \WC_Unit_Test_Case {
 	public function tearDown(): void {
 		global $wpdb;
 
+		remove_all_filters( 'woocommerce_layered_nav_count_cache_max_entries' );
+
 		parent::tearDown();
 
 		// Unregister all product attributes.
@@ -95,6 +98,47 @@ class FiltererTest extends \WC_Unit_Test_Case {
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}wc_product_attributes_lookup" );
 
 		\WC_Query::reset_chosen_attributes();
+	}
+
+	/**
+	 * @testdox Layered nav count cache entries are capped per taxonomy transient.
+	 */
+	public function test_layered_nav_count_cache_entries_are_capped() {
+		add_filter( 'woocommerce_layered_nav_count_cache_max_entries', fn() => 2 );
+
+		$cached_counts = array(
+			'first'  => array( 1 => 1 ),
+			'second' => array( 2 => 2 ),
+			'third'  => array( 3 => 3 ),
+		);
+
+		$limited_counts = Filterer::limit_layered_nav_count_cache_entries( $cached_counts, 'third' );
+
+		$this->assertSame(
+			array(
+				'second' => array( 2 => 2 ),
+				'third'  => array( 3 => 3 ),
+			),
+			$limited_counts
+		);
+	}
+
+	/**
+	 * @testdox The layered nav count cache cap can be disabled.
+	 */
+	public function test_layered_nav_count_cache_cap_can_be_disabled() {
+		add_filter( 'woocommerce_layered_nav_count_cache_max_entries', '__return_zero' );
+
+		$cached_counts = array(
+			'first'  => array( 1 => 1 ),
+			'second' => array( 2 => 2 ),
+			'third'  => array( 3 => 3 ),
+		);
+
+		$this->assertSame(
+			$cached_counts,
+			Filterer::limit_layered_nav_count_cache_entries( $cached_counts, 'third' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Tests\Internal\ProductAttributesLookup;
 
 use Automattic\WooCommerce\Enums\ProductTaxStatus;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

- Limit the number of query-hash entries stored in each `wc_layered_nav_counts_*` transient.
- Apply the same bounded cache behavior to the Brands layered-nav count path.
- Add focused regression coverage for the cache cap and the opt-out filter.

Fixes #17355.

#### Why

Layered-nav count caching stores many query hashes inside a single transient per taxonomy. Under many unique filter/catalog query combinations, that single `wp_options` row can grow without bound. This is the failure mode reported in #17355.

This change bounds the number of cached query-hash entries per layered-nav count transient. The default cap is `1000`, and stores can override it with `woocommerce_layered_nav_count_cache_max_entries` or set it to `0` to disable the cap.

#### Evidence

Merged Homeboy rig evidence PR: https://github.com/chubes4/homeboy-rigs/pull/179

Direct cache-path workload:

| Run | Woo | Iterations | Cap | Final entries | Serialized bytes | Exceeded cap | Run ID |
|---|---|---:|---:|---:|---:|---|---|
| direct cache | trunk | 150 | 25 | 151 | 15,916 | yes | `9b786582-1f33-41c3-a2e4-7e7ab7824da8` |
| direct cache | candidate | 150 | 25 | 25 | 2,657 | no | `da777062-497f-48bd-8098-a33dfc80700e` |
| direct cache | trunk | 1200 | 1000 | 1201 | 127,217 | yes | `718d4f94-4a9c-423c-b7bf-635268685c54` |
| direct cache | candidate | 1200 | 1000 | 1000 | 106,009 | no | `a90790cd-42e3-4ef6-9485-6ed6ebbeb248` |

Catalog-crawl workload:

| Run | Woo | Requests | Cap | Final entries | Serialized bytes | Exceeded cap | Run ID |
|---|---|---:|---:|---:|---:|---|---|
| catalog crawl | trunk | 150 | 25 | 151 | 6,996 | yes | `0e7d2e9a-c154-4633-9e79-0aac15906789` |
| catalog crawl | candidate | 150 | 25 | 25 | 1,167 | no | `12517768-7caa-42ca-8473-fa4614b66763` |
| catalog crawl | trunk | 1200 | 1000 | 1201 | 55,327 | yes | `f8ba4b8e-16ac-4739-b315-088213b51fb1` |
| catalog crawl | candidate | 1200 | 1000 | 1000 | 46,039 | no | `f92eb748-c3c7-41bb-89ab-f4853150797a` |

### Screenshots or screen recordings:

Not applicable. This is a server-side cache growth fix with no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. In a test store with WooCommerce active, add enough products and attributes or brands to exercise layered navigation filters.
2. Apply layered navigation filters across several different catalog query combinations.
3. Inspect the `wc_layered_nav_counts_*` transients and confirm the number of cached query-hash entries remains bounded by the `woocommerce_layered_nav_count_cache_max_entries` value.
4. Set the `woocommerce_layered_nav_count_cache_max_entries` filter to `0`, repeat the filtered catalog requests, and confirm the cap is disabled.

<!-- End testing instructions -->

### Testing that has already taken place:

- `php -l plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php`
- `php -l plugins/woocommerce/includes/widgets/class-wc-widget-brand-nav.php`
- `php -l plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php`
- `git diff --check`
- `composer run-script lint-branch origin/trunk`
- WP Codebox/HBEX targeted PHPUnit: `OK (2 tests, 2 assertions)` for `test_layered_nav_count_cache*`

Environment and analysis details:

- Tested with targeted PHPUnit in WP Codebox/Homeboy against the WooCommerce plugin test harness.
- Performance/cache-growth analysis used the linked Homeboy rig evidence PR and direct cache/catalog-crawl workloads above.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Limit layered navigation count cache growth for product attributes and brands.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation, regression tests, Homeboy/WP Codebox evidence generation, and PR drafting under Chris review.
