### PR TITLE
Render product image without link when disabled

### DIFF
--- a/plugins/woocommerce/changelog/65682-64660-image-no-link-archive
+++ b/plugins/woocommerce/changelog/65682-64660-image-no-link-archive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Updates anchor rendering logic to not show an anchor tag when product image link is disabled

--- a/plugins/woocommerce/changelog/65682-64660-image-no-link-archive
+++ b/plugins/woocommerce/changelog/65682-64660-image-no-link-archive
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: fix
 
 Updates anchor rendering logic to not show an anchor tag when product image link is disabled

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -103,21 +103,20 @@ class ProductImage extends AbstractBlock {
 	private function render_anchor( $product, $on_sale_badge, $product_image, $attributes, $inner_blocks_content ) {
 		$product_permalink = $product->get_permalink();
 
-		$is_link        = isset( $attributes['showProductLink'] ) ? $attributes['showProductLink'] : true;
-		$href_attribute = $is_link ? sprintf( 'href="%s"', esc_url( $product_permalink ) ) : 'href="#" onclick="return false;"';
-		$wrapper_style  = ! $is_link ? 'pointer-events: none; cursor: default;' : '';
-		$directive      = $is_link ? 'data-wp-on--click="woocommerce/product-collection::actions.viewProduct"' : '';
+		$is_link = isset( $attributes['showProductLink'] ) ? $attributes['showProductLink'] : true;
 
 		$inner_blocks_container = sprintf(
 			'<div class="wc-block-components-product-image__inner-container">%s</div>',
 			$inner_blocks_content
 		);
 
+		if ( ! $is_link ) {
+			return $on_sale_badge . $product_image . $inner_blocks_container;
+		}
+
 		return sprintf(
-			'<a %1$s style="%2$s" %3$s>%4$s%5$s%6$s</a>',
-			$href_attribute,
-			esc_attr( $wrapper_style ),
-			$directive,
+			'<a href="%1$s" data-wp-on--click="woocommerce/product-collection::actions.viewProduct">%2$s%3$s%4$s</a>',
+			esc_url( $product_permalink ),
 			$on_sale_badge,
 			$product_image,
 			$inner_blocks_container

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -117,6 +117,41 @@ class ProductImage extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the ProductImage block renders a link by default.
+	 */
+	public function test_product_image_render_includes_product_link_by_default() {
+		$data = $this->create_product_with_image();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( '<a href="' . $data['product']->get_permalink() . '"', $markup );
+		$this->assertStringContainsString( 'data-wp-on--click="woocommerce/product-collection::actions.viewProduct"', $markup );
+
+		// Clean up.
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
+	}
+
+	/**
+	 * Test that the ProductImage block does not render a disabled link when product links are hidden.
+	 */
+	public function test_product_image_render_omits_anchor_when_product_link_is_hidden() {
+		$data = $this->create_product_with_image();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image {"showProductLink":false} /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'data-testid="product-image"', $markup );
+		$this->assertStringNotContainsString( '<a ', $markup );
+		$this->assertStringNotContainsString( 'href="#"', $markup );
+		$this->assertStringNotContainsString( 'onclick="return false;"', $markup );
+		$this->assertStringNotContainsString( 'data-wp-on--click="woocommerce/product-collection::actions.viewProduct"', $markup );
+
+		// Clean up.
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
+	}
+
+	/**
 	 * Test that the ProductImage block renders correctly for a variable product with variation images.
 	 * This is the main test case: if product is variable product and has some images attached to the variation
 	 * (but not in the main gallery) and the imageId of variation image is provided via context,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the anchor rendering logic for the ProductImage to not render an empty anchor link when product image links are disabled.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #64660  .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1693" height="842" alt="image" src="https://github.com/user-attachments/assets/744f3bdd-c282-4bda-b315-39f04efbbfc3" /> | <img width="1580" height="869" alt="image" src="https://github.com/user-attachments/assets/0491f5de-2ea5-41bf-bedb-67f2fb38ffe9" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

```bash
pnpm run test:php:env -- tests/php/src/Blocks/BlockTypes/ProductImage.php
```

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Updates anchor rendering logic to not show an anchor tag when product image link is disabled

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
