### PR TITLE
Product Filter: add option disabling filter drawer

### DIFF
--- a/plugins/woocommerce/changelog/add-product-filters-disable-responsive
+++ b/plugins/woocommerce/changelog/add-product-filters-disable-responsive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add option disabling filter drawer on smaller screens.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/block.json
@@ -39,6 +39,10 @@
 		"isPreview": {
 			"type": "boolean",
 			"default": false
+		},
+		"showFilterDrawer": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"example": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/edit.tsx
@@ -78,13 +78,78 @@ export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 		},
 	} );
 
+	let filtersContent: JSX.Element;
+
+	if ( isPreview ) {
+		filtersContent = (
+			<div className="wc-block-product-filters__overlay-content">
+				<InnerBlocks templateLock={ false } template={ TEMPLATE } />
+			</div>
+		);
+	} else if ( showFilterDrawer ) {
+		filtersContent = (
+			<>
+				<button
+					className="wc-block-product-filters__open-overlay"
+					onClick={ () => setIsOpen( ! isOpen ) }
+				>
+					<Icon icon={ filterThreeLines } />
+					<span>{ __( 'Filter products', 'woocommerce' ) }</span>
+				</button>
+
+				<div className="wc-block-product-filters__overlay">
+					<div className="wc-block-product-filters__overlay-wrapper">
+						<div
+							className="wc-block-product-filters__overlay-dialog"
+							role="dialog"
+						>
+							<header className="wc-block-product-filters__overlay-header">
+								<button
+									className="wc-block-product-filters__close-overlay"
+									onClick={ () => setIsOpen( ! isOpen ) }
+								>
+									<span>
+										{ __( 'Close', 'woocommerce' ) }
+									</span>
+									<Icon icon={ close } />
+								</button>
+							</header>
+							<div className="wc-block-product-filters__overlay-content">
+								<InnerBlocks
+									templateLock={ false }
+									template={ TEMPLATE }
+								/>
+							</div>
+							<footer className="wc-block-product-filters__overlay-footer">
+								<button
+									className="wc-block-product-filters__apply wp-block-button__link wp-element-button"
+									onClick={ () => setIsOpen( ! isOpen ) }
+								>
+									<span>
+										{ __( 'Apply', 'woocommerce' ) }
+									</span>
+								</button>
+							</footer>
+						</div>
+					</div>
+				</div>
+			</>
+		);
+	} else {
+		filtersContent = (
+			<div className="wc-block-product-filters__content">
+				<InnerBlocks templateLock={ false } template={ TEMPLATE } />
+			</div>
+		);
+	}
+
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
 					<ToggleControl
 						label={ __(
-							'Show filter button on small screens',
+							'Use drawer on small screens',
 							'woocommerce'
 						) }
 						help={
@@ -105,71 +170,7 @@ export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div { ...blockProps }>
-				{ isPreview ? (
-					<div className="wc-block-product-filters__overlay-content">
-						<InnerBlocks
-							templateLock={ false }
-							template={ TEMPLATE }
-						/>
-					</div>
-				) : (
-					<>
-						{ showFilterDrawer && (
-							<button
-								className="wc-block-product-filters__open-overlay"
-								onClick={ () => setIsOpen( ! isOpen ) }
-							>
-								<Icon icon={ filterThreeLines } />
-								<span>
-									{ __( 'Filter products', 'woocommerce' ) }
-								</span>
-							</button>
-						) }
-
-						<div className="wc-block-product-filters__overlay">
-							<div className="wc-block-product-filters__overlay-wrapper">
-								<div
-									className="wc-block-product-filters__overlay-dialog"
-									role="dialog"
-								>
-									<header className="wc-block-product-filters__overlay-header">
-										<button
-											className="wc-block-product-filters__close-overlay"
-											onClick={ () =>
-												setIsOpen( ! isOpen )
-											}
-										>
-											<span>
-												{ __( 'Close', 'woocommerce' ) }
-											</span>
-											<Icon icon={ close } />
-										</button>
-									</header>
-									<div className="wc-block-product-filters__overlay-content">
-										<InnerBlocks
-											templateLock={ false }
-											template={ TEMPLATE }
-										/>
-									</div>
-									<footer className="wc-block-product-filters__overlay-footer">
-										<button
-											className="wc-block-product-filters__apply wp-block-button__link wp-element-button"
-											onClick={ () =>
-												setIsOpen( ! isOpen )
-											}
-										>
-											<span>
-												{ __( 'Apply', 'woocommerce' ) }
-											</span>
-										</button>
-									</footer>
-								</div>
-							</div>
-						</div>
-					</>
-				) }
-			</div>
+			<div { ...blockProps }>{ filtersContent }</div>
 		</>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/edit.tsx
@@ -115,15 +115,17 @@ export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 					</div>
 				) : (
 					<>
-						<button
-							className="wc-block-product-filters__open-overlay"
-							onClick={ () => setIsOpen( ! isOpen ) }
-						>
-							<Icon icon={ filterThreeLines } />
-							<span>
-								{ __( 'Filter products', 'woocommerce' ) }
-							</span>
-						</button>
+						{ showFilterDrawer && (
+							<button
+								className="wc-block-product-filters__open-overlay"
+								onClick={ () => setIsOpen( ! isOpen ) }
+							>
+								<Icon icon={ filterThreeLines } />
+								<span>
+									{ __( 'Filter products', 'woocommerce' ) }
+								</span>
+							</button>
+						) }
 
 						<div className="wc-block-product-filters__overlay">
 							<div className="wc-block-product-filters__overlay-wrapper">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/edit.tsx
@@ -1,8 +1,13 @@
 /**
  * External dependencies
  */
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { BlockEditProps, InnerBlockTemplate } from '@wordpress/blocks';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, close } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
@@ -39,8 +44,9 @@ const TEMPLATE: InnerBlockTemplate[] = [
 ];
 
 export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
-	const { attributes } = props;
+	const { attributes, setAttributes } = props;
 	const { isPreview } = attributes;
+	const showFilterDrawer = attributes.showFilterDrawer !== false;
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const globalColors = getSetting< { background?: string; text?: string } >(
@@ -59,6 +65,7 @@ export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 	const blockProps = useBlockProps( {
 		className: clsx( 'wc-block-product-filters', {
 			'is-overlay-opened': isOpen,
+			'is-filter-drawer-disabled': ! showFilterDrawer,
 		} ),
 		style: {
 			'--wc-product-filters-background-color':
@@ -72,59 +79,95 @@ export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 	} );
 
 	return (
-		<div { ...blockProps }>
-			{ isPreview ? (
-				<div className="wc-block-product-filters__overlay-content">
-					<InnerBlocks templateLock={ false } template={ TEMPLATE } />
-				</div>
-			) : (
-				<>
-					<button
-						className="wc-block-product-filters__open-overlay"
-						onClick={ () => setIsOpen( ! isOpen ) }
-					>
-						<Icon icon={ filterThreeLines } />
-						<span>{ __( 'Filter products', 'woocommerce' ) }</span>
-					</button>
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
+					<ToggleControl
+						label={ __(
+							'Show filter button on small screens',
+							'woocommerce'
+						) }
+						help={
+							showFilterDrawer
+								? __(
+										'Shoppers tap the button to open filters.',
+										'woocommerce'
+								  )
+								: __(
+										'Filters are shown directly on the page.',
+										'woocommerce'
+								  )
+						}
+						checked={ showFilterDrawer }
+						onChange={ ( value ) =>
+							setAttributes( { showFilterDrawer: value } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				{ isPreview ? (
+					<div className="wc-block-product-filters__overlay-content">
+						<InnerBlocks
+							templateLock={ false }
+							template={ TEMPLATE }
+						/>
+					</div>
+				) : (
+					<>
+						<button
+							className="wc-block-product-filters__open-overlay"
+							onClick={ () => setIsOpen( ! isOpen ) }
+						>
+							<Icon icon={ filterThreeLines } />
+							<span>
+								{ __( 'Filter products', 'woocommerce' ) }
+							</span>
+						</button>
 
-					<div className="wc-block-product-filters__overlay">
-						<div className="wc-block-product-filters__overlay-wrapper">
-							<div
-								className="wc-block-product-filters__overlay-dialog"
-								role="dialog"
-							>
-								<header className="wc-block-product-filters__overlay-header">
-									<button
-										className="wc-block-product-filters__close-overlay"
-										onClick={ () => setIsOpen( ! isOpen ) }
-									>
-										<span>
-											{ __( 'Close', 'woocommerce' ) }
-										</span>
-										<Icon icon={ close } />
-									</button>
-								</header>
-								<div className="wc-block-product-filters__overlay-content">
-									<InnerBlocks
-										templateLock={ false }
-										template={ TEMPLATE }
-									/>
+						<div className="wc-block-product-filters__overlay">
+							<div className="wc-block-product-filters__overlay-wrapper">
+								<div
+									className="wc-block-product-filters__overlay-dialog"
+									role="dialog"
+								>
+									<header className="wc-block-product-filters__overlay-header">
+										<button
+											className="wc-block-product-filters__close-overlay"
+											onClick={ () =>
+												setIsOpen( ! isOpen )
+											}
+										>
+											<span>
+												{ __( 'Close', 'woocommerce' ) }
+											</span>
+											<Icon icon={ close } />
+										</button>
+									</header>
+									<div className="wc-block-product-filters__overlay-content">
+										<InnerBlocks
+											templateLock={ false }
+											template={ TEMPLATE }
+										/>
+									</div>
+									<footer className="wc-block-product-filters__overlay-footer">
+										<button
+											className="wc-block-product-filters__apply wp-block-button__link wp-element-button"
+											onClick={ () =>
+												setIsOpen( ! isOpen )
+											}
+										>
+											<span>
+												{ __( 'Apply', 'woocommerce' ) }
+											</span>
+										</button>
+									</footer>
 								</div>
-								<footer className="wc-block-product-filters__overlay-footer">
-									<button
-										className="wc-block-product-filters__apply wp-block-button__link wp-element-button"
-										onClick={ () => setIsOpen( ! isOpen ) }
-									>
-										<span>
-											{ __( 'Apply', 'woocommerce' ) }
-										</span>
-									</button>
-								</footer>
 							</div>
 						</div>
-					</div>
-				</>
-			) }
-		</div>
+					</>
+				) }
+			</div>
+		</>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/save.tsx
@@ -8,10 +8,17 @@ import clsx from 'clsx';
  * Internal dependencies
  */
 import './editor.scss';
+import { type BlockAttributes } from './types';
 
-export const Save = (): JSX.Element => {
+export const Save = ( {
+	attributes,
+}: {
+	attributes: BlockAttributes;
+} ): JSX.Element => {
 	const blockProps = useBlockProps.save( {
-		className: clsx( 'wc-block-product-filters' ),
+		className: clsx( 'wc-block-product-filters', {
+			'is-filter-drawer-disabled': attributes.showFilterDrawer === false,
+		} ),
 	} );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return <div { ...innerBlocksProps } />;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
@@ -69,10 +69,9 @@
 		flex-flow: row-reverse;
 	}
 
+	.wc-block-product-filters__content,
 	.wc-block-product-filters__overlay-content {
 		display: flex;
-		padding: 0 var(--wp--preset--spacing--40);
-		overflow-y: scroll;
 		flex-grow: 1;
 		flex-direction: column;
 		gap: var(
@@ -83,6 +82,11 @@
 		> *:first-child {
 			margin-top: 0;
 		}
+	}
+
+	.wc-block-product-filters__overlay-content {
+		padding: 0 var(--wp--preset--spacing--40);
+		overflow-y: scroll;
 	}
 
 	.wc-block-product-filters__overlay-footer {
@@ -140,6 +144,7 @@
 			color: inherit;
 		}
 
+		.wc-block-product-filters__content,
 		.wc-block-product-filters__overlay-content {
 			padding: 0;
 			overflow: visible;
@@ -194,6 +199,7 @@
 	}
 
 	@include breakpoint("<600px") {
+		.wc-block-product-filters__content,
 		.wc-block-product-filters__overlay-content {
 			.wp-block-group {
 				display: block;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
@@ -155,8 +155,8 @@
 	}
 
 	@include breakpoint(">600px") {
-		&:not(.is-filter-drawer-disabled),
-		&:not(.is-filter-drawer-disabled).is-overlay-opened {
+		&,
+		&.is-overlay-opened {
 			display: flex;
 
 			.wc-block-product-filters__overlay-header,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
@@ -107,12 +107,51 @@
 		}
 	}
 
+	&.is-filter-drawer-disabled,
+	&.is-filter-drawer-disabled.is-overlay-opened {
+		display: flex;
+
+		.wc-block-product-filters__overlay-header,
+		.wc-block-product-filters__overlay-footer,
+		.wc-block-product-filters__open-overlay {
+			display: none;
+		}
+
+		.wc-block-product-filters__overlay {
+			position: relative;
+			pointer-events: auto;
+			inset: 0;
+			background: inherit;
+			color: inherit;
+			transition: none;
+			flex-grow: 1;
+		}
+		.wc-block-product-filters__overlay-wrapper {
+			width: auto;
+			height: auto;
+			background: inherit;
+			color: inherit;
+		}
+
+		.wc-block-product-filters__overlay-dialog {
+			position: relative;
+			transform: none;
+			background: inherit;
+			color: inherit;
+		}
+
+		.wc-block-product-filters__overlay-content {
+			padding: 0;
+			overflow: visible;
+			flex-grow: 1;
+			background: inherit;
+			color: inherit;
+		}
+	}
+
 	@include breakpoint(">600px") {
-		// If we add "Always show" option in the future, we can support that behavior
-		// by adding a class to the wrapper and refer it here, like this:
-		// &:not(.always-show) {
-		&,
-		&.is-overlay-opened {
+		&:not(.is-filter-drawer-disabled),
+		&:not(.is-filter-drawer-disabled).is-overlay-opened {
 			display: flex;
 
 			.wc-block-product-filters__overlay-header,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
@@ -111,47 +111,8 @@
 		}
 	}
 
-	&.is-filter-drawer-disabled,
-	&.is-filter-drawer-disabled.is-overlay-opened {
+	&.is-filter-drawer-disabled {
 		display: flex;
-
-		.wc-block-product-filters__overlay-header,
-		.wc-block-product-filters__overlay-footer,
-		.wc-block-product-filters__open-overlay {
-			display: none;
-		}
-
-		.wc-block-product-filters__overlay {
-			position: relative;
-			pointer-events: auto;
-			inset: 0;
-			background: inherit;
-			color: inherit;
-			transition: none;
-			flex-grow: 1;
-		}
-		.wc-block-product-filters__overlay-wrapper {
-			width: auto;
-			height: auto;
-			background: inherit;
-			color: inherit;
-		}
-
-		.wc-block-product-filters__overlay-dialog {
-			position: relative;
-			transform: none;
-			background: inherit;
-			color: inherit;
-		}
-
-		.wc-block-product-filters__content,
-		.wc-block-product-filters__overlay-content {
-			padding: 0;
-			overflow: visible;
-			flex-grow: 1;
-			background: inherit;
-			color: inherit;
-		}
 	}
 
 	@include breakpoint(">600px") {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
@@ -54,6 +54,7 @@ export type ProductFiltersContext = {
 export type BlockAttributes = {
 	productId?: string;
 	isPreview: boolean;
+	showFilterDrawer?: boolean;
 };
 
 export type EditProps = BlockEditProps< BlockAttributes >;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -142,6 +142,7 @@ class ProductFilters extends AbstractBlock {
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<?php if ( $show_filter_drawer ) : ?>
 				<button
+					type="button"
 					class="wc-block-product-filters__open-overlay"
 					data-wp-on--click="actions.openOverlay"
 				>
@@ -157,6 +158,7 @@ class ProductFilters extends AbstractBlock {
 						>
 							<header class="wc-block-product-filters__overlay-header">
 								<button
+									type="button"
 									class="wc-block-product-filters__close-overlay"
 									data-wp-on--click="actions.closeOverlay"
 								>
@@ -171,6 +173,7 @@ class ProductFilters extends AbstractBlock {
 								class="wc-block-product-filters__overlay-footer"
 							>
 								<button
+									type="button"
 									class="wc-block-product-filters__apply wp-element-button"
 									data-wp-interactive="<?php echo esc_attr( $this->get_full_block_name() ); ?>"
 									data-wp-on--click="actions.closeOverlay"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -111,25 +111,26 @@ class ProductFilters extends AbstractBlock {
 			'forcePageReload' => isset( $block->context['forcePageReload'] ) ? (bool) $block->context['forcePageReload'] : null,
 		);
 
-		$wrapper_classes = array( 'wc-block-product-filters' );
-		if (
-			isset( $attributes['showFilterDrawer'] ) &&
-			false === $attributes['showFilterDrawer']
-		) {
+		$show_filter_drawer = ! isset( $attributes['showFilterDrawer'] ) || false !== $attributes['showFilterDrawer'];
+		$wrapper_classes    = array( 'wc-block-product-filters' );
+		if ( ! $show_filter_drawer ) {
 			$wrapper_classes[] = 'is-filter-drawer-disabled';
 		}
 
 		$wrapper_attributes = array(
-			'class'                            => implode( ' ', $wrapper_classes ),
-			'data-wp-interactive'              => $this->get_full_block_name(),
-			'data-wp-init--colors'             => 'callbacks.initColors',
-			'data-wp-watch--scrolling'         => 'callbacks.scrollLimit',
-			'data-wp-watch--active-filters'    => 'callbacks.syncActiveFiltersWithServer',
-			'data-wp-on--keyup'                => 'actions.closeOverlayOnEscape',
-			'data-wp-context'                  => (string) wp_json_encode( $interactivity_context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
-			'data-wp-class--is-overlay-opened' => 'context.isOverlayOpened',
-			'style'                            => $this->get_css_variables( $attributes ),
+			'class'                         => implode( ' ', $wrapper_classes ),
+			'data-wp-interactive'           => $this->get_full_block_name(),
+			'data-wp-init--colors'          => 'callbacks.initColors',
+			'data-wp-watch--active-filters' => 'callbacks.syncActiveFiltersWithServer',
+			'data-wp-context'               => (string) wp_json_encode( $interactivity_context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
+			'style'                         => $this->get_css_variables( $attributes ),
 		);
+
+		if ( $show_filter_drawer ) {
+			$wrapper_attributes['data-wp-watch--scrolling']         = 'callbacks.scrollLimit';
+			$wrapper_attributes['data-wp-on--keyup']                = 'actions.closeOverlayOnEscape';
+			$wrapper_attributes['data-wp-class--is-overlay-opened'] = 'context.isOverlayOpened';
+		}
 
 		// TODO: Remove this conditional once the fix is released in WP. https://github.com/woocommerce/gutenberg/pull/4.
 		if ( ! isset( $block->context['productCollectionLocation'] ) ) {
@@ -139,46 +140,52 @@ class ProductFilters extends AbstractBlock {
 		ob_start();
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<button
-				class="wc-block-product-filters__open-overlay"
-				data-wp-on--click="actions.openOverlay"
-			>
-				<?php echo $this->get_svg_icon( 'filter-icon-2' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				<span><?php echo esc_html__( 'Filter products', 'woocommerce' ); ?></span>
-			</button>
-			<div class="wc-block-product-filters__overlay">
-				<div class="wc-block-product-filters__overlay-wrapper">
-					<div
-						class="wc-block-product-filters__overlay-dialog"
-						role="dialog"
-						aria-label="<?php echo esc_html__( 'Product Filters', 'woocommerce' ); ?>"
-					>
-						<header class="wc-block-product-filters__overlay-header">
-							<button
-								class="wc-block-product-filters__close-overlay"
-								data-wp-on--click="actions.closeOverlay"
-							>
-								<span><?php echo esc_html__( 'Close', 'woocommerce' ); ?></span>
-								<?php echo $this->get_svg_icon( 'close' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-							</button>
-						</header>
-						<div class="wc-block-product-filters__overlay-content">
-							<?php echo $inner_blocks; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						</div>
-						<footer
-							class="wc-block-product-filters__overlay-footer"
+			<?php if ( $show_filter_drawer ) : ?>
+				<button
+					class="wc-block-product-filters__open-overlay"
+					data-wp-on--click="actions.openOverlay"
+				>
+					<?php echo $this->get_svg_icon( 'filter-icon-2' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<span><?php echo esc_html__( 'Filter products', 'woocommerce' ); ?></span>
+				</button>
+				<div class="wc-block-product-filters__overlay">
+					<div class="wc-block-product-filters__overlay-wrapper">
+						<div
+							class="wc-block-product-filters__overlay-dialog"
+							role="dialog"
+							aria-label="<?php echo esc_html__( 'Product Filters', 'woocommerce' ); ?>"
 						>
-							<button
-								class="wc-block-product-filters__apply wp-element-button"
-								data-wp-interactive="<?php echo esc_attr( $this->get_full_block_name() ); ?>"
-								data-wp-on--click="actions.closeOverlay"
+							<header class="wc-block-product-filters__overlay-header">
+								<button
+									class="wc-block-product-filters__close-overlay"
+									data-wp-on--click="actions.closeOverlay"
+								>
+									<span><?php echo esc_html__( 'Close', 'woocommerce' ); ?></span>
+									<?php echo $this->get_svg_icon( 'close' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+								</button>
+							</header>
+							<div class="wc-block-product-filters__overlay-content">
+								<?php echo $inner_blocks; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+							</div>
+							<footer
+								class="wc-block-product-filters__overlay-footer"
 							>
-								<span><?php echo esc_html__( 'Apply', 'woocommerce' ); ?></span>
-							</button>
-						</footer>
+								<button
+									class="wc-block-product-filters__apply wp-element-button"
+									data-wp-interactive="<?php echo esc_attr( $this->get_full_block_name() ); ?>"
+									data-wp-on--click="actions.closeOverlay"
+								>
+									<span><?php echo esc_html__( 'Apply', 'woocommerce' ); ?></span>
+								</button>
+							</footer>
+						</div>
 					</div>
 				</div>
-			</div>
+			<?php else : ?>
+				<div class="wc-block-product-filters__content">
+					<?php echo $inner_blocks; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</div>
+			<?php endif; ?>
 		</div>
 		<?php
 		return ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -111,8 +111,16 @@ class ProductFilters extends AbstractBlock {
 			'forcePageReload' => isset( $block->context['forcePageReload'] ) ? (bool) $block->context['forcePageReload'] : null,
 		);
 
+		$wrapper_classes = array( 'wc-block-product-filters' );
+		if (
+			isset( $attributes['showFilterDrawer'] ) &&
+			false === $attributes['showFilterDrawer']
+		) {
+			$wrapper_classes[] = 'is-filter-drawer-disabled';
+		}
+
 		$wrapper_attributes = array(
-			'class'                            => 'wc-block-product-filters',
+			'class'                            => implode( ' ', $wrapper_classes ),
 			'data-wp-interactive'              => $this->get_full_block_name(),
 			'data-wp-init--colors'             => 'callbacks.initColors',
 			'data-wp-watch--scrolling'         => 'callbacks.scrollLimit',
@@ -234,7 +242,14 @@ class ProductFilters extends AbstractBlock {
 	private function generate_navigation_id( $block ) {
 		return sprintf(
 			'wc-product-filters-%s',
-			md5( wp_json_encode( $block->parsed_block['innerBlocks'] ) )
+			md5(
+				wp_json_encode(
+					array(
+						'attrs'       => $block->parsed_block['attrs'] ?? array(),
+						'innerBlocks' => $block->parsed_block['innerBlocks'] ?? array(),
+					)
+				)
+			)
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In #65622, we added the support for multiple filter block instances:

> A realistic layout is to place one Product Filters block above the Product Collection with only Active Filters, and another Product Filters block in a sidebar with the selectable filter options.

To make this layout possible, we need a setting to disable the filter button. This PR is about adding that setting and conditional rendering the toggle button.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<img width="2561" height="1411" alt="image" src="https://github.com/user-attachments/assets/4d046918-0f8d-4721-a138-473bffcf1cda" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor and edit the Shop template.
2. Select a Product Filters block.
3. In the block settings, turn off Show filter button on small screens, then save the template.
4. Open the Shop page on a small screen or mobile viewport.
5. Confirm filters are shown directly on the page and the Filter products button is not rendered for that block.
6. Turn Show filter button on small screens back on, save, and refresh the Shop page.
7. Confirm the Filter products button appears on small screens and opens the filter drawer.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>