### PR TITLE
Fix emptied customer address fields being restored from saved values

### DIFF
--- a/plugins/woocommerce/changelog/65225-fix-customer-session-empty-values
+++ b/plugins/woocommerce/changelog/65225-fix-customer-session-empty-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix customer address fields that are emptied during checkout being restored with the previously saved values on subsequent requests.

--- a/plugins/woocommerce/changelog/65225-fix-customer-session-empty-values
+++ b/plugins/woocommerce/changelog/65225-fix-customer-session-empty-values
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix customer address fields that are emptied during checkout being restored with the previously saved values on subsequent requests.

--- a/plugins/woocommerce/changelog/65703-add-customer-session-empty-value-tests
+++ b/plugins/woocommerce/changelog/65703-add-customer-session-empty-value-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add unit tests covering empty customer session values overriding persisted customer data.

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -111,6 +111,9 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 		 * There is a valid session if $data is not empty, and the ID matches the logged in user ID.
 		 *
 		 * If the user object has been updated since the session was created (based on date_modified) we should not load the session - data should be reloaded.
+		 *
+		 * Empty session values must be applied too (hence isset and not empty below): the session snapshot always contains all the keys,
+		 * so an empty value means the field was explicitly cleared and must override the value loaded from the database.
 		 */
 		if ( isset( $data['id'], $data['date_modified'] ) && $data['id'] === (string) $customer->get_id() && $data['date_modified'] === (string) $customer->get_date_modified( 'edit' ) ) {
 			foreach ( $this->session_keys as $session_key ) {
@@ -121,7 +124,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				if ( 'billing_' === substr( $session_key, 0, 8 ) ) {
 					$session_key = str_replace( 'billing_', '', $session_key );
 				}
-				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
+				if ( isset( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
 					if ( 'meta_data' === $session_key ) {
 						if ( is_array( $data[ $session_key ] ) ) {
 							foreach ( $data[ $session_key ] as $meta_data_value ) {

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
@@ -4,6 +4,24 @@
  * Tests relating to the WC_Customer_Data_Store_Session class.
  */
 class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		WC()->session->set( 'customer', null );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		WC()->session->set( 'customer', null );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
 	/**
 	 * Ensure that the country and state shipping address fields only inherit
 	 * the corresponding billing address values if a shipping address is not set.
@@ -63,6 +81,112 @@ class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
 		$session_data = WC()->session->get_session_data();
 
 		$this->assertArrayNotHasKey( 'customer', $session_data );
+	}
+
+	/**
+	 * @testdox Should override a persisted shipping field with an empty value stored in the session.
+	 */
+	public function test_empty_session_value_overrides_persisted_shipping_field(): void {
+		$customer_id = WC_Helper_Customer::create_customer( 'session_empty_shipping', 'password', 'session-empty-shipping@example.com' )->get_id();
+
+		$session_customer = new WC_Customer( $customer_id, true );
+		$session_customer->set_shipping_address_2( '' );
+		$session_customer->save();
+
+		$reloaded_customer = new WC_Customer( $customer_id, true );
+
+		$this->assertSame( '', $reloaded_customer->get_shipping_address_2(), 'A shipping field emptied in the session should not be restored from the persisted customer data' );
+	}
+
+	/**
+	 * @testdox Should override a persisted billing field with an empty value stored in the session.
+	 */
+	public function test_empty_session_value_overrides_persisted_billing_field(): void {
+		$customer_id = WC_Helper_Customer::create_customer( 'session_empty_billing', 'password', 'session-empty-billing@example.com' )->get_id();
+
+		$session_customer = new WC_Customer( $customer_id, true );
+		$session_customer->set_billing_address_2( '' );
+		$session_customer->save();
+
+		$reloaded_customer = new WC_Customer( $customer_id, true );
+
+		$this->assertSame( '', $reloaded_customer->get_billing_address_2(), 'A billing field emptied in the session should not be restored from the persisted customer data' );
+	}
+
+	/**
+	 * @testdox Should leave persisted values untouched for keys that are absent from the session data.
+	 */
+	public function test_keys_absent_from_session_data_keep_persisted_values(): void {
+		$customer_id   = WC_Helper_Customer::create_customer( 'session_absent_keys', 'password', 'session-absent-keys@example.com' )->get_id();
+		$date_modified = (string) ( new WC_Customer( $customer_id ) )->get_date_modified( 'edit' );
+
+		WC()->session->set(
+			'customer',
+			array(
+				'id'            => (string) $customer_id,
+				'date_modified' => $date_modified,
+				'first_name'    => 'Session-Name',
+			)
+		);
+
+		$customer = new WC_Customer( $customer_id, true );
+
+		$this->assertSame( 'Session-Name', $customer->get_billing_first_name(), 'Keys present in the session data should be applied' );
+		$this->assertSame( 'Apt 1', $customer->get_shipping_address_2(), 'Keys absent from the session data should keep the persisted values' );
+	}
+
+	/**
+	 * @testdox Should ignore the session data entirely when the date modified does not match the persisted customer.
+	 */
+	public function test_stale_session_data_is_ignored(): void {
+		$customer_id = WC_Helper_Customer::create_customer( 'session_stale_data', 'password', 'session-stale-data@example.com' )->get_id();
+
+		WC()->session->set(
+			'customer',
+			array(
+				'id'                 => (string) $customer_id,
+				'date_modified'      => 'stale-date',
+				'address_2'          => '',
+				'shipping_address_2' => '',
+			)
+		);
+
+		$customer = new WC_Customer( $customer_id, true );
+
+		$this->assertSame( 'Apt 1', $customer->get_billing_address_2(), 'Stale session data should not override the persisted billing values' );
+		$this->assertSame( 'Apt 1', $customer->get_shipping_address_2(), 'Stale session data should not override the persisted shipping values' );
+	}
+
+	/**
+	 * @testdox Should fall back to the default location when the billing country is emptied in the session.
+	 */
+	public function test_emptied_billing_country_falls_back_to_default_location(): void {
+		$customer_id = WC_Helper_Customer::create_customer( 'session_empty_country', 'password', 'session-empty-country@example.com' )->get_id();
+
+		$session_customer = new WC_Customer( $customer_id, true );
+		$session_customer->set_billing_country( '' );
+		$session_customer->save();
+
+		$reloaded_customer = new WC_Customer( $customer_id, true );
+		$default_location  = wc_get_customer_default_location();
+
+		$this->assertSame( $default_location['country'], $reloaded_customer->get_billing_country(), 'An emptied billing country should be replaced with the default location country' );
+	}
+
+	/**
+	 * @testdox Should fall back to the account email when the billing email is emptied in the session for a logged in user.
+	 */
+	public function test_emptied_billing_email_falls_back_to_account_email_for_logged_in_user(): void {
+		$customer_id = WC_Helper_Customer::create_customer( 'session_empty_email', 'password', 'session-empty-email@example.com' )->get_id();
+		wp_set_current_user( $customer_id );
+
+		$session_customer = new WC_Customer( $customer_id, true );
+		$session_customer->set_billing_email( '' );
+		$session_customer->save();
+
+		$reloaded_customer = new WC_Customer( $customer_id, true );
+
+		$this->assertSame( 'session-empty-email@example.com', $reloaded_customer->get_billing_email(), 'An emptied billing email should be replaced with the account email for logged in users' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
@@ -84,21 +84,6 @@ class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should override a persisted shipping field with an empty value stored in the session.
-	 */
-	public function test_empty_session_value_overrides_persisted_shipping_field(): void {
-		$customer_id = WC_Helper_Customer::create_customer( 'session_empty_shipping', 'password', 'session-empty-shipping@example.com' )->get_id();
-
-		$session_customer = new WC_Customer( $customer_id, true );
-		$session_customer->set_shipping_address_2( '' );
-		$session_customer->save();
-
-		$reloaded_customer = new WC_Customer( $customer_id, true );
-
-		$this->assertSame( '', $reloaded_customer->get_shipping_address_2(), 'A shipping field emptied in the session should not be restored from the persisted customer data' );
-	}
-
-	/**
 	 * @testdox Should override a persisted billing field with an empty value stored in the session.
 	 */
 	public function test_empty_session_value_overrides_persisted_billing_field(): void {


### PR DESCRIPTION
_*NOTE:* This change has been already implemented in #65633. This PR is still kept for the unit tests it adds._

### Changes proposed in this Pull Request:

`WC_Customer_Data_Store_Session::read()` overlays the customer data stored in the session on top of the data loaded from the database, but it skipped any session value that was empty (`! empty()` check). As a result, a field that a logged in customer explicitly cleared during checkout (e.g. the "Apartment, suite, etc." / `address_2` field) was restored with the previously saved value from the database on every subsequent request. This was visible in the block-based checkout, where Store API requests such as `/wc/store/v1/cart/extensions` or `/wc/store/v1/cart/select-shipping-rate` returned the old value again after the field had been emptied.

This PR replaces the `! empty()` check with `isset()` so that empty values stored in the session are applied to the customer object too. This is safe because:

-   The session snapshot is only applied when its `id` and `date_modified` match the customer loaded from the database, so a stale session can never override fresher database data (that existing guard is unchanged).
-   The session snapshot always contains all the keys (they are written unconditionally as strings by `get_customer_session_data()`), so an empty value in a valid snapshot can only mean the field was explicitly cleared.
-   `set_defaults()` still runs after the overlay, so an emptied billing country/state falls back to the default location and an emptied billing email falls back to the account email for logged in users.
-   The boolean keys (`is_vat_exempt`, `calculated_shipping`) go through `wc_string_to_bool()`, for which an empty string yields the same result (`false`) as skipping the setter did before.

Unit tests covering the new behavior (and pinning the pre-existing guards) are included.

Closes #65225.

Bug introduced in PR #12353 (the `! empty()` check has been present since the session data store was introduced in WooCommerce 3.0).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Log in as a registered customer and, in **My account → Addresses**, save a shipping address that includes a value for the "Apartment, suite, etc." (`address_2`) field.
2. Add a product to the cart and go to the block-based checkout page.
3. In the shipping address form, clear the "Apartment, suite, etc." field.
4. Trigger another Store API request, for example by selecting a different shipping method, or by using an extension that calls `/wc/store/v1/cart/extensions`. Alternatively, reload the checkout page.
5. Verify that the "Apartment, suite, etc." field stays empty instead of being filled again with the previously saved value.

Alternatively, the issue can be reproduced without the UI by temporarily adding this snippet (after saving a shipping `address_2` value for the logged in customer): with the snippet below, the dumped value must be an empty string, not the previously saved value.

```php
add_action( 'init', function() {
	$customer = wc()->customer;

	$customer->set_shipping_address_2( '' );
	$customer->save();

	wc()->customer = null;
	wc_load_cart();

	var_dump( wc()->customer->get_shipping_address_2() );
	exit();
} );
```

<!-- End testing instructions -->

### Testing that has already taken place:

-   Added unit tests to `WC_Customer_Data_Store_Session_Test` covering: empty session values overriding persisted billing and shipping fields, keys absent from the session data keeping the persisted values, stale session data (mismatched `date_modified`) being ignored entirely, and the defaults (default location country, account email) still being applied after an empty overlay. The new regression tests were verified to fail against the unfixed code.
-   All Customer-related (444 tests) and Session-related (155 tests) PHP test classes were run locally via `wp-env` with no regressions.
-   `phpcs-changed` and PHPStan run clean on the modified files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

The changelog entry was created manually: `plugins/woocommerce/changelog/65225-fix-customer-session-empty-values`.

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

Tests-only PR, no changelog required.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
