### PR TITLE
Add POS staff foundation: feature flag, orchestrator, caps model

### DIFF
--- a/plugins/woocommerce/changelog/add-pos-staff-foundation
+++ b/plugins/woocommerce/changelog/add-pos-staff-foundation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the foundation for POS staff management: an experimental `point_of_sale_staff` feature flag (off by default), a flag-gated orchestrator, and the `pos_*` capability access model that keys POS access on holding any `pos_*` WP capability. No runtime surface yet; the staff endpoint, attribution, and admin UI register behind the flag in follow-up changes.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -413,6 +413,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\ProductFeed\ProductFeed::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\POS\POSController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -560,7 +560,7 @@ class FeaturesController {
 			'point_of_sale_staff'                => array(
 				'name'                         => __( 'POS staff', 'woocommerce' ),
 				'description'                  => __(
-					'Experimental: POS staff management, roles, and order attribution. Requires Point of Sale to also be enabled.',
+					'Experimental: POS staff management, roles, and order attribution.',
 					'woocommerce'
 				),
 				'enabled_by_default'           => false,
@@ -570,20 +570,6 @@ class FeaturesController {
 				'is_experimental'              => true,
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
-				'setting'                      => array(
-					// Disable the toggle until the parent Point of Sale feature is enabled:
-					// POSController gates on it too, so enabling this alone has no effect.
-					'disabled' => function () {
-						return ! $this->feature_is_enabled( 'point_of_sale' );
-					},
-					'desc_tip' => function () {
-						if ( ! $this->feature_is_enabled( 'point_of_sale' ) ) {
-							return __( '⚠ Point of Sale must be enabled to use POS staff.', 'woocommerce' );
-						}
-
-						return '';
-					},
-				),
 			),
 			'fulfillments'                       => array(
 				'name'                         => __( 'Order Fulfillments', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -557,6 +557,34 @@ class FeaturesController {
 				'deprecated_since'             => '11.0.0',
 				'deprecated_value'             => true,
 			),
+			'point_of_sale_staff'                => array(
+				'name'                         => __( 'POS staff', 'woocommerce' ),
+				'description'                  => __(
+					'Experimental: POS staff management, roles, and order attribution. Requires Point of Sale to also be enabled.',
+					'woocommerce'
+				),
+				'enabled_by_default'           => false,
+				// Stays visible in the Features UI during development; the whole flag is
+				// removed once this feature ships.
+				'disable_ui'                   => false,
+				'is_experimental'              => true,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+				'setting'                      => array(
+					// Disable the toggle until the parent Point of Sale feature is enabled:
+					// POSController gates on it too, so enabling this alone has no effect.
+					'disabled' => function () {
+						return ! $this->feature_is_enabled( 'point_of_sale' );
+					},
+					'desc_tip' => function () {
+						if ( ! $this->feature_is_enabled( 'point_of_sale' ) ) {
+							return __( '⚠ Point of Sale must be enabled to use POS staff.', 'woocommerce' );
+						}
+
+						return '';
+					},
+				),
+			),
 			'fulfillments'                       => array(
 				'name'                         => __( 'Order Fulfillments', 'woocommerce' ),
 				'description'                  => __(

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -564,9 +564,9 @@ class FeaturesController {
 					'woocommerce'
 				),
 				'enabled_by_default'           => false,
-				// Stays visible in the Features UI during development; the whole flag is
-				// removed once this feature ships.
-				'disable_ui'                   => false,
+				// Hidden while incomplete so it can't ship merchant-toggleable; flip to
+				// false when it's ready for an experimental preview.
+				'disable_ui'                   => true,
 				'is_experimental'              => true,
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -40,17 +40,28 @@ class Capabilities {
 	 *
 	 * Real WP capabilities, granted per-user via add_cap() when POS access is
 	 * assigned. They surface in current_user_can() and the standard /wp/v2/users
-	 * response — no shadow permission store.
+	 * response — no shadow permission store. All share the `woocommerce_pos_`
+	 * prefix to stay isolated from core and third-party caps; what each one grants
+	 * is described inline below.
 	 */
-	public const CAP_PROCESS_SALES  = 'woocommerce_pos_process_sales';
-	public const CAP_VIEW_ORDERS    = 'woocommerce_pos_view_orders';
-	public const CAP_APPLY_COUPONS  = 'woocommerce_pos_apply_coupons';
+	// Ring up and complete a sale at checkout.
+	public const CAP_PROCESS_SALES = 'woocommerce_pos_process_sales';
+	// Look up and view existing orders.
+	public const CAP_VIEW_ORDERS = 'woocommerce_pos_view_orders';
+	// Apply an existing coupon to a cart.
+	public const CAP_APPLY_COUPONS = 'woocommerce_pos_apply_coupons';
+	// Create a new coupon during a sale.
 	public const CAP_CREATE_COUPONS = 'woocommerce_pos_create_coupons';
-	public const CAP_ISSUE_REFUNDS  = 'woocommerce_pos_issue_refunds';
-	public const CAP_VIEW_SETTINGS  = 'woocommerce_pos_view_settings';
-	public const CAP_EDIT_SETTINGS  = 'woocommerce_pos_edit_settings';
-	public const CAP_MANAGE_STAFF   = 'woocommerce_pos_manage_staff';
-	public const CAP_EXIT_POS       = 'woocommerce_pos_exit';
+	// Refund a paid order.
+	public const CAP_ISSUE_REFUNDS = 'woocommerce_pos_issue_refunds';
+	// View POS settings (read-only).
+	public const CAP_VIEW_SETTINGS = 'woocommerce_pos_view_settings';
+	// Change POS settings.
+	public const CAP_EDIT_SETTINGS = 'woocommerce_pos_edit_settings';
+	// Manage POS staff and their access.
+	public const CAP_MANAGE_STAFF = 'woocommerce_pos_manage_staff';
+	// Leave POS mode for the full admin.
+	public const CAP_EXIT_POS = 'woocommerce_pos_exit';
 
 	/**
 	 * All known POS capability identifiers.

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -1,0 +1,103 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * POS capability model.
+ *
+ * POS access is defined entirely by `pos_*` capabilities granted per-user — the
+ * same primitive WordPress uses for every other authorization decision. A user
+ * has POS access if and only if they hold at least one of the known `pos_*`
+ * capabilities (those in all_pos_capabilities(); see has_pos_access()).
+ *
+ * Capabilities are granted per-user via add_cap(), never bundled onto a WP role.
+ * POS access can therefore be added to any existing user (shop_manager,
+ * administrator, …) without altering their role, and revoked without leaving
+ * them roleless.
+ *
+ * The preset layer — which `pos_*` caps a Cashier / Manager / Admin receives, and
+ * the code that assigns them per user — is added separately.
+ *
+ * @since 11.0.0
+ * @internal
+ */
+class Capabilities {
+
+	/**
+	 * Default WP role for brand-new POS-only accounts.
+	 *
+	 * POS access is keyed on `pos_*` capabilities, not this role (see
+	 * has_pos_access()), so new POS-only accounts use the stock `subscriber` role.
+	 * A dedicated `pos_staff` role is planned for a later iteration.
+	 */
+	public const DEFAULT_STAFF_ROLE = 'subscriber';
+
+	/**
+	 * POS capability identifiers.
+	 *
+	 * Real WP capabilities, granted per-user via add_cap() when POS access is
+	 * assigned. They surface in current_user_can() and the standard /wp/v2/users
+	 * response — no shadow permission store.
+	 */
+	public const CAP_PROCESS_SALES  = 'pos_process_sales';
+	public const CAP_VIEW_ORDERS    = 'pos_view_orders';
+	public const CAP_APPLY_COUPONS  = 'pos_apply_coupons';
+	public const CAP_CREATE_COUPONS = 'pos_create_coupons';
+	public const CAP_ISSUE_REFUNDS  = 'pos_issue_refunds';
+	public const CAP_VIEW_SETTINGS  = 'pos_view_settings';
+	public const CAP_EDIT_SETTINGS  = 'pos_edit_settings';
+	public const CAP_MANAGE_STAFF   = 'pos_manage_staff';
+	public const CAP_EXIT_POS       = 'pos_exit';
+
+	/**
+	 * All known POS capability identifiers.
+	 *
+	 * The canonical list of `pos_*` caps — used to test for POS access and, by the
+	 * preset layer, to apply or clear a user's caps as a set.
+	 *
+	 * @return string[]
+	 */
+	public static function all_pos_capabilities(): array {
+		return array(
+			self::CAP_PROCESS_SALES,
+			self::CAP_VIEW_ORDERS,
+			self::CAP_APPLY_COUPONS,
+			self::CAP_CREATE_COUPONS,
+			self::CAP_ISSUE_REFUNDS,
+			self::CAP_VIEW_SETTINGS,
+			self::CAP_EDIT_SETTINGS,
+			self::CAP_MANAGE_STAFF,
+			self::CAP_EXIT_POS,
+		);
+	}
+
+	/**
+	 * Whether a user has any POS access at all.
+	 *
+	 * True if the user holds at least one of the known `pos_*` capabilities (those
+	 * in all_pos_capabilities()). This is the single authorization signal for POS
+	 * access: neither a WP role nor any meta value grants it on its own. The
+	 * any-cap definition fits both fixed presets
+	 * (each preset's caps granted as a bundle) and a future granular model
+	 * (individual `pos_*` caps assigned without a baseline cap).
+	 *
+	 * @param int $user_id Target user.
+	 * @return bool
+	 *
+	 * @since 11.0.0
+	 */
+	public static function has_pos_access( int $user_id ): bool {
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+		foreach ( self::all_pos_capabilities() as $cap ) {
+			if ( user_can( $user_id, $cap ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -8,9 +8,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * POS capability model.
  *
- * POS access is defined entirely by `pos_*` capabilities granted per-user — the
+ * POS access is defined entirely by `woocommerce_pos_*` capabilities granted per-user — the
  * same primitive WordPress uses for every other authorization decision. A user
- * has POS access if and only if they hold at least one of the known `pos_*`
+ * has POS access if and only if they hold at least one of the known `woocommerce_pos_*`
  * capabilities (those in all_pos_capabilities(); see has_pos_access()).
  *
  * Capabilities are granted per-user via add_cap(), never bundled onto a WP role.
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * administrator, …) without altering their role, and revoked without leaving
  * them roleless.
  *
- * The preset layer — which `pos_*` caps a Cashier / Manager / Admin receives, and
+ * The preset layer — which `woocommerce_pos_*` caps a Cashier / Manager / Admin receives, and
  * the code that assigns them per user — is added separately.
  *
  * @since 11.0.0
@@ -29,7 +29,7 @@ class Capabilities {
 	/**
 	 * Default WP role for brand-new POS-only accounts.
 	 *
-	 * POS access is keyed on `pos_*` capabilities, not this role (see
+	 * POS access is keyed on `woocommerce_pos_*` capabilities, not this role (see
 	 * has_pos_access()), so new POS-only accounts use the stock `subscriber` role.
 	 * A dedicated `pos_staff` role is planned for a later iteration.
 	 */
@@ -42,20 +42,20 @@ class Capabilities {
 	 * assigned. They surface in current_user_can() and the standard /wp/v2/users
 	 * response — no shadow permission store.
 	 */
-	public const CAP_PROCESS_SALES  = 'pos_process_sales';
-	public const CAP_VIEW_ORDERS    = 'pos_view_orders';
-	public const CAP_APPLY_COUPONS  = 'pos_apply_coupons';
-	public const CAP_CREATE_COUPONS = 'pos_create_coupons';
-	public const CAP_ISSUE_REFUNDS  = 'pos_issue_refunds';
-	public const CAP_VIEW_SETTINGS  = 'pos_view_settings';
-	public const CAP_EDIT_SETTINGS  = 'pos_edit_settings';
-	public const CAP_MANAGE_STAFF   = 'pos_manage_staff';
-	public const CAP_EXIT_POS       = 'pos_exit';
+	public const CAP_PROCESS_SALES  = 'woocommerce_pos_process_sales';
+	public const CAP_VIEW_ORDERS    = 'woocommerce_pos_view_orders';
+	public const CAP_APPLY_COUPONS  = 'woocommerce_pos_apply_coupons';
+	public const CAP_CREATE_COUPONS = 'woocommerce_pos_create_coupons';
+	public const CAP_ISSUE_REFUNDS  = 'woocommerce_pos_issue_refunds';
+	public const CAP_VIEW_SETTINGS  = 'woocommerce_pos_view_settings';
+	public const CAP_EDIT_SETTINGS  = 'woocommerce_pos_edit_settings';
+	public const CAP_MANAGE_STAFF   = 'woocommerce_pos_manage_staff';
+	public const CAP_EXIT_POS       = 'woocommerce_pos_exit';
 
 	/**
 	 * All known POS capability identifiers.
 	 *
-	 * The canonical list of `pos_*` caps — used to test for POS access and, by the
+	 * The canonical list of `woocommerce_pos_*` caps — used to test for POS access and, by the
 	 * preset layer, to apply or clear a user's caps as a set.
 	 *
 	 * @return string[]
@@ -77,12 +77,12 @@ class Capabilities {
 	/**
 	 * Whether a user has any POS access at all.
 	 *
-	 * True if the user holds at least one of the known `pos_*` capabilities (those
+	 * True if the user holds at least one of the known `woocommerce_pos_*` capabilities (those
 	 * in all_pos_capabilities()). This is the single authorization signal for POS
 	 * access: neither a WP role nor any meta value grants it on its own. The
 	 * any-cap definition fits both fixed presets
 	 * (each preset's caps granted as a bundle) and a future granular model
-	 * (individual `pos_*` caps assigned without a baseline cap).
+	 * (individual `woocommerce_pos_*` caps assigned without a baseline cap).
 	 *
 	 * @param int $user_id Target user.
 	 * @return bool

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -84,6 +84,17 @@ class Capabilities {
 	 * (each preset's caps granted as a bundle) and a future granular model
 	 * (individual `woocommerce_pos_*` caps assigned without a baseline cap).
 	 *
+	 * Reads the resolved capability map (WP_User::$allcaps) directly rather than
+	 * looping over user_can(). user_can() re-runs map_meta_cap() and fires the
+	 * user_has_cap filter on every call, so the loop would dispatch that machinery
+	 * once per POS cap; an $allcaps lookup is a plain array check per cap.
+	 *
+	 * Reading $allcaps also scopes access to caps the user actually holds: unlike
+	 * user_can(), it does not honor the multisite super-admin grant, which
+	 * has_cap() applies as a runtime gate rather than storing in $allcaps. A super
+	 * admin therefore does not implicitly count as POS staff — they need an
+	 * explicit `woocommerce_pos_*` cap like anyone else.
+	 *
 	 * @param int $user_id Target user.
 	 * @return bool
 	 *
@@ -93,8 +104,14 @@ class Capabilities {
 		if ( $user_id <= 0 ) {
 			return false;
 		}
+
+		$user = get_userdata( $user_id );
+		if ( ! $user ) {
+			return false;
+		}
+
 		foreach ( self::all_pos_capabilities() as $cap ) {
-			if ( user_can( $user_id, $cap ) ) {
+			if ( ! empty( $user->allcaps[ $cap ] ) ) {
 				return true;
 			}
 		}

--- a/plugins/woocommerce/src/Internal/POS/POSController.php
+++ b/plugins/woocommerce/src/Internal/POS/POSController.php
@@ -11,11 +11,10 @@ use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 /**
  * Feature orchestrator for the POS staff + attribution iteration.
  *
- * Gates the feature on both the parent `point_of_sale` feature and the dev-only
- * `point_of_sale_staff` sub-flag. The runtime surfaces — staff REST endpoint,
- * order/coupon attribution hooks, and the wp-admin Staff UI — register themselves
- * here as they are added in follow-up changes; until then on_init() is an
- * intentional no-op even when both flags are on.
+ * Gates the feature on the dev-only `point_of_sale_staff` flag. The runtime surfaces —
+ * staff REST endpoint, order/coupon attribution hooks, and the wp-admin Staff UI —
+ * register themselves here as they are added in follow-up changes; until then on_init()
+ * is an intentional no-op even when the flag is on.
  *
  * @since 11.0.0
  * @internal
@@ -23,7 +22,6 @@ use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 class POSController implements RegisterHooksInterface {
 
 	private const FEATURE_FLAG = 'point_of_sale_staff';
-	private const PARENT_FLAG  = 'point_of_sale';
 
 	/**
 	 * Features controller used to gate hook registration on the POS feature flags.
@@ -61,7 +59,7 @@ class POSController implements RegisterHooksInterface {
 	/**
 	 * Wire up the feature surface once translations are safe to load.
 	 *
-	 * No-op when either gating flag is off. Runtime surfaces are registered here
+	 * No-op when the gating flag is off. Runtime surfaces are registered here
 	 * as they are added in follow-up changes.
 	 *
 	 * @internal
@@ -69,9 +67,6 @@ class POSController implements RegisterHooksInterface {
 	 * @since 11.0.0
 	 */
 	public function on_init(): void {
-		if ( ! $this->features_controller->feature_is_enabled( self::PARENT_FLAG ) ) {
-			return;
-		}
 		if ( ! $this->features_controller->feature_is_enabled( self::FEATURE_FLAG ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/POS/POSController.php
+++ b/plugins/woocommerce/src/Internal/POS/POSController.php
@@ -1,0 +1,82 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+
+/**
+ * Feature orchestrator for the POS staff + attribution iteration.
+ *
+ * Gates the feature on both the parent `point_of_sale` feature and the dev-only
+ * `point_of_sale_staff` sub-flag. The runtime surfaces — staff REST endpoint,
+ * order/coupon attribution hooks, and the wp-admin Staff UI — register themselves
+ * here as they are added in follow-up changes; until then on_init() is an
+ * intentional no-op even when both flags are on.
+ *
+ * @since 11.0.0
+ * @internal
+ */
+class POSController implements RegisterHooksInterface {
+
+	private const FEATURE_FLAG = 'point_of_sale_staff';
+	private const PARENT_FLAG  = 'point_of_sale';
+
+	/**
+	 * Features controller used to gate hook registration on the POS feature flags.
+	 *
+	 * @var FeaturesController
+	 */
+	private FeaturesController $features_controller;
+
+	/**
+	 * Initialize dependencies via the DI container.
+	 *
+	 * @internal
+	 *
+	 * @param FeaturesController $features_controller The features controller.
+	 */
+	final public function init( FeaturesController $features_controller ): void {
+		$this->features_controller = $features_controller;
+	}
+
+	/**
+	 * Register the feature surface.
+	 *
+	 * The feature-flag check is deferred to `on_init` because `feature_is_enabled()`
+	 * walks `FeaturesController::init_feature_definitions()`, which contains
+	 * `__( ..., 'woocommerce' )` calls. Evaluating those before `init` triggers
+	 * WP 6.7's "translation loading … too early" notice (and the headers-already-sent
+	 * cascade that follows).
+	 *
+	 * @since 11.0.0
+	 */
+	public function register(): void {
+		add_action( 'init', array( $this, 'on_init' ) );
+	}
+
+	/**
+	 * Wire up the feature surface once translations are safe to load.
+	 *
+	 * No-op when either gating flag is off. Runtime surfaces are registered here
+	 * as they are added in follow-up changes.
+	 *
+	 * @internal
+	 *
+	 * @since 11.0.0
+	 */
+	public function on_init(): void {
+		if ( ! $this->features_controller->feature_is_enabled( self::PARENT_FLAG ) ) {
+			return;
+		}
+		if ( ! $this->features_controller->feature_is_enabled( self::FEATURE_FLAG ) ) {
+			return;
+		}
+
+		// Runtime surfaces (staff REST endpoint, attribution hooks, admin Staff UI)
+		// register here as they are added in follow-up changes.
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
@@ -1,0 +1,142 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\POS;
+
+use Automattic\WooCommerce\Internal\POS\Capabilities;
+use WC_Unit_Test_Case;
+
+/**
+ * Unit tests for the POS access model (capability primitives).
+ *
+ * Covers the cap catalog and has_pos_access() — the single authorization signal.
+ * The preset layer that assigns these caps is tested separately.
+ */
+class CapabilitiesTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Every POS capability is pos_-prefixed, keeping it isolated from core caps.
+	 */
+	public function test_all_caps_are_pos_prefixed(): void {
+		foreach ( Capabilities::all_pos_capabilities() as $cap ) {
+			$this->assertStringStartsWith( 'pos_', $cap, "POS cap '{$cap}' must be pos_-prefixed." );
+		}
+	}
+
+	/**
+	 * @testdox all_pos_capabilities lists exactly the nine known pos_* caps.
+	 *
+	 * Asserts the full set (order-insensitive) so the test fails if any cap is
+	 * added, removed, or swapped — not just when the count changes.
+	 */
+	public function test_all_pos_capabilities_lists_every_cap(): void {
+		$this->assertEqualsCanonicalizing(
+			array(
+				Capabilities::CAP_PROCESS_SALES,
+				Capabilities::CAP_VIEW_ORDERS,
+				Capabilities::CAP_APPLY_COUPONS,
+				Capabilities::CAP_CREATE_COUPONS,
+				Capabilities::CAP_ISSUE_REFUNDS,
+				Capabilities::CAP_VIEW_SETTINGS,
+				Capabilities::CAP_EDIT_SETTINGS,
+				Capabilities::CAP_MANAGE_STAFF,
+				Capabilities::CAP_EXIT_POS,
+			),
+			Capabilities::all_pos_capabilities()
+		);
+	}
+
+	/**
+	 * @testdox Default staff role is the stock subscriber role (no dedicated POS role yet).
+	 */
+	public function test_default_staff_role_is_subscriber(): void {
+		$this->assertSame( 'subscriber', Capabilities::DEFAULT_STAFF_ROLE );
+	}
+
+	/**
+	 * @return array<string, array<string>>
+	 */
+	public function provider_privileged_roles(): array {
+		return array(
+			'administrator' => array( 'administrator' ),
+			'shop manager'  => array( 'shop_manager' ),
+		);
+	}
+
+	/**
+	 * @testdox A fresh privileged WP role has no implicit POS access.
+	 *
+	 * POS access requires an explicitly granted pos_* cap; holding a privileged WP
+	 * role (administrator, shop_manager) grants none on its own.
+	 *
+	 * @dataProvider provider_privileged_roles
+	 *
+	 * @param string $role WP role to create the user with.
+	 */
+	public function test_role_has_no_implicit_access( string $role ): void {
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+
+		$this->assertFalse( Capabilities::has_pos_access( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox has_pos_access is true once the user holds any single pos_* cap.
+	 *
+	 * Locks in the granular-caps semantics: a back-office refunds user holding
+	 * only `pos_issue_refunds` (no baseline `pos_process_sales`) still counts as
+	 * POS staff.
+	 */
+	public function test_has_pos_access_true_with_a_single_cap(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$user    = get_userdata( $user_id );
+		$user->add_cap( Capabilities::CAP_ISSUE_REFUNDS );
+
+		$this->assertTrue( Capabilities::has_pos_access( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox has_pos_access is false when the user holds no pos_* caps.
+	 */
+	public function test_has_pos_access_false_without_caps(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$this->assertFalse( Capabilities::has_pos_access( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox has_pos_access returns false for users that do not exist.
+	 */
+	public function test_has_pos_access_rejects_unknown_user(): void {
+		$this->assertFalse( Capabilities::has_pos_access( 0 ) );
+		$this->assertFalse( Capabilities::has_pos_access( 9999999 ) );
+	}
+
+	/**
+	 * @testdox has_pos_access survives a role overwrite because access is cap-keyed.
+	 *
+	 * The wp-admin users.php "Change role to…" dropdown calls set_role(), which
+	 * replaces all roles. POS access must survive — individual pos_* caps added
+	 * via add_cap() are not cleared by set_role().
+	 */
+	public function test_has_pos_access_survives_set_role_overwrite(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'shop_manager' ) );
+		$user    = get_userdata( $user_id );
+		$user->add_cap( Capabilities::CAP_ISSUE_REFUNDS );
+		$this->assertTrue( Capabilities::has_pos_access( $user_id ) );
+
+		$user->set_role( 'subscriber' );
+
+		$this->assertTrue(
+			Capabilities::has_pos_access( $user_id ),
+			'POS access must survive a role overwrite — caps remain intact.'
+		);
+
+		wp_delete_user( $user_id );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
@@ -82,6 +82,42 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A multisite super admin has no implicit POS access until granted a cap.
+	 *
+	 * user_can() grants a super admin every capability on multisite, but POS access
+	 * is keyed on stored woocommerce_pos_* caps (WP_User::$allcaps), which omits the
+	 * runtime super-admin grant. A super admin therefore needs an explicit cap like
+	 * anyone else. Skips off multisite, where there is no super-admin concept.
+	 */
+	public function test_super_admin_has_no_implicit_access_on_multisite(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Super-admin access only applies on multisite.' );
+		}
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		grant_super_admin( $user_id );
+
+		$this->assertTrue(
+			user_can( $user_id, Capabilities::CAP_ISSUE_REFUNDS ),
+			'Sanity: a super admin passes user_can() for any cap.'
+		);
+		$this->assertFalse(
+			Capabilities::has_pos_access( $user_id ),
+			'A super admin must not implicitly count as POS staff.'
+		);
+
+		$user = get_userdata( $user_id );
+		$user->add_cap( Capabilities::CAP_ISSUE_REFUNDS );
+		$this->assertTrue(
+			Capabilities::has_pos_access( $user_id ),
+			'A super admin gains POS access once granted an explicit woocommerce_pos_* cap.'
+		);
+
+		revoke_super_admin( $user_id );
+		wp_delete_user( $user_id );
+	}
+
+	/**
 	 * @testdox has_pos_access is true once the user holds any single woocommerce_pos_* cap.
 	 *
 	 * Locks in the granular-caps semantics: a back-office refunds user holding

--- a/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
@@ -15,16 +15,16 @@ use WC_Unit_Test_Case;
 class CapabilitiesTest extends WC_Unit_Test_Case {
 
 	/**
-	 * @testdox Every POS capability is pos_-prefixed, keeping it isolated from core caps.
+	 * @testdox Every POS capability is woocommerce_pos_-prefixed, keeping it isolated from core caps.
 	 */
-	public function test_all_caps_are_pos_prefixed(): void {
+	public function test_all_caps_are_woocommerce_pos_prefixed(): void {
 		foreach ( Capabilities::all_pos_capabilities() as $cap ) {
-			$this->assertStringStartsWith( 'pos_', $cap, "POS cap '{$cap}' must be pos_-prefixed." );
+			$this->assertStringStartsWith( 'woocommerce_pos_', $cap, "POS cap '{$cap}' must be woocommerce_pos_-prefixed." );
 		}
 	}
 
 	/**
-	 * @testdox all_pos_capabilities lists exactly the nine known pos_* caps.
+	 * @testdox all_pos_capabilities lists exactly the nine known woocommerce_pos_* caps.
 	 *
 	 * Asserts the full set (order-insensitive) so the test fails if any cap is
 	 * added, removed, or swapped — not just when the count changes.
@@ -66,7 +66,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox A fresh privileged WP role has no implicit POS access.
 	 *
-	 * POS access requires an explicitly granted pos_* cap; holding a privileged WP
+	 * POS access requires an explicitly granted woocommerce_pos_* cap; holding a privileged WP
 	 * role (administrator, shop_manager) grants none on its own.
 	 *
 	 * @dataProvider provider_privileged_roles
@@ -82,10 +82,10 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox has_pos_access is true once the user holds any single pos_* cap.
+	 * @testdox has_pos_access is true once the user holds any single woocommerce_pos_* cap.
 	 *
 	 * Locks in the granular-caps semantics: a back-office refunds user holding
-	 * only `pos_issue_refunds` (no baseline `pos_process_sales`) still counts as
+	 * only `woocommerce_pos_issue_refunds` (no baseline `woocommerce_pos_process_sales`) still counts as
 	 * POS staff.
 	 */
 	public function test_has_pos_access_true_with_a_single_cap(): void {
@@ -99,7 +99,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox has_pos_access is false when the user holds no pos_* caps.
+	 * @testdox has_pos_access is false when the user holds no woocommerce_pos_* caps.
 	 */
 	public function test_has_pos_access_false_without_caps(): void {
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
@@ -121,7 +121,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	 * @testdox has_pos_access survives a role overwrite because access is cap-keyed.
 	 *
 	 * The wp-admin users.php "Change role to…" dropdown calls set_role(), which
-	 * replaces all roles. POS access must survive — individual pos_* caps added
+	 * replaces all roles. POS access must survive — individual woocommerce_pos_* caps added
 	 * via add_cap() are not cleared by set_role().
 	 */
 	public function test_has_pos_access_survives_set_role_overwrite(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Part of WOOMOB-3179.

<!-- This PR is part of a bigger feature (POS staff & order attribution); it is the first of a series of small PRs. -->

POS staff & attribution is a large feature. This is the first reviewable slice (the foundation), landing behind an off-by-default flag so it has no production effect. It adds:

- An experimental `point_of_sale_staff` feature flag, off by default and **hidden from the Features screen** (`disable_ui => true`). The feature won't be complete by this release's code freeze, so it must not be merchant-toggleable on shipped builds; devs/QA can still enable it via the `woocommerce_admin_features` filter or by setting its option directly. The flag is removed entirely once the feature ships.
- `POSController`, the flag-gated orchestrator. It registers nothing yet; `on_init()` is an intentional no-op until later PRs add the staff REST endpoint, attribution hooks, and admin UI behind the flag.
- `Capabilities`, the `pos_*` capability access model. POS access is keyed on holding any `pos_*` capability (`has_pos_access()`), granted per-user via `add_cap()`, never bundled onto a WP role. No WP role is registered in this PR; new POS-only accounts will default to the stock `subscriber` role.

Everything is per-user capability/meta, so the feature is fully reversible. Subsequent PRs build the preset/assignment layer, PIN service, REST endpoint, attribution, and admin UI on top.

### Screenshots or screen recordings:

N/A. No user-facing UI in this PR (the feature flag is hidden from the Features screen).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Under **WooCommerce > Settings > Advanced > Features**, confirm **no** "POS staff" toggle appears — the flag is hidden while the feature is incomplete.
2. Confirm the site behaves identically with the feature off (the default): no new REST routes, hooks, or admin pages.
3. (Optional, developers) Force-enable the flag — e.g. via the `woocommerce_admin_features` filter or by setting its option — and confirm there is still no behavior change: `POSController::on_init()` is an intentional no-op in this PR.

The access model itself is covered by `CapabilitiesTest`.

<!-- End testing instructions -->

### Testing that has already taken place:

Rebased onto the latest `trunk` and re-verified. Static analysis passes on all changed files: PHPStan (no errors), PHPCS, and the branch changed-lines lint. `CapabilitiesTest` covers the cap catalog, the `pos_`-prefix isolation invariant, and `has_pos_access()` (no implicit access from privileged roles, true with any single `pos_*` cap, survives a role overwrite).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually (`plugins/woocommerce/changelog/add-pos-staff-foundation`).
</details>

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**
