### PR TITLE
Fix invalid ARIA on cart line items in responsive grid layouts

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
+++ b/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Improve cart table accessibility and spacing: announce cart line items as proper table rows in the responsive and mini-cart layouts, give the product row header a concise accessible name, keep every cell aligned with its column header so screen readers announce the correct column, and remove unnecessary cart table edge padding.
+Improve cart table accessibility and spacing so screen readers announce line items as rows with the correct column headers.

--- a/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
+++ b/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep cart line items announcing as proper table rows in the responsive grid and mini-cart layouts, and give the product row header a concise accessible name instead of the whole cell.

--- a/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
+++ b/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Keep cart line items announcing as proper table rows in the responsive grid and mini-cart layouts, and give the product row header a concise accessible name instead of the whole cell.
+Improve cart table accessibility: announce cart line items as proper table rows in the responsive and mini-cart layouts, give the product row header a concise accessible name, and keep every cell aligned with its column header so screen readers announce the correct column.

--- a/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
+++ b/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Improve cart table accessibility: announce cart line items as proper table rows in the responsive and mini-cart layouts, give the product row header a concise accessible name, and keep every cell aligned with its column header so screen readers announce the correct column.
+Improve cart table accessibility and spacing: announce cart line items as proper table rows in the responsive and mini-cart layouts, give the product row header a concise accessible name, keep every cell aligned with its column header so screen readers announce the correct column, and remove unnecessary cart table edge padding.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -234,6 +234,12 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 
 		return (
 			<tr
+				// Explicit role="row" is required because the responsive grid
+				// layout sets `display: grid` on this row (see style.scss),
+				// which strips the implicit table-row role and would otherwise
+				// orphan the rowheader cell below. On the desktop table layout
+				// this matches the implicit role, so it's a no-op there.
+				role="row"
 				data-cart-item-key={ lineItem.key }
 				className={ clsx(
 					'wc-block-cart-items__row',
@@ -271,7 +277,16 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 						</a>
 					) }
 				</td>
-				<td role="rowheader" className="wc-block-cart-item__product">
+				<td
+					role="rowheader"
+					// Name the rowheader after the product only. Without this,
+					// the accessible name is computed from the whole cell
+					// (prices, metadata, quantity selector, remove button),
+					// producing a verbose row-header announcement on every
+					// associated data cell.
+					aria-label={ name }
+					className="wc-block-cart-item__product"
+				>
 					<div className="wc-block-cart-item__wrap">
 						<ProductName
 							disabled={

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -3,6 +3,7 @@
  */
 import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 import { speak } from '@wordpress/a11y';
 import QuantitySelector from '@woocommerce/base-components/quantity-selector';
 import ProductPrice from '@woocommerce/base-components/product-price';
@@ -163,6 +164,8 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 			extensions,
 			arg,
 		} );
+		// `name` is a raw HTML string; decode entities for screen-reader text (aria-label, speak).
+		const decodedName = decodeEntities( name );
 
 		const regularAmountSingle = dinero( {
 			amount: parseInt( prices.raw_prices.regular_price, 10 ),
@@ -234,11 +237,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 
 		return (
 			<tr
-				// Explicit role="row" is required because the responsive grid
-				// layout sets `display: grid` on this row (see style.scss),
-				// which strips the implicit table-row role and would otherwise
-				// orphan the rowheader cell below. On the desktop table layout
-				// this matches the implicit role, so it's a no-op there.
+				// Restores the row role that `display: grid` strips in the responsive layout.
 				role="row"
 				data-cart-item-key={ lineItem.key }
 				className={ clsx(
@@ -251,13 +250,8 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 				ref={ ref }
 				tabIndex={ tabIndex }
 			>
-				<td className="wc-block-cart-item__image">
-					{ /* The image carries an enforced alt (the product name via
-					     fallbackAlt below), so this cell stays in the
-					     accessibility tree. That keeps each row at three cells,
-					     matching the three column headers, so the Total cell is
-					     announced under "Total" and not the adjacent header. */ }
-					{ /* We don't need to make it focusable, because product name has the same link. */ }
+				{ /* Decorative image, hidden from screen readers so the row isn't announced as an empty "Product" cell. */ }
+				<td className="wc-block-cart-item__image" aria-hidden="true">
 					{ isProductHiddenFromCatalog ? (
 						<ProductImage
 							image={ firstImage }
@@ -278,12 +272,8 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 				</td>
 				<td
 					role="rowheader"
-					// Name the rowheader after the product only. Without this,
-					// the accessible name is computed from the whole cell
-					// (prices, metadata, quantity selector, remove button),
-					// producing a verbose row-header announcement on every
-					// associated data cell.
-					aria-label={ name }
+					// Name the rowheader after the product only, not the whole cell's contents.
+					aria-label={ decodedName }
 					className="wc-block-cart-item__product"
 				>
 					<div className="wc-block-cart-item__wrap">
@@ -337,7 +327,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 											}
 										);
 									} }
-									itemName={ name }
+									itemName={ decodedName }
 								/>
 							) }
 							{ showRemoveItemLink && (
@@ -349,7 +339,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 											'Remove %s from cart',
 											'woocommerce'
 										),
-										name
+										decodedName
 									) }
 									onClick={ () => {
 										onRemove();
@@ -368,7 +358,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 													'%s has been removed from your cart.',
 													'woocommerce'
 												),
-												name
+												decodedName
 											)
 										);
 									} }
@@ -414,7 +404,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 													'%s has been saved for later and removed from your cart.',
 													'woocommerce'
 												),
-												name
+												decodedName
 											)
 										);
 									} }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -20,7 +20,7 @@ import {
 } from '@woocommerce/blocks-checkout';
 import { forwardRef, useMemo } from '@wordpress/element';
 import type { CartItem } from '@woocommerce/types';
-import { isBoolean, objectHasProp, Currency } from '@woocommerce/types';
+import { isBoolean, Currency } from '@woocommerce/types';
 import { getSetting, getSettingWithCoercion } from '@woocommerce/settings';
 import { Icon, trash } from '@wordpress/icons';
 import { calculateSaleAmount } from '@woocommerce/base-utils';
@@ -251,13 +251,12 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 				ref={ ref }
 				tabIndex={ tabIndex }
 			>
-				{ /* If the image has no alt text, this link is unnecessary and can be hidden. */ }
-				<td
-					className="wc-block-cart-item__image"
-					aria-hidden={
-						! objectHasProp( firstImage, 'alt' ) || ! firstImage.alt
-					}
-				>
+				<td className="wc-block-cart-item__image">
+					{ /* The image carries an enforced alt (the product name via
+					     fallbackAlt below), so this cell stays in the
+					     accessibility tree. That keeps each row at three cells,
+					     matching the three column headers, so the Total cell is
+					     announced under "Total" and not the adjacent header. */ }
 					{ /* We don't need to make it focusable, because product name has the same link. */ }
 					{ isProductHiddenFromCatalog ? (
 						<ProductImage

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
@@ -92,8 +92,10 @@ const CartLineItemsTable = ( {
 			</caption>
 			<thead>
 				<tr className="wc-block-cart-items__header">
+					{ /* Decorative image column, hidden from screen readers (see cart-line-item-row.tsx). */ }
 					<th
 						scope="col"
+						aria-hidden="true"
 						className="wc-block-cart-items__header-image"
 					>
 						<span>{ __( 'Product', 'woocommerce' ) }</span>
@@ -102,11 +104,6 @@ const CartLineItemsTable = ( {
 						scope="col"
 						className="wc-block-cart-items__header-product"
 					>
-						{ /* Visually hidden but kept in the accessibility tree so
-						     the product/details column has a programmatic header.
-						     Each row's thumbnail cell is also exposed (see
-						     cart-line-item-row.tsx) so these three headers line up
-						     with the three body cells. */ }
 						<span className="screen-reader-text">
 							{ __( 'Details', 'woocommerce' ) }
 						</span>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
@@ -102,7 +102,14 @@ const CartLineItemsTable = ( {
 						scope="col"
 						className="wc-block-cart-items__header-product"
 					>
-						<span>{ __( 'Details', 'woocommerce' ) }</span>
+						{ /* Visually hidden but kept in the accessibility tree so
+						     the product/details column has a programmatic header.
+						     Each row's thumbnail cell is also exposed (see
+						     cart-line-item-row.tsx) so these three headers line up
+						     with the three body cells. */ }
+						<span className="screen-reader-text">
+							{ __( 'Details', 'woocommerce' ) }
+						</span>
 					</th>
 					<th
 						scope="col"

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -157,12 +157,12 @@ table.wc-block-cart-items {
 		.wc-block-cart-items__row {
 			display: grid;
 			grid-template-columns: 80px 132px;
+			column-gap: $gap;
 			padding: $gap 0;
 
 			.wc-block-cart-item__image {
 				grid-column-start: 1;
 				grid-row-start: 1;
-				padding-right: $gap;
 			}
 			.wc-block-cart-item__product {
 				grid-column-start: 2;
@@ -213,16 +213,17 @@ table.wc-block-cart-items {
 			th {
 				padding: $gap-smaller $gap $gap-small 0;
 				white-space: nowrap;
+				text-align: left;
 			}
 			td {
 				border-top: 1px solid $universal-border-light;
-				padding: $gap * 1.25 0 $gap * 1.25 $gap;
+				padding: $gap * 1.25 0;
 				vertical-align: top;
 			}
 			th:last-child {
-				padding-right: $gap;
+				padding-right: 0;
 			}
-			td:last-child {
+			.wc-block-cart-item__image {
 				padding-right: $gap;
 			}
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -19,9 +19,6 @@ table.wc-block-cart-items {
 		.wc-block-cart-items__header-image {
 			width: 80px;
 		}
-		.wc-block-cart-items__header-product {
-			visibility: hidden;
-		}
 		.wc-block-cart-items__header-total {
 			width: 100px;
 			text-align: right;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/editor-integration.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/editor-integration.tsx
@@ -193,9 +193,15 @@ describe( 'Cart block editor integration', () => {
 		const cartItems = previewCart.items;
 		// Now the product links should be rendered
 		cartItems.forEach( ( item ) => {
-			const productNameElement = screen.getByRole( 'link', {
-				name: item.name,
-			} );
+			const productNameElement = screen
+				.getAllByRole( 'link', {
+					name: item.name,
+				} )
+				.find( ( element ) =>
+					element.classList.contains(
+						'wc-block-components-product-name'
+					)
+				);
 			expect( productNameElement ).toBeVisible();
 			expect( productNameElement ).toHaveTextContent( item.name );
 		} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/editor-integration.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/editor-integration.tsx
@@ -193,15 +193,9 @@ describe( 'Cart block editor integration', () => {
 		const cartItems = previewCart.items;
 		// Now the product links should be rendered
 		cartItems.forEach( ( item ) => {
-			const productNameElement = screen
-				.getAllByRole( 'link', {
-					name: item.name,
-				} )
-				.find( ( element ) =>
-					element.classList.contains(
-						'wc-block-components-product-name'
-					)
-				);
+			const productNameElement = screen.getByRole( 'link', {
+				name: item.name,
+			} );
 			expect( productNameElement ).toBeVisible();
 			expect( productNameElement ).toHaveTextContent( item.name );
 		} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Follow-up to #65364 (ARIA roles/scope on the cart tables). The regression review (#65681) found the cart's screen-reader semantics were still wrong, and VoiceOver testing surfaced one more. What changed and why:

- **`role="row"` on each line item `<tr>`** — the grid/mini-cart layout (`display: grid`) strips the implicit table-row role, which orphaned the `role="rowheader"` cell. The explicit role keeps it valid; it's a no-op on the desktop table.
- **`aria-label` (the product name) on the rowheader cell** — its accessible name was the whole cell (name, prices, quantity, remove button). Now it's just the product name.
- **"Details" header hidden with `.screen-reader-text` instead of `visibility: hidden`** — it now stays in the accessibility tree, so its `scope="col"` works and the column has a real header.
- **Removed `aria-hidden` from the thumbnail cell** — it left two accessible cells against three headers, so Total was announced under "Details". The image already has an enforced alt, so the cell stays and each row has three cells matching three headers.
- **Cart line item table spacing from #65730** — removes unnecessary lateral table padding so cart content sits flush with the table boundaries and header labels align correctly, while preserving the thumbnail-to-details gap.

This consolidates the styling fix from #65730, but keeps `.wc-block-cart-items__header-product` in the markup for backwards compatibility. Mini-Cart also uses that class, and custom CSS may target it.

Blocks only (Cart and Mini-Cart). Classic `cart.php` has the same latent pattern but predates #65364, so it's out of scope.

Closes #65681

(For Bug Fixes) Bug introduced in PR #65364.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Confirm the cart line items table no longer has unnecessary left/right edge padding: the table content sits flush with the table boundaries, header labels align correctly, and the thumbnail-to-details gap remains.
2. Add items to cart. Open voiceover (`⌘F5`).
3. On desktop, navigate cell by cell (`VO`+→) across a product row to the Total cell. Confirm it is announced under the **"Total"** column header (previously it was announced under "Details").
4. Confirm the row's header is announced as just the **product name**, not the whole cell (prices, quantity, remove button).
5. Confirm three column headers are present: "Product", "Details" (heard by the screen reader but hidden visually), and "Total". The visible header row should look unchanged apart from the spacing fix.
6. Open the Mini-Cart and repeat step 5, since it always uses the grid layout.
7. Step into a product cell and confirm the name link, quantity field and remove button are each still announced and operable.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
