### PR TITLE
Remove WC Brands code related to the deprecated product editor

### DIFF
--- a/plugins/woocommerce/changelog/remove-brands-beta-product-editor
+++ b/plugins/woocommerce/changelog/remove-brands-beta-product-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Remove WC Brands code related to the deprecated product editor
+
+

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -78,9 +78,6 @@ class WC_Brands {
 		add_action( 'woocommerce_product_set_stock_status', array( $this, 'recount_after_stock_change' ) );
 		add_action( 'woocommerce_update_options_products_inventory', array( $this, 'recount_all_brands' ) );
 
-		// Product Editor compatibility.
-		add_action( 'woocommerce_layout_template_after_instantiation', array( $this, 'wc_brands_on_block_template_register' ), 10, 3 );
-
 		// Block theme integration.
 		add_filter( 'hooked_block_types', array( $this, 'hook_product_brand_block' ), 10, 4 );
 		add_filter( 'hooked_block_core/post-terms', array( $this, 'configure_product_brand_block' ), 10, 5 );
@@ -1096,35 +1093,6 @@ class WC_Brands {
 	function reset_layered_nav_counts_on_status_change( $new_status, $old_status, $post ) {
 		if ( $post->post_type === 'product' && $old_status !== $new_status ) {
 			$this->invalidate_wc_layered_nav_counts_cache();
-		}
-	}
-
-	/**
-	 * Add a new block to the template.
-	 *
-	 * @param string                 $template_id Template ID.
-	 * @param string                 $template_area Template area.
-	 * @param BlockTemplateInterface $template Template instance.
-	 */
-	public function wc_brands_on_block_template_register( $template_id, $template_area, $template ) {
-
-		if ( 'simple-product' === $template->get_id() ) {
-			$section = $template->get_section_by_id( 'product-catalog-section' );
-			if ( $section !== null ) {
-				$section->add_block(
-					array(
-						'id'         => 'woocommerce-brands-select',
-						'blockName'  => 'woocommerce/product-taxonomy-field',
-						'order'      => 15,
-						'attributes' => array(
-							'label'       => __( 'Brands', 'woocommerce-brands' ),
-							'createTitle' => __( 'Create new brand', 'woocommerce-brands' ),
-							'slug'        => 'product_brand',
-							'property'    => 'brands',
-						),
-					)
-				);
-			}
 		}
 	}
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -9295,18 +9295,6 @@ parameters:
 			path: includes/class-wc-brands.php
 
 		-
-			message: '#^Call to method get_id\(\) on an unknown class BlockTemplateInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/class-wc-brands.php
-
-		-
-			message: '#^Call to method get_section_by_id\(\) on an unknown class BlockTemplateInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/class-wc-brands.php
-
-		-
 			message: '#^Cannot access property \$labels on WP_Taxonomy\|false\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -9499,12 +9487,6 @@ parameters:
 			path: includes/class-wc-brands.php
 
 		-
-			message: '#^Method WC_Brands\:\:wc_brands_on_block_template_register\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-brands.php
-
-		-
 			message: '#^Parameter \#1 \$args of function get_terms expects array\{taxonomy\?\: array\<string\>\|string, object_ids\?\: array\<int\>\|int, orderby\?\: string, order\?\: string, hide_empty\?\: bool\|int, include\?\: array\<int\>\|string, exclude\?\: array\<int\>\|string, exclude_tree\?\: array\<int\>\|string, \.\.\.\}, ''product_brand'' given\.$#'
 			identifier: argument.type
 			count: 2
@@ -9532,12 +9514,6 @@ parameters:
 			message: '#^Parameter \#2 \$taxonomy of function _wc_term_recount expects WP_Taxonomy, WP_Taxonomy\|false given\.$#'
 			identifier: argument.type
 			count: 2
-			path: includes/class-wc-brands.php
-
-		-
-			message: '#^Parameter \$template of method WC_Brands\:\:wc_brands_on_block_template_register\(\) has invalid type BlockTemplateInterface\.$#'
-			identifier: class.notFound
-			count: 1
 			path: includes/class-wc-brands.php
 
 		-


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With the new product editor gone (https://github.com/woocommerce/woocommerce/pull/65500), there was a hook in `wc-brands.php` that was [never run](https://github.com/woocommerce/woocommerce/pull/65500/changes#diff-3edfa77dfc20ecd6f163384c13c7125191c01e5113f43b53c30bb12a2ab35a56L159). This PR gets rid of it.

### How to test the changes in this Pull Request:

There is nothing to test because the deprecated product editor was already removed, simply make sure CI passes.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
