### PR TITLE
Fix backslashes stripped from Store API address fields (#58214)

### DIFF
--- a/plugins/woocommerce/changelog/58214-fix-backslash-address-store-api
+++ b/plugins/woocommerce/changelog/58214-fix-backslash-address-store-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix silent backslash corruption in Store API (block checkout) address fields. Calling wp_unslash() on JSON body data that is never magic-quoted was stripping real backslashes from address_1, address_2, and other address fields.

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php
@@ -271,7 +271,10 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 				continue;
 			}
 
-			if ( update_user_meta( $customer->get_id(), $meta_key, $customer->{"get_$prop"}( 'edit' ) ) ) {
+			$value = $customer->{"get_$prop"}( 'edit' );
+			$value = is_string( $value ) ? wp_slash( $value ) : $value;
+
+			if ( update_user_meta( $customer->get_id(), $meta_key, $value ) ) {
 				$updated_props[] = $prop;
 			}
 		}
@@ -297,7 +300,10 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 				continue;
 			}
 
-			if ( update_user_meta( $customer->get_id(), $meta_key, $customer->{"get_$prop"}( 'edit' ) ) ) {
+			$value = $customer->{"get_$prop"}( 'edit' );
+			$value = is_string( $value ) ? wp_slash( $value ) : $value;
+
+			if ( update_user_meta( $customer->get_id(), $meta_key, $value ) ) {
 				$updated_props[] = $prop;
 			}
 		}
@@ -322,7 +328,10 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 				continue;
 			}
 
-			if ( update_user_meta( $customer->get_id(), $meta_key, $customer->{"get_$prop"}( 'edit' ) ) ) {
+			$value = $customer->{"get_$prop"}( 'edit' );
+			$value = is_string( $value ) ? wp_slash( $value ) : $value;
+
+			if ( update_user_meta( $customer->get_id(), $meta_key, $value ) ) {
 				$updated_props[] = $prop;
 			}
 		}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -127,16 +127,16 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			function ( $carry, $key ) use ( $address, $validation_util, $schema ) {
 				switch ( $key ) {
 					case 'country':
-						$carry[ $key ] = wc_strtoupper( sanitize_text_field( wp_unslash( $address[ $key ] ) ) );
+						$carry[ $key ] = wc_strtoupper( sanitize_text_field( $address[ $key ] ) );
 						break;
 					case 'state':
-						$carry[ $key ] = $validation_util->format_state( sanitize_text_field( wp_unslash( $address[ $key ] ) ), $address['country'] );
+						$carry[ $key ] = $validation_util->format_state( sanitize_text_field( $address[ $key ] ), $address['country'] );
 						break;
 					case 'postcode':
-						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
+						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( $address['postcode'] ), $address['country'] ) : '';
 						break;
 					default:
-						$carry[ $key ] = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $schema[ $key ], $key );
+						$carry[ $key ] = rest_sanitize_value_from_schema( $address[ $key ], $schema[ $key ], $key );
 						break;
 				}
 				if ( $this->additional_fields_controller->is_field( $key ) ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/BillingAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/BillingAddressSchema.php
@@ -55,7 +55,7 @@ class BillingAddressSchema extends AbstractAddressSchema {
 	public function sanitize_callback( $address, $request, $param ) {
 		$address = parent::sanitize_callback( $address, $request, $param );
 		if ( isset( $address['email'] ) ) {
-			$address['email'] = sanitize_email( wp_unslash( $address['email'] ) );
+			$address['email'] = sanitize_email( $address['email'] );
 		}
 		return $address;
 	}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -428,7 +428,7 @@ class CheckoutSchema extends AbstractSchema {
 						return $carry;
 					}
 					$field_schema   = $properties[ $key ];
-					$rest_sanitized = rest_sanitize_value_from_schema( wp_unslash( $fields[ $key ] ), $field_schema, $key );
+					$rest_sanitized = rest_sanitize_value_from_schema( $fields[ $key ], $field_schema, $key );
 					$rest_sanitized = $this->additional_fields_controller->sanitize_field( $key, $rest_sanitized );
 					$carry[ $key ]  = $rest_sanitized;
 					return $carry;

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-test.php
@@ -61,6 +61,33 @@ class WC_Customer_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A backslash in a customer address field survives a save/read round-trip.
+	 *
+	 * Addresses entered through the Store API (block checkout) are not magic-quoted, so the value
+	 * reaches the customer object unslashed (e.g. "apt 4\"). When the data store persists it via
+	 * WP's update_user_meta(), update_metadata() runs wp_unslash() on the value before writing,
+	 * stripping the backslash. The customer fix in PR #65643 only stops the Store API schema from
+	 * unslashing; the meta-persistence layer still corrupts the value for logged-in users.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/58214
+	 * @link https://github.com/woocommerce/woocommerce/pull/65643#pullrequestreview-4485832478
+	 */
+	public function test_backslash_in_address_survives_save_and_read(): void {
+		$customer = WC_Helper_Customer::create_customer();
+
+		$customer->set_billing_address_2( 'apt 4\\' );
+		$customer->save();
+
+		$read_customer = new WC_Customer( $customer->get_id() );
+
+		$this->assertSame(
+			'apt 4\\',
+			$read_customer->get_billing_address_2(),
+			'The trailing backslash should be preserved when the customer address is persisted and read back.'
+		);
+	}
+
+	/**
 	 * Handler for the wc_order_statuses filter, returns just 'pending" as the valid order statuses list.
 	 *
 	 * @return string[]

--- a/plugins/woocommerce/tests/php/src/StoreApi/Schemas/V1/AbstractAddressSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Schemas/V1/AbstractAddressSchemaTest.php
@@ -1,0 +1,115 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Schemas\V1\BillingAddressSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests that AbstractAddressSchema::sanitize_callback() does not strip
+ * backslashes from address fields.
+ *
+ * The Store API reads a JSON request body via json_decode(), which is never
+ * subject to WordPress "magic quotes". Calling wp_unslash() on that data used
+ * to silently drop real backslashes the user typed (e.g. "apt 4\"). These
+ * tests guard against a regression of that behaviour.
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/58214
+ */
+class AbstractAddressSchemaTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The system under test. BillingAddressSchema is the concrete child of
+	 * AbstractAddressSchema and exercises the shared sanitize_callback().
+	 *
+	 * @var BillingAddressSchema
+	 */
+	private $sut;
+
+	/**
+	 * Set up before test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+
+		$extend            = new ExtendSchema( $formatters );
+		$schema_controller = new SchemaController( $extend );
+		$this->sut         = $schema_controller->get( BillingAddressSchema::IDENTIFIER );
+	}
+
+	/**
+	 * Build a minimal valid address with the given overrides.
+	 *
+	 * @param array $overrides Fields to override on the base address.
+	 * @return array
+	 */
+	private function make_address( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'first_name' => 'Jane',
+				'last_name'  => 'Doe',
+				'company'    => '',
+				'address_1'  => '123 Main Street',
+				'address_2'  => '',
+				'city'       => 'New York',
+				'state'      => 'NY',
+				'postcode'   => '10001',
+				'country'    => 'US',
+				'phone'      => '',
+				'email'      => 'jane@example.com',
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * @testdox Should preserve a trailing backslash in address_2.
+	 */
+	public function test_preserves_trailing_backslash_in_address_2(): void {
+		$address = $this->make_address( array( 'address_2' => 'apt 4\\' ) );
+
+		$result = $this->sut->sanitize_callback( $address, null, 'billing_address' );
+
+		$this->assertSame( 'apt 4\\', $result['address_2'], 'A trailing backslash should not be stripped.' );
+	}
+
+	/**
+	 * @testdox Should preserve a mid-string backslash in address_1.
+	 */
+	public function test_preserves_mid_string_backslash_in_address_1(): void {
+		$address = $this->make_address( array( 'address_1' => 'a\\b Street' ) );
+
+		$result = $this->sut->sanitize_callback( $address, null, 'billing_address' );
+
+		$this->assertSame( 'a\\b Street', $result['address_1'], 'A mid-string backslash should not be stripped.' );
+	}
+
+	/**
+	 * @testdox Should not corrupt plain backslash-free fields.
+	 */
+	public function test_does_not_corrupt_backslash_free_fields(): void {
+		$address = $this->make_address(
+			array(
+				'address_1' => '123 Main Street',
+				'address_2' => 'Suite 100',
+			)
+		);
+
+		$result = $this->sut->sanitize_callback( $address, null, 'billing_address' );
+
+		$this->assertSame( '123 Main Street', $result['address_1'], 'A plain field should be unchanged.' );
+		$this->assertSame( 'Suite 100', $result['address_2'], 'A plain field should be unchanged.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/StoreApi/Schemas/V1/CheckoutSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Schemas/V1/CheckoutSchemaTest.php
@@ -1,0 +1,119 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests that CheckoutSchema::sanitize_additional_fields() does not strip
+ * backslashes from additional checkout field values.
+ *
+ * Additional fields are read from the same JSON request body as the address
+ * fields, so json_decode() (never magic-quoted) delivers them already
+ * unslashed. Calling wp_unslash() on that data silently drops real
+ * backslashes the user typed (e.g. "apt 4\").
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/58214
+ * @see https://github.com/woocommerce/woocommerce/pull/65643#pullrequestreview-4485832478
+ */
+class CheckoutSchemaTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var CheckoutSchema
+	 */
+	private $sut;
+
+	/**
+	 * The id of the additional text field registered for these tests.
+	 *
+	 * @var string
+	 */
+	private $field_id = 'plugin-namespace/gov-id';
+
+	/**
+	 * Set up before test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'       => $this->field_id,
+				'label'    => 'Government ID',
+				'location' => 'contact',
+				'type'     => 'text',
+				'required' => false,
+			)
+		);
+
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+
+		$extend            = new ExtendSchema( $formatters );
+		$schema_controller = new SchemaController( $extend );
+		$this->sut         = $schema_controller->get( CheckoutSchema::IDENTIFIER );
+	}
+
+	/**
+	 * Tear down after test.
+	 */
+	public function tearDown(): void {
+		__internal_woocommerce_blocks_deregister_checkout_field( $this->field_id );
+		remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should preserve a trailing backslash in an additional text field.
+	 */
+	public function test_preserves_trailing_backslash_in_additional_field(): void {
+		$result = $this->sut->sanitize_additional_fields( array( $this->field_id => 'apt 4\\' ) );
+
+		$this->assertSame(
+			'apt 4\\',
+			$result[ $this->field_id ],
+			'A trailing backslash should not be stripped from an additional checkout field.'
+		);
+	}
+
+	/**
+	 * @testdox Should preserve a mid-string backslash in an additional text field.
+	 */
+	public function test_preserves_mid_string_backslash_in_additional_field(): void {
+		$result = $this->sut->sanitize_additional_fields( array( $this->field_id => 'a\\b' ) );
+
+		$this->assertSame(
+			'a\\b',
+			$result[ $this->field_id ],
+			'A mid-string backslash should not be stripped from an additional checkout field.'
+		);
+	}
+
+	/**
+	 * @testdox Should not corrupt a backslash-free additional text field.
+	 */
+	public function test_does_not_corrupt_backslash_free_additional_field(): void {
+		$result = $this->sut->sanitize_additional_fields( array( $this->field_id => 'AB12345' ) );
+
+		$this->assertSame(
+			'AB12345',
+			$result[ $this->field_id ],
+			'A plain additional checkout field should be unchanged.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Store API checkout requests arrive from JSON, so their values are already unslashed. This PR removes the extra unslashing that stripped real backslashes, and fixes the customer meta write path that exposed the same issue for logged-in customers.

Fixes:

- Preserve backslashes in Store API address fields by removing `wp_unslash()` from address schema sanitization.
- Preserve backslashes in additional checkout fields by removing `wp_unslash()` from `CheckoutSchema::sanitize_additional_fields()`.
- Preserve backslashes when customer address fields are saved to user meta by slashing string values before `update_user_meta()`, matching other WooCommerce data stores.
- Keep the existing sanitization paths intact.

Closes #58214

### How to test the changes in this Pull Request:

1. In the block checkout, enter `apt 4\` in *Apartment, suite, etc.* and place an order.
2. Confirm the saved order/customer address still shows `apt 4\`.

### Testing that has already taken place:

New tests:

- `AbstractAddressSchemaTest` covers trailing and mid-string backslashes in address fields, plus a backslash-free guard.
- `CheckoutSchemaTest` covers trailing and mid-string backslashes in additional checkout fields, plus a backslash-free guard.
- `WC_Customer_Data_Store_CPT_Test::test_backslash_in_address_survives_save_and_read` covers customer address persistence through user meta.

Local verification:

- `CheckoutSchemaTest` → `OK (3 tests, 3 assertions)`.
- `WC_Customer_Data_Store_CPT_Test` → `OK (9 tests, 11 assertions)`.
- `composer exec -- phpstan analyse includes/data-stores/class-wc-customer-data-store.php src/StoreApi/Schemas/V1/CheckoutSchema.php --memory-limit=2G` → no errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- A changelog fragment (patch / fix) was already added to the branch, so the auto-create options below are intentionally left unchecked. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
