### PR TITLE
Fix push notification safety net not canceled on delivery

### DIFF
--- a/plugins/woocommerce/changelog/fix-push-notification-safety-net-cancel
+++ b/plugins/woocommerce/changelog/fix-push-notification-safety-net-cancel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Push notifications: cancel the safety-net Action Scheduler action on delivery by matching schedule and cancel on a single identity-keyed args shape, so stale actions no longer fire ~60s later (and the retry path can no longer produce duplicate pushes).

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/Notification.php
@@ -173,6 +173,28 @@ abstract class Notification {
 	}
 
 	/**
+	 * Canonical positional ActionScheduler arguments for the safety-net job.
+	 *
+	 * Single source of truth shared by the scheduler (and its dedupe guard) and
+	 * the cancel path so the serialized args always match. Action Scheduler
+	 * matches the stored args by exact equality, so any divergence between the
+	 * schedule-side and cancel-side shapes silently breaks cancellation.
+	 *
+	 * The args are keyed on the notification's *identity* — the minimal data
+	 * needed to uniquely identify and reconstruct the notification — mirroring
+	 * {@see self::get_identifier()}. Volatile payload fields (e.g. a stock
+	 * snapshot captured at trigger time) must not be included: they are not part
+	 * of the identity and may differ between schedule and cancel.
+	 *
+	 * @return array<int, mixed>
+	 *
+	 * @since 10.9.0
+	 */
+	public function get_safety_net_args(): array {
+		return array( $this->get_type(), $this->get_resource_id() );
+	}
+
+	/**
 	 * Decide whether this notification should be delivered to a user given
 	 * their stored preference value for {@see static::get_type()}.
 	 *

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/StockNotification.php
@@ -155,6 +155,32 @@ class StockNotification extends Notification {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Appends `event_type` because it is part of this notification's identity
+	 * (see {@see self::get_identifier()}): the same product can have distinct
+	 * low_stock / out_of_stock / on_backorder safety nets pending at once, and
+	 * the callback needs it to reconstruct the correct subtype.
+	 *
+	 * `stock_quantity_at_trigger` is deliberately omitted — it is volatile
+	 * payload data, not identity, and does not round-trip through every cancel
+	 * path, so including it in the match key would risk breaking cancellation.
+	 * The safety-net fallback message reads current product stock when it is
+	 * absent (see {@see self::build_message()}).
+	 *
+	 * @return array<int, mixed>
+	 *
+	 * @since 10.9.0
+	 */
+	public function get_safety_net_args(): array {
+		return array(
+			$this->get_type(),
+			$this->get_resource_id(),
+			array( 'event_type' => $this->event_type ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * Extends the parent array with `event_type` and the trigger-time stock
 	 * snapshot so both fields survive serialization through the safety-net
 	 * scheduler and the internal-REST round-trip.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -246,12 +246,12 @@ class NotificationProcessor {
 	 * @since 10.9.0
 	 */
 	private function cancel_safety_net( Notification $notification ): void {
+		// Must match the shape PendingNotificationStore::schedule_safety_net() used;
+		// both derive the args from Notification::get_safety_net_args() so the
+		// exact-equality match Action Scheduler performs succeeds.
 		as_unschedule_all_actions(
 			self::SAFETY_NET_HOOK,
-			array(
-				'type'        => $notification->get_type(),
-				'resource_id' => $notification->get_resource_id(),
-			),
+			$notification->get_safety_net_args(),
 			self::ACTION_SCHEDULER_GROUP
 		);
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -120,16 +120,10 @@ class PendingNotificationStore {
 	 * @since 10.7.0
 	 */
 	private function schedule_safety_net( Notification $notification ): void {
-		$data        = $notification->to_array();
-		$type        = $data['type'];
-		$resource_id = $data['resource_id'];
-		unset( $data['type'], $data['resource_id'] );
-
-		// Pass `type` and `resource_id` positionally and bundle any subclass-specific
-		// extras (event_type, stock_quantity_at_trigger, etc.) into a single array
-		// argument so the safety-net callback signature stays stable as new
-		// notification subclasses add fields to to_array().
-		$args = array( $type, $resource_id, $data );
+		// Canonical, identity-keyed args shared with NotificationProcessor::cancel_safety_net().
+		// Action Scheduler matches stored args by exact equality, so both sides must derive
+		// them from the same place; see Notification::get_safety_net_args().
+		$args = $notification->get_safety_net_args();
 
 		if ( as_has_scheduled_action( NotificationProcessor::SAFETY_NET_HOOK, $args, NotificationProcessor::ACTION_SCHEDULER_GROUP ) ) {
 			return;

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Services;
 
 use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\WpcomNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
@@ -15,6 +16,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
 use WC_Helper_Product;
 use WC_Unit_Test_Case;
@@ -615,28 +617,21 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 
 		$notification = new NewOrderNotification( $this->order_id );
 
-		as_schedule_single_action(
-			time() + NotificationProcessor::SAFETY_NET_DELAY,
-			NotificationProcessor::SAFETY_NET_HOOK,
-			array(
-				'type'        => $notification->get_type(),
-				'resource_id' => $this->order_id,
-			),
-			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		// Seed the precondition through the REAL schedule path so the test setup
+		// and production use the same arg shape; if the schedule shape ever drifts
+		// from the cancel shape again, this assertion fails in CI.
+		$this->schedule_safety_net( $notification );
+		$this->assertTrue(
+			$this->is_safety_net_pending( $notification ),
+			'Safety net should be pending before processing.'
 		);
 
 		$this->sut->process( $notification );
 
-		$scheduled = as_next_scheduled_action(
-			NotificationProcessor::SAFETY_NET_HOOK,
-			array(
-				'type'        => 'store_order',
-				'resource_id' => $this->order_id,
-			),
-			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		$this->assertFalse(
+			$this->is_safety_net_pending( $notification ),
+			'Safety net should be cancelled after successful send.'
 		);
-
-		$this->assertFalse( $scheduled, 'Safety net should be cancelled after successful send.' );
 	}
 
 	/**
@@ -652,28 +647,94 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 
 		$notification = new NewOrderNotification( $this->order_id );
 
-		as_schedule_single_action(
-			time() + NotificationProcessor::SAFETY_NET_DELAY,
-			NotificationProcessor::SAFETY_NET_HOOK,
-			array(
-				'type'        => $notification->get_type(),
-				'resource_id' => $this->order_id,
-			),
-			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		$this->schedule_safety_net( $notification );
+		$this->assertTrue(
+			$this->is_safety_net_pending( $notification ),
+			'Safety net should be pending before processing.'
 		);
 
 		$this->sut->process( $notification );
 
-		$scheduled = as_next_scheduled_action(
-			NotificationProcessor::SAFETY_NET_HOOK,
+		$this->assertFalse(
+			$this->is_safety_net_pending( $notification ),
+			'Safety net should be cancelled when retry is scheduled.'
+		);
+	}
+
+	/**
+	 * Locks the schedule/cancel arg-shape contract for the StockNotification
+	 * subclass, whose identity (and therefore safety-net match key) includes
+	 * `event_type`. Schedules via the real path, then cancels using a
+	 * notification reconstructed from the serialized payload — exactly what the
+	 * loopback controller does on the primary success path — to prove the
+	 * round-tripped args still match.
+	 *
+	 * @testdox Should cancel a stock notification's safety net using a reconstructed notification.
+	 */
+	public function test_process_cancels_safety_net_for_stock_notification(): void {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
 			array(
-				'type'        => 'store_order',
-				'resource_id' => $this->order_id,
-			),
-			NotificationProcessor::ACTION_SCHEDULER_GROUP
+				'manage_stock'   => true,
+				'stock_quantity' => 0,
+			)
 		);
 
-		$this->assertFalse( $scheduled, 'Safety net should be cancelled when retry is scheduled.' );
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_OUT_OF_STOCK );
+
+		$this->schedule_safety_net( $notification );
+		$this->assertTrue(
+			$this->is_safety_net_pending( $notification ),
+			'Stock safety net should be pending before processing.'
+		);
+
+		// Reconstruct from the serialized payload, mirroring the loopback controller.
+		$reconstructed = Notification::from_array( $notification->to_array() );
+		$this->sut->process( $reconstructed );
+
+		$this->assertFalse(
+			$this->is_safety_net_pending( $notification ),
+			'Stock safety net should be cancelled after successful send.'
+		);
+	}
+
+	/**
+	 * Schedules a safety-net action through the real
+	 * {@see PendingNotificationStore::schedule_safety_net()} so tests exercise
+	 * the production schedule shape rather than a hand-built fixture.
+	 *
+	 * @param Notification $notification The notification to schedule a safety net for.
+	 * @return void
+	 */
+	private function schedule_safety_net( Notification $notification ): void {
+		$store = new PendingNotificationStore();
+		$store->init( $this->createMock( InternalNotificationDispatcher::class ) );
+
+		$method = new \ReflectionMethod( PendingNotificationStore::class, 'schedule_safety_net' );
+		$method->setAccessible( true );
+		$method->invoke( $store, $notification );
+	}
+
+	/**
+	 * Whether a safety-net action is currently scheduled for a notification,
+	 * matched on its canonical args.
+	 *
+	 * @param Notification $notification The notification to check.
+	 * @return bool
+	 */
+	private function is_safety_net_pending( Notification $notification ): bool {
+		return as_has_scheduled_action(
+			NotificationProcessor::SAFETY_NET_HOOK,
+			$notification->get_safety_net_args(),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a push notification is queued, `PendingNotificationStore::schedule_safety_net()` schedules an Action Scheduler fallback action using **positional** args, but `NotificationProcessor::cancel_safety_net()` tried to cancel it using **associative** args. Action Scheduler matches stored args by exact equality, so the cancel never matched: the stale safety-net action survived and fired ~60s after delivery (wasted work + table growth on the success path, and a potential **duplicate push** on the retry-scheduled path).

This makes schedule, the dedupe guard, and cancel all derive the Action Scheduler args from a single source of truth — a new `Notification::get_safety_net_args()` (identity-keyed; `StockNotification` overrides it to include `event_type`) — so the two shapes can never drift apart again. It also reworks the cancel unit tests to seed the precondition through the **real** schedule path (the originals seeded a fixture in the cancel shape, which masked the bug) and adds `StockNotification` coverage.

Closes #65453.

(For Bug Fixes) Bug introduced in PR #64600 (refactored schedule args to positional) and PR #63980 (added cancel using the older associative shape) — a clean-merge interaction.

### Screenshots or screen recordings:

<!-- This section can be removed if not applicable. -->

Not applicable — no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install this version
2. Trigger a notification — place an order, or push a product across a stock threshold (low/out/backorder).
3. Go to **WP Admin → Tools → Scheduled Actions** and filter by hook `wc_push_notification_safety_net`.
4. After delivery completes, refresh. The matching action should now be **`Canceled`**. Before this fix it remained pending and fired ~60s later (status `Complete`).
5. For stock notifications, note the action's arg 2 is now `array( 'event_type' => '<event>' )` (the volatile `stock_quantity_at_trigger` is intentionally excluded from the match key).


<!-- End testing instructions -->

### Testing that has already taken place:

Manuall tests as above

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

Milestone manually set to **10.9.0** so the merged change is cherry-picked to `release/10.9` (the bug is a 10.9-cycle regression).

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually (`plugins/woocommerce/changelog/fix-push-notification-safety-net-cancel`).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>