### PR TITLE
Coupon edit: apply 2-column grid sizing standard (720 / 24 / 320)

### DIFF
--- a/plugins/woocommerce/changelog/coupon-edit-new-column-sizing
+++ b/plugins/woocommerce/changelog/coupon-edit-new-column-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Apply the agreed 2-column sizing (720 / 24 / 320) to the Coupon edit and new screens.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3084,7 +3084,7 @@ ul.wc_coupon_list_block {
 		// stranded full-width.
 		// NOTE: this intentionally diverges from the Order screen recipe, which spans an
 		// (effectively empty) `#post-body-content` across both columns. Coupons put real
-		// content there, so spanning would push the Coupon data panel below it look wrong.
+		// content there, so spanning would push the Coupon data panel below it, which looks wrong.
 		#post-body-content {
 			grid-column: 1;
 			grid-row: 1;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3043,6 +3043,121 @@ ul.wc_coupon_list_block {
 	}
 }
 
+.post-type-shop_coupon {
+	// Apply the agreed team-wide 2-column grid sizing standard to the Coupon edit/new screens.
+	// Sibling retrofit to the Order screen standard (DSGWOO-1375); coupons are a classic-editor
+	// CPT, so the same metabox-grid recipe applies, scoped to the single `.post-type-shop_coupon`
+	// body class (no HPOS equivalent). `:has(#poststuff)` excludes the coupons list screen.
+	// Total width is derived (not hardcoded) from the two column tokens plus the gap token:
+	// surface-width-xl (720) + padding-2xl (24) + surface-width-sm (320) = 1064px.
+	.wrap:has(#poststuff) {
+		// Cap .wrap to the derived grid width and center it on the page. This also
+		// keeps the "Edit coupon" / "Add new coupon" page-title row aligned with the grid below.
+		max-width: calc(
+			var(--wpds-dimension-surface-width-xl, 720px)
+			+ var(--wpds-dimension-padding-2xl, 24px)
+			+ var(--wpds-dimension-surface-width-sm, 320px)
+		);
+		margin-inline: auto;
+
+		#post-body.columns-2 {
+			display: grid;
+			grid-template-columns:
+				minmax(0, var(--wpds-dimension-surface-width-xl, 720px))
+				var(--wpds-dimension-surface-width-sm, 320px);
+			gap: var(--wpds-dimension-padding-2xl, 24px);
+			// Top-align items so the spanned Publish box (below) doesn't stretch and
+			// so an uneven column doesn't open a gap between the stacked primary items.
+			align-items: start;
+			float: none;
+			// WP core's edit.css sets `margin-right: 300px` on `#post-body.columns-2`
+			// to reserve space for the side-sortable floating in. Zero it out so the
+			// grid uses the full width of #poststuff.
+			margin: 0;
+		}
+
+		// `#post-body-content` holds the coupon code field and the description textarea
+		// (rendered via `edit_form_after_title`); it's a sibling of the postbox containers.
+		// Place it at the TOP of the 720px primary column (row 1), with the Coupon data
+		// panel directly below it (row 2). This preserves the default screen's reading
+		// order (code → description → data) and keeps the description at 720px rather than
+		// stranded full-width.
+		// NOTE: this intentionally diverges from the Order screen recipe, which spans an
+		// (effectively empty) `#post-body-content` across both columns. Coupons put real
+		// content there, so spanning would push the Coupon data panel below it look wrong.
+		#post-body-content {
+			grid-column: 1;
+			grid-row: 1;
+		}
+
+		#postbox-container-1,
+		#postbox-container-2 {
+			float: none;
+			width: auto;
+			min-width: 0;
+			// WP core's edit.css sets `margin: 0 300px 0 0` on container-2 (and a
+			// negative margin-left on container-1) to reserve space for the old
+			// float-based sidebar. Zero them out so the grid controls width.
+			margin: 0;
+		}
+
+		// WP core's edit.css also pins `#side-sortables` to width: 280px (legacy
+		// float layout). Let it fill its 320px grid cell instead. Targeting
+		// `#post-body.columns-2 #side-sortables` matches WP core's selector specificity
+		// and the extra parent classes from the `.wrap:has(#poststuff)` chain put us over.
+		#post-body.columns-2 #side-sortables {
+			width: auto;
+		}
+
+		// Main "Coupon data" metabox: 720px primary column, directly below the
+		// code/description strip.
+		#postbox-container-2 {
+			grid-column: 1;
+			grid-row: 2;
+		}
+
+		// Sidebar "Publish" box: 320px secondary column. Span both rows so the Publish
+		// box height doesn't dictate row 1's height and open a gap between the
+		// description (row 1) and the Coupon data panel (row 2) in the primary column.
+		// `align-items: start` (on the grid above) keeps it top-aligned within the span.
+		#postbox-container-1 {
+			grid-column: 2;
+			grid-row: 1 / span 2;
+		}
+
+		// Stack to a single column on narrow viewports. Target is wrap < 960px
+		// (--wpds-dimension-surface-width-2xl). At expanded WP admin sidebar (~180px chrome),
+		// that maps to viewport ~1140px.
+		// TODO: switch to `@container (max-width: 960px)` once grunt-contrib-cssmin is
+		// upgraded (current clean-css 4.x strips @container rules).
+		@media (max-width: 1140px) {
+			#post-body.columns-2 {
+				grid-template-columns: 1fr;
+			}
+
+			// Single column. Stack with the SIDEBAR (Publish) on top, then the
+			// code/description, then the Coupon data panel — opposite of the design
+			// system "primary above secondary" rule. Reason: the primary "Publish"/"Update"
+			// CTA lives in the Publish metabox in the sidebar, so flipping the stack would
+			// hide it under the full coupon-data panel. Mirrors the Order screen decision.
+			#postbox-container-1 {
+				grid-column: 1;
+				grid-row: 1;
+			}
+
+			#post-body-content {
+				grid-column: 1;
+				grid-row: 2;
+			}
+
+			#postbox-container-2 {
+				grid-column: 1;
+				grid-row: 3;
+			}
+		}
+	}
+}
+
 .woocommerce_page_wc-orders,
 .post-type-shop_order {
 	// Gated behind the `order-detail-redesign` feature flag (body class added by OrderDetailRedesign\Init).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Applies the agreed team-wide [2-column grid sizing standard](https://www.figma.com/design/gXdQoz5sdk2CrUqq0UkaLp/2-column-grid-standarization?node-id=65-2) to the **Coupon edit** and **Add new coupon** screens. Sibling retrofit to the Order screen (#65699); coupons are a classic-editor custom post type, so the same metabox-grid recipe applies, scoped to the `.post-type-shop_coupon` body class.

**Sizing (all WPDS tokens, no hardcoded values):**

- Primary column: \`--wpds-dimension-surface-width-xl\` (720px)
- Secondary column: \`--wpds-dimension-surface-width-sm\` (320px)
- Gap: \`--wpds-dimension-padding-2xl\` (24px)
- Page width: derived (720 + 24 + 320 = 1064px), applied via \`calc()\` on \`.wrap:has(#poststuff)\` and centered, so the page-title row aligns with the grid below.

**Notes for reviewers:**

- **Not behind a feature flag.** Like the Order retrofit (#65699), this is the agreed team-wide standard, not an experiment, so it ships unconditionally. (The adjacent order block in this file is still flag-gated only because #65699 hasn't merged yet.)
- **Intentional divergence from #65699.** The Order recipe spans \`#post-body-content\` full-width across both columns because that strip is effectively empty there. On coupons that strip holds real content (the coupon code field and the description box), so here it is placed at the **top of the 720px primary column** with the **Coupon data** panel directly below it. Spanning it full-width pushed the Coupon data panel underneath and looked wrong.
- **\`@media\` instead of \`@container\`.** Same constraint as #65699: the legacy admin CSS pipeline (\`grunt-contrib-cssmin\` / clean-css 4.x) strips \`@container\` at-rules, so a \`@media (max-width: 1140px)\` fallback is used, with a TODO to revisit once cssmin is upgraded.
- **Stacked order: sidebar on top.** When stacked on narrow viewports, the Publish box sits above the coupon content so the primary Publish/Update CTA stays reachable — mirrors the Order screen decision.
- **No HPOS path.** Coupons are always a CPT, so unlike #65699 there is a single \`.post-type-shop_coupon\` selector and no dual-path concern.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

| Before | After |
| ------ | ----- |
| _Default WP metabox layout: full-width coupon content, ~280px floated Publish sidebar._ | _Coupon code + description + Coupon data stacked in a 720px primary column, 320px Publish secondary, 24px gap, derived 1064px page width, centered._ |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to **Marketing → Coupons** and open an existing coupon (or **Add new coupon**).
2. Verify the layout: the primary column (coupon code, description, then the **Coupon data** panel) is **720px** wide on the **left**; the **Publish** box is **320px** on the **right**; the gap is **24px**; the whole layout is **centered** with the page title aligned to the grid.
3. Verify the reading order top-to-bottom in the left column: coupon code field, description, then Coupon data panel.
4. Repeat on the **Add new coupon** screen — same sizing should apply.
5. Resize the browser narrow (below ~1140px viewport): the columns should **stack with the Publish box on top**, then code/description, then Coupon data.
6. RTL eyeball: with an RTL locale, the primary column flips to the right and the secondary to the left (CSS Grid handles this automatically).

<!-- End testing instructions -->

### Testing that has already taken place:

- Manually verified on Studio (classic CPT editor) at desktop (~1900px) and narrow viewports, on both the **Edit coupon** and **Add new coupon** screens.
- Verified the compiled \`admin.css\` to confirm the \`@container\` strip and \`@media\` survival through the cssmin pipeline, and that RTL (\`admin-rtl.css\`) regenerates with the rule.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually in this PR (\`plugins/woocommerce/changelog/coupon-edit-new-column-sizing\`).

</details>

### Release Communication

<!-- release-communication-section -->

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)