### PR TITLE
Fix: normalize related products heading size and spacing to match upsells section

### DIFF
--- a/plugins/woocommerce/changelog/fix-related-products-heading-styles
+++ b/plugins/woocommerce/changelog/fix-related-products-heading-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Normalize the Related products heading size and spacing on the single product page so it matches the upsells section's heading instead of being forced to the small font preset and a different margin.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
@@ -5,10 +5,6 @@
 		text-align: center;
 	}
 
-	h2.wp-block-heading {
-		@include font-small-locked;
-	}
-
 	// Gutenberg adds margin between elements but notices are often empty
 	// resulting in an unnecessary margin on product template.
 	.wc-block-components-notices:not(:has(*)) + .wc-block-product-template {

--- a/plugins/woocommerce/patterns/related-products.php
+++ b/plugins/woocommerce/patterns/related-products.php
@@ -9,8 +9,8 @@
 
 <!-- wp:woocommerce/product-collection {"align":"wide","queryId":0,"query":{"perPage":5,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":5,"shrinkColumns":false},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/related","hideControls":["inherit"],"queryContextIncludes":["collection"]} -->
 	<div class="wp-block-woocommerce-product-collection alignwide">
-		<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
-		<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)">
+		<!-- wp:heading {"style":{"spacing":{"margin":{"top":"0.83em","bottom":"0.83em"}}}} -->
+		<h2 class="wp-block-heading" style="margin-top:0.83em;margin-bottom:0.83em">
 				<?php
 					echo esc_html__(
 						'Related products',


### PR DESCRIPTION
## Changes proposed in this Pull Request

The "Related products" heading on the single product page was rendering much smaller than the "You may also like..." heading directly above it. Two separate issues caused this:

1. `product-collection/style.scss` was forcing any `h2.wp-block-heading` inside the Product Collection block down to the small font-size preset (`font-small-locked`), overriding the theme's natural h2 size.

2. `patterns/related-products.php` had a spacing preset (`var:preset|spacing|30` → 20px) on the Heading block that produced tighter margins than the upsells heading, which falls back to the browser default (`0.83em`).

This PR removes the font-size override and aligns the heading margin to `0.83em` top and bottom, bringing both headings to visual parity.

## Screenshots

Before
<img width="2946" height="5586" alt="screencapture-testshopyoannj-wpcomstaging-product-mix-and-match-2026-06-11-11_50_00" src="https://github.com/user-attachments/assets/fac1602e-a056-4dbc-8e8b-923df159fde3" />

After
<img width="2946" height="5446" alt="screencapture-localhost-8889-2026-06-11-11_50_53" src="https://github.com/user-attachments/assets/439d2c1b-141a-4852-abe3-4148d3682456" />