### PR TITLE
Fix Blocks E2E site editor save panel handling

### DIFF
--- a/plugins/woocommerce/changelog/fix-blocks-site-editor-save-panel
+++ b/plugins/woocommerce/changelog/fix-blocks-site-editor-save-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stabilize Blocks E2E site editor saves when the save panel opens with multiple dirty entities.

--- a/plugins/woocommerce/tests/e2e-pw/utils/blocks/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/blocks/editor/editor-utils.page.ts
@@ -242,8 +242,6 @@ export class Editor extends CoreEditor {
 	 * This extends the upstream `saveSiteEditorEntities` helper to handle cases
 	 * where the save panel opens even when the caller expected only the current
 	 * entity to be dirty.
-	 *
-	 * @see https://github.com/WordPress/gutenberg/issues/69042
 	 */
 	saveSiteEditorEntities = async ( {
 		isOnlyCurrentEntityDirty = false,

--- a/plugins/woocommerce/tests/e2e-pw/utils/blocks/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/blocks/editor/editor-utils.page.ts
@@ -239,9 +239,9 @@ export class Editor extends CoreEditor {
 	}
 
 	/**
-	 * This is to avoid tests failing due to two notices appearing at the same
-	 * time. This is an upstream issue with the `saveSiteEditorEntities` method.
-	 * It should be removed once the upstream issue is fixed.
+	 * This extends the upstream `saveSiteEditorEntities` helper to handle cases
+	 * where the save panel opens even when the caller expected only the current
+	 * entity to be dirty.
 	 *
 	 * @see https://github.com/WordPress/gutenberg/issues/69042
 	 */
@@ -250,19 +250,55 @@ export class Editor extends CoreEditor {
 	}: {
 		isOnlyCurrentEntityDirty?: boolean;
 	} = {} ) => {
-		try {
-			await new CoreEditor( { page: this.page } ).saveSiteEditorEntities(
-				{
-					isOnlyCurrentEntityDirty,
-				}
-			);
-		} catch ( error ) {
-			if (
-				! ( error instanceof Error ) ||
-				! error.message.includes( 'strict mode violation' )
-			) {
-				throw error;
+		const editorTopBar = this.page.getByRole( 'region', {
+			name: 'Editor top bar',
+		} );
+		const saveButton = editorTopBar.getByRole( 'button', {
+			name: 'Save',
+			exact: true,
+		} );
+		const publishButton = editorTopBar.getByRole( 'button', {
+			name: 'Publish',
+		} );
+		const saveNoticeDismissButton = this.page
+			.getByRole( 'button', { name: 'Dismiss this notice' } )
+			.filter( { hasText: /(updated|published)\./ } );
+
+		const staleSaveNoticeCount = await saveNoticeDismissButton.count();
+		for ( let i = 0; i < staleSaveNoticeCount; i++ ) {
+			const staleSaveNotice = saveNoticeDismissButton.first();
+			if ( ! ( await staleSaveNotice.isVisible() ) ) {
+				break;
 			}
+			await staleSaveNotice.click();
 		}
+
+		const buttonToClick = ( await saveButton.isVisible() )
+			? saveButton
+			: publishButton;
+
+		await buttonToClick.click();
+
+		const panelSaveButton = this.page
+			.getByRole( 'region', {
+				name: /(Editor publish|Save panel)/,
+			} )
+			.getByRole( 'button', { name: 'Save', exact: true } );
+		const saveNotice = saveNoticeDismissButton.first();
+
+		if ( isOnlyCurrentEntityDirty ) {
+			await expect(
+				panelSaveButton.or( saveNotice ).first()
+			).toBeVisible();
+		}
+
+		if (
+			! isOnlyCurrentEntityDirty ||
+			( await panelSaveButton.isVisible() )
+		) {
+			await panelSaveButton.click();
+		}
+
+		await expect( saveNotice ).toBeVisible();
 	};
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Stabilizes Woo Blocks E2E site-editor saves after this failure:

https://github.com/woocommerce/woocommerce/actions/runs/27233444162/job/80419320305

The failing artifact showed the save panel still open with 2 site changes waiting to be saved. Some callers pass `isOnlyCurrentEntityDirty: true`; the upstream helper skips the panel Save click in that mode. In these template flows, another entity can also be dirty, so the success notice never appears.

This PR updates the Woo Blocks wrapper to:

- clear existing success notices before starting a new save, so stale notices cannot satisfy the assertion
- click the top-bar Save/Publish button
- click the panel Save button when the save panel appears
- keep asserting the save success notice afterward

A manual changelog entry is included.

### Screenshots or screen recordings:

Not applicable. Test-helper-only change.

### How to test the changes in this Pull Request:

1. Run the Blocks E2E template customization shard or wait for CI.
2. Confirm `template-customization.block_theme.spec.ts` no longer times out waiting for the save success notice when the save panel opens with multiple dirty entities.
3. Confirm the helper still fails if no save panel and no success notice appears.

### Testing that has already taken place:

- `pnpm install --frozen-lockfile`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- E2E-focused review pass against the diff: no fix-now findings after stale-notice handling was added.

I also ran the narrow Blocks E2E TypeScript project check; it reports existing config/type issues outside this helper, and did not flag this touched file.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Manual changelog entry added in this PR.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Dev - Development related task

#### Message

Stabilize Blocks E2E site editor saves when the save panel opens with multiple dirty entities.

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
