### PR TITLE
Render settings UI number fields with design-spec spin controls

### DIFF
--- a/packages/js/settings-ui-sdk/changelog/update-number-control-spin-buttons
+++ b/packages/js/settings-ui-sdk/changelog/update-number-control-spin-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Render number fields with NumberControl and custom +/- spin controls instead of a native number input.

--- a/packages/js/settings-ui-sdk/src/native-fields.tsx
+++ b/packages/js/settings-ui-sdk/src/native-fields.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis -- NumberControl has no stable export; required for the design-spec custom spin controls. */
 /**
  * External dependencies
  */
@@ -7,6 +8,7 @@ import {
 	SelectControl,
 	TextControl,
 	TextareaControl,
+	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
 import { createElement, RawHTML } from '@wordpress/element';
 
@@ -25,8 +27,7 @@ type TextInputType =
 	| 'time'
 	| 'email'
 	| 'url'
-	| 'tel'
-	| 'number';
+	| 'tel';
 
 const textInputTypes: TextInputType[] = [
 	'text',
@@ -37,7 +38,6 @@ const textInputTypes: TextInputType[] = [
 	'email',
 	'url',
 	'tel',
-	'number',
 ];
 
 const toStringValue = ( value: SettingsValue ) =>
@@ -149,6 +149,23 @@ export const NativeSettingsField = ( {
 					) ) }
 				</select>
 			</BaseControl>
+		);
+	}
+
+	if ( field.type === 'number' ) {
+		return (
+			<NumberControl
+				className="wc-settings-ui__control"
+				label={ field.label }
+				help={ getHelp( field.description ) }
+				value={ toStringValue( value ) }
+				placeholder={ field.placeholder }
+				disabled={ field.disabled }
+				onChange={ ( next ) => onChange( next ?? '' ) }
+				spinControls="custom"
+				__next40pxDefaultSize
+				{ ...field.customAttributes }
+			/>
 		);
 	}
 

--- a/packages/js/settings-ui-sdk/src/test/native-fields.test.tsx
+++ b/packages/js/settings-ui-sdk/src/test/native-fields.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { NativeSettingsField } from '../native-fields';
+import type {
+	SettingsFieldComponentProps,
+	SettingsUIField,
+	SettingsValue,
+} from '../types';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderElement = ( element: JSX.Element ) => {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	act( () => {
+		root.render( element );
+	} );
+
+	return { container, root };
+};
+
+const makeProps = (
+	field: SettingsUIField,
+	value: SettingsValue,
+	onChange: ( next: SettingsValue ) => void = () => {}
+): SettingsFieldComponentProps => ( {
+	field,
+	value,
+	onChange,
+	values: { [ field.id ]: value },
+	initialValues: { [ field.id ]: value },
+	setValue: () => {},
+	setValues: () => {},
+	context: { page: 'test-page' },
+} );
+
+describe( 'NativeSettingsField', () => {
+	let cleanup: ( () => void ) | null = null;
+
+	afterEach( () => {
+		cleanup?.();
+		cleanup = null;
+	} );
+
+	const render = ( element: JSX.Element ) => {
+		const { container, root } = renderElement( element );
+		cleanup = () => {
+			act( () => {
+				root.unmount();
+			} );
+			container.remove();
+		};
+		return container;
+	};
+
+	describe( 'number fields', () => {
+		const numberField: SettingsUIField = {
+			id: 'wc_test_number',
+			label: 'Low stock threshold',
+			type: 'number',
+			customAttributes: { min: 0, step: 1 },
+		};
+
+		it( 'renders a number input with custom spin buttons instead of native spinners', () => {
+			const container = render(
+				<NativeSettingsField { ...makeProps( numberField, '5' ) } />
+			);
+
+			const input = container.querySelector( 'input[type="number"]' );
+			expect( input ).not.toBeNull();
+			expect( input?.getAttribute( 'min' ) ).toBe( '0' );
+			expect( input?.getAttribute( 'step' ) ).toBe( '1' );
+
+			expect(
+				container.querySelector( '[aria-label="Increment"]' )
+			).not.toBeNull();
+			expect(
+				container.querySelector( '[aria-label="Decrement"]' )
+			).not.toBeNull();
+		} );
+
+		it( 'calls onChange with the stepped value when a spin button is clicked', () => {
+			const onChange = jest.fn();
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps( numberField, '5', onChange ) }
+				/>
+			);
+
+			const increment = container.querySelector(
+				'[aria-label="Increment"]'
+			) as HTMLButtonElement;
+
+			act( () => {
+				increment.dispatchEvent(
+					new MouseEvent( 'click', { bubbles: true } )
+				);
+			} );
+
+			expect( onChange ).toHaveBeenCalledWith( '6' );
+		} );
+	} );
+
+	describe( 'text fields', () => {
+		it( 'renders text fields without spin buttons', () => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps(
+						{
+							id: 'wc_test_text',
+							label: 'Store name',
+							type: 'text',
+						},
+						'hello'
+					) }
+				/>
+			);
+
+			expect(
+				container.querySelector( 'input[type="text"]' )
+			).not.toBeNull();
+			expect(
+				container.querySelector( '[aria-label="Increment"]' )
+			).toBeNull();
+		} );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Design review of pages rendered through the settings UI SDK flagged that number fields render with the browser's native up/down spinner arrows, while the designs specify the design-system number input with explicit **+/−** spin buttons.

Number fields now render through `NumberControl` with `spinControls="custom"` instead of `TextControl` with `type="number"`. Value semantics (string values, empty string for cleared input) and `customAttributes` passthrough (min/max/step) are unchanged.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the `settings-ui` feature flag, e.g. with a small must-use plugin:

    ```php
    add_filter( 'woocommerce_admin_features', static function ( array $features ): array {
        $features[] = 'settings-ui';
        return $features;
    } );
    ```

2. Go to **WooCommerce → Settings → Products → Inventory**.
3. Verify number fields ("Hold stock (minutes)", "Low stock threshold", etc.) render with **+** and **−** spin buttons instead of the browser's native up/down arrows.
4. Click the buttons and confirm the value steps correctly and respects the field's min/step; type a value manually and confirm it still saves as before.
5. Disable the feature flag and confirm legacy settings pages are unaffected.

<!-- End testing instructions -->

### Testing that has already taken place:

- New Jest tests in `@woocommerce/settings-ui-sdk` cover the number field renderer: custom spin buttons render, clicking them calls `onChange` with the stepped value, `min`/`step` custom attributes pass through, and text fields are unaffected (19/19 package tests pass).
- Verified in a local Docker environment (WP trunk, `settings-ui` flag on): number fields on Products → Inventory render `NumberControl` with working +/− buttons.
- ESLint and `tsc` pass on the changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually for `@woocommerce/settings-ui-sdk`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>