### PR TITLE
Fix unparseable glob in extend-cart-checkout-block .gitignore

### DIFF
--- a/packages/js/extend-cart-checkout-block/.gitignore
+++ b/packages/js/extend-cart-checkout-block/.gitignore
@@ -26,5 +26,3 @@ tests/e2e/config/local-*
 
 dist
 build
-
-{{slug}}.zip

--- a/packages/js/extend-cart-checkout-block/changelog/dev-gitignore-glob-parsing
+++ b/packages/js/extend-cart-checkout-block/changelog/dev-gitignore-glob-parsing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove a stray placeholder line from the literal .gitignore (the real template lives in .gitignore.mustache) so glob-based ignore parsers no longer fail on it.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The literal `packages/js/extend-cart-checkout-block/.gitignore` is a byte-identical copy of its `.gitignore.mustache` template and still carried the mustache placeholder `{{slug}}.zip`. In the non-template file that token is never substituted, so it ignores nothing real — but it makes tools built on Rust's `ignore` crate (watchexec, ripgrep, fd) fail to parse the file with `error parsing glob '{{slug}}.zip': nested alternate groups are not allowed`.

This removes the offending line from the literal `.gitignore`. The `.gitignore.mustache` template is left untouched, so scaffolded extensions still ignore their built `<slug>.zip`.

This fixes Conductor Spotlight feature on my machine. Before, spotlight would abort right away. 

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually in this PR (`packages/js/extend-cart-checkout-block/changelog/dev-gitignore-glob-parsing`).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)