### PR TITLE
Add 'wc' debug group to WP_CLI::debug calls in CLIRunner

### DIFF
--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -218,7 +218,8 @@ class CLIRunner {
 					__( 'Beginning batch #%1$d (%2$d orders/batch).', 'woocommerce' ),
 					$batch_count,
 					$batch_size
-				)
+				),
+				'wc'
 			);
 			$batch_start_time = microtime( true );
 			$order_ids        = $this->synchronizer->get_next_batch_to_process( $batch_size );
@@ -235,7 +236,8 @@ class CLIRunner {
 					$batch_count,
 					count( $order_ids ),
 					$batch_total_time
-				)
+				),
+				'wc'
 			);
 
 			++$batch_count;
@@ -411,7 +413,8 @@ class CLIRunner {
 					__( 'Beginning verification for batch #%1$d (%2$d orders/batch).', 'woocommerce' ),
 					$batch_count,
 					$batch_size
-				)
+				),
+				'wc'
 			);
 
 			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Inputs are prepared.
@@ -510,7 +513,8 @@ class CLIRunner {
 					$batch_count,
 					count( $order_ids ),
 					$batch_total_time
-				)
+				),
+				'wc'
 			);
 
 			$order_id_start  = max( $order_ids ) + 1;
@@ -980,7 +984,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 					++$count;
 
 					// translators: %d is an order ID.
-					WP_CLI::debug( sprintf( __( 'Cleanup completed for order %d.', 'woocommerce' ), $order_id ) );
+					WP_CLI::debug( sprintf( __( 'Cleanup completed for order %d.', 'woocommerce' ), $order_id ), 'wc' );
 				} catch ( \Exception $e ) {
 					// translators: %1$d is an order ID, %2$s is an error message.
 					WP_CLI::warning( sprintf( __( 'An error occurred while cleaning up order %1$d: %2$s', 'woocommerce' ), $order_id, $e->getMessage() ) );


### PR DESCRIPTION
## What

Adds the `'wc'` debug group parameter to all 5 `WP_CLI::debug()` calls in `CLIRunner.php` that were missing it.

## Why

Currently these debug messages are ungrouped, so running any HPOS CLI command with `--debug` outputs debug messages from **all** groups, making it noisy. With this change, users can filter with `--debug=wc` to see only WooCommerce-related debug output, consistent with the existing pattern in `class-wc-cli-runner.php` and `class-wc-cli-rest-command.php`.

## Testing

1. Run `wp wc hpos sync --debug=wc` — should show the batch debug messages.
2. Run `wp wc hpos sync --debug` — should show all debug output as before.
3. Run `wp wc hpos cleanup <order_id> --debug=wc` — should show cleanup debug message.

Fixes #46855