### PR TITLE
Fix Product Collection context inside Query Loop

### DIFF
--- a/plugins/woocommerce/changelog/65637-wooplug-4673-product-collection-block-several-inner-blocks-dont-work
+++ b/plugins/woocommerce/changelog/65637-wooplug-4673-product-collection-block-several-inner-blocks-dont-work
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Product Collection inner blocks when rendered inside Query Loop post content.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
@@ -93,28 +93,29 @@ class ProductTemplate extends AbstractBlock {
 			// Get an instance of the current Post Template block.
 			$block_instance = $block->parsed_block;
 			$product_id     = (int) get_the_ID();
+			$post_type      = get_post_type();
 
 			// Set the block name to one that does not correspond to an existing registered block.
 			// This ensures that for the inner instances of the Post Template block, we do not render any block supports.
 			$block_instance['blockName'] = 'core/null';
 
-			// Relay the block context to the inner blocks.
-			$available_context = array_merge(
-				(array) $block->context,
-				array(
-					'postType' => get_post_type(),
-					'postId'   => $product_id,
-				)
-			);
+			$filter_block_context = static function ( $context ) use ( $product_id, $post_type ) {
+				$context['postType'] = $post_type;
+				$context['postId']   = $product_id;
+				return $context;
+			};
 
+			// Use an early priority so that other 'render_block_context' filters have access to the values.
+			add_filter( 'render_block_context', $filter_block_context, 1 );
 			// Render the inner blocks of the Post Template block with `dynamic` set to `false` to prevent calling
 			// `render_callback` and ensure that no wrapper markup is included.
 			$block_content = (
 				new WP_Block(
 					$block_instance,
-					$available_context
+					$block->context
 				)
 			)->render( array( 'dynamic' => false ) );
+			remove_filter( 'render_block_context', $filter_block_context, 1 );
 
 			// Load product into the shared products store.
 			wc_interactivity_api_load_product(

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductTemplateTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Product Template block type.
+ */
+class ProductTemplateTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Renders a Product Collection inside a Query Loop post content block.
+	 *
+	 * @param int $product_id Product ID.
+	 * @param int $author_id  Outer post author ID.
+	 * @return string Rendered block markup.
+	 */
+	private function render_product_collection_inside_query_loop( int $product_id, int $author_id ): string {
+		$product_collection = $this->get_product_collection_markup( $product_id );
+		$post_id            = self::factory()->post->create(
+			array(
+				'post_author'  => $author_id,
+				'post_title'   => 'Post containing Product Collection',
+				'post_content' => $product_collection,
+			)
+		);
+
+		$query_loop = sprintf(
+			'<!-- wp:query {"query":{"perPage":1,"postType":"post","order":"desc","orderBy":"date","author":"%1$d","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<div class="wp-block-query"><!-- wp:post-template --><!-- wp:post-content /--><!-- /wp:post-template --></div>
+<!-- /wp:query -->',
+			$author_id
+		);
+
+		try {
+			return do_blocks( $query_loop );
+		} finally {
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	/**
+	 * Gets Product Collection block markup for a hand-picked product.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return string Product Collection block markup.
+	 */
+	private function get_product_collection_markup( int $product_id ): string {
+		$attributes = array(
+			'queryId'    => 0,
+			'query'      => array(
+				'perPage'                       => 1,
+				'pages'                         => 1,
+				'offset'                        => 0,
+				'postType'                      => 'product',
+				'order'                         => 'asc',
+				'orderBy'                       => 'post__in',
+				'search'                        => '',
+				'exclude'                       => array(),
+				'inherit'                       => false,
+				'taxQuery'                      => array(),
+				'isProductCollectionBlock'      => true,
+				'featured'                      => false,
+				'woocommerceOnSale'             => false,
+				'woocommerceStockStatus'        => array( 'instock' ),
+				'woocommerceAttributes'         => array(),
+				'woocommerceHandPickedProducts' => array( $product_id ),
+				'filterable'                    => false,
+			),
+			'collection' => 'woocommerce/product-collection/hand-picked',
+		);
+
+		return sprintf(
+			'<!-- wp:woocommerce/product-collection %1$s -->
+<div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
+<!-- wp:woocommerce/product-image /-->
+<!-- wp:woocommerce/product-price /-->
+<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-collection -->',
+			wp_json_encode( $attributes )
+		);
+	}
+
+	/**
+	 * @testdox Should preserve product context when rendered inside a Query Loop post content block.
+	 */
+	public function test_preserves_product_context_inside_query_loop_post_content(): void {
+		$product   = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 25,
+				'price'         => 25,
+			)
+		);
+		$author_id = self::factory()->user->create();
+
+		try {
+			$markup = $this->render_product_collection_inside_query_loop( $product->get_id(), $author_id );
+
+			$this->assertStringContainsString( 'wc-block-components-product-image', $markup, 'Product image should render using product context.' );
+			$this->assertStringContainsString( 'wc-block-components-product-price', $markup, 'Product price should render using product context.' );
+		} finally {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Following Core Query Loop block approach, this PR uses filter to forcing the context for Product Collection items to be the correct product id and type. We need to use the filter because if we don't, Query Loop context will override them.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58931.

(For Bug Fixes) Bug introduced in PR # .

Bug-introducing PR unknown.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

No UI changes.

| Before | After |
| ------ | ----- |
|        |       |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create and publish a post containing a Product Collection block with Product Image, Product Title, and Product Price inner blocks.
2. Create and publish a page containing a Query Loop block that queries posts and renders the Content block inside the Post Template.
3. Open the page on the frontend and verify the Product Collection inside the queried post content renders product images and prices.
4. Verify Product Title links point to product pages, not the Query Loop page or queried post.
5. Open the original post directly and verify the Product Collection still renders correctly.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Product Collection inner blocks when rendered inside Query Loop post content.

</details>

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

-   [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
-   [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

-   Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

-   Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>
