### PR TITLE
Fix undefined behavior in WC_Post_Data::do_deferred_product_sync

### DIFF
--- a/plugins/woocommerce/changelog/fix-do_deferred_product_sync-undefined-behavior
+++ b/plugins/woocommerce/changelog/fix-do_deferred_product_sync-undefined-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix undefined behavior and potential infinite loop in WC_Post_Data::do_deferred_product_sync when more products are deferred for sync while a deferred sync is running.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -113,9 +113,18 @@ class WC_Post_Data {
 	public static function do_deferred_product_sync() {
 		global $wc_deferred_product_sync;
 
-		if ( ! empty( $wc_deferred_product_sync ) ) {
-			$wc_deferred_product_sync = wp_parse_id_list( $wc_deferred_product_sync );
-			array_walk( $wc_deferred_product_sync, array( __CLASS__, 'deferred_product_sync' ) );
+		// Syncing a product may defer more products (e.g. from hooks fired while saving it),
+		// so the queue is drained in rounds, syncing each product at most once.
+		$processed = array();
+		while ( ! empty( $wc_deferred_product_sync ) ) {
+			$product_ids              = array_diff( wp_parse_id_list( $wc_deferred_product_sync ), $processed );
+			$wc_deferred_product_sync = array();
+
+			foreach ( $product_ids as $product_id ) {
+				self::deferred_product_sync( $product_id );
+			}
+
+			$processed = array_merge( $processed, $product_ids );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
@@ -162,4 +162,94 @@ class WC_Post_Data_Test extends \WC_Unit_Test_Case {
 		remove_action( 'woocommerce_product_published', $callback );
 		$product->delete( true );
 	}
+
+	/**
+	 * @testdox do_deferred_product_sync should sync each queued product once (even if queued multiple times) and empty the queue.
+	 */
+	public function test_do_deferred_product_sync_syncs_queued_products(): void {
+		global $wc_deferred_product_sync;
+
+		$wc_deferred_product_sync = array();
+		$product_1                = WC_Helper_Product::create_grouped_product();
+		$product_2                = WC_Helper_Product::create_grouped_product();
+
+		$synced_ids = array();
+		$callback   = function ( $product_id ) use ( &$synced_ids ) {
+			$synced_ids[] = $product_id;
+		};
+		add_action( 'woocommerce_update_product', $callback );
+
+		wc_deferred_product_sync( $product_1->get_id() );
+		wc_deferred_product_sync( $product_2->get_id() );
+		wc_deferred_product_sync( $product_1->get_id() );
+
+		WC_Post_Data::do_deferred_product_sync();
+
+		remove_action( 'woocommerce_update_product', $callback );
+
+		$this->assertSame( array( $product_1->get_id(), $product_2->get_id() ), $synced_ids, 'Each queued product should be synced exactly once' );
+		$this->assertEmpty( $wc_deferred_product_sync, 'The queue should be empty after the sync' );
+	}
+
+	/**
+	 * @testdox do_deferred_product_sync should also sync products that get deferred while another product is being synced.
+	 */
+	public function test_do_deferred_product_sync_processes_products_deferred_during_sync(): void {
+		global $wc_deferred_product_sync;
+
+		$wc_deferred_product_sync = array();
+		$product_1                = WC_Helper_Product::create_grouped_product();
+		$product_2                = WC_Helper_Product::create_grouped_product();
+
+		$synced_ids = array();
+		$callback   = function ( $product_id ) use ( &$synced_ids, $product_1, $product_2 ) {
+			$synced_ids[] = $product_id;
+			if ( $product_1->get_id() === $product_id ) {
+				wc_deferred_product_sync( $product_2->get_id() );
+			}
+		};
+		add_action( 'woocommerce_update_product', $callback );
+
+		wc_deferred_product_sync( $product_1->get_id() );
+
+		WC_Post_Data::do_deferred_product_sync();
+
+		remove_action( 'woocommerce_update_product', $callback );
+
+		$this->assertSame( array( $product_1->get_id(), $product_2->get_id() ), $synced_ids, 'Products deferred while syncing another product should be synced too' );
+		$this->assertEmpty( $wc_deferred_product_sync, 'The queue should be empty after the sync' );
+	}
+
+	/**
+	 * @testdox do_deferred_product_sync should terminate, syncing each product at most once, when synced products keep re-deferring each other.
+	 */
+	public function test_do_deferred_product_sync_terminates_on_mutual_re_deferral(): void {
+		global $wc_deferred_product_sync;
+
+		$wc_deferred_product_sync = array();
+		$product_1                = WC_Helper_Product::create_grouped_product();
+		$product_2                = WC_Helper_Product::create_grouped_product();
+
+		// Each product defers the other one when synced, as e.g. translation plugins do.
+		// With the old array_walk-based implementation this caused an infinite loop,
+		// hence the cap on the number of syncs: it makes the test fail instead of hanging.
+		$synced_ids = array();
+		$callback   = function ( $product_id ) use ( &$synced_ids, $product_1, $product_2 ) {
+			$synced_ids[] = $product_id;
+			if ( count( $synced_ids ) > 100 ) {
+				$this->fail( 'do_deferred_product_sync does not terminate when synced products keep re-deferring each other' );
+			}
+			wc_deferred_product_sync( $product_1->get_id() === $product_id ? $product_2->get_id() : $product_1->get_id() );
+		};
+		add_action( 'woocommerce_update_product', $callback );
+
+		wc_deferred_product_sync( $product_1->get_id() );
+
+		WC_Post_Data::do_deferred_product_sync();
+
+		remove_action( 'woocommerce_update_product', $callback );
+
+		$this->assertSame( array( $product_1->get_id(), $product_2->get_id() ), $synced_ids, 'Each product should be synced at most once per request' );
+		$this->assertEmpty( $wc_deferred_product_sync, 'The queue should be empty after the sync' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

`WC_Post_Data::do_deferred_product_sync()` (hooked on `shutdown`) ran `array_walk()` directly over the `$wc_deferred_product_sync` global. Syncing a product saves it, and callbacks hooked into the save process (e.g. translation plugins such as Polylang, or WooCommerce core itself when a child product is deleted) can call `wc_deferred_product_sync()`, which appends to the very array being walked. Altering the structure of an array while `array_walk()` iterates it is [documented as undefined behavior in PHP](https://www.php.net/manual/en/function.array-walk.php), and in practice it causes an infinite loop when two products keep re-deferring each other (e.g. a product and its translation).

This pull request replaces the `array_walk()` call with a loop that drains the queue in rounds:

-   Each round iterates over a local snapshot of the queue, so callbacks can no longer alter the structure of the array being iterated (this removes the undefined behavior).
-   The global queue is emptied before each round, so products deferred *while* another product is being synced are still processed in a later round instead of being silently dropped.
-   A list of already processed IDs guarantees that each product is synced at most once per request, so the loop always terminates even if synced products keep re-deferring each other.

Closes #63857.

Bug introduced in PR #14026.

### How to test the changes in this Pull Request

#### Automated tests

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Post_Data_Test` and verify that all tests pass. The three `do_deferred_product_sync` tests are the new ones.

#### Manual testing

Prerequisites: a test site with debug logging enabled (`WP_DEBUG` and `WP_DEBUG_LOG` set to `true`).

1. Create two products, both of type **Variable** (adding variations is not necessary). Take note of their IDs (referred to as A and B below).
2. Add the following snippet (e.g. in the active theme's `functions.php`), replacing `123` and `456` with the actual IDs of products A and B. It mimics what translation plugins do: whenever one of the products is saved, the other one is queued for a deferred sync that runs on shutdown:

    ```php
    add_action(
        'woocommerce_update_product',
        function ( $product_id ) {
            $product_a = 123;
            $product_b = 456;
            if ( $product_a === $product_id ) {
                error_log( 'Product A updated' );
                wc_deferred_product_sync( $product_b );
            } elseif ( $product_b === $product_id ) {
                error_log( 'Product B updated' );
                wc_deferred_product_sync( $product_a );
            }
        }
    );
    ```

3. To reproduce the bug, on `trunk` (without this PR): in wp-admin, edit product A and click "Update". The request hangs and eventually fails with a timeout or server error, and `wp-content/debug.log` fills with alternating "Product A updated" / "Product B updated" lines. (Saving A defers B; on shutdown, syncing B defers A again, syncing A defers B again, and so on forever.)
4. With this PR applied, repeat step 3. The product saves normally, and `debug.log` only gets three new lines: "Product A updated" (from the manual save), then "Product B updated" and "Product A updated" once each (from the deferred sync on shutdown).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
