### PR TITLE
Lazy-load legacy classes and skip admin-only boot work on frontend

### DIFF
--- a/plugins/woocommerce/changelog/update-boot-performance-lazy-loading
+++ b/plugins/woocommerce/changelog/update-boot-performance-lazy-loading
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-Reduce boot-time work: load interfaces, abstracts, data stores and other side-effect-free classes in includes/ on demand via the WC_Autoloader class map, resolve internal REST API controllers lazily on the woocommerce_rest_api_get_rest_namespaces filter, and skip instantiating admin-screen-only classes on regular frontend page loads.
+Reduce boot-time work: load interfaces, abstracts, data stores and other side-effect-free classes in includes/ on demand via the WC_Autoloader class map, resolve internal REST API controllers lazily on the woocommerce_rest_api_get_rest_namespaces filter, skip instantiating admin-screen-only classes on regular frontend page loads, and stop loading wc-admin feature classes on the frontend for users with the manage_woocommerce capability (the LaunchYourStore coming soon banner hooks now register unconditionally instead).

--- a/plugins/woocommerce/changelog/update-boot-performance-lazy-loading
+++ b/plugins/woocommerce/changelog/update-boot-performance-lazy-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduce boot-time work: load interfaces, abstracts, data stores and other side-effect-free classes in includes/ on demand via the WC_Autoloader class map, resolve internal REST API controllers lazily on the woocommerce_rest_api_get_rest_namespaces filter, and skip instantiating admin-screen-only classes on regular frontend page loads.

--- a/plugins/woocommerce/changelog/update-boot-performance-lys-footer-banner
+++ b/plugins/woocommerce/changelog/update-boot-performance-lys-footer-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Register the LaunchYourStore hooks unconditionally instead of through the wc-admin feature loader, and stop loading admin feature classes on frontend requests for users with the manage_woocommerce capability.

--- a/plugins/woocommerce/changelog/update-boot-performance-lys-footer-banner
+++ b/plugins/woocommerce/changelog/update-boot-performance-lys-footer-banner
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Register the LaunchYourStore hooks unconditionally instead of through the wc-admin feature loader, and stop loading admin feature classes on frontend requests for users with the manage_woocommerce capability.

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -108,8 +108,11 @@ class WC_Autoloader {
 		'wc_queue'                                      => 'queue/class-wc-queue.php',
 		// Other classes in subdirectories not covered by the prefix rules.
 		'wc_blocks_utils'                               => 'blocks/class-wc-blocks-utils.php',
-		'wc_marketplace_updater'                        => 'admin/marketplace-suggestions/class-wc-marketplace-updater.php',
 		'wc_shop_customizer'                            => 'customizer/class-wc-shop-customizer.php',
+		// Note: WC_Marketplace_Updater is intentionally NOT mapped here. Its file calls
+		// WC_Marketplace_Updater::load() at include time, so it must only be loaded on admin-side
+		// requests via WooCommerce::includes(). Mapping it would let a frontend autoload pull in that
+		// admin-only boot work, undermining the request-type gating.
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -18,6 +18,101 @@ use Automattic\WooCommerce\Admin\Features\Features;
 class WC_Autoloader {
 
 	/**
+	 * Map of lowercased class names to file paths, relative to the includes directory, for classes whose
+	 * files live outside the directories covered by the prefix rules in autoload(), or whose file names
+	 * don't follow the standard `class-{name}.php` convention (interfaces, traits, abstract classes,
+	 * data stores).
+	 *
+	 * These files used to be loaded unconditionally on every request from WooCommerce::includes().
+	 * Mapping them here allows them to be loaded on demand instead. The map is checked before the
+	 * WC_ prefix rules, since some of these classes (Abstract_WC_*) don't use the WC_ prefix.
+	 *
+	 * @var array<string, string>
+	 */
+	private const CLASS_MAP = array(
+		// Interfaces.
+		'wc_abstract_order_data_store_interface'        => 'interfaces/class-wc-abstract-order-data-store-interface.php',
+		'wc_coupon_data_store_interface'                => 'interfaces/class-wc-coupon-data-store-interface.php',
+		'wc_customer_data_store_interface'              => 'interfaces/class-wc-customer-data-store-interface.php',
+		'wc_customer_download_data_store_interface'     => 'interfaces/class-wc-customer-download-data-store-interface.php',
+		'wc_customer_download_log_data_store_interface' => 'interfaces/class-wc-customer-download-log-data-store-interface.php',
+		'wc_importer_interface'                         => 'interfaces/class-wc-importer-interface.php',
+		'wc_log_handler_interface'                      => 'interfaces/class-wc-log-handler-interface.php',
+		'wc_logger_interface'                           => 'interfaces/class-wc-logger-interface.php',
+		'wc_object_data_store_interface'                => 'interfaces/class-wc-object-data-store-interface.php',
+		'wc_order_data_store_interface'                 => 'interfaces/class-wc-order-data-store-interface.php',
+		'wc_order_item_data_store_interface'            => 'interfaces/class-wc-order-item-data-store-interface.php',
+		'wc_order_item_product_data_store_interface'    => 'interfaces/class-wc-order-item-product-data-store-interface.php',
+		'wc_order_item_type_data_store_interface'       => 'interfaces/class-wc-order-item-type-data-store-interface.php',
+		'wc_order_refund_data_store_interface'          => 'interfaces/class-wc-order-refund-data-store-interface.php',
+		'wc_payment_token_data_store_interface'         => 'interfaces/class-wc-payment-token-data-store-interface.php',
+		'wc_product_data_store_interface'               => 'interfaces/class-wc-product-data-store-interface.php',
+		'wc_product_variable_data_store_interface'      => 'interfaces/class-wc-product-variable-data-store-interface.php',
+		'wc_queue_interface'                            => 'interfaces/class-wc-queue-interface.php',
+		'wc_shipping_zone_data_store_interface'         => 'interfaces/class-wc-shipping-zone-data-store-interface.php',
+		'wc_webhook_data_store_interface'               => 'interfaces/class-wc-webhooks-data-store-interface.php',
+		// Traits.
+		'wc_item_totals'                                => 'traits/trait-wc-item-totals.php',
+		// Abstract classes.
+		'wc_abstract_order'                             => 'abstracts/abstract-wc-order.php',
+		'wc_abstract_privacy'                           => 'abstracts/abstract-wc-privacy.php',
+		'wc_address_provider'                           => 'abstracts/abstract-wc-address-provider.php',
+		'wc_background_process'                         => 'abstracts/class-wc-background-process.php',
+		'wc_data'                                       => 'abstracts/abstract-wc-data.php',
+		'wc_deprecated_hooks'                           => 'abstracts/abstract-wc-deprecated-hooks.php',
+		'wc_integration'                                => 'abstracts/abstract-wc-integration.php',
+		'wc_log_handler'                                => 'abstracts/abstract-wc-log-handler.php',
+		'wc_object_query'                               => 'abstracts/abstract-wc-object-query.php',
+		'wc_payment_gateway'                            => 'abstracts/abstract-wc-payment-gateway.php',
+		'wc_payment_token'                              => 'abstracts/abstract-wc-payment-token.php',
+		'wc_product'                                    => 'abstracts/abstract-wc-product.php',
+		'wc_session'                                    => 'abstracts/abstract-wc-session.php',
+		'wc_settings_api'                               => 'abstracts/abstract-wc-settings-api.php',
+		'wc_shipping_method'                            => 'abstracts/abstract-wc-shipping-method.php',
+		'wc_widget'                                     => 'abstracts/abstract-wc-widget.php',
+		// Data stores.
+		'abstract_wc_order_data_store_cpt'              => 'data-stores/abstract-wc-order-data-store-cpt.php',
+		'abstract_wc_order_item_type_data_store'        => 'data-stores/abstract-wc-order-item-type-data-store.php',
+		'wc_coupon_data_store_cpt'                      => 'data-stores/class-wc-coupon-data-store-cpt.php',
+		'wc_customer_data_store'                        => 'data-stores/class-wc-customer-data-store.php',
+		'wc_customer_data_store_session'                => 'data-stores/class-wc-customer-data-store-session.php',
+		'wc_customer_download_data_store'               => 'data-stores/class-wc-customer-download-data-store.php',
+		'wc_customer_download_log_data_store'           => 'data-stores/class-wc-customer-download-log-data-store.php',
+		'wc_data_store_wp'                              => 'data-stores/class-wc-data-store-wp.php',
+		'wc_order_data_store_cpt'                       => 'data-stores/class-wc-order-data-store-cpt.php',
+		'wc_order_item_coupon_data_store'               => 'data-stores/class-wc-order-item-coupon-data-store.php',
+		'wc_order_item_data_store'                      => 'data-stores/class-wc-order-item-data-store.php',
+		'wc_order_item_fee_data_store'                  => 'data-stores/class-wc-order-item-fee-data-store.php',
+		'wc_order_item_product_data_store'              => 'data-stores/class-wc-order-item-product-data-store.php',
+		'wc_order_item_shipping_data_store'             => 'data-stores/class-wc-order-item-shipping-data-store.php',
+		'wc_order_item_tax_data_store'                  => 'data-stores/class-wc-order-item-tax-data-store.php',
+		'wc_order_refund_data_store_cpt'                => 'data-stores/class-wc-order-refund-data-store-cpt.php',
+		'wc_payment_token_data_store'                   => 'data-stores/class-wc-payment-token-data-store.php',
+		'wc_product_data_store_cpt'                     => 'data-stores/class-wc-product-data-store-cpt.php',
+		'wc_product_grouped_data_store_cpt'             => 'data-stores/class-wc-product-grouped-data-store-cpt.php',
+		'wc_product_variable_data_store_cpt'            => 'data-stores/class-wc-product-variable-data-store-cpt.php',
+		'wc_product_variation_data_store_cpt'           => 'data-stores/class-wc-product-variation-data-store-cpt.php',
+		'wc_shipping_zone_data_store'                   => 'data-stores/class-wc-shipping-zone-data-store.php',
+		'wc_webhook_data_store'                         => 'data-stores/class-wc-webhook-data-store.php',
+		// Core payment gateways.
+		'wc_payment_gateway_cc'                         => 'gateways/class-wc-payment-gateway-cc.php',
+		'wc_payment_gateway_echeck'                     => 'gateways/class-wc-payment-gateway-echeck.php',
+		// Tracks.
+		'wc_site_tracking'                              => 'tracks/class-wc-site-tracking.php',
+		'wc_tracks'                                     => 'tracks/class-wc-tracks.php',
+		'wc_tracks_client'                              => 'tracks/class-wc-tracks-client.php',
+		'wc_tracks_event'                               => 'tracks/class-wc-tracks-event.php',
+		'wc_tracks_footer_pixel'                        => 'tracks/class-wc-tracks-footer-pixel.php',
+		// Queue.
+		'wc_action_queue'                               => 'queue/class-wc-action-queue.php',
+		'wc_queue'                                      => 'queue/class-wc-queue.php',
+		// Other classes in subdirectories not covered by the prefix rules.
+		'wc_blocks_utils'                               => 'blocks/class-wc-blocks-utils.php',
+		'wc_marketplace_updater'                        => 'admin/marketplace-suggestions/class-wc-marketplace-updater.php',
+		'wc_shop_customizer'                            => 'customizer/class-wc-shop-customizer.php',
+	);
+
+	/**
 	 * Path to the includes directory.
 	 *
 	 * @var string
@@ -40,11 +135,11 @@ class WC_Autoloader {
 	/**
 	 * Take a class name and turn it into a file name.
 	 *
-	 * @param  string $class Class name.
+	 * @param  string $class_name Class name.
 	 * @return string
 	 */
-	private function get_file_name_from_class( $class ) {
-		return 'class-' . str_replace( '_', '-', $class ) . '.php';
+	private function get_file_name_from_class( $class_name ) {
+		return 'class-' . str_replace( '_', '-', $class_name ) . '.php';
 	}
 
 	/**
@@ -64,12 +159,19 @@ class WC_Autoloader {
 	/**
 	 * Auto-load WC classes on demand to reduce memory consumption.
 	 *
-	 * @param string $class Class name.
+	 * @param string $class_name Class name.
 	 */
-	public function autoload( $class ) {
-		$class = strtolower( $class );
+	public function autoload( $class_name ) {
+		$class_name = strtolower( $class_name );
 
-		if ( 0 !== strpos( $class, 'wc_' ) ) {
+		// Check the explicit class map first: it covers classes whose file locations can't be derived
+		// from the prefix rules below, including the Abstract_WC_* classes that lack the WC_ prefix.
+		if ( isset( self::CLASS_MAP[ $class_name ] ) ) {
+			$this->load_file( $this->include_path . self::CLASS_MAP[ $class_name ] );
+			return;
+		}
+
+		if ( 0 !== strpos( $class_name, 'wc_' ) ) {
 			return;
 		}
 
@@ -77,42 +179,42 @@ class WC_Autoloader {
 		// the includes/class-wc-api.php file after they upgrade, which causes a fatal error when executing
 		// "class_exists('WC_API')". This will prevent this error, while still making the class visible
 		// when it's provided by the WooCommerce Legacy REST API plugin.
-		if ( 'wc_api' === $class ) {
+		if ( 'wc_api' === $class_name ) {
 			return;
 		}
 
 		// If the class is already loaded from a merged package, prevent autoloader from loading it as well.
-		if ( \Automattic\WooCommerce\Packages::should_load_class( $class ) ) {
+		if ( \Automattic\WooCommerce\Packages::should_load_class( $class_name ) ) {
 			return;
 		}
 
-		$file = $this->get_file_name_from_class( $class );
+		$file = $this->get_file_name_from_class( $class_name );
 		$path = '';
 
-		if ( 0 === strpos( $class, 'wc_addons_gateway_' ) ) {
-			$path = $this->include_path . 'gateways/' . substr( str_replace( '_', '-', $class ), 18 ) . '/';
-		} elseif ( 0 === strpos( $class, 'wc_gateway_' ) ) {
-			$path = $this->include_path . 'gateways/' . substr( str_replace( '_', '-', $class ), 11 ) . '/';
-		} elseif ( 0 === strpos( $class, 'wc_shipping_' ) ) {
-			$path = $this->include_path . 'shipping/' . substr( str_replace( '_', '-', $class ), 12 ) . '/';
-		} elseif ( 0 === strpos( $class, 'wc_shortcode_' ) ) {
+		if ( 0 === strpos( $class_name, 'wc_addons_gateway_' ) ) {
+			$path = $this->include_path . 'gateways/' . substr( str_replace( '_', '-', $class_name ), 18 ) . '/';
+		} elseif ( 0 === strpos( $class_name, 'wc_gateway_' ) ) {
+			$path = $this->include_path . 'gateways/' . substr( str_replace( '_', '-', $class_name ), 11 ) . '/';
+		} elseif ( 0 === strpos( $class_name, 'wc_shipping_' ) ) {
+			$path = $this->include_path . 'shipping/' . substr( str_replace( '_', '-', $class_name ), 12 ) . '/';
+		} elseif ( 0 === strpos( $class_name, 'wc_shortcode_' ) ) {
 			$path = $this->include_path . 'shortcodes/';
-		} elseif ( 0 === strpos( $class, 'wc_meta_box' ) ) {
+		} elseif ( 0 === strpos( $class_name, 'wc_meta_box' ) ) {
 			$path = $this->include_path . 'admin/meta-boxes/';
-		} elseif ( 0 === strpos( $class, 'wc_admin' ) ) {
+		} elseif ( 0 === strpos( $class_name, 'wc_admin' ) ) {
 			$path = $this->include_path . 'admin/';
-		} elseif ( 0 === strpos( $class, 'wc_payment_token_' ) ) {
+		} elseif ( 0 === strpos( $class_name, 'wc_payment_token_' ) ) {
 			$path = $this->include_path . 'payment-tokens/';
-		} elseif ( 0 === strpos( $class, 'wc_log_handler_' ) ) {
+		} elseif ( 0 === strpos( $class_name, 'wc_log_handler_' ) ) {
 			$path = $this->include_path . 'log-handlers/';
-		} elseif ( 0 === strpos( $class, 'wc_integration' ) ) {
-			$path = $this->include_path . 'integrations/' . substr( str_replace( '_', '-', $class ), 15 ) . '/';
-		} elseif ( 0 === strpos( $class, 'wc_notes_' ) ) {
+		} elseif ( 0 === strpos( $class_name, 'wc_integration' ) ) {
+			$path = $this->include_path . 'integrations/' . substr( str_replace( '_', '-', $class_name ), 15 ) . '/';
+		} elseif ( 0 === strpos( $class_name, 'wc_notes_' ) ) {
 			$path = $this->include_path . 'admin/notes/';
-		} elseif ( 0 === strpos( $class, 'wc_rest_' ) ) {
+		} elseif ( 0 === strpos( $class_name, 'wc_rest_' ) ) {
 			// Handle REST API controllers in subdirectories.
 			// For V4 controllers, check if the feature is enabled first.
-			if ( false !== strpos( $class, '_v4_' ) ) {
+			if ( false !== strpos( $class_name, '_v4_' ) ) {
 				// Only load V4 controllers if the feature is enabled.
 				if ( Features::is_enabled( 'rest-api-v4' ) ) {
 					$rest_controller_paths = array(

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -135,11 +135,11 @@ class WC_Autoloader {
 	/**
 	 * Take a class name and turn it into a file name.
 	 *
-	 * @param  string $class_name Class name.
+	 * @param  string $class Class name.
 	 * @return string
 	 */
-	private function get_file_name_from_class( $class_name ) {
-		return 'class-' . str_replace( '_', '-', $class_name ) . '.php';
+	private function get_file_name_from_class( $class ) {
+		return 'class-' . str_replace( '_', '-', $class ) . '.php';
 	}
 
 	/**
@@ -159,19 +159,19 @@ class WC_Autoloader {
 	/**
 	 * Auto-load WC classes on demand to reduce memory consumption.
 	 *
-	 * @param string $class_name Class name.
+	 * @param string $class Class name.
 	 */
-	public function autoload( $class_name ) {
-		$class_name = strtolower( $class_name );
+	public function autoload( $class ) {
+		$class = strtolower( $class );
 
 		// Check the explicit class map first: it covers classes whose file locations can't be derived
 		// from the prefix rules below, including the Abstract_WC_* classes that lack the WC_ prefix.
-		if ( isset( self::CLASS_MAP[ $class_name ] ) ) {
-			$this->load_file( $this->include_path . self::CLASS_MAP[ $class_name ] );
+		if ( isset( self::CLASS_MAP[ $class ] ) ) {
+			$this->load_file( $this->include_path . self::CLASS_MAP[ $class ] );
 			return;
 		}
 
-		if ( 0 !== strpos( $class_name, 'wc_' ) ) {
+		if ( 0 !== strpos( $class, 'wc_' ) ) {
 			return;
 		}
 
@@ -179,42 +179,42 @@ class WC_Autoloader {
 		// the includes/class-wc-api.php file after they upgrade, which causes a fatal error when executing
 		// "class_exists('WC_API')". This will prevent this error, while still making the class visible
 		// when it's provided by the WooCommerce Legacy REST API plugin.
-		if ( 'wc_api' === $class_name ) {
+		if ( 'wc_api' === $class ) {
 			return;
 		}
 
 		// If the class is already loaded from a merged package, prevent autoloader from loading it as well.
-		if ( \Automattic\WooCommerce\Packages::should_load_class( $class_name ) ) {
+		if ( \Automattic\WooCommerce\Packages::should_load_class( $class ) ) {
 			return;
 		}
 
-		$file = $this->get_file_name_from_class( $class_name );
+		$file = $this->get_file_name_from_class( $class );
 		$path = '';
 
-		if ( 0 === strpos( $class_name, 'wc_addons_gateway_' ) ) {
-			$path = $this->include_path . 'gateways/' . substr( str_replace( '_', '-', $class_name ), 18 ) . '/';
-		} elseif ( 0 === strpos( $class_name, 'wc_gateway_' ) ) {
-			$path = $this->include_path . 'gateways/' . substr( str_replace( '_', '-', $class_name ), 11 ) . '/';
-		} elseif ( 0 === strpos( $class_name, 'wc_shipping_' ) ) {
-			$path = $this->include_path . 'shipping/' . substr( str_replace( '_', '-', $class_name ), 12 ) . '/';
-		} elseif ( 0 === strpos( $class_name, 'wc_shortcode_' ) ) {
+		if ( 0 === strpos( $class, 'wc_addons_gateway_' ) ) {
+			$path = $this->include_path . 'gateways/' . substr( str_replace( '_', '-', $class ), 18 ) . '/';
+		} elseif ( 0 === strpos( $class, 'wc_gateway_' ) ) {
+			$path = $this->include_path . 'gateways/' . substr( str_replace( '_', '-', $class ), 11 ) . '/';
+		} elseif ( 0 === strpos( $class, 'wc_shipping_' ) ) {
+			$path = $this->include_path . 'shipping/' . substr( str_replace( '_', '-', $class ), 12 ) . '/';
+		} elseif ( 0 === strpos( $class, 'wc_shortcode_' ) ) {
 			$path = $this->include_path . 'shortcodes/';
-		} elseif ( 0 === strpos( $class_name, 'wc_meta_box' ) ) {
+		} elseif ( 0 === strpos( $class, 'wc_meta_box' ) ) {
 			$path = $this->include_path . 'admin/meta-boxes/';
-		} elseif ( 0 === strpos( $class_name, 'wc_admin' ) ) {
+		} elseif ( 0 === strpos( $class, 'wc_admin' ) ) {
 			$path = $this->include_path . 'admin/';
-		} elseif ( 0 === strpos( $class_name, 'wc_payment_token_' ) ) {
+		} elseif ( 0 === strpos( $class, 'wc_payment_token_' ) ) {
 			$path = $this->include_path . 'payment-tokens/';
-		} elseif ( 0 === strpos( $class_name, 'wc_log_handler_' ) ) {
+		} elseif ( 0 === strpos( $class, 'wc_log_handler_' ) ) {
 			$path = $this->include_path . 'log-handlers/';
-		} elseif ( 0 === strpos( $class_name, 'wc_integration' ) ) {
-			$path = $this->include_path . 'integrations/' . substr( str_replace( '_', '-', $class_name ), 15 ) . '/';
-		} elseif ( 0 === strpos( $class_name, 'wc_notes_' ) ) {
+		} elseif ( 0 === strpos( $class, 'wc_integration' ) ) {
+			$path = $this->include_path . 'integrations/' . substr( str_replace( '_', '-', $class ), 15 ) . '/';
+		} elseif ( 0 === strpos( $class, 'wc_notes_' ) ) {
 			$path = $this->include_path . 'admin/notes/';
-		} elseif ( 0 === strpos( $class_name, 'wc_rest_' ) ) {
+		} elseif ( 0 === strpos( $class, 'wc_rest_' ) ) {
 			// Handle REST API controllers in subdirectories.
 			// For V4 controllers, check if the feature is enabled first.
-			if ( false !== strpos( $class_name, '_v4_' ) ) {
+			if ( false !== strpos( $class, '_v4_' ) ) {
 				// Only load V4 controllers if the feature is enabled.
 				if ( Features::is_enabled( 'rest-api-v4' ) ) {
 					$rest_controller_paths = array(

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -651,12 +651,17 @@ final class WooCommerce {
 	 * @return bool
 	 */
 	public function is_rest_api_request() {
-		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+		// With plain permalinks, REST requests are routed via the `rest_route` query parameter
+		// (e.g. /index.php?rest_route=/wc/v3/...) rather than the wp-json URL prefix, so the prefix is
+		// absent from REQUEST_URI. Detect that form too, otherwise such requests are misclassified.
+		$has_rest_route_param = ! empty( $_GET['rest_route'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( ! $has_rest_route_param && empty( $_SERVER['REQUEST_URI'] ) ) {
 			return false;
 		}
 
 		$rest_prefix         = trailingslashit( rest_get_url_prefix() );
-		$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) ); // phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$is_rest_api_request = $has_rest_route_param || ( ! empty( $_SERVER['REQUEST_URI'] ) && false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		/**
 		 * Whether this is a REST API request.
@@ -672,10 +677,17 @@ final class WooCommerce {
 	 * @return bool
 	 */
 	public function is_store_api_request() {
+		// With plain permalinks, Store API requests are routed via the `rest_route` query parameter
+		// (e.g. /index.php?rest_route=/wc/store/...) rather than the wp-json URL prefix.
+		if ( isset( $_GET['rest_route'] ) && is_string( $_GET['rest_route'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			return 0 === strpos( wp_unslash( $_GET['rest_route'] ), '/wc/store/' );
+		}
+
 		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
 			return false;
 		}
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		return false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' );
 	}
 
@@ -690,19 +702,24 @@ final class WooCommerce {
 
 	/**
 	 * Returns true for request types on which admin-side functionality may run: admin screens
-	 * (including admin-ajax), REST API, cron and WP-CLI. Returns false only for regular frontend
-	 * page loads, where purely admin-side hooks can never fire.
+	 * (including admin-ajax), non-Store-API REST requests, cron and WP-CLI. Returns false for regular
+	 * frontend page loads and Store API requests, where purely admin-side hooks can never fire.
 	 *
 	 * REST requests are included because admin features are commonly driven through the REST API
 	 * (wc-admin), and cron because Action Scheduler/WP-Cron jobs registered by admin-side classes
-	 * must remain runnable when executed from cron.
+	 * must remain runnable when executed from cron. Store API requests are excluded: they are
+	 * frontend traffic (cart, checkout and other block-driven requests) that needs no admin-side boot
+	 * work. This mirrors the gating used by Features::should_load_features().
 	 *
 	 * @since 11.0.0
 	 *
 	 * @return bool
 	 */
 	private function is_admin_side_request(): bool {
-		return $this->is_request( 'admin' ) || $this->is_rest_api_request() || defined( 'DOING_CRON' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+		return $this->is_request( 'admin' )
+			|| ( $this->is_rest_api_request() && ! $this->is_store_api_request() )
+			|| defined( 'DOING_CRON' )
+			|| ( defined( 'WP_CLI' ) && WP_CLI );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController;
 use Automattic\WooCommerce\Internal\AssignDefaultCategory;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
 use Automattic\WooCommerce\Internal\Caches\ProductCacheController;
+use Automattic\WooCommerce\Admin\Features\LaunchYourStore;
 use Automattic\WooCommerce\Internal\ComingSoon\ComingSoonAdminBarBadge;
 use Automattic\WooCommerce\Internal\ComingSoon\ComingSoonCacheInvalidator;
 use Automattic\WooCommerce\Internal\ComingSoon\ComingSoonRequestHandler;
@@ -372,6 +373,10 @@ final class WooCommerce {
 		$container->get( ComingSoonAdminBarBadge::class );
 		$container->get( ComingSoonCacheInvalidator::class );
 		$container->get( ComingSoonRequestHandler::class );
+		// Resolved unconditionally (rather than through the wc-admin feature loader, which skips it)
+		// because its coming soon footer banner and login hooks must run on frontend requests, where
+		// the feature loader doesn't run. See Features::load_features().
+		$container->get( LaunchYourStore::class );
 		$container->get( OrderCountCacheService::class );
 		$container->get( DeferredEmailQueue::class );
 		$container->get( AddressProviderController::class );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -425,29 +425,13 @@ final class WooCommerce {
 
 		// Classes inheriting from RestApiControllerBase. Their register() method only adds them to the
 		// 'woocommerce_rest_api_get_rest_namespaces' filter, which the REST API server applies on
-		// 'rest_api_init'. A single shared filter callback that resolves them on demand avoids
-		// instantiating the controllers (and their dependencies) on requests that never initialize
-		// the REST API.
+		// 'rest_api_init'. A single shared filter callback resolves them on demand, which avoids
+		// instantiating the controllers (and their dependencies) on requests that never initialize the
+		// REST API. A named callback is used (rather than a closure) so it remains removable via
+		// remove_filter(). See register_internal_rest_api_controllers().
 		add_filter(
 			'woocommerce_rest_api_get_rest_namespaces',
-			static function ( $namespaces ) {
-				$rest_controller_classes = array(
-					Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class,
-					Automattic\WooCommerce\Internal\Orders\OrderActionsRestController::class,
-					Automattic\WooCommerce\Internal\Orders\OrderStatusRestController::class,
-					Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController::class,
-					Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsRestController::class,
-					Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController::class,
-					Automattic\WooCommerce\Internal\Admin\Emails\EmailListingRestController::class,
-				);
-
-				$container = wc_get_container();
-				foreach ( $rest_controller_classes as $rest_controller_class ) {
-					$namespaces = $container->get( $rest_controller_class )->handle_woocommerce_rest_api_get_rest_namespaces( $namespaces );
-				}
-
-				return $namespaces;
-			}
+			array( $this, 'register_internal_rest_api_controllers' )
 		);
 
 		$container->get( Automattic\WooCommerce\Internal\ProductFilters\MainQueryController::class )->register();
@@ -458,6 +442,36 @@ final class WooCommerce {
 
 		// Integration point between legacy reports and orders APIs (the reports caches invalidation focused).
 		\WC_Admin_Reports::register_orders_hook_handlers();
+	}
+
+	/**
+	 * Register the internal REST API controllers on the 'woocommerce_rest_api_get_rest_namespaces' filter.
+	 *
+	 * Each controller inherits from RestApiControllerBase and only needs to be instantiated when the REST
+	 * API server applies this filter on 'rest_api_init'. Resolving them here, on demand, avoids
+	 * instantiating the controllers (and their dependencies) on requests that never initialize the REST
+	 * API. This is registered as a named callback so it can still be removed with remove_filter().
+	 *
+	 * @param array $namespaces REST API namespaces and their controller classes.
+	 * @return array
+	 */
+	public function register_internal_rest_api_controllers( $namespaces ) {
+		$rest_controller_classes = array(
+			Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class,
+			Automattic\WooCommerce\Internal\Orders\OrderActionsRestController::class,
+			Automattic\WooCommerce\Internal\Orders\OrderStatusRestController::class,
+			Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController::class,
+			Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsRestController::class,
+			Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController::class,
+			Automattic\WooCommerce\Internal\Admin\Emails\EmailListingRestController::class,
+		);
+
+		$container = wc_get_container();
+		foreach ( $rest_controller_classes as $rest_controller_class ) {
+			$namespaces = $container->get( $rest_controller_class )->handle_woocommerce_rest_api_get_rest_namespaces( $namespaces );
+		}
+
+		return $namespaces;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -368,13 +368,11 @@ final class WooCommerce {
 		$container->get( BatchProcessingController::class );
 		$container->get( FeaturesController::class );
 		$container->get( WebhookUtil::class );
-		$container->get( Marketplace::class );
 		$container->get( TimeUtil::class );
 		$container->get( ComingSoonAdminBarBadge::class );
 		$container->get( ComingSoonCacheInvalidator::class );
 		$container->get( ComingSoonRequestHandler::class );
 		$container->get( OrderCountCacheService::class );
-		$container->get( EmailImprovements::class );
 		$container->get( DeferredEmailQueue::class );
 		$container->get( AddressProviderController::class );
 		$container->get( AbilitiesRegistry::class );
@@ -397,13 +395,9 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderAttributionController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderAttributionBlocksController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsController::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Utilities\LegacyRestApiStub::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\VariationGallery\Telemetry::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Email\EmailStyleSync::class )->register();
 		$container->get( EmailLogger::class )->register();
-		$container->get( VisualAttributeTermAdmin::class )->register();
 		$container->get( Automattic\WooCommerce\Admin\Features\Fulfillments\FulfillmentsController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Admin\Agentic\AgenticController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ProductFeed\ProductFeed::class )->register();
@@ -411,14 +405,45 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
 
-		// Classes inheriting from RestApiControllerBase.
-		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\Orders\OrderActionsRestController::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\Orders\OrderStatusRestController::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsRestController::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController::class )->register();
-		$container->get( Automattic\WooCommerce\Internal\Admin\Emails\EmailListingRestController::class )->register();
+		// Classes that only register admin-side hooks (admin screens, admin-ajax, settings pages,
+		// tracker snapshots). They are not resolved on regular frontend page loads, where none of
+		// their hooks can fire. REST and cron requests are included: settings are saved through the
+		// REST API and tracker data is collected from scheduled actions.
+		if ( $this->is_admin_side_request() ) {
+			$container->get( Marketplace::class );
+			$container->get( EmailImprovements::class );
+			$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsController::class )->register();
+			$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsController::class )->register();
+			$container->get( Automattic\WooCommerce\Internal\VariationGallery\Telemetry::class )->register();
+			$container->get( VisualAttributeTermAdmin::class )->register();
+		}
+
+		// Classes inheriting from RestApiControllerBase. Their register() method only adds them to the
+		// 'woocommerce_rest_api_get_rest_namespaces' filter, which the REST API server applies on
+		// 'rest_api_init'. A single shared filter callback that resolves them on demand avoids
+		// instantiating the controllers (and their dependencies) on requests that never initialize
+		// the REST API.
+		add_filter(
+			'woocommerce_rest_api_get_rest_namespaces',
+			static function ( $namespaces ) {
+				$rest_controller_classes = array(
+					Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class,
+					Automattic\WooCommerce\Internal\Orders\OrderActionsRestController::class,
+					Automattic\WooCommerce\Internal\Orders\OrderStatusRestController::class,
+					Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController::class,
+					Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsRestController::class,
+					Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController::class,
+					Automattic\WooCommerce\Internal\Admin\Emails\EmailListingRestController::class,
+				);
+
+				$container = wc_get_container();
+				foreach ( $rest_controller_classes as $rest_controller_class ) {
+					$namespaces = $container->get( $rest_controller_class )->handle_woocommerce_rest_api_get_rest_namespaces( $namespaces );
+				}
+
+				return $namespaces;
+			}
+		);
 
 		$container->get( Automattic\WooCommerce\Internal\ProductFilters\MainQueryController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ProductFilters\CacheController::class )->register();
@@ -645,6 +670,23 @@ final class WooCommerce {
 	}
 
 	/**
+	 * Returns true for request types on which admin-side functionality may run: admin screens
+	 * (including admin-ajax), REST API, cron and WP-CLI. Returns false only for regular frontend
+	 * page loads, where purely admin-side hooks can never fire.
+	 *
+	 * REST requests are included because admin features are commonly driven through the REST API
+	 * (wc-admin), and cron because Action Scheduler/WP-Cron jobs registered by admin-side classes
+	 * must remain runnable when executed from cron.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return bool
+	 */
+	private function is_admin_side_request(): bool {
+		return $this->is_request( 'admin' ) || $this->is_rest_api_request() || defined( 'DOING_CRON' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+	}
+
+	/**
 	 * What type of request is this?
 	 *
 	 * @param  string $type admin, ajax, cron or frontend.
@@ -677,140 +719,49 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-autoloader.php';
 
 		/**
-		 * Interfaces.
+		 * Interfaces, traits, abstract classes and data stores are loaded on demand by WC_Autoloader
+		 * (see its CLASS_MAP constant). They are intentionally not loaded eagerly here: referencing
+		 * any of these classes triggers the autoloader at any point after this method has run.
 		 */
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-abstract-order-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-coupon-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-customer-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-customer-download-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-customer-download-log-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-object-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-item-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-item-product-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-item-type-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-refund-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-payment-token-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-product-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-product-variable-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-shipping-zone-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-logger-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-log-handler-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-webhooks-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-queue-interface.php';
-
-		/**
-		 * Core traits.
-		 */
-		include_once WC_ABSPATH . 'includes/traits/trait-wc-item-totals.php';
-
-		/**
-		 * Abstract classes.
-		 */
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-address-provider.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-data.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-object-query.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-token.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-product.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-order.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-settings-api.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-shipping-method.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-gateway.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-integration.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-log-handler.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-deprecated-hooks.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-session.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-privacy.php';
 
 		/**
 		 * Core classes.
+		 *
+		 * Only files that have side effects at include time (registering hooks, shortcodes, post
+		 * types...) or whose classes are instantiated unconditionally on every request are loaded
+		 * here. Plain class definitions (WC_Discounts, WC_Cart_Totals, data stores, queue, Tracks
+		 * and so on) are loaded on demand by WC_Autoloader.
 		 */
 		include_once WC_ABSPATH . 'includes/wc-core-functions.php';
-		include_once WC_ABSPATH . 'includes/class-wc-datetime.php';
 		include_once WC_ABSPATH . 'includes/class-wc-post-types.php';
 		include_once WC_ABSPATH . 'includes/class-wc-install.php';
-		include_once WC_ABSPATH . 'includes/class-wc-geolocation.php';
 		include_once WC_ABSPATH . 'includes/class-wc-download-handler.php';
 		include_once WC_ABSPATH . 'includes/class-wc-comments.php';
 		include_once WC_ABSPATH . 'includes/class-wc-post-data.php';
 		include_once WC_ABSPATH . 'includes/class-wc-ajax.php';
 		include_once WC_ABSPATH . 'includes/class-wc-emails.php';
-		include_once WC_ABSPATH . 'includes/class-wc-data-exception.php';
 		include_once WC_ABSPATH . 'includes/class-wc-query.php';
-		include_once WC_ABSPATH . 'includes/class-wc-meta-data.php';
 		include_once WC_ABSPATH . 'includes/class-wc-order-factory.php';
-		include_once WC_ABSPATH . 'includes/class-wc-order-query.php';
 		include_once WC_ABSPATH . 'includes/class-wc-product-factory.php';
-		include_once WC_ABSPATH . 'includes/class-wc-product-query.php';
-		include_once WC_ABSPATH . 'includes/class-wc-payment-tokens.php';
-		include_once WC_ABSPATH . 'includes/class-wc-shipping-zone.php';
-		include_once WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-cc.php';
-		include_once WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-echeck.php';
 		include_once WC_ABSPATH . 'includes/class-wc-countries.php';
 		include_once WC_ABSPATH . 'includes/class-wc-integrations.php';
 		include_once WC_ABSPATH . 'includes/class-wc-cache-helper.php';
 		include_once WC_ABSPATH . 'includes/class-wc-https.php';
 		include_once WC_ABSPATH . 'includes/class-wc-deprecated-action-hooks.php';
 		include_once WC_ABSPATH . 'includes/class-wc-deprecated-filter-hooks.php';
-		include_once WC_ABSPATH . 'includes/class-wc-background-emailer.php';
-		include_once WC_ABSPATH . 'includes/class-wc-discounts.php';
-		include_once WC_ABSPATH . 'includes/class-wc-cart-totals.php';
-		include_once WC_ABSPATH . 'includes/customizer/class-wc-shop-customizer.php';
 		include_once WC_ABSPATH . 'includes/class-wc-regenerate-images.php';
 		include_once WC_ABSPATH . 'includes/class-wc-privacy.php';
 		include_once WC_ABSPATH . 'includes/class-wc-structured-data.php';
 		include_once WC_ABSPATH . 'includes/class-wc-shortcodes.php';
-		include_once WC_ABSPATH . 'includes/class-wc-logger.php';
-		include_once WC_ABSPATH . 'includes/queue/class-wc-action-queue.php';
-		include_once WC_ABSPATH . 'includes/queue/class-wc-queue.php';
-		include_once WC_ABSPATH . 'includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php';
-		include_once WC_ABSPATH . 'includes/admin/class-wc-admin-marketplace-promotions.php';
-		include_once WC_ABSPATH . 'includes/blocks/class-wc-blocks-utils.php';
-
-		/**
-		 * Data stores - used to store and retrieve CRUD object data from the database.
-		 */
-		include_once WC_ABSPATH . 'includes/class-wc-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-data-store-wp.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-coupon-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-grouped-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-variable-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-variation-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/abstract-wc-order-item-type-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-coupon-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-fee-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-product-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-shipping-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-tax-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-payment-token-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-customer-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-customer-data-store-session.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-customer-download-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-customer-download-log-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-shipping-zone-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/abstract-wc-order-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-refund-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-webhook-data-store.php';
 
 		/**
 		 * REST API.
+		 *
+		 * These two files register authentication filters and the wc-auth endpoint handlers at
+		 * include time, so they must be loaded eagerly on every request type.
 		 */
 		include_once WC_ABSPATH . 'includes/class-wc-rest-authentication.php';
-		include_once WC_ABSPATH . 'includes/class-wc-rest-exception.php';
 		include_once WC_ABSPATH . 'includes/class-wc-auth.php';
-		include_once WC_ABSPATH . 'includes/class-wc-register-wp-admin-settings.php';
-
-		/**
-		 * Tracks.
-		 */
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 
 		/**
 		 * WCCOM Site.
@@ -836,6 +787,16 @@ final class WooCommerce {
 			// Simulate loading plugin for the legacy reports.
 			// This will be removed after moving the legacy reports to a separate plugin.
 			include_once WC_ABSPATH . 'includes/admin/woocommerce-legacy-reports.php';
+			// Registers the admin_init hook that sets the Tracks identity cookie, which can only fire in admin.
+			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+		}
+
+		// These files register admin screen hooks and Action Scheduler/WP-Cron job callbacks at include
+		// time. They are not needed on regular frontend page loads, but must be loaded for cron and REST
+		// requests so their scheduled job callbacks remain available when the jobs run.
+		if ( $this->is_admin_side_request() ) {
+			include_once WC_ABSPATH . 'includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php';
+			include_once WC_ABSPATH . 'includes/admin/class-wc-admin-marketplace-promotions.php';
 		}
 
 		// We load frontend includes in the post editor, because they may be invoked via pre-loading of blocks.

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -130,6 +130,14 @@ class Features {
 
 		$features = self::get_features();
 		foreach ( $features as $feature ) {
+			// LaunchYourStore is instantiated unconditionally from WooCommerce::init_hooks() so that
+			// its frontend hooks (the coming soon footer banner and the login dismissal reset) work
+			// without loading the feature system on frontend requests. Skip it here so its hooks
+			// aren't registered twice in admin contexts.
+			if ( 'launch-your-store' === $feature ) {
+				continue;
+			}
+
 			$feature_class = self::get_feature_class( $feature );
 
 			if ( $feature_class ) {
@@ -156,6 +164,7 @@ class Features {
 		$optional_feature_keys         = array_keys( self::$optional_features );
 		$optional_features_unavailable = array();
 
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		/**
 		 * Filter allowing WooCommerce Admin optional features to be disabled.
 		 *
@@ -164,6 +173,7 @@ class Features {
 		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
 			return array_values( array_diff( $features, $optional_feature_keys ) );
 		}
+		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
 		foreach ( $optional_feature_keys as $optional_feature_key ) {
 			$feature_class = self::get_feature_class( $optional_feature_key );
@@ -337,9 +347,7 @@ class Features {
 			wp_doing_ajax() ||
 			wp_doing_cron() ||
 			( defined( 'WP_CLI' ) && WP_CLI ) ||
-			( WC()->is_rest_api_request() && ! WC()->is_store_api_request() ) ||
-			// Allow features to be loaded in frontend for admin users. This is needed for the use case such as the coming soon footer banner.
-			current_user_can( 'manage_woocommerce' )
+			( WC()->is_rest_api_request() && ! WC()->is_store_api_request() )
 		);
 
 		/**

--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -161,9 +161,8 @@ class LaunchYourStore {
 			return false;
 		}
 
-		$has_dismissed_banner = WCAdminUser::get_user_data_field( $current_user_id, self::BANNER_DISMISS_USER_META_KEY )
-				// Remove this check in WC 9.4.
-				|| get_user_meta( $current_user_id, 'woocommerce_' . self::BANNER_DISMISS_USER_META_KEY, true ) === 'yes';
+		$has_dismissed_banner = 'yes' === WCAdminUser::get_user_data_field( $current_user_id, self::BANNER_DISMISS_USER_META_KEY );
+
 		if ( $has_dismissed_banner ) {
 			return false;
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-autoloader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-autoloader-test.php
@@ -1,0 +1,63 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the WC_Autoloader class.
+ */
+class WC_Autoloader_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Returns the CLASS_MAP constant of WC_Autoloader.
+	 *
+	 * @return array<string, string>
+	 */
+	private function get_class_map(): array {
+		return ( new ReflectionClass( WC_Autoloader::class ) )->getConstant( 'CLASS_MAP' );
+	}
+
+	/**
+	 * @testdox Every CLASS_MAP entry points to an existing file that declares the mapped class, interface or trait.
+	 */
+	public function test_class_map_entries_point_to_files_declaring_the_mapped_name(): void {
+		$class_map = $this->get_class_map();
+
+		$this->assertNotEmpty( $class_map, 'CLASS_MAP should not be empty' );
+
+		foreach ( $class_map as $class_name => $relative_path ) {
+			$path = WC_ABSPATH . 'includes/' . $relative_path;
+
+			$this->assertFileExists( $path, "CLASS_MAP entry for '{$class_name}' points to a missing file" );
+
+			$declared = $this->get_declared_name( $path );
+			$this->assertSame(
+				$class_name,
+				strtolower( $declared ),
+				"CLASS_MAP entry '{$class_name}' maps to {$relative_path}, but that file declares '{$declared}'"
+			);
+		}
+	}
+
+	/**
+	 * @testdox Every CLASS_MAP class, interface and trait is resolvable through autoloading.
+	 */
+	public function test_class_map_entries_are_resolvable(): void {
+		foreach ( array_keys( $this->get_class_map() ) as $class_name ) {
+			$resolvable = class_exists( $class_name ) || interface_exists( $class_name ) || trait_exists( $class_name );
+			$this->assertTrue( $resolvable, "Class '{$class_name}' in CLASS_MAP could not be resolved via autoloading" );
+		}
+	}
+
+	/**
+	 * Extracts the first class/interface/trait name declared in a PHP file.
+	 *
+	 * @param string $path File path.
+	 * @return string The declared name, or an empty string if none found.
+	 */
+	private function get_declared_name( string $path ): string {
+		$content = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( preg_match( '/^\s*(?:abstract\s+|final\s+)?(?:class|interface|trait)\s+([A-Za-z0-9_]+)/m', $content, $matches ) ) {
+			return $matches[1];
+		}
+		return '';
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -40,6 +40,14 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 
 
 	/**
+	 * Clean up request globals after each test so request-classification state does not leak.
+	 */
+	public function tearDown(): void {
+		unset( $_GET['rest_route'] );
+		parent::tearDown();
+	}
+
+	/**
 	 * Restore the default URI.
 	 */
 	public static function tearDownAfterClass(): void {
@@ -69,5 +77,37 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		// Set the request uri to a rest api request.
 		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
 		$this->assertEquals( WC()->is_rest_api_request(), true );
+	}
+
+	/**
+	 * Test that REST requests routed via the `rest_route` query parameter (used with plain permalinks)
+	 * are detected, even though the wp-json prefix is absent from the request URI.
+	 */
+	public function test_rest_api_returns_true_for_rest_route_query_param() {
+		$_SERVER['REQUEST_URI'] = '/index.php';
+		$_GET['rest_route']     = '/wc/v3/products';
+		$this->assertTrue( WC()->is_rest_api_request() );
+	}
+
+	/**
+	 * Test that Store API requests routed via the `rest_route` query parameter are recognised as Store
+	 * API requests (and therefore as REST requests).
+	 */
+	public function test_store_api_request_detected_via_rest_route_query_param() {
+		$_SERVER['REQUEST_URI'] = '/index.php';
+		$_GET['rest_route']     = '/wc/store/v1/cart';
+		$this->assertTrue( WC()->is_store_api_request() );
+		$this->assertTrue( WC()->is_rest_api_request() );
+	}
+
+	/**
+	 * Test that a non-Store-API request routed via the `rest_route` query parameter is a REST request
+	 * but not a Store API request.
+	 */
+	public function test_non_store_rest_route_is_not_a_store_api_request() {
+		$_SERVER['REQUEST_URI'] = '/index.php';
+		$_GET['rest_route']     = '/wc/v3/products';
+		$this->assertFalse( WC()->is_store_api_request() );
+		$this->assertTrue( WC()->is_rest_api_request() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/Features/LaunchYourStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/LaunchYourStoreTest.php
@@ -144,7 +144,7 @@ class LaunchYourStoreTest extends \WC_Unit_Test_Case {
 			foreach ( $wp_filter['wp_footer']->callbacks as $callbacks ) {
 				foreach ( $callbacks as $callback ) {
 					if ( is_array( $callback['function'] ) && $callback['function'][0] instanceof LaunchYourStore && 'maybe_add_coming_soon_banner_on_frontend' === $callback['function'][1] ) {
-						$count++;
+						++$count;
 					}
 				}
 			}

--- a/plugins/woocommerce/tests/php/src/Admin/Features/LaunchYourStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/LaunchYourStoreTest.php
@@ -1,0 +1,155 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\Features;
+
+use Automattic\WooCommerce\Admin\Features\LaunchYourStore;
+use Automattic\WooCommerce\Internal\Admin\WCAdminUser;
+
+/**
+ * Tests for the LaunchYourStore class, focusing on the frontend coming soon banner
+ * behavior that runs outside the wc-admin feature loader.
+ */
+class LaunchYourStoreTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * System under test.
+	 *
+	 * @var LaunchYourStore
+	 */
+	private $sut;
+
+	/**
+	 * Setup.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = wc_get_container()->get( LaunchYourStore::class );
+		update_option( 'woocommerce_coming_soon', 'yes' );
+		update_option( 'woocommerce_store_pages_only', 'no' );
+	}
+
+	/**
+	 * Teardown.
+	 */
+	public function tearDown(): void {
+		delete_option( 'woocommerce_coming_soon' );
+		delete_option( 'woocommerce_store_pages_only' );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Renders the banner and returns the output.
+	 *
+	 * @return string
+	 */
+	private function render_banner(): string {
+		ob_start();
+		$this->sut->maybe_add_coming_soon_banner_on_frontend();
+		return ob_get_clean();
+	}
+
+	/**
+	 * @testdox The frontend hooks are registered on the shared container instance.
+	 */
+	public function test_frontend_hooks_are_registered(): void {
+		$this->assertNotFalse( has_action( 'wp_footer', array( $this->sut, 'maybe_add_coming_soon_banner_on_frontend' ) ), 'wp_footer hook should be registered' );
+		$this->assertNotFalse( has_action( 'wp_login', array( $this->sut, 'reset_woocommerce_coming_soon_banner_dismissed' ) ), 'wp_login hook should be registered' );
+		$this->assertNotFalse( has_filter( 'woocommerce_tracks_event_properties', array( $this->sut, 'append_coming_soon_global_tracks' ) ), 'tracks properties filter should be registered' );
+	}
+
+	/**
+	 * @testdox The banner is rendered for administrators when coming soon mode is enabled.
+	 */
+	public function test_banner_is_rendered_for_admin_in_coming_soon_mode(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertStringContainsString( 'coming-soon-footer-banner', $this->render_banner(), 'Admins should see the banner in coming soon mode' );
+	}
+
+	/**
+	 * @testdox The banner is not rendered for logged-out visitors.
+	 */
+	public function test_banner_is_not_rendered_for_logged_out_visitors(): void {
+		wp_set_current_user( 0 );
+
+		$this->assertSame( '', $this->render_banner(), 'Logged-out visitors should not see the banner' );
+	}
+
+	/**
+	 * @testdox The banner is not rendered for users without store management roles.
+	 */
+	public function test_banner_is_not_rendered_for_customers(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'customer' ) ) );
+
+		$this->assertSame( '', $this->render_banner(), 'Customers should not see the banner' );
+	}
+
+	/**
+	 * @testdox The banner is not rendered when coming soon mode is disabled.
+	 */
+	public function test_banner_is_not_rendered_when_coming_soon_is_off(): void {
+		update_option( 'woocommerce_coming_soon', 'no' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertSame( '', $this->render_banner(), 'The banner should not render when coming soon mode is off' );
+	}
+
+	/**
+	 * @testdox The banner is not rendered when the user has dismissed it.
+	 */
+	public function test_banner_is_not_rendered_when_dismissed(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		WCAdminUser::update_user_data_field( $user_id, LaunchYourStore::BANNER_DISMISS_USER_META_KEY, 'yes' );
+
+		$this->assertSame( '', $this->render_banner(), 'The banner should not render after being dismissed' );
+	}
+
+	/**
+	 * @testdox Logging in resets the dismissed state so the banner reappears each session.
+	 */
+	public function test_login_resets_dismissed_state(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		WCAdminUser::update_user_data_field( $user_id, LaunchYourStore::BANNER_DISMISS_USER_META_KEY, 'yes' );
+
+		$user = get_user_by( 'id', $user_id );
+		$this->sut->reset_woocommerce_coming_soon_banner_dismissed( $user->user_login, $user );
+
+		$this->assertSame( 'no', WCAdminUser::get_user_data_field( $user_id, LaunchYourStore::BANNER_DISMISS_USER_META_KEY ), 'Dismissed state should reset to no on login' );
+	}
+
+	/**
+	 * @testdox Tracks event properties get the coming_soon property appended.
+	 */
+	public function test_tracks_properties_include_coming_soon_state(): void {
+		$this->assertSame( 'site', $this->sut->append_coming_soon_global_tracks( array() )['coming_soon'], 'Site-wide coming soon should report "site"' );
+
+		update_option( 'woocommerce_store_pages_only', 'yes' );
+		$this->assertSame( 'store', $this->sut->append_coming_soon_global_tracks( array() )['coming_soon'], 'Store-pages-only coming soon should report "store"' );
+
+		update_option( 'woocommerce_coming_soon', 'no' );
+		$this->assertSame( 'no', $this->sut->append_coming_soon_global_tracks( array() )['coming_soon'], 'Live sites should report "no"' );
+	}
+
+	/**
+	 * @testdox The feature loader skips launch-your-store so its hooks are not registered twice.
+	 */
+	public function test_feature_loader_does_not_duplicate_hook_registration(): void {
+		global $wp_filter;
+
+		$count = 0;
+		if ( isset( $wp_filter['wp_footer'] ) ) {
+			foreach ( $wp_filter['wp_footer']->callbacks as $callbacks ) {
+				foreach ( $callbacks as $callback ) {
+					if ( is_array( $callback['function'] ) && $callback['function'][0] instanceof LaunchYourStore && 'maybe_add_coming_soon_banner_on_frontend' === $callback['function'][1] ) {
+						$count++;
+					}
+				}
+			}
+		}
+
+		$this->assertSame( 1, $count, 'The banner callback should be registered exactly once' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/Features/LaunchYourStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/LaunchYourStoreTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Admin\Features;
 
+use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\LaunchYourStore;
 use Automattic\WooCommerce\Internal\Admin\WCAdminUser;
 
@@ -134,9 +135,12 @@ class LaunchYourStoreTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The feature loader skips launch-your-store so its hooks are not registered twice.
+	 * Counts how many wp_footer callbacks are bound to the coming soon banner method across any
+	 * LaunchYourStore instance.
+	 *
+	 * @return int
 	 */
-	public function test_feature_loader_does_not_duplicate_hook_registration(): void {
+	private function count_banner_footer_callbacks(): int {
 		global $wp_filter;
 
 		$count = 0;
@@ -150,6 +154,36 @@ class LaunchYourStoreTest extends \WC_Unit_Test_Case {
 			}
 		}
 
-		$this->assertSame( 1, $count, 'The banner callback should be registered exactly once' );
+		return $count;
+	}
+
+	/**
+	 * @testdox The feature loader skips launch-your-store so its hooks are not registered twice.
+	 */
+	public function test_feature_loader_does_not_duplicate_hook_registration(): void {
+		// LaunchYourStore is instantiated unconditionally from WooCommerce::init_hooks(), so the banner
+		// callback is already registered exactly once.
+		$this->assertSame( 1, $this->count_banner_footer_callbacks(), 'The banner callback should start registered exactly once' );
+
+		// Drive the wc-admin feature loader the way it runs in admin/REST contexts, but constrained to
+		// launch-your-store with unrelated features disabled so nothing else is instantiated. If the
+		// loader stopped skipping launch-your-store, it would create a second instance via
+		// `new LaunchYourStore()` and register the banner callback again.
+		$only_launch_your_store = static function () {
+			return array( 'launch-your-store' );
+		};
+		add_filter( 'woocommerce_admin_should_load_features', '__return_true' );
+		add_filter( 'woocommerce_admin_features', $only_launch_your_store );
+		update_option( 'woocommerce_feature_blueprint_enabled', 'no' );
+		update_option( 'woocommerce_feature_order-detail-redesign_enabled', 'no' );
+
+		Features::load_features();
+
+		delete_option( 'woocommerce_feature_order-detail-redesign_enabled' );
+		delete_option( 'woocommerce_feature_blueprint_enabled' );
+		remove_filter( 'woocommerce_admin_features', $only_launch_your_store );
+		remove_filter( 'woocommerce_admin_should_load_features', '__return_true' );
+
+		$this->assertSame( 1, $this->count_banner_footer_callbacks(), 'The feature loader must not register the banner callback a second time' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

I asked Fable 5 to find boot-time bottlenecks with a heavy bias toward backwards compatibility, and these were the low-risk, high-impact wins. `WooCommerce::includes()` eagerly loads ~140 files on every request, and `init_hooks()` instantiates ~50 container classes even on frontend page loads where many of their hooks can never fire. This PR adds lazy loading, plus a class map for the older non-namespaced classes.

- **Lazy class loading.** ~85 side-effect-free files (interfaces, abstract classes, data stores, traits) are no longer eagerly included — a new `CLASS_MAP` in `WC_Autoloader` resolves them on demand. Names and paths are unchanged, so `class_exists()`, `new`, and `extends` behave exactly as before. Files with include-time side effects stay eager.
- **Lazy REST controller registration.** The internal `RestApiControllerBase` controllers were instantiated on every request just to add themselves to the `woocommerce_rest_api_get_rest_namespaces` filter. One shared callback now resolves them from the container on `rest_api_init`, so non-REST requests skip them. Route output is identical.
- **Request-type gating for admin-side classes.** Classes whose hooks can only fire in admin/REST/cron contexts are skipped on frontend loads via a new `is_admin_side_request()` helper (admin, admin-ajax, REST, cron, WP-CLI — Store API counts as frontend). Action Scheduler callbacks and REST settings saves still work; classes with frontend-reachable hooks were left unconditional.
- **wc-admin feature loader skipped on the frontend for store managers.** `Features::should_load_features()` loaded all 17 feature classes on every frontend view for logged-in merchants, just to render the LaunchYourStore coming soon banner. `LaunchYourStore` is the only one with frontend-reachable hooks, so it's now resolved unconditionally in `init_hooks()` (and skipped in `load_features()` to avoid double registration) and the `manage_woocommerce` clause is gone. This also fixes the `wp_login` dismissal-reset hook, which never registered on classic `wp-login.php` requests. The `woocommerce_admin_should_load_features` filter is unchanged.

On a wp-env install, a frontend page load drops from 923 to 840 WooCommerce PHP files (~9% fewer), and a `wc/v3` REST request from 1074 to 1011 — identical HTTP responses throughout.

Two notes for reviewers:
- extensions can no longer `remove_filter()` an individual REST controller's namespaces callback (now one shared callback); filtering the namespaces array at a later priority still works.
- `LaunchYourStore` hooks no longer depend on the `launch-your-store` entry in `woocommerce_admin_features`, so removing that entry via the filter no longer unregisters the banner/settings hooks.

### How to test the changes in this Pull Request:

CI should catch most issues given the breadth of class changes. For manual testing:

1. Browse the frontend logged out and logged in (home, shop, product, cart, checkout); confirm pages render and add-to-cart/checkout work.
2. Open wp-admin and confirm WooCommerce screens work, including WooCommerce → Settings → Payments and the Marketplace page.
3. Enable coming soon mode (WooCommerce → Settings → Site visibility), view the frontend as a logged-in admin, and confirm the footer banner appears, dismisses, and reappears after logging out and back in.
4. With authentication, confirm `GET /wp-json/wc/v3/products` works, and that `GET /wp-json/wc/v3/orders/{id}/receipt` without auth returns `401` (not `404 rest_no_route`) — verifies the lazily registered REST controllers.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
