### PR TITLE
Prevent duplicate wc_product_start_scheduled_sale and wc_product_end_scheduled_sale actions

### DIFF
--- a/plugins/woocommerce/changelog/63517-fix-duplicate-scheduled-sale-events
+++ b/plugins/woocommerce/changelog/63517-fix-duplicate-scheduled-sale-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent duplicate wc_product_start_scheduled_sale and wc_product_end_scheduled_sale actions from piling up in Action Scheduler when concurrent processes schedule sale events for the same product.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -578,11 +578,30 @@ function wc_schedule_product_sale_events( WC_Product $product ): void {
 		}
 
 		$timestamp = $date->getTimestamp();
-		$args      = array( 'product_id' => $product_id );
+		if ( $timestamp <= time() ) {
+			return;
+		}
+
+		$args = array( 'product_id' => $product_id );
 
 		// An identical pending action means a concurrent process (parallel save, importer,
-		// daily cron) already scheduled it after the unschedule-all step ran.
-		if ( $timestamp > time() && as_next_scheduled_action( $hook, $args, 'woocommerce-sales' ) !== $timestamp ) {
+		// daily cron) already scheduled it after the unschedule-all step ran. The query
+		// filters by the exact timestamp: a pending action for a different time (e.g. left
+		// behind by a process that saw older sale dates) must not block scheduling.
+		$identical_pending = as_get_scheduled_actions(
+			array(
+				'hook'         => $hook,
+				'args'         => $args,
+				'group'        => 'woocommerce-sales',
+				'status'       => ActionScheduler_Store::STATUS_PENDING,
+				'date'         => gmdate( 'Y-m-d H:i:s', $timestamp ),
+				'date_compare' => '=',
+				'per_page'     => 1,
+			),
+			'ids'
+		);
+
+		if ( empty( $identical_pending ) ) {
 			as_schedule_single_action( $timestamp, $hook, $args, 'woocommerce-sales' );
 		}
 	};

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -561,38 +561,34 @@ function wc_get_formatted_variation( $variation, $flat = false, $include_names =
  * Uses Action Scheduler to fire events at the exact sale start/end times,
  * rather than relying on the daily cron.
  *
+ * An action is not scheduled if an identical one (same hook, args, group and
+ * timestamp) is already pending, so concurrent processes saving the same
+ * product don't pile up duplicate actions.
+ *
  * @since 10.5.0
  * @param WC_Product $product Product object.
  * @return void
  */
 function wc_schedule_product_sale_events( WC_Product $product ): void {
 	$product_id = $product->get_id();
-	$date_from  = $product->get_date_on_sale_from( 'edit' );
-	$date_to    = $product->get_date_on_sale_to( 'edit' );
 
-	if ( $date_from ) {
-		$start_ts = $date_from->getTimestamp();
-		if ( $start_ts > time() ) {
-			as_schedule_single_action(
-				$start_ts,
-				'wc_product_start_scheduled_sale',
-				array( 'product_id' => $product_id ),
-				'woocommerce-sales'
-			);
+	$schedule = function ( ?WC_DateTime $date, string $hook ) use ( $product_id ): void {
+		if ( is_null( $date ) ) {
+			return;
 		}
-	}
 
-	if ( $date_to ) {
-		$end_ts = $date_to->getTimestamp();
-		if ( $end_ts > time() ) {
-			as_schedule_single_action(
-				$end_ts,
-				'wc_product_end_scheduled_sale',
-				array( 'product_id' => $product_id ),
-				'woocommerce-sales'
-			);
+		$timestamp = $date->getTimestamp();
+		$args      = array( 'product_id' => $product_id );
+
+		// An identical pending action means a concurrent process (parallel save, importer,
+		// daily cron) already scheduled it after the unschedule-all step ran.
+		if ( $timestamp > time() && as_next_scheduled_action( $hook, $args, 'woocommerce-sales' ) !== $timestamp ) {
+			as_schedule_single_action( $timestamp, $hook, $args, 'woocommerce-sales' );
 		}
-	}
+	};
+
+	$schedule( $product->get_date_on_sale_from( 'edit' ), 'wc_product_start_scheduled_sale' );
+	$schedule( $product->get_date_on_sale_to( 'edit' ), 'wc_product_end_scheduled_sale' );
 }
 
 /**

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -411,6 +411,35 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox An identical pending sale event is not scheduled twice even when an earlier action is also pending.
+	 */
+	public function test_wc_schedule_product_sale_events_skips_identical_pending_action_behind_an_earlier_one() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_price( 100 );
+		$product->set_regular_price( 100 );
+		$product->set_sale_price( 50 );
+		$product->save();
+
+		$earlier_ts = time() + 3600;
+		$target_ts  = time() + 7200;
+
+		// Simulate a stale action left behind by a concurrent process that saw older sale dates.
+		as_schedule_single_action( $earlier_ts, 'wc_product_start_scheduled_sale', array( 'product_id' => $product->get_id() ), 'woocommerce-sales' );
+
+		// Not saved on purpose: saving would trigger the unschedule-all step and remove the stale action.
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', $target_ts ) );
+
+		wc_schedule_product_sale_events( $product );
+		wc_schedule_product_sale_events( $product );
+
+		$this->assertSame(
+			2,
+			$this->count_pending_sale_actions( 'wc_product_start_scheduled_sale', $product->get_id() ),
+			'The action at the new time should be scheduled exactly once alongside the stale earlier action'
+		);
+	}
+
+	/**
 	 * @testDox A sale event pending for a different time does not prevent scheduling at the new time.
 	 */
 	public function test_wc_schedule_product_sale_events_schedules_when_pending_action_has_different_timestamp() {

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -380,6 +380,83 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox Identical pending sale events are not scheduled twice when scheduling runs concurrently.
+	 */
+	public function test_wc_schedule_product_sale_events_skips_identical_pending_actions() {
+		$future_start = time() + 3600;
+		$future_end   = time() + 86400;
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_price( 100 );
+		$product->set_regular_price( 100 );
+		$product->set_sale_price( 50 );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', $future_start ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', $future_end ) );
+		$product->save();
+
+		// Simulate a concurrent process that already passed the unschedule-all step
+		// by invoking the scheduling function directly, without unscheduling first.
+		wc_schedule_product_sale_events( wc_get_product( $product->get_id() ) );
+
+		$this->assertSame(
+			1,
+			$this->count_pending_sale_actions( 'wc_product_start_scheduled_sale', $product->get_id() ),
+			'Only one start sale action should be pending after concurrent scheduling'
+		);
+		$this->assertSame(
+			1,
+			$this->count_pending_sale_actions( 'wc_product_end_scheduled_sale', $product->get_id() ),
+			'Only one end sale action should be pending after concurrent scheduling'
+		);
+	}
+
+	/**
+	 * @testDox A sale event pending for a different time does not prevent scheduling at the new time.
+	 */
+	public function test_wc_schedule_product_sale_events_schedules_when_pending_action_has_different_timestamp() {
+		$future_start = time() + 3600;
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_price( 100 );
+		$product->set_regular_price( 100 );
+		$product->set_sale_price( 50 );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', $future_start ) );
+		$product->save();
+
+		$product = wc_get_product( $product->get_id() );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', $future_start + 3600 ) );
+		wc_schedule_product_sale_events( $product );
+
+		$this->assertSame(
+			2,
+			$this->count_pending_sale_actions( 'wc_product_start_scheduled_sale', $product->get_id() ),
+			'A start sale action with a different timestamp should still be scheduled'
+		);
+	}
+
+	/**
+	 * Count pending Action Scheduler sale actions for a product.
+	 *
+	 * @param string $hook       Action hook name.
+	 * @param int    $product_id Product ID.
+	 * @return int
+	 */
+	private function count_pending_sale_actions( string $hook, int $product_id ): int {
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'args'     => array( 'product_id' => $product_id ),
+				'group'    => 'woocommerce-sales',
+				'status'   => \ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => -1,
+			),
+			'ids'
+		);
+
+		return count( $actions );
+	}
+
+	/**
 	 * @testDox Action Scheduler events are scheduled when sale date meta is written directly via update_post_meta.
 	 */
 	public function test_wc_schedule_product_sale_events_on_direct_meta_write() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`wc_maybe_schedule_product_sale_events()` uses a clear-first-then-schedule pattern: it cancels all pending `wc_product_start_scheduled_sale` / `wc_product_end_scheduled_sale` actions for the product and then schedules new ones. This sequence is not atomic, so two processes saving the same product concurrently (parallel REST updates, an importer running alongside an admin save, or the daily `wc_scheduled_sales()` cron overlapping with an Action Scheduler event) can both complete the unschedule phase and then both insert a new action, leaving duplicate pending actions in Action Scheduler that accumulate over time.

This pull request makes `wc_schedule_product_sale_events()` skip scheduling when an identical action (same hook, args, group and timestamp) is already pending. With this check in place, the only way to produce a duplicate is for both processes to pass the check before either inserts — a much narrower window — and a duplicate that slips through is harmless because the event handlers re-verify sale dates and prices at fire time.

Notes on the approach:

- Action Scheduler's `unique` flag on `as_schedule_single_action()` was considered and rejected: in Action Scheduler the uniqueness check covers hook + group only and ignores arguments, so `unique=true` would prevent scheduling sale events for *any* product while one is pending for *another* product.
- The comparison uses the exact timestamp, so a pending action for a *different* time (a concurrent process saw newer sale dates) does not block scheduling; stale actions are still cleaned up by the unschedule-all step and the handlers' fire-time verification.

Closes #63517.

### How to test the changes in this Pull Request:

1. On a site with this branch, create a simple product with a regular price, a sale price, and a "Sale start date" / "Sale end date" in the future, then save it.
2. Go to **WooCommerce → Status → Scheduled Actions** and filter by hook `wc_product_start_scheduled_sale`. Confirm there is exactly one pending action for the product.
3. Run `wp eval 'wc_schedule_product_sale_events( wc_get_product( <product_id> ) );'` (simulates a concurrent process that already passed the unschedule step).
4. Refresh the Scheduled Actions screen and confirm there is still exactly **one** pending `wc_product_start_scheduled_sale` and one `wc_product_end_scheduled_sale` action for the product (before this change, step 3 created duplicates).
5. Edit the product and change the sale start date to a different future time, then save. Confirm the pending actions are rescheduled to the new time and no duplicates exist.
6. Wait for the sale start time to pass (or set it 1–2 minutes ahead) and let Action Scheduler run. Confirm the sale price is applied to the product.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually in `plugins/woocommerce/changelog/63517-fix-duplicate-scheduled-sale-events`.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
