### PR TITLE
Fix: Preserve taxonomy attribute term order for variable products

### DIFF
--- a/plugins/woocommerce/changelog/fix-preserve-taxonomy-attribute-term-order
+++ b/plugins/woocommerce/changelog/fix-preserve-taxonomy-attribute-term-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Taxonomy attribute term order is now preserved after saving a variable product, resolving alphabetical reordering introduced

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -619,8 +619,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					if ( ! taxonomy_exists( $meta_value['name'] ) ) {
 						continue;
 					}
-					$id      = wc_attribute_taxonomy_id_by_name( $meta_value['name'] );
-					$options = wc_get_object_terms( $product_id, $meta_value['name'], 'term_id' );
+					$id = wc_attribute_taxonomy_id_by_name( $meta_value['name'] );
+					if ( ! empty( $meta_value['value'] ) ) {
+						// Use stored ordered term IDs.
+						$options = array_map( 'intval', explode( '|', $meta_value['value'] ) );
+					} else {
+						// Fallback for older products without stored order.
+						$options = wc_get_object_terms( $product_id, $meta_value['name'], 'term_id' );
+					}
 				} else {
 					$id      = 0;
 					$options = wc_get_text_attributes( $meta_value['value'] );
@@ -1092,7 +1098,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						continue;
 
 					} elseif ( $attribute->is_taxonomy() ) {
-						wp_set_object_terms( $product->get_id(), wp_list_pluck( (array) $attribute->get_terms(), 'term_id' ), $attribute->get_name() );
+						$term_ids = array_map( 'intval', $attribute->get_options() );
+						wp_set_object_terms( $product->get_id(), $term_ids, $attribute->get_name() );
+						$value = implode( '|', $term_ids ); // store ordered IDs
 					} else {
 						$value = wc_implode_text_attributes( $attribute->get_options() );
 					}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -619,13 +619,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					if ( ! taxonomy_exists( $meta_value['name'] ) ) {
 						continue;
 					}
-					$id = wc_attribute_taxonomy_id_by_name( $meta_value['name'] );
-					if ( ! empty( $meta_value['value'] ) ) {
-						// Use stored ordered term IDs.
-						$options = array_map( 'intval', explode( '|', $meta_value['value'] ) );
-					} else {
-						// Fallback for older products without stored order.
-						$options = wc_get_object_terms( $product_id, $meta_value['name'], 'term_id' );
+					$id       = wc_attribute_taxonomy_id_by_name( $meta_value['name'] );
+					$options  = wc_get_object_terms( $product_id, $meta_value['name'], 'term_id' );
+					$ordering = array_filter( array_map( 'absint', explode( '|', (string) $meta_value['value'] ) ) );
+					if ( ! empty( $ordering ) ) {
+						$options = array_merge(
+							array_values( array_intersect( $ordering, $options ) ),
+							array_values( array_diff( $options, $ordering ) )
+						);
 					}
 				} else {
 					$id      = 0;
@@ -1098,9 +1099,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						continue;
 
 					} elseif ( $attribute->is_taxonomy() ) {
-						$term_ids = array_map( 'intval', $attribute->get_options() );
+						$term_ids = wp_list_pluck( (array) $attribute->get_terms(), 'term_id' );
 						wp_set_object_terms( $product->get_id(), $term_ids, $attribute->get_name() );
-						$value = implode( '|', $term_ids ); // store ordered IDs
+						$value = implode( '|', $term_ids );
+						// Store ordered term IDs.
 					} else {
 						$value = wc_implode_text_attributes( $attribute->get_options() );
 					}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -89,8 +89,15 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 						continue;
 					}
 					// Performance note: at this stage, the product factory has already primed the caches, so wc_get_object_terms does not present a concern.
-					$id      = wc_attribute_taxonomy_id_by_name( $meta_value['name'] );
-					$options = wc_get_object_terms( $product_id, $meta_value['name'], 'term_id' );
+					$id       = wc_attribute_taxonomy_id_by_name( $meta_value['name'] );
+					$options  = wc_get_object_terms( $product_id, $meta_value['name'], 'term_id' );
+					$ordering = array_filter( array_map( 'absint', explode( '|', (string) $meta_value['value'] ) ) );
+					if ( ! empty( $ordering ) ) {
+						$options = array_merge(
+							array_values( array_intersect( $ordering, $options ) ),
+							array_values( array_diff( $options, $ordering ) )
+						);
+					}
 				} else {
 					$id      = 0;
 					$options = wc_get_text_attributes( $meta_value['value'] );

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
@@ -178,4 +178,37 @@ class WC_Tests_Product_Variable extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $expected_stock_status, $product->get_stock_status() );
 	}
+
+	/**
+	 * @testdox Frontend display preserves taxonomy attribute term order.
+	 */
+	public function test_frontend_display_preserves_taxonomy_attribute_term_order() {
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
+		$term_ids  = $attribute->get_options();
+
+		$product = new WC_Product_Variable();
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		// Get expected names in saved order.
+		$expected_names = array_map( fn( $id ) => get_term( $id )->name, $term_ids );
+
+		// Call the REAL function and capture output.
+		ob_start();
+		wc_display_product_attributes( $product );
+		$html = ob_get_clean();
+
+		// Extract term names from rendered HTML in order.
+		preg_match( '/<p>(.*?)<\/p>/s', $html, $matches );
+		$rendered_names = array_map( 'trim', explode( ',', wp_strip_all_tags( $matches[1] ?? '' ) ) );
+
+		$this->assertEquals(
+			$expected_names,
+			$rendered_names,
+			'wc_display_product_attributes() should render terms in saved order, not alphabetical.'
+		);
+
+		$product->delete( true );
+		WC_Helper_Product::delete_attribute( 'size' );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
@@ -183,32 +183,37 @@ class WC_Tests_Product_Variable extends WC_Unit_Test_Case {
 	 * @testdox Frontend display preserves taxonomy attribute term order.
 	 */
 	public function test_frontend_display_preserves_taxonomy_attribute_term_order() {
-		$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
-		$term_ids  = $attribute->get_options();
+		try {
+			$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
+			$term_ids  = $attribute->get_options();
 
-		$product = new WC_Product_Variable();
-		$product->set_attributes( array( $attribute ) );
-		$product->save();
+			$product = new WC_Product_Variable();
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
 
-		// Get expected names in saved order.
-		$expected_names = array_map( fn( $id ) => get_term( $id )->name, $term_ids );
+			// Get expected names in saved order.
+			$expected_names = array_map( fn( $id ) => get_term( $id )->name, $term_ids );
 
-		// Call the REAL function and capture output.
-		ob_start();
-		wc_display_product_attributes( $product );
-		$html = ob_get_clean();
+			// Call the REAL function and capture output.
+			ob_start();
+			wc_display_product_attributes( $product );
+			$html = ob_get_clean();
 
-		// Extract term names from rendered HTML in order.
-		preg_match( '/<p>(.*?)<\/p>/s', $html, $matches );
-		$rendered_names = array_map( 'trim', explode( ',', wp_strip_all_tags( $matches[1] ?? '' ) ) );
+			// Extract term names from rendered HTML in order.
+			preg_match( '/<p>(.*?)<\/p>/s', $html, $matches );
+			$rendered_names = array_map( 'trim', explode( ',', wp_strip_all_tags( $matches[1] ?? '' ) ) );
 
-		$this->assertEquals(
-			$expected_names,
-			$rendered_names,
-			'wc_display_product_attributes() should render terms in saved order, not alphabetical.'
-		);
+			$this->assertEquals(
+				$expected_names,
+				$rendered_names,
+				'wc_display_product_attributes() should render terms in saved order, not alphabetical.'
+			);
 
-		$product->delete( true );
-		WC_Helper_Product::delete_attribute( 'size' );
+		} finally {
+			if ( $product ) {
+				$product->delete( true );
+			}
+			WC_Helper_Product::delete_attribute( $attribute->get_id() );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
@@ -178,42 +178,4 @@ class WC_Tests_Product_Variable extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $expected_stock_status, $product->get_stock_status() );
 	}
-
-	/**
-	 * @testdox Frontend display preserves taxonomy attribute term order.
-	 */
-	public function test_frontend_display_preserves_taxonomy_attribute_term_order() {
-		try {
-			$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
-			$term_ids  = $attribute->get_options();
-
-			$product = new WC_Product_Variable();
-			$product->set_attributes( array( $attribute ) );
-			$product->save();
-
-			// Get expected names in saved order.
-			$expected_names = array_map( fn( $id ) => get_term( $id )->name, $term_ids );
-
-			// Call the REAL function and capture output.
-			ob_start();
-			wc_display_product_attributes( $product );
-			$html = ob_get_clean();
-
-			// Extract term names from rendered HTML in order.
-			preg_match( '/<p>(.*?)<\/p>/s', $html, $matches );
-			$rendered_names = array_map( 'trim', explode( ',', wp_strip_all_tags( $matches[1] ?? '' ) ) );
-
-			$this->assertEquals(
-				$expected_names,
-				$rendered_names,
-				'wc_display_product_attributes() should render terms in saved order, not alphabetical.'
-			);
-
-		} finally {
-			if ( $product ) {
-				$product->delete( true );
-			}
-			WC_Helper_Product::delete_attribute( $attribute->get_id() );
-		}
-	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -740,57 +740,102 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * Test Taxonomy attribute term order is preserved after save and read for simple products.
 	 */
 	public function test_taxonomy_attribute_term_order_is_preserved_for_simple_product() {
-		// Create attribute with terms in non-alphabetical order: S, XL, M.
-		$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
-		$expected_order = $attribute->get_options();
+		try {
+			// Create attribute with terms in non-alphabetical order: S, XL, M.
+			$attribute      = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
+			$expected_order = $attribute->get_options();
 
-		// Create simple product with the attribute.
-		$product = new WC_Product_Simple();
-		$product->set_attributes( array( $attribute ) );
-		$product->save();
+			// Create simple product with the attribute.
+			$product = new WC_Product_Simple();
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
 
-		// Read product back fresh (no cache).
-		wp_cache_delete( $product->get_id(), 'posts' );
-		$product = wc_get_product( $product->get_id() );
+			// Read product back fresh (no cache).
+			wp_cache_delete( $product->get_id(), 'posts' );
+			$product = wc_get_product( $product->get_id() );
 
-		$saved_options = $product->get_attributes()['pa_size']->get_options();
+			$saved_options = $product->get_attributes()['pa_size']->get_options();
 
-		// Assert insertion order S, XL, M is preserved (not alphabetical M, S, XL).
-		$this->assertEquals(
-			$expected_order,
-			$saved_options,
-			'Taxonomy attribute term order should be preserved after save/read, not sorted alphabetically.'
-		);
+			// Assert insertion order S, XL, M is preserved (not alphabetical M, S, XL).
+			$this->assertEquals(
+				$expected_order,
+				$saved_options,
+				'Taxonomy attribute term order should be preserved after save/read, not sorted alphabetically.'
+			);
 
-		// Cleanup.
-		$product->delete( true );
-		WC_Helper_Product::delete_attribute( 'size' );
+		} finally {
+			if ( $product ) {
+				$product->delete( true );
+			}
+			WC_Helper_Product::delete_attribute( $attribute->get_id() );
+		}
 	}
 
 	/**
 	 * Test Taxonomy attribute term order is preserved after multiple saves.
 	 */
 	public function test_taxonomy_attribute_term_order_is_preserved_after_multiple_saves() {
-		$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'XL', 'S', 'M', 'L' ) );
-		$expected_order = $attribute->get_options();
+		try {
+			$attribute      = WC_Helper_Product::create_product_attribute_object( 'size', array( 'XL', 'S', 'M', 'L' ) );
+			$expected_order = $attribute->get_options();
 
-		$product = new WC_Product_Simple();
-		$product->set_attributes( array( $attribute ) );
-		$product->save();
+			$product = new WC_Product_Simple();
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
 
-		// Simulate re-saving from admin.
-		$product->save();
+			// Simulate re-saving from admin.
+			$product->save();
 
-		wp_cache_delete( $product->get_id(), 'posts' );
-		$product = wc_get_product( $product->get_id() );
+			wp_cache_delete( $product->get_id(), 'posts' );
+			$product = wc_get_product( $product->get_id() );
 
-		$this->assertEquals(
-			$expected_order,
-			$product->get_attributes()['pa_size']->get_options(),
-			'Taxonomy attribute term order should survive multiple saves.'
-		);
+			$this->assertEquals(
+				$expected_order,
+				$product->get_attributes()['pa_size']->get_options(),
+				'Taxonomy attribute term order should survive multiple saves.'
+			);
 
-		$product->delete( true );
-		WC_Helper_Product::delete_attribute( 'size' );
+		} finally {
+			if ( $product ) {
+				$product->delete( true );
+			}
+			WC_Helper_Product::delete_attribute( $attribute->get_id() );
+		}
+	}
+
+	public function test_rest_api_term_names_are_resolved_correctly() {
+		$product = null;
+		try {
+			$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'M', 'L' ) );
+
+			// Simulate REST API: set options as term names, not IDs.
+			$rest_attribute = new WC_Product_Attribute();
+			$rest_attribute->set_id( $attribute->get_id() );
+			$rest_attribute->set_name( 'pa_size' );
+			$rest_attribute->set_options( array( 'S', 'M', 'L' ) );
+			// names not IDs
+			$rest_attribute->set_variation( true );
+
+			$product = new WC_Product_Variable();
+			$product->set_attributes( array( $rest_attribute ) );
+			$product->save();
+
+			wp_cache_delete( $product->get_id(), 'posts' );
+			$product = wc_get_product( $product->get_id() );
+
+			$options = $product->get_attributes()['pa_size']->get_options();
+
+			// Should have 3 valid term IDs, not [0, 0, 0].
+			$this->assertCount( 3, $options );
+			$this->assertNotContains( 0, $options );
+			foreach ( $options as $option ) {
+				$this->assertGreaterThan( 0, $option );
+			}
+		} finally {
+			if ( $product ) {
+				$product->delete( true );
+			}
+			WC_Helper_Product::delete_attribute( $attribute->get_id() );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -740,6 +740,8 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * Test Taxonomy attribute term order is preserved after save and read for simple products.
 	 */
 	public function test_taxonomy_attribute_term_order_is_preserved_for_simple_product() {
+		$product   = null;
+		$attribute = null;
 		try {
 			// Create attribute with terms in non-alphabetical order: S, XL, M.
 			$attribute      = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
@@ -767,7 +769,9 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			if ( $product ) {
 				$product->delete( true );
 			}
-			WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			if ( $attribute ) {
+				WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			}
 		}
 	}
 
@@ -775,6 +779,8 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * Test Taxonomy attribute term order is preserved after multiple saves.
 	 */
 	public function test_taxonomy_attribute_term_order_is_preserved_after_multiple_saves() {
+		$product   = null;
+		$attribute = null;
 		try {
 			$attribute      = WC_Helper_Product::create_product_attribute_object( 'size', array( 'XL', 'S', 'M', 'L' ) );
 			$expected_order = $attribute->get_options();
@@ -799,12 +805,15 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			if ( $product ) {
 				$product->delete( true );
 			}
-			WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			if ( $attribute ) {
+				WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			}
 		}
 	}
 
 	public function test_rest_api_term_names_are_resolved_correctly() {
-		$product = null;
+		$product   = null;
+		$attribute = null;
 		try {
 			$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'M', 'L' ) );
 
@@ -835,7 +844,9 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			if ( $product ) {
 				$product->delete( true );
 			}
-			WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			if ( $attribute ) {
+				WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -735,4 +735,62 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$store->update_product_sales( $product_id, 30.5, 'set' );
 		$this->assertSame( '30.500000', get_post_meta( $product_id, 'total_sales', true ) );
 	}
+
+	/**
+	 * Test Taxonomy attribute term order is preserved after save and read for simple products.
+	 */
+	public function test_taxonomy_attribute_term_order_is_preserved_for_simple_product() {
+		// Create attribute with terms in non-alphabetical order: S, XL, M.
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
+		$expected_order = $attribute->get_options();
+
+		// Create simple product with the attribute.
+		$product = new WC_Product_Simple();
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		// Read product back fresh (no cache).
+		wp_cache_delete( $product->get_id(), 'posts' );
+		$product = wc_get_product( $product->get_id() );
+
+		$saved_options = $product->get_attributes()['pa_size']->get_options();
+
+		// Assert insertion order S, XL, M is preserved (not alphabetical M, S, XL).
+		$this->assertEquals(
+			$expected_order,
+			$saved_options,
+			'Taxonomy attribute term order should be preserved after save/read, not sorted alphabetically.'
+		);
+
+		// Cleanup.
+		$product->delete( true );
+		WC_Helper_Product::delete_attribute( 'size' );
+	}
+
+	/**
+	 * Test Taxonomy attribute term order is preserved after multiple saves.
+	 */
+	public function test_taxonomy_attribute_term_order_is_preserved_after_multiple_saves() {
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'XL', 'S', 'M', 'L' ) );
+		$expected_order = $attribute->get_options();
+
+		$product = new WC_Product_Simple();
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		// Simulate re-saving from admin.
+		$product->save();
+
+		wp_cache_delete( $product->get_id(), 'posts' );
+		$product = wc_get_product( $product->get_id() );
+
+		$this->assertEquals(
+			$expected_order,
+			$product->get_attributes()['pa_size']->get_options(),
+			'Taxonomy attribute term order should survive multiple saves.'
+		);
+
+		$product->delete( true );
+		WC_Helper_Product::delete_attribute( 'size' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -1163,7 +1163,6 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-
 	 * @testdox read_variation_attributes returns the cached result on a second call.
 	 */
 	public function test_read_variation_attributes_returns_cached_result(): void {
@@ -1181,6 +1180,42 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertSame( $first, wp_cache_get( $cache_key, 'products' ) );
 
 		$product->delete();
+	}
+
+	/**
+	 * @testdox Taxonomy attribute term order is preserved after save and read for variable products.
+	 */
+	public function test_taxonomy_attribute_term_order_is_preserved_for_variable_product() {
+
+		try {
+			// Create attribute with terms in non-alphabetical order: S, XL, M.
+			$attribute      = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'XL', 'M' ) );
+			$expected_order = $attribute->get_options();
+
+			// Create variable product.
+			$product = new WC_Product_Variable();
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
+
+			wp_cache_delete( $product->get_id(), 'posts' );
+			$product = wc_get_product( $product->get_id() );
+
+			$saved_options = $product->get_attributes()['pa_size']->get_options();
+
+			// Assert insertion order S, XL, M is preserved.
+			$this->assertEquals(
+				$expected_order,
+				$saved_options,
+				'Variable product taxonomy attribute term order should be preserved after save/read.'
+			);
+		} finally {
+			if ( $product ) {
+				$product->delete( true );
+			}
+			if ( $attribute ) {
+				WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			}
+		}
 	}
 
 	/**
@@ -1929,7 +1964,6 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$sizes = ( new WC_Product_Variable_Data_Store_CPT() )->read_variation_attributes( $product )['pa_size'];
 
 		$this->assertSame( array( 'small', 'large', 'huge' ), $sizes );
-
 		$product->delete( true );
 	}
 
@@ -1992,5 +2026,80 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertSame( array( $display_hash, $current_hash ), array_slice( array_keys( $stored ), -2 ), 'Display and opposite price hashes should be the last two entries after pruning.' );
 
 		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Taxonomy attribute term order falls back gracefully for products saved.
+	 */
+	public function test_taxonomy_attribute_term_order_fallback_for_legacy_products() {
+		$product   = null;
+		$attribute = null;
+		try {
+			// Create attribute normally.
+			$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'M', 'L' ) );
+
+			$product = new WC_Product_Variable();
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
+
+			// Simulate legacy product: manually remove 'value' from stored meta.
+			$meta                     = get_post_meta( $product->get_id(), '_product_attributes', true );
+			$meta['pa_size']['value'] = '';
+			// legacy: no stored order
+			update_post_meta( $product->get_id(), '_product_attributes', $meta );
+
+			wp_cache_delete( $product->get_id(), 'posts' );
+			$product = wc_get_product( $product->get_id() );
+
+			// Should fall back to wc_get_object_terms without error.
+			$options = $product->get_attributes()['pa_size']->get_options();
+			$this->assertEquals(
+				array_values( wc_get_object_terms( $product->get_id(), 'pa_size', 'term_id' ) ),
+				array_values( $options ),
+				'Legacy products should load all assigned terms.'
+			);
+		} finally {
+			if ( $product ) {
+				$product->delete( true );
+			}
+			if ( $attribute ) {
+				WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			}
+		}
+	}
+
+	public function test_legacy_value_containing_term_names_does_not_break_load() {
+		$product   = null;
+		$attribute = null;
+		try {
+			$attribute = WC_Helper_Product::create_product_attribute_object( 'size', array( 'S', 'M', 'L' ) );
+
+			$product = new WC_Product_Variable();
+			$product->set_attributes( array( $attribute ) );
+			$product->save();
+
+			// Simulate legacy importer: store term names in value with is_taxonomy=1.
+			$meta                     = get_post_meta( $product->get_id(), '_product_attributes', true );
+			$meta['pa_size']['value'] = 'S|M|L';
+			// names not IDs.
+			update_post_meta( $product->get_id(), '_product_attributes', $meta );
+
+			wp_cache_delete( $product->get_id(), 'posts' );
+			$product = wc_get_product( $product->get_id() );
+
+			// Should load terms from wc_get_object_terms, not ghost terms.
+			$options = $product->get_attributes()['pa_size']->get_options();
+			$this->assertNotEmpty( $options );
+			foreach ( $options as $option ) {
+				$this->assertGreaterThan( 0, $option, 'Options should be valid term IDs, not 0.' );
+			}
+		} finally {
+			if ( $product ) {
+				$product->delete( true );
+			}
+			if ( $attribute ) {
+				WC_Helper_Product::delete_attribute( $attribute->get_id() );
+			}
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -1163,6 +1163,7 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+
 	 * @testdox read_variation_attributes returns the cached result on a second call.
 	 */
 	public function test_read_variation_attributes_returns_cached_result(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

## Changes

**`includes/data-stores/class-wc-product-data-store-cpt.php`**
- Save: store ordered term IDs as pipe-delimited string in `value` field
- Read: use the stored order as an ordering hint when reconstructing options; `wc_get_object_terms()` remains the source of truth for which terms are assigned, so legacy/stale/malformed `value` data degrades gracefully

**`includes/data-stores/class-wc-product-variable-data-store-cpt.php`**
- Read: same ordering-hint fix as above for variable products (the affected product type)

Closes https://github.com/woocommerce/woocommerce/issues/65301.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a variable product
2. Add a global attribute (e.g. Size), and via "Add existing" select terms in a non-alphabetical order: S → XL → M → 3XL → L → 2XL
3. Check "Used for variations", click **Save attributes**
4. Reload the product edit page, verify the attribute chips still show the saved order (S, XL, M, 3XL, L, 2XL), not alphabetical
5. Generate variations, confirm variation rows are created correctly
6. Frontend product page is **not** expected to reflect the saved order, it should display alphabetically, unchanged from current behavior. This is expected and out of scope for this PR.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - The `value` field of `_product_attributes` meta for taxonomy attributes now stores pipe delimited term IDs (e.g. `12|34|56`) to preserve order. Previously this field was always empty (`''`) for taxonomy attributes. Code that renders this field directly will now display raw IDs.
