### PR TITLE
Fix PHP 8.5 deprecation: null array offset in html-order-items.php

### DIFF
--- a/plugins/woocommerce/changelog/65706-fix-order-items-null-tax-rate-id
+++ b/plugins/woocommerce/changelog/65706-fix-order-items-null-tax-rate-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent PHP 8.5 deprecation notices when an order tax item is missing a rate ID.

--- a/plugins/woocommerce/changelog/65706-fix-order-items-null-tax-rate-id
+++ b/plugins/woocommerce/changelog/65706-fix-order-items-null-tax-rate-id
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent PHP 8.5 deprecation notices when an order tax item is missing a rate ID.
+Prevent PHP 8.5 deprecation notices when an order tax item has no matching tax rate.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -52,7 +52,7 @@ if ( wc_tax_enabled() ) {
 				<?php
 				if ( ! empty( $order_taxes ) ) :
 					foreach ( $order_taxes as $tax_id => $tax_item ) :
-						$tax_class      = wc_get_tax_class_by_tax_id( $tax_item['rate_id'] ?? 0 );
+						$tax_class      = wc_get_tax_class_by_tax_id( $tax_item['rate_id'] ?? 0 ) ?? '';
 						$tax_class_name = isset( $classes_options[ $tax_class ] ) ? $classes_options[ $tax_class ] : __( 'Tax', 'woocommerce' );
 						$column_label   = ! empty( $tax_item['label'] ) ? $tax_item['label'] : __( 'Tax', 'woocommerce' );
 						/* translators: %1$s: tax item name %2$s: tax class name  */

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -52,7 +52,7 @@ if ( wc_tax_enabled() ) {
 				<?php
 				if ( ! empty( $order_taxes ) ) :
 					foreach ( $order_taxes as $tax_id => $tax_item ) :
-						$tax_class      = wc_get_tax_class_by_tax_id( $tax_item['rate_id'] );
+						$tax_class      = wc_get_tax_class_by_tax_id( $tax_item['rate_id'] ?? 0 );
 						$tax_class_name = isset( $classes_options[ $tax_class ] ) ? $classes_options[ $tax_class ] : __( 'Tax', 'woocommerce' );
 						$column_label   = ! empty( $tax_item['label'] ) ? $tax_item['label'] : __( 'Tax', 'woocommerce' );
 						/* translators: %1$s: tax item name %2$s: tax class name  */


### PR DESCRIPTION
## Summary

Fixes #65690

When `$tax_item["rate_id"]` is `null`, PHP 8.5 emits a deprecation notice:

```
PHP Deprecated: Using null as an array offset is deprecated, use an empty string instead
in html-order-items.php on line 56
```

This occurs because `wc_get_tax_class_by_tax_id()` receives `null`, which then gets passed to `$wpdb->prepare()` with a `%d` placeholder.

## Changes

- Use null coalescing operator (`?? 0`) on `$tax_item["rate_id"]` before passing to `wc_get_tax_class_by_tax_id()`

## Testing

1. Run PHP 8.5
2. View an order with tax items in admin
3. Verify no deprecation notice in error logs