### PR TITLE
Add OrderUtil::custom_orders_table_data_sync_is_enabled() accessor

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6190-order-util-data-sync-enabled-accessor
+++ b/plugins/woocommerce/changelog/wooplug-6190-order-util-data-sync-enabled-accessor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add OrderUtil::custom_orders_table_data_sync_is_enabled() so extensions can cheaply check whether HPOS data sync is enabled without running the expensive is_custom_order_tables_in_sync() query.

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -82,6 +82,21 @@ class COTMigrationUtil {
 	}
 
 	/**
+	 * Checks whether the real-time data sync between the posts and orders tables is enabled.
+	 *
+	 * Unlike is_custom_order_tables_in_sync(), this only reflects whether the sync setting is enabled and does
+	 * not run a query to determine whether the tables are currently fully synchronized, so it is much cheaper
+	 * to call. Use this when you only need to know if sync is turned on, not whether every order is in sync.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return bool True if data sync is enabled, false otherwise.
+	 */
+	public function custom_orders_table_data_sync_is_enabled() : bool {
+		return $this->data_synchronizer->data_sync_is_enabled();
+	}
+
+	/**
 	 * Gets value of a meta key from WC_Data object if passed, otherwise from the post object.
 	 * This helper function support backward compatibility for meta box functions, when moving from posts based store to custom tables.
 	 *

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -92,7 +92,7 @@ class COTMigrationUtil {
 	 *
 	 * @return bool True if data sync is enabled, false otherwise.
 	 */
-	public function custom_orders_table_data_sync_is_enabled() : bool {
+	public function custom_orders_table_data_sync_is_enabled(): bool {
 		return $this->data_synchronizer->data_sync_is_enabled();
 	}
 

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -68,6 +68,21 @@ final class OrderUtil {
 	}
 
 	/**
+	 * Checks whether the real-time data sync between the posts and orders tables is enabled.
+	 *
+	 * Unlike is_custom_order_tables_in_sync(), this only reflects whether the sync setting is enabled (a cheap
+	 * option read) and does not run a query to check whether the tables are currently fully synchronized. Use
+	 * this when you only need to know if sync is turned on, not whether every order is currently in sync.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return bool True if data sync is enabled, false otherwise.
+	 */
+	public static function custom_orders_table_data_sync_is_enabled(): bool {
+		return wc_get_container()->get( COTMigrationUtil::class )->custom_orders_table_data_sync_is_enabled();
+	}
+
+	/**
 	 * Gets value of a meta key from WC_Data object if passed, otherwise from the post object.
 	 * This helper function support backward compatibility for meta box functions, when moving from posts based store to custom tables.
 	 *

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
@@ -138,6 +138,67 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox `custom_orders_table_data_sync_is_enabled` should return true when data sync is enabled.
+	 */
+	public function test_custom_orders_table_data_sync_is_enabled_is_true() {
+		$data_sync_mock = $this->getMockBuilder( DataSynchronizer::class )
+			->setMethods( array( 'data_sync_is_enabled' ) )
+			->getMock();
+
+		$data_sync_mock->method( 'data_sync_is_enabled' )->willReturn( true );
+
+		// This is needed to prevent "Call to private method Mock_DataSynchronizer_xxxx::process_added_option" errors.
+		remove_filter( 'updated_option', array( $data_sync_mock, 'process_updated_option' ), 999, 3 );
+		remove_filter( 'added_option', array( $data_sync_mock, 'process_added_option' ), 999, 2 );
+
+		$cot_controller = wc_get_container()->get( CustomOrdersTableController::class );
+		$this->sut      = new COTMigrationUtil();
+		$this->sut->init( $cot_controller, $data_sync_mock );
+		$this->assertTrue( $this->sut->custom_orders_table_data_sync_is_enabled() );
+	}
+
+	/**
+	 * @testdox `custom_orders_table_data_sync_is_enabled` should return false when data sync is disabled.
+	 */
+	public function test_custom_orders_table_data_sync_is_enabled_is_false() {
+		$data_sync_mock = $this->getMockBuilder( DataSynchronizer::class )
+			->setMethods( array( 'data_sync_is_enabled' ) )
+			->getMock();
+
+		$data_sync_mock->method( 'data_sync_is_enabled' )->willReturn( false );
+
+		// This is needed to prevent "Call to private method Mock_DataSynchronizer_xxxx::process_added_option" errors.
+		remove_filter( 'updated_option', array( $data_sync_mock, 'process_updated_option' ), 999, 3 );
+		remove_filter( 'added_option', array( $data_sync_mock, 'process_added_option' ), 999, 2 );
+
+		$cot_controller = wc_get_container()->get( CustomOrdersTableController::class );
+		$this->sut      = new COTMigrationUtil();
+		$this->sut->init( $cot_controller, $data_sync_mock );
+		$this->assertFalse( $this->sut->custom_orders_table_data_sync_is_enabled() );
+	}
+
+	/**
+	 * @testdox `custom_orders_table_data_sync_is_enabled` should not run the expensive pending-sync query.
+	 */
+	public function test_custom_orders_table_data_sync_is_enabled_does_not_query_pending_sync() {
+		$data_sync_mock = $this->getMockBuilder( DataSynchronizer::class )
+			->setMethods( array( 'has_orders_pending_sync', 'data_sync_is_enabled' ) )
+			->getMock();
+
+		$data_sync_mock->method( 'data_sync_is_enabled' )->willReturn( true );
+		$data_sync_mock->expects( $this->never() )->method( 'has_orders_pending_sync' );
+
+		// This is needed to prevent "Call to private method Mock_DataSynchronizer_xxxx::process_added_option" errors.
+		remove_filter( 'updated_option', array( $data_sync_mock, 'process_updated_option' ), 999, 3 );
+		remove_filter( 'added_option', array( $data_sync_mock, 'process_added_option' ), 999, 2 );
+
+		$cot_controller = wc_get_container()->get( CustomOrdersTableController::class );
+		$this->sut      = new COTMigrationUtil();
+		$this->sut->init( $cot_controller, $data_sync_mock );
+		$this->sut->custom_orders_table_data_sync_is_enabled();
+	}
+
+	/**
 	 * @testdox `get_table_for_orders` should return the name of the posts table when HPOS is not in use.
 	 */
 	public function test_get_table_for_orders_posts() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds `OrderUtil::custom_orders_table_data_sync_is_enabled()` — a cheap public check for whether HPOS data sync is enabled (a single option read).

Callers that only need "is sync on?" currently use `is_custom_order_tables_in_sync()`, which also runs an expensive `posts`↔`orders` pending-sync query. From broad hooks like `woocommerce_admin_reports`, that runs on every admin page and slows large stores. This gives them the option read instead; `is_custom_order_tables_in_sync()` stays for callers that need full-sync state.

Closes #62979.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter COTMigrationUtilTest`.
2. Confirm the new tests pass: `true` when sync is enabled, `false` when disabled, and that it never calls `has_orders_pending_sync()`.

### Testing that has already taken place:

PHPStan and phpcs pass. Unit tests added; the method is a pure delegation to the existing `DataSynchronizer::data_sync_is_enabled()`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Added manually (Significance: minor, Type: add).
