### PR TITLE
Add 'wc' debug group to WP_CLI::debug calls in CLIRunner

### DIFF
--- a/plugins/woocommerce/changelog/65701-add-wc-cli-debug-group
+++ b/plugins/woocommerce/changelog/65701-add-wc-cli-debug-group
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add the WooCommerce debug group to HPOS CLI debug messages.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -218,7 +218,8 @@ class CLIRunner {
 					__( 'Beginning batch #%1$d (%2$d orders/batch).', 'woocommerce' ),
 					$batch_count,
 					$batch_size
-				)
+				),
+				'wc'
 			);
 			$batch_start_time = microtime( true );
 			$order_ids        = $this->synchronizer->get_next_batch_to_process( $batch_size );
@@ -235,7 +236,8 @@ class CLIRunner {
 					$batch_count,
 					count( $order_ids ),
 					$batch_total_time
-				)
+				),
+				'wc'
 			);
 
 			++$batch_count;
@@ -411,7 +413,8 @@ class CLIRunner {
 					__( 'Beginning verification for batch #%1$d (%2$d orders/batch).', 'woocommerce' ),
 					$batch_count,
 					$batch_size
-				)
+				),
+				'wc'
 			);
 
 			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Inputs are prepared.
@@ -510,7 +513,8 @@ class CLIRunner {
 					$batch_count,
 					count( $order_ids ),
 					$batch_total_time
-				)
+				),
+				'wc'
 			);
 
 			$order_id_start  = max( $order_ids ) + 1;
@@ -980,7 +984,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 					++$count;
 
 					// translators: %d is an order ID.
-					WP_CLI::debug( sprintf( __( 'Cleanup completed for order %d.', 'woocommerce' ), $order_id ) );
+					WP_CLI::debug( sprintf( __( 'Cleanup completed for order %d.', 'woocommerce' ), $order_id ), 'wc' );
 				} catch ( \Exception $e ) {
 					// translators: %1$d is an order ID, %2$s is an error message.
 					WP_CLI::warning( sprintf( __( 'An error occurred while cleaning up order %1$d: %2$s', 'woocommerce' ), $order_id, $e->getMessage() ) );

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/MockWPCLI.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/MockWPCLI.php
@@ -72,10 +72,10 @@ class MockWPCLI {
 	/**
 	 * Mock debug method.
 	 *
-	 * @param string $message Debug message.
-	 * @param bool   $group   Debug group.
+	 * @param string      $message Debug message.
+	 * @param string|bool $group   Debug group.
 	 */
-	public static function debug( $message, $group = false ): void {
+	public static function debug( $message, $group = false ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		self::$last_debug_message = $message;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/MockWPCLI.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Mocks/MockWPCLI.php
@@ -73,8 +73,9 @@ class MockWPCLI {
 	 * Mock debug method.
 	 *
 	 * @param string $message Debug message.
+	 * @param bool   $group   Debug group.
 	 */
-	public static function debug( $message ): void {
+	public static function debug( $message, $group = false ): void {
 		self::$last_debug_message = $message;
 	}
 


### PR DESCRIPTION
## Summary

All `WP_CLI::debug()` calls in `CLIRunner.php` were missing a debug group parameter. This causes noisy output when running CLI commands with `--debug` (all debug groups shown), instead of filtering to just WooCommerce-related debug messages.

This PR adds the `wc` debug group to all 5 `WP_CLI::debug()` calls in the CLIRunner, consistent with other WooCommerce REST-based CLI commands.

### Changes

- Added `wc` debug group to 5 `WP_CLI::debug()` calls in `plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php`

### Testing

1. Run `wp wc hpos cleanup <order_id> --debug` (without group filter) — previously showed all debug groups
2. Run `wp wc hpos cleanup <order_id> --debug=wc` — now shows only WooCommerce debug messages
3. Both approaches work correctly; the grouped version produces cleaner output

Fixes #46855

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.