### PR TITLE
Fix: improve My Account login form layout for block themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-login-form-ux-improvements
+++ b/plugins/woocommerce/changelog/fix-login-form-ux-improvements
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Improve the My Account login form layout by moving the Login and Register headings inside their form elements, styling them like an H3, placing the Remember me checkbox in its own row before the submit button, and trimming the leading padding on form rows.
+Improve the My Account login form layout for block themes with CSS only (no template changes): the Login and Register headings now sit inside their boxes, the Remember me checkbox gets its own row above the submit button, and the leading padding on form rows is trimmed. No markup changes, so there is no backwards-compatibility risk for stores overriding the template.

--- a/plugins/woocommerce/changelog/fix-login-form-ux-improvements
+++ b/plugins/woocommerce/changelog/fix-login-form-ux-improvements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve the My Account login form layout by moving the Login and Register headings inside their form elements, styling them like an H3, placing the Remember me checkbox in its own row before the submit button, and trimming the leading padding on form rows.

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -456,16 +456,49 @@ a.added_to_cart {
 	}
 }
 
-.woocommerce-form-login h2,
-.woocommerce-form-register h2 {
-	// Heading now sits as the first child of the form (see templates/myaccount/form-login.php).
-	// Remove the top margin so it sits flush with the top of the form.
+// My Account login/register: make each heading appear to belong to its box
+// using CSS only, without changing the template markup. The <h2> stays a
+// sibling before the <form> in the DOM (templates/myaccount/form-login.php).
+
+// Move the card border from the form up to the column wrapper, so the
+// heading and the form sit inside the same box.
+#customer_login .u-column1,
+#customer_login .u-column2 {
+	box-sizing: border-box;
+	padding: 20px;
+	border: 1px solid darken($secondary, 10%); // Matches form.login in woocommerce.scss.
+	border-radius: 5px;
+}
+
+// Remove the inner form box to avoid a double border.
+#customer_login form.login,
+#customer_login form.register {
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
+// Heading flush at the top of the card.
+#customer_login .u-column1 > h2,
+#customer_login .u-column2 > h2 {
 	margin-top: 0;
 	font-size: var(--wp--preset--font-size--large);
 }
 
-.woocommerce form.woocommerce-form-login .form-row,
-.woocommerce form.woocommerce-form-register .form-row {
+// Remember me on its own row above the submit button.
+#customer_login .woocommerce-form-login__rememberme {
+	display: block;
+	margin-bottom: 1em;
+}
+
+#customer_login .woocommerce-form-login__submit {
+	float: none;
+	margin-right: 0;
+}
+
+// Remove padding-left on form rows inside login/register.
+#customer_login form.login .form-row,
+#customer_login form.register .form-row {
 	padding-left: 0;
 }
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -456,6 +456,19 @@ a.added_to_cart {
 	}
 }
 
+.woocommerce-form-login h2,
+.woocommerce-form-register h2 {
+	// Heading now sits as the first child of the form (see templates/myaccount/form-login.php).
+	// Remove the top margin so it sits flush with the top of the form.
+	margin-top: 0;
+	font-size: var(--wp--preset--font-size--large);
+}
+
+.woocommerce form.woocommerce-form-login .form-row,
+.woocommerce form.woocommerce-form-register .form-row {
+	padding-left: 0;
+}
+
 /**
 * My account - Login form
 */

--- a/plugins/woocommerce/templates/myaccount/form-login.php
+++ b/plugins/woocommerce/templates/myaccount/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 11.0.0
+ * @version 9.9.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,9 +29,9 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 <?php endif; ?>
 
-		<form class="woocommerce-form woocommerce-form-login login" method="post" novalidate>
+		<h2><?php esc_html_e( 'Login', 'woocommerce' ); ?></h2>
 
-			<h2><?php esc_html_e( 'Login', 'woocommerce' ); ?></h2>
+		<form class="woocommerce-form woocommerce-form-login login" method="post" novalidate>
 
 			<?php do_action( 'woocommerce_login_form_start' ); ?>
 
@@ -50,8 +50,6 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 				<label class="woocommerce-form__label woocommerce-form__label-for-checkbox woocommerce-form-login__rememberme">
 					<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
 				</label>
-			</p>
-			<p class="form-row">
 				<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
 			</p>
@@ -69,9 +67,9 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 	<div class="u-column2 col-2">
 
-		<form method="post" class="woocommerce-form woocommerce-form-register register" <?php do_action( 'woocommerce_register_form_tag' ); ?> >
+		<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
 
-			<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
+		<form method="post" class="woocommerce-form woocommerce-form-register register" <?php do_action( 'woocommerce_register_form_tag' ); ?> >
 
 			<?php do_action( 'woocommerce_register_form_start' ); ?>
 

--- a/plugins/woocommerce/templates/myaccount/form-login.php
+++ b/plugins/woocommerce/templates/myaccount/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.9.0
+ * @version 11.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,9 +29,9 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 <?php endif; ?>
 
-		<h2><?php esc_html_e( 'Login', 'woocommerce' ); ?></h2>
-
 		<form class="woocommerce-form woocommerce-form-login login" method="post" novalidate>
+
+			<h2><?php esc_html_e( 'Login', 'woocommerce' ); ?></h2>
 
 			<?php do_action( 'woocommerce_login_form_start' ); ?>
 
@@ -50,6 +50,8 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 				<label class="woocommerce-form__label woocommerce-form__label-for-checkbox woocommerce-form-login__rememberme">
 					<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
 				</label>
+			</p>
+			<p class="form-row">
 				<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
 			</p>
@@ -67,9 +69,9 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 	<div class="u-column2 col-2">
 
-		<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
-
 		<form method="post" class="woocommerce-form woocommerce-form-register register" <?php do_action( 'woocommerce_register_form_tag' ); ?> >
+
+			<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
 
 			<?php do_action( 'woocommerce_register_form_start' ); ?>
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Several UX improvements to the My Account login form on block themes:

1. **Headings inside the boxes** — the "Login" and "Register" `<h2>` headings were sitting outside their respective `<form>` elements. Moved inside as the first child so they visually belong to the box they label.

2. **Heading size** — styled the `<h2>` headings to match the theme's natural `<h3>` size (`var(--wp--preset--font-size--large)`) and removed the inherited top margin. The markup stays `<h2>` for semantic correctness and backward compatibility.

3. **Remember me placement** — moved the "Remember me" checkbox to sit between the password field and the Log In button, which is the expected UX position for this control.

4. **Form row alignment** — removed the 3px `padding-left` on form rows inside the login/register forms so inputs align flush with the heading.

## Backward compatibility

- The `<h2>` headings are now inside the `<form>` tags. Stores using CSS selectors like `#customer_login > h2` or `.u-column1 > h2` will need to update their selectors.
- The `woocommerce_login_form` hook now fires before the Remember me row instead of before the submit button. Plugins injecting via this hook will be affected.
- Template version bumped to `11.0.0` — stores overriding `form-login.php` will see the standard outdated template notice.

## Screenshots

Before:
<img width="1381" height="927" alt="Capture d’écran 2026-06-11 à 13 42 11" src="https://github.com/user-attachments/assets/12a227c3-449b-44d8-8519-9e457dd1d851" />

After:
<img width="3374" height="2880" alt="image" src="https://github.com/user-attachments/assets/5be16ced-dba3-4b77-9b77-244d89227678" />

## Out of scope

Form control styles (label line-height, field spacing, required asterisk color) and border/separator consistency are not addressed in this PR. These will be covered in broader upcoming work on unified form controls and a shared WooCommerce separator token.