### PR TITLE
Improve legacy WooCommerce dashboard widgets

### DIFF
--- a/plugins/woocommerce/changelog/tweak-dashboard-setup-post-launch-widgets
+++ b/plugins/woocommerce/changelog/tweak-dashboard-setup-post-launch-widgets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Improve WooCommerce dashboard setup, status, and recent reviews widgets.
+Show WooCommerce Status and Recent Reviews dashboard widgets during store setup.

--- a/plugins/woocommerce/changelog/tweak-dashboard-setup-post-launch-widgets
+++ b/plugins/woocommerce/changelog/tweak-dashboard-setup-post-launch-widgets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improve WooCommerce dashboard setup, status, and recent reviews widgets.

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -28,6 +28,7 @@ $subtext:           #767676 !default;                                  // small,
 $gray-900:            #1e1e1e !default;                                // Primary admin text
 $gray-700:            #757575 !default;                                // Placeholder / secondary admin text
 $wp-admin-hover-gray: #f0f0f0 !default;                                // WordPress dashboard hover background.
+$wp-admin-text-gray:  #50575e !default;                                // WordPress dashboard text color.
 $wp-admin-icon-gray:  #646970 !default;                                // WordPress dashboard icon color.
 
 // Mirrors @wordpress/base-styles/colors.scss alert colors.

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -25,8 +25,8 @@ $contentbg:         #fff !default;                                     // Conten
 $subtext:           #767676 !default;                                  // small, breadcrumbs etc
 
 // Mirrors @wordpress/base-styles/colors.scss (WP 7.0 admin gray scale).
-$gray-900:          #1e1e1e !default;                                  // Primary admin text
-$gray-700:          #757575 !default;                                  // Placeholder / secondary admin text
+$gray-900:            #1e1e1e !default;                                // Primary admin text
+$gray-700:            #757575 !default;                                // Placeholder / secondary admin text
 $wp-admin-icon-gray:  #646970 !default;                                // WordPress dashboard icon color.
 
 // Mirrors @wordpress/base-styles/colors.scss alert colors.

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -27,6 +27,7 @@ $subtext:           #767676 !default;                                  // small,
 // Mirrors @wordpress/base-styles/colors.scss (WP 7.0 admin gray scale).
 $gray-900:            #1e1e1e !default;                                // Primary admin text
 $gray-700:            #757575 !default;                                // Placeholder / secondary admin text
+$wp-admin-hover-gray: #f0f0f0 !default;                                // WordPress dashboard hover background.
 $wp-admin-icon-gray:  #646970 !default;                                // WordPress dashboard icon color.
 
 // Mirrors @wordpress/base-styles/colors.scss alert colors.

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -27,6 +27,10 @@ $subtext:           #767676 !default;                                  // small,
 // Mirrors @wordpress/base-styles/colors.scss (WP 7.0 admin gray scale).
 $gray-900:          #1e1e1e !default;                                  // Primary admin text
 $gray-700:          #757575 !default;                                  // Placeholder / secondary admin text
+$wp-admin-icon-gray: #646970 !default;                                 // WordPress dashboard icon color.
+
+// Mirrors @wordpress/base-styles/colors.scss alert colors.
+$wp-alert-red:      #cc1818 !default;
 
 // Border radius tokens — mirrors WP Design System naming.
 $radius-s:          2px !default;                                      // Small radius: inputs, buttons, selects.
@@ -59,7 +63,7 @@ $grid-unit-60:      48px !default;                                     // Matche
 	--wc-form-border-radius: 4px;
 	--wc-form-border-width: 1px;
 	// Matches WP 7.0 $alert-red token for destructive actions.
-	--wc-destructive: #cc1818;
+	--wc-destructive: #{$wp-alert-red};
 	// Matches WP 7.0 $radius-l token (used on dashboard widgets).
 	--wc-card-border-radius: 8px;
 }

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -27,7 +27,7 @@ $subtext:           #767676 !default;                                  // small,
 // Mirrors @wordpress/base-styles/colors.scss (WP 7.0 admin gray scale).
 $gray-900:          #1e1e1e !default;                                  // Primary admin text
 $gray-700:          #757575 !default;                                  // Placeholder / secondary admin text
-$wp-admin-icon-gray: #646970 !default;                                 // WordPress dashboard icon color.
+$wp-admin-icon-gray:  #646970 !default;                                // WordPress dashboard icon color.
 
 // Mirrors @wordpress/base-styles/colors.scss alert colors.
 $wp-alert-red:      #cc1818 !default;

--- a/plugins/woocommerce/client/legacy/css/dashboard-setup.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard-setup.scss
@@ -29,7 +29,7 @@
 		display: flex;
 		align-items: center;
 		gap: 24px;
-		margin-top: var(--grid-unit-20, 16px);
+		margin-top: 11px;
 	}
 
 	&__content {

--- a/plugins/woocommerce/client/legacy/css/dashboard-setup.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard-setup.scss
@@ -25,15 +25,62 @@
 		color: #757575;
 	}
 
-	.description div {
-		margin-top: 11px;
-		float: left;
-		width: 70%;
+	.description {
+		display: flex;
+		align-items: center;
+		gap: 24px;
+		margin-top: var(--grid-unit-20, 16px);
 	}
 
-	.description img {
-		float: right;
-		width: 30%;
+	&__content {
+		flex: 1;
+		min-width: 0;
+
+		h3 {
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			gap: var(--grid-unit-10, 8px);
+			margin: var(--grid-unit-20, 16px) 0 var(--grid-unit-10, 8px);
+			font-size: 18px;
+			line-height: 1.3;
+		}
+
+		p {
+			margin: 0 0 16px;
+			color: #50575e;
+		}
+	}
+
+	#dashboard-widgets & &__content h3 {
+		margin: var(--grid-unit-20, 16px) 0 var(--grid-unit-10, 8px);
+	}
+
+	&__meta {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: var(--grid-unit-10, 8px);
+	}
+
+	&__in-progress {
+		background-color: var(--Alias-bg-bg-surface-warning, #fff2d7);
+		border-radius: 4px;
+		color: var(--Alias-text-text-warning, #4d3716);
+		display: inline-block;
+		font-size: 12px;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 16px;
+		padding: var(--grid-unit-05, 4px) var(--grid-unit-10, 8px);
+	}
+
+	&__image {
+		flex: 0 0 90px;
+		width: 90px;
+		max-width: 90px;
+		height: auto;
+		margin-right: 24px;
 	}
 
 	.circle-progress {
@@ -42,11 +89,11 @@
 
 		circle {
 			stroke: #f0f0f0;
-			stroke-width: 1px;
+			stroke-width: 2px;
 		}
 
 		.bar {
-			stroke: #949494;
+			stroke: #3858e9;
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -108,7 +108,7 @@ ul.woocommerce_stats {
 
 				&:hover,
 				&:focus {
-					background-color: $gray-100;
+					background-color: $wp-admin-hover-gray;
 				}
 
 				.wc_sparkline {

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -88,6 +88,7 @@ ul.woocommerce_stats {
 	.wc_status_list {
 		overflow: hidden;
 		margin: 0;
+		border-radius: 0 0 var(--wc-card-border-radius, 8px) var(--wc-card-border-radius, 8px);
 
 		li {
 			width: 50%;

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -101,7 +101,7 @@ ul.woocommerce_stats {
 
 			a {
 				display: block;
-				padding: 9px 12px;
+				padding: 9px 12px 9px 44px;
 				position: relative;
 				font-size: 13px;
 				line-height: 1.5;
@@ -136,13 +136,16 @@ ul.woocommerce_stats {
 
 					@include icon_dashicons( "\f14c" );
 					font-size: 20px;
-					position: relative;
+					position: absolute;
+					top: 50%;
+					left: 12px;
+					transform: translateY(-50%);
 					width: 20px;
-					line-height: 1;
+					height: 20px;
+					line-height: 20px;
 					color: $wp-admin-icon-gray;
-					float: left;
-					margin-right: 12px;
-					margin-bottom: 12px;
+					float: none;
+					margin: 0;
 				}
 			}
 		}
@@ -176,7 +179,7 @@ ul.woocommerce_stats {
 			border-right: 1px solid #ececec;
 
 			a::before {
-				content: "\f121";
+				content: "\f469";
 			}
 		}
 
@@ -191,14 +194,14 @@ ul.woocommerce_stats {
 			border-right: 1px solid #ececec;
 
 			a::before {
-				content: "\f534";
+				content: "\f14c";
 			}
 		}
 
 		li.out-of-stock {
 
 			a::before {
-				content: "\f153";
+				content: "\f158";
 			}
 		}
 	}
@@ -293,7 +296,7 @@ ul.woocommerce_stats {
 			left: 0;
 			letter-spacing: 0.1em;
 			letter-spacing: 0\9; // IE8 & below hack ;-(
-			color: $wp-admin-icon-gray;
+			color: $wp-admin-text-gray;
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -13,6 +13,28 @@
 /**
  * Styling begins
  */
+.wc-dashboard-widget-loading {
+	padding: 16px 10px;
+	text-align: center;
+
+	p {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin: 0;
+	}
+
+	.spinner {
+		float: none;
+		margin: 0;
+	}
+
+	&__text {
+		color: $gray-700;
+	}
+}
+
 ul.woocommerce_stats {
 	overflow: hidden;
 	zoom: 1;
@@ -48,10 +70,6 @@ ul.woocommerce_stats {
 
 #woocommerce_dashboard_status {
 
-	.wc-status-widget-loading {
-		padding: 0 10px;
-	}
-
 	.inside {
 		padding: 0;
 		margin: 0;
@@ -85,6 +103,7 @@ ul.woocommerce_stats {
 				padding: 9px 12px;
 				position: relative;
 				font-size: 12px;
+				color: $gray-700;
 
 				.wc_sparkline {
 					width: 4em;
@@ -103,16 +122,17 @@ ul.woocommerce_stats {
 					line-height: 1.2em;
 					font-weight: normal;
 					display: block;
+					color: var(--wp-admin-theme-color, #3858e9);
 				}
 
 				&::before {
 
-					@include icon();
-					font-size: 2em;
+					@include icon_dashicons( "\f14c" );
+					font-size: 20px;
 					position: relative;
-					width: auto;
-					line-height: 1.2em;
-					color: #464646;
+					width: 20px;
+					line-height: 1;
+					color: $wp-admin-icon-gray;
 					float: left;
 					margin-right: 12px;
 					margin-bottom: 12px;
@@ -124,11 +144,15 @@ ul.woocommerce_stats {
 			border-top: 0;
 		}
 
+		li:not(.sales-this-month):not(.best-seller-this-month):not(.processing-orders):not(.on-hold-orders):not(.low-in-stock):not(.out-of-stock) {
+			clear: both;
+			width: 100%;
+		}
+
 		li.sales-this-month {
 			width: 100%;
 
 			a::before {
-				font-family: "Dashicons";
 				content: "\f185";
 			}
 		}
@@ -137,7 +161,7 @@ ul.woocommerce_stats {
 			width: 100%;
 
 			a::before {
-				content: "\e006";
+				content: "\f174";
 			}
 		}
 
@@ -145,16 +169,14 @@ ul.woocommerce_stats {
 			border-right: 1px solid #ececec;
 
 			a::before {
-				content: "\e011";
-				color: $green;
+				content: "\f121";
 			}
 		}
 
 		li.on-hold-orders {
 
 			a::before {
-				content: "\e033";
-				color: #999;
+				content: "\f523";
 			}
 		}
 
@@ -162,16 +184,14 @@ ul.woocommerce_stats {
 			border-right: 1px solid #ececec;
 
 			a::before {
-				content: "\e016";
-				color: $orange;
+				content: "\f534";
 			}
 		}
 
 		li.out-of-stock {
 
 			a::before {
-				content: "\e013";
-				color: $red;
+				content: "\f153";
 			}
 		}
 	}
@@ -179,30 +199,54 @@ ul.woocommerce_stats {
 
 #woocommerce_dashboard_recent_reviews {
 
+	ul {
+		margin: 0;
+	}
+
 	li {
-		line-height: 1.5em;
+		display: grid;
+		grid-template-columns: 32px minmax(0, 1fr) max-content;
+		column-gap: 10px;
+		align-items: start;
+		font-size: 13px;
+		line-height: 1.4;
 		margin-bottom: 12px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	h4.meta {
-		line-height: 1.4;
-		margin: -0.2em 0 0 0;
+		grid-column: 2;
+		grid-row: 1;
+		font-size: 13px;
+		line-height: 1.5;
+		margin: 0;
 		font-weight: normal;
-		color: #999;
+		color: $wp-admin-icon-gray;
 	}
 
 	blockquote {
+		grid-column: 2 / -1;
+		grid-row: 2;
+		line-height: 1.4;
 		padding: 0;
 		margin: 0;
 	}
 
 	.avatar {
-		float: left;
-		margin: 0 10px 5px 0;
+		float: none;
+		grid-column: 1;
+		grid-row: 1 / span 2;
+		margin: 0;
 	}
 
 	.star-rating {
-		float: right;
+		float: none;
+		grid-column: 3;
+		grid-row: 1;
+		justify-self: end;
 		overflow: hidden;
 		position: relative;
 		height: 1.5em;
@@ -213,7 +257,7 @@ ul.woocommerce_stats {
 
 		&::before {
 			content: "\e021\e021\e021\e021\e021";
-			color: darken(#ccc, 10%);
+			color: $wp-admin-icon-gray;
 			float: left;
 			top: 0;
 			left: 0;
@@ -238,7 +282,7 @@ ul.woocommerce_stats {
 			left: 0;
 			letter-spacing: 0.1em;
 			letter-spacing: 0\9; // IE8 & below hack ;-(
-			color: var(--wc-primary);
+			color: $wp-admin-icon-gray;
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -104,7 +104,7 @@ ul.woocommerce_stats {
 				position: relative;
 				font-size: 13px;
 				line-height: 1.5;
-				color: $gray-700;
+				color: $wp-admin-icon-gray;
 
 				.wc_sparkline {
 					width: 4em;

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -106,6 +106,11 @@ ul.woocommerce_stats {
 				line-height: 1.5;
 				color: $wp-admin-icon-gray;
 
+				&:hover,
+				&:focus {
+					background-color: $gray-100;
+				}
+
 				.wc_sparkline {
 					width: 4em;
 					height: 2em;
@@ -123,7 +128,7 @@ ul.woocommerce_stats {
 					line-height: 1.2em;
 					font-weight: normal;
 					display: block;
-					color: var(--wp-admin-theme-color, #3858e9);
+					color: $gray-900;
 				}
 
 				&::before {

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -205,6 +205,10 @@ ul.woocommerce_stats {
 
 #woocommerce_dashboard_recent_reviews {
 
+	#wc-recent-reviews-widget-content > p {
+		margin-bottom: 0;
+	}
+
 	ul {
 		margin: 0;
 	}

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -119,7 +119,7 @@ ul.woocommerce_stats {
 				}
 
 				strong {
-					font-size: 18px;
+					font-size: 16px;
 					line-height: 1.2em;
 					font-weight: normal;
 					display: block;

--- a/plugins/woocommerce/client/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/client/legacy/css/dashboard.scss
@@ -102,7 +102,8 @@ ul.woocommerce_stats {
 				display: block;
 				padding: 9px 12px;
 				position: relative;
-				font-size: 12px;
+				font-size: 13px;
+				line-height: 1.5;
 				color: $gray-700;
 
 				.wc_sparkline {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -107,44 +107,44 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 			);
 			$task_images         = array(
 				'store_details'        => array(
-					'image_url'    => $asset_url . 'images/task_list/store-details-illustration.png',
-					'image_alt'    => __( 'Store location illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/store-details-illustration.png',
+					'image_alt' => __( 'Store location illustration', 'woocommerce' ),
 				),
 				'customize-store'      => array(
-					'image_url'    => $asset_url . 'images/task_list/customize-store-illustration.svg',
-					'image_alt'    => __( 'Customize your store illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/customize-store-illustration.svg',
+					'image_alt' => __( 'Customize your store illustration', 'woocommerce' ),
 				),
 				'tax'                  => array(
-					'image_url'    => $asset_url . 'images/task_list/tax-illustration.svg',
-					'image_alt'    => __( 'Tax illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/tax-illustration.svg',
+					'image_alt' => __( 'Tax illustration', 'woocommerce' ),
 				),
 				'shipping'             => array(
-					'image_url'    => $asset_url . 'images/task_list/shipping-illustration.svg',
-					'image_alt'    => __( 'Shipping illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/shipping-illustration.svg',
+					'image_alt' => __( 'Shipping illustration', 'woocommerce' ),
 				),
 				'marketing'            => array(
-					'image_url'    => $asset_url . 'images/task_list/sales-illustration.svg',
-					'image_alt'    => __( 'Marketing illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/sales-illustration.svg',
+					'image_alt' => __( 'Marketing illustration', 'woocommerce' ),
 				),
 				'payments'             => array(
-					'image_url'    => $asset_url . 'images/task_list/payment-illustration.svg',
-					'image_alt'    => __( 'Payment illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/payment-illustration.svg',
+					'image_alt' => __( 'Payment illustration', 'woocommerce' ),
 				),
 				'woocommerce-payments' => array(
-					'image_url'    => $asset_url . 'images/task_list/payment-illustration.svg',
-					'image_alt'    => __( 'Payment illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/payment-illustration.svg',
+					'image_alt' => __( 'Payment illustration', 'woocommerce' ),
 				),
 				'products'             => array(
-					'image_url'    => $asset_url . 'images/task_list/sales-section-illustration.svg',
-					'image_alt'    => __( 'Products illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/sales-section-illustration.svg',
+					'image_alt' => __( 'Products illustration', 'woocommerce' ),
 				),
 				'purchase'             => array(
-					'image_url'    => $asset_url . 'images/task_list/purchase-illustration.png',
-					'image_alt'    => __( 'Purchase illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/purchase-illustration.png',
+					'image_alt' => __( 'Purchase illustration', 'woocommerce' ),
 				),
 				'launch-your-store'    => array(
-					'image_url'    => $asset_url . 'images/task_list/launch-your-store-illustration.svg',
-					'image_alt'    => __( 'Launch your store illustration', 'woocommerce' ),
+					'image_url' => $asset_url . 'images/task_list/launch-your-store-illustration.svg',
+					'image_alt' => __( 'Launch your store illustration', 'woocommerce' ),
 				),
 			);
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -96,88 +96,59 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return array
 		 */
 		private function get_task_header( $task ) {
-			$asset_url    = WC()->plugin_url() . '/assets/';
-			$task_json    = $task->get_json();
-			$task_headers = array(
-				'store_details'        => array(
-					'title'        => __( 'First, tell us about your store', 'woocommerce' ),
-					'content'      => __( 'Get your store up and running in no time. Add your store’s address to set up shipping, tax and payments faster.', 'woocommerce' ),
-					'button_label' => __( 'Add details', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/store-details-illustration.png',
-					'image_alt'    => __( 'Store location illustration', 'woocommerce' ),
-				),
-				'customize-store'      => array(
-					'title'        => __( 'Start customizing your store', 'woocommerce' ),
-					'content'      => __( 'Quickly create a beautiful looking store using our built-in store designer, or select a pre-built theme and customize it to fit your brand.', 'woocommerce' ),
-					'button_label' => __( 'Start customizing', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/customize-store-illustration.svg',
-					'image_alt'    => __( 'Customize your store illustration', 'woocommerce' ),
-				),
-				'tax'                  => array(
-					'title'        => __( 'Configure your tax settings', 'woocommerce' ),
-					'content'      => __( 'Choose to set up your tax rates manually, or use one of our tax automation tools.', 'woocommerce' ),
-					'button_label' => __( 'Collect sales tax', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/tax-illustration.svg',
-					'image_alt'    => __( 'Tax illustration', 'woocommerce' ),
-				),
-				'shipping'             => array(
-					'title'        => __( 'Get your products shipped', 'woocommerce' ),
-					'content'      => __( 'Choose where and how you’d like to ship your products, along with any fixed or calculated rates.', 'woocommerce' ),
-					'button_label' => __( 'Start shipping', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/shipping-illustration.svg',
-					'image_alt'    => __( 'Shipping illustration', 'woocommerce' ),
-				),
-				'marketing'            => array(
-					'title'        => __( 'Reach more customers', 'woocommerce' ),
-					'content'      => __( 'Start growing your business by showcasing your products on social media and Google, boost engagement with email marketing, and more!', 'woocommerce' ),
-					'button_label' => __( 'Grow your business', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/sales-illustration.svg',
-					'image_alt'    => __( 'Marketing illustration', 'woocommerce' ),
-				),
-				'payments'             => array(
-					'title'        => __( 'It’s time to get paid', 'woocommerce' ),
-					'content'      => __( 'Give your customers an easy and convenient way to pay! Set up one (or more!) of our fast and secure online or in person payment methods.', 'woocommerce' ),
-					'button_label' => __( 'Get paid', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/payment-illustration.svg',
-					'image_alt'    => __( 'Payment illustration', 'woocommerce' ),
-				),
-				'woocommerce-payments' => array(
-					'title'        => __( 'It’s time to get paid', 'woocommerce' ),
-					'content'      => __( 'Power your payments with a simple, all-in-one option. Verify your business details to start managing transactions with WooCommerce Payments.', 'woocommerce' ),
-					'button_label' => __( 'Get paid', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/payment-illustration.svg',
-					'image_alt'    => __( 'Payment illustration', 'woocommerce' ),
-				),
-				'products'             => array(
-					'title'        => __( 'List your products', 'woocommerce' ),
-					'content'      => __( 'Start selling by adding products or services to your store. Choose to list products manually, or import them from a different store.', 'woocommerce' ),
-					'button_label' => __( 'Add products', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/sales-section-illustration.svg',
-					'image_alt'    => __( 'Products illustration', 'woocommerce' ),
-				),
-				'purchase'             => array(
-					'title'        => $task->get_title(),
-					'content'      => __( 'Good choice! You chose to add amazing new features to your store. Continue to checkout to complete your purchase.', 'woocommerce' ),
-					'button_label' => __( 'Continue', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/purchase-illustration.png',
-					'image_alt'    => __( 'Purchase illustration', 'woocommerce' ),
-				),
-				'launch-your-store'    => array(
-					'title'        => __( 'Your store is ready for launch!', 'woocommerce' ),
-					'content'      => __( 'It’s time to celebrate – you’re ready to launch your store! Woo! Hit the button to preview your store and make it public.', 'woocommerce' ),
-					'button_label' => __( 'Launch store', 'woocommerce' ),
-					'image_url'    => $asset_url . 'images/task_list/launch-your-store-illustration.svg',
-					'image_alt'    => __( 'Launch your store illustration', 'woocommerce' ),
-				),
-			);
-
-			return $task_headers[ $task->get_id() ] ?? array(
+			$asset_url           = WC()->plugin_url() . '/assets/';
+			$task_json           = $task->get_json();
+			$default_task_header = array(
 				'title'        => $task->get_title(),
 				'content'      => $task_json['content'] ?? '',
 				'button_label' => $task_json['actionLabel'] ?? $task->get_title(),
 				'image_url'    => $asset_url . 'images/dashboard-widget-setup.png',
 				'image_alt'    => __( 'WooCommerce setup illustration', 'woocommerce' ),
 			);
+			$task_images         = array(
+				'store_details'        => array(
+					'image_url'    => $asset_url . 'images/task_list/store-details-illustration.png',
+					'image_alt'    => __( 'Store location illustration', 'woocommerce' ),
+				),
+				'customize-store'      => array(
+					'image_url'    => $asset_url . 'images/task_list/customize-store-illustration.svg',
+					'image_alt'    => __( 'Customize your store illustration', 'woocommerce' ),
+				),
+				'tax'                  => array(
+					'image_url'    => $asset_url . 'images/task_list/tax-illustration.svg',
+					'image_alt'    => __( 'Tax illustration', 'woocommerce' ),
+				),
+				'shipping'             => array(
+					'image_url'    => $asset_url . 'images/task_list/shipping-illustration.svg',
+					'image_alt'    => __( 'Shipping illustration', 'woocommerce' ),
+				),
+				'marketing'            => array(
+					'image_url'    => $asset_url . 'images/task_list/sales-illustration.svg',
+					'image_alt'    => __( 'Marketing illustration', 'woocommerce' ),
+				),
+				'payments'             => array(
+					'image_url'    => $asset_url . 'images/task_list/payment-illustration.svg',
+					'image_alt'    => __( 'Payment illustration', 'woocommerce' ),
+				),
+				'woocommerce-payments' => array(
+					'image_url'    => $asset_url . 'images/task_list/payment-illustration.svg',
+					'image_alt'    => __( 'Payment illustration', 'woocommerce' ),
+				),
+				'products'             => array(
+					'image_url'    => $asset_url . 'images/task_list/sales-section-illustration.svg',
+					'image_alt'    => __( 'Products illustration', 'woocommerce' ),
+				),
+				'purchase'             => array(
+					'image_url'    => $asset_url . 'images/task_list/purchase-illustration.png',
+					'image_alt'    => __( 'Purchase illustration', 'woocommerce' ),
+				),
+				'launch-your-store'    => array(
+					'image_url'    => $asset_url . 'images/task_list/launch-your-store-illustration.svg',
+					'image_alt'    => __( 'Launch your store illustration', 'woocommerce' ),
+				),
+			);
+
+			return array_merge( $default_task_header, $task_images[ $task->get_id() ] ?? array() );
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -8,6 +8,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 
@@ -72,10 +73,13 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 				return;
 			}
 
-			$button_link           = $this->get_button_link( $task );
-			$completed_tasks_count = $this->get_completed_tasks_count();
-			$step_number           = $this->get_completed_tasks_count() + 1;
-			$tasks_count           = count( $this->get_tasks() );
+			$button_link            = $this->get_button_link( $task );
+			$task_header            = $this->get_task_header( $task );
+			$task_is_in_progress    = $task->is_in_progress();
+			$task_in_progress_label = $task_is_in_progress ? $task->in_progress_label() : '';
+			$completed_tasks_count  = $this->get_completed_tasks_count();
+			$step_number            = $completed_tasks_count + 1;
+			$tasks_count            = count( $this->get_tasks() );
 
 			// Given 'r' (circle element's r attr), dashoffset = ((100-$desired_percentage)/100) * PI * (r*2).
 			$progress_percentage = ( $completed_tasks_count / $tasks_count ) * 100;
@@ -83,6 +87,97 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 			$circle_dashoffset   = ( ( 100 - $progress_percentage ) / 100 ) * ( pi() * ( $circle_r * 2 ) );
 
 			include __DIR__ . '/views/html-admin-dashboard-setup.php';
+		}
+
+		/**
+		 * Get dashboard widget header data for a task.
+		 *
+		 * @param Task $task Task.
+		 * @return array
+		 */
+		private function get_task_header( $task ) {
+			$asset_url    = WC()->plugin_url() . '/assets/';
+			$task_json    = $task->get_json();
+			$task_headers = array(
+				'store_details'        => array(
+					'title'        => __( 'First, tell us about your store', 'woocommerce' ),
+					'content'      => __( 'Get your store up and running in no time. Add your store’s address to set up shipping, tax and payments faster.', 'woocommerce' ),
+					'button_label' => __( 'Add details', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/store-details-illustration.png',
+					'image_alt'    => __( 'Store location illustration', 'woocommerce' ),
+				),
+				'customize-store'      => array(
+					'title'        => __( 'Start customizing your store', 'woocommerce' ),
+					'content'      => __( 'Quickly create a beautiful looking store using our built-in store designer, or select a pre-built theme and customize it to fit your brand.', 'woocommerce' ),
+					'button_label' => __( 'Start customizing', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/customize-store-illustration.svg',
+					'image_alt'    => __( 'Customize your store illustration', 'woocommerce' ),
+				),
+				'tax'                  => array(
+					'title'        => __( 'Configure your tax settings', 'woocommerce' ),
+					'content'      => __( 'Choose to set up your tax rates manually, or use one of our tax automation tools.', 'woocommerce' ),
+					'button_label' => __( 'Collect sales tax', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/tax-illustration.svg',
+					'image_alt'    => __( 'Tax illustration', 'woocommerce' ),
+				),
+				'shipping'             => array(
+					'title'        => __( 'Get your products shipped', 'woocommerce' ),
+					'content'      => __( 'Choose where and how you’d like to ship your products, along with any fixed or calculated rates.', 'woocommerce' ),
+					'button_label' => __( 'Start shipping', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/shipping-illustration.svg',
+					'image_alt'    => __( 'Shipping illustration', 'woocommerce' ),
+				),
+				'marketing'            => array(
+					'title'        => __( 'Reach more customers', 'woocommerce' ),
+					'content'      => __( 'Start growing your business by showcasing your products on social media and Google, boost engagement with email marketing, and more!', 'woocommerce' ),
+					'button_label' => __( 'Grow your business', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/sales-illustration.svg',
+					'image_alt'    => __( 'Marketing illustration', 'woocommerce' ),
+				),
+				'payments'             => array(
+					'title'        => __( 'It’s time to get paid', 'woocommerce' ),
+					'content'      => __( 'Give your customers an easy and convenient way to pay! Set up one (or more!) of our fast and secure online or in person payment methods.', 'woocommerce' ),
+					'button_label' => __( 'Get paid', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/payment-illustration.svg',
+					'image_alt'    => __( 'Payment illustration', 'woocommerce' ),
+				),
+				'woocommerce-payments' => array(
+					'title'        => __( 'It’s time to get paid', 'woocommerce' ),
+					'content'      => __( 'Power your payments with a simple, all-in-one option. Verify your business details to start managing transactions with WooCommerce Payments.', 'woocommerce' ),
+					'button_label' => __( 'Get paid', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/payment-illustration.svg',
+					'image_alt'    => __( 'Payment illustration', 'woocommerce' ),
+				),
+				'products'             => array(
+					'title'        => __( 'List your products', 'woocommerce' ),
+					'content'      => __( 'Start selling by adding products or services to your store. Choose to list products manually, or import them from a different store.', 'woocommerce' ),
+					'button_label' => __( 'Add products', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/sales-section-illustration.svg',
+					'image_alt'    => __( 'Products illustration', 'woocommerce' ),
+				),
+				'purchase'             => array(
+					'title'        => $task->get_title(),
+					'content'      => __( 'Good choice! You chose to add amazing new features to your store. Continue to checkout to complete your purchase.', 'woocommerce' ),
+					'button_label' => __( 'Continue', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/purchase-illustration.png',
+					'image_alt'    => __( 'Purchase illustration', 'woocommerce' ),
+				),
+				'launch-your-store'    => array(
+					'title'        => __( 'Your store is ready for launch!', 'woocommerce' ),
+					'content'      => __( 'It’s time to celebrate – you’re ready to launch your store! Woo! Hit the button to preview your store and make it public.', 'woocommerce' ),
+					'button_label' => __( 'Launch store', 'woocommerce' ),
+					'image_url'    => $asset_url . 'images/task_list/launch-your-store-illustration.svg',
+					'image_alt'    => __( 'Launch your store illustration', 'woocommerce' ),
+				),
+			);
+
+			return $task_headers[ $task->get_id() ] ?? array(
+				'title'        => $task->get_title(),
+				'content'      => $task_json['content'] ?? '',
+				'button_label' => $task_json['actionLabel'] ?? $task->get_title(),
+				'image_url'    => $asset_url . 'images/dashboard-widget-setup.png',
+				'image_alt'    => __( 'WooCommerce setup illustration', 'woocommerce' ),
+			);
 		}
 
 		/**
@@ -165,7 +260,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		/**
 		 * Get the next task.
 		 *
-		 * @return array|null
+		 * @return Task|null
 		 */
 		private function get_next_task() {
 			foreach ( $this->get_tasks() as $task ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -239,8 +239,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 					<?php echo wp_kses( $sparkline, $sparkline_allowed_html ); ?>
 					<?php
 						printf(
-							/* translators: 1: top seller product title 2: top seller quantity */
-							esc_html__( 'Top seller this month %1$s (sold %2$d)', 'woocommerce' ),
+							/* translators: 1: top seller product title 2: top seller quantity sold */
+							esc_html( _n( 'Top seller this month %1$s (%2$d sale)', 'Top seller this month %1$s (%2$d sales)', $top_seller->qty, 'woocommerce' ) ),
 							'<strong>' . get_the_title( $top_seller->product_id ) . '</strong>',
 							$top_seller->qty
 						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -72,10 +72,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				return false;
 			}
 
-			$has_permission           = current_user_can( 'view_woocommerce_reports' ) || current_user_can( 'manage_woocommerce' ) || current_user_can( 'publish_shop_orders' );
-			$task_completed_or_hidden = 'yes' === get_option( 'woocommerce_task_list_complete' ) || 'yes' === get_option( 'woocommerce_task_list_hidden' );
-			$store_launched           = 'yes' !== get_option( 'woocommerce_coming_soon' );
-			return ( $task_completed_or_hidden || $store_launched ) && $has_permission;
+			return current_user_can( 'view_woocommerce_reports' ) || current_user_can( 'manage_woocommerce' ) || current_user_can( 'publish_shop_orders' );
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -42,11 +42,12 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		 * Init dashboard widgets.
 		 */
 		public function init() {
+			wp_add_dashboard_widget( 'woocommerce_dashboard_status', __( 'WooCommerce Status', 'woocommerce' ), array( $this, 'status_widget' ), null, null, 'normal', 'high' );
+
 			// Reviews Widget.
 			if ( current_user_can( 'publish_shop_orders' ) && post_type_supports( 'product', 'comments' ) ) {
-				wp_add_dashboard_widget( 'woocommerce_dashboard_recent_reviews', __( 'WooCommerce Recent Reviews', 'woocommerce' ), array( $this, 'recent_reviews' ) );
+				wp_add_dashboard_widget( 'woocommerce_dashboard_recent_reviews', __( 'WooCommerce Recent Reviews', 'woocommerce' ), array( $this, 'recent_reviews' ), null, null, 'normal', 'high' );
 			}
-			wp_add_dashboard_widget( 'woocommerce_dashboard_status', __( 'WooCommerce Status', 'woocommerce' ), array( $this, 'status_widget' ) );
 
 			// Network Order Widget.
 			if ( is_multisite() && is_main_site() ) {
@@ -73,7 +74,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 
 			$has_permission           = current_user_can( 'view_woocommerce_reports' ) || current_user_can( 'manage_woocommerce' ) || current_user_can( 'publish_shop_orders' );
 			$task_completed_or_hidden = 'yes' === get_option( 'woocommerce_task_list_complete' ) || 'yes' === get_option( 'woocommerce_task_list_hidden' );
-			return $task_completed_or_hidden && $has_permission;
+			$store_launched           = 'yes' !== get_option( 'woocommerce_coming_soon' );
+			return ( $task_completed_or_hidden || $store_launched ) && $has_permission;
 		}
 
 		/**
@@ -150,8 +152,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			);
 
 			// Display loading placeholder.
-			echo '<div id="wc-status-widget-loading" class="wc-status-widget-loading">';
-			echo '<p>' . esc_html__( 'Loading status data...', 'woocommerce' ) . ' <span class="spinner is-active"></span></p>';
+			echo '<div id="wc-status-widget-loading" class="wc-dashboard-widget-loading wc-status-widget-loading" aria-busy="true">';
+			echo '<p><span class="spinner is-active"></span><span class="wc-dashboard-widget-loading__text">' . esc_html__( 'Loading status data...', 'woocommerce' ) . '</span></p>';
 			echo '</div>';
 			echo '<div id="wc-status-widget-content" style="display:none;"></div>';
 		}
@@ -493,8 +495,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			);
 
 			// Display loading placeholder.
-			echo '<div id="wc-recent-reviews-widget-loading" class="wc-recent-reviews-widget-loading">';
-			echo '<p>' . esc_html__( 'Loading reviews data...', 'woocommerce' ) . ' <span class="spinner is-active"></span></p>';
+			echo '<div id="wc-recent-reviews-widget-loading" class="wc-dashboard-widget-loading wc-recent-reviews-widget-loading" aria-busy="true">';
+			echo '<p><span class="spinner is-active"></span><span class="wc-dashboard-widget-loading__text">' . esc_html__( 'Loading reviews data...', 'woocommerce' ) . '</span></p>';
 			echo '</div>';
 			echo '<div id="wc-recent-reviews-widget-content" style="display:none;"></div>';
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			wp_add_dashboard_widget( 'woocommerce_dashboard_status', __( 'WooCommerce Status', 'woocommerce' ), array( $this, 'status_widget' ), null, null, 'normal', 'high' );
 
 			// Reviews Widget.
-			if ( current_user_can( 'publish_shop_orders' ) && post_type_supports( 'product', 'comments' ) ) {
+			if ( wc_reviews_enabled() && current_user_can( 'publish_shop_orders' ) && post_type_supports( 'product', 'comments' ) ) {
 				wp_add_dashboard_widget( 'woocommerce_dashboard_recent_reviews', __( 'WooCommerce Recent Reviews', 'woocommerce' ), array( $this, 'recent_reviews' ), null, null, 'normal', 'high' );
 			}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -216,7 +216,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 					<?php
 						printf(
 							/* translators: %s: net sales */
-							esc_html__( '%s net sales this month', 'woocommerce' ),
+							esc_html__( 'Net sales this month %s', 'woocommerce' ),
 							'<strong>' . wc_price( $report_data->net_sales ) . '</strong>'
 						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 					?>
@@ -236,7 +236,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 					<?php
 						printf(
 							/* translators: 1: top seller product title 2: top seller quantity */
-							esc_html__( '%1$s top seller this month (sold %2$d)', 'woocommerce' ),
+							esc_html__( 'Top seller this month %1$s (sold %2$d)', 'woocommerce' ),
 							'<strong>' . get_the_title( $top_seller->product_id ) . '</strong>',
 							$top_seller->qty
 						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
@@ -286,7 +286,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				<?php
 					printf(
 						/* translators: %s: order count */
-						_n( '<strong>%s order</strong> awaiting processing', '<strong>%s orders</strong> awaiting processing', $processing_count, 'woocommerce' ),
+						_n( 'Awaiting processing <strong>%s order</strong>', 'Awaiting processing <strong>%s orders</strong>', $processing_count, 'woocommerce' ),
 						$processing_count
 					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>
@@ -297,7 +297,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				<?php
 					printf(
 						/* translators: %s: order count */
-						_n( '<strong>%s order</strong> on-hold', '<strong>%s orders</strong> on-hold', $on_hold_count, 'woocommerce' ),
+						_n( 'On-hold <strong>%s order</strong>', 'On-hold <strong>%s orders</strong>', $on_hold_count, 'woocommerce' ),
 						$on_hold_count
 					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>
@@ -391,7 +391,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				<?php
 					printf(
 						/* translators: %s: order count */
-						_n( '<strong>%s product</strong> low in stock', '<strong>%s products</strong> low in stock', $lowinstock_count, 'woocommerce' ),
+						_n( 'Low in stock <strong>%s product</strong>', 'Low in stock <strong>%s products</strong>', $lowinstock_count, 'woocommerce' ),
 						$lowinstock_count
 					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>
@@ -402,7 +402,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				<?php
 					printf(
 						/* translators: %s: order count */
-						_n( '<strong>%s product</strong> out of stock', '<strong>%s products</strong> out of stock', $outofstock_count, 'woocommerce' ),
+						_n( 'Out of stock <strong>%s product</strong>', 'Out of stock <strong>%s products</strong>', $outofstock_count, 'woocommerce' ),
 						$outofstock_count
 					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -284,23 +284,27 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			<li class="processing-orders">
 			<a href="<?php echo esc_url( admin_url( 'edit.php?post_status=wc-processing&post_type=shop_order' ) ); ?>">
 				<?php
-					printf(
-						/* translators: %s: order count */
-						_n( 'Awaiting processing <strong>%s order</strong>', 'Awaiting processing <strong>%s orders</strong>', $processing_count, 'woocommerce' ),
-						$processing_count
-					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-				?>
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: order count */
+							_n( 'Awaiting processing <strong>%s order</strong>', 'Awaiting processing <strong>%s orders</strong>', $processing_count, 'woocommerce' ),
+							$processing_count
+						)
+					);
+					?>
 				</a>
 			</li>
 			<li class="on-hold-orders">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_status=wc-on-hold&post_type=shop_order' ) ); ?>">
 				<?php
-					printf(
-						/* translators: %s: order count */
-						_n( 'On-hold <strong>%s order</strong>', 'On-hold <strong>%s orders</strong>', $on_hold_count, 'woocommerce' ),
-						$on_hold_count
-					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-				?>
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: order count */
+							_n( 'On-hold <strong>%s order</strong>', 'On-hold <strong>%s orders</strong>', $on_hold_count, 'woocommerce' ),
+							$on_hold_count
+						)
+					);
+					?>
 				</a>
 			</li>
 			<?php
@@ -389,23 +393,27 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			<li class="low-in-stock">
 				<a href="<?php echo esc_url( $lowstock_url ); ?>">
 				<?php
-					printf(
-						/* translators: %s: order count */
-						_n( 'Low in stock <strong>%s product</strong>', 'Low in stock <strong>%s products</strong>', $lowinstock_count, 'woocommerce' ),
-						$lowinstock_count
-					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-				?>
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: order count */
+							_n( 'Low in stock <strong>%s product</strong>', 'Low in stock <strong>%s products</strong>', $lowinstock_count, 'woocommerce' ),
+							$lowinstock_count
+						)
+					);
+					?>
 				</a>
 			</li>
 			<li class="out-of-stock">
 				<a href="<?php echo esc_url( $outofstock_url ); ?>">
 				<?php
-					printf(
-						/* translators: %s: order count */
-						_n( 'Out of stock <strong>%s product</strong>', 'Out of stock <strong>%s products</strong>', $outofstock_count, 'woocommerce' ),
-						$outofstock_count
-					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-				?>
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: order count */
+							_n( 'Out of stock <strong>%s product</strong>', 'Out of stock <strong>%s products</strong>', $outofstock_count, 'woocommerce' ),
+							$outofstock_count
+						)
+					);
+					?>
 				</a>
 			</li>
 			<?php

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -291,7 +291,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 							$processing_count
 						)
 					);
-					?>
+				?>
 				</a>
 			</li>
 			<li class="on-hold-orders">
@@ -304,7 +304,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 							$on_hold_count
 						)
 					);
-					?>
+				?>
 				</a>
 			</li>
 			<?php
@@ -400,7 +400,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 							$lowinstock_count
 						)
 					);
-					?>
+				?>
 				</a>
 			</li>
 			<li class="out-of-stock">
@@ -413,7 +413,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 							$outofstock_count
 						)
 					);
-					?>
+				?>
 				</a>
 			</li>
 			<?php

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -135,6 +135,10 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			$suffix  = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
 			$version = Constants::get_constant( 'WC_VERSION' );
 
+			if ( ! wp_script_is( 'wc-flot', 'registered' ) ) {
+				wp_register_script( 'wc-flot', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot' . $suffix . '.js', array( 'jquery' ), $version, true );
+			}
+
 			wp_enqueue_script( 'wc-status-widget', WC()->plugin_url() . '/assets/js/admin/wc-status-widget' . $suffix . '.js', array( 'jquery', 'wc-flot' ), $version, true );
 			wp_enqueue_script( 'wc-status-widget-async', WC()->plugin_url() . '/assets/js/admin/wc-status-widget-async' . $suffix . '.js', array( 'jquery' ), $version, true );
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			wp_add_dashboard_widget( 'woocommerce_dashboard_status', __( 'WooCommerce Status', 'woocommerce' ), array( $this, 'status_widget' ), null, null, 'normal', 'high' );
 
 			// Reviews Widget.
-			if ( wc_reviews_enabled() && current_user_can( 'publish_shop_orders' ) && post_type_supports( 'product', 'comments' ) ) {
+			if ( 'yes' === get_option( 'woocommerce_enable_reviews', 'yes' ) && current_user_can( 'publish_shop_orders' ) && post_type_supports( 'product', 'comments' ) ) {
 				wp_add_dashboard_widget( 'woocommerce_dashboard_recent_reviews', __( 'WooCommerce Recent Reviews', 'woocommerce' ), array( $this, 'recent_reviews' ), null, null, 'normal', 'high' );
 			}
 

--- a/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
@@ -10,9 +10,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Dashboard setup widget view variables.
+ *
  * @var array{title:string, content:string, button_label:string, image_url:string, image_alt:string} $task_header Task header data.
- * @var bool                                                                                         $task_is_in_progress Whether the task is in progress.
- * @var string                                                                                       $task_in_progress_label Task in-progress label.
+ * @var bool $task_is_in_progress Whether the task is in progress.
+ * @var string $task_in_progress_label Task in-progress label.
  */
 ?>
 <div class="dashboard-widget-finish-setup" data-current-step="<?php echo esc_attr( (string) ( $step_number - 1 ) ); ?>" data-total-steps="<?php echo esc_attr( (string) $tasks_count ); ?>">
@@ -21,8 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<div class="dashboard-widget-finish-setup__meta">
 				<span class='progress-wrapper'>
 					<svg class="circle-progress" width="17" height="17" version="1.1" xmlns="http://www.w3.org/2000/svg">
-					  <circle r="6.5" cx="10" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="0"></circle>
-					  <circle class="bar" r="6.5" cx="190" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="<?php echo esc_attr( $circle_dashoffset ); ?>" transform='rotate(-90 100 100)'></circle>
+						<circle r="6.5" cx="10" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="0"></circle>
+						<circle class="bar" r="6.5" cx="190" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="<?php echo esc_attr( $circle_dashoffset ); ?>" transform='rotate(-90 100 100)'></circle>
 					</svg>
 					<span><?php esc_html_e( 'Step', 'woocommerce' ); ?> <?php echo esc_html( $step_number ); ?> <?php esc_html_e( 'of', 'woocommerce' ); ?> <?php echo esc_html( $tasks_count ); ?></span>
 				</span>

--- a/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
@@ -8,8 +8,14 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+/**
+ * @var array{title:string, content:string, button_label:string, image_url:string, image_alt:string} $task_header Task header data.
+ * @var bool                                                                                         $task_is_in_progress Whether the task is in progress.
+ * @var string                                                                                       $task_in_progress_label Task in-progress label.
+ */
 ?>
-<div class="dashboard-widget-finish-setup" data-current-step="<?php echo esc_attr( $step_number - 1 ); ?>" data-total-steps="<?php echo esc_attr( $tasks_count ); ?>">
+<div class="dashboard-widget-finish-setup" data-current-step="<?php echo esc_attr( (string) ( $step_number - 1 ) ); ?>" data-total-steps="<?php echo esc_attr( (string) $tasks_count ); ?>">
 	<div class="description">
 		<div class="dashboard-widget-finish-setup__content">
 			<div class="dashboard-widget-finish-setup__meta">

--- a/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
@@ -9,21 +9,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<div class="dashboard-widget-finish-setup" data-current-step="<?php echo esc_html( $step_number - 1 ); ?>" data-total-steps="<?php echo esc_html( $tasks_count ); ?>">
-	<span class='progress-wrapper'>
-		<svg class="circle-progress" width="17" height="17" version="1.1" xmlns="http://www.w3.org/2000/svg">
-		  <circle r="6.5" cx="10" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="0"></circle>
-		  <circle class="bar" r="6.5" cx="190" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="<?php echo esc_attr( $circle_dashoffset ); ?>" transform='rotate(-90 100 100)'></circle>
-		</svg>
-		<span><?php esc_html_e( 'Step', 'woocommerce' ); ?> <?php echo esc_html( $step_number ); ?> <?php esc_html_e( 'of', 'woocommerce' ); ?> <?php echo esc_html( $tasks_count ); ?></span>
-	</span>
-
+<div class="dashboard-widget-finish-setup" data-current-step="<?php echo esc_attr( $step_number - 1 ); ?>" data-total-steps="<?php echo esc_attr( $tasks_count ); ?>">
 	<div class="description">
-		<div>
-			<?php esc_html_e( 'You\'re almost there! Once you complete store setup you can start receiving orders.', 'woocommerce' ); ?>
-			<div><a href='<?php echo esc_attr( $button_link ); ?>' class='button button-primary'><?php esc_html_e( 'Start selling', 'woocommerce' ); ?></a></div>
+		<div class="dashboard-widget-finish-setup__content">
+			<div class="dashboard-widget-finish-setup__meta">
+				<span class='progress-wrapper'>
+					<svg class="circle-progress" width="17" height="17" version="1.1" xmlns="http://www.w3.org/2000/svg">
+					  <circle r="6.5" cx="10" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="0"></circle>
+					  <circle class="bar" r="6.5" cx="190" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="<?php echo esc_attr( $circle_dashoffset ); ?>" transform='rotate(-90 100 100)'></circle>
+					</svg>
+					<span><?php esc_html_e( 'Step', 'woocommerce' ); ?> <?php echo esc_html( $step_number ); ?> <?php esc_html_e( 'of', 'woocommerce' ); ?> <?php echo esc_html( $tasks_count ); ?></span>
+				</span>
+			</div>
+			<h3 class="dashboard-widget-finish-setup__title">
+				<?php echo esc_html( $task_header['title'] ); ?>
+				<?php if ( $task_is_in_progress && $task_in_progress_label ) : ?>
+					<span class="dashboard-widget-finish-setup__in-progress"><?php echo esc_html( $task_in_progress_label ); ?></span>
+				<?php endif; ?>
+			</h3>
+			<p><?php echo esc_html( $task_header['content'] ); ?></p>
+			<div><a href='<?php echo esc_url( $button_link ); ?>' class='button button-primary'><?php echo esc_html( $task_header['button_label'] ); ?></a></div>
 		</div>
-		<img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/dashboard-widget-setup.png" />
+		<img
+			class="dashboard-widget-finish-setup__image"
+			src="<?php echo esc_url( $task_header['image_url'] ); ?>"
+			alt="<?php echo esc_attr( $task_header['image_alt'] ); ?>"
+		/>
 	</div>
 	<div class="clear"></div>
 </div>

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -1723,18 +1723,6 @@ parameters:
 			path: includes/admin/class-wc-admin-brands.php
 
 		-
-			message: '#^Call to method get_id\(\) on an unknown class Task\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/admin/class-wc-admin-dashboard-setup.php
-
-		-
-			message: '#^Call to method get_json\(\) on an unknown class Task\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/admin/class-wc-admin-dashboard-setup.php
-
-		-
 			message: '#^Cannot call method get_viewable_tasks\(\) on array\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -1773,18 +1761,6 @@ parameters:
 		-
 			message: '#^Method WC_Admin_Dashboard_Setup\:\:set_task_list\(\) has parameter \$task_list with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/admin/class-wc-admin-dashboard-setup.php
-
-		-
-			message: '#^Parameter \#1 \$task of method WC_Admin_Dashboard_Setup\:\:get_button_link\(\) expects Task, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/admin/class-wc-admin-dashboard-setup.php
-
-		-
-			message: '#^Parameter \$task of method WC_Admin_Dashboard_Setup\:\:get_button_link\(\) has invalid type Task\.$#'
-			identifier: class.notFound
 			count: 1
 			path: includes/admin/class-wc-admin-dashboard-setup.php
 
@@ -7925,12 +7901,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: includes/admin/settings/views/html-webhooks-edit.php
-
-		-
-			message: '#^Parameter \#1 \$text of function esc_html expects string, \(float\|int\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/admin/views/html-admin-dashboard-setup.php
 
 		-
 			message: '#^Variable \$button_link might not be defined\.$#'

--- a/plugins/woocommerce/templates/dashboard-widget-reviews.php
+++ b/plugins/woocommerce/templates/dashboard-widget-reviews.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.5.0
+ * @version 11.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -23,6 +23,11 @@ defined( 'ABSPATH' ) || exit;
  * @var $product \WC_Product
  * @var $comment \WP_Comment
  */
+
+$product_name          = $product->get_name();
+$product_name_display  = wc_trim_string( $product_name, 40 );
+$review_author         = get_comment_author( $comment->comment_ID );
+$review_author_display = wc_trim_string( $review_author, 24 );
 
 ?>
 
@@ -36,10 +41,20 @@ defined( 'ABSPATH' ) || exit;
 	<?php echo wc_get_rating_html( (int) get_comment_meta( $comment->comment_ID, 'rating', true ) ); ?>
 
 	<h4 class="meta">
-		<a href="<?php echo esc_url( get_comment_link( $comment->comment_ID ) ); ?>"><?php echo wp_kses_post( $product->get_name() ); ?></a>
+		<a href="<?php echo esc_url( get_comment_link( $comment->comment_ID ) ); ?>" title="<?php echo esc_attr( $product_name ); ?>"><?php echo wp_kses_post( $product_name_display ); ?></a>
 		<?php
 		/* translators: %s: review author */
-		printf( esc_html__( 'reviewed by %s', 'woocommerce' ), esc_html( get_comment_author( $comment->comment_ID ) ) );
+		echo wp_kses(
+			sprintf(
+				__( 'reviewed by %s', 'woocommerce' ),
+				'<span title="' . esc_attr( $review_author ) . '">' . esc_html( $review_author_display ) . '</span>'
+			),
+			array(
+				'span' => array(
+					'title' => true,
+				),
+			)
+		);
 		?>
 	</h4>
 

--- a/plugins/woocommerce/templates/dashboard-widget-reviews.php
+++ b/plugins/woocommerce/templates/dashboard-widget-reviews.php
@@ -43,12 +43,14 @@ $review_author_display = wc_trim_string( $review_author, 24 );
 	<h4 class="meta">
 		<a href="<?php echo esc_url( get_comment_link( $comment->comment_ID ) ); ?>" title="<?php echo esc_attr( $product_name ); ?>"><?php echo wp_kses_post( $product_name_display ); ?></a>
 		<?php
-		/* translators: %s: review author */
+		$reviewed_by = sprintf(
+			// translators: %s: review author.
+			__( 'reviewed by %s', 'woocommerce' ),
+			'<span title="' . esc_attr( $review_author ) . '">' . esc_html( $review_author_display ) . '</span>'
+		);
+
 		echo wp_kses(
-			sprintf(
-				__( 'reviewed by %s', 'woocommerce' ),
-				'<span title="' . esc_attr( $review_author ) . '">' . esc_html( $review_author_display ) . '</span>'
-			),
+			$reviewed_by,
 			array(
 				'span' => array(
 					'title' => true,

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
@@ -71,6 +71,39 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test: recent reviews widget truncates long product and reviewer names.
+	 */
+	public function test_recent_reviews_widget_content_truncates_long_product_and_reviewer_names() {
+		$product_name = 'Extra long dashboard review stress test product name with multiple descriptive words';
+		$author_name  = 'Alexandria Montgomery-Silverstein With A Very Long Reviewer Name';
+		$product      = WC_Helper_Product::create_simple_product();
+		$product->set_name( $product_name );
+		$product->save();
+
+		$comment_id = WC_Helper_Product::create_product_review( $product->get_id(), 'Review content here' );
+		wp_update_comment(
+			array(
+				'comment_ID'       => $comment_id,
+				'comment_author'   => $author_name,
+				'comment_date'     => current_time( 'mysql' ),
+				'comment_date_gmt' => current_time( 'mysql', true ),
+			)
+		);
+
+		wp_set_current_user( $this->user );
+		ob_start();
+		( new WC_Admin_Dashboard() )->recent_reviews_content();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'title="' . esc_attr( $product_name ) . '"', $html );
+		$this->assertStringContainsString( '>' . esc_html( wc_trim_string( $product_name, 40 ) ) . '</a>', $html );
+		$this->assertStringContainsString( 'title="' . esc_attr( $author_name ) . '"', $html );
+		$this->assertStringContainsString( '>' . esc_html( wc_trim_string( $author_name, 24 ) ) . '</span>', $html );
+
+		$product->delete();
+	}
+
+	/**
 	 * Test: recent reviews widget content (legacy).
 	 */
 	public function test_recent_reviews_widget_content_legacy_version() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
@@ -44,6 +44,7 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		( new WC_Admin_Dashboard() )->recent_reviews();
 		$this->expectOutputRegex( '/Loading reviews data.../' );
+		$this->expectOutputRegex( '/wc-dashboard-widget-loading/' );
 		$this->expectOutputRegex( '/wc-recent-reviews-widget-loading/' );
 		$this->expectOutputRegex( '/wc-recent-reviews-widget-content/' );
 	}
@@ -102,7 +103,7 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		( new WC_Admin_Dashboard() )->status_widget();
 		$this->expectOutputRegex( '/Loading status data.../' );
-		$this->expectOutputRegex( '/<div id="wc-status-widget-loading" class="wc-status-widget-loading">/' );
+		$this->expectOutputRegex( '/<div id="wc-status-widget-loading" class="wc-dashboard-widget-loading wc-status-widget-loading" aria-busy="true">/' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -201,6 +201,9 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 						public function get_action_url() {
 							return 'payments';
 						}
+						public function get_action_label() {
+							return 'Configure payments';
+						}
 						public function is_complete() {
 							return false;
 						}
@@ -224,9 +227,9 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		$html = ob_get_clean();
 
 		$this->assertStringContainsString( 'dashboard-widget-finish-setup__in-progress', $html );
-		$this->assertStringContainsString( 'time to get paid', $html );
-		$this->assertStringContainsString( 'Give your customers an easy and convenient way to pay!', $html );
-		$this->assertStringContainsString( 'Get paid', $html );
+		$this->assertStringContainsString( 'Set up payments', $html );
+		$this->assertStringContainsString( 'Choose payment providers and enable payment methods at checkout.', $html );
+		$this->assertStringContainsString( 'Configure payments', $html );
 		$this->assertStringContainsString( 'payment-illustration.svg', $html );
 		$this->assertStringContainsString( 'Test account', $html );
 		$this->assertMatchesRegularExpression( '/<h3 class="dashboard-widget-finish-setup__title">.*Test account.*<\/h3>/s', $html );

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -171,6 +171,8 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 
 	/**
 	 * Tests the widget output when the next task is in progress.
+	 *
+	 * @testdox Widget output includes the in-progress label for the next task.
 	 */
 	public function test_widget_output_includes_in_progress_label() {
 		// phpcs:disable Squiz.Commenting

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -160,13 +160,74 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 
 		$required_strings = array(
 			'Step \d+ of \d+',
-			'You&#039;re almost there! Once you complete store setup you can start receiving orders.',
-			'Start selling',
+			'dashboard-widget-finish-setup__title',
+			'dashboard-widget-finish-setup__image',
 		);
 
 		foreach ( $required_strings as $required_string ) {
 			$this->assertMatchesRegularExpression( "/{$required_string}/", $html );
 		}
+	}
+
+	/**
+	 * Tests the widget output when the next task is in progress.
+	 */
+	public function test_widget_output_includes_in_progress_label() {
+		// phpcs:disable Squiz.Commenting
+		$task_list = new class() {
+			public function is_complete() {
+				return false;
+			}
+			public function is_hidden() {
+				return false;
+			}
+			public function get_viewable_tasks() {
+				return array(
+					new class() extends \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task {
+						public function get_id() {
+							return 'payments';
+						}
+						public function get_title() {
+							return 'Set up payments';
+						}
+						public function get_content() {
+							return 'Choose payment providers and enable payment methods at checkout.';
+						}
+						public function get_time() {
+							return '5 minutes';
+						}
+						public function get_action_url() {
+							return 'payments';
+						}
+						public function is_complete() {
+							return false;
+						}
+						public function is_in_progress() {
+							return true;
+						}
+						public function in_progress_label() {
+							return 'Test account';
+						}
+					},
+				);
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+
+		$widget = $this->get_widget();
+		$widget->set_task_list( $task_list );
+
+		ob_start();
+		$widget->render();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'dashboard-widget-finish-setup__in-progress', $html );
+		$this->assertStringContainsString( 'time to get paid', $html );
+		$this->assertStringContainsString( 'Give your customers an easy and convenient way to pay!', $html );
+		$this->assertStringContainsString( 'Get paid', $html );
+		$this->assertStringContainsString( 'payment-illustration.svg', $html );
+		$this->assertStringContainsString( 'Test account', $html );
+		$this->assertMatchesRegularExpression( '/<h3 class="dashboard-widget-finish-setup__title">.*Test account.*<\/h3>/s', $html );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -258,7 +258,7 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 		$this->assertTrue( wp_script_is( 'wc-flot', 'registered' ) );
 		$this->assertStringContainsString( 'class="wc-dashboard-widget-loading wc-status-widget-loading"', $html );
 		$this->assertStringContainsString( 'aria-busy="true"', $html );
-		$this->assertMatchesRegularExpression( '/<p><span class="spinner is-active"><\/span><span class="wc-dashboard-widget-loading__text">Loading status data\.\.\.<\/span><\/p>/', $html );
+		$this->assertStringContainsString( '<p><span class="spinner is-active"></span><span class="wc-dashboard-widget-loading__text">Loading status data...</span></p>', $html );
 	}
 
 	/**
@@ -271,7 +271,7 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'class="wc-dashboard-widget-loading wc-recent-reviews-widget-loading"', $html );
 		$this->assertStringContainsString( 'aria-busy="true"', $html );
-		$this->assertMatchesRegularExpression( '/<p><span class="spinner is-active"><\/span><span class="wc-dashboard-widget-loading__text">Loading reviews data\.\.\.<\/span><\/p>/', $html );
+		$this->assertStringContainsString( '<p><span class="spinner is-active"></span><span class="wc-dashboard-widget-loading__text">Loading reviews data...</span></p>', $html );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -99,30 +99,15 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Widget shows when task list is incomplete and store is pre-launch.
+	 * @testdox Widget shows when task list is incomplete.
 	 */
-	public function test_widget_shows_when_task_list_is_incomplete_and_store_is_pre_launch(): void {
-		delete_option( 'woocommerce_task_list_completed_lists' );
-		delete_option( 'woocommerce_task_list_hidden_lists' );
-		update_option( 'woocommerce_coming_soon', 'yes' );
-
-		$this->assertTrue(
-			$this->invoke_should_display_widget( $this->sut ),
-			'Widget should display even when the task list is incomplete and the store is pre-launch'
-		);
-	}
-
-	/**
-	 * @testdox Widget shows when store has launched and task list is incomplete.
-	 */
-	public function test_widget_shows_when_store_has_launched_and_task_list_incomplete(): void {
-		update_option( 'woocommerce_coming_soon', 'no' );
+	public function test_widget_shows_when_task_list_is_incomplete(): void {
 		delete_option( 'woocommerce_task_list_completed_lists' );
 		delete_option( 'woocommerce_task_list_hidden_lists' );
 
 		$this->assertTrue(
 			$this->invoke_should_display_widget( $this->sut ),
-			'Widget should display when store has launched even if task list is incomplete'
+			'Widget should display even when the task list is incomplete'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -133,7 +133,7 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 
 		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 		set_current_screen( 'dashboard' );
-		$wp_meta_boxes['dashboard'] = array();
+		unset( $wp_meta_boxes['dashboard'] );
 
 		$this->sut->init();
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -55,6 +55,7 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 		delete_option( 'woocommerce_task_list_complete' );
 		remove_all_filters( 'pre_option_woocommerce_task_list_complete' );
 		remove_all_filters( 'pre_option_woocommerce_task_list_hidden' );
+		delete_option( 'woocommerce_enable_reviews' );
 
 		parent::tearDown();
 	}
@@ -133,6 +134,7 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 
 		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 		set_current_screen( 'dashboard' );
+		update_option( 'woocommerce_enable_reviews', 'yes' );
 		unset( $wp_meta_boxes['dashboard'] );
 
 		add_meta_box(
@@ -168,6 +170,55 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 			),
 			$widget_order
 		);
+	}
+
+	/**
+	 * @testdox Recent reviews widget is not registered when product reviews are disabled.
+	 */
+	public function test_init_does_not_register_recent_reviews_widget_when_reviews_are_disabled(): void {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+		set_current_screen( 'dashboard' );
+		update_option( 'woocommerce_enable_reviews', 'no' );
+		$had_comments_support = post_type_supports( 'product', 'comments' );
+		add_post_type_support( 'product', 'comments' );
+		unset( $wp_meta_boxes['dashboard'] );
+
+		try {
+			$this->sut->init();
+
+			$this->assertArrayHasKey( 'woocommerce_dashboard_status', $wp_meta_boxes['dashboard']['normal']['high'] );
+			$this->assertArrayNotHasKey( 'woocommerce_dashboard_recent_reviews', $wp_meta_boxes['dashboard']['normal']['high'] );
+		} finally {
+			if ( ! $had_comments_support ) {
+				remove_post_type_support( 'product', 'comments' );
+			}
+		}
+	}
+
+	/**
+	 * @testdox Recent reviews widget is registered when product reviews are enabled.
+	 */
+	public function test_init_registers_recent_reviews_widget_when_reviews_are_enabled(): void {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+		set_current_screen( 'dashboard' );
+		update_option( 'woocommerce_enable_reviews', 'yes' );
+		$had_comments_support = post_type_supports( 'product', 'comments' );
+		add_post_type_support( 'product', 'comments' );
+		unset( $wp_meta_boxes['dashboard'] );
+
+		try {
+			$this->sut->init();
+
+			$this->assertArrayHasKey( 'woocommerce_dashboard_recent_reviews', $wp_meta_boxes['dashboard']['normal']['high'] );
+		} finally {
+			if ( ! $had_comments_support ) {
+				remove_post_type_support( 'product', 'comments' );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -222,6 +222,30 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Recent reviews widget uses the enabled default when the reviews setting has not been saved.
+	 */
+	public function test_init_registers_recent_reviews_widget_when_reviews_setting_is_missing(): void {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+		set_current_screen( 'dashboard' );
+		delete_option( 'woocommerce_enable_reviews' );
+		$had_comments_support = post_type_supports( 'product', 'comments' );
+		add_post_type_support( 'product', 'comments' );
+		unset( $wp_meta_boxes['dashboard'] );
+
+		try {
+			$this->sut->init();
+
+			$this->assertArrayHasKey( 'woocommerce_dashboard_recent_reviews', $wp_meta_boxes['dashboard']['normal']['high'] );
+		} finally {
+			if ( ! $had_comments_support ) {
+				remove_post_type_support( 'product', 'comments' );
+			}
+		}
+	}
+
+	/**
 	 * @testdox Status widget loading placeholder renders the spinner above the loading text.
 	 */
 	public function test_status_widget_loading_placeholder_renders_stacked_loader(): void {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -42,6 +42,7 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 			)
 		);
 		wp_set_current_user( $this->admin_user );
+		update_option( 'woocommerce_coming_soon', 'yes' );
 		$this->sut = new WC_Admin_Dashboard();
 	}
 
@@ -53,6 +54,7 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 		delete_option( 'woocommerce_task_list_hidden' );
 		delete_option( 'woocommerce_task_list_hidden_lists' );
 		delete_option( 'woocommerce_task_list_complete' );
+		delete_option( 'woocommerce_coming_soon' );
 		remove_all_filters( 'pre_option_woocommerce_task_list_complete' );
 		remove_all_filters( 'pre_option_woocommerce_task_list_hidden' );
 
@@ -108,6 +110,70 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 			$this->invoke_should_display_widget( $this->sut ),
 			'Widget should not display when task list is neither complete nor hidden'
 		);
+	}
+
+	/**
+	 * @testdox Widget shows when store has launched and task list is incomplete.
+	 */
+	public function test_widget_shows_when_store_has_launched_and_task_list_incomplete(): void {
+		update_option( 'woocommerce_coming_soon', 'no' );
+		delete_option( 'woocommerce_task_list_completed_lists' );
+		delete_option( 'woocommerce_task_list_hidden_lists' );
+
+		$this->assertTrue(
+			$this->invoke_should_display_widget( $this->sut ),
+			'Widget should display when store has launched even if task list is incomplete'
+		);
+	}
+
+	/**
+	 * @testdox Status and reviews widgets are registered high in the normal dashboard column.
+	 */
+	public function test_init_registers_status_and_reviews_widgets_in_high_normal_context(): void {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+		set_current_screen( 'dashboard' );
+		$wp_meta_boxes['dashboard'] = array();
+
+		$this->sut->init();
+
+		$this->assertArrayHasKey( 'woocommerce_dashboard_status', $wp_meta_boxes['dashboard']['normal']['high'] );
+		$this->assertArrayHasKey( 'woocommerce_dashboard_recent_reviews', $wp_meta_boxes['dashboard']['normal']['high'] );
+
+		$widget_order  = array_keys( $wp_meta_boxes['dashboard']['normal']['high'] );
+		$status_index  = array_search( 'woocommerce_dashboard_status', $widget_order, true );
+		$reviews_index = array_search( 'woocommerce_dashboard_recent_reviews', $widget_order, true );
+
+		$this->assertNotFalse( $status_index );
+		$this->assertNotFalse( $reviews_index );
+		$this->assertLessThan( $reviews_index, $status_index );
+	}
+
+	/**
+	 * @testdox Status widget loading placeholder renders the spinner above the loading text.
+	 */
+	public function test_status_widget_loading_placeholder_renders_stacked_loader(): void {
+		ob_start();
+		$this->sut->status_widget();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'class="wc-dashboard-widget-loading wc-status-widget-loading"', $html );
+		$this->assertStringContainsString( 'aria-busy="true"', $html );
+		$this->assertMatchesRegularExpression( '/<p><span class="spinner is-active"><\/span><span class="wc-dashboard-widget-loading__text">Loading status data\.\.\.<\/span><\/p>/', $html );
+	}
+
+	/**
+	 * @testdox Recent reviews widget loading placeholder renders the spinner above the loading text.
+	 */
+	public function test_recent_reviews_widget_loading_placeholder_renders_stacked_loader(): void {
+		ob_start();
+		$this->sut->recent_reviews();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'class="wc-dashboard-widget-loading wc-recent-reviews-widget-loading"', $html );
+		$this->assertStringContainsString( 'aria-busy="true"', $html );
+		$this->assertMatchesRegularExpression( '/<p><span class="spinner is-active"><\/span><span class="wc-dashboard-widget-loading__text">Loading reviews data\.\.\.<\/span><\/p>/', $html );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -174,10 +174,13 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 	 * @testdox Status widget loading placeholder renders the spinner above the loading text.
 	 */
 	public function test_status_widget_loading_placeholder_renders_stacked_loader(): void {
+		wp_deregister_script( 'wc-flot' );
+
 		ob_start();
 		$this->sut->status_widget();
 		$html = ob_get_clean();
 
+		$this->assertTrue( wp_script_is( 'wc-flot', 'registered' ) );
 		$this->assertStringContainsString( 'class="wc-dashboard-widget-loading wc-status-widget-loading"', $html );
 		$this->assertStringContainsString( 'aria-busy="true"', $html );
 		$this->assertMatchesRegularExpression( '/<p><span class="spinner is-active"><\/span><span class="wc-dashboard-widget-loading__text">Loading status data\.\.\.<\/span><\/p>/', $html );

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -42,7 +42,6 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 			)
 		);
 		wp_set_current_user( $this->admin_user );
-		update_option( 'woocommerce_coming_soon', 'yes' );
 		$this->sut = new WC_Admin_Dashboard();
 	}
 
@@ -54,7 +53,6 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 		delete_option( 'woocommerce_task_list_hidden' );
 		delete_option( 'woocommerce_task_list_hidden_lists' );
 		delete_option( 'woocommerce_task_list_complete' );
-		delete_option( 'woocommerce_coming_soon' );
 		remove_all_filters( 'pre_option_woocommerce_task_list_complete' );
 		remove_all_filters( 'pre_option_woocommerce_task_list_hidden' );
 
@@ -100,15 +98,16 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Widget does not show when neither complete nor hidden.
+	 * @testdox Widget shows when task list is incomplete and store is pre-launch.
 	 */
-	public function test_widget_does_not_show_when_neither_complete_nor_hidden(): void {
+	public function test_widget_shows_when_task_list_is_incomplete_and_store_is_pre_launch(): void {
 		delete_option( 'woocommerce_task_list_completed_lists' );
 		delete_option( 'woocommerce_task_list_hidden_lists' );
+		update_option( 'woocommerce_coming_soon', 'yes' );
 
-		$this->assertFalse(
+		$this->assertTrue(
 			$this->invoke_should_display_widget( $this->sut ),
-			'Widget should not display when task list is neither complete nor hidden'
+			'Widget should display even when the task list is incomplete and the store is pre-launch'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -176,6 +176,21 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Status widget order rows render labels before counts.
+	 */
+	public function test_status_widget_order_rows_render_labels_before_counts(): void {
+		$method = new ReflectionMethod( WC_Admin_Dashboard::class, 'status_widget_order_rows' );
+		$method->setAccessible( true );
+
+		ob_start();
+		$method->invoke( $this->sut );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'Awaiting processing <strong>0 orders</strong>', $html );
+		$this->assertStringContainsString( 'On-hold <strong>0 orders</strong>', $html );
+	}
+
+	/**
 	 * @testdox Widget does not show without proper capabilities.
 	 */
 	public function test_widget_does_not_show_without_capabilities(): void {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-test.php
@@ -126,27 +126,48 @@ class WC_Admin_Dashboard_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Status and reviews widgets are registered high in the normal dashboard column.
+	 * @testdox WooCommerce widgets are registered high in the normal dashboard column in their current order.
 	 */
-	public function test_init_registers_status_and_reviews_widgets_in_high_normal_context(): void {
+	public function test_init_registers_woocommerce_widgets_in_high_normal_context_in_current_order(): void {
 		global $wp_meta_boxes;
 
 		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 		set_current_screen( 'dashboard' );
 		unset( $wp_meta_boxes['dashboard'] );
 
+		add_meta_box(
+			'wc_admin_dashboard_setup',
+			'WooCommerce Setup',
+			'__return_empty_string',
+			'dashboard',
+			'normal',
+			'high'
+		);
 		$this->sut->init();
 
+		$this->assertArrayHasKey( 'wc_admin_dashboard_setup', $wp_meta_boxes['dashboard']['normal']['high'] );
 		$this->assertArrayHasKey( 'woocommerce_dashboard_status', $wp_meta_boxes['dashboard']['normal']['high'] );
 		$this->assertArrayHasKey( 'woocommerce_dashboard_recent_reviews', $wp_meta_boxes['dashboard']['normal']['high'] );
 
-		$widget_order  = array_keys( $wp_meta_boxes['dashboard']['normal']['high'] );
-		$status_index  = array_search( 'woocommerce_dashboard_status', $widget_order, true );
-		$reviews_index = array_search( 'woocommerce_dashboard_recent_reviews', $widget_order, true );
+		$widget_order = array_values(
+			array_intersect(
+				array_keys( $wp_meta_boxes['dashboard']['normal']['high'] ),
+				array(
+					'wc_admin_dashboard_setup',
+					'woocommerce_dashboard_status',
+					'woocommerce_dashboard_recent_reviews',
+				)
+			)
+		);
 
-		$this->assertNotFalse( $status_index );
-		$this->assertNotFalse( $reviews_index );
-		$this->assertLessThan( $reviews_index, $status_index );
+		$this->assertSame(
+			array(
+				'wc_admin_dashboard_setup',
+				'woocommerce_dashboard_status',
+				'woocommerce_dashboard_recent_reviews',
+			),
+			$widget_order
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Merchants should be able to see the WooCommerce dashboard widgets throughout setup, including before the store launches, so they know what to expect after setup is complete. This updates the legacy dashboard widgets so eligible users can see the WooCommerce widgets together in the current dashboard order: WooCommerce Setup, WooCommerce Status, then WooCommerce Recent Reviews. The Recent Reviews widget remains conditional on product reviews being enabled for the store.

The setup widget now mirrors the next task more closely with contextual copy, CTA, illustration, and in-progress badge support. The status and recent reviews widgets also get visual refinements for neutral Dashicons, dashboard-aligned loading states, label-first status rows, and review layout/typography.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:
<img width="3512" height="2444" alt="Screens" src="https://github.com/user-attachments/assets/6d4eed32-4690-4d21-b61b-cc3ac98d3e9c" />
<img width="1248" height="2346" alt="Setup" src="https://github.com/user-attachments/assets/bf29eb1c-d97a-45b0-b669-b7abfb32e126" />
<img width="1249" height="1052" alt="Status" src="https://github.com/user-attachments/assets/6dd4468a-dcf7-4e9c-821a-81446f16c0d6" />
<img width="1248" height="817" alt="Reviews" src="https://github.com/user-attachments/assets/fdcdf90e-d22f-48f3-85ff-90dffb7a5cf6" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set up a local WooCommerce store with the setup task list visible and at least one setup task incomplete.
2. Set `woocommerce_coming_soon` to `yes`, then open `wp-admin/index.php` and confirm WooCommerce Setup, WooCommerce Status, and WooCommerce Recent Reviews appear together before launch.
3. Confirm the WooCommerce setup widget appears with contextual task copy, CTA, progress badge, and illustration.
4. Confirm the widgets keep the current order in the main dashboard column: WooCommerce Setup, WooCommerce Status, then WooCommerce Recent Reviews.
5. Confirm the status widget uses neutral gray Dashicons, label-first rows, dark gray values, and a subtle hover background, including any additional rows added through `woocommerce_dashboard_status_widget_reports`.
6. Confirm the recent reviews widget aligns review text, avatar, and stars without overflowing, and that the loading states show a centered spinner above the loading text.
7. Disable product reviews under WooCommerce > Settings > Products, then confirm WooCommerce Recent Reviews no longer appears on the main dashboard.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm wc:build:classic-assets`
- `pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter WC_Admin_Dashboard_Setup_Test`
- `pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter 'WC_Admin_Dashboard_Test|WC_Tests_Admin_Dashboard'`
- `git diff --check`
- Container PHP syntax check for touched PHP files with `php -l`

Host-side PHP lint commands were attempted, but the local PHP/Composer process aborts before linting because Homebrew is missing `/opt/homebrew/opt/libvmaf/lib/libvmaf.1.dylib`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>