### PR TITLE
Fix horizontal overflow of the settings UI tab bar

### DIFF
--- a/plugins/woocommerce/changelog/fix-settings-ui-tabs-horizontal-overflow
+++ b/plugins/woocommerce/changelog/fix-settings-ui-tabs-horizontal-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix horizontal page overflow caused by the Settings UI tab bar including its padding outside the declared width.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -141,6 +141,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 
 	.wc-settings-ui-shell__tabs {
 		background: #fff;
+		box-sizing: border-box;
 		display: flex;
 		margin: 0 !important;
 		overflow-x: auto;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -341,7 +341,10 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 			padding-right: 24px;
 		}
 
-		.wc-settings-ui-shell {
+		// Match the base `.wc-settings-ui-shell.admin-ui-page` specificity so
+		// this breakpoint's full-bleed margin actually overrides the -48px
+		// base value instead of losing the cascade.
+		.wc-settings-ui-shell.admin-ui-page {
 			margin-left: -24px;
 			margin-right: -24px;
 		}
@@ -349,12 +352,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		.wc-settings-ui-shell .admin-ui-page__header {
 			padding-left: 24px;
 			padding-right: 24px;
-		}
-
-		.wc-settings-ui-shell__navigation {
-			margin-left: -24px;
-			margin-right: -24px;
-			width: calc(100% + 48px);
 		}
 
 		.wc-settings-ui-shell__tabs {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes a horizontal page overflow on Settings UI pages. `.wc-settings-ui-shell__tabs` sets `width: 100%` together with `padding: 0 48px`, but the nav element is `content-box`, so any settings UI page that renders a `sectionNavigation` tab bar ends up 96px wider than the viewport and shows a horizontal scrollbar with empty space on the right.

This is reproducible on the Products reference migration with the `settings-ui` feature flag enabled (e.g. at a 1200px viewport: `document.documentElement.scrollWidth` is 1296 vs `clientWidth` 1200), and equally affects extensions adopting the SDK.

The fix includes the padding in the declared width with `box-sizing: border-box`.

(For Bug Fixes) Bug introduced in PR #64387.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1200" height="800" alt="image-1781272840762" src="https://github.com/user-attachments/assets/ce99083c-6c84-41a7-9a12-c647159ea4f4" /> Horizontal scrollbar; `scrollWidth` 1296 @ 1200px viewport | <img width="1200" height="800" alt="image-1781272847897" src="https://github.com/user-attachments/assets/10164d25-bd9f-42cd-8d84-8724a00994b3" /> No scrollbar; `scrollWidth` 1200 @ 1200px viewport |

### How to test the changes in this Pull Request:

1. Enable the `settings-ui` feature flag (e.g. `add_filter( 'woocommerce_admin_features', fn( $f ) => array_merge( (array) $f, [ 'settings-ui' ] ) );`).
2. Go to WooCommerce > Settings > Products at a viewport around 1200px wide.
3. Without this change: the page shows a horizontal scrollbar, and in the browser console `document.documentElement.scrollWidth > document.documentElement.clientWidth` is `true`.
4. With this change: confirm there is no horizontal scrollbar and `document.documentElement.scrollWidth === document.documentElement.clientWidth`.
5. Confirm the section tab bar (General / Inventory / …) still renders edge-to-edge with its 48px side padding and the active-tab underline intact, including at narrow widths where the tabs scroll horizontally inside the bar (`overflow-x: auto`).

### Testing that has already taken place:

- Verified in the browser on WooCommerce 10.9.0-beta.1 with `settings-ui` enabled: both the Products settings page and an extension page rendering through the SDK show the 96px overflow before the change and no overflow after (measured via `document.documentElement.scrollWidth`/`clientWidth`, and `getComputedStyle` confirming `border-box` applies).
- `git diff --check`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry file is included manually in the PR (`plugins/woocommerce/changelog/fix-settings-ui-tabs-horizontal-overflow`).

</details>
