### PR TITLE
Replace PanelBody with ToolsPanel in Attribute Filter inspector controls

### DIFF
--- a/plugins/woocommerce/changelog/fix-59464-use-toolspanel-in-attribute-filter
+++ b/plugins/woocommerce/changelog/fix-59464-use-toolspanel-in-attribute-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace PanelBody with ToolsPanel in Attribute Filter inspector controls.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/edit.tsx
@@ -29,6 +29,10 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
 /**
@@ -179,123 +183,198 @@ const Edit = ( {
 				<PanelBody>
 					<UpgradeNotice clientId={ clientId } />
 				</PanelBody>
-				<PanelBody title={ __( 'Display Settings', 'woocommerce' ) }>
-					<ToggleControl
+				<ToolsPanel
+					label={ __( 'Display Settings', 'woocommerce' ) }
+					resetAll={ () =>
+						setAttributes( {
+							showCounts: false,
+							selectType: 'multiple',
+							queryType: 'or',
+							displayStyle: 'list',
+							showFilterButton: false,
+						} )
+					}
+				>
+					<ToolsPanelItem
 						label={ __( 'Display product count', 'woocommerce' ) }
-						checked={ showCounts }
-						onChange={ () =>
-							setAttributes( {
-								showCounts: ! showCounts,
-							} )
+						hasValue={ () => showCounts !== false }
+						onDeselect={ () =>
+							setAttributes( { showCounts: false } )
 						}
-					/>
-					<ToggleGroupControl
+						isShownByDefault
+					>
+						<ToggleControl
+							label={ __(
+								'Display product count',
+								'woocommerce'
+							) }
+							checked={ showCounts }
+							onChange={ () =>
+								setAttributes( {
+									showCounts: ! showCounts,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
 						label={ __(
 							'Allow selecting multiple options?',
 							'woocommerce'
 						) }
-						isBlock
-						value={ selectType || 'multiple' }
-						onChange={ ( value: string ) =>
-							setAttributes( {
-								selectType: value,
-							} )
+						hasValue={ () => selectType !== 'multiple' }
+						onDeselect={ () =>
+							setAttributes( { selectType: 'multiple' } )
 						}
-						className="wc-block-attribute-filter__multiple-toggle"
+						isShownByDefault
 					>
-						<ToggleGroupControlOption
-							value="multiple"
-							label={ _x(
-								'Multiple',
-								'Number of filters',
-								'woocommerce'
-							) }
-						/>
-						<ToggleGroupControlOption
-							value="single"
-							label={ _x(
-								'Single',
-								'Number of filters',
-								'woocommerce'
-							) }
-						/>
-					</ToggleGroupControl>
-					{ selectType === 'multiple' && (
 						<ToggleGroupControl
-							label={ __( 'Filter Conditions', 'woocommerce' ) }
+							label={ __(
+								'Allow selecting multiple options?',
+								'woocommerce'
+							) }
 							isBlock
-							help={
-								queryType === 'and'
-									? __(
-											'Choose to return filter results for all of the attributes selected.',
-											'woocommerce'
-									  )
-									: __(
-											'Choose to return filter results for any of the attributes selected.',
-											'woocommerce'
-									  )
-							}
-							value={ queryType }
+							value={ selectType || 'multiple' }
 							onChange={ ( value: string ) =>
 								setAttributes( {
-									queryType: value,
+									selectType: value,
 								} )
 							}
-							className="wc-block-attribute-filter__conditions-toggle"
+							className="wc-block-attribute-filter__multiple-toggle"
 						>
 							<ToggleGroupControlOption
-								value="or"
-								label={ __( 'Any', 'woocommerce' ) }
+								value="multiple"
+								label={ _x(
+									'Multiple',
+									'Number of filters',
+									'woocommerce'
+								) }
 							/>
 							<ToggleGroupControlOption
-								value="and"
-								label={ __( 'All', 'woocommerce' ) }
+								value="single"
+								label={ _x(
+									'Single',
+									'Number of filters',
+									'woocommerce'
+								) }
 							/>
 						</ToggleGroupControl>
+					</ToolsPanelItem>
+					{ selectType === 'multiple' && (
+						<ToolsPanelItem
+							label={ __( 'Filter Conditions', 'woocommerce' ) }
+							hasValue={ () => queryType !== 'or' }
+							onDeselect={ () =>
+								setAttributes( { queryType: 'or' } )
+							}
+							isShownByDefault
+						>
+							<ToggleGroupControl
+								label={ __(
+									'Filter Conditions',
+									'woocommerce'
+								) }
+								isBlock
+								help={
+									queryType === 'and'
+										? __(
+												'Choose to return filter results for all of the attributes selected.',
+												'woocommerce'
+										  )
+										: __(
+												'Choose to return filter results for any of the attributes selected.',
+												'woocommerce'
+										  )
+								}
+								value={ queryType }
+								onChange={ ( value: string ) =>
+									setAttributes( {
+										queryType: value,
+									} )
+								}
+								className="wc-block-attribute-filter__conditions-toggle"
+							>
+								<ToggleGroupControlOption
+									value="or"
+									label={ __( 'Any', 'woocommerce' ) }
+								/>
+								<ToggleGroupControlOption
+									value="and"
+									label={ __( 'All', 'woocommerce' ) }
+								/>
+							</ToggleGroupControl>
+						</ToolsPanelItem>
 					) }
-					<ToggleGroupControl
+					<ToolsPanelItem
 						label={ __( 'Display Style', 'woocommerce' ) }
-						isBlock
-						value={ displayStyle }
-						onChange={ ( value: string ) =>
-							setAttributes( {
-								displayStyle: value,
-							} )
+						hasValue={ () => displayStyle !== 'list' }
+						onDeselect={ () =>
+							setAttributes( { displayStyle: 'list' } )
 						}
-						className="wc-block-attribute-filter__display-toggle"
+						isShownByDefault
 					>
-						<ToggleGroupControlOption
-							value="list"
-							label={ __( 'List', 'woocommerce' ) }
-						/>
-						<ToggleGroupControlOption
-							value="dropdown"
-							label={ __( 'Dropdown', 'woocommerce' ) }
-						/>
-					</ToggleGroupControl>
-					<ToggleControl
+						<ToggleGroupControl
+							label={ __( 'Display Style', 'woocommerce' ) }
+							isBlock
+							value={ displayStyle }
+							onChange={ ( value: string ) =>
+								setAttributes( {
+									displayStyle: value,
+								} )
+							}
+							className="wc-block-attribute-filter__display-toggle"
+						>
+							<ToggleGroupControlOption
+								value="list"
+								label={ __( 'List', 'woocommerce' ) }
+							/>
+							<ToggleGroupControlOption
+								value="dropdown"
+								label={ __( 'Dropdown', 'woocommerce' ) }
+							/>
+						</ToggleGroupControl>
+					</ToolsPanelItem>
+					<ToolsPanelItem
 						label={ __(
 							"Show 'Apply filters' button",
 							'woocommerce'
 						) }
-						help={ __(
-							'Products will update when the button is clicked.',
-							'woocommerce'
-						) }
-						checked={ showFilterButton }
-						onChange={ ( value ) =>
-							setAttributes( {
-								showFilterButton: value,
-							} )
+						hasValue={ () => showFilterButton !== false }
+						onDeselect={ () =>
+							setAttributes( { showFilterButton: false } )
 						}
-					/>
-				</PanelBody>
-				<PanelBody
-					title={ __( 'Content Settings', 'woocommerce' ) }
-					initialOpen={ false }
+						isShownByDefault
+					>
+						<ToggleControl
+							label={ __(
+								"Show 'Apply filters' button",
+								'woocommerce'
+							) }
+							help={ __(
+								'Products will update when the button is clicked.',
+								'woocommerce'
+							) }
+							checked={ showFilterButton }
+							onChange={ ( value ) =>
+								setAttributes( {
+									showFilterButton: value,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Content Settings', 'woocommerce' ) }
+					resetAll={ () => setAttributes( { attributeId: 0 } ) }
 				>
-					{ renderAttributeControl( { isCompact: true } ) }
-				</PanelBody>
+					<ToolsPanelItem
+						label={ __( 'Attribute', 'woocommerce' ) }
+						hasValue={ () => attributeId !== 0 }
+						onDeselect={ () => setAttributes( { attributeId: 0 } ) }
+						isShownByDefault
+					>
+						{ renderAttributeControl( { isCompact: true } ) }
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 		);
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Replaces the `PanelBody` panels in `attribute-filter/edit.tsx` with `ToolsPanel` and `ToolsPanelItem`:

- **Display Settings** panel: `showCounts`, `selectType`, `queryType` (conditional — only shown when `selectType === 'multiple'`), `displayStyle`, `showFilterButton` are each wrapped in individual `ToolsPanelItem`s with proper `hasValue`, `onDeselect`, and `resetAll` support.
- **Content Settings** panel: `renderAttributeControl` wrapped in a single `ToolsPanelItem`.
- The bare `PanelBody` wrapping `<UpgradeNotice>` is intentionally left unchanged as it is informational only (no user settings).

Part of #59464 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="285" height="1056" alt="Screenshot 2026-06-11 at 6 03 34 PM" src="https://github.com/user-attachments/assets/d602f971-8a56-481c-a3f7-46ef30fa84c4" /> | <img width="283" height="1031" alt="Screenshot 2026-06-11 at 6 05 04 PM" src="https://github.com/user-attachments/assets/44bc5568-65fd-4e1b-84a2-bffe490afb74" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add the **Filter by Attribute Controls** block to a page via the Code Editor:
```html
<!-- wp:woocommerce/filter-wrapper {"filterType":"attribute-filter","heading":"Filter by attribute"} -->
<div class="wp-block-woocommerce-filter-wrapper"><!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Filter by attribute</h3>
<!-- /wp:heading -->
<!-- wp:woocommerce/attribute-filter {"heading":"","lock":{"remove":true}} -->
<div class="wp-block-woocommerce-attribute-filter is-loading"></div>
<!-- /wp:woocommerce/attribute-filter --></div>
<!-- /wp:woocommerce/filter-wrapper -->
```
2. Switch back to Visual editor and click the inner **Filter by Attribute Controls** block.
3. Open the **Inspector Controls** sidebar (right panel).
4. Verify the "Display Settings" section renders as a `ToolsPanel` with a "Reset all" option.
5. Verify the "Content Settings" section renders as a second `ToolsPanel`.
6. Set "Allow selecting multiple options?" to "Multiple" — verify the "Filter Conditions" item appears.
7. Set it to "Single" — verify "Filter Conditions" disappears.
8. Toggle individual items off — verify their values reset to defaults (`showCounts: false`, `selectType: "multiple"`, `queryType: "or"`, `displayStyle: "list"`, `showFilterButton: false`).
9. Change multiple settings, then click "Reset all" — verify all attributes in that panel return to defaults.
10. Save the page and reload — verify settings are persisted correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested locally with `wp-env`. Verified both `ToolsPanel`s render correctly, individual `ToolsPanelItem` toggles work, the conditional "Filter Conditions" item shows/hides based on `selectType`, deselect resets to defaults, and "Reset all" resets all attributes. Lint passes clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
