### PR TITLE
Pin dessant/repo-lockdown to a commit SHA (woocommerce-analytics mirror workflow)

### DIFF
--- a/packages/php/woocommerce-analytics/tasks/mirror-github/workflows/readonly.yml
+++ b/packages/php/woocommerce-analytics/tasks/mirror-github/workflows/readonly.yml
@@ -15,7 +15,7 @@ jobs:
     lockdown:
         runs-on: ubuntu-latest
         steps:
-            - uses: dessant/repo-lockdown@v5
+            - uses: dessant/repo-lockdown@17c2cc64a91eff426f242b05dd523c6f098889b6 # v5.0.2
               with:
                   github-token: ${{ github.token }}
                   issue-comment: |


### PR DESCRIPTION
## What

Pins the `dessant/repo-lockdown` action in the `woocommerce-analytics` mirror workflow from the mutable tag `@v5` to the immutable commit SHA it currently resolves to.

```
- uses: dessant/repo-lockdown@v5
+ uses: dessant/repo-lockdown@17c2cc64a91eff426f242b05dd523c6f098889b6 # v5.0.2
```

## Why

`@v5` is a mutable tag that can be repointed at any time. Pinning to the exact commit it currently resolves to (`v5.0.2`) removes that supply-chain risk. **There is no behaviour change** — the resolved commit is identical to what `@v5` runs today.

This template (`packages/php/woocommerce-analytics/tasks/mirror-github/workflows/readonly.yml`) is mirrored into the read-only `Automattic/woocommerce-analytics` repository on publish. Pinning here lets that mirror pass org-wide **"require SHA pinning"** enforcement on its next publish.

Part of DEVPROD-1072.

## Verification

```
gh api repos/dessant/repo-lockdown/commits/v5.0.2 --jq .sha
# expect: 17c2cc64a91eff426f242b05dd523c6f098889b6
```