### PR TITLE
Fix blurry footer logo in developer documentation

### DIFF
--- a/docs/_docu-tools/docusaurus.config.ts
+++ b/docs/_docu-tools/docusaurus.config.ts
@@ -123,6 +123,12 @@ const config: Config = {
 			],
 		},
 		footer: {
+			logo: {
+				alt: 'WooCommerce',
+				src: 'img/woo-dev-site-logo.svg',
+				srcDark: 'img/woo-dev-site-logo-dark.svg',
+				href: 'https://developer.woocommerce.com/',
+			},
 			links: [
 				{
 					title: 'COMMUNITY',

--- a/docs/_docu-tools/src/css/custom.css
+++ b/docs/_docu-tools/src/css/custom.css
@@ -55,6 +55,22 @@
   font-size: 12px;
 }
 
+/* Footer logo sizing — SVG renders crisp at any resolution */
+.footer__logo {
+  max-width: 160px;
+  height: auto;
+}
+
+/* Hide dark footer logo in light mode */
+html[data-theme='light'] .footer__logo--dark {
+  display: none;
+}
+
+/* Hide light footer logo in dark mode */
+html[data-theme='dark'] .footer__logo--light {
+  display: none;
+}
+
 
 .docusaurus-footer-for-automattic {
   padding-top: 10px;


### PR DESCRIPTION
## Summary

Fixes #65648

The footer of the WooCommerce developer documentation site (powered by Docusaurus) was missing a configured footer logo, resulting in either no logo or a blurry/pixelated fallback being displayed — especially noticeable on high-DPI (Retina) displays.

## Changes

- **`docs/_docu-tools/docusaurus.config.ts`**: Added `footer.logo` configuration pointing to the existing SVG logo assets (`woo-dev-site-logo.svg` for light mode, `woo-dev-site-logo-dark.svg` for dark mode). SVGs render crisply at any resolution.

- **`docs/_docu-tools/src/css/custom.css`**: Added CSS rules to:
  - Constrain the footer logo to a reasonable max-width (160px) with auto height
  - Properly toggle light/dark logo variants based on the active theme

## How to test

1. Navigate to the developer documentation site footer
2. Verify the WooCommerce logo appears crisp and clear in both light and dark modes
3. Verify the logo links to `https://developer.woocommerce.com/`
4. Test on a Retina/high-DPI display to confirm no blurriness

## Screenshots

The footer logo will now display using the same high-quality SVG assets already used in the navbar, ensuring visual consistency across the documentation site.