### PR TITLE
Fix: use a fixed black overlay color for the drawer instead of inheriting the theme palette

### DIFF
--- a/plugins/woocommerce/changelog/fix-drawer-overlay-color
+++ b/plugins/woocommerce/changelog/fix-drawer-overlay-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use a fixed black overlay color for the drawer instead of inheriting the theme palette.

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
@@ -18,3 +18,6 @@ $universal-border-medium: color-mix(in srgb, currentColor 48%, transparent);
 $universal-border-strong: color-mix(in srgb, currentColor 80%, transparent);
 // Used for low contrast decorative elements background color.
 $universal-background: rgba(17, 17, 17, 0.02);
+
+// Backdrop color for the drawer's screen overlay (mini-cart, etc.).
+$drawer-overlay-background: rgba(0, 0, 0, 0.35);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
@@ -31,7 +31,7 @@ $drawer-animation-duration: 0.3s;
 }
 
 .wc-block-components-drawer__screen-overlay {
-	background-color: rgba(95, 95, 95, 0.35);
+	background-color: $drawer-overlay-background;
 	bottom: 0;
 	left: 0;
 	position: fixed;
@@ -60,7 +60,6 @@ $drawer-animation-duration: 0.3s;
 }
 
 .wc-block-components-drawer {
-	border-left: 1px solid $universal-translucent-border-color;
 	background: #fff;
 	display: block;
 	height: 100%;


### PR DESCRIPTION
## Changes proposed in this Pull Request

The drawer screen overlay was using `rgba(95, 95, 95, 0.35)` as its background color. On sites using color palettes with unexpected or light text colors, this produced inconsistent overlay appearance.

This PR replaces it with `rgba(0, 0, 0, 0.35)` — same opacity, but a fixed black that is independent of the active theme palette. Also removes the `border-left` on `.wc-block-components-drawer` which created a visible hard edge between the drawer and the overlay.

Current:
<img width="1727" height="928" alt="Capture d’écran 2026-06-08 à 11 38 39" src="https://github.com/user-attachments/assets/422669c7-190c-4d82-93bc-d5e1d6bb359d" />

Fixed:
<img width="1722" height="926" alt="Capture d’écran 2026-06-08 à 11 36 32" src="https://github.com/user-attachments/assets/99b4c402-dc8e-4f6d-ac0c-9b38bbd321c6" />