### PR TITLE
[HPOS] Speed up order admin list queries on large stores

### DIFF
--- a/plugins/woocommerce/changelog/hpos-orders-empty-search-count
+++ b/plugins/woocommerce/changelog/hpos-orders-empty-search-count
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-HPOS: don't add the search filter to the order admin list query when the search term is empty, so such requests keep using cached order counts instead of running a potentially slow COUNT query.

--- a/plugins/woocommerce/changelog/hpos-orders-empty-search-count
+++ b/plugins/woocommerce/changelog/hpos-orders-empty-search-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+HPOS: don't add the search filter to the order admin list query when the search term is empty, so such requests keep using cached order counts instead of running a potentially slow COUNT query.

--- a/plugins/woocommerce/changelog/hpos-orders-status-union-rewrite
+++ b/plugins/woocommerce/changelog/hpos-orders-status-union-rewrite
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-HPOS: rewrite order queries filtering by multiple statuses and ordered by creation date (such as the default order admin list query) as a UNION ALL of single-status queries, so each branch can be fully served by the type_status_date index regardless of optimizer heuristics. The rewrite is enabled by default only on stores where cached order counts for the queried statuses reach 500,000 (below that the regular query is already fast), is skipped for queries customized through query args or the existing clauses/SQL filters, and can be overridden either way via the new woocommerce_orders_table_query_status_union_optimization filter.
+HPOS: speed up the order admin list on large stores by rewriting multi-status order queries as per-status UNIONs.

--- a/plugins/woocommerce/changelog/hpos-orders-status-union-rewrite
+++ b/plugins/woocommerce/changelog/hpos-orders-status-union-rewrite
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-HPOS: rewrite order queries filtering by multiple statuses and ordered by creation date (such as the default order admin list query) as a UNION ALL of single-status queries, so each branch can be fully served by the type_status_date index regardless of optimizer heuristics. The rewrite is skipped for queries customized through query args or the existing clauses/SQL filters, and can be disabled entirely via the new woocommerce_orders_table_query_status_union_optimization filter.
+HPOS: rewrite order queries filtering by multiple statuses and ordered by creation date (such as the default order admin list query) as a UNION ALL of single-status queries, so each branch can be fully served by the type_status_date index regardless of optimizer heuristics. The rewrite is enabled by default only on stores where cached order counts for the queried statuses reach 500,000 (below that the regular query is already fast), is skipped for queries customized through query args or the existing clauses/SQL filters, and can be overridden either way via the new woocommerce_orders_table_query_status_union_optimization filter.

--- a/plugins/woocommerce/changelog/hpos-orders-status-union-rewrite
+++ b/plugins/woocommerce/changelog/hpos-orders-status-union-rewrite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+HPOS: rewrite order queries filtering by multiple statuses and ordered by creation date (such as the default order admin list query) as a UNION ALL of single-status queries, so each branch can be fully served by the type_status_date index regardless of optimizer heuristics. The rewrite is skipped for queries customized through query args or the existing clauses/SQL filters, and can be disabled entirely via the new woocommerce_orders_table_query_status_union_optimization filter.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -577,11 +577,14 @@ class ListTable extends WP_List_Table {
 		if ( ! empty( $search_term ) ) {
 			$this->order_query_args['s'] = $search_term;
 			$this->has_filter            = true;
-		}
 
-		$filter = trim( sanitize_text_field( $this->request['search-filter'] ) );
-		if ( ! empty( $filter ) ) {
-			$this->order_query_args['search_filter'] = $filter;
+			// 'search_filter' is only meaningful when there is a search term. The search form always submits the
+			// filter dropdown value, and setting it without a term would needlessly disqualify the query from the
+			// cached-count fast path in prepare_items(), triggering a potentially slow COUNT query.
+			$filter = trim( sanitize_text_field( $this->request['search-filter'] ) );
+			if ( ! empty( $filter ) ) {
+				$this->order_query_args['search_filter'] = $filter;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -578,9 +578,8 @@ class ListTable extends WP_List_Table {
 			$this->order_query_args['s'] = $search_term;
 			$this->has_filter            = true;
 
-			// 'search_filter' is only meaningful when there is a search term. The search form always submits the
-			// filter dropdown value, and setting it without a term would needlessly disqualify the query from the
-			// cached-count fast path in prepare_items(), triggering a potentially slow COUNT query.
+			// 'search_filter' is inert without a search term, but setting it (the form always submits the dropdown)
+			// would disqualify the request from the cached-count fast path in prepare_items() and force a COUNT.
 			$filter = trim( sanitize_text_field( $this->request['search-filter'] ) );
 			if ( ! empty( $filter ) ) {
 				$this->order_query_args['search_filter'] = $filter;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -938,10 +938,10 @@ class OrdersTableQuery {
 				compact( 'fields', 'join', 'where', 'groupby', 'orderby', 'limits' ),
 				$this->suppress_filters
 			);
-			$this->sql        = $status_union_sql ?? $this->sql;
-		} else {
-			$this->sql = $filtered_sql;
+			$filtered_sql     = $status_union_sql ?? $this->sql;
 		}
+
+		$this->sql = $filtered_sql;
 
 		$this->build_count_query( $fields, $join, $where, $groupby );
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -32,20 +32,6 @@ class OrdersTableQuery {
 	public const REGEX_SHORTHAND_DATES = '/([^.<>]*)(>=|<=|>|<|\.\.\.)([^.<>]+)/';
 
 	/**
-	 * Maximum number of UNION branches (one per type/status pair) allowed when rewriting a multi-status query
-	 * ordered by creation date as a UNION of single-status queries. Queries needing more branches than this are
-	 * left untouched.
-	 */
-	private const STATUS_UNION_MAX_BRANCHES = 24;
-
-	/**
-	 * Maximum row depth (offset + row count) allowed when rewriting a multi-status query ordered by creation
-	 * date as a UNION of single-status queries. Each UNION branch must fetch up to this many rows, so deeply
-	 * paginated queries are left untouched.
-	 */
-	private const STATUS_UNION_MAX_ROWS = 10000;
-
-	/**
 	 * Names of all COT tables (orders, addresses, operational_data, meta) in the form 'table_id' => 'table name'.
 	 *
 	 * @var array
@@ -931,7 +917,7 @@ class OrdersTableQuery {
 			 * Filters the completed SQL query.
 			 *
 			 * Note: queries left unmodified by this filter may later be rewritten for performance (see
-			 * maybe_get_status_union_sql()), in which case the SQL received here is not the SQL that ends up
+			 * OrdersTableStatusUnionQuery), in which case the SQL received here is not the SQL that ends up
 			 * being executed. Returning a modified query from this filter disables any such rewrite.
 			 *
 			 * @since 7.9.0
@@ -949,8 +935,11 @@ class OrdersTableQuery {
 			// large stores. Rewriting it as a UNION of single-status queries lets each branch be fully served
 			// (filtering and ordering) by the type_status_date index. The rewrite is only attempted when no
 			// 'woocommerce_orders_table_query_sql' callback modified the query, so that code customizing the SQL
-			// always operates on (and gets) the regular query shape. See maybe_get_status_union_sql().
-			$status_union_sql = $this->maybe_get_status_union_sql( $fields, $join, $where, $groupby, $orderby, $limits );
+			// always operates on (and gets) the regular query shape. See OrdersTableStatusUnionQuery.
+			$status_union_sql = ( new OrdersTableStatusUnionQuery( $this ) )->get_sql(
+				compact( 'fields', 'join', 'where', 'groupby', 'orderby', 'limits' ),
+				$this->suppress_filters
+			);
 			if ( ! is_null( $status_union_sql ) ) {
 				$this->sql = $status_union_sql;
 			}
@@ -959,135 +948,6 @@ class OrdersTableQuery {
 		}
 
 		$this->build_count_query( $fields, $join, $where, $groupby );
-	}
-
-	/**
-	 * Rewrites a "multiple statuses, ordered by creation date" query (such as the default order admin list screen
-	 * query) as a UNION ALL of single-status queries, or returns NULL when the query doesn't have exactly that
-	 * shape after all filters have been applied.
-	 *
-	 * `status IN (...)` prevents the `type_status_date` index from providing a global `date_created_gmt` ordering,
-	 * so the optimizer must either sort all matching rows or walk the `date_created` index while filtering. On
-	 * large stores it may choose a plan that examines millions of rows to produce a single page of results,
-	 * depending on the optimizer heuristics available (e.g. the MySQL `prefer_ordering_index` switch). With one
-	 * branch per (type, status) pair, each branch is fully served — filtering and ordering — by the
-	 * `type_status_date` index regardless of optimizer behavior or status selectivity, and the outer query only
-	 * needs to merge a handful of pre-sorted candidate rows.
-	 *
-	 * The rewrite is skipped unless the clauses passed in are byte-identical to those generated purely by the
-	 * 'type' and 'status' query args, which guarantees that queries customized in any way (other query args,
-	 * search, meta queries, or modifications via the 'woocommerce_orders_table_query_clauses' filter) are never
-	 * altered. Queries modified via the 'woocommerce_orders_table_query_sql' filter are not rewritten either:
-	 * build_query() only calls this method when that filter returned the query unchanged.
-	 *
-	 * @param string $fields  Prepared SELECT clause.
-	 * @param string $join    Prepared JOIN clause.
-	 * @param string $where   Prepared WHERE clause.
-	 * @param string $groupby Prepared GROUP BY clause (including the GROUP BY keyword).
-	 * @param string $orderby Prepared ORDER BY clause (including the ORDER BY keyword).
-	 * @param string $limits  Prepared LIMIT clause.
-	 * @return string|null The rewritten SQL query, or NULL if the query is not eligible for the rewrite.
-	 */
-	private function maybe_get_status_union_sql( string $fields, string $join, string $where, string $groupby, string $orderby, string $limits ): ?string {
-		global $wpdb;
-
-		$orders_table = $this->tables['orders'];
-
-		if ( '' !== $join || '' !== $groupby || "{$orders_table}.id" !== $fields ) {
-			return null;
-		}
-
-		// Only an ORDER BY on date_created_gmt alone can be satisfied by the type_status_date index within each branch.
-		$direction = null;
-		foreach ( array( 'ASC', 'DESC' ) as $_direction ) {
-			if ( "ORDER BY {$orders_table}.date_created_gmt {$_direction}" === $orderby ) {
-				$direction = $_direction;
-			}
-		}
-
-		if ( is_null( $direction ) ) {
-			return null;
-		}
-
-		// Unlimited or deeply paginated queries gain nothing from the rewrite: each branch would have to fetch
-		// (offset + row count) rows.
-		if ( count( $this->limits ) !== 2 ) {
-			return null;
-		}
-
-		$offset    = (int) $this->limits[0];
-		$row_count = (int) $this->limits[1];
-
-		if ( $offset < 0 || $row_count <= 0 || ( $offset + $row_count ) > self::STATUS_UNION_MAX_ROWS || "LIMIT {$offset}, {$row_count}" !== $limits ) {
-			return null;
-		}
-
-		if ( ! $this->arg_isset( 'type' ) || ! $this->arg_isset( 'status' ) ) {
-			return null;
-		}
-
-		$types    = array_values( array_unique( (array) $this->args['type'] ) );
-		$statuses = array_values( array_unique( (array) $this->args['status'] ) );
-
-		foreach ( array_merge( $types, $statuses ) as $value ) {
-			if ( ! is_string( $value ) || '' === $value ) {
-				return null;
-			}
-		}
-
-		// A single status doesn't need the rewrite (the type_status_date index already provides the ordering).
-		if ( count( $statuses ) < 2 || ( count( $types ) * count( $statuses ) ) > self::STATUS_UNION_MAX_BRANCHES ) {
-			return null;
-		}
-
-		// Require the WHERE clause to be exactly the one the 'type' and 'status' args generate (same order as
-		// process_orders_table_query_args()). Any other contribution — other query args or filters — disqualifies
-		// the query.
-		$expected_where = '1=1';
-		foreach ( array( 'status', 'type' ) as $arg_key ) {
-			$clause          = $this->where( $orders_table, $arg_key, '=', $this->args[ $arg_key ], $this->mappings['orders'][ $arg_key ]['type'] );
-			$expected_where .= " AND ({$clause})";
-		}
-
-		if ( $where !== $expected_where ) {
-			return null;
-		}
-
-		if ( ! $this->suppress_filters ) {
-			/**
-			 * Filters whether a query for multiple order statuses ordered by creation date may be rewritten as a
-			 * UNION ALL of single-status queries for performance. The rewrite produces the same results and only
-			 * applies to queries generated purely from the 'type' and 'status' query args (no search, meta or
-			 * field filters), such as the default order admin list screen query.
-			 *
-			 * @param bool             $enabled Whether the rewrite is enabled. Default TRUE.
-			 * @param OrdersTableQuery $query   The OrdersTableQuery instance.
-			 *
-			 * @since 11.0.0
-			 */
-			if ( ! apply_filters( 'woocommerce_orders_table_query_status_union_optimization', true, $this ) ) {
-				return null;
-			}
-		}
-
-		// Each branch is wrapped in a derived table (instead of using parenthesized UNION members) so that the
-		// per-branch ORDER BY + LIMIT is honored across MySQL, MariaDB and SQLite.
-		$branch_rows = $offset + $row_count;
-		$branches    = array();
-
-		foreach ( $types as $type ) {
-			foreach ( $statuses as $status ) {
-				$branch = $wpdb->prepare(
-					"SELECT id, date_created_gmt FROM {$orders_table} WHERE type = %s AND status = %s ORDER BY date_created_gmt {$direction} LIMIT {$branch_rows}", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-					$type,
-					$status
-				);
-
-				$branches[] = 'SELECT id, date_created_gmt FROM ( ' . $branch . ' ) wco_branch_' . count( $branches );
-			}
-		}
-
-		return 'SELECT id FROM ( ' . implode( ' UNION ALL ', $branches ) . " ) wco_candidates ORDER BY date_created_gmt {$direction} {$limits}";
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -32,6 +32,20 @@ class OrdersTableQuery {
 	public const REGEX_SHORTHAND_DATES = '/([^.<>]*)(>=|<=|>|<|\.\.\.)([^.<>]+)/';
 
 	/**
+	 * Maximum number of UNION branches (one per type/status pair) allowed when rewriting a multi-status query
+	 * ordered by creation date as a UNION of single-status queries. Queries needing more branches than this are
+	 * left untouched.
+	 */
+	private const STATUS_UNION_MAX_BRANCHES = 24;
+
+	/**
+	 * Maximum row depth (offset + row count) allowed when rewriting a multi-status query ordered by creation
+	 * date as a UNION of single-status queries. Each UNION branch must fetch up to this many rows, so deeply
+	 * paginated queries are left untouched.
+	 */
+	private const STATUS_UNION_MAX_ROWS = 10000;
+
+	/**
 	 * Names of all COT tables (orders, addresses, operational_data, meta) in the form 'table_id' => 'table name'.
 	 *
 	 * @var array
@@ -911,9 +925,14 @@ class OrdersTableQuery {
 
 		$this->sql = "SELECT $fields FROM $orders_table $join WHERE $where $groupby $orderby $limits";
 
+		$filtered_sql = $this->sql;
 		if ( ! $this->suppress_filters ) {
 			/**
 			 * Filters the completed SQL query.
+			 *
+			 * Note: queries left unmodified by this filter may later be rewritten for performance (see
+			 * maybe_get_status_union_sql()), in which case the SQL received here is not the SQL that ends up
+			 * being executed. Returning a modified query from this filter disables any such rewrite.
 			 *
 			 * @since 7.9.0
 			 *
@@ -921,10 +940,154 @@ class OrdersTableQuery {
 			 * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).
 			 * @param array            $args  Query args.
 			 */
-			$this->sql = apply_filters_ref_array( 'woocommerce_orders_table_query_sql', array( $this->sql, &$this, $this->args ) );
+			$filtered_sql = apply_filters_ref_array( 'woocommerce_orders_table_query_sql', array( $this->sql, &$this, $this->args ) );
+		}
+
+		if ( $filtered_sql === $this->sql ) {
+			// Performance note: a query filtering by multiple statuses and ordered by creation date can't be served
+			// efficiently by a single index, and the optimizer may choose a plan that examines millions of rows on
+			// large stores. Rewriting it as a UNION of single-status queries lets each branch be fully served
+			// (filtering and ordering) by the type_status_date index. The rewrite is only attempted when no
+			// 'woocommerce_orders_table_query_sql' callback modified the query, so that code customizing the SQL
+			// always operates on (and gets) the regular query shape. See maybe_get_status_union_sql().
+			$status_union_sql = $this->maybe_get_status_union_sql( $fields, $join, $where, $groupby, $orderby, $limits );
+			if ( ! is_null( $status_union_sql ) ) {
+				$this->sql = $status_union_sql;
+			}
+		} else {
+			$this->sql = $filtered_sql;
 		}
 
 		$this->build_count_query( $fields, $join, $where, $groupby );
+	}
+
+	/**
+	 * Rewrites a "multiple statuses, ordered by creation date" query (such as the default order admin list screen
+	 * query) as a UNION ALL of single-status queries, or returns NULL when the query doesn't have exactly that
+	 * shape after all filters have been applied.
+	 *
+	 * `status IN (...)` prevents the `type_status_date` index from providing a global `date_created_gmt` ordering,
+	 * so the optimizer must either sort all matching rows or walk the `date_created` index while filtering. On
+	 * large stores it may choose a plan that examines millions of rows to produce a single page of results,
+	 * depending on the optimizer heuristics available (e.g. the MySQL `prefer_ordering_index` switch). With one
+	 * branch per (type, status) pair, each branch is fully served — filtering and ordering — by the
+	 * `type_status_date` index regardless of optimizer behavior or status selectivity, and the outer query only
+	 * needs to merge a handful of pre-sorted candidate rows.
+	 *
+	 * The rewrite is skipped unless the clauses passed in are byte-identical to those generated purely by the
+	 * 'type' and 'status' query args, which guarantees that queries customized in any way (other query args,
+	 * search, meta queries, or modifications via the 'woocommerce_orders_table_query_clauses' filter) are never
+	 * altered. Queries modified via the 'woocommerce_orders_table_query_sql' filter are not rewritten either:
+	 * build_query() only calls this method when that filter returned the query unchanged.
+	 *
+	 * @param string $fields  Prepared SELECT clause.
+	 * @param string $join    Prepared JOIN clause.
+	 * @param string $where   Prepared WHERE clause.
+	 * @param string $groupby Prepared GROUP BY clause (including the GROUP BY keyword).
+	 * @param string $orderby Prepared ORDER BY clause (including the ORDER BY keyword).
+	 * @param string $limits  Prepared LIMIT clause.
+	 * @return string|null The rewritten SQL query, or NULL if the query is not eligible for the rewrite.
+	 */
+	private function maybe_get_status_union_sql( string $fields, string $join, string $where, string $groupby, string $orderby, string $limits ): ?string {
+		global $wpdb;
+
+		$orders_table = $this->tables['orders'];
+
+		if ( '' !== $join || '' !== $groupby || "{$orders_table}.id" !== $fields ) {
+			return null;
+		}
+
+		// Only an ORDER BY on date_created_gmt alone can be satisfied by the type_status_date index within each branch.
+		$direction = null;
+		foreach ( array( 'ASC', 'DESC' ) as $_direction ) {
+			if ( "ORDER BY {$orders_table}.date_created_gmt {$_direction}" === $orderby ) {
+				$direction = $_direction;
+			}
+		}
+
+		if ( is_null( $direction ) ) {
+			return null;
+		}
+
+		// Unlimited or deeply paginated queries gain nothing from the rewrite: each branch would have to fetch
+		// (offset + row count) rows.
+		if ( count( $this->limits ) !== 2 ) {
+			return null;
+		}
+
+		$offset    = (int) $this->limits[0];
+		$row_count = (int) $this->limits[1];
+
+		if ( $offset < 0 || $row_count <= 0 || ( $offset + $row_count ) > self::STATUS_UNION_MAX_ROWS || "LIMIT {$offset}, {$row_count}" !== $limits ) {
+			return null;
+		}
+
+		if ( ! $this->arg_isset( 'type' ) || ! $this->arg_isset( 'status' ) ) {
+			return null;
+		}
+
+		$types    = array_values( array_unique( (array) $this->args['type'] ) );
+		$statuses = array_values( array_unique( (array) $this->args['status'] ) );
+
+		foreach ( array_merge( $types, $statuses ) as $value ) {
+			if ( ! is_string( $value ) || '' === $value ) {
+				return null;
+			}
+		}
+
+		// A single status doesn't need the rewrite (the type_status_date index already provides the ordering).
+		if ( count( $statuses ) < 2 || ( count( $types ) * count( $statuses ) ) > self::STATUS_UNION_MAX_BRANCHES ) {
+			return null;
+		}
+
+		// Require the WHERE clause to be exactly the one the 'type' and 'status' args generate (same order as
+		// process_orders_table_query_args()). Any other contribution — other query args or filters — disqualifies
+		// the query.
+		$expected_where = '1=1';
+		foreach ( array( 'status', 'type' ) as $arg_key ) {
+			$clause          = $this->where( $orders_table, $arg_key, '=', $this->args[ $arg_key ], $this->mappings['orders'][ $arg_key ]['type'] );
+			$expected_where .= " AND ({$clause})";
+		}
+
+		if ( $where !== $expected_where ) {
+			return null;
+		}
+
+		if ( ! $this->suppress_filters ) {
+			/**
+			 * Filters whether a query for multiple order statuses ordered by creation date may be rewritten as a
+			 * UNION ALL of single-status queries for performance. The rewrite produces the same results and only
+			 * applies to queries generated purely from the 'type' and 'status' query args (no search, meta or
+			 * field filters), such as the default order admin list screen query.
+			 *
+			 * @param bool             $enabled Whether the rewrite is enabled. Default TRUE.
+			 * @param OrdersTableQuery $query   The OrdersTableQuery instance.
+			 *
+			 * @since 11.0.0
+			 */
+			if ( ! apply_filters( 'woocommerce_orders_table_query_status_union_optimization', true, $this ) ) {
+				return null;
+			}
+		}
+
+		// Each branch is wrapped in a derived table (instead of using parenthesized UNION members) so that the
+		// per-branch ORDER BY + LIMIT is honored across MySQL, MariaDB and SQLite.
+		$branch_rows = $offset + $row_count;
+		$branches    = array();
+
+		foreach ( $types as $type ) {
+			foreach ( $statuses as $status ) {
+				$branch = $wpdb->prepare(
+					"SELECT id, date_created_gmt FROM {$orders_table} WHERE type = %s AND status = %s ORDER BY date_created_gmt {$direction} LIMIT {$branch_rows}", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$type,
+					$status
+				);
+
+				$branches[] = 'SELECT id, date_created_gmt FROM ( ' . $branch . ' ) wco_branch_' . count( $branches );
+			}
+		}
+
+		return 'SELECT id FROM ( ' . implode( ' UNION ALL ', $branches ) . " ) wco_candidates ORDER BY date_created_gmt {$direction} {$limits}";
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -930,19 +930,15 @@ class OrdersTableQuery {
 		}
 
 		if ( $filtered_sql === $this->sql ) {
-			// Performance note: a query filtering by multiple statuses and ordered by creation date can't be served
-			// efficiently by a single index, and the optimizer may choose a plan that examines millions of rows on
-			// large stores. Rewriting it as a UNION of single-status queries lets each branch be fully served
-			// (filtering and ordering) by the type_status_date index. The rewrite is only attempted when no
-			// 'woocommerce_orders_table_query_sql' callback modified the query, so that code customizing the SQL
-			// always operates on (and gets) the regular query shape. See OrdersTableStatusUnionQuery.
+			// On large HPOS stores this multi-status, date-ordered query can get a slow plan (scanning millions of
+			// rows); rewriting it as a UNION of single-status queries lets the type_status_date index serve each
+			// branch. Only attempted when no 'woocommerce_orders_table_query_sql' callback changed the query. See
+			// OrdersTableStatusUnionQuery.
 			$status_union_sql = ( new OrdersTableStatusUnionQuery( $this ) )->get_sql(
 				compact( 'fields', 'join', 'where', 'groupby', 'orderby', 'limits' ),
 				$this->suppress_filters
 			);
-			if ( ! is_null( $status_union_sql ) ) {
-				$this->sql = $status_union_sql;
-			}
+			$this->sql        = $status_union_sql ?? $this->sql;
 		} else {
 			$this->sql = $filtered_sql;
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableStatusUnionQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableStatusUnionQuery.php
@@ -7,7 +7,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
-use Automattic\WooCommerce\Caches\OrderCountCache;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -89,17 +89,17 @@ class OrdersTableStatusUnionQuery {
 		}
 
 		$direction = $this->extract_order_direction( $clauses['orderby'] ?? '' );
-		if ( is_null( $direction ) ) {
+		if ( null === $direction ) {
 			return null;
 		}
 
 		$limit = $this->extract_limit( $clauses['limits'] ?? '' );
-		if ( is_null( $limit ) ) {
+		if ( null === $limit ) {
 			return null;
 		}
 
 		$types_and_statuses = $this->extract_types_and_statuses();
-		if ( is_null( $types_and_statuses ) ) {
+		if ( null === $types_and_statuses ) {
 			return null;
 		}
 		list( $types, $statuses ) = $types_and_statuses;
@@ -149,14 +149,14 @@ class OrdersTableStatusUnionQuery {
 
 	/**
 	 * Extracts the offset and row count from the LIMIT clause, or NULL when the query is unlimited or too deeply
-	 * paginated to benefit (each branch would have to fetch offset + row count rows). The digit cap also rejects
-	 * the "unlimited" sentinel row count.
+	 * paginated to benefit (each branch would have to fetch offset + row count rows). The offset + row count cap
+	 * also rejects the "unlimited" sentinel row count.
 	 *
 	 * @param string $limits The LIMIT clause, including the keyword.
 	 * @return int[]|null Array of [ offset, row count ], or NULL when ineligible.
 	 */
 	private function extract_limit( string $limits ): ?array {
-		if ( ! preg_match( '/^LIMIT (\d{1,7}), (\d{1,7})$/', $limits, $limit_parts ) ) {
+		if ( ! preg_match( '/^LIMIT (\d+), (\d+)$/', $limits, $limit_parts ) ) {
 			return null;
 		}
 
@@ -241,18 +241,19 @@ class OrdersTableStatusUnionQuery {
 					$status
 				);
 
-				$branches[] = 'SELECT id, date_created_gmt FROM ( ' . $branch . ' ) wco_branch_' . count( $branches );
+				$branches[] = 'SELECT id, date_created_gmt FROM ( ' . $branch . ' ) union' . count( $branches );
 			}
 		}
 
-		return 'SELECT id FROM ( ' . implode( ' UNION ALL ', $branches ) . " ) wco_candidates ORDER BY date_created_gmt {$direction} {$limits}";
+		return 'SELECT id FROM ( ' . implode( ' UNION ALL ', $branches ) . " ) candidates ORDER BY date_created_gmt {$direction} {$limits}";
 	}
 
 	/**
 	 * Returns whether the rewrite should be used for the given types and statuses.
 	 *
-	 * Enabled by default once the matching order count reaches MIN_ORDER_COUNT. Counts are read from the cache
-	 * without recomputing them, so the rewrite stays disabled while the cache is cold.
+	 * Enabled by default once the matching order count reaches MIN_ORDER_COUNT. Counts come from
+	 * OrderUtil::get_count_for_type() — the same facade the order admin list screen uses for its status counts —
+	 * which reads the order count cache and computes (and caches) the counts on a miss.
 	 *
 	 * @param string[] $types            Queried order types.
 	 * @param string[] $statuses         Queried order statuses.
@@ -260,20 +261,14 @@ class OrdersTableStatusUnionQuery {
 	 * @return bool Whether the rewrite should be used.
 	 */
 	private function is_enabled( array $types, array $statuses, bool $suppress_filters ): bool {
-		$count_cache  = new OrderCountCache();
 		$orders_count = 0;
 
 		foreach ( $types as $type ) {
-			$counts = $count_cache->get( $type, $statuses );
+			$counts = OrderUtil::get_count_for_type( $type );
 
-			// A cold count cache for a type (get() returns null when any of its queried statuses is missing)
-			// contributes nothing rather than disqualifying the whole check, so the fast path can kick in off the
-			// counts we already have without waiting for every type's cache to warm.
-			if ( is_null( $counts ) ) {
-				continue;
+			foreach ( $statuses as $status ) {
+				$orders_count += $counts[ $status ] ?? 0;
 			}
-
-			$orders_count += array_sum( $counts );
 		}
 
 		$enabled = $orders_count >= self::MIN_ORDER_COUNT;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableStatusUnionQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableStatusUnionQuery.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * OrdersTableStatusUnionQuery class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\DataStores\Orders;
+
+use Automattic\WooCommerce\Caches\OrderCountCache;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rewrites a "multiple statuses, ordered by creation date" order query (such as the default order admin list screen
+ * query) as a UNION ALL of single-status queries.
+ *
+ * `status IN (...)` prevents the `type_status_date` index from providing a global `date_created_gmt` ordering, so
+ * the optimizer must either sort all matching rows or walk the `date_created` index while filtering. On large
+ * stores it may choose a plan that examines millions of rows to produce a single page of results, depending on the
+ * optimizer heuristics available (e.g. the MySQL `prefer_ordering_index` switch). With one branch per (type,
+ * status) pair, each branch is fully served — filtering and ordering — by the `type_status_date` index regardless
+ * of optimizer behavior or status selectivity, and the outer query only needs to merge a handful of pre-sorted
+ * candidate rows.
+ *
+ * The rewrite is skipped unless the final query clauses are byte-identical to those generated purely by the 'type'
+ * and 'status' query args, which guarantees that queries customized in any way (other query args, search, meta
+ * queries, or modifications via the 'woocommerce_orders_table_query_clauses' filter) are never altered. Queries
+ * modified via the 'woocommerce_orders_table_query_sql' filter are not rewritten either: build_query() only
+ * attempts the rewrite when that filter returned the query unchanged.
+ *
+ * By default the rewrite is also gated by store size: on stores below the order count threshold the regular query
+ * is already fast even with a suboptimal plan, while each UNION branch adds a small constant cost.
+ */
+class OrdersTableStatusUnionQuery {
+
+	/**
+	 * Maximum number of UNION branches (one per type/status pair). Queries needing more branches than this are
+	 * left untouched.
+	 */
+	private const MAX_BRANCHES = 24;
+
+	/**
+	 * Maximum row depth (offset + row count). Each UNION branch must fetch up to this many rows, so deeply
+	 * paginated queries are left untouched.
+	 */
+	private const MAX_ROWS = 2000;
+
+	/**
+	 * Minimum number of orders (per the order count cache) matching the queried types and statuses for the
+	 * rewrite to be enabled by default. An educated guess at the store size where a mis-planned query becomes
+	 * user-visible, not a measured crossover: the rewrite never beats a well-planned regular query, so this
+	 * only balances its small constant cost against the risk of a slow plan on bigger tables.
+	 */
+	private const MIN_ORDER_COUNT = 500000;
+
+	/**
+	 * The query being rewritten.
+	 *
+	 * @var OrdersTableQuery
+	 */
+	private $query;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param OrdersTableQuery $query The query to rewrite.
+	 *
+	 * @since 11.0.0
+	 */
+	public function __construct( OrdersTableQuery $query ) {
+		$this->query = $query;
+	}
+
+	/**
+	 * Returns the rewritten SQL query, or NULL when the query is not eligible for the rewrite.
+	 *
+	 * @param string[] $clauses          Associative array with the final 'fields', 'join', 'where', 'groupby',
+	 *                                   'orderby' and 'limits' clauses (the latter four including their keywords).
+	 * @param bool     $suppress_filters Whether the query is running with filters suppressed.
+	 * @return string|null The rewritten SQL query, or NULL if the query is not eligible.
+	 *
+	 * @since 11.0.0
+	 */
+	public function get_sql( array $clauses, bool $suppress_filters ): ?string {
+		global $wpdb;
+
+		$orders_table = $this->query->get_table_name( 'orders' );
+
+		$fields  = $clauses['fields'] ?? '';
+		$join    = $clauses['join'] ?? '';
+		$where   = $clauses['where'] ?? '';
+		$groupby = $clauses['groupby'] ?? '';
+		$orderby = $clauses['orderby'] ?? '';
+		$limits  = $clauses['limits'] ?? '';
+
+		if ( '' !== $join || '' !== $groupby || "{$orders_table}.id" !== $fields ) {
+			return null;
+		}
+
+		// Only an ORDER BY on date_created_gmt alone can be satisfied by the type_status_date index within each branch.
+		$direction = null;
+		foreach ( array( 'ASC', 'DESC' ) as $_direction ) {
+			if ( "ORDER BY {$orders_table}.date_created_gmt {$_direction}" === $orderby ) {
+				$direction = $_direction;
+			}
+		}
+
+		if ( is_null( $direction ) ) {
+			return null;
+		}
+
+		// Unlimited or deeply paginated queries gain nothing from the rewrite: each branch would have to fetch
+		// (offset + row count) rows. The digit cap also rejects the "unlimited" sentinel row count.
+		if ( ! preg_match( '/^LIMIT (\d{1,7}), (\d{1,7})$/', $limits, $limit_parts ) ) {
+			return null;
+		}
+
+		$offset    = (int) $limit_parts[1];
+		$row_count = (int) $limit_parts[2];
+
+		if ( $row_count < 1 || ( $offset + $row_count ) > self::MAX_ROWS ) {
+			return null;
+		}
+
+		if ( ! $this->query->arg_isset( 'type' ) || ! $this->query->arg_isset( 'status' ) ) {
+			return null;
+		}
+
+		$types    = array_values( array_unique( (array) $this->query->get( 'type' ) ) );
+		$statuses = array_values( array_unique( (array) $this->query->get( 'status' ) ) );
+
+		foreach ( array_merge( $types, $statuses ) as $value ) {
+			if ( ! is_string( $value ) || '' === $value ) {
+				return null;
+			}
+		}
+
+		// A single status doesn't need the rewrite (the type_status_date index already provides the ordering).
+		if ( count( $statuses ) < 2 || ( count( $types ) * count( $statuses ) ) > self::MAX_BRANCHES ) {
+			return null;
+		}
+
+		if ( ! $this->is_enabled( $types, $statuses, $suppress_filters ) ) {
+			return null;
+		}
+
+		// Require the WHERE clause to be exactly the one the 'type' and 'status' args generate (same order as
+		// OrdersTableQuery::process_orders_table_query_args()). Any other contribution — other query args or
+		// filters — disqualifies the query. Both columns are of the 'string' type per the OrdersTableDataStore
+		// column mappings.
+		$expected_where = '1=1';
+		foreach ( array( 'status', 'type' ) as $arg_key ) {
+			$clause          = $this->query->where( $orders_table, $arg_key, '=', $this->query->get( $arg_key ), 'string' );
+			$expected_where .= " AND ({$clause})";
+		}
+
+		if ( $where !== $expected_where ) {
+			return null;
+		}
+
+		// Each branch is wrapped in a derived table (instead of using parenthesized UNION members) so that the
+		// per-branch ORDER BY + LIMIT is honored across MySQL, MariaDB and SQLite.
+		$branch_rows = $offset + $row_count;
+		$branches    = array();
+
+		foreach ( $types as $type ) {
+			foreach ( $statuses as $status ) {
+				$branch = $wpdb->prepare(
+					"SELECT id, date_created_gmt FROM {$orders_table} WHERE type = %s AND status = %s ORDER BY date_created_gmt {$direction} LIMIT {$branch_rows}", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$type,
+					$status
+				);
+
+				$branches[] = 'SELECT id, date_created_gmt FROM ( ' . $branch . ' ) wco_branch_' . count( $branches );
+			}
+		}
+
+		return 'SELECT id FROM ( ' . implode( ' UNION ALL ', $branches ) . " ) wco_candidates ORDER BY date_created_gmt {$direction} {$limits}";
+	}
+
+	/**
+	 * Returns whether the rewrite should be used for the given types and statuses.
+	 *
+	 * By default the rewrite is only enabled when the number of orders matching the queried types and statuses
+	 * (per the order count cache) reaches MIN_ORDER_COUNT: below that, the regular query is fast even with a
+	 * suboptimal execution plan, while each UNION branch adds a small constant cost. The counts are read from the
+	 * cache without recomputing them, so the rewrite stays disabled while the cache is cold (it is kept warm by
+	 * the order admin list screen, among others).
+	 *
+	 * @param string[] $types            Queried order types.
+	 * @param string[] $statuses         Queried order statuses.
+	 * @param bool     $suppress_filters Whether the query is running with filters suppressed.
+	 * @return bool Whether the rewrite should be used.
+	 */
+	private function is_enabled( array $types, array $statuses, bool $suppress_filters ): bool {
+		$count_cache  = new OrderCountCache();
+		$orders_count = 0;
+
+		foreach ( $types as $type ) {
+			$counts = $count_cache->get( $type, $statuses );
+
+			if ( is_null( $counts ) ) {
+				$orders_count = 0;
+				break;
+			}
+
+			$orders_count += array_sum( $counts );
+		}
+
+		$enabled = $orders_count >= self::MIN_ORDER_COUNT;
+
+		if ( $suppress_filters ) {
+			return $enabled;
+		}
+
+		/**
+		 * Filters whether a query for multiple order statuses ordered by creation date may be rewritten as a
+		 * UNION ALL of single-status queries for performance. The rewrite produces the same results and, even
+		 * when enabled here, only applies to queries generated purely from the 'type' and 'status' query args
+		 * (no search, meta or field filters), such as the default order admin list screen query.
+		 *
+		 * Hosts that know their database benefits from the rewrite regardless of store size (or that don't want
+		 * to depend on the order count cache being warm) can force-enable it with
+		 * add_filter( 'woocommerce_orders_table_query_status_union_optimization', '__return_true' ); the
+		 * structural eligibility checks above still apply.
+		 *
+		 * @param bool             $enabled Whether the rewrite is enabled. Defaults to TRUE only when the cached
+		 *                                  number of orders matching the queried types and statuses is at least
+		 *                                  500,000; FALSE otherwise (including when the order count cache is cold).
+		 * @param OrdersTableQuery $query   The OrdersTableQuery instance.
+		 *
+		 * @since 11.0.0
+		 */
+		return (bool) apply_filters( 'woocommerce_orders_table_query_status_union_optimization', $enabled, $this->query );
+	}
+}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableStatusUnionQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableStatusUnionQuery.php
@@ -12,25 +12,16 @@ use Automattic\WooCommerce\Caches\OrderCountCache;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Rewrites a "multiple statuses, ordered by creation date" order query (such as the default order admin list screen
- * query) as a UNION ALL of single-status queries.
+ * Rewrites a "multiple statuses, ordered by creation date" order query (such as the default order admin list
+ * screen query) as a UNION ALL of single-status queries.
  *
- * `status IN (...)` prevents the `type_status_date` index from providing a global `date_created_gmt` ordering, so
- * the optimizer must either sort all matching rows or walk the `date_created` index while filtering. On large
- * stores it may choose a plan that examines millions of rows to produce a single page of results, depending on the
- * optimizer heuristics available (e.g. the MySQL `prefer_ordering_index` switch). With one branch per (type,
- * status) pair, each branch is fully served — filtering and ordering — by the `type_status_date` index regardless
- * of optimizer behavior or status selectivity, and the outer query only needs to merge a handful of pre-sorted
- * candidate rows.
+ * `status IN (...)` prevents the `type_status_date` index from serving a global `date_created_gmt` ordering, so on
+ * large stores the optimizer may pick a plan that scans millions of rows for a single page. One branch per (type,
+ * status) pair is fully served — filter and order — by `type_status_date`, leaving the outer query to merge a few
+ * pre-sorted rows.
  *
- * The rewrite is skipped unless the final query clauses are byte-identical to those generated purely by the 'type'
- * and 'status' query args, which guarantees that queries customized in any way (other query args, search, meta
- * queries, or modifications via the 'woocommerce_orders_table_query_clauses' filter) are never altered. Queries
- * modified via the 'woocommerce_orders_table_query_sql' filter are not rewritten either: build_query() only
- * attempts the rewrite when that filter returned the query unchanged.
- *
- * By default the rewrite is also gated by store size: on stores below the order count threshold the regular query
- * is already fast even with a suboptimal plan, while each UNION branch adds a small constant cost.
+ * Eligibility (exact clause match) and the store-size gate are documented at the methods that enforce them
+ * (get_sql() and is_enabled()).
  */
 class OrdersTableStatusUnionQuery {
 
@@ -44,22 +35,28 @@ class OrdersTableStatusUnionQuery {
 	 * Maximum row depth (offset + row count). Each UNION branch must fetch up to this many rows, so deeply
 	 * paginated queries are left untouched.
 	 */
-	private const MAX_ROWS = 2000;
+	private const MAX_ROWS = 2_000;
 
 	/**
-	 * Minimum number of orders (per the order count cache) matching the queried types and statuses for the
-	 * rewrite to be enabled by default. An educated guess at the store size where a mis-planned query becomes
-	 * user-visible, not a measured crossover: the rewrite never beats a well-planned regular query, so this
-	 * only balances its small constant cost against the risk of a slow plan on bigger tables.
+	 * Minimum number of orders (per the order count cache) matching the queried types and statuses for the rewrite
+	 * to be enabled by default. A rough threshold for where a mis-planned query gets user-visible, not a measured
+	 * crossover.
 	 */
-	private const MIN_ORDER_COUNT = 500000;
+	private const MIN_ORDER_COUNT = 500_000;
 
 	/**
 	 * The query being rewritten.
 	 *
 	 * @var OrdersTableQuery
 	 */
-	private $query;
+	private OrdersTableQuery $query;
+
+	/**
+	 * The orders table name.
+	 *
+	 * @var string
+	 */
+	private string $orders_table;
 
 	/**
 	 * Constructor.
@@ -69,7 +66,8 @@ class OrdersTableStatusUnionQuery {
 	 * @since 11.0.0
 	 */
 	public function __construct( OrdersTableQuery $query ) {
-		$this->query = $query;
+		$this->query        = $query;
+		$this->orders_table = $query->get_table_name( 'orders' );
 	}
 
 	/**
@@ -83,35 +81,81 @@ class OrdersTableStatusUnionQuery {
 	 * @since 11.0.0
 	 */
 	public function get_sql( array $clauses, bool $suppress_filters ): ?string {
-		global $wpdb;
-
-		$orders_table = $this->query->get_table_name( 'orders' );
-
-		$fields  = $clauses['fields'] ?? '';
-		$join    = $clauses['join'] ?? '';
-		$where   = $clauses['where'] ?? '';
-		$groupby = $clauses['groupby'] ?? '';
-		$orderby = $clauses['orderby'] ?? '';
-		$limits  = $clauses['limits'] ?? '';
-
-		if ( '' !== $join || '' !== $groupby || "{$orders_table}.id" !== $fields ) {
+		// Each step either extracts a validated piece of the rewrite or bails out (returns null) when the query
+		// isn't the plain "type + status, ordered by creation date" shape we can safely rewrite. The UNION is only
+		// assembled once every piece is in place.
+		if ( ! $this->has_rewritable_clause_shape( $clauses ) ) {
 			return null;
 		}
 
-		// Only an ORDER BY on date_created_gmt alone can be satisfied by the type_status_date index within each branch.
-		$direction = null;
-		foreach ( array( 'ASC', 'DESC' ) as $_direction ) {
-			if ( "ORDER BY {$orders_table}.date_created_gmt {$_direction}" === $orderby ) {
-				$direction = $_direction;
-			}
-		}
-
+		$direction = $this->extract_order_direction( $clauses['orderby'] ?? '' );
 		if ( is_null( $direction ) ) {
 			return null;
 		}
 
-		// Unlimited or deeply paginated queries gain nothing from the rewrite: each branch would have to fetch
-		// (offset + row count) rows. The digit cap also rejects the "unlimited" sentinel row count.
+		$limit = $this->extract_limit( $clauses['limits'] ?? '' );
+		if ( is_null( $limit ) ) {
+			return null;
+		}
+
+		$types_and_statuses = $this->extract_types_and_statuses();
+		if ( is_null( $types_and_statuses ) ) {
+			return null;
+		}
+		list( $types, $statuses ) = $types_and_statuses;
+
+		if ( ! $this->is_enabled( $types, $statuses, $suppress_filters ) ) {
+			return null;
+		}
+
+		if ( ! $this->where_matches_type_status_args( $clauses['where'] ?? '' ) ) {
+			return null;
+		}
+
+		list( $offset, $row_count ) = $limit;
+
+		return $this->build_union_sql( $types, $statuses, $direction, $offset + $row_count, $clauses['limits'] ?? '' );
+	}
+
+	/**
+	 * Checks the fixed clauses (selected fields, join, group by) are exactly those of the plain order id list
+	 * query. Any join, grouping or extra selected field means the query isn't a candidate for the rewrite.
+	 *
+	 * @param string[] $clauses The query clauses (see get_sql()).
+	 * @return bool Whether the clause shape is rewritable.
+	 */
+	private function has_rewritable_clause_shape( array $clauses ): bool {
+		return '' === ( $clauses['join'] ?? '' )
+			&& '' === ( $clauses['groupby'] ?? '' )
+			&& "{$this->orders_table}.id" === ( $clauses['fields'] ?? '' );
+	}
+
+	/**
+	 * Extracts the sort direction from the ORDER BY clause, or NULL when it isn't an ORDER BY on date_created_gmt
+	 * alone (the only ordering the type_status_date index can satisfy within each branch).
+	 *
+	 * @param string $orderby The ORDER BY clause, including the keyword.
+	 * @return string|null 'ASC', 'DESC', or NULL when ineligible.
+	 */
+	private function extract_order_direction( string $orderby ): ?string {
+		foreach ( array( 'ASC', 'DESC' ) as $direction ) {
+			if ( "ORDER BY {$this->orders_table}.date_created_gmt {$direction}" === $orderby ) {
+				return $direction;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extracts the offset and row count from the LIMIT clause, or NULL when the query is unlimited or too deeply
+	 * paginated to benefit (each branch would have to fetch offset + row count rows). The digit cap also rejects
+	 * the "unlimited" sentinel row count.
+	 *
+	 * @param string $limits The LIMIT clause, including the keyword.
+	 * @return int[]|null Array of [ offset, row count ], or NULL when ineligible.
+	 */
+	private function extract_limit( string $limits ): ?array {
 		if ( ! preg_match( '/^LIMIT (\d{1,7}), (\d{1,7})$/', $limits, $limit_parts ) ) {
 			return null;
 		}
@@ -123,6 +167,17 @@ class OrdersTableStatusUnionQuery {
 			return null;
 		}
 
+		return array( $offset, $row_count );
+	}
+
+	/**
+	 * Extracts the queried order types and statuses, or NULL when they don't form a rewritable set: the 'type' and
+	 * 'status' args must both be set and contain only non-empty strings, cover at least two statuses (a single
+	 * status is already served by the type_status_date index), and stay within the branch cap.
+	 *
+	 * @return array[]|null Array of [ types, statuses ] (each a list of unique strings), or NULL when ineligible.
+	 */
+	private function extract_types_and_statuses(): ?array {
 		if ( ! $this->query->arg_isset( 'type' ) || ! $this->query->arg_isset( 'status' ) ) {
 			return null;
 		}
@@ -136,38 +191,52 @@ class OrdersTableStatusUnionQuery {
 			}
 		}
 
-		// A single status doesn't need the rewrite (the type_status_date index already provides the ordering).
 		if ( count( $statuses ) < 2 || ( count( $types ) * count( $statuses ) ) > self::MAX_BRANCHES ) {
 			return null;
 		}
 
-		if ( ! $this->is_enabled( $types, $statuses, $suppress_filters ) ) {
-			return null;
-		}
+		return array( $types, $statuses );
+	}
 
-		// Require the WHERE clause to be exactly the one the 'type' and 'status' args generate (same order as
-		// OrdersTableQuery::process_orders_table_query_args()). Any other contribution — other query args or
-		// filters — disqualifies the query. Both columns are of the 'string' type per the OrdersTableDataStore
-		// column mappings.
+	/**
+	 * Checks the WHERE clause is exactly the one the 'type' and 'status' args generate (same order as
+	 * OrdersTableQuery::process_orders_table_query_args()). Any other contribution — other query args or filters —
+	 * disqualifies the query. Both columns are of the 'string' type per the OrdersTableDataStore column mappings.
+	 *
+	 * @param string $where The WHERE clause (without the WHERE keyword).
+	 * @return bool Whether the WHERE clause is exactly the type/status one.
+	 */
+	private function where_matches_type_status_args( string $where ): bool {
 		$expected_where = '1=1';
 		foreach ( array( 'status', 'type' ) as $arg_key ) {
-			$clause          = $this->query->where( $orders_table, $arg_key, '=', $this->query->get( $arg_key ), 'string' );
+			$clause          = $this->query->where( $this->orders_table, $arg_key, '=', $this->query->get( $arg_key ), 'string' );
 			$expected_where .= " AND ({$clause})";
 		}
 
-		if ( $where !== $expected_where ) {
-			return null;
-		}
+		return $where === $expected_where;
+	}
 
-		// Each branch is wrapped in a derived table (instead of using parenthesized UNION members) so that the
-		// per-branch ORDER BY + LIMIT is honored across MySQL, MariaDB and SQLite.
-		$branch_rows = $offset + $row_count;
-		$branches    = array();
+	/**
+	 * Assembles the UNION ALL rewrite from the validated pieces. Each branch is wrapped in a derived table (instead
+	 * of using parenthesized UNION members) so that the per-branch ORDER BY + LIMIT is honored across MySQL,
+	 * MariaDB and SQLite.
+	 *
+	 * @param string[] $types       Queried order types.
+	 * @param string[] $statuses    Queried order statuses.
+	 * @param string   $direction   Sort direction ('ASC' or 'DESC').
+	 * @param int      $branch_rows Number of rows each branch must fetch (offset + row count).
+	 * @param string   $limits      The outer LIMIT clause, including the keyword.
+	 * @return string The rewritten SQL query.
+	 */
+	private function build_union_sql( array $types, array $statuses, string $direction, int $branch_rows, string $limits ): string {
+		global $wpdb;
+
+		$branches = array();
 
 		foreach ( $types as $type ) {
 			foreach ( $statuses as $status ) {
 				$branch = $wpdb->prepare(
-					"SELECT id, date_created_gmt FROM {$orders_table} WHERE type = %s AND status = %s ORDER BY date_created_gmt {$direction} LIMIT {$branch_rows}", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"SELECT id, date_created_gmt FROM {$this->orders_table} WHERE type = %s AND status = %s ORDER BY date_created_gmt {$direction} LIMIT {$branch_rows}", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					$type,
 					$status
 				);
@@ -182,11 +251,8 @@ class OrdersTableStatusUnionQuery {
 	/**
 	 * Returns whether the rewrite should be used for the given types and statuses.
 	 *
-	 * By default the rewrite is only enabled when the number of orders matching the queried types and statuses
-	 * (per the order count cache) reaches MIN_ORDER_COUNT: below that, the regular query is fast even with a
-	 * suboptimal execution plan, while each UNION branch adds a small constant cost. The counts are read from the
-	 * cache without recomputing them, so the rewrite stays disabled while the cache is cold (it is kept warm by
-	 * the order admin list screen, among others).
+	 * Enabled by default once the matching order count reaches MIN_ORDER_COUNT. Counts are read from the cache
+	 * without recomputing them, so the rewrite stays disabled while the cache is cold.
 	 *
 	 * @param string[] $types            Queried order types.
 	 * @param string[] $statuses         Queried order statuses.
@@ -200,6 +266,9 @@ class OrdersTableStatusUnionQuery {
 		foreach ( $types as $type ) {
 			$counts = $count_cache->get( $type, $statuses );
 
+			// A cold cache for any queried type means we have no confident total, so bail out (count 0, rewrite
+			// disabled) rather than enable on a partial count — hence reset and break, not continue.
+			// OrderCountCache::get() returns null when any of the type's queried statuses is missing from the cache.
 			if ( is_null( $counts ) ) {
 				$orders_count = 0;
 				break;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableStatusUnionQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableStatusUnionQuery.php
@@ -266,12 +266,11 @@ class OrdersTableStatusUnionQuery {
 		foreach ( $types as $type ) {
 			$counts = $count_cache->get( $type, $statuses );
 
-			// A cold cache for any queried type means we have no confident total, so bail out (count 0, rewrite
-			// disabled) rather than enable on a partial count — hence reset and break, not continue.
-			// OrderCountCache::get() returns null when any of the type's queried statuses is missing from the cache.
+			// A cold count cache for a type (get() returns null when any of its queried statuses is missing)
+			// contributes nothing rather than disqualifying the whole check, so the fast path can kick in off the
+			// counts we already have without waiting for every type's cache to warm.
 			if ( is_null( $counts ) ) {
-				$orders_count = 0;
-				break;
+				continue;
 			}
 
 			$orders_count += array_sum( $counts );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
@@ -232,4 +232,55 @@ class ListTableTest extends \WC_Unit_Test_Case {
 
 		$this->assertCount( 2, $filtered_items ); // Both orders should be shown.
 	}
+
+	/**
+	 * Helper to read the order query args prepared by the list table.
+	 *
+	 * @return array
+	 */
+	private function get_order_query_args(): array {
+		$getter = function () {
+			return $this->order_query_args;
+		};
+
+		return $getter->call( $this->sut );
+	}
+
+	/**
+	 * @testdox Submitting the search form with an empty search term keeps the cached-count fast path.
+	 */
+	public function test_empty_search_term_uses_cached_count_fast_path(): void {
+		\WC_Helper_Order::create_order();
+
+		$_REQUEST['s']             = '';
+		$_REQUEST['search-filter'] = 'all';
+
+		$this->sut->prepare_items();
+		$query_args = $this->get_order_query_args();
+
+		unset( $_REQUEST['s'], $_REQUEST['search-filter'] );
+
+		$this->assertArrayNotHasKey( 's', $query_args, 'An empty search term should not be added to the query args' );
+		$this->assertArrayNotHasKey( 'search_filter', $query_args, 'The search filter should not be added without a search term' );
+		$this->assertTrue( $query_args['no_found_rows'] ?? false, 'An empty search should use cached order counts instead of a COUNT query' );
+	}
+
+	/**
+	 * @testdox Searching with a term applies the selected search filter and uses a real results count.
+	 */
+	public function test_search_term_sets_search_filter_and_counts_results(): void {
+		\WC_Helper_Order::create_order();
+
+		$_REQUEST['s']             = 'some-term';
+		$_REQUEST['search-filter'] = 'order_id';
+
+		$this->sut->prepare_items();
+		$query_args = $this->get_order_query_args();
+
+		unset( $_REQUEST['s'], $_REQUEST['search-filter'] );
+
+		$this->assertSame( 'some-term', $query_args['s'] ?? null, 'The search term should be added to the query args' );
+		$this->assertSame( 'order_id', $query_args['search_filter'] ?? null, 'The selected search filter should be applied' );
+		$this->assertArrayNotHasKey( 'no_found_rows', $query_args, 'Searches should count their actual results' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\DataStores\Orders;
 
+use Automattic\WooCommerce\Caches\OrderCountCache;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
@@ -834,6 +835,21 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 		return array( $ids, $captured_sql );
 	}
 
+
+	/**
+	 * Helper function to force-enable the status union rewrite, which by default is gated by store size.
+	 */
+	private function force_enable_status_union_rewrite(): void {
+		add_filter( 'woocommerce_orders_table_query_status_union_optimization', '__return_true' );
+	}
+
+	/**
+	 * Helper function to remove the force-enablement of the status union rewrite.
+	 */
+	private function reset_status_union_rewrite(): void {
+		remove_filter( 'woocommerce_orders_table_query_status_union_optimization', '__return_true' );
+	}
+
 	/**
 	 * @testdox Multi-status queries ordered by creation date are rewritten as a UNION of single-status queries and return the same results.
 	 */
@@ -846,7 +862,9 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 			'limit'   => 4,
 		);
 
+		$this->force_enable_status_union_rewrite();
 		list( $queried_ids, $sql ) = $this->get_orders_and_capture_sql( $args );
+		$this->reset_status_union_rewrite();
 
 		$this->assertStringContainsString( 'UNION ALL', $sql, 'Eligible multi-status queries should be rewritten as a UNION of single-status queries' );
 		$this->assertSame( array_slice( $ids, 0, 4 ), $queried_ids, 'The rewritten query should return the most recent orders across all statuses' );
@@ -865,7 +883,9 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 	public function test_status_union_rewrite_applies_to_default_query(): void {
 		$ids = $this->create_orders_with_interleaved_statuses( 3 );
 
+		$this->force_enable_status_union_rewrite();
 		list( $queried_ids, $sql ) = $this->get_orders_and_capture_sql( array() );
+		$this->reset_status_union_rewrite();
 
 		$this->assertStringContainsString( 'UNION ALL', $sql, 'The default order query should be rewritten as a UNION of single-status queries' );
 		$this->assertSame( $ids, $queried_ids, 'The rewritten default query should return all orders, most recent first' );
@@ -876,6 +896,8 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 	 */
 	public function test_status_union_rewrite_pagination_and_sort_direction(): void {
 		$this->create_orders_with_interleaved_statuses( 9 );
+
+		$this->force_enable_status_union_rewrite();
 
 		foreach ( array( 'DESC', 'ASC' ) as $order ) {
 			foreach ( array( 1, 2, 3 ) as $page ) {
@@ -897,6 +919,8 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 				$this->assertSame( $unoptimized_ids, $queried_ids, "Page {$page} ({$order}) of the rewritten query should match the regular query" );
 			}
 		}
+
+		$this->reset_status_union_rewrite();
 	}
 
 	/**
@@ -904,6 +928,7 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 	 */
 	public function test_status_union_rewrite_skipped_for_ineligible_queries(): void {
 		$this->create_orders_with_interleaved_statuses( 3 );
+		$this->force_enable_status_union_rewrite();
 
 		$ineligible_args = array(
 			'a single status'    => array( 'status' => array( OrderStatus::PENDING ) ),
@@ -936,6 +961,8 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 
 			$this->assertStringNotContainsString( 'UNION ALL', $sql, "A query with {$description} should not be rewritten" );
 		}
+
+		$this->reset_status_union_rewrite();
 	}
 
 	/**
@@ -943,6 +970,7 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 	 */
 	public function test_status_union_rewrite_skipped_when_clauses_modified(): void {
 		$ids = $this->create_orders_with_interleaved_statuses( 3 );
+		$this->force_enable_status_union_rewrite();
 
 		$filter_callback = function ( $clauses ) {
 			$clauses['where'] .= ' AND 1=1';
@@ -960,6 +988,8 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 		);
 		remove_filter( 'woocommerce_orders_table_query_clauses', $filter_callback );
 
+		$this->reset_status_union_rewrite();
+
 		$this->assertStringNotContainsString( 'UNION ALL', $sql, 'Queries modified via the clauses filter should not be rewritten' );
 		$this->assertSame( array( $ids[0], $ids[1] ), $queried_ids, 'The unmodified query should still return matching orders' );
 	}
@@ -969,6 +999,7 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 	 */
 	public function test_status_union_rewrite_skipped_when_sql_modified(): void {
 		$ids = $this->create_orders_with_interleaved_statuses( 3 );
+		$this->force_enable_status_union_rewrite();
 
 		$filter_callback = function ( $sql ) {
 			return $sql . ' -- modified';
@@ -985,8 +1016,60 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 		);
 		remove_filter( 'woocommerce_orders_table_query_sql', $filter_callback );
 
+		$this->reset_status_union_rewrite();
+
 		$this->assertStringNotContainsString( 'UNION ALL', $sql, 'Queries modified via the SQL filter should not be rewritten' );
 		$this->assertStringEndsWith( '-- modified', $sql, 'The SQL modified by the filter should be the SQL that gets executed' );
 		$this->assertSame( array( $ids[0], $ids[1] ), $queried_ids, 'The filter-modified query should still return matching orders' );
+	}
+
+	/**
+	 * @testdox The status union rewrite is disabled by default on stores below the order count threshold.
+	 */
+	public function test_status_union_rewrite_disabled_by_default_on_small_stores(): void {
+		$this->create_orders_with_interleaved_statuses( 3 );
+
+		list( , $sql ) = $this->get_orders_and_capture_sql(
+			array(
+				'status'  => array( OrderStatus::PENDING, OrderStatus::PROCESSING, OrderStatus::COMPLETED ),
+				'orderby' => 'date',
+				'order'   => 'DESC',
+				'limit'   => 4,
+			)
+		);
+
+		$this->assertStringNotContainsString( 'UNION ALL', $sql, 'The rewrite should be disabled by default on stores below the order count threshold' );
+	}
+
+	/**
+	 * @testdox The status union rewrite is enabled by default once cached order counts reach the threshold.
+	 */
+	public function test_status_union_rewrite_enabled_by_default_on_large_stores(): void {
+		$ids = $this->create_orders_with_interleaved_statuses( 3 );
+
+		$count_cache = new OrderCountCache();
+		$count_cache->set_multiple(
+			'shop_order',
+			array(
+				'wc-pending'    => 200000,
+				'wc-processing' => 200000,
+				'wc-completed'  => 200000,
+			)
+		);
+
+		list( $queried_ids, $sql ) = $this->get_orders_and_capture_sql(
+			array(
+				'type'    => 'shop_order',
+				'status'  => array( OrderStatus::PENDING, OrderStatus::PROCESSING, OrderStatus::COMPLETED ),
+				'orderby' => 'date',
+				'order'   => 'DESC',
+				'limit'   => 4,
+			)
+		);
+
+		$count_cache->flush( 'shop_order' );
+
+		$this->assertStringContainsString( 'UNION ALL', $sql, 'The rewrite should be enabled by default once cached order counts reach the threshold' );
+		$this->assertSame( $ids, $queried_ids, 'The rewritten query should return all orders, most recent first' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -790,4 +790,203 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 		$order2->delete( true );
 		$order3->delete( true );
 	}
+
+	/**
+	 * Helper function to create orders with interleaved statuses and strictly decreasing creation dates.
+	 *
+	 * @param int $count Number of orders to create.
+	 * @return int[] Order IDs, ordered by creation date descending.
+	 */
+	private function create_orders_with_interleaved_statuses( int $count ): array {
+		$statuses = array( OrderStatus::PENDING, OrderStatus::PROCESSING, OrderStatus::COMPLETED );
+		$ids      = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$order = new \WC_Order();
+			$order->set_status( $statuses[ $i % count( $statuses ) ] );
+			$order->set_date_created( strtotime( '2023-06-01 12:00:00' ) - ( $i * HOUR_IN_SECONDS ) );
+			$order->save();
+			$ids[] = $order->get_id();
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Helper function to run wc_get_orders() and capture the SQL query executed by OrdersTableQuery.
+	 *
+	 * @param array $args Query args ('return' => 'ids' is always added).
+	 * @return array Two-element array containing the queried order IDs and the executed SQL query.
+	 */
+	private function get_orders_and_capture_sql( array $args ): array {
+		$captured_sql = '';
+		$callback     = function ( $result, $query, $sql ) use ( &$captured_sql ) {
+			// Avoid parameter not used PHPCS errors.
+			unset( $query );
+			$captured_sql = $sql;
+			return $result;
+		};
+
+		add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );
+		$ids = wc_get_orders( array_merge( $args, array( 'return' => 'ids' ) ) );
+		remove_filter( 'woocommerce_hpos_pre_query', $callback );
+
+		return array( $ids, $captured_sql );
+	}
+
+	/**
+	 * @testdox Multi-status queries ordered by creation date are rewritten as a UNION of single-status queries and return the same results.
+	 */
+	public function test_status_union_rewrite_applies_and_preserves_results(): void {
+		$ids  = $this->create_orders_with_interleaved_statuses( 9 );
+		$args = array(
+			'status'  => array( OrderStatus::PENDING, OrderStatus::PROCESSING, OrderStatus::COMPLETED ),
+			'orderby' => 'date',
+			'order'   => 'DESC',
+			'limit'   => 4,
+		);
+
+		list( $queried_ids, $sql ) = $this->get_orders_and_capture_sql( $args );
+
+		$this->assertStringContainsString( 'UNION ALL', $sql, 'Eligible multi-status queries should be rewritten as a UNION of single-status queries' );
+		$this->assertSame( array_slice( $ids, 0, 4 ), $queried_ids, 'The rewritten query should return the most recent orders across all statuses' );
+
+		add_filter( 'woocommerce_orders_table_query_status_union_optimization', '__return_false' );
+		list( $unoptimized_ids, $unoptimized_sql ) = $this->get_orders_and_capture_sql( $args );
+		remove_filter( 'woocommerce_orders_table_query_status_union_optimization', '__return_false' );
+
+		$this->assertStringNotContainsString( 'UNION ALL', $unoptimized_sql, 'The rewrite should be disabled by the woocommerce_orders_table_query_status_union_optimization filter' );
+		$this->assertSame( $unoptimized_ids, $queried_ids, 'Rewritten and regular queries should return identical results' );
+	}
+
+	/**
+	 * @testdox The default order query (multiple statuses, ordered by creation date) is rewritten as a UNION of single-status queries.
+	 */
+	public function test_status_union_rewrite_applies_to_default_query(): void {
+		$ids = $this->create_orders_with_interleaved_statuses( 3 );
+
+		list( $queried_ids, $sql ) = $this->get_orders_and_capture_sql( array() );
+
+		$this->assertStringContainsString( 'UNION ALL', $sql, 'The default order query should be rewritten as a UNION of single-status queries' );
+		$this->assertSame( $ids, $queried_ids, 'The rewritten default query should return all orders, most recent first' );
+	}
+
+	/**
+	 * @testdox The status union rewrite returns the same results as the regular query across pages and sort directions.
+	 */
+	public function test_status_union_rewrite_pagination_and_sort_direction(): void {
+		$this->create_orders_with_interleaved_statuses( 9 );
+
+		foreach ( array( 'DESC', 'ASC' ) as $order ) {
+			foreach ( array( 1, 2, 3 ) as $page ) {
+				$args = array(
+					'status'  => array( OrderStatus::PENDING, OrderStatus::PROCESSING, OrderStatus::COMPLETED ),
+					'orderby' => 'date',
+					'order'   => $order,
+					'limit'   => 4,
+					'page'    => $page,
+				);
+
+				list( $queried_ids, $sql ) = $this->get_orders_and_capture_sql( $args );
+
+				add_filter( 'woocommerce_orders_table_query_status_union_optimization', '__return_false' );
+				list( $unoptimized_ids ) = $this->get_orders_and_capture_sql( $args );
+				remove_filter( 'woocommerce_orders_table_query_status_union_optimization', '__return_false' );
+
+				$this->assertStringContainsString( 'UNION ALL', $sql, "Page {$page} ({$order}) should be served by the rewritten query" );
+				$this->assertSame( $unoptimized_ids, $queried_ids, "Page {$page} ({$order}) of the rewritten query should match the regular query" );
+			}
+		}
+	}
+
+	/**
+	 * @testdox The status union rewrite is skipped for queries it cannot serve identically.
+	 */
+	public function test_status_union_rewrite_skipped_for_ineligible_queries(): void {
+		$this->create_orders_with_interleaved_statuses( 3 );
+
+		$ineligible_args = array(
+			'a single status'    => array( 'status' => array( OrderStatus::PENDING ) ),
+			'no row limit'       => array( 'limit' => -1 ),
+			'a non-date orderby' => array( 'orderby' => 'id' ),
+			'a field filter'     => array( 'customer_id' => 123 ),
+			'a meta query'       => array(
+				'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+
+					array(
+						'key'   => 'some_key',
+						'value' => 'some_value',
+					),
+				),
+			),
+		);
+
+		foreach ( $ineligible_args as $description => $args ) {
+			$args = array_merge(
+				array(
+					'status'  => array( OrderStatus::PENDING, OrderStatus::PROCESSING ),
+					'orderby' => 'date',
+					'order'   => 'DESC',
+					'limit'   => 4,
+				),
+				$args
+			);
+
+			list( , $sql ) = $this->get_orders_and_capture_sql( $args );
+
+			$this->assertStringNotContainsString( 'UNION ALL', $sql, "A query with {$description} should not be rewritten" );
+		}
+	}
+
+	/**
+	 * @testdox Queries customized via the clauses filter are not rewritten.
+	 */
+	public function test_status_union_rewrite_skipped_when_clauses_modified(): void {
+		$ids = $this->create_orders_with_interleaved_statuses( 3 );
+
+		$filter_callback = function ( $clauses ) {
+			$clauses['where'] .= ' AND 1=1';
+			return $clauses;
+		};
+
+		add_filter( 'woocommerce_orders_table_query_clauses', $filter_callback );
+		list( $queried_ids, $sql ) = $this->get_orders_and_capture_sql(
+			array(
+				'status'  => array( OrderStatus::PENDING, OrderStatus::PROCESSING ),
+				'orderby' => 'date',
+				'order'   => 'DESC',
+				'limit'   => 4,
+			)
+		);
+		remove_filter( 'woocommerce_orders_table_query_clauses', $filter_callback );
+
+		$this->assertStringNotContainsString( 'UNION ALL', $sql, 'Queries modified via the clauses filter should not be rewritten' );
+		$this->assertSame( array( $ids[0], $ids[1] ), $queried_ids, 'The unmodified query should still return matching orders' );
+	}
+
+	/**
+	 * @testdox Queries modified via the SQL filter are not rewritten, and the modified SQL is the one executed.
+	 */
+	public function test_status_union_rewrite_skipped_when_sql_modified(): void {
+		$ids = $this->create_orders_with_interleaved_statuses( 3 );
+
+		$filter_callback = function ( $sql ) {
+			return $sql . ' -- modified';
+		};
+
+		add_filter( 'woocommerce_orders_table_query_sql', $filter_callback );
+		list( $queried_ids, $sql ) = $this->get_orders_and_capture_sql(
+			array(
+				'status'  => array( OrderStatus::PENDING, OrderStatus::PROCESSING ),
+				'orderby' => 'date',
+				'order'   => 'DESC',
+				'limit'   => 4,
+			)
+		);
+		remove_filter( 'woocommerce_orders_table_query_sql', $filter_callback );
+
+		$this->assertStringNotContainsString( 'UNION ALL', $sql, 'Queries modified via the SQL filter should not be rewritten' );
+		$this->assertStringEndsWith( '-- modified', $sql, 'The SQL modified by the filter should be the SQL that gets executed' );
+		$this->assertSame( array( $ids[0], $ids[1] ), $queried_ids, 'The filter-modified query should still return matching orders' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
 
TL;DR; In order to make it more likely that SQL optimizer will use index `date_created` this PR is changing shape of the query (only it's unchanged by the filters):

```
SELECT wp_wc_orders.id
FROM wp_wc_orders
WHERE 1=1
AND (wp_wc_orders.status IN ('wc-pending','wc-processing','wc-on-hold','wc-completed','wc-cancelled','wc-refunded','wc-failed'))
AND (wp_wc_orders.type = 'shop_order')
ORDER BY wp_wc_orders.date_created_gmt DESC
LIMIT 0, 20
```

to 

```

SELECT id
FROM (
  SELECT id, date_created_gmt
  FROM (
    SELECT id, date_created_gmt
    FROM wp_wc_orders
    WHERE type = 'shop_order' AND status = 'wc-pending'
    ORDER BY date_created_gmt DESC
    LIMIT 20
  ) s1

  UNION ALL

  SELECT id, date_created_gmt
  FROM (
    SELECT id, date_created_gmt
    FROM wp_wc_orders
    WHERE type = 'shop_order' AND status = 'wc-processing'
    ORDER BY date_created_gmt DESC
    LIMIT 20
  ) s2

  UNION ALL

  ....
) candidates
ORDER BY date_created_gmt DESC
LIMIT 20;
```


Two fixes for slow Orders admin list queries on large HPOS stores (~12M orders in production).

**1. Rewrite multi-status list queries as per-status UNIONs.** `status IN (...)` prevents the `type_status_date` index from providing a global date ordering for the default list query, so the optimizer can pick a plan that examines millions of rows for one page — 12–21s on the store above (e.g. with MySQL's `prefer_ordering_index=off`). Related: #47865, #65413.

Eligible queries become a `UNION ALL` of single-status branches, each fully served — filtering and ordering — by `type_status_date`: **12–21s → ~3ms**. The rewrite fails closed: it only applies to queries built purely from the `type`/`status` args (byte-identical clause check; search, meta/field/date queries, and clauses-filter changes disqualify), left unchanged by the `woocommerce_orders_table_query_sql` filter (SQL customizations always win), ordered exactly by `date_created_gmt` with a `LIMIT`, ≥2 statuses, ≤24 branches, and offset + row count ≤2,000. Count query, pagination, and all filter contracts are unchanged; the new `woocommerce_orders_table_query_status_union_optimization` filter disables it entirely. BC notes: tie order among identical `date_created_gmt` values may differ (never guaranteed), and `woocommerce_hpos_pre_query` now sees the UNION-shaped executed SQL.

**2. Keep empty-search list requests on the cached-count fast path.** The search form always submits its filter dropdown value (`search-filter=all`), and `set_search_args()` recorded it even with an empty search term. The stray `search_filter` arg is inert in the query layer but disqualified the request from the cached-count fast path, so such page loads ran `SELECT COUNT(*)` over the whole orders table. It's now only set when a search term is present.

Bug introduced in PR #43356 (stray arg); became a performance issue when the cached-count fast path was added in PR #54034.

#### Before: current values from our production

<img width="2124" height="395" alt="image" src="https://github.com/user-attachments/assets/a9eae18e-66ba-4392-b900-14b48d15de5d" />

#### After: tested on production sandbox

- no slow queries when accessing WP admin > WooCommerce > orders
- page loads in ~1.5s instead in 20-30s


### How to test the changes in this Pull Request:

1. Enable HPOS and create orders across several statuses with different creation dates.
2. In WooCommerce > Orders ("All" view), verify newest-first ordering, pagination, and date sorting behave as before; optionally compare with the rewrite disabled via `add_filter( 'woocommerce_orders_table_query_status_union_optimization', '__return_false' );`.
3. Log the executed SQL with `add_filter( 'woocommerce_hpos_pre_query', function( $r, $q, $sql ) { error_log( $sql ); return $r; }, 10, 3 );` — the "All" view should contain `UNION ALL`; single-status views, search, and date filters should not.
4. Submit the orders search form with an **empty** search term and paginate: list and totals stay correct, and no `SELECT COUNT(*) FROM wp_wc_orders ...` runs (e.g. via Query Monitor). A real search still works and counts its actual results.
5. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'OrdersTableQueryTests|ListTableTest'`.

### Testing that has already taken place:

- Unit tests cover rewrite result parity vs. the unoptimized query, pagination and both sort directions, all ineligible shapes, filter bail-outs, and the ListTable empty-search fast path (wp-env, PHP 8.1, MySQL 8). Broader `OrdersTable*` suites pass except one pre-existing trunk failure (verified unrelated).
- Both fixes validated on a production sandbox (~12M orders, Vitess/MySQL, `prefer_ordering_index=off`) — see Before/After above. `phpcs-changed`, branch-level lint, and PHPStan clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually (two entries, one per change).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)