### PR TITLE
Fix Product Filters sync across multiple instances

### DIFF
--- a/plugins/woocommerce/changelog/fix-synced-product-filters-instances
+++ b/plugins/woocommerce/changelog/fix-synced-product-filters-instances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Sync active filters across multiple Product Filters blocks on the same page.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/block.json
@@ -15,7 +15,6 @@
 			"enableContrastChecker": false,
 			"button": true
 		},
-		"multiple": false,
 		"inserter": true,
 		"interactivity": true,
 		"typography": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/constants.ts
@@ -1,5 +1,9 @@
+export const PRODUCT_FILTERS_STORE_NAME = 'woocommerce/product-filters';
+export const PRODUCT_FILTERS_STORE_LOCK =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
 export const EXCLUDED_BLOCKS = [
-	'woocommerce/product-filters',
+	PRODUCT_FILTERS_STORE_NAME,
 	'woocommerce/product-filter-attribute',
 	'woocommerce/product-filter-active',
 	'woocommerce/product-filter-price',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -15,10 +15,14 @@ import type {
 	ProductFiltersContext,
 } from './types';
 import { getClosestColor } from './utils/get-closest-color';
+import {
+	PRODUCT_FILTERS_STORE_LOCK,
+	PRODUCT_FILTERS_STORE_NAME,
+} from './constants';
 
 const { getContext, getElement, store, getServerContext, getConfig } = iAPI;
 
-const BLOCK_NAME = 'woocommerce/product-filters';
+const BLOCK_NAME = PRODUCT_FILTERS_STORE_NAME;
 
 type ValidFilterOptionItem = FilterOptionItem & {
 	type: string;
@@ -321,5 +325,6 @@ export type ProductFiltersStore = typeof productFiltersStore;
 
 const { state, actions } = store< ProductFiltersStore >(
 	BLOCK_NAME,
-	productFiltersStore
+	productFiltersStore,
+	{ lock: PRODUCT_FILTERS_STORE_LOCK }
 );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -77,7 +77,6 @@ function unselectFilter( item: ValidFilterOptionItem ) {
 const productFiltersStore = {
 	state: {
 		get params() {
-			const { activeFilters } = getContext< ProductFiltersContext >();
 			const params: Record< string, string > = {};
 
 			function addParam( key: string, value: string ) {
@@ -89,7 +88,7 @@ const productFiltersStore = {
 			const config = getConfig( BLOCK_NAME );
 			const taxonomyParamsMap = config?.taxonomyParamsMap || {};
 
-			activeFilters.forEach( ( filter ) => {
+			state.activeFilters.forEach( ( filter ) => {
 				// todo: refactor this to use params data from Automattic\WooCommerce\Internal\ProductFilters\Params.
 				const { type, value } = filter;
 
@@ -199,7 +198,7 @@ const productFiltersStore = {
 					? itemArg
 					: context.item;
 			if ( ! item || ! isValidFilterOptionItem( item ) ) return;
-			const isSelected = context.activeFilters.some(
+			const isSelected = state.activeFilters.some(
 				( f ) => f.type === item.type && f.value === item.value
 			);
 			if ( isSelected ) {
@@ -301,6 +300,15 @@ const productFiltersStore = {
 			} else {
 				document.body.style.overflow = 'auto';
 			}
+		},
+		syncActiveFiltersWithServer: () => {
+			if ( ! getServerContext ) return;
+			const context = getContext< ProductFiltersContext >();
+			const serverContext = getServerContext< ProductFiltersContext >();
+
+			context.activeFilters = Array.isArray( serverContext.activeFilters )
+				? serverContext.activeFilters.map( ( item ) => ( { ...item } ) )
+				: [];
 		},
 	},
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/frontend.ts
@@ -12,6 +12,10 @@ import type {
 	RemovableItem,
 	RemovableItemsParentStore,
 } from '../../../../types/type-defs/removable-items';
+import {
+	PRODUCT_FILTERS_STORE_LOCK,
+	PRODUCT_FILTERS_STORE_NAME,
+} from '../../constants';
 
 type RemovableItemContext = {
 	item: RemovableItem;
@@ -66,4 +70,6 @@ activeFiltersStore satisfies RemovableItemsParentStore;
 
 const { state, actions } = store<
 	ProductFiltersStore & typeof activeFiltersStore
->( 'woocommerce/product-filters', activeFiltersStore );
+>( PRODUCT_FILTERS_STORE_NAME, activeFiltersStore, {
+	lock: PRODUCT_FILTERS_STORE_LOCK,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/frontend.ts
@@ -24,14 +24,12 @@ type RemovableItemContext = {
 const activeFiltersStore = {
 	state: {
 		get removableItems(): RemovableItem[] {
-			return state.activeFilters
-				.filter( ( f ) => !! f.value )
-				.map( ( f ) => ( {
-					id: f.type + '_' + f.value,
-					type: f.type,
-					value: f.value,
-					label: f.activeLabel,
-				} ) );
+			return state.activeFilters.map( ( f ) => ( {
+				id: f.type + '_' + f.value,
+				type: f.type,
+				value: f.value,
+				label: f.activeLabel,
+			} ) );
 		},
 		get removeItemLabel() {
 			const { item } = getContext< RemovableItemContext >();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/frontend.ts
@@ -19,9 +19,8 @@ type RemovableItemContext = {
 
 const activeFiltersStore = {
 	state: {
-		get removableItems() {
-			const { activeFilters } = getContext< ProductFiltersContext >();
-			return activeFilters
+		get removableItems(): RemovableItem[] {
+			return state.activeFilters
 				.filter( ( f ) => !! f.value )
 				.map( ( f ) => ( {
 					id: f.type + '_' + f.value,
@@ -40,9 +39,8 @@ const activeFiltersStore = {
 			const label = typeof item?.label === 'string' ? item.label : '';
 			return template.replace( '{{label}}', label );
 		},
-		get hasActiveFilters() {
-			const { activeFilters } = getContext< ProductFiltersContext >();
-			return activeFilters.length > 0;
+		get hasActiveFilters(): boolean {
+			return state.activeFilters.length > 0;
 		},
 	},
 	actions: {
@@ -66,7 +64,6 @@ const activeFiltersStore = {
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 activeFiltersStore satisfies RemovableItemsParentStore;
 
-const { actions } = store< ProductFiltersStore & typeof activeFiltersStore >(
-	'woocommerce/product-filters',
-	activeFiltersStore
-);
+const { state, actions } = store<
+	ProductFiltersStore & typeof activeFiltersStore
+>( 'woocommerce/product-filters', activeFiltersStore );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/frontend.ts
@@ -15,6 +15,10 @@ import {
 	isVisualAttributeTermEmpty,
 } from '../../../../base/utils/visual-attribute-terms';
 import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
+import {
+	PRODUCT_FILTERS_STORE_LOCK,
+	PRODUCT_FILTERS_STORE_NAME,
+} from '../../constants';
 
 type CheckboxListItem = SelectableItem< {
 	visual?: VisualAttributeTerm;
@@ -44,6 +48,11 @@ type CheckboxListStore = {
 
 function getParentStore( storeNamespace?: string ) {
 	if ( ! storeNamespace ) return undefined;
+	if ( storeNamespace === PRODUCT_FILTERS_STORE_NAME ) {
+		return store<
+			SelectableItemsParentStore< { visual?: VisualAttributeTerm } >
+		>( storeNamespace, undefined, { lock: PRODUCT_FILTERS_STORE_LOCK } );
+	}
 	return store<
 		SelectableItemsParentStore< { visual?: VisualAttributeTerm } >
 	>( storeNamespace );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/frontend.ts
@@ -16,6 +16,10 @@ import {
 } from '../../../../base/utils/visual-attribute-terms';
 import type { VisualAttributeTerm } from '../../../../base/utils/visual-attribute-terms';
 import { getClosestColor } from '../../utils/get-closest-color';
+import {
+	PRODUCT_FILTERS_STORE_LOCK,
+	PRODUCT_FILTERS_STORE_NAME,
+} from '../../constants';
 
 type ChipsItem = SelectableItem< {
 	visual?: VisualAttributeTerm;
@@ -49,6 +53,11 @@ type ChipsStore = {
 
 function getParentStore( storeNamespace?: string ) {
 	if ( ! storeNamespace ) return undefined;
+	if ( storeNamespace === PRODUCT_FILTERS_STORE_NAME ) {
+		return store<
+			SelectableItemsParentStore< { visual?: VisualAttributeTerm } >
+		>( storeNamespace, undefined, { lock: PRODUCT_FILTERS_STORE_LOCK } );
+	}
 	return store<
 		SelectableItemsParentStore< { visual?: VisualAttributeTerm } >
 	>( storeNamespace );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/frontend.ts
@@ -25,12 +25,11 @@ export type ProductFilterPriceContext = {
 
 const productFilterPriceStore = {
 	state: {
-		get minPrice() {
-			const { activeFilters } = getContext< ProductFiltersContext >();
+		get minPrice(): number {
 			const { minRange } = getServerContext
 				? getServerContext< ProductFilterPriceContext >()
 				: getContext< ProductFilterPriceContext >();
-			const priceFilter = activeFilters.find(
+			const priceFilter = state.activeFilters.find(
 				( filter ) => filter.type === 'price'
 			);
 			if ( priceFilter ) {
@@ -39,12 +38,11 @@ const productFilterPriceStore = {
 			}
 			return minRange;
 		},
-		get maxPrice() {
-			const { activeFilters } = getContext< ProductFiltersContext >();
+		get maxPrice(): number {
 			const { maxRange } = getServerContext
 				? getServerContext< ProductFilterPriceContext >()
 				: getContext< ProductFilterPriceContext >();
-			const priceFilter = activeFilters.find(
+			const priceFilter = state.activeFilters.find(
 				( filter ) => filter.type === 'price'
 			);
 			if ( priceFilter ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/frontend.ts
@@ -11,6 +11,10 @@ import type { ProductFiltersContext } from '../../types';
 import type { ProductFiltersStore } from '../../frontend';
 import { formatPrice, getCurrency } from '../../utils/price-currency';
 import type { RangeInputParentStore } from '../../../../types/type-defs/range-input';
+import {
+	PRODUCT_FILTERS_STORE_LOCK,
+	PRODUCT_FILTERS_STORE_NAME,
+} from '../../constants';
 
 const { store, getContext, getServerContext, getConfig } = iAPI;
 
@@ -179,4 +183,6 @@ export type ProductFilterPriceStore = typeof productFilterPriceStore;
 
 const { state, actions } = store<
 	ProductFiltersStore & ProductFilterPriceStore
->( 'woocommerce/product-filters', productFilterPriceStore );
+>( PRODUCT_FILTERS_STORE_NAME, productFilterPriceStore, {
+	lock: PRODUCT_FILTERS_STORE_LOCK,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/frontend.ts
@@ -12,6 +12,10 @@ import type {
 	ProductFilterPriceContext,
 	ProductFilterPriceStore,
 } from '../price-filter/frontend';
+import {
+	PRODUCT_FILTERS_STORE_LOCK,
+	PRODUCT_FILTERS_STORE_NAME,
+} from '../../constants';
 
 const { store, getContext, getElement, withScope, getServerContext } = iAPI;
 
@@ -73,4 +77,6 @@ const { state, actions } = store<
 	ProductFiltersStore &
 		ProductFilterPriceStore &
 		typeof productFilterPriceSliderStore
->( 'woocommerce/product-filters', productFilterPriceSliderStore );
+>( PRODUCT_FILTERS_STORE_NAME, productFilterPriceSliderStore, {
+	lock: PRODUCT_FILTERS_STORE_LOCK,
+} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/content-templates/template_archive-product_multiple-product-filters.handlebars
+++ b/plugins/woocommerce/client/blocks/tests/e2e/content-templates/template_archive-product_multiple-product-filters.handlebars
@@ -1,0 +1,42 @@
+<!-- wp:woocommerce/product-filters -->
+<div class="wp-block-woocommerce-product-filters wc-block-product-filters" style="--wc-product-filters-text-color:#111;--wc-product-filters-background-color:#fff">
+	<!-- wp:woocommerce/product-filter-active -->
+	<div class="wp-block-woocommerce-product-filter-active">
+		<!-- wp:woocommerce/product-filter-removable-chips {"lock":{"remove":true}} -->
+		<div class="wp-block-woocommerce-product-filter-removable-chips wc-block-product-filter-removable-chips"></div>
+		<!-- /wp:woocommerce/product-filter-removable-chips -->
+	</div>
+	<!-- /wp:woocommerce/product-filter-active -->
+</div>
+<!-- /wp:woocommerce/product-filters -->
+
+<!-- wp:woocommerce/product-filters -->
+<div class="wp-block-woocommerce-product-filters wc-block-product-filters" style="--wc-product-filters-text-color:#111;--wc-product-filters-background-color:#fff">
+{{#> wp-block blockName='woocommerce/product-filter-attribute' attributes=attributes }}
+<div class="wp-block-woocommerce-product-filter-attribute"><!-- wp:group {"metadata":{"name":"Header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Attribute</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:woocommerce/product-filter-checkbox-list {"lock":{"remove":true}} -->
+<div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
+<!-- /wp:woocommerce/product-filter-checkbox-list --></div>
+{{/ wp-block }}
+</div>
+<!-- /wp:woocommerce/product-filters -->
+
+<!-- wp:woocommerce/product-collection {"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":true,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"queryContextIncludes":["collection"]} -->
+<div class="wp-block-woocommerce-product-collection">
+	<!-- wp:woocommerce/product-template -->
+	<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+		<!-- wp:woocommerce/product-sale-badge {"isDescendentOfQueryLoop":true,"align":"right"} /-->
+	<!-- /wp:woocommerce/product-image -->
+	<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+	<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+
+	<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
+	<!-- /wp:woocommerce/product-template -->
+</div>
+<!-- /wp:woocommerce/product-collection -->

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/product-filters-frontend.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/product-filters-frontend.block_theme.spec.ts
@@ -117,4 +117,71 @@ test.describe( 'woocommerce/product-filters - Frontend', () => {
 			await expect( products ).toHaveCount( 2 );
 		} );
 	} );
+
+	test.describe( 'Multiple instances', () => {
+		test.beforeEach( async ( { page } ) => {
+			await page.addInitScript( () => {
+				// Mock the wc global variable.
+				if ( typeof window.wc === 'undefined' ) {
+					window.wc = {
+						wcSettings: {
+							getSetting() {
+								return true;
+							},
+						},
+					};
+				}
+			} );
+		} );
+
+		test( 'syncs active filters between Product Filters blocks', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const templateCompiler = await requestUtils.createTemplateFromFile(
+				'archive-product_multiple-product-filters'
+			);
+
+			await templateCompiler.compile( {
+				attributes: {
+					attributeId: 1,
+				},
+			} );
+
+			await page.goto( '/shop' );
+
+			const productFilters = page.locator(
+				'.wp-block-woocommerce-product-filters'
+			);
+			await expect( productFilters ).toHaveCount( 2 );
+
+			const activeFiltersBlock = productFilters.first();
+			const filterOptionsBlock = productFilters.nth( 1 );
+			const grayCheckbox = filterOptionsBlock.getByRole( 'checkbox', {
+				name: 'Gray',
+			} );
+			const grayActiveFilter =
+				activeFiltersBlock.getByText( 'Color: Gray' );
+
+			await expect( grayActiveFilter ).toBeHidden();
+
+			await grayCheckbox.click();
+			await page.waitForURL( /.*filter_color=gray.*/ );
+
+			await expect( grayActiveFilter ).toBeVisible();
+			await expect( grayCheckbox ).toBeChecked();
+
+			await activeFiltersBlock
+				.getByRole( 'button', {
+					name: 'Remove filter: Color: Gray',
+				} )
+				.click();
+			await page.waitForURL(
+				( url ) => ! url.searchParams.has( 'filter_color' )
+			);
+
+			await expect( grayActiveFilter ).toBeHidden();
+			await expect( grayCheckbox ).not.toBeChecked();
+		} );
+	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/product-filters-frontend.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/product-filters-frontend.block_theme.spec.ts
@@ -160,13 +160,17 @@ test.describe( 'woocommerce/product-filters - Frontend', () => {
 			const grayCheckbox = filterOptionsBlock.getByRole( 'checkbox', {
 				name: 'Gray',
 			} );
-			const grayActiveFilter =
-				activeFiltersBlock.getByText( 'Color: Gray' );
+			const grayActiveFilter = activeFiltersBlock.getByText(
+				'Color: Gray',
+				{ exact: true }
+			);
 
 			await expect( grayActiveFilter ).toBeHidden();
 
 			await grayCheckbox.click();
-			await page.waitForURL( /.*filter_color=gray.*/ );
+			await page.waitForURL(
+				( url ) => url.searchParams.get( 'filter_color' ) === 'gray'
+			);
 
 			await expect( grayActiveFilter ).toBeVisible();
 			await expect( grayCheckbox ).toBeChecked();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -116,6 +116,7 @@ class ProductFilters extends AbstractBlock {
 			'data-wp-interactive'              => $this->get_full_block_name(),
 			'data-wp-init--colors'             => 'callbacks.initColors',
 			'data-wp-watch--scrolling'         => 'callbacks.scrollLimit',
+			'data-wp-watch--active-filters'    => 'callbacks.syncActiveFiltersWithServer',
 			'data-wp-on--keyup'                => 'actions.closeOverlayOnEscape',
 			'data-wp-context'                  => (string) wp_json_encode( $interactivity_context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
 			'data-wp-class--is-overlay-opened' => 'context.isOverlayOpened',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the usage of state vs context in the Product Filters block with this general rules of thumb:

-   For state/actions display the data, use derived `activeFilters` state.
-   For ones mutating the data, use context.

This also adds a callback to synced the state between multiple instance of Product Filters mentioned in #56877.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56877.
Fixes WOOPLUG-3709.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->



https://github.com/user-attachments/assets/25ed9331-0f3d-43ae-8654-76432955fe04


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a Shop template with two Product Filters blocks containing identical filter content.
2. Visit the shop frontend.
3. Select a filter in one Product Filters block.
4. Confirm the active/selected filter state is synced in the other Product Filters block after navigation.
5. Remove the active filter from either Product Filters block.
6. Confirm the active/selected filter state is cleared in both Product Filters blocks after navigation.

A realistic layout is to place one Product Filters block above the Product Collection with only Active Filters, and another Product Filters block in a sidebar with the selectable filter options.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Sync active filters across multiple Product Filters blocks on the same page.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

-   [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
-   [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

-   Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

-   Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>
