### PR TITLE
Guard mini-cart and review-order templates against non-products

### DIFF
--- a/plugins/woocommerce/changelog/pcb-201-harden-cart-item-product-guards
+++ b/plugins/woocommerce/changelog/pcb-201-harden-cart-item-product-guards
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error in the mini-cart and checkout review-order templates when a filter hooked on woocommerce_cart_item_product returns a truthy non-product value.

--- a/plugins/woocommerce/templates/cart/mini-cart.php
+++ b/plugins/woocommerce/templates/cart/mini-cart.php
@@ -34,7 +34,7 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 			/**
 			 * Filter whether this cart item is visible in the mini-cart.
 			 *
-			 * @since 2.1.0
+			 * @since 1.6.0
 			 * @param bool   $visible       Whether the cart item is visible. Default true.
 			 * @param array  $cart_item     The cart item data.
 			 * @param string $cart_item_key The cart item key.

--- a/plugins/woocommerce/templates/cart/mini-cart.php
+++ b/plugins/woocommerce/templates/cart/mini-cart.php
@@ -14,7 +14,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.0.0
+ * @version 11.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -31,7 +31,17 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 			$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 			$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
 
-			if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_widget_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+			/**
+			 * Filter whether this cart item is visible in the mini-cart.
+			 *
+			 * @since 2.1.0
+			 * @param bool   $visible       Whether the cart item is visible. Default true.
+			 * @param array  $cart_item     The cart item data.
+			 * @param string $cart_item_key The cart item key.
+			 */
+			$visible = apply_filters( 'woocommerce_widget_cart_item_visible', true, $cart_item, $cart_item_key );
+
+			if ( $_product instanceof WC_Product && $_product->exists() && $cart_item['quantity'] > 0 && $visible ) {
 				/**
 				 * This filter is documented in woocommerce/templates/cart/cart.php.
 				 *

--- a/plugins/woocommerce/templates/checkout/review-order.php
+++ b/plugins/woocommerce/templates/checkout/review-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 5.2.0
+ * @version 11.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -31,7 +31,17 @@ defined( 'ABSPATH' ) || exit;
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 			$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 
-			if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+			/**
+			 * Filter whether this cart item is visible in the checkout review order table.
+			 *
+			 * @since 2.1.0
+			 * @param bool   $visible       Whether the cart item is visible. Default true.
+			 * @param array  $cart_item     The cart item data.
+			 * @param string $cart_item_key The cart item key.
+			 */
+			$visible = apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key );
+
+			if ( $_product instanceof WC_Product && $_product->exists() && $cart_item['quantity'] > 0 && $visible ) {
 				?>
 				<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
 					<td class="product-name">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`woocommerce_cart_item_product` is extension-controlled, and a filter that returns anything other than a `WC_Product` (`true`, an array, a string, a `stdClass`) slips past the `$_product && $_product->exists()` check in `cart/mini-cart.php` and `checkout/review-order.php` and fatals on `->exists()`. I've switched both to an `instanceof WC_Product` guard, which matches the fix already merged into `cart/cart.php` in #64252.

This is the follow-up to #64252 to harden the two remaining surfaces that use the same filter, so a non-product result simply skips the row rather than taking down the page.

### How to test the changes in this Pull Request:

1. Add any product to the cart.
2. In a snippet plugin or your theme's `functions.php`, add a filter that returns a truthy non-product:
   ```php
   add_filter( 'woocommerce_cart_item_product', function () {
       return true; // also try [], 'foo', or new stdClass()
   } );
   ```
3. View the **Cart** page (mini-cart in the cart widget) and the **Checkout** page.
4. **Expected:** each surface renders without the affected item row and no fatal error. On `trunk` you'd hit a `Call to a member function exists() on bool` fatal instead.
5. Remove the snippet, reload, and confirm the product rows render normally.

### Testing that has already taken place:

- Reproduced the fatal on `trunk` in both `cart/mini-cart.php` and `checkout/review-order.php` using the snippet above, and confirmed the guarded templates skip the row instead of fataling.
- `php -l` clean on both files, and no new PHPCS warnings on the changed lines.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually in `plugins/woocommerce/changelog/pcb-201-harden-cart-item-product-guards`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)