### PR TITLE
Add textarea field type to the additional checkout fields API

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -31,6 +31,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import clsx from 'clsx';
 import fastDeepEqual from 'fast-deep-equal/es6';
+import { TextareaControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -409,6 +410,29 @@ const Form = <
 							errorMessage={
 								fieldProps.errorMessage || undefined
 							}
+						/>
+					);
+				}
+
+				if ( field.type === 'textarea' ) {
+					return (
+						<TextareaControl
+							key={ field.key }
+							{ ...fieldProps }
+							label={ fieldProps.label || '' }
+							value={
+								decodeEntities(
+									values[ field.key as keyof T ] as string
+								) ?? ''
+							}
+							onChange={ ( newValue: string ) =>
+								onChange( {
+									...values,
+									[ field.key ]: newValue,
+								} )
+							}
+							rows={ 4 }
+							className={ clsx( 'wc-block-components-textarea', `wc-block-components-textarea-${ field.key }`.replaceAll( '/', '-' ) ) }
 						/>
 					);
 				}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -37,7 +37,7 @@ class CheckoutFields {
 	 *
 	 * @var array
 	 */
-	private $supported_field_types = [ 'text', 'select', 'checkbox' ];
+	private $supported_field_types = [ 'text', 'select', 'checkbox', 'textarea' ];
 
 	/**
 	 * Groups of fields to be saved.
@@ -157,7 +157,10 @@ class CheckoutFields {
 	 * @param array $field Field data.
 	 * @return mixed
 	 */
-	public function default_sanitize_callback( $value, $field ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public function default_sanitize_callback( $value, $field ) {
+		if ( 'textarea' === ( $field['type'] ?? 'text' ) ) {
+			return sanitize_textarea_field( $value );
+		}
 		return $value;
 	}
 
@@ -609,6 +612,11 @@ class CheckoutFields {
 			'autocomplete',
 			'autocapitalize',
 			'title',
+			'rows',
+			'cols',
+			'minLength',
+			'placeholder',
+			'spellcheck',
 		];
 
 		$valid_attributes = array_filter(

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -390,6 +390,11 @@ class CheckoutSchema extends AbstractSchema {
 				$field_schema['enum'][] = true;
 			}
 
+			if ( 'textarea' === $field['type'] ) {
+				if ( ! empty( $field['attributes']['maxLength'] ) ) {
+					$field_schema['maxLength'] = (int) $field['attributes']['maxLength'];
+				}
+			}
 			$schema[ $key ] = $field_schema;
 		}
 		return $schema;

--- a/plugins/woocommerce/tests/e2e-pw/test-plugins/blocks/additional-checkout-fields.php
+++ b/plugins/woocommerce/tests/e2e-pw/test-plugins/blocks/additional-checkout-fields.php
@@ -325,6 +325,20 @@ class Additional_Checkout_Fields_Test_Helper {
 				),
 			)
 		);
+
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'       => 'plugin-namespace/gift-message',
+				'label'    => 'Gift message',
+				'location' => 'order',
+				'type'     => 'textarea',
+				'required' => false,
+				'attributes' => array(
+					'rows'      => '4',
+					'maxLength' => '500',
+				),
+			)
+		);
 	}
 }
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -188,4 +188,46 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields );
 		$this->assertArrayNotHasKey( 'namespace/vat-number', $fields );
 	}
+
+	/**
+	 * Tests that a field with type 'textarea' can be successfully registered
+	 * using woocommerce_register_additional_checkout_field without errors.
+	 */
+	public function test_textarea_field_registers_successfully() {
+		woocommerce_register_additional_checkout_field( [
+			'id'       => 'test/textarea',
+			'label'    => 'Test textarea',
+			'location' => 'order',
+			'type'     => 'textarea',
+		] );
+		$fields = $this->controller->get_fields_for_location( 'order' );
+		$this->assertArrayHasKey( 'test/textarea', $fields );
+		$this->assertSame( 'textarea', $fields['test/textarea']['type'] );
+	}
+
+	/**
+	 * Tests that the default sanitization callback preserves newline characters for textarea fields
+	 */
+	public function test_textarea_sanitize_preserves_newlines() {
+		$field  = [ 'type' => 'textarea' ];
+		$value  = "line one\nline two";
+		$result = $this->controller->default_sanitize_callback( $value, $field );
+		$this->assertStringContainsString( "\n", $result );
+	}
+
+	/**
+	 * Tests that textarea-specific attributes (rows, maxLength) are accepted by the attribute allowlist.
+	 */
+	public function test_textarea_rows_attribute_allowed() {
+		woocommerce_register_additional_checkout_field( [
+			'id'         => 'test/textarea-attrs',
+			'label'      => 'Test',
+			'location'   => 'order',
+			'type'       => 'textarea',
+			'attributes' => [ 'rows' => '6', 'maxLength' => '200' ],
+		] );
+		$fields = $this->controller->get_fields_for_location( 'order' );
+		$this->assertArrayHasKey( 'test/textarea-attrs', $fields );
+		$this->assertSame( '6', $fields['test/textarea-attrs']['attributes']['rows'] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Adds support for a `textarea` field type in the additional checkout fields API, allowing developers to collect multi-line text input from customers at checkout.

Closes #63845 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->
<img width="877" height="403" alt="Screenshot 2026-06-12 at 6 24 28 PM" src="https://github.com/user-attachments/assets/0eb5a7cf-ea79-4c58-8b63-f2d2136f92de" />



### How to test the changes in this Pull Request:

1. Run `pnpm build` from `plugins/woocommerce/client/blocks`.

2. In a plugin or theme's `functions.php`, register a textarea field:
```php
woocommerce_register_additional_checkout_field(
    array(
        'id'         => 'myplugin/gift-message',
        'label'      => 'Gift message',
        'location'   => 'order',
        'type'       => 'textarea',
        'required'   => false,
        'attributes' => array(
            'rows'      => '4',
            'maxLength' => '500',
        ),
    )
);
```

3. Add a product to cart and go to `/checkout`. Verify a "Gift message" textarea is visible in the "Additional order information" section.

4. Type a multi-line message and place the order.

5. Go to **WooCommerce → Orders** and open the order. Verify the gift message is saved and newlines are preserved.

6. Verify that registering a field with `type` other than `textarea`, `text`, `select`, or `checkbox` still triggers a `_doing_it_wrong` notice.

7. Verify that omitting `type` still defaults to `text` and renders a text input as before — no regression.
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
