### PR TITLE
Fix order edit screen text color contrast for WCAG AA

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-admin-color-contrast
+++ b/plugins/woocommerce/changelog/fix-order-admin-color-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve text color contrast on the admin order edit screen so order data, line-item details, and column headers meet WCAG AA accessibility standards.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1921,7 +1921,7 @@ ul.wc_coupon_list_block {
 	}
 
 	p {
-		color: #777;
+		color: $gray-900;
 	}
 
 	p.order_number {
@@ -2005,7 +2005,7 @@ ul.wc_coupon_list_block {
 			small {
 				display: block;
 				margin: 5px 0 0;
-				color: #999;
+				color: $gray-900;
 			}
 		}
 
@@ -2048,7 +2048,7 @@ ul.wc_coupon_list_block {
 		}
 
 		p.none_set {
-			color: #999;
+			color: $gray-900;
 		}
 
 		div.edit_address {
@@ -2291,7 +2291,7 @@ ul.wc_coupon_list_block {
 	}
 
 	h3 small {
-		color: #999;
+		color: $gray-900;
 	}
 
 	.amount {
@@ -2359,7 +2359,7 @@ ul.wc_coupon_list_block {
 				text-align: left;
 				padding: 1em;
 				font-weight: normal;
-				color: #999;
+				color: $gray-900;
 				background: #f8f8f8;
 				-webkit-touch-callout: none;
 				-webkit-user-select: none;
@@ -2470,7 +2470,7 @@ ul.wc_coupon_list_block {
 					display: block;
 					margin-top: 0.5em;
 					font-size: 0.92em !important;
-					color: #888;
+					color: $gray-700;
 				}
 			}
 
@@ -2501,7 +2501,7 @@ ul.wc_coupon_list_block {
 
 				label {
 					white-space: nowrap;
-					color: #999;
+					color: $gray-700;
 					font-size: 0.833em;
 
 					input {
@@ -2588,7 +2588,7 @@ ul.wc_coupon_list_block {
 				.wc-order-item-discount,
 				.wc-order-item-refund-fields {
 					font-size: 0.92em !important;
-					color: #888;
+					color: $gray-700;
 				}
 
 				.wc-order-item-taxes,
@@ -2641,7 +2641,7 @@ ul.wc_coupon_list_block {
 			table.display_meta {
 				margin: 0.5em 0 0;
 				font-size: 0.92em !important;
-				color: #888;
+				color: $gray-700;
 
 				tr {
 					th {
@@ -2870,7 +2870,7 @@ ul.wc_coupon_list_block {
 	}
 
 	h3 small {
-		color: #999;
+		color: $gray-900;
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

On the admin order edit screen, several text elements used low-contrast greys (`#777` / `#888` / `#999`) that fell below the WCAG AA minimum of 4.5:1. This swaps them for the repo's existing WordPress gray tokens — `$gray-900` (`#1e1e1e`) for primary text and `$gray-700` (`#757575`) for secondary text — so every affected element clears AA.

**Accessibility — contrast before & after** (all on `#fff` except column headers on `#f8f8f8`):

| Element (what the user sees) | Selector | Before | After |
| --- | --- | --- | --- |
| Order data paragraph | `#order_data p` | `#777` — 4.48:1 ❌ | `$gray-900` — 16.67:1 ✅ |
| "No address set" message | `p.none_set` | `#999` — 2.85:1 ❌ | `$gray-900` — 16.67:1 ✅ |
| Line-item column headers | `thead th` | `#999` — 2.68:1 ❌ | `$gray-900` — 15.70:1 ✅ |
| Product SKU / variation | `.wc-order-item-sku`, `.wc-order-item-variation` | `#888` — 3.54:1 ❌ | `$gray-700` — 4.61:1 ✅ |
| Line-item field labels | `.cost label` etc. | `#999` — 2.85:1 ❌ | `$gray-700` — 4.61:1 ✅ |
| "× qty", struck prices, tax/discount/refund | `small.times`, `del`, … | `#888` — 3.54:1 ❌ | `$gray-700` — 4.61:1 ✅ |
| Item meta table | `table.meta`, `table.display_meta` | `#888` — 3.54:1 ❌ | `$gray-700` — 4.61:1 ✅ |

Two further selectors (`small`, `h3 small`) were updated for consistency; they have no matching markup on a stock order screen, so nothing visibly changes from them.

> **Note on color choice:** issue #60961 suggests `#3c434a` for the primary text. I used the repo's own primary-text token `$gray-900` (`#1e1e1e`) instead — already defined in this stylesheet and even higher contrast. Interactive **icon** contrast (WCAG 1.4.11) is intentionally out of scope, tracked in **DSGWOO-1378**. See my comment below re: the order-notes date text.

Closes #60961

### Screenshots or screen recordings:

### BEFORE
<img width="3600" height="2086" alt="Edit-order-17-‹-wc-color-contrast-—-WordPress-06-12-2026_03_27_PM" src="https://github.com/user-attachments/assets/bcf75f26-ab12-4383-8938-eca3a558b34a" />


### AFTER
<img width="3600" height="2086" alt="Edit-order-17-‹-wc-color-contrast-—-WordPress-06-12-2026_03_23_PM" src="https://github.com/user-attachments/assets/0f567871-1b9d-4fe6-8423-ce3839bd9481" />



### How to test the changes in this Pull Request:

1. On a store with WooCommerce active, go to **WooCommerce → Orders** and open any order (ideally one with multiple line items, product SKUs/variations, item meta, and a fee or shipping line).
2. Inspect the order-data column, the line-items table headers (Item / Cost / Qty / Total), product SKU/variation text, item meta, and the totals rows.
3. Confirm the text reads clearly and, with the [WAVE extension](https://wave.webaim.org/extension/) or the [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/), that each text element meets ≥ 4.5:1.
4. Compare against `trunk` to confirm the previously faint grey text is now legible.

### Testing that has already taken place:

- Verified the compiled `admin.css` reflects the token values (`#order_data p` → `#1e1e1e`).
- Confirmed each changed element's contrast ratio against its background (see table above).
- Audited the rest of the order screen; remaining low-contrast greys are non-text (icons/borders) or outside the order-edit meta boxes — tracked separately in **DSGWOO-1378**.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was added manually in the branch (`changelog/fix-order-admin-color-contrast`, significance `patch`, type `fix`), so neither auto-create box is checked.

- [ ] Automatically create a changelog entry from the details below.
