### PR TITLE
Fix checkout order creation retry idempotency

### DIFF
--- a/plugins/woocommerce/changelog/65588-fix-checkout-create-order-idempotency
+++ b/plugins/woocommerce/changelog/65588-fix-checkout-create-order-idempotency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent duplicate checkout orders when the same cart/session retries order creation before payment processing starts.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1116,7 +1116,10 @@ class WC_Checkout {
 		// We save the session early because if the payment gateway hangs
 		// the request will never finish, thus the session data will never be saved,
 		// and this can lead to duplicate orders if the user submits the order again.
-		WC()->session->save_data();
+		$save_session_data = array( WC()->session, 'save_data' );
+		if ( is_callable( $save_session_data ) ) {
+			$save_session_data();
+		}
 
 		// Process Payment.
 		$result = $available_gateways[ $payment_method ]->process_payment( $order_id );

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -487,6 +487,12 @@ class WC_Checkout {
 				}
 			}
 
+			// Store the order as soon as it has been persisted so retries before payment processing reuse it.
+			if ( WC()->session ) {
+				WC()->session->set( 'order_awaiting_payment', $order_id );
+				WC()->session->save_data();
+			}
+
 			/**
 			 * Action hook fired after an order is created used to add custom meta to the order.
 			 *

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -490,7 +490,10 @@ class WC_Checkout {
 			// Store the order as soon as it has been persisted so retries before payment processing reuse it.
 			if ( WC()->session ) {
 				WC()->session->set( 'order_awaiting_payment', $order_id );
-				WC()->session->save_data();
+				$save_session_data = array( WC()->session, 'save_data' );
+				if ( is_callable( $save_session_data ) ) {
+					$save_session_data();
+				}
 			}
 
 			/**

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -387,10 +387,13 @@ class WC_Checkout {
 		}
 
 		try {
-			$order_id           = absint( WC()->session->get( 'order_awaiting_payment' ) );
+			$order_id           = absint( WC()->session->get( 'order_awaiting_payment' ) ) ?: absint( WC()->session->get( 'checkout_pending_order_id' ) );
 			$cart_hash          = WC()->cart->get_cart_hash();
 			$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+			$customer_id        = apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() );
 			$order              = $order_id ? wc_get_order( $order_id ) : null;
+			$resuming_order     = false;
+			$resuming_failed_order = false;
 
 			/**
 			 * If there is an order pending payment, we can resume it here so
@@ -398,7 +401,16 @@ class WC_Checkout {
 			 * different items or cost, create a new order. We use a hash to
 			 * detect changes which is based on cart items + order total.
 			 */
-			if ( $order && $order->has_cart_hash( $cart_hash ) && $order->has_status( array( OrderStatus::PENDING, OrderStatus::FAILED ) ) ) {
+			if (
+				$order &&
+				$order->has_cart_hash( $cart_hash ) &&
+				$order->has_status( array( OrderStatus::PENDING, OrderStatus::FAILED ) ) &&
+				absint( $order->get_customer_id() ) === absint( $customer_id ) &&
+				( empty( $data['billing_email'] ) || wc_strtolower( $order->get_billing_email() ) === wc_strtolower( $data['billing_email'] ) )
+			) {
+				$resuming_order        = true;
+				$resuming_failed_order = $order->has_status( OrderStatus::FAILED );
+
 				/**
 				 * Indicates that we are resuming checkout for an existing order (which is pending payment, and which
 				 * has not changed since it was added to the current shopping session).
@@ -408,9 +420,6 @@ class WC_Checkout {
 				 * @param int $order_id The ID of the order being resumed.
 				 */
 				do_action( 'woocommerce_resume_order', $order_id );
-
-				// Remove all items - we will re-add them later.
-				$order->remove_order_items();
 			} else {
 				$order = new WC_Order();
 			}
@@ -436,7 +445,7 @@ class WC_Checkout {
 				}
 			}
 
-			if ( isset( $data['billing_email'] ) ) {
+			if ( isset( $data['billing_email'] ) && ( ! $resuming_order || $resuming_failed_order ) ) {
 				$order->hold_applied_coupons( $data['billing_email'] );
 			}
 
@@ -447,16 +456,18 @@ class WC_Checkout {
 			 *
 			 * @since 3.0.0 or earlier
 			 */
-			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
+			$order->set_customer_id( $customer_id );
 			$order->set_currency( get_woocommerce_currency() );
 			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
 			$order->set_customer_user_agent( wc_get_user_agent() );
 			$order->set_customer_note( isset( $data['order_comments'] ) ? $data['order_comments'] : '' );
 			$order->set_payment_method( isset( $available_gateways[ $data['payment_method'] ] ) ? $available_gateways[ $data['payment_method'] ] : $data['payment_method'] );
-			$this->set_data_from_cart( $order );
+			if ( ! $resuming_order ) {
+				$this->set_data_from_cart( $order );
+			}
 
-			if ( $order->has_cogs() && $this->cogs_is_enabled() ) {
+			if ( ! $resuming_order && $order->has_cogs() && $this->cogs_is_enabled() ) {
 				$order->calculate_cogs_total_value();
 			}
 
@@ -487,9 +498,9 @@ class WC_Checkout {
 				}
 			}
 
-			// Store the order as soon as it has been persisted so retries before payment processing reuse it.
+			// Store the checkout-created order separately from payment-attempt state so retries before payment processing reuse it.
 			if ( WC()->session ) {
-				WC()->session->set( 'order_awaiting_payment', $order_id );
+				WC()->session->set( 'checkout_pending_order_id', $order_id );
 				$save_session_data = array( WC()->session, 'save_data' );
 				if ( is_callable( $save_session_data ) ) {
 					$save_session_data();

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -10471,12 +10471,6 @@ parameters:
 			path: includes/class-wc-checkout.php
 
 		-
-			message: '#^Call to an undefined method WC_Session\:\:save_data\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/class-wc-checkout.php
-
-		-
 			message: '#^Cannot call method get_checkout_order_received_url\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
 			identifier: method.nonObject
 			count: 2

--- a/plugins/woocommerce/tests/legacy/unit-tests/checkout/checkout.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/checkout/checkout.php
@@ -59,6 +59,8 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 		$this->assertEquals( strpos( $coupon_held_key[ $coupon->get_id() ], '_coupon_held_' ), 0 );
 		$this->assertEquals( $coupon_data_store->get_tentative_usage_count( $coupon->get_id() ), 1 );
 
+		WC()->session->__unset( 'order_awaiting_payment' );
+
 		$order2_id = $checkout->create_order(
 			array(
 				'billing_email'  => 'a@c.com',
@@ -102,6 +104,8 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 		$this->assertNotWPError( $order_id1 );
 		$this->assertEquals( $coupon_data_store->get_tentative_usage_count( $coupon1->get_id() ), 1 );
 		$this->assertEquals( $coupon_data_store->get_tentative_usage_count( $coupon2->get_id() ), 1 );
+
+		WC()->session->__unset( 'order_awaiting_payment' );
 
 		$order2_id = $checkout->create_order(
 			array(

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -1,4 +1,7 @@
 <?php
+
+declare( strict_types = 1 );
+
 /**
  * Unit tests for the WC_Cart_Test class.
  *

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -304,4 +304,132 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( 'checkout-error', $result->get_error_code(), 'Error code should come from the checkout try/catch path.' );
 		$this->assertStringContainsString( 'Order items could not be saved', $result->get_error_message(), 'Error message should surface the defense-in-depth guard message.' );
 	}
+
+	/**
+	 * @testdox create_order reuses the pending checkout order for repeated attempts from the same cart.
+	 */
+	public function test_create_order_reuses_pending_order_for_same_cart_retry() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->calculate_totals();
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'customer@example.com',
+		);
+
+		try {
+			$first_order_id  = $this->sut->create_order( $data );
+			$second_order_id = $this->sut->create_order( $data );
+		} finally {
+			WC()->cart->empty_cart();
+			WC()->session->__unset( 'order_awaiting_payment' );
+		}
+
+		$this->assertIsInt( $first_order_id );
+		$this->assertSame( $first_order_id, $second_order_id, 'Repeated order creation for the same cart should resume the pending order.' );
+
+		$order = wc_get_order( $first_order_id );
+		$this->assertInstanceOf( WC_Order::class, $order );
+		$this->assertSame( 1, count( $order->get_items() ) );
+		$this->assertSame( 'pending', $order->get_status() );
+	}
+
+	/**
+	 * @testdox create_order creates a new order when the cart changes after a pending order was created.
+	 */
+	public function test_create_order_creates_new_order_when_cart_changes_after_pending_order() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->calculate_totals();
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'customer@example.com',
+		);
+
+		try {
+			$first_order_id = $this->sut->create_order( $data );
+
+			$second_product = WC_Helper_Product::create_simple_product();
+			WC()->cart->add_to_cart( $second_product->get_id() );
+			WC()->cart->calculate_totals();
+
+			$second_order_id = $this->sut->create_order( $data );
+		} finally {
+			WC()->cart->empty_cart();
+			WC()->session->__unset( 'order_awaiting_payment' );
+		}
+
+		$this->assertIsInt( $first_order_id );
+		$this->assertIsInt( $second_order_id );
+		$this->assertNotSame( $first_order_id, $second_order_id, 'A changed cart should not reuse the previous pending order.' );
+
+		$second_order = wc_get_order( $second_order_id );
+		$this->assertInstanceOf( WC_Order::class, $second_order );
+		$this->assertSame( 2, count( $second_order->get_items() ) );
+	}
+
+	/**
+	 * @testdox create_order does not reuse a completed order for the same cart.
+	 */
+	public function test_create_order_does_not_reuse_completed_order_for_same_cart_retry() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->calculate_totals();
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'customer@example.com',
+		);
+
+		try {
+			$first_order_id = $this->sut->create_order( $data );
+			$first_order    = wc_get_order( $first_order_id );
+			$first_order->set_status( 'completed' );
+			$first_order->save();
+
+			$second_order_id = $this->sut->create_order( $data );
+		} finally {
+			WC()->cart->empty_cart();
+			WC()->session->__unset( 'order_awaiting_payment' );
+		}
+
+		$this->assertIsInt( $first_order_id );
+		$this->assertIsInt( $second_order_id );
+		$this->assertNotSame( $first_order_id, $second_order_id, 'A completed order should not be reused for a checkout retry.' );
+	}
+
+	/**
+	 * @testdox create_order reuses a failed order for the same cart retry.
+	 */
+	public function test_create_order_reuses_failed_order_for_same_cart_retry() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->calculate_totals();
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'customer@example.com',
+		);
+
+		try {
+			$first_order_id = $this->sut->create_order( $data );
+			$first_order    = wc_get_order( $first_order_id );
+			$first_order->set_status( 'failed' );
+			$first_order->save();
+
+			$second_order_id = $this->sut->create_order( $data );
+		} finally {
+			WC()->cart->empty_cart();
+			WC()->session->__unset( 'order_awaiting_payment' );
+		}
+
+		$this->assertIsInt( $first_order_id );
+		$this->assertSame( $first_order_id, $second_order_id, 'A failed order should be reused for a same-cart checkout retry.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -319,15 +319,134 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		} finally {
 			WC()->cart->empty_cart();
 			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
 		}
 
 		$this->assertIsInt( $first_order_id );
 		$this->assertSame( $first_order_id, $second_order_id, 'Repeated order creation for the same cart should resume the pending order.' );
+		$this->assertEmpty( WC()->session->get( 'order_awaiting_payment' ), 'create_order() should not mark an order as awaiting payment before payment processing starts.' );
 
 		$order = wc_get_order( $first_order_id );
 		$this->assertInstanceOf( WC_Order::class, $order );
 		$this->assertSame( 1, count( $order->get_items() ) );
 		$this->assertSame( 'pending', $order->get_status() );
+	}
+
+	/**
+	 * @testdox create_order does not reuse or mutate a pending order for a different billing email.
+	 */
+	public function test_create_order_does_not_reuse_pending_order_for_different_billing_email() {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->calculate_totals();
+
+		$first_data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'first-customer@example.com',
+		);
+		$second_data = array_merge(
+			$first_data,
+			array(
+				'billing_email' => 'second-customer@example.com',
+			)
+		);
+
+		try {
+			$first_order_id  = $this->sut->create_order( $first_data );
+			$second_order_id = $this->sut->create_order( $second_data );
+		} finally {
+			WC()->cart->empty_cart();
+			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
+		}
+
+		$this->assertIsInt( $first_order_id );
+		$this->assertIsInt( $second_order_id );
+		$this->assertNotSame( $first_order_id, $second_order_id, 'A pending order should not be reused for a different billing email.' );
+
+		$first_order = wc_get_order( $first_order_id );
+		$this->assertInstanceOf( WC_Order::class, $first_order );
+		$this->assertSame( 'first-customer@example.com', $first_order->get_billing_email(), 'A second checkout identity should not mutate the first order.' );
+	}
+
+	/**
+	 * @testdox create_order does not reuse or mutate a pending order for a different customer ID.
+	 */
+	public function test_create_order_does_not_reuse_pending_order_for_different_customer_id() {
+		$product     = WC_Helper_Product::create_simple_product();
+		$customer_id = 111;
+		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->calculate_totals();
+
+		$get_customer_id = function () use ( &$customer_id ) {
+			return $customer_id;
+		};
+		add_filter( 'woocommerce_checkout_customer_id', $get_customer_id );
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'same-email@example.com',
+		);
+
+		try {
+			$first_order_id = $this->sut->create_order( $data );
+			$customer_id    = 222;
+			$second_order_id = $this->sut->create_order( $data );
+		} finally {
+			remove_filter( 'woocommerce_checkout_customer_id', $get_customer_id );
+			WC()->cart->empty_cart();
+			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
+		}
+
+		$this->assertIsInt( $first_order_id );
+		$this->assertIsInt( $second_order_id );
+		$this->assertNotSame( $first_order_id, $second_order_id, 'A pending order should not be reused for a different customer ID.' );
+
+		$first_order = wc_get_order( $first_order_id );
+		$this->assertInstanceOf( WC_Order::class, $first_order );
+		$this->assertSame( 111, $first_order->get_customer_id(), 'A second checkout customer should not mutate the first order.' );
+	}
+
+	/**
+	 * @testdox create_order does not double-reserve coupon usage when reusing a pending order for the same cart.
+	 */
+	public function test_create_order_reuses_pending_order_without_double_reserving_coupon_usage() {
+		$product = WC_Helper_Product::create_simple_product();
+		$coupon  = new WC_Coupon();
+		$coupon->set_code( 'same-cart-retry-coupon' );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_amount( 1 );
+		$coupon->set_usage_limit( 2 );
+		$coupon->save();
+
+		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->apply_coupon( $coupon->get_code() );
+		WC()->cart->calculate_totals();
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'coupon-customer@example.com',
+		);
+
+		try {
+			$first_order_id  = $this->sut->create_order( $data );
+			$second_order_id = $this->sut->create_order( $data );
+		} finally {
+			WC()->cart->empty_cart();
+			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
+		}
+
+		$this->assertSame( $first_order_id, $second_order_id, 'Same-cart retries should reuse the pending order.' );
+		$this->assertSame(
+			1,
+			$coupon->get_data_store()->get_tentative_usages_for_user( $coupon->get_id(), array( 'coupon-customer@example.com' ) ),
+			'Reusing a pending order should not create a second coupon hold.'
+		);
 	}
 
 	/**
@@ -355,6 +474,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		} finally {
 			WC()->cart->empty_cart();
 			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
 		}
 
 		$this->assertIsInt( $first_order_id );
@@ -390,6 +510,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		} finally {
 			WC()->cart->empty_cart();
 			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
 		}
 
 		$this->assertIsInt( $first_order_id );
@@ -421,6 +542,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		} finally {
 			WC()->cart->empty_cart();
 			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
 		}
 
 		$this->assertIsInt( $first_order_id );

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -1,18 +1,9 @@
 <?php
-
 declare( strict_types = 1 );
-
-/**
- * Unit tests for the WC_Cart_Test class.
- *
- * @package WooCommerce\Tests\Checkout.
- */
 
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 
-/**
- * Class WC_Checkout
- */
+// phpcs:ignore Squiz.Commenting.ClassComment.Missing
 class WC_Checkout_Test extends \WC_Unit_Test_Case {
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR closes a checkout order-creation retry gap that can persist duplicate orders for the same cart/session before payment processing starts.

WooCommerce already uses `order_awaiting_payment` as payment-attempt state in `process_order_payment()`. This PR keeps that boundary intact and adds a checkout-only retry pointer, `checkout_pending_order_id`, after `WC_Checkout::create_order()` persists an order. If a request fails, hangs, or is retried after order creation but before payment processing, the repeated checkout attempt can reuse the existing checkout-created order without marking it as awaiting payment early.

Existing order reuse is limited to the same checkout identity and cart state:

- same cart + pending order + same customer ID + same billing email: reuse
- same cart + failed order + same customer ID + same billing email: reuse
- different billing email: create a new order
- different customer ID: create a new order
- changed cart: create a new order
- completed order: create a new order

Same-cart pending retries also avoid item churn and avoid double-reserving coupon usage. Failed-order retries can still restore coupon reservations.

Closes #62659.

Related: #14541, #43770.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

Not applicable. This is checkout order-creation/session behavior with no UI changes.

### How to test the changes in this Pull Request:

1. Run the focused checkout PHPUnit tests:

   ```bash
   vendor/bin/phpunit tests/php/includes/class-wc-checkout-test.php --filter 'test_create_order_(reuses_pending_order|does_not_reuse_pending_order_for_different_billing_email|does_not_reuse_pending_order_for_different_customer_id|reuses_pending_order_without_double_reserving_coupon_usage|creates_new_order_when_cart_changes|does_not_reuse_completed_order|reuses_failed_order)'
   ```

2. Confirm the following behavior:

   - Same cart retry while pending returns the first order ID.
   - Same cart retry while pending does not set `order_awaiting_payment` before payment processing starts.
   - Different billing email does not reuse or mutate the first pending order.
   - Different customer ID does not reuse or mutate the first pending order.
   - Same-cart pending retry does not double-reserve coupon usage.
   - Cart changes after the first pending order create a new order.
   - Existing completed orders are not reused or mutated.
   - Existing failed orders can be reused for the same checkout identity/cart.

3. Review the deterministic rig evidence summary linked below for baseline vs revised checkout side-effect results and gateway plugin coverage.

### Testing that has already taken place:

#### Static checks

- `php -l plugins/woocommerce/includes/class-wc-checkout.php`
- `php -l plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php`
- `git diff --check`

#### PHPUnit coverage added

This PR adds coverage for:

- same-cart pending order retry reuse
- different billing email isolation
- different customer ID isolation
- same-cart coupon retry without double-reserving coupon usage
- changed-cart retry creating a new order
- completed order non-reuse
- failed order reuse
- `create_order()` not setting `order_awaiting_payment` before payment processing starts

#### Deterministic rig evidence

The broader checkout side-effect evidence is summarized in this PR comment, including the unsafe baseline, revised broad concurrent matrix runs, revised core gateway matrix run, and the current gateway plugin coverage limits:

https://github.com/woocommerce/woocommerce/pull/65588#issuecomment-4707797226

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent duplicate checkout orders when the same cart/session retries order creation before payment processing starts.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Isolated the checkout order-creation retry gap, drafted the checkout/session boundary changes and regression tests, and organized the rig evidence; Chris remains responsible for review and submission.