### PR TITLE
[Email Editor] Fix crash for users lacking edit_theme_options

### DIFF
--- a/packages/js/email-editor/changelog/fix-wooprd-3501-global-styles-react-error-185
+++ b/packages/js/email-editor/changelog/fix-wooprd-3501-global-styles-react-error-185
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Memoize the regularized entity record so the global styles and template selectors return a stable reference, preventing an infinite re-render loop (React error #185) for users who lack the edit_theme_options capability.

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -74,15 +74,31 @@ function enhancePatternWithParsedBlocks(
 	return enhancedPattern;
 }
 
+// Caches the regularized record keyed on the source entity record so repeated
+// calls with the same (referentially stable) record return the same object.
+// `@wordpress/core-data` memoizes `getEntityRecord`, so without this cache the
+// spread below would produce a new object on every selector call. That breaks
+// the referential stability `useSelect` relies on and drives an infinite
+// re-render loop (React error #185) for users who lack `edit_theme_options`,
+// because the `context: 'view'` branch — unlike `getEditedEntityRecord` — is
+// not otherwise memoized.
+const regularizedRecordCache = new WeakMap< object, object >();
+
 function regularizedGetEntityRecord( template ) {
 	if ( ! template ) {
 		return null;
 	}
-	return {
+	const cached = regularizedRecordCache.get( template );
+	if ( cached ) {
+		return cached;
+	}
+	const regularized = {
 		...template,
 		title: template?.title?.raw || template?.title || '',
 		content: template?.content?.raw || template?.content || '',
 	};
+	regularizedRecordCache.set( template, regularized );
+	return regularized;
 }
 
 export const isFeatureActive = createRegistrySelector(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3501 

When a user lacks the `edit_theme_options` capability, the email editor reads global styles and the post template through a read-only `context: 'view'` branch. That branch ran the records through `regularizedGetEntityRecord`, which built a brand-new object on every call, so the `getGlobalEmailStylesPost` and `getEditedPostTemplate` selectors returned a fresh reference each time. `useSelect` compares by reference, so it re-rendered on every store tick, which on some `@wordpress/data` versions spirals into an infinite re-render loop and crashes the editor with React error #185. Users with the capability were never affected because their branch uses core-data's already-memoized `getEditedEntityRecord`.

This memoizes `regularizedGetEntityRecord` with a `WeakMap` keyed on the source entity record (which core-data keeps referentially stable), so the read-only branch now returns a stable reference too. The fix is independent of the user's capability setup.


### Screenshots or screen recordings:

Not applicable — the change prevents an editor crash; there is no visual difference for users who can already load the editor.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This bug only surfaces for a user who can open the email editor but lacks `edit_theme_options`. No stock role meets both conditions (administrators and shop managers both have `edit_theme_options`), so a temporary capability tweak is needed to reproduce locally:

1. In `plugins/woocommerce/src/Internal/EmailEditor/Integration.php`, in `add_email_post_type()`, temporarily set `'capability_type' => 'post'` and comment out the `capabilities` array and `'map_meta_cap' => false`. This lets an editor-role user open the email editor.
2. Create an `editor`-role user (it lacks `edit_theme_options` by default) and install the **User Switching** plugin.
3. Switch to the editor user and open any email at `wp-admin/post.php?post=<woo_email id>&action=edit`.
4. Open the browser console. **Before this fix:** `@wordpress/data` logs "The `useSelect` hook returns different values when called with the same state and parameters. Non-equal value keys: globalStylePost / template", and on `@wordpress/data` builds without the re-render guard the editor crashes with React error #185.
5. **With this fix:** the warnings are gone and the editor loads normally.
6. Revert the temporary `Integration.php` change.

A quicker console check (as the editor user, with the editor open):

```js
const sel = wp.data.select( 'email-editor/editor' );
sel.canUserEditGlobalEmailStyles().canEdit;                              // false
sel.getGlobalEmailStylesPost() === sel.getGlobalEmailStylesPost();        // true with fix (was false)
sel.getEditedPostTemplate() === sel.getEditedPostTemplate();              // true with fix (was false)
```

<!-- End testing instructions -->

### Testing that has already taken place:

Reproduced locally with wp-env (WordPress 7.0, Gutenberg 23.2.2) as an `editor`-role user lacking `edit_theme_options`, using the temporary `capability_type => 'post'` tweak and the User Switching plugin. Confirmed the `@wordpress/data` instability warnings for `globalStylePost` and `template` before the fix, and verified at runtime that both selectors returned unstable references (`false`). After the fix, both selectors return stable references (`true`), the warnings are gone, and the editor loads. `eslint` and `prettier` pass on the changed file.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually in packages/js/email-editor/changelog.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)