### PR TITLE
Add POS capability presets and per-user assignment

### DIFF
--- a/plugins/woocommerce/changelog/add-pos-staff-presets
+++ b/plugins/woocommerce/changelog/add-pos-staff-presets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add the POS preset layer to the capability model: capability bundles for the Cashier, Manager, and Admin presets, assigned or cleared per user via `pos_*` capabilities (never WP roles), with the assigned preset recorded in user meta and cleaned up on uninstall. Behind the off-by-default `point_of_sale_staff` feature flag.
+Add the POS preset layer to the capability model: capability bundles for the Cashier, Manager, and Admin presets, assigned or cleared per user via `woocommerce_pos_*` capabilities (never WP roles), with the assigned preset recorded in user meta and cleaned up on uninstall. Behind the off-by-default `point_of_sale_staff` feature flag.

--- a/plugins/woocommerce/changelog/add-pos-staff-presets
+++ b/plugins/woocommerce/changelog/add-pos-staff-presets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the POS preset layer to the capability model: capability bundles for the Cashier, Manager, and Admin presets, assigned or cleared per user via `pos_*` capabilities (never WP roles), with the assigned preset recorded in user meta and cleaned up on uninstall. Behind the off-by-default `point_of_sale_staff` feature flag.

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Internal\POS;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use WP_User;
 
 /**
@@ -73,7 +74,8 @@ class Capabilities {
 	 *
 	 * The value is one of the POSPreset constants. It drives the admin UI, but it
 	 * is not the authorization signal: has_pos_access() reads the `woocommerce_pos_*` caps, not
-	 * this meta.
+	 * this meta. Stored per-site via Users::*_site_user_meta() (which suffixes the blog prefix)
+	 * so it stays aligned with the blog-scoped capabilities on multisite.
 	 */
 	public const POS_PRESET_META_KEY = 'woocommerce_pos_preset';
 
@@ -149,13 +151,16 @@ class Capabilities {
 	 * Returns the `woocommerce_pos_preset` meta value only if it matches an
 	 * assignable preset, so a stale or hand-edited value reads as "no preset".
 	 *
+	 * The meta is stored per-site (see set_pos_preset()) so it stays aligned with the
+	 * blog-scoped POS capabilities on multisite.
+	 *
 	 * @param int $user_id Target user.
 	 * @return string|null One of the POSPreset constants, or null.
 	 *
 	 * @since 11.0.0
 	 */
 	public static function get_pos_preset( int $user_id ): ?string {
-		$meta = get_user_meta( $user_id, self::POS_PRESET_META_KEY, true );
+		$meta = Users::get_site_user_meta( $user_id, self::POS_PRESET_META_KEY, true );
 		if ( in_array( $meta, POSPreset::get_all(), true ) ) {
 			return (string) $meta;
 		}
@@ -297,11 +302,14 @@ class Capabilities {
 		}
 
 		if ( null === $preset ) {
-			delete_user_meta( $user_id, self::POS_PRESET_META_KEY );
+			Users::delete_site_user_meta( $user_id, self::POS_PRESET_META_KEY );
 			return true;
 		}
 
-		update_user_meta( $user_id, self::POS_PRESET_META_KEY, $preset );
+		// Store the preset per-site so the bookkeeping stays aligned with the blog-scoped
+		// POS capabilities on multisite (Users::update_site_user_meta suffixes the blog prefix,
+		// so the key still matches the woocommerce_% uninstall sweep).
+		Users::update_site_user_meta( $user_id, self::POS_PRESET_META_KEY, $preset );
 
 		foreach ( array_keys( self::capabilities_for_preset( $preset ) ) as $cap ) {
 			$user->add_cap( $cap );

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -22,7 +22,7 @@ use WP_User;
  *
  * The preset layer maps each preset (see POSPreset) to a bundle of
  * `woocommerce_pos_*` caps and assigns or clears them per user via
- * set_pos_preset(). The assigned preset is recorded in `_woocommerce_pos_preset`
+ * set_pos_preset(). The assigned preset is recorded in `woocommerce_pos_preset`
  * user meta for the UI; the caps remain the authorization signal, so a stray
  * meta value alone grants nothing.
  *
@@ -75,7 +75,7 @@ class Capabilities {
 	 * is not the authorization signal: has_pos_access() reads the `woocommerce_pos_*` caps, not
 	 * this meta.
 	 */
-	public const POS_PRESET_META_KEY = '_woocommerce_pos_preset';
+	public const POS_PRESET_META_KEY = 'woocommerce_pos_preset';
 
 	/**
 	 * All known POS capability identifiers.
@@ -146,7 +146,7 @@ class Capabilities {
 	/**
 	 * Resolve the assigned POS preset for a user, or null if none is set.
 	 *
-	 * Returns the `_woocommerce_pos_preset` meta value only if it matches an
+	 * Returns the `woocommerce_pos_preset` meta value only if it matches an
 	 * assignable preset, so a stale or hand-edited value reads as "no preset".
 	 *
 	 * @param int $user_id Target user.

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -163,15 +163,22 @@ class Capabilities {
 	}
 
 	/**
-	 * WP_User_Query args selecting every user with POS access.
+	 * WP_User_Query args selecting candidate POS staff — every user holding any
+	 * `woocommerce_pos_*` capability, via WP_User_Query's capability__in.
 	 *
-	 * Matches has_pos_access(): selects users holding any `woocommerce_pos_*` capability, via
-	 * WP_User_Query's capability__in. Use it to enumerate POS staff — e.g. the
-	 * GET /wc/pos/v1/staff endpoint and the wp-admin Staff list — which then refine
-	 * the candidates for their own needs (the staff endpoint also requires a PIN).
-	 * Keying on caps rather than the preset meta keeps this consistent with the
-	 * authorization signal: a user whose caps were stripped is excluded, and a cap
-	 * granted outside a preset is still included.
+	 * Use it to enumerate POS staff — e.g. the GET /wc/pos/v1/staff endpoint and the
+	 * wp-admin Staff list — which refine the candidates for their own needs (the staff
+	 * endpoint also requires a PIN). Keying on caps rather than the preset meta keeps
+	 * this aligned with the authorization signal: a user whose caps were stripped is
+	 * excluded, and a cap granted outside a preset is still included.
+	 *
+	 * This is a candidate query, not exact parity with has_pos_access(): capability__in
+	 * matches the capability *name* wherever it appears in the serialized capabilities
+	 * row, so a user with an explicit denial (add_cap( $cap, false )) is still selected
+	 * even though has_pos_access() — which reads the resolved capabilities — treats them
+	 * as no access. Capabilities only ever grants or strips caps, never denies, so this
+	 * diverges only when external code sets an explicit denial; callers needing exact
+	 * parity should refine results with has_pos_access().
 	 *
 	 * @return array<string, mixed>
 	 *

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -281,13 +281,12 @@ class Capabilities {
 			return false;
 		}
 
-		// Strip the user's directly-held woocommerce_pos_* caps so a preset change (or clear) starts
-		// clean. This class only grants them per-user via add_cap(), so $user->caps is the
-		// full set to clear here; role-granted caps are out of scope.
+		// Strip the user's directly-held woocommerce_pos_* caps so a preset change (or clear)
+		// starts clean. remove_cap() is a no-op for caps the user does not hold and strips a cap
+		// whether it was granted (true) or explicitly denied (false). This class only grants caps
+		// per-user via add_cap(), so role-granted caps are out of scope.
 		foreach ( self::all_pos_capabilities() as $cap ) {
-			if ( isset( $user->caps[ $cap ] ) ) {
-				$user->remove_cap( $cap );
-			}
+			$user->remove_cap( $cap );
 		}
 
 		if ( null === $preset ) {

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -72,7 +72,7 @@ class Capabilities {
 	 * User meta key recording which preset was assigned to a user.
 	 *
 	 * The value is one of the POSPreset constants. It drives the admin UI, but it
-	 * is not the authorization signal: has_pos_access() reads the `pos_*` caps, not
+	 * is not the authorization signal: has_pos_access() reads the `woocommerce_pos_*` caps, not
 	 * this meta.
 	 */
 	public const POS_PRESET_META_KEY = '_woocommerce_pos_preset';
@@ -165,7 +165,7 @@ class Capabilities {
 	/**
 	 * WP_User_Query args selecting every user with POS access.
 	 *
-	 * Matches has_pos_access(): selects users holding any `pos_*` capability, via
+	 * Matches has_pos_access(): selects users holding any `woocommerce_pos_*` capability, via
 	 * WP_User_Query's capability__in. Use it to enumerate POS staff — e.g. the
 	 * GET /wc/pos/v1/staff endpoint and the wp-admin Staff list — which then refine
 	 * the candidates for their own needs (the staff endpoint also requires a PIN).
@@ -184,22 +184,22 @@ class Capabilities {
 	}
 
 	/**
-	 * Preset metadata: the `pos_*` cap bundle and display label for each preset.
+	 * Preset metadata: the `woocommerce_pos_*` cap bundle and display label for each preset.
 	 *
 	 * Single source of truth for capabilities_for_preset() and preset_label(), so
 	 * adding or renaming a preset is one edit here (plus the POSPreset constant)
 	 * rather than several parallel switches.
 	 *
-	 *     Capability           Cashier  Manager  Admin
-	 *     pos_process_sales      yes      yes     yes
-	 *     pos_view_orders        yes      yes     yes
-	 *     pos_apply_coupons      yes      yes     yes
-	 *     pos_create_coupons     no       yes     yes
-	 *     pos_issue_refunds      no       yes     yes
-	 *     pos_view_settings      no       yes     yes
-	 *     pos_edit_settings      no       no      yes
-	 *     pos_manage_staff       no       no      yes
-	 *     pos_exit               no       no      yes
+	 *     Capability                       Cashier  Manager  Admin
+	 *     woocommerce_pos_process_sales    yes      yes      yes
+	 *     woocommerce_pos_view_orders      yes      yes      yes
+	 *     woocommerce_pos_apply_coupons    yes      yes      yes
+	 *     woocommerce_pos_create_coupons   no       yes      yes
+	 *     woocommerce_pos_issue_refunds    no       yes      yes
+	 *     woocommerce_pos_view_settings    no       yes      yes
+	 *     woocommerce_pos_edit_settings    no       no       yes
+	 *     woocommerce_pos_manage_staff     no       no       yes
+	 *     woocommerce_pos_exit             no       no       yes
 	 *
 	 * @return array<string, array{caps: array<string, true>, label: string}>
 	 */
@@ -239,7 +239,7 @@ class Capabilities {
 	}
 
 	/**
-	 * The `pos_*` capability bundle for a given preset (see preset_definitions()).
+	 * The `woocommerce_pos_*` capability bundle for a given preset (see preset_definitions()).
 	 *
 	 * @param string $preset One of the POSPreset constants.
 	 * @return array<string, true> Map of granted cap => true. Empty for unknown presets.
@@ -257,10 +257,10 @@ class Capabilities {
 	 *
 	 * Touches only caps + meta, never WP roles: granting access to an existing user
 	 * leaves their role intact, and clearing it never leaves them roleless. Every
-	 * `pos_*` cap the user holds directly (via add_cap — the only way this class grants
+	 * `woocommerce_pos_*` cap the user holds directly (via add_cap — the only way this class grants
 	 * them) is stripped first, so a preset change (Manager to Cashier) drops the caps
 	 * the new preset omits, and a clear (null) removes them along with the preset meta.
-	 * Role-granted `pos_*` caps, if any, are out of scope: this class never adds caps
+	 * Role-granted `woocommerce_pos_*` caps, if any, are out of scope: this class never adds caps
 	 * to roles.
 	 *
 	 * @param int         $user_id Target user.
@@ -281,7 +281,7 @@ class Capabilities {
 			return false;
 		}
 
-		// Strip the user's directly-held pos_* caps so a preset change (or clear) starts
+		// Strip the user's directly-held woocommerce_pos_* caps so a preset change (or clear) starts
 		// clean. This class only grants them per-user via add_cap(), so $user->caps is the
 		// full set to clear here; role-granted caps are out of scope.
 		foreach ( self::all_pos_capabilities() as $cap ) {

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -184,7 +184,11 @@ class Capabilities {
 	}
 
 	/**
-	 * The `pos_*` capability bundle for a given preset.
+	 * Preset metadata: the `pos_*` cap bundle and display label for each preset.
+	 *
+	 * Single source of truth for capabilities_for_preset() and preset_label(), so
+	 * adding or renaming a preset is one edit here (plus the POSPreset constant)
+	 * rather than several parallel switches.
 	 *
 	 *     Capability           Cashier  Manager  Admin
 	 *     pos_process_sales      yes      yes     yes
@@ -197,12 +201,9 @@ class Capabilities {
 	 *     pos_manage_staff       no       no      yes
 	 *     pos_exit               no       no      yes
 	 *
-	 * @param string $preset One of the POSPreset constants.
-	 * @return array<string, true> Map of granted cap => true. Empty for unknown presets.
-	 *
-	 * @since 11.0.0
+	 * @return array<string, array{caps: array<string, true>, label: string}>
 	 */
-	public static function capabilities_for_preset( string $preset ): array {
+	private static function preset_definitions(): array {
 		$cashier_caps = array(
 			self::CAP_PROCESS_SALES => true,
 			self::CAP_VIEW_ORDERS   => true,
@@ -221,16 +222,34 @@ class Capabilities {
 			self::CAP_EXIT_POS      => true,
 		);
 
-		switch ( $preset ) {
-			case POSPreset::CASHIER:
-				return $cashier_caps;
-			case POSPreset::MANAGER:
-				return $manager_caps;
-			case POSPreset::ADMIN:
-				return $admin_caps;
-			default:
-				return array();
-		}
+		return array(
+			POSPreset::CASHIER => array(
+				'caps'  => $cashier_caps,
+				'label' => __( 'POS cashier', 'woocommerce' ),
+			),
+			POSPreset::MANAGER => array(
+				'caps'  => $manager_caps,
+				'label' => __( 'POS manager', 'woocommerce' ),
+			),
+			POSPreset::ADMIN   => array(
+				'caps'  => $admin_caps,
+				'label' => __( 'POS admin', 'woocommerce' ),
+			),
+		);
+	}
+
+	/**
+	 * The `pos_*` capability bundle for a given preset (see preset_definitions()).
+	 *
+	 * @param string $preset One of the POSPreset constants.
+	 * @return array<string, true> Map of granted cap => true. Empty for unknown presets.
+	 *
+	 * @since 11.0.0
+	 */
+	public static function capabilities_for_preset( string $preset ): array {
+		$definitions = self::preset_definitions();
+
+		return isset( $definitions[ $preset ] ) ? $definitions[ $preset ]['caps'] : array();
 	}
 
 	/**
@@ -294,15 +313,8 @@ class Capabilities {
 	 * @since 11.0.0
 	 */
 	public static function preset_label( string $preset ): string {
-		switch ( $preset ) {
-			case POSPreset::CASHIER:
-				return __( 'POS cashier', 'woocommerce' );
-			case POSPreset::MANAGER:
-				return __( 'POS manager', 'woocommerce' );
-			case POSPreset::ADMIN:
-				return __( 'POS admin', 'woocommerce' );
-			default:
-				return '';
-		}
+		$definitions = self::preset_definitions();
+
+		return isset( $definitions[ $preset ] ) ? $definitions[ $preset ]['label'] : '';
 	}
 }

--- a/plugins/woocommerce/src/Internal/POS/Capabilities.php
+++ b/plugins/woocommerce/src/Internal/POS/Capabilities.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Internal\POS;
 
 defined( 'ABSPATH' ) || exit;
 
+use WP_User;
+
 /**
  * POS capability model.
  *
@@ -18,8 +20,11 @@ defined( 'ABSPATH' ) || exit;
  * administrator, …) without altering their role, and revoked without leaving
  * them roleless.
  *
- * The preset layer — which `woocommerce_pos_*` caps a Cashier / Manager / Admin receives, and
- * the code that assigns them per user — is added separately.
+ * The preset layer maps each preset (see POSPreset) to a bundle of
+ * `woocommerce_pos_*` caps and assigns or clears them per user via
+ * set_pos_preset(). The assigned preset is recorded in `_woocommerce_pos_preset`
+ * user meta for the UI; the caps remain the authorization signal, so a stray
+ * meta value alone grants nothing.
  *
  * @since 11.0.0
  * @internal
@@ -62,6 +67,15 @@ class Capabilities {
 	public const CAP_MANAGE_STAFF = 'woocommerce_pos_manage_staff';
 	// Leave POS mode for the full admin.
 	public const CAP_EXIT_POS = 'woocommerce_pos_exit';
+
+	/**
+	 * User meta key recording which preset was assigned to a user.
+	 *
+	 * The value is one of the POSPreset constants. It drives the admin UI, but it
+	 * is not the authorization signal: has_pos_access() reads the `pos_*` caps, not
+	 * this meta.
+	 */
+	public const POS_PRESET_META_KEY = '_woocommerce_pos_preset';
 
 	/**
 	 * All known POS capability identifiers.
@@ -127,5 +141,168 @@ class Capabilities {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Resolve the assigned POS preset for a user, or null if none is set.
+	 *
+	 * Returns the `_woocommerce_pos_preset` meta value only if it matches an
+	 * assignable preset, so a stale or hand-edited value reads as "no preset".
+	 *
+	 * @param int $user_id Target user.
+	 * @return string|null One of the POSPreset constants, or null.
+	 *
+	 * @since 11.0.0
+	 */
+	public static function get_pos_preset( int $user_id ): ?string {
+		$meta = get_user_meta( $user_id, self::POS_PRESET_META_KEY, true );
+		if ( in_array( $meta, POSPreset::get_all(), true ) ) {
+			return (string) $meta;
+		}
+		return null;
+	}
+
+	/**
+	 * WP_User_Query args selecting every user with POS access.
+	 *
+	 * Matches has_pos_access(): selects users holding any `pos_*` capability, via
+	 * WP_User_Query's capability__in. Use it to enumerate POS staff — e.g. the
+	 * GET /wc/pos/v1/staff endpoint and the wp-admin Staff list — which then refine
+	 * the candidates for their own needs (the staff endpoint also requires a PIN).
+	 * Keying on caps rather than the preset meta keeps this consistent with the
+	 * authorization signal: a user whose caps were stripped is excluded, and a cap
+	 * granted outside a preset is still included.
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @since 11.0.0
+	 */
+	public static function pos_staff_user_query_args(): array {
+		return array(
+			'capability__in' => self::all_pos_capabilities(),
+		);
+	}
+
+	/**
+	 * The `pos_*` capability bundle for a given preset.
+	 *
+	 *     Capability           Cashier  Manager  Admin
+	 *     pos_process_sales      yes      yes     yes
+	 *     pos_view_orders        yes      yes     yes
+	 *     pos_apply_coupons      yes      yes     yes
+	 *     pos_create_coupons     no       yes     yes
+	 *     pos_issue_refunds      no       yes     yes
+	 *     pos_view_settings      no       yes     yes
+	 *     pos_edit_settings      no       no      yes
+	 *     pos_manage_staff       no       no      yes
+	 *     pos_exit               no       no      yes
+	 *
+	 * @param string $preset One of the POSPreset constants.
+	 * @return array<string, true> Map of granted cap => true. Empty for unknown presets.
+	 *
+	 * @since 11.0.0
+	 */
+	public static function capabilities_for_preset( string $preset ): array {
+		$cashier_caps = array(
+			self::CAP_PROCESS_SALES => true,
+			self::CAP_VIEW_ORDERS   => true,
+			self::CAP_APPLY_COUPONS => true,
+		);
+
+		$manager_caps = $cashier_caps + array(
+			self::CAP_CREATE_COUPONS => true,
+			self::CAP_ISSUE_REFUNDS  => true,
+			self::CAP_VIEW_SETTINGS  => true,
+		);
+
+		$admin_caps = $manager_caps + array(
+			self::CAP_EDIT_SETTINGS => true,
+			self::CAP_MANAGE_STAFF  => true,
+			self::CAP_EXIT_POS      => true,
+		);
+
+		switch ( $preset ) {
+			case POSPreset::CASHIER:
+				return $cashier_caps;
+			case POSPreset::MANAGER:
+				return $manager_caps;
+			case POSPreset::ADMIN:
+				return $admin_caps;
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Assign or clear the POS preset for a user.
+	 *
+	 * Touches only caps + meta, never WP roles: granting access to an existing user
+	 * leaves their role intact, and clearing it never leaves them roleless. Every
+	 * `pos_*` cap the user holds directly (via add_cap — the only way this class grants
+	 * them) is stripped first, so a preset change (Manager to Cashier) drops the caps
+	 * the new preset omits, and a clear (null) removes them along with the preset meta.
+	 * Role-granted `pos_*` caps, if any, are out of scope: this class never adds caps
+	 * to roles.
+	 *
+	 * @param int         $user_id Target user.
+	 * @param string|null $preset  One of POSPreset::get_all(), or null to clear.
+	 * @return bool True on success (including clears); false if the user does not
+	 *              exist or the preset value is not assignable.
+	 *
+	 * @since 11.0.0
+	 */
+	public static function set_pos_preset( int $user_id, ?string $preset ): bool {
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user instanceof WP_User ) {
+			return false;
+		}
+
+		// Validate before mutating any state.
+		if ( null !== $preset && ! in_array( $preset, POSPreset::get_all(), true ) ) {
+			return false;
+		}
+
+		// Strip the user's directly-held pos_* caps so a preset change (or clear) starts
+		// clean. This class only grants them per-user via add_cap(), so $user->caps is the
+		// full set to clear here; role-granted caps are out of scope.
+		foreach ( self::all_pos_capabilities() as $cap ) {
+			if ( isset( $user->caps[ $cap ] ) ) {
+				$user->remove_cap( $cap );
+			}
+		}
+
+		if ( null === $preset ) {
+			delete_user_meta( $user_id, self::POS_PRESET_META_KEY );
+			return true;
+		}
+
+		update_user_meta( $user_id, self::POS_PRESET_META_KEY, $preset );
+
+		foreach ( array_keys( self::capabilities_for_preset( $preset ) ) as $cap ) {
+			$user->add_cap( $cap );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Translated label for a POS preset.
+	 *
+	 * @param string $preset One of the POSPreset constants.
+	 * @return string Empty string for an unknown preset.
+	 *
+	 * @since 11.0.0
+	 */
+	public static function preset_label( string $preset ): string {
+		switch ( $preset ) {
+			case POSPreset::CASHIER:
+				return __( 'POS cashier', 'woocommerce' );
+			case POSPreset::MANAGER:
+				return __( 'POS manager', 'woocommerce' );
+			case POSPreset::ADMIN:
+				return __( 'POS admin', 'woocommerce' );
+			default:
+				return '';
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/POS/POSPreset.php
+++ b/plugins/woocommerce/src/Internal/POS/POSPreset.php
@@ -1,0 +1,57 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enum-style class for the assignable POS staff presets.
+ *
+ * Presets are UI-curated bundles of `pos_*` capabilities (Cashier / Manager /
+ * Admin); see Capabilities::capabilities_for_preset(). Kept under the POS
+ * namespace rather than the shared `Enums` namespace because presets are a
+ * UI-level grouping that may change as the granular-caps model matures, not a
+ * stable store-wide vocabulary.
+ *
+ * Constant class rather than a native PHP enum so it stays within WooCommerce's
+ * PHP 7.4 minimum.
+ *
+ * @since 11.0.0
+ * @internal
+ */
+final class POSPreset {
+	/**
+	 * Cashier preset.
+	 *
+	 * @var string
+	 */
+	public const CASHIER = 'pos_cashier';
+
+	/**
+	 * Manager preset.
+	 *
+	 * @var string
+	 */
+	public const MANAGER = 'pos_manager';
+
+	/**
+	 * Admin preset.
+	 *
+	 * @var string
+	 */
+	public const ADMIN = 'pos_admin';
+
+	/**
+	 * All assignable presets, in ascending capability order.
+	 *
+	 * @return string[]
+	 */
+	public static function get_all(): array {
+		return array(
+			self::CASHIER,
+			self::MANAGER,
+			self::ADMIN,
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/POS/POSPreset.php
+++ b/plugins/woocommerce/src/Internal/POS/POSPreset.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Enum-style class for the assignable POS staff presets.
  *
- * Presets are UI-curated bundles of `pos_*` capabilities (Cashier / Manager /
+ * Presets are UI-curated bundles of `woocommerce_pos_*` capabilities (Cashier / Manager /
  * Admin); see Capabilities::capabilities_for_preset(). Kept under the POS
  * namespace rather than the shared `Enums` namespace because presets are a
  * UI-level grouping that may change as the granular-caps model matures, not a

--- a/plugins/woocommerce/src/Internal/POS/POSPreset.php
+++ b/plugins/woocommerce/src/Internal/POS/POSPreset.php
@@ -46,6 +46,8 @@ final class POSPreset {
 	 * All assignable presets, in ascending capability order.
 	 *
 	 * @return string[]
+	 *
+	 * @since 11.0.0
 	 */
 	public static function get_all(): array {
 		return array(

--- a/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
@@ -4,13 +4,15 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\POS;
 
 use Automattic\WooCommerce\Internal\POS\Capabilities;
+use Automattic\WooCommerce\Internal\POS\POSPreset;
 use WC_Unit_Test_Case;
 
 /**
  * Unit tests for the POS access model (capability primitives).
  *
- * Covers the cap catalog and has_pos_access() — the single authorization signal.
- * The preset layer that assigns these caps is tested separately.
+ * Covers the cap catalog, has_pos_access() (the single authorization signal), and
+ * the preset layer (POSPreset, capabilities_for_preset / get_pos_preset /
+ * set_pos_preset / preset_label).
  */
 class CapabilitiesTest extends WC_Unit_Test_Case {
 
@@ -172,6 +174,254 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 			Capabilities::has_pos_access( $user_id ),
 			'POS access must survive a role overwrite — caps remain intact.'
 		);
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox POSPreset::get_all returns the three presets in ascending order.
+	 */
+	public function test_pos_preset_get_all(): void {
+		$this->assertSame(
+			array(
+				POSPreset::CASHIER,
+				POSPreset::MANAGER,
+				POSPreset::ADMIN,
+			),
+			POSPreset::get_all()
+		);
+	}
+
+	/**
+	 * @return array<string, array<mixed>>
+	 */
+	public function provider_preset_caps(): array {
+		$cashier = array( Capabilities::CAP_PROCESS_SALES, Capabilities::CAP_VIEW_ORDERS, Capabilities::CAP_APPLY_COUPONS );
+		$manager = array_merge( $cashier, array( Capabilities::CAP_CREATE_COUPONS, Capabilities::CAP_ISSUE_REFUNDS, Capabilities::CAP_VIEW_SETTINGS ) );
+		$admin   = array_merge( $manager, array( Capabilities::CAP_EDIT_SETTINGS, Capabilities::CAP_MANAGE_STAFF, Capabilities::CAP_EXIT_POS ) );
+
+		return array(
+			'cashier' => array( POSPreset::CASHIER, $cashier ),
+			'manager' => array( POSPreset::MANAGER, $manager ),
+			'admin'   => array( POSPreset::ADMIN, $admin ),
+		);
+	}
+
+	/**
+	 * @testdox capabilities_for_preset returns exactly the documented cap bundle per preset.
+	 *
+	 * Asserts the full expected set (including caps inherited from lower tiers), so a
+	 * regression that drops a base cap or adds an unexpected one fails the test.
+	 *
+	 * @dataProvider provider_preset_caps
+	 *
+	 * @param string   $preset   Preset slug.
+	 * @param string[] $expected The exact caps the preset grants.
+	 */
+	public function test_capabilities_for_preset( string $preset, array $expected ): void {
+		$this->assertEqualsCanonicalizing(
+			$expected,
+			array_keys( Capabilities::capabilities_for_preset( $preset ) )
+		);
+	}
+
+	/**
+	 * @testdox capabilities_for_preset returns an empty bundle for an unknown preset.
+	 */
+	public function test_capabilities_for_unknown_preset_is_empty(): void {
+		$this->assertSame( array(), Capabilities::capabilities_for_preset( 'bogus' ) );
+	}
+
+	/**
+	 * @testdox preset_label returns a non-empty label per preset and empty for unknown.
+	 */
+	public function test_preset_label(): void {
+		$this->assertNotSame( '', Capabilities::preset_label( POSPreset::CASHIER ) );
+		$this->assertNotSame( '', Capabilities::preset_label( POSPreset::MANAGER ) );
+		$this->assertNotSame( '', Capabilities::preset_label( POSPreset::ADMIN ) );
+		$this->assertSame( '', Capabilities::preset_label( 'bogus' ) );
+	}
+
+	/**
+	 * @testdox pos_staff_user_query_args selects POS cap-holders and excludes others.
+	 *
+	 * Verifies the query matches the access definition (any pos_* cap), not the
+	 * preset meta: a cap-holder is returned and a fresh administrator is not.
+	 */
+	public function test_pos_staff_user_query_args_selects_cap_holders(): void {
+		$staff    = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$outsider = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		get_userdata( $staff )->add_cap( Capabilities::CAP_ISSUE_REFUNDS );
+
+		$results = ( new \WP_User_Query( Capabilities::pos_staff_user_query_args() ) )->get_results();
+		$ids     = wp_list_pluck( $results, 'ID' );
+
+		$this->assertContains( $staff, $ids, 'A user holding a pos_* cap should be selected.' );
+		$this->assertNotContains( $outsider, $ids, 'An administrator without any pos_* cap should not be selected.' );
+
+		wp_delete_user( $staff );
+		wp_delete_user( $outsider );
+	}
+
+	/**
+	 * @testdox get_pos_preset returns the assigned preset.
+	 */
+	public function test_get_pos_preset_returns_assigned_preset(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		Capabilities::set_pos_preset( $user_id, POSPreset::MANAGER );
+
+		$this->assertSame( POSPreset::MANAGER, Capabilities::get_pos_preset( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox get_pos_preset returns null when unset or when the meta is not an assignable preset.
+	 */
+	public function test_get_pos_preset_null_when_unset_or_invalid(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$this->assertNull( Capabilities::get_pos_preset( $user_id ) );
+
+		update_user_meta( $user_id, Capabilities::POS_PRESET_META_KEY, 'bogus' );
+		$this->assertNull( Capabilities::get_pos_preset( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox set_pos_preset grants the preset's pos_* caps as real WP capabilities.
+	 */
+	public function test_set_pos_preset_grants_preset_caps(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$this->assertTrue( Capabilities::set_pos_preset( $user_id, POSPreset::MANAGER ) );
+
+		$this->assertTrue( user_can( $user_id, Capabilities::CAP_PROCESS_SALES ) );
+		$this->assertTrue( user_can( $user_id, Capabilities::CAP_ISSUE_REFUNDS ) );
+		$this->assertFalse( user_can( $user_id, Capabilities::CAP_MANAGE_STAFF ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox Switching a preset from Manager to Cashier strips the manager-only caps.
+	 */
+	public function test_set_pos_preset_downgrade_strips_higher_caps(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		Capabilities::set_pos_preset( $user_id, POSPreset::MANAGER );
+
+		Capabilities::set_pos_preset( $user_id, POSPreset::CASHIER );
+
+		$this->assertTrue( user_can( $user_id, Capabilities::CAP_PROCESS_SALES ) );
+		$this->assertFalse( user_can( $user_id, Capabilities::CAP_ISSUE_REFUNDS ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox Clearing a preset strips every pos_* cap and deletes the preset meta.
+	 */
+	public function test_set_pos_preset_clear_strips_caps_and_meta(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		Capabilities::set_pos_preset( $user_id, POSPreset::ADMIN );
+
+		$this->assertTrue( Capabilities::set_pos_preset( $user_id, null ) );
+
+		foreach ( Capabilities::all_pos_capabilities() as $cap ) {
+			$this->assertFalse( user_can( $user_id, $cap ), "Cap {$cap} should be cleared." );
+		}
+		$this->assertNull( Capabilities::get_pos_preset( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox Clearing a preset leaves the user's non-POS capabilities untouched.
+	 *
+	 * The strip loop iterates only all_pos_capabilities(), so a directly-granted cap
+	 * outside the pos_* set must survive a clear — guarding against a regression to a
+	 * blanket reset.
+	 */
+	public function test_set_pos_preset_clear_leaves_non_pos_caps_untouched(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$user    = get_userdata( $user_id );
+		$user->add_cap( 'edit_posts' );
+		Capabilities::set_pos_preset( $user_id, POSPreset::MANAGER );
+
+		Capabilities::set_pos_preset( $user_id, null );
+
+		$this->assertFalse( Capabilities::has_pos_access( $user_id ), 'POS caps should be cleared.' );
+		$this->assertTrue( user_can( $user_id, 'edit_posts' ), 'A non-POS cap held directly must survive a preset clear.' );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox set_pos_preset rejects an invalid preset without mutating existing caps.
+	 */
+	public function test_set_pos_preset_rejects_invalid_preset(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		Capabilities::set_pos_preset( $user_id, POSPreset::MANAGER );
+
+		$this->assertFalse( Capabilities::set_pos_preset( $user_id, 'bogus' ) );
+
+		$this->assertTrue( user_can( $user_id, Capabilities::CAP_ISSUE_REFUNDS ) );
+		$this->assertSame( POSPreset::MANAGER, Capabilities::get_pos_preset( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox set_pos_preset returns false for a non-existent user.
+	 */
+	public function test_set_pos_preset_rejects_unknown_user(): void {
+		$this->assertFalse( Capabilities::set_pos_preset( 0, POSPreset::CASHIER ) );
+		$this->assertFalse( Capabilities::set_pos_preset( 9999999, POSPreset::CASHIER ) );
+	}
+
+	/**
+	 * @testdox Granting or clearing a preset leaves the user's WP role untouched.
+	 */
+	public function test_set_pos_preset_leaves_role_untouched(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'shop_manager' ) );
+
+		Capabilities::set_pos_preset( $user_id, POSPreset::MANAGER );
+		$this->assertSame( array( 'shop_manager' ), get_userdata( $user_id )->roles );
+
+		Capabilities::set_pos_preset( $user_id, null );
+		$this->assertSame( array( 'shop_manager' ), get_userdata( $user_id )->roles );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox has_pos_access tracks set_pos_preset: true after assign, false after clear.
+	 */
+	public function test_has_pos_access_tracks_set_pos_preset(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		Capabilities::set_pos_preset( $user_id, POSPreset::CASHIER );
+		$this->assertTrue( Capabilities::has_pos_access( $user_id ) );
+
+		Capabilities::set_pos_preset( $user_id, null );
+		$this->assertFalse( Capabilities::has_pos_access( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * @testdox Preset meta without any pos_* cap does not grant POS access.
+	 *
+	 * The caps are the authorization signal, not the meta: a planted or partially
+	 * migrated preset meta value must not by itself confer access.
+	 */
+	public function test_has_pos_access_false_with_stale_preset_meta_only(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		update_user_meta( $user_id, Capabilities::POS_PRESET_META_KEY, POSPreset::CASHIER );
+
+		$this->assertFalse( Capabilities::has_pos_access( $user_id ) );
 
 		wp_delete_user( $user_id );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\POS;
 
 use Automattic\WooCommerce\Internal\POS\Capabilities;
 use Automattic\WooCommerce\Internal\POS\POSPreset;
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use WC_Unit_Test_Case;
 
 /**
@@ -283,7 +284,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 
 		$this->assertNull( Capabilities::get_pos_preset( $user_id ) );
 
-		update_user_meta( $user_id, Capabilities::POS_PRESET_META_KEY, 'bogus' );
+		Users::update_site_user_meta( $user_id, Capabilities::POS_PRESET_META_KEY, 'bogus' );
 		$this->assertNull( Capabilities::get_pos_preset( $user_id ) );
 
 		wp_delete_user( $user_id );
@@ -419,7 +420,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	public function test_has_pos_access_false_with_stale_preset_meta_only(): void {
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 
-		update_user_meta( $user_id, Capabilities::POS_PRESET_META_KEY, POSPreset::CASHIER );
+		Users::update_site_user_meta( $user_id, Capabilities::POS_PRESET_META_KEY, POSPreset::CASHIER );
 
 		$this->assertFalse( Capabilities::has_pos_access( $user_id ) );
 

--- a/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/CapabilitiesTest.php
@@ -245,7 +245,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox pos_staff_user_query_args selects POS cap-holders and excludes others.
 	 *
-	 * Verifies the query matches the access definition (any pos_* cap), not the
+	 * Verifies the query matches the access definition (any woocommerce_pos_* cap), not the
 	 * preset meta: a cap-holder is returned and a fresh administrator is not.
 	 */
 	public function test_pos_staff_user_query_args_selects_cap_holders(): void {
@@ -256,8 +256,8 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 		$results = ( new \WP_User_Query( Capabilities::pos_staff_user_query_args() ) )->get_results();
 		$ids     = wp_list_pluck( $results, 'ID' );
 
-		$this->assertContains( $staff, $ids, 'A user holding a pos_* cap should be selected.' );
-		$this->assertNotContains( $outsider, $ids, 'An administrator without any pos_* cap should not be selected.' );
+		$this->assertContains( $staff, $ids, 'A user holding a woocommerce_pos_* cap should be selected.' );
+		$this->assertNotContains( $outsider, $ids, 'An administrator without any woocommerce_pos_* cap should not be selected.' );
 
 		wp_delete_user( $staff );
 		wp_delete_user( $outsider );
@@ -290,7 +290,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox set_pos_preset grants the preset's pos_* caps as real WP capabilities.
+	 * @testdox set_pos_preset grants the preset's woocommerce_pos_* caps as real WP capabilities.
 	 */
 	public function test_set_pos_preset_grants_preset_caps(): void {
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
@@ -320,7 +320,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Clearing a preset strips every pos_* cap and deletes the preset meta.
+	 * @testdox Clearing a preset strips every woocommerce_pos_* cap and deletes the preset meta.
 	 */
 	public function test_set_pos_preset_clear_strips_caps_and_meta(): void {
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
@@ -340,7 +340,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	 * @testdox Clearing a preset leaves the user's non-POS capabilities untouched.
 	 *
 	 * The strip loop iterates only all_pos_capabilities(), so a directly-granted cap
-	 * outside the pos_* set must survive a clear — guarding against a regression to a
+	 * outside the woocommerce_pos_* set must survive a clear — guarding against a regression to a
 	 * blanket reset.
 	 */
 	public function test_set_pos_preset_clear_leaves_non_pos_caps_untouched(): void {
@@ -411,7 +411,7 @@ class CapabilitiesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Preset meta without any pos_* cap does not grant POS access.
+	 * @testdox Preset meta without any woocommerce_pos_* cap does not grant POS access.
 	 *
 	 * The caps are the authorization signal, not the meta: a planted or partially
 	 * migrated preset meta value must not by itself confer access.

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -133,6 +133,41 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 			OR meta_key IN ( 'wc_last_active', 'wc_marketplace_suggestions_dismissed_suggestions' );"
 	);
 
+	/*
+	 * Remove direct POS capabilities (woocommerce_pos_*) granted per user via WP_User::add_cap().
+	 *
+	 * Unlike the woocommerce_pos_preset meta removed above, these caps live inside the serialized
+	 * {prefix}capabilities meta row rather than a woocommerce_ meta key, so the sweep above can't reach
+	 * them. Left behind, a reinstall would silently restore POS access because has_pos_access() keys off
+	 * these caps. The row also stores the user's role, so strip only the woocommerce_pos_ caps per user
+	 * via remove_cap() rather than deleting the row.
+	 *
+	 * Users are matched by the woocommerce_pos_ cap prefix — the same {prefix}capabilities LIKE that
+	 * WP_User_Query's capability__in (used by Capabilities::pos_staff_user_query_args()) is built on —
+	 * so no fixed cap list is duplicated here; the PSR-4 Capabilities class is not autoloadable during
+	 * uninstall. The per-user strip is prefix-based for the same reason.
+	 */
+	$pos_staff_ids = get_users(
+		array(
+			'fields'     => 'ID',
+			'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- one-off uninstall cleanup, not a runtime query.
+				array(
+					'key'     => $wpdb->prefix . 'capabilities',
+					'value'   => 'woocommerce_pos_',
+					'compare' => 'LIKE',
+				),
+			),
+		)
+	);
+	foreach ( $pos_staff_ids as $pos_staff_id ) {
+		$pos_staff_user = new WP_User( (int) $pos_staff_id );
+		foreach ( array_keys( $pos_staff_user->caps ) as $pos_capability ) {
+			if ( 0 === strpos( (string) $pos_capability, 'woocommerce_pos_' ) ) {
+				$pos_staff_user->remove_cap( (string) $pos_capability );
+			}
+		}
+	}
+
 	// Delete our data from the post and post meta tables, and remove any additional tables we created.
 	$wpdb->query( "DELETE FROM {$wpdb->posts} WHERE post_type IN ( 'product', 'product_variation', 'shop_coupon', 'shop_order', 'shop_order_refund' );" );
 	$wpdb->query( "DELETE meta FROM {$wpdb->postmeta} meta LEFT JOIN {$wpdb->posts} posts ON posts.ID = meta.post_id WHERE posts.ID IS NULL;" );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Part of WOOMOB-3179.

<!-- Part of the POS staff & order attribution feature. Builds on #65657, now merged to trunk. -->

Builds on #65657 (POS staff foundation), now **merged to `trunk`** — so this PR is based directly on `trunk` (its base commit is the #65657 squash, `1a1326dce7b`) and contains only the preset layer.

#### What's a "preset"?

A **preset** is a named bundle of `woocommerce_pos_*` capabilities — a ready-made POS role, so a merchant assigns one preset instead of picking nine individual caps by hand. Assigning a preset to a user grants exactly that bundle via `add_cap()` and records the chosen preset in `woocommerce_pos_preset` user meta for the admin UI. The caps stay the single source of truth; the meta is bookkeeping only. Three presets ship, each a superset of the one before:

| Capability | Cashier | Manager | Admin |
| --- | :---: | :---: | :---: |
| `woocommerce_pos_process_sales` — ring up and complete a sale | ✅ | ✅ | ✅ |
| `woocommerce_pos_view_orders` — look up and view orders | ✅ | ✅ | ✅ |
| `woocommerce_pos_apply_coupons` — apply an existing coupon | ✅ | ✅ | ✅ |
| `woocommerce_pos_create_coupons` — create a coupon during a sale | — | ✅ | ✅ |
| `woocommerce_pos_issue_refunds` — refund a paid order | — | ✅ | ✅ |
| `woocommerce_pos_view_settings` — view POS settings (read-only) | — | ✅ | ✅ |
| `woocommerce_pos_edit_settings` — change POS settings | — | — | ✅ |
| `woocommerce_pos_manage_staff` — manage POS staff and their access | — | — | ✅ |
| `woocommerce_pos_exit` — leave POS mode for the full admin | — | — | ✅ |

This PR adds the preset layer on top of the `woocommerce_pos_*` capability model from #65657 (now in `trunk`):

- `capabilities_for_preset()`: the Cashier / Manager / Admin capability bundles.
- `set_pos_preset()`: assigns or clears a preset per user via `woocommerce_pos_*` caps + the `woocommerce_pos_preset` user meta, never touching WP roles (so an existing user's role is untouched, and clearing never leaves them roleless).
- `POSPreset` (a constant-class enum for the Cashier / Manager / Admin presets, kept under the POS namespace), plus `get_pos_preset()`, `preset_label()`, `pos_staff_user_query_args()`.
- The preset meta is stored per-site via `Users::*_site_user_meta()` (which *suffixes* the blog prefix, e.g. `woocommerce_pos_preset_wp`) so it stays aligned with the blog-scoped capabilities on multisite. The key still carries no leading underscore and still starts with `woocommerce_`, so WooCommerce's existing uninstall sweep (`meta_key LIKE 'woocommerce_%'`, under `WC_REMOVE_ALL_DATA`) already removes it, and future `woocommerce_pos_*` user meta is cleaned up for free. The per-user `woocommerce_pos_*` **capabilities** granted by `set_pos_preset()` are a different story: they live in the serialized `{prefix}capabilities` row rather than a `woocommerce_` meta key, so that sweep can't reach them — `uninstall.php` now strips them explicitly per user (selected and matched by the `woocommerce_pos_` prefix) so a reinstall doesn't silently restore POS access.

Caps remain the single authorization signal; the preset meta is UI bookkeeping only. Everything stays behind the off-by-default `point_of_sale_staff` flag.

### Screenshots or screen recordings:

N/A. No user-facing UI in this PR (the staff admin form lands in a later PR).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This PR adds **library code only** — no hooks, REST routes, or admin UI yet — so it's exercised programmatically. The `point_of_sale_staff` feature flag does **not** need to be enabled; `Capabilities` is a plain class called directly.

Open a WordPress shell against your dev site (e.g. with `wp-env`):

```sh
pnpm --filter=@woocommerce/plugin-woocommerce exec wp-env run cli wp shell
```

**1. Assign a preset and confirm the caps land.** Create a throwaway user, then assign the Manager preset:

```php
use Automattic\WooCommerce\Internal\POS\Capabilities;
use Automattic\WooCommerce\Internal\POS\POSPreset;

$uid = wp_insert_user( [ 'user_login' => 'pos_tester', 'user_pass' => wp_generate_password(), 'user_email' => 'pos_tester@example.com' ] );

Capabilities::set_pos_preset( $uid, POSPreset::MANAGER );   // returns true
user_can( $uid, 'woocommerce_pos_issue_refunds' );          // true  — Manager grants it
user_can( $uid, 'woocommerce_pos_manage_staff' );           // false — Admin-only
Capabilities::get_pos_preset( $uid );                       // 'pos_manager'
```

**2. Clear the preset** and confirm the caps + meta are gone but the WP role is untouched:

```php
Capabilities::set_pos_preset( $uid, null );                 // returns true
user_can( $uid, 'woocommerce_pos_process_sales' );          // false — every woocommerce_pos_* cap stripped
Capabilities::get_pos_preset( $uid );                       // null — preset cleared
get_userdata( $uid )->roles;                                // unchanged (e.g. ['subscriber'])
```

<!-- End testing instructions -->

### Testing that has already taken place:

Rebased onto the latest `trunk` (after #65657 merged) and re-verified. Static analysis passes on all changed files: PHPStan (no errors), PHPCS, and the branch changed-lines lint. `CapabilitiesTest` adds preset coverage: the per-preset cap matrix (data-provider driven), assign / downgrade / clear behavior, role-untouched, invalid-preset and unknown-user rejection, and the "preset meta alone does not grant access" invariant.

I've also exercised this preset layer end-to-end in the POC branch (#65913), where it's consumed by the rest of the POS staff feature — the staff admin UI (assign / edit a preset) and the `/wc/pos/v1/staff` REST endpoint (which reports each member's preset and resolved caps) — confirming it integrates correctly in context.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually (`plugins/woocommerce/changelog/add-pos-staff-presets`).
</details>

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**


