### PR TITLE
Performance: reduce variation slug collision queries during batch creation

### DIFF
--- a/plugins/woocommerce/changelog/65617-fix-rest-variation-generated-slugs
+++ b/plugins/woocommerce/changelog/65617-fix-rest-variation-generated-slugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduce variation slug collision queries during batch creation.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -133,7 +133,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		if ( '' === $product->get_slug( 'edit' ) ) {
-			$product->set_slug( $this->generate_product_slug( $product ) );
+			$product->set_slug( $this->generate_product_variation_slug( $product ) );
 		}
 
 		$id = wp_insert_post(
@@ -329,7 +329,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 * @param WC_Product_Variation $product Product variation to generate a slug for.
 	 * @return string
 	 */
-	protected function generate_product_slug( $product ) {
+	protected function generate_product_variation_slug( $product ) {
 		$attributes = (array) $product->get_attributes();
 		ksort( $attributes );
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -132,6 +132,10 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$product->set_parent_id( 0 );
 		}
 
+		if ( '' === $product->get_slug( 'edit' ) ) {
+			$product->set_slug( $this->generate_product_slug( $product ) );
+		}
+
 		$id = wp_insert_post(
 			apply_filters(
 				'woocommerce_new_product_variation_data',
@@ -316,6 +320,38 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$title_suffix              = $should_include_attributes ? wc_get_formatted_variation( $product, true, false ) : '';
 
 		return apply_filters( 'woocommerce_product_variation_title', $title_suffix ? $title_base . $separator . $title_suffix : $title_base, $product, $title_base, $title_suffix );
+	}
+
+	/**
+	 * Generates a stable slug for a new variation when no explicit slug is set.
+	 *
+	 * @since 11.0.0
+	 * @param WC_Product_Variation $product Product variation to generate a slug for.
+	 * @return string
+	 */
+	protected function generate_product_slug( $product ) {
+		$attributes = (array) $product->get_attributes();
+		ksort( $attributes );
+
+		$slug_parts = array(
+			'product',
+			'variation',
+			(string) $product->get_parent_id(),
+		);
+
+		foreach ( $attributes as $name => $value ) {
+			$slug_parts[] = $name;
+			$slug_parts[] = $value;
+		}
+
+		$slug_parts = array_filter(
+			array_map(
+				'sanitize_title',
+				$slug_parts
+			)
+		);
+
+		return implode( '-', $slug_parts );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -348,7 +348,10 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			array_map(
 				'sanitize_title',
 				$slug_parts
-			)
+			),
+			static function ( $part ) {
+				return '' !== $part;
+			}
 		);
 
 		return implode( '-', $slug_parts );

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -699,14 +699,15 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$variation->set_parent_id( $product->get_id() );
 		$variation->set_attributes(
 			array(
-				'color' => 'Green',
 				'size'  => 'Large',
+				'level' => '0',
+				'color' => 'Green',
 			)
 		);
 		$variation->save();
 
 		$loaded_variation = wc_get_product( $variation->get_id() );
-		$this->assertEquals( 'product-variation-' . $product->get_id() . '-color-green-size-large', $loaded_variation->get_slug() );
+		$this->assertEquals( 'product-variation-' . $product->get_id() . '-color-green-level-0-size-large', $loaded_variation->get_slug() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -688,6 +688,75 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests automatic generation of variation slug.
+	 */
+	public function test_generate_product_slug() {
+		$product = new WC_Product();
+		$product->set_name( 'Test Product' );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_attributes(
+			array(
+				'color' => 'Green',
+				'size'  => 'Large',
+			)
+		);
+		$variation->save();
+
+		$loaded_variation = wc_get_product( $variation->get_id() );
+		$this->assertEquals( 'product-variation-' . $product->get_id() . '-color-green-size-large', $loaded_variation->get_slug() );
+	}
+
+	/**
+	 * Tests that automatic variation slug generation preserves explicit slugs.
+	 */
+	public function test_generate_product_slug_preserves_explicit_slug() {
+		$product = new WC_Product();
+		$product->set_name( 'Test Product' );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_slug( 'custom-variation-slug' );
+		$variation->set_attributes( array( 'color' => 'Green' ) );
+		$variation->save();
+
+		$loaded_variation = wc_get_product( $variation->get_id() );
+		$this->assertEquals( 'custom-variation-slug', $loaded_variation->get_slug() );
+	}
+
+	/**
+	 * Tests that automatic variation slug generation still uses WordPress uniqueness handling.
+	 */
+	public function test_generate_product_slug_preserves_wordpress_collision_handling() {
+		$product = new WC_Product();
+		$product->set_name( 'Test Product' );
+		$product->save();
+
+		$attributes = array(
+			'color' => 'Green',
+			'size'  => 'Large',
+		);
+
+		$first_variation = new WC_Product_Variation();
+		$first_variation->set_parent_id( $product->get_id() );
+		$first_variation->set_attributes( $attributes );
+		$first_variation->save();
+
+		$second_variation = new WC_Product_Variation();
+		$second_variation->set_parent_id( $product->get_id() );
+		$second_variation->set_attributes( $attributes );
+		$second_variation->save();
+
+		$base_slug = 'product-variation-' . $product->get_id() . '-color-green-size-large';
+
+		$this->assertEquals( $base_slug, wc_get_product( $first_variation->get_id() )->get_slug() );
+		$this->assertEquals( $base_slug . '-2', wc_get_product( $second_variation->get_id() )->get_slug() );
+	}
+
+	/**
 	 * Tests Product variation attribute_summary prop and its update on data store read.
 	 *
 	 * @since 3.6.0

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -690,7 +690,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	/**
 	 * Tests automatic generation of variation slug.
 	 */
-	public function test_generate_product_slug() {
+	public function test_generate_product_variation_slug() {
 		$product = new WC_Product();
 		$product->set_name( 'Test Product' );
 		$product->save();
@@ -712,7 +712,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	/**
 	 * Tests that automatic variation slug generation preserves explicit slugs.
 	 */
-	public function test_generate_product_slug_preserves_explicit_slug() {
+	public function test_generate_product_variation_slug_preserves_explicit_slug() {
 		$product = new WC_Product();
 		$product->set_name( 'Test Product' );
 		$product->save();
@@ -730,7 +730,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	/**
 	 * Tests that automatic variation slug generation still uses WordPress uniqueness handling.
 	 */
-	public function test_generate_product_slug_preserves_wordpress_collision_handling() {
+	public function test_generate_product_variation_slug_preserves_wordpress_collision_handling() {
 		$product = new WC_Product();
 		$product->set_name( 'Test Product' );
 		$product->save();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #26029.

This improves the generated slug for newly-created product variations when no explicit slug is supplied. Instead of letting WordPress derive every new variation slug from the parent-like generated title, WooCommerce now seeds a stable variation slug from the parent product ID and sorted variation attributes.

This keeps WordPress uniqueness handling in place for true collisions, while avoiding the repeated `wp_unique_post_slug()` collision loop that appears during REST batch variation creation when generated titles collapse to the same value.

Explicit variation slugs are preserved.

### Screenshots or screen recordings:

Not applicable; this is a data-store performance change with no UI changes.

### How to test the changes in this Pull Request:

1. Create a variable product.
2. Create multiple variations without explicitly setting a slug, including variations that use the same parent product and different attribute values.
3. Confirm each variation receives a generated slug that includes the parent product ID and attribute name/value pairs.
4. Create a variation with an explicit slug and confirm the explicit slug is preserved.
5. Create two variations with the same attribute values and confirm WordPress still applies suffix-based uniqueness, e.g. `-2`.

### Testing that has already taken place:

PHP syntax and diff checks passed after rebasing on current `trunk`:

- `php -l includes/data-stores/class-wc-product-variation-data-store-cpt.php`
- `php -l tests/legacy/unit-tests/product/data-store.php`
- `git diff --check origin/trunk...HEAD`
- `git diff --check`

WooCommerce PHPUnit subset passed via WP Codebox/Homeboy lab before the rebase:

- `tests/legacy/unit-tests/product/data-store.php`
- Result: `OK (37 tests, 147 assertions)`

#### Performance and side-effect proof

I used the reusable Homeboy/WP Codebox WooCommerce benchmark rig from https://github.com/chubes4/homeboy-rigs/pull/239.

Both runs below are on top of current `trunk`, which includes the merged transient-coalescing optimization from #65591.

Scenario shape:

- Scenario: `rest-product-batch-import`
- Workload source: `rig`
- Workload SHA: `1f8288d23a9d8827938e7a149a29c8539b8403853a5b9793134ec06f74a88ecd`
- Homeboy WordPress extension SHA: `19cdd6a5`
- Batch size: `25`
- Attributes: `3`
- Terms per attribute: `2`
- Catalog seed products: `0`
- Expanded side-effect scenarios include re-entrant `save_post_product` and shared product/variation data stores.

Run IDs:

| Run | SHA | Persisted run |
| --- | --- | --- |
| Current trunk baseline | `5b05a100380f3474cd9221153e027cc855b6d0be` | `be146054-ab14-41d1-93c8-e464540b87ef` |
| This PR | `73a0bdd8f5706405f95918a8d47b41f0703c3d4a` | `84ba2b57-6097-4f4c-a966-d770f34ce373` |

Query metrics:

| Metric | Current trunk | This PR | Delta |
| --- | ---: | ---: | ---: |
| `variation_create_queries` | 4847 | 4691 | -156 (-3.2%) |
| `variation_create_queries_per_item` | 193.88 | 187.64 | -6.24 |
| `variation_create_profile_slug_lookup_queries` | 450 | 294 | -156 (-34.7%) |
| `variation_create_profile_slug_post_name_collision_check_queries` | 350 | 194 | -156 (-44.6%) |
| `variation_create_profile_slug_post_lookup_queries` | 50 | 50 | 0 |
| `variation_create_transient_clears` | 26 | 26 | 0 |

Side-effect guardrails:

| Guardrail | Current trunk | This PR |
| --- | ---: | ---: |
| `success_rate` | 1 | 1 |
| `side_effect_invariant_failure_count` | 0 | 0 |
| `side_effect_attribute_lookup_missing_rows_after_callbacks` | 0 | 0 |
| `side_effect_variation_create_response_errors` | 0 | 0 |
| `side_effect_variation_created_count` | 25 | 25 |
| `side_effect_variation_loaded_count` | 25 | 25 |
| `side_effect_variation_missing_lookup_rows` | 0 | 0 |
| `side_effect_variation_duplicate_skus` | 0 | 0 |
| `side_effect_variation_duplicate_meta_row_count` | 0 | 0 |
| `side_effect_postmeta_row_delta` | 1075 | 1075 |
| `side_effect_lookup_table_row_delta` | 50 | 50 |
| `side_effect_attribute_lookup_table_row_delta` | 75 | 75 |
| `side_effect_pending_action_count_delta` | 100 | 100 |
| `variation_create_hook_added_post_meta` | 600 | 600 |
| `variation_create_hook_updated_post_meta` | 150 | 150 |
| `variation_create_hook_deleted_post_meta` | 25 | 25 |
| `variation_create_hook_save_post_product_variation` | 50 | 50 |
| `variation_create_hook_clean_post_cache` | 75 | 75 |

A tiny expanded-rig smoke run with 2 items also passed, but the slug collision bucket is too small at that size to show a useful performance signal. The 25-item run above is the slug-sensitive proof.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Reduce variation slug collision queries during batch creation.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (`openai/gpt-5.5`)
- **Used for:** Drafting the data-store slug generation change, regression tests, benchmark analysis, and PR description updates. Chris remains responsible for review and validation.