### PR TITLE
Replace Newest Products with Product Collection in Empty Cart block

### DIFF
--- a/plugins/woocommerce/changelog/update-empty-cart-product-collection
+++ b/plugins/woocommerce/changelog/update-empty-cart-product-collection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Replace Newest Products with Product Collection in Empty Cart block

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/hydrate-interactivity-regions.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/hydrate-interactivity-regions.ts
@@ -1,0 +1,102 @@
+/**
+ * Hydrate WordPress Interactivity API regions that were added to the DOM
+ * after the Interactivity API runtime performed its initial hydration on
+ * page load.
+ *
+ * Some blocks (e.g. Cart) are rendered with React on the frontend and
+ * re-create their server-rendered inner HTML. Any Interactivity API powered
+ * blocks (e.g. Product Collection with its Add to Cart button) contained in
+ * that HTML lose their interactivity, because the Interactivity API runtime
+ * only hydrates regions present in the DOM when the page loads. This utility
+ * hydrates such regions using the same private APIs that
+ * `@wordpress/interactivity-router` uses for client-side navigation.
+ */
+
+/**
+ * Consent string required to unlock the private APIs of
+ * `@wordpress/interactivity`. It must match the string defined in the
+ * package.
+ */
+const PRIVATE_APIS_CONSENT =
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';
+
+interface InteractivityPrivateApis {
+	getRegionRootFragment: ( region: Element ) => unknown;
+	toVdom: ( node: Node ) => unknown;
+	render: ( vdom: unknown, rootFragment: unknown ) => void;
+}
+
+// Tracks regions hydrated by this utility to prevent double hydration.
+const hydratedRegions = new WeakSet< Element >();
+
+/**
+ * Move child nodes of `<template>` elements into their `content` fragment.
+ *
+ * When server-rendered HTML is re-created with React (e.g. parsed with
+ * `html-react-parser` and rendered again), children of `<template>` elements
+ * become regular child nodes instead of being placed in the template
+ * `content` fragment, which is where the Interactivity API reads them from
+ * (e.g. for `data-wp-each` directives).
+ */
+const fixTemplateContents = ( region: Element ) => {
+	region.querySelectorAll( 'template' ).forEach( ( template ) => {
+		if (
+			template.content.childNodes.length === 0 &&
+			template.childNodes.length > 0
+		) {
+			template.content.append( ...Array.from( template.childNodes ) );
+		}
+	} );
+};
+
+/**
+ * Hydrates all Interactivity API regions (`data-wp-interactive` elements)
+ * found within the given container.
+ *
+ * Nested regions are hydrated as part of their closest ancestor region, like
+ * the Interactivity API runtime does on page load.
+ */
+export const hydrateInteractivityRegions = async (
+	container: HTMLElement
+): Promise< void > => {
+	const regions = Array.from(
+		container.querySelectorAll( '[data-wp-interactive]' )
+	).filter(
+		( region ) =>
+			! region.parentElement?.closest( '[data-wp-interactive]' ) &&
+			! hydratedRegions.has( region )
+	);
+
+	if ( regions.length === 0 ) {
+		return;
+	}
+
+	try {
+		// This must be a native dynamic import resolved through the page's
+		// import map (hence the `webpackIgnore` comment), so it returns the
+		// exact same Interactivity API runtime instance (and store registry)
+		// used by the script modules loaded by WordPress.
+		const { privateApis } = await import(
+			/* webpackIgnore: true */ '@wordpress/interactivity'
+		);
+		const { getRegionRootFragment, toVdom, render } = privateApis(
+			PRIVATE_APIS_CONSENT
+		) as InteractivityPrivateApis;
+
+		regions.forEach( ( region ) => {
+			// The region may have been unmounted or hydrated by a concurrent
+			// call while the module import was being awaited.
+			if ( ! region.isConnected || hydratedRegions.has( region ) ) {
+				return;
+			}
+			hydratedRegions.add( region );
+			fixTemplateContents( region );
+			render( toVdom( region ), getRegionRootFragment( region ) );
+		} );
+	} catch {
+		// The Interactivity API runtime is not available, e.g. there are no
+		// script modules on the page or the browser doesn't support import
+		// maps. Regions stay non-interactive, matching the behavior before
+		// this utility existed.
+	}
+};

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/hydrate-interactivity-regions.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/hydrate-interactivity-regions.ts
@@ -10,6 +10,9 @@
  * only hydrates regions present in the DOM when the page loads. This utility
  * hydrates such regions using the same private APIs that
  * `@wordpress/interactivity-router` uses for client-side navigation.
+ *
+ * This is a temporary solution until those blocks are fully migrated to the
+ * Interactivity API, in which case this utility will no longer be needed.
  */
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/index.js
@@ -18,3 +18,4 @@ export * from './keyby';
 export * from './pick';
 export * from './get-inline-styles';
 export * from './use-return-focus';
+export * from './hydrate-interactivity-regions';

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/test/hydrate-interactivity-regions.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/test/hydrate-interactivity-regions.ts
@@ -1,0 +1,111 @@
+/**
+ * Internal dependencies
+ */
+import { hydrateInteractivityRegions } from '../hydrate-interactivity-regions';
+
+const mockRender = jest.fn();
+const mockToVdom = jest.fn( ( node: Node ) => ( { node } ) );
+const mockGetRegionRootFragment = jest.fn( ( region: Element ) => ( {
+	region,
+} ) );
+
+jest.mock( '@wordpress/interactivity', () => ( {
+	privateApis: () => ( {
+		getRegionRootFragment: mockGetRegionRootFragment,
+		toVdom: mockToVdom,
+		render: mockRender,
+	} ),
+} ) );
+
+describe( 'hydrateInteractivityRegions', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		jest.clearAllMocks();
+	} );
+
+	it( 'hydrates top-level interactive regions inside the container', async () => {
+		document.body.innerHTML = `
+			<div id="container">
+				<div id="region-1" data-wp-interactive="my-plugin/one"></div>
+				<div>
+					<div id="region-2" data-wp-interactive="my-plugin/two"></div>
+				</div>
+			</div>
+		`;
+		const container = document.getElementById( 'container' ) as HTMLElement;
+
+		await hydrateInteractivityRegions( container );
+
+		expect( mockRender ).toHaveBeenCalledTimes( 2 );
+		expect( mockToVdom ).toHaveBeenCalledWith(
+			document.getElementById( 'region-1' )
+		);
+		expect( mockToVdom ).toHaveBeenCalledWith(
+			document.getElementById( 'region-2' )
+		);
+	} );
+
+	it( 'skips nested interactive regions', async () => {
+		document.body.innerHTML = `
+			<div id="container">
+				<div id="outer" data-wp-interactive="my-plugin/outer">
+					<div id="inner" data-wp-interactive="my-plugin/inner"></div>
+				</div>
+			</div>
+		`;
+		const container = document.getElementById( 'container' ) as HTMLElement;
+
+		await hydrateInteractivityRegions( container );
+
+		expect( mockRender ).toHaveBeenCalledTimes( 1 );
+		expect( mockToVdom ).toHaveBeenCalledWith(
+			document.getElementById( 'outer' )
+		);
+	} );
+
+	it( 'does not hydrate the same region twice', async () => {
+		document.body.innerHTML = `
+			<div id="container">
+				<div data-wp-interactive="my-plugin/one"></div>
+			</div>
+		`;
+		const container = document.getElementById( 'container' ) as HTMLElement;
+
+		await hydrateInteractivityRegions( container );
+		await hydrateInteractivityRegions( container );
+
+		expect( mockRender ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does nothing when there are no interactive regions', async () => {
+		document.body.innerHTML = `<div id="container"><p>No regions</p></div>`;
+		const container = document.getElementById( 'container' ) as HTMLElement;
+
+		await hydrateInteractivityRegions( container );
+
+		expect( mockRender ).not.toHaveBeenCalled();
+	} );
+
+	it( 'moves template children into the template content fragment', async () => {
+		document.body.innerHTML = `
+			<div id="container">
+				<div id="region" data-wp-interactive="my-plugin/one"></div>
+			</div>
+		`;
+		const region = document.getElementById( 'region' ) as HTMLElement;
+		// Recreate what happens when React renders a parsed `<template>`:
+		// children are appended as regular child nodes instead of being
+		// placed in the `content` fragment.
+		const template = document.createElement( 'template' );
+		template.appendChild( document.createElement( 'span' ) );
+		region.appendChild( template );
+		expect( template.content.childNodes ).toHaveLength( 0 );
+
+		await hydrateInteractivityRegions(
+			document.getElementById( 'container' ) as HTMLElement
+		);
+
+		expect( template.content.childNodes ).toHaveLength( 1 );
+		expect( template.childNodes ).toHaveLength( 0 );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
@@ -15,7 +15,9 @@ import {
 	useForcedLayout,
 	getAllowedBlocks,
 } from '../../../cart-checkout-shared';
+import newArrivals from '../../../product-collection/collections/new-arrivals';
 import { INNER_BLOCKS_PRODUCT_TEMPLATE } from '../../../product-collection/constants';
+import { CoreCollectionNames } from '../../../product-collection/types';
 
 const browseStoreTemplate = SHOP_URL
 	? [
@@ -60,14 +62,21 @@ const defaultTemplate = [
 	[
 		'woocommerce/product-collection',
 		{
-			query: {
-				perPage: 4,
-				order: 'desc',
-				orderBy: 'date',
-				woocommerceStockStatus: [ 'instock' ],
-				isProductCollectionBlock: true,
+			...newArrivals.attributes,
+			displayLayout: {
+				...newArrivals.attributes.displayLayout,
+				columns: 4,
 			},
-			displayLayout: { type: 'flex', columns: 4 },
+			query: {
+				// Copy all properties from newArrivals.attributes.query except timeFrame
+				...( ( { timeFrame, ...rest } ) => rest )(
+					newArrivals.attributes.query
+				),
+				postType: 'product',
+				perPage: 4,
+				woocommerceStockStatus: [ 'instock' ],
+			},
+			collection: CoreCollectionNames.NEW_ARRIVALS,
 		},
 		[ INNER_BLOCKS_PRODUCT_TEMPLATE ],
 	],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
@@ -15,6 +15,7 @@ import {
 	useForcedLayout,
 	getAllowedBlocks,
 } from '../../../cart-checkout-shared';
+import { INNER_BLOCKS_PRODUCT_TEMPLATE } from '../../../product-collection/constants';
 
 const browseStoreTemplate = SHOP_URL
 	? [
@@ -57,11 +58,17 @@ const defaultTemplate = [
 		},
 	],
 	[
-		'woocommerce/product-new',
+		'woocommerce/product-collection',
 		{
-			columns: 4,
-			rows: 1,
+			query: {
+				perPage: 4,
+				order: 'desc',
+				orderBy: 'date',
+				woocommerceStockStatus: [ 'instock' ],
+			},
+			displayLayout: { type: 'flex', columns: 4 },
 		},
+		[ INNER_BLOCKS_PRODUCT_TEMPLATE ],
 	],
 ].filter( Boolean ) as unknown as TemplateArray;
 
@@ -69,6 +76,10 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
 	const { currentView } = useEditorContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.EMPTY_CART );
+	// Product Collection is used for the New Arrivals block.
+	// We don't want to set a parent on the Product Collection block
+	// so we add it here manually.
+	allowedBlocks.push( 'woocommerce/product-collection' );
 
 	useForcedLayout( {
 		clientId,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
@@ -65,6 +65,7 @@ const defaultTemplate = [
 				order: 'desc',
 				orderBy: 'date',
 				woocommerceStockStatus: [ 'instock' ],
+				isProductCollectionBlock: true,
 			},
 			displayLayout: { type: 'flex', columns: 4 },
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/frontend.tsx
@@ -2,8 +2,11 @@
  * External dependencies
  */
 import { useStoreCart } from '@woocommerce/base-context/hooks';
-import { useEffect } from '@wordpress/element';
-import { dispatchEvent } from '@woocommerce/base-utils';
+import { useEffect, useRef } from '@wordpress/element';
+import {
+	dispatchEvent,
+	hydrateInteractivityRegions,
+} from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -18,8 +21,10 @@ const FrontendBlock = ( {
 	className: string;
 } ): JSX.Element | null => {
 	const { cartItems, cartIsLoading } = useStoreCart();
+	const isCartEmpty = ! cartIsLoading && cartItems.length === 0;
+	const containerRef = useRef< HTMLDivElement >( null );
 	useEffect( () => {
-		if ( cartItems.length !== 0 || cartIsLoading ) {
+		if ( ! isCartEmpty ) {
 			return;
 		}
 		dispatchEvent( 'wc-blocks_render_blocks_frontend', {
@@ -27,9 +32,20 @@ const FrontendBlock = ( {
 				'.wp-block-woocommerce-cart'
 			),
 		} );
-	}, [ cartIsLoading, cartItems ] );
-	if ( ! cartIsLoading && cartItems.length === 0 ) {
-		return <div className={ className }>{ children }</div>;
+		// The contents of the empty cart are mounted after the Interactivity
+		// API runtime has already hydrated the page, so any Interactivity API
+		// powered blocks they contain (e.g. Product Collection with its Add
+		// to Cart button) must be hydrated manually.
+		if ( containerRef.current ) {
+			hydrateInteractivityRegions( containerRef.current );
+		}
+	}, [ isCartEmpty ] );
+	if ( isCartEmpty ) {
+		return (
+			<div ref={ containerRef } className={ className }>
+				{ children }
+			</div>
+		);
 	}
 	return null;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/editor-integration.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/editor-integration.tsx
@@ -20,7 +20,6 @@ import {
 import '../index';
 import '../inner-blocks/index';
 import '../inner-blocks/cart-order-summary-coupon-form/index';
-import '../../product-new/index';
 import '../../../atomic/blocks/product-elements/sale-badge/index';
 import '../../../atomic/blocks/product-elements/image/index';
 import '../../../atomic/blocks/product-elements/price/index';

--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/pages/cart.html
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/pages/cart.html
@@ -117,7 +117,7 @@
 		<h2 class="wp-block-heading has-text-align-center">New in store</h2>
 		<!-- /wp:heading -->
 
-		<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":4,"postType":"product","order":"desc","orderBy":"date","woocommerceStockStatus":["instock"],"isProductCollectionBlock":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"]} -->
+		<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"orderBy":"date","order":"desc","perPage":4,"pages":1,"postType":"product","woocommerceStockStatus":["instock"]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/new-arrivals","hideControls":["order","filterable"],"queryContextIncludes":["collection"]} -->
 		<div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
 			<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
 			<!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->

--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/pages/cart.html
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/pages/cart.html
@@ -117,7 +117,7 @@
 		<h2 class="wp-block-heading has-text-align-center">New in store</h2>
 		<!-- /wp:heading -->
 
-		<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":4,"postType":"product","order":"desc","orderBy":"date","woocommerceStockStatus":["instock"]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"]} -->
+		<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":4,"postType":"product","order":"desc","orderBy":"date","woocommerceStockStatus":["instock"],"isProductCollectionBlock":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"]} -->
 		<div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
 			<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
 			<!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->

--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/pages/cart.html
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/pages/cart.html
@@ -117,7 +117,20 @@
 		<h2 class="wp-block-heading has-text-align-center">New in store</h2>
 		<!-- /wp:heading -->
 
-		<!-- wp:woocommerce/product-new {"rows":1} /-->
+		<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":4,"postType":"product","order":"desc","orderBy":"date","woocommerceStockStatus":["instock"]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"]} -->
+		<div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
+			<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+			<!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->
+			<!-- /wp:woocommerce/product-image -->
+
+			<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}},"typography":{"lineHeight":"1.4"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+			<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+
+			<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
+			<!-- /wp:woocommerce/product-template -->
+		</div>
+		<!-- /wp:woocommerce/product-collection -->
 	</div>
 	<!-- /wp:woocommerce/empty-cart-block -->
 </div>

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-block.shopper.block_theme.spec.ts
@@ -123,7 +123,7 @@ test.describe( 'Shopper → Cart block', () => {
 		expect( hoodiePriceText ).toBe( '$50.00' );
 	} );
 
-	test( 'User can view empty cart message', async ( {
+	test( 'User can view empty cart message and can add products to cart', async ( {
 		frontendUtils,
 		page,
 	} ) => {
@@ -135,6 +135,16 @@ test.describe( 'Shopper → Cart block', () => {
 				name: 'Your cart is currently empty!',
 			} )
 		).toBeVisible();
+
+		// Add a product to cart.
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+		await addToCartButton.click();
+
+		await expect(
+			page.getByRole( 'spinbutton', { name: 'Quantity of' } )
+		).toHaveValue( '1' );
 	} );
 
 	test( 'User can remove a product from cart', async ( {

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -3091,7 +3091,7 @@ EOT;
 <h2 class="wp-block-heading has-text-align-center">' . __( 'New in store', 'woocommerce' ) . '</h2>
 <!-- /wp:heading -->
 
-<!-- wp:woocommerce/product-collection {"queryId":1,"query":{"perPage":4,"postType":"product","order":"desc","orderBy":"date","woocommerceStockStatus":["instock"],"isProductCollectionBlock":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"]} -->
+<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"orderBy":"date","order":"desc","perPage":4,"pages":1,"postType":"product","woocommerceStockStatus":["instock"]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/new-arrivals","hideControls":["order","filterable"],"queryContextIncludes":["collection"]} -->
 <div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
 <!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
 <!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -3091,7 +3091,7 @@ EOT;
 <h2 class="wp-block-heading has-text-align-center">' . __( 'New in store', 'woocommerce' ) . '</h2>
 <!-- /wp:heading -->
 
-<!-- wp:woocommerce/product-collection {"queryId":1,"query":{"perPage":4,"postType":"product","order":"desc","orderBy":"date","woocommerceStockStatus":["instock"]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"]} -->
+<!-- wp:woocommerce/product-collection {"queryId":1,"query":{"perPage":4,"postType":"product","order":"desc","orderBy":"date","woocommerceStockStatus":["instock"],"isProductCollectionBlock":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"]} -->
 <div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
 <!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
 <!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -3091,7 +3091,19 @@ EOT;
 <h2 class="wp-block-heading has-text-align-center">' . __( 'New in store', 'woocommerce' ) . '</h2>
 <!-- /wp:heading -->
 
-<!-- wp:woocommerce/product-new {"columns":4,"rows":1} /--></div>
+<!-- wp:woocommerce/product-collection {"queryId":1,"query":{"perPage":4,"postType":"product","order":"desc","orderBy":"date","woocommerceStockStatus":["instock"]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"]} -->
+<div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
+<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+<!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->
+<!-- /wp:woocommerce/product-image -->
+
+<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}},"typography":{"lineHeight":"1.4"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+
+<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
+<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:woocommerce/empty-cart-block --></div>
 <!-- /wp:woocommerce/cart -->';
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the _Empty Cart_ block so it uses the _Product Collection_ block instead of the deprecated _Newest Products_ block.

**Note: this PR requires WordPress 7.0, so don't merge until WooCommerce's minimal supported version is raised from WP 6.9 to WP 7.0.**

### How to test the changes in this Pull Request:

**In an existing store:**

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Page: Cart_ or edit the _Cart_ page.
2. Using the list view, open the _Empty Cart_ block.
3. Verify the _Newest Products_ block is still used, meaning this PR didn't introduce unexpected change to live stores.
4. Remove the whole _Cart_ block.
5. Insert it again.
6. Verify new instances of the _Cart_ block uses the _Product Collection_ block (in the list, it will show up as _Newest Arrivals_) instead of the _Newest Products_ block.
7. Go to the _Cart_ page in the frontend. Remove all products in cart so you see the empty cart view.
8. Verify the _New in store_ section displays the newest products.
9. Verify you can add one of the products to cart and, when done, the block updates to the _Filled cart_.

**In a new store:**

1. Create a new store using this branch.
2. Go to _Appearance_ > _Editor_ > _Templates_ > _Page: Cart_ or edit the _Cart_ page.
3. Using the list view, open the _Empty Cart_ block.
4. Verify the _Product Collection_ block is the new default.
5. Go to the _Cart_ page in the frontend. Remove all products in cart so you see the empty cart view.
6. Verify the _New in store_ section displays the newest products.
7. Verify you can add one of the products to cart and, when done, the block updates to the _Filled cart_.

Before | After
--- | ---
<img width="443" height="775" alt="imatge" src="https://github.com/user-attachments/assets/15b4ee0a-e0ff-4a88-9b51-86b8d6a532cd" /> | <img width="443" height="775" alt="imatge" src="https://github.com/user-attachments/assets/a81ec0e2-2298-4531-bf3f-628cec7b0fad" />


### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
