### PR TITLE
Disable Playwright HTML report auto-open on failure in e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/disable-playwright-report-on-failure
+++ b/plugins/woocommerce/changelog/disable-playwright-report-on-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.ts
@@ -72,7 +72,7 @@ if ( process.env.CI ) {
 		'html',
 		{
 			outputFolder: `${ TESTS_ROOT_PATH }/playwright-report`,
-			open: 'on-failure',
+			open: 'never',
 		},
 	] );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The local e2e HTML reporter was configured with `open: 'on-failure'`, which auto-opens the Playwright report after a failing run. This is disruptive for automated and agent-driven runs, so this changes the setting to `open: 'never'`.

### How to test the changes in this Pull Request:

1. Run an e2e Playwright test locally (not in CI) that fails, e.g. `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:default`.
2. Confirm the HTML report does NOT automatically open in a browser after the run finishes.
3. Confirm the report is still generated under `tests/e2e-pw/playwright-report` and can be opened manually.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
