### PR TITLE
Fix: remove font-weight override on mini-cart badge and fix count text color in order summary

### DIFF
--- a/plugins/woocommerce/changelog/fix-count-badge-styles
+++ b/plugins/woocommerce/changelog/fix-count-badge-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unnecessary font-weight override on the mini-cart quantity badge and use a theme-resolvable color for the count text in the checkout order summary item badge.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -84,7 +84,7 @@
 		// The span containing the text should be padded, not the quantity container itself.
 		span {
 			padding: 0 0.4em;
-			color: var(--wp--preset--color--background, #fff);
+			color: var(--wp--preset--color--base, #fff);
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/quantity-badge/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/quantity-badge/style.scss
@@ -14,7 +14,6 @@
 	box-sizing: border-box;
 	display: flex;
 	font-size: 0.875em;
-	font-weight: 600;
 	height: math.div(em(20px), 0.875);
 	justify-content: center;
 	left: 100%;


### PR DESCRIPTION
## Changes proposed in this Pull Request

Two small visual fixes to quantity badge consistency:

1. **Mini-cart icon badge** — removes the hardcoded `font-weight: 600` on `.wc-block-mini-cart__badge` so the digit inherits the body font weight like every other UI element.

2. **Checkout order summary badge** — fixes the count text color inside `.wc-block-components-order-summary-item__quantity span`. The previous value `var(--wp--preset--color--background)` was not resolving on most themes, causing it to always fall back to `#fff`. Replaced with `var(--wp--preset--color--base, #fff)` which correctly resolves to the theme's base/background color.

## Screenshots

Before:
<img width="1187" height="89" alt="Capture d’écran 2026-06-10 à 13 24 53" src="https://github.com/user-attachments/assets/f3054038-352c-4343-862d-45f8e5f30034" />
<img width="418" height="616" alt="Capture d’écran 2026-06-10 à 13 26 01" src="https://github.com/user-attachments/assets/0109c22c-dbbc-4d7b-813c-0dae6021b4af" />

After:
<img width="1190" height="90" alt="Capture d’écran 2026-06-10 à 13 25 03" src="https://github.com/user-attachments/assets/8b5116dc-7c33-4c91-a048-403a8a6e9b1a" />
<img width="413" height="426" alt="Capture d’écran 2026-06-10 à 13 26 10" src="https://github.com/user-attachments/assets/f74dca1b-2e84-43a8-aab7-55c521cdb20e" />
