### PR TITLE
Fix Block Checkout country change not persisting to the session (#62728)

### DIFF
--- a/plugins/woocommerce/changelog/62728-fix-block-checkout-country-change-session-persistence
+++ b/plugins/woocommerce/changelog/62728-fix-block-checkout-country-change-session-persistence
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Block Checkout: persist valid address fields (e.g. country) to the WC session when a country change auto-blanks state/postcode, instead of aborting the entire push because those fields temporarily fail validation.

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/push-changes.ts
@@ -14,7 +14,12 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  */
 import { store as cartStore } from './index';
 import { processErrorResponse } from '../utils';
-import { getDirtyKeys, validateDirtyProps, BaseAddressKey } from './utils';
+import {
+	getDirtyKeys,
+	validateDirtyProps,
+	filterValidDirtyProps,
+	BaseAddressKey,
+} from './utils';
 
 // This is used to track and cache the local state of push changes.
 const localState = {
@@ -130,33 +135,81 @@ const updateCustomerData = (): void => {
 		return;
 	}
 
-	// Check props are valid, or abort.
-	if ( ! validateDirtyProps( localState.dirtyProps ) ) {
+	// Determine which dirty props to actually push. When all dirty props are
+	// valid, push the full address objects (existing behaviour). When some are
+	// invalid (e.g. state/postcode blanked after a country change), push only
+	// the valid subset so the country persists to the WC session while the
+	// still-empty required fields are withheld until the user fills them in.
+	const allPropsValid = validateDirtyProps( localState.dirtyProps );
+	const propsToPush = allPropsValid
+		? localState.dirtyProps
+		: filterValidDirtyProps( localState.dirtyProps );
+
+	const hasBillingToPush = propsToPush.billingAddress.length > 0;
+	const hasShippingToPush = propsToPush.shippingAddress.length > 0;
+
+	// Nothing valid to push — every dirty prop has a validation error.
+	if ( ! hasBillingToPush && ! hasShippingToPush ) {
 		localState.doingPush = false;
 		return;
 	}
 
 	const haveAddressFieldsForShippingRatesChanged =
-		localState.dirtyProps.shippingAddress.some( ( field ) =>
+		propsToPush.shippingAddress.some( ( field ) =>
 			addressFieldsForShippingRates.includes( field as string )
 		);
+
+	// When all props are valid, send the full cached address (existing
+	// behaviour). When filtering, send only the valid dirty fields so that
+	// temporarily-blanked values are not pushed to the server.
+	const billingPayload = allPropsValid
+		? localState.customerData.billingAddress
+		: ( Object.fromEntries(
+				propsToPush.billingAddress.map( ( key ) => [
+					key,
+					localState.customerData.billingAddress[ key ],
+				] )
+		  ) as CartBillingAddress );
+
+	const shippingPayload = allPropsValid
+		? localState.customerData.shippingAddress
+		: ( Object.fromEntries(
+				propsToPush.shippingAddress.map( ( key ) => [
+					key,
+					localState.customerData.shippingAddress[ key ],
+				] )
+		  ) as CartShippingAddress );
 
 	dispatch( cartStore )
 		.updateCustomerData(
 			{
-				...( isBillingAddressDirty && {
-					billing_address: localState.customerData.billingAddress,
+				...( hasBillingToPush && {
+					billing_address: billingPayload,
 				} ),
-				...( isShippingAddressDirty && {
-					shipping_address: localState.customerData.shippingAddress,
+				...( hasShippingToPush && {
+					shipping_address: shippingPayload,
 				} ),
 			},
 			true,
 			haveAddressFieldsForShippingRatesChanged
 		)
 		.then( () => {
-			localState.dirtyProps.billingAddress = [];
-			localState.dirtyProps.shippingAddress = [];
+			// When only a subset was pushed, keep the invalid (unpushed) props
+			// dirty so they are retried on the next push once filled in.
+			if ( allPropsValid ) {
+				localState.dirtyProps.billingAddress = [];
+				localState.dirtyProps.shippingAddress = [];
+			} else {
+				localState.dirtyProps.billingAddress =
+					localState.dirtyProps.billingAddress.filter(
+						( key ) => ! propsToPush.billingAddress.includes( key )
+					);
+				localState.dirtyProps.shippingAddress =
+					localState.dirtyProps.shippingAddress.filter(
+						( key ) =>
+							! propsToPush.shippingAddress.includes( key )
+					);
+			}
 			localState.doingPush = false;
 		} )
 		.catch( ( response ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/push-changes.ts
@@ -10,6 +10,7 @@ import { cartStore, validationStore } from '@woocommerce/block-data';
 import { pushChanges } from '../push-changes';
 
 let updateCustomerDataMock = jest.fn();
+let getValidationErrorMock = jest.fn().mockReturnValue( undefined );
 let getCustomerDataMock = jest.fn().mockReturnValue( {
 	billingAddress: {
 		first_name: 'John',
@@ -67,6 +68,7 @@ async function resetToInitialAddressMock() {
 	pushChanges( false );
 	updateCustomerDataMock.mockReset();
 	updateCustomerDataMock.mockResolvedValue( jest.fn() );
+	getValidationErrorMock = jest.fn().mockReturnValue( undefined );
 
 	getCustomerDataMock = jest.fn().mockReturnValue( {
 		billingAddress: {
@@ -114,9 +116,7 @@ describe( 'pushChanges', () => {
 						...jest
 							.requireActual( '@wordpress/data' )
 							.select( storeNameOrDescriptor ),
-						getValidationError: jest
-							.fn()
-							.mockReturnValue( undefined ),
+						getValidationError: getValidationErrorMock,
 					};
 				}
 				return jest
@@ -477,5 +477,105 @@ describe( 'pushChanges', () => {
 			true,
 			false // because no shipping rate impacting fields are changed
 		);
+	} );
+
+	it( 'Pushes only the valid dirty fields (country) when state/postcode have validation errors after a country change', async () => {
+		// Simulate country changing to GB; state/postcode are blanked by
+		// updateDirtyProps and then fail validation because they are required
+		// but now empty for the new country.
+		getValidationErrorMock = jest.fn().mockImplementation( ( key: string ) => {
+			if ( key === 'billing_state' || key === 'billing_postcode' ) {
+				return { message: 'Invalid for selected country', hidden: false };
+			}
+			return undefined;
+		} );
+
+		getCustomerDataMock.mockReturnValue( {
+			billingAddress: {
+				first_name: 'John',
+				last_name: 'Doe',
+				address_1: '123 Main St',
+				address_2: '',
+				city: 'New York',
+				state: '',
+				postcode: '',
+				country: 'GB',
+				email: 'john.doe@mail.com',
+				phone: '555-555-5555',
+			},
+			shippingAddress: {
+				first_name: 'John',
+				last_name: 'Doe',
+				address_1: '123 Main St',
+				address_2: '',
+				city: 'New York',
+				state: 'NY',
+				postcode: '10001',
+				country: 'US',
+				phone: '555-555-5555',
+			},
+		} );
+
+		pushChanges( false );
+
+		// Country should be pushed; invalid state/postcode should not.
+		await expect( updateCustomerDataMock ).toHaveBeenCalledWith(
+			{
+				billing_address: { country: 'GB' },
+			},
+			true,
+			false // country is not a shipping-rate-impacting field
+		);
+
+		// Flush async resolution so doingPush is cleared before the next test.
+		await expect( updateCustomerDataMock ).toHaveReturned();
+	} );
+
+	it( 'Does not push anything when every dirty prop has a validation error', async () => {
+		// Clear any calls recorded during the beforeEach reset so this test
+		// has a clean baseline for the "not called" assertion.
+		updateCustomerDataMock.mockClear();
+
+		// All three dirty fields (country, state, postcode) report errors.
+		getValidationErrorMock = jest.fn().mockImplementation( ( key: string ) => {
+			if (
+				key === 'billing_country' ||
+				key === 'billing_state' ||
+				key === 'billing_postcode'
+			) {
+				return { message: 'Invalid', hidden: false };
+			}
+			return undefined;
+		} );
+
+		getCustomerDataMock.mockReturnValue( {
+			billingAddress: {
+				first_name: 'John',
+				last_name: 'Doe',
+				address_1: '123 Main St',
+				address_2: '',
+				city: 'New York',
+				state: '',
+				postcode: '',
+				country: 'XX',
+				email: 'john.doe@mail.com',
+				phone: '555-555-5555',
+			},
+			shippingAddress: {
+				first_name: 'John',
+				last_name: 'Doe',
+				address_1: '123 Main St',
+				address_2: '',
+				city: 'New York',
+				state: 'NY',
+				postcode: '10001',
+				country: 'US',
+				phone: '555-555-5555',
+			},
+		} );
+
+		pushChanges( false );
+
+		expect( updateCustomerDataMock ).not.toHaveBeenCalled();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/utils.ts
@@ -124,6 +124,33 @@ export const validateDirtyProps = ( dirtyProps: {
 };
 
 /**
+ * Returns the subset of dirty props that currently have no validation error.
+ * Used when some dirty fields are invalid (e.g. state/postcode blanked after a
+ * country change) so the valid ones can still be pushed to the server.
+ */
+export const filterValidDirtyProps = ( dirtyProps: {
+	billingAddress: BaseAddressKey[];
+	shippingAddress: BaseAddressKey[];
+} ): { billingAddress: BaseAddressKey[]; shippingAddress: BaseAddressKey[] } => {
+	const validationStore = select(
+		VALIDATION_STORE_KEY
+	) as CurriedSelectorsOf< ValidationStoreDescriptor >;
+
+	return {
+		billingAddress: dirtyProps.billingAddress.filter(
+			( key ) =>
+				validationStore.getValidationError( 'billing_' + key ) ===
+				undefined
+		),
+		shippingAddress: dirtyProps.shippingAddress.filter(
+			( key ) =>
+				validationStore.getValidationError( 'shipping_' + key ) ===
+				undefined
+		),
+	};
+};
+
+/**
  * Gets the localStorage flag to indicate whether the customer data is dirty.
  */
 export const getIsCustomerDataDirty = () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In the Block Checkout, changing the billing/shipping **country** is not persisted to the WC session, so the selection is lost on refresh.

Closes #62728.

#### Why

The cart → server sync lives in `client/blocks/assets/js/data/cart/push-changes.ts`:

- When the country changes, `updateDirtyProps()` blanks `state`/`postcode` and marks them dirty (so stale values aren't kept for the new country).
- `updateCustomerData()` then called `validateDirtyProps()` and **aborted the entire push** if *any* dirty prop was invalid. Because the just-blanked, now-required `state`/`postcode` fail validation, the whole push — including the valid **country** — was aborted. The country change never reached the session and was lost on refresh.

This is independent of draft-order creation: the cart `update-customer` push runs regardless of whether a draft order exists, so the recent change to defer draft-order creation does not affect this path.

#### How

Instead of aborting when not every dirty prop is valid, push **only the valid subset**:

- New `filterValidDirtyProps()` helper in `cart/utils.ts` returns the dirty props that currently have no validation error.
- `updateCustomerData()` now:
  - sends the full address objects when everything is valid (unchanged behaviour);
  - sends a payload of just the valid dirty fields when some are invalid — so `country` persists while still-empty required fields are withheld;
  - aborts only when *no* dirty prop is valid;
  - keeps the unpushed (invalid) props dirty so they're retried on the next push once the user fills them in.

This follows the direction suggested by @senadir on the issue.

### How to test the changes in this Pull Request:

1. Go to the Block Checkout with items in the cart.
2. Change the country to one with different required fields (e.g. US → GB).
3. Refresh the page.
4. **Expected:** the country selection persists; `state`/`postcode` remain empty (to be filled for the new country) rather than the whole address reverting.

### Testing that has already taken place:

Automated coverage added in `cart/test/push-changes.ts`:

- A country change pushes `billing_address: { country }` while withholding the invalid empty `state`/`postcode`.
- Nothing is pushed when *every* dirty prop is invalid.

Run: `pnpm --filter=@woocommerce/block-library test:js -- push-changes`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

A `fix` changelog entry is included.

<!-- A changelog entry already exists in the branch, so the auto-create options below are intentionally left unchecked. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
