### PR TITLE
Order detail: apply 2-column grid sizing standard (720 / 24 / 320)

### DIFF
--- a/plugins/woocommerce/changelog/order-detail-new-column-sizing
+++ b/plugins/woocommerce/changelog/order-detail-new-column-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Apply the agreed 2-column sizing (720 / 24 / 320) to the Order edit and new screens.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3045,11 +3045,100 @@ ul.wc_coupon_list_block {
 
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
-	// Gated behind the `order-detail-redesign` feature flag (body class added by OrderDetailRedesign\Init).
+	// Apply the agreed team-wide 2-column grid sizing standard to the Order edit/new screens.
 	// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
-	&.woocommerce-feature-enabled-order-detail-redesign .wrap:has(#poststuff) {
-		max-width: 1200px;
+	// Total width is derived (not hardcoded) from the two column tokens plus the gap token:
+	// surface-width-xl (720) + padding-2xl (24) + surface-width-sm (320) = 1064px.
+	.wrap:has(#poststuff) {
+		// Cap .wrap to the derived grid width and center it on the page. This also
+		// keeps the "Edit order" / "Add order" page-title row aligned with the grid below.
+		max-width: calc(
+			var(--wpds-dimension-surface-width-xl, 720px)
+			+ var(--wpds-dimension-padding-2xl, 24px)
+			+ var(--wpds-dimension-surface-width-sm, 320px)
+		);
 		margin-inline: auto;
+
+		#post-body.columns-2 {
+			display: grid;
+			grid-template-columns:
+				minmax(0, var(--wpds-dimension-surface-width-xl, 720px))
+				var(--wpds-dimension-surface-width-sm, 320px);
+			gap: var(--wpds-dimension-padding-2xl, 24px);
+			float: none;
+			// WP core's edit.css sets `margin-right: 300px` on `#post-body.columns-2`
+			// to reserve space for the side-sortable floating in. Zero it out so the
+			// grid uses the full width of #poststuff.
+			margin: 0;
+		}
+
+		// `#post-body-content` is a small top area that's a sibling of the postbox
+		// containers. Span it across both columns so it doesn't hog column 1 and
+		// push the main metaboxes down to row 2.
+		#post-body-content {
+			grid-column: 1 / -1;
+		}
+
+		#postbox-container-1,
+		#postbox-container-2 {
+			float: none;
+			width: auto;
+			min-width: 0;
+			// WP core's edit.css sets `margin: 0 300px 0 0` on container-2 (and a
+			// negative margin-left on container-1) to reserve space for the old
+			// float-based sidebar. Zero them out so the grid controls width.
+			margin: 0;
+		}
+
+		// WP core's edit.css also pins `#side-sortables` to width: 280px (legacy
+		// float layout). Let it fill its 320px grid cell instead. Targeting
+		// `#post-body.columns-2 #side-sortables` matches WP core's selector specificity
+		// and the extra parent classes from the `.wrap:has(#poststuff)` chain put us over.
+		#post-body.columns-2 #side-sortables {
+			width: auto;
+		}
+
+		// WP puts `#postbox-container-1` (sidebar) before `#postbox-container-2`
+		// (main content) in the DOM, but its float layout visually places main on
+		// the left and sidebar on the right. Re-create that placement explicitly:
+		// main → 720px primary column, sidebar → 320px secondary, both at row 1.
+		// `grid-row: 1` is required because the default placement cursor advances
+		// past row 1 once container-1 lands in column 2, pushing container-2 to row 2.
+		#postbox-container-2 {
+			grid-column: 1;
+			grid-row: 1;
+		}
+
+		#postbox-container-1 {
+			grid-column: 2;
+			grid-row: 1;
+		}
+
+		// Stack to a single column on narrow viewports. Target is wrap < 960px
+		// (--wpds-dimension-surface-width-2xl). At expanded WP admin sidebar (~180px chrome),
+		// that maps to viewport ~1140px.
+		// TODO: switch to `@container (max-width: 960px)` once grunt-contrib-cssmin is
+		// upgraded (current clean-css 4.x strips @container rules).
+		@media (max-width: 1140px) {
+			#post-body.columns-2 {
+				grid-template-columns: 1fr;
+			}
+
+			// Stack with the SIDEBAR on top, primary below — opposite of the design
+			// system "primary above secondary" rule. Reason: the primary "Update" CTA
+			// currently lives in the Order actions metabox in the sidebar; flipping
+			// the stack would hide it under a long page of order content. Revisit
+			// once the CTA moves out of the sidebar (see GH #60962).
+			#postbox-container-1 {
+				grid-column: 1;
+				grid-row: 1;
+			}
+
+			#postbox-container-2 {
+				grid-column: 1;
+				grid-row: 2;
+			}
+		}
 	}
 
 	.tablenav .one-page .displaying-num {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3045,7 +3045,6 @@ ul.wc_coupon_list_block {
 
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
-	// Apply the agreed team-wide 2-column grid sizing standard to the Order edit/new screens.
 	// `:has(#poststuff)` excludes the orders list screen (which doesn't render #poststuff).
 	// Total width is derived (not hardcoded) from the two column tokens plus the gap token:
 	// surface-width-xl (720) + padding-2xl (24) + surface-width-sm (320) = 1064px.


### PR DESCRIPTION
### Changes proposed in this Pull Request

Applies the agreed team-wide gXdQoz5sdk2CrUqq0UkaLp-fi-65_2 to the Order edit and new screens (HPOS and legacy CPT). First retrofit of the standard aligned in #woo-design (June 2026).

**Sizing (all WPDS tokens, no hardcoded values):**
- Primary column: `--wpds-dimension-surface-width-xl` (720px)
- Secondary column: `--wpds-dimension-surface-width-sm` (320px)
- Gap: `--wpds-dimension-padding-2xl` (24px)
- Page width: derived (720 + 24 + 320 = 1064px), applied via `calc()` on `.wrap:has(#poststuff)` so the page-title row aligns with the grid below.

**Notes for reviewers:**

- **Not behind a feature flag.** This is the agreed team-wide standard, not an experiment, so it ships unconditionally. The existing `order-detail-redesign` flag-gated `max-width: 1200px` rule on `.wrap` is removed — it conflicted with the new derived width.
- **`@media` instead of `@container`.** The brief specifies container queries, but the legacy admin CSS pipeline uses `grunt-contrib-cssmin@3.0.0` / `clean-css 4.x`, which strips `@container` at-rules entirely (verified — they don't survive the build). The workaround uses `@media (max-width: 1140px)` (≈ wrap < 960px after WP admin chrome). A `TODO` comment in the SCSS marks this for revisit once cssmin is upgraded.
- **Stacked order: sidebar on top.** When stacked on narrow viewports, the **secondary** column sits *above* the primary — opposite of the design-system "primary above secondary" rule. Reason: the primary `Update` CTA currently lives in the Order actions metabox in the sidebar; flipping the stack would hide it below the full order detail. Revisit once #60962 moves the CTA out of the sidebar.
- **Postbox drag/reorder preserved.** Manually verified on Studio (HPOS) that moving metaboxes between containers and reordering inside a container still works correctly under the new CSS Grid layout.
- **WP core float-layout resets.** WP core's `edit.css` sets several float-era widths/margins on `#post-body.columns-2`, `#postbox-container-{1,2}`, and `#side-sortables`. All four are reset in this PR with inline comments explaining why.

Implements DSGWOO-1375.

### Screenshots or screen recordings

### BEFORE
<img width="3600" height="2086" alt="Edit-order-289-‹-Jana-s-tienda-—-WordPress-06-12-2026_09_52_AM" src="https://github.com/user-attachments/assets/dd27c48a-0308-481a-9c2d-4abdc9266b2a" />
Default WP metabox layout


### AFTER
<img width="3600" height="2086" alt="Edit-order-289-‹-Jana-s-tienda-—-WordPress-06-12-2026_09_51_AM" src="https://github.com/user-attachments/assets/e27c8a05-9ffb-4355-a760-51e7b4bd5d2b" />
720px primary + 320px secondary + 24px gap, derived 1064px page width, centered.

### How to test the changes in this Pull Request

1. Open an order on the Order edit screen — both URLs should look identical:
   - HPOS: `/wp-admin/admin.php?page=wc-orders&action=edit&id=<id>`
   - Legacy CPT: `/wp-admin/post.php?post=<id>&action=edit`
2. Verify the layout:
   - Primary column (Order details, Items, Downloadable permissions, Custom fields) is **720px wide** on the **left**.
   - Secondary column (Order actions, Order attribution, Customer history, Order notes) is **320px wide** on the **right**.
   - Gap between columns is **24px**.
   - Whole layout is **centered** on the page; the `Edit order` page heading and `Add order` button line up with the grid.
3. Drag a metabox from one column to the other — drag/reorder should still work and persist on reload.
4. Resize the browser narrow (or open Responsive mode). Below ~1140px viewport, the columns should **stack with the sidebar on top** and the order details below.
5. Repeat on the **New Order** screen (`/wp-admin/admin.php?page=wc-orders&action=new`) — same sizing should apply.
6. RTL eyeball: with an RTL locale, primary should flip to the right, secondary to the left (CSS Grid handles this automatically).

### Testing that has already taken place

- Manually verified the layout on Studio (HPOS path) at desktop (~1900px viewport) and at narrow viewports (mobile responsive mode in DevTools).
- Verified postbox drag/reorder works correctly across both containers.
- Verified the compiled CSS via the served `admin.css` to confirm `@container` strip and `@media` survival through the cssmin pipeline.

### Follow-ups (separate PRs)

- **Prev/next nav alignment.** The sibling PR adding the prev/next order navigation will need a small follow-up tweak once both this PR and the nav PR land — the nav should align to the right edge of the new 1064px grid. This PR has priority over the nav PR.
- **Order details internal layout.** Separate PR to come for the **General / Billing / Shipping** stacking behavior *inside* the Order details metabox. Out of scope here.
- **cssmin upgrade.** When the legacy admin CSS pipeline is updated (clean-css 5.x+), swap the `@media` workaround back to `@container (max-width: 960px)`. Not blocking this PR.
- **Stacked order revisit.** Once #60962 moves the primary `Update` CTA out of the sidebar, swap the stacked layout back to "primary above secondary" per the design-system standard.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

The changelog entry was created manually in this PR (`plugins/woocommerce/changelog/order-detail-new-column-sizing`).

<details>
<summary>Changelog Entry Details</summary>

**Significance:** patch
**Type:** update
**Message:** Apply the agreed 2-column sizing (720 / 24 / 320) to the Order edit and new screens.

</details>