### PR TITLE
Log POS feed .htaccess write failures and skip unreadable files

### DIFF
--- a/plugins/woocommerce/changelog/fix-pos-feed-htaccess-write-logging
+++ b/plugins/woocommerce/changelog/fix-pos-feed-htaccess-write-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Log when the POS product feed directory's .htaccess cannot be updated, and avoid overwriting an unreadable or custom file during the legacy upgrade.

--- a/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
@@ -311,18 +311,19 @@ class JsonFileFeed implements FeedInterface {
 	}
 
 	/**
-	 * Ensures an existing feed directory allows file access while preventing directory listing.
+	 * Upgrades a legacy `deny from all` .htaccess in an existing feed directory to allow file access.
 	 *
-	 * Installs created before file access was enabled have a `deny from all` .htaccess in this
-	 * directory, which blocks feed downloads. This replaces only that known legacy directive (or
-	 * recreates a missing file); any other content — the already-correct directive, or custom rules
-	 * a site or host may have added — is left untouched.
+	 * Installs created before file access was enabled have a `deny from all` .htaccess here, which
+	 * blocks feed downloads. This upgrades only that known legacy directive, in place. Anything else
+	 * — an already-correct directive, custom rules a site or host added, a file we cannot read, or a
+	 * missing file — is left untouched. (The directory's initial .htaccess is written when the
+	 * directory is first created, by `mkdir_p_not_indexable()`.)
 	 *
 	 * Native file functions are used here (like the feed writes elsewhere in this class) rather
 	 * than WP_Filesystem: the directory is local, and routing through a possibly FTP/SSH-backed
 	 * filesystem could fail to initialize and leave the old `deny from all` in place even though
-	 * the feed file itself was written natively. Failures are ignored so this can never interrupt
-	 * feed generation.
+	 * the feed file itself was written natively. A failure is ignored (and logged) so it can never
+	 * interrupt feed generation.
 	 *
 	 * @param string $directory_path The feed directory path (trailing-slashed).
 	 * @return void
@@ -330,21 +331,24 @@ class JsonFileFeed implements FeedInterface {
 	private function ensure_feed_dir_file_access( string $directory_path ): void {
 		$htaccess_path = $directory_path . '.htaccess';
 
-		if ( is_file( $htaccess_path ) ) {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-			$current_content = @file_get_contents( $htaccess_path );
-
-			// Only upgrade the known legacy `deny from all` directive. Leave anything else — an
-			// already-correct directive, custom rules, or a file we cannot even read — untouched,
-			// so we never clobber content we did not write.
-			if ( false === $current_content || FilesystemUtil::HTACCESS_DENY_ALL !== trim( $current_content ) ) {
-				return;
-			}
+		// Only act on an existing file. A missing .htaccess does not block downloads, so there is
+		// nothing to fix — and we should not create a file the directory did not already have.
+		if ( ! is_file( $htaccess_path ) ) {
+			return;
 		}
 
-		// Reaching here, the .htaccess is either missing or still holds the legacy `deny from all`,
-		// so (re)create it with the file-access directive. Best effort: a failure must never
-		// interrupt feed generation, but log it — otherwise the feed would silently stay 403.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$current_content = @file_get_contents( $htaccess_path );
+
+		// Upgrade only the known legacy `deny from all` directive. Leave anything else — already
+		// correct, custom rules, or a file we cannot read — untouched, never clobbering content
+		// we did not write.
+		if ( false === $current_content || FilesystemUtil::HTACCESS_DENY_ALL !== trim( $current_content ) ) {
+			return;
+		}
+
+		// Best effort: a failure must never interrupt feed generation, but log it — otherwise the
+		// feed would silently stay 403 behind the stale rule.
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		if ( false === @file_put_contents( $htaccess_path, FilesystemUtil::HTACCESS_ALLOW_FILE_ACCESS ) ) {
 			wc_get_logger()->warning(

--- a/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
@@ -342,8 +342,9 @@ class JsonFileFeed implements FeedInterface {
 			}
 		}
 
-		// Best effort: a failure here must never interrupt feed generation, but log it — otherwise
-		// the generated feed would silently remain unreachable (HTTP 403) behind the stale rule.
+		// Reaching here, the .htaccess is either missing or still holds the legacy `deny from all`,
+		// so (re)create it with the file-access directive. Best effort: a failure must never
+		// interrupt feed generation, but log it — otherwise the feed would silently stay 403.
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		if ( false === @file_put_contents( $htaccess_path, FilesystemUtil::HTACCESS_ALLOW_FILE_ACCESS ) ) {
 			wc_get_logger()->warning(

--- a/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
@@ -330,17 +330,29 @@ class JsonFileFeed implements FeedInterface {
 	private function ensure_feed_dir_file_access( string $directory_path ): void {
 		$htaccess_path = $directory_path . '.htaccess';
 
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$current_content = is_file( $htaccess_path ) ? trim( (string) @file_get_contents( $htaccess_path ) ) : '';
+		if ( is_file( $htaccess_path ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$current_content = @file_get_contents( $htaccess_path );
 
-		// Only upgrade the known legacy `deny from all` directive or recreate a missing file.
-		// Leave anything else (already correct, or custom rules) untouched.
-		if ( '' !== $current_content && FilesystemUtil::HTACCESS_DENY_ALL !== $current_content ) {
-			return;
+			// Only upgrade the known legacy `deny from all` directive. Leave anything else — an
+			// already-correct directive, custom rules, or a file we cannot even read — untouched,
+			// so we never clobber content we did not write.
+			if ( false === $current_content || FilesystemUtil::HTACCESS_DENY_ALL !== trim( $current_content ) ) {
+				return;
+			}
 		}
 
-		// Best effort: a failure here must never interrupt feed generation.
+		// Best effort: a failure here must never interrupt feed generation, but log it — otherwise
+		// the generated feed would silently remain unreachable (HTTP 403) behind the stale rule.
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		@file_put_contents( $htaccess_path, FilesystemUtil::HTACCESS_ALLOW_FILE_ACCESS );
+		if ( false === @file_put_contents( $htaccess_path, FilesystemUtil::HTACCESS_ALLOW_FILE_ACCESS ) ) {
+			wc_get_logger()->warning(
+				'Could not update the product feed .htaccess to allow file access; generated feeds may remain inaccessible.',
+				array(
+					'source' => 'product-feed',
+					'path'   => $htaccess_path,
+				)
+			);
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
@@ -274,10 +274,11 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should create the .htaccess when the feed directory exists without one.
+	 * @testdox Should leave the feed directory alone when it has no .htaccess.
 	 */
-	public function test_existing_feed_dir_without_htaccess_gets_one_created(): void {
+	public function test_existing_feed_dir_without_htaccess_is_left_alone(): void {
 		// Directory exists but its .htaccess is missing (e.g. it was removed) — the is_file() === false case.
+		// A missing file is not a blocked feed, so the refresh must not create one.
 		$directory = wp_upload_dir()['basedir'] . '/product-feeds';
 		wp_mkdir_p( $directory );
 		if ( file_exists( $directory . '/.htaccess' ) ) {
@@ -289,31 +290,51 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 		$feed->end();
 		$feed->get_file_url();
 
-		$this->assertSame(
-			'Options -Indexes',
-			trim( (string) file_get_contents( $directory . '/.htaccess' ) ),
-			'A missing .htaccess in an existing feed directory should be created with file access allowed.'
+		$this->assertFileDoesNotExist(
+			$directory . '/.htaccess',
+			'A missing .htaccess must be left alone, not created by the refresh.'
 		);
 	}
 
 	/**
-	 * @testdox Should log a warning when the feed directory .htaccess cannot be written.
+	 * @testdox Should log a warning when an existing legacy .htaccess cannot be overwritten.
 	 */
 	public function test_logs_warning_when_htaccess_cannot_be_written(): void {
-		// Occupy the .htaccess path with a directory so the write fails, surfacing the log path.
-		$directory = wp_upload_dir()['basedir'] . '/product-feeds';
-		wp_mkdir_p( $directory . '/.htaccess' );
+		// Redirect uploads to a container-local path: wp-env's bind-mounted uploads ignore chmod,
+		// so the read-only legacy file must live where file permissions are actually enforced.
+		$base     = get_temp_dir() . 'wc-feed-perms';
+		$feed_dir = $base . '/product-feeds';
+		$htaccess = $feed_dir . '/.htaccess';
+		mkdir( $feed_dir, 0755, true );
+		file_put_contents( $htaccess, 'deny from all' );
+		chmod( $htaccess, 0444 );
 
-		$feed = new JsonFileFeed( 'test-feed' );
-		$feed->start();
-		$feed->end();
-		$feed->get_file_url();
+		$filter = function ( $dir ) use ( $base ) {
+			$dir['basedir'] = $base;
+			$dir['baseurl'] = 'http://example.test/uploads';
+			$dir['error']   = false;
+			return $dir;
+		};
+		add_filter( 'upload_dir', $filter );
 
-		$this->assertLogged(
-			'warning',
-			'Could not update the product feed .htaccess',
-			array( 'source' => 'product-feed' )
-		);
+		try {
+			$feed = new JsonFileFeed( 'test-feed' );
+			$feed->start();
+			$feed->end();
+			$feed->get_file_url();
+
+			$this->assertLogged(
+				'warning',
+				'Could not update the product feed .htaccess',
+				array( 'source' => 'product-feed' )
+			);
+		} finally {
+			remove_filter( 'upload_dir', $filter );
+			chmod( $htaccess, 0644 );
+			global $wp_filesystem;
+			WP_Filesystem();
+			$wp_filesystem->rmdir( $base, true );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\ProductFeed\Storage;
 
 use Automattic\WooCommerce\Internal\ProductFeed\Storage\JsonFileFeed;
+use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
 
 // This file works directly with local files. That's fine.
 // phpcs:disable WordPress.WP.AlternativeFunctions
@@ -17,6 +18,8 @@ if ( ! function_exists( 'WP_Filesystem' ) ) {
  * JsonFileFeedTest class.
  */
 class JsonFileFeedTest extends \WC_Unit_Test_Case {
+	use LoggerSpyTrait;
+
 	/**
 	 * Clean up test fixtures.
 	 */
@@ -267,6 +270,26 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 			$custom_content,
 			file_get_contents( $directory . '/.htaccess' ),
 			'Custom .htaccess content must be preserved, not overwritten by the refresh.'
+		);
+	}
+
+	/**
+	 * @testdox Should log a warning when the feed directory .htaccess cannot be written.
+	 */
+	public function test_logs_warning_when_htaccess_cannot_be_written(): void {
+		// Occupy the .htaccess path with a directory so the write fails, surfacing the log path.
+		$directory = wp_upload_dir()['basedir'] . '/product-feeds';
+		wp_mkdir_p( $directory . '/.htaccess' );
+
+		$feed = new JsonFileFeed( 'test-feed' );
+		$feed->start();
+		$feed->end();
+		$feed->get_file_url();
+
+		$this->assertLogged(
+			'warning',
+			'Could not update the product feed .htaccess',
+			array( 'source' => 'product-feed' )
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
@@ -274,6 +274,29 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should create the .htaccess when the feed directory exists without one.
+	 */
+	public function test_existing_feed_dir_without_htaccess_gets_one_created(): void {
+		// Directory exists but its .htaccess is missing (e.g. it was removed) — the is_file() === false case.
+		$directory = wp_upload_dir()['basedir'] . '/product-feeds';
+		wp_mkdir_p( $directory );
+		if ( file_exists( $directory . '/.htaccess' ) ) {
+			unlink( $directory . '/.htaccess' );
+		}
+
+		$feed = new JsonFileFeed( 'test-feed' );
+		$feed->start();
+		$feed->end();
+		$feed->get_file_url();
+
+		$this->assertSame(
+			'Options -Indexes',
+			trim( (string) file_get_contents( $directory . '/.htaccess' ) ),
+			'A missing .htaccess in an existing feed directory should be created with file access allowed.'
+		);
+	}
+
+	/**
 	 * @testdox Should log a warning when the feed directory .htaccess cannot be written.
 	 */
 	public function test_logs_warning_when_htaccess_cannot_be_written(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
@@ -302,7 +302,7 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	public function test_logs_warning_when_htaccess_cannot_be_written(): void {
 		// Redirect uploads to a container-local path: wp-env's bind-mounted uploads ignore chmod,
 		// so the read-only legacy file must live where file permissions are actually enforced.
-		$base     = get_temp_dir() . 'wc-feed-perms';
+		$base     = get_temp_dir() . uniqid( 'wc-feed-perms-', true );
 		$feed_dir = $base . '/product-feeds';
 		$htaccess = $feed_dir . '/.htaccess';
 		mkdir( $feed_dir, 0755, true );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up to #65563, addressing the AI regression review in #65620. The in-place `.htaccess` refresh added there discarded the `file_put_contents()` result, so on installs where the legacy `deny from all` file is unwritable, the feed reports `completed` with a URL that 403s and nothing is logged. It also treated an unreadable existing file as empty and overwrote it, which could clobber custom rules.

This change:

1. **Logs a warning** via `wc_get_logger()` (source `product-feed`) when the `.htaccess` write fails, so the otherwise-silent failure is diagnosable.
2. **Only upgrades the known legacy `deny from all` directive** — an already-correct, custom, or unreadable file is now left untouched (a failed read no longer reads as empty-and-overwritten).

Both paths remain best-effort and never interrupt feed generation. `mkdir_p_not_indexable()` is unchanged.

Closes #65620.

Bug introduced in PR #65563.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

In all cases, "trigger feed generation" = as a user with `manage_woocommerce`, `POST /wp-json/wc/pos/v1/catalog/create?force=true`, then let Action Scheduler run `woocommerce_product_feed_generation`.

1. **Custom file preserved:** put custom content in `wp-content/uploads/product-feeds/.htaccess` (e.g. `# custom`), trigger generation, and confirm it is left untouched (only a literal `deny from all` is upgraded to `Options -Indexes`).
2. **Write-failure is logged:** make the `.htaccess` path unwritable (e.g. on macOS, right click on the file to get info and enable "Locked"), trigger generation, and confirm a `warning` is logged ("Could not update the product feed .htaccess…") and generation still completes.

<!-- End testing instructions -->

### Testing that has already taken place:

- @jaclync tested regenerating catalog without any .htaccess file --> the dir remains without .htaccess
- @jaclync tested regenerating catalog with a writtable .htaccess `deny from all` file --> the .htaccess is overwritten and the catalog file becomes accessible
- @jaclync tested regenerating catalog with a locked .htaccess `deny from all` file --> error logged at WC status > logs > product-feed:

<img width="1893" height="479" alt="Screenshot 2026-06-11 at 11 10 23 AM" src="https://github.com/user-attachments/assets/582810e6-c5a6-442f-b957-db398fcd75fd" />


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

A changelog entry is included in this PR, added manually at `plugins/woocommerce/changelog/fix-pos-feed-htaccess-write-logging` (Significance: patch, Type: fix). "Automatically create" is left unchecked so CI does not push a duplicate.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
