### PR TITLE
Move inline comment off statement line in wc_customer_bought_product (PHPCS)

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpcs-poststatement-wc-user-functions
+++ b/plugins/woocommerce/changelog/fix-phpcs-poststatement-wc-user-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Move an inline comment to its own line in wc_customer_bought_product() to satisfy PHPCS (no functional change).

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -439,7 +439,8 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 		$cache_version = WC_Cache_Helper::get_transient_version( 'orders' );
 	}
 
-	$aggregation_version = 'v3'; // Update the version when modifying the aggregation implementation to ensure the cache is repopulated.
+	// Update the version when modifying the aggregation implementation to ensure the cache is repopulated.
+	$aggregation_version = 'v3';
 	$cache_group         = 'orders';
 	$cache_key           = 'wc_customer_bought_product_' . md5( $customer_email . '-' . $user_id . '-' . $use_lookup_tables . '-' . $aggregation_version );
 	$cache_value         = wp_cache_get( $cache_key, $cache_group );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Moves an inline comment to its own line in `wc_customer_bought_product()` so it no longer trails the `$aggregation_version` statement, resolving a PHPCS `Squiz.Commenting.PostStatementComment` error.

The violation surfaced in the `release/10.9` branch lint after the `v2`→`v3` cache-version bump in #65517 pulled that line into the changed-lines diff. The style issue itself predates it (introduced in #63995). No functional change.

Bug introduced in PR #63995.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` (or `composer exec -- phpcs plugins/woocommerce/includes/wc-user-functions.php`).
3. Confirm there is no `Squiz.Commenting.PostStatementComment.Found` error for `wc-user-functions.php`.

### Changelog entry

> Added a changelog entry manually (`Significance: patch`, `Type: dev`).
