### PR TITLE
Reject duplicate line_item_id entries in v4 refunds endpoints

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-6830-duplicate-refund-line-items
+++ b/plugins/woocommerce/changelog/fix-wooplug-6830-duplicate-refund-line-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reject duplicate line_item_id entries in v4 refunds create and preview validation, which previously passed per-line caps individually and produced inflated preview totals that the create endpoint could not reproduce.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -179,12 +179,24 @@ class DataUtils {
 	 * @return boolean|WP_Error
 	 */
 	public function validate_line_items( $line_items, WC_Order $order ) {
+		$seen_line_item_ids = array();
+
 		foreach ( $line_items as $line_item ) {
 			$line_item_id = $line_item['line_item_id'] ?? null;
 
 			if ( ! $line_item_id ) {
 				return new WP_Error( 'invalid_line_item', __( 'Line item ID is required.', 'woocommerce' ) );
 			}
+
+			// Reject duplicate entries: quantities and totals are validated per
+			// entry against the order, so duplicates of the same line item would
+			// each pass individually while their sum exceeds the line's
+			// refundable amount.
+			if ( isset( $seen_line_item_ids[ $line_item_id ] ) ) {
+				/* translators: %d: order line item ID */
+				return new WP_Error( 'duplicate_line_item', sprintf( __( 'Line item %d is included more than once. Each line item can only appear once per refund.', 'woocommerce' ), $line_item_id ) );
+			}
+			$seen_line_item_ids[ $line_item_id ] = true;
 
 			$item = $order->get_item( $line_item_id );
 
@@ -525,6 +537,8 @@ class DataUtils {
 
 		$refund_data = $this->compute_refunded_quantities_and_totals( $order );
 
+		$seen_line_item_ids = array();
+
 		foreach ( $line_items as $line_item ) {
 			$line_item_id = $line_item['line_item_id'] ?? null;
 			if ( ! $line_item_id ) {
@@ -534,6 +548,23 @@ class DataUtils {
 					array( 'status' => WP_Http::BAD_REQUEST )
 				);
 			}
+
+			// Reject duplicate entries: caps below are checked per entry against
+			// prior refunds only, so duplicates of the same line item would each
+			// pass individually while build_refund_preview() sums them all,
+			// inflating the preview totals.
+			if ( isset( $seen_line_item_ids[ $line_item_id ] ) ) {
+				return new WP_Error(
+					'duplicate_line_item',
+					sprintf(
+						/* translators: %d: order line item ID */
+						__( 'Line item %d is included more than once. Each line item can only appear once per refund.', 'woocommerce' ),
+						$line_item_id
+					),
+					array( 'status' => WP_Http::BAD_REQUEST )
+				);
+			}
+			$seen_line_item_ids[ $line_item_id ] = true;
 
 			$item = $order->get_item( $line_item_id );
 			if ( ! $item || $item->get_order_id() !== $order->get_id() ) {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
@@ -469,6 +469,58 @@ class WC_REST_Refunds_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test refund creation rejects duplicate line_item_id entries.
+	 *
+	 * Each duplicate entry passes the per-line caps on its own, but duplicates
+	 * are summed by calculate_refund_amount() while collapsed last-wins by
+	 * convert_line_items_to_internal_format(), so the refund amount and the
+	 * stored refund lines would disagree.
+	 */
+	public function test_refunds_create_with_duplicate_line_items_returns_400(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$order   = $this->create_test_order(
+			array(
+				'line_items' => array(
+					array(
+						'product_id' => $product->get_id(),
+						'quantity'   => 2,
+					),
+				),
+			)
+		);
+
+		$line_items = $order->get_items();
+		$line_item  = reset( $line_items );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v4/refunds' );
+		$request->set_body_params(
+			array(
+				'order_id'   => $order->get_id(),
+				'line_items' => array(
+					array(
+						'line_item_id' => $line_item->get_id(),
+						'quantity'     => 1,
+						'refund_total' => 5.00,
+					),
+					array(
+						'line_item_id' => $line_item->get_id(),
+						'quantity'     => 1,
+						'refund_total' => 5.00,
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$response_data = $response->get_data();
+		$this->assertEquals( 'duplicate_line_item', $response_data['code'] );
+		$this->assertCount( 0, $order->get_refunds(), 'No refund should be created for duplicate line items' );
+
+		$product->delete( true );
+	}
+
+	/**
 	 * Test refund creation with automatic tax extraction (multiple non-compound rates).
 	 */
 	public function test_refunds_create_with_automatic_tax_extraction(): void {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-preview-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-preview-tests.php
@@ -298,6 +298,36 @@ class WC_REST_Refunds_V4_Preview_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Preview with duplicate line_item_id entries returns 400 duplicate_line_item.
+	 *
+	 * Each duplicate entry passes the per-line caps on its own (quantity 1 of 2)
+	 * and the doubled sum stays under max_refundable, so without the duplicate
+	 * guard the preview would return 200 with inflated totals.
+	 */
+	public function test_preview_duplicate_line_items_returns_400(): void {
+		$order   = $this->create_order_with_product( 25.00, 2 );
+		$item_id = $this->get_first_line_item_id( $order );
+
+		$response = $this->do_preview_request(
+			$order->get_id(),
+			array(
+				array(
+					'line_item_id' => $item_id,
+					'quantity'     => 1,
+				),
+				array(
+					'line_item_id' => $item_id,
+					'quantity'     => 1,
+				),
+			)
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'duplicate_line_item', $data['code'] );
+	}
+
+	/**
 	 * @testdox P8: Preview with invalid line item ID returns line_item_not_found.
 	 */
 	public function test_preview_invalid_line_item(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Refunds/DataUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Refunds/DataUtilsTest.php
@@ -419,6 +419,100 @@ class DataUtilsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should return error when preview line items contain duplicate line item IDs.
+	 */
+	public function test_validate_preview_line_items_rejects_duplicate_line_item_ids(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 25.00 );
+		$product->save();
+
+		$order = wc_create_order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 2,
+				'subtotal' => 50.00,
+				'total'    => 50.00,
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+		$order->set_total( 50.00 );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		// Each entry passes the per-line cap on its own (quantity 1 of 2).
+		$result = $this->data_utils->validate_preview_line_items(
+			array(
+				array(
+					'line_item_id' => $item->get_id(),
+					'quantity'     => 1,
+				),
+				array(
+					'line_item_id' => $item->get_id(),
+					'quantity'     => 1,
+				),
+			),
+			$order
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'duplicate_line_item', $result->get_error_code() );
+
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * @testdox Should return error when refund line items contain duplicate line item IDs.
+	 */
+	public function test_validate_line_items_rejects_duplicate_line_item_ids(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 25.00 );
+		$product->save();
+
+		$order = wc_create_order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 2,
+				'subtotal' => 50.00,
+				'total'    => 50.00,
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+		$order->set_total( 50.00 );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		// Each entry passes the per-line caps on its own (quantity 1 of 2, total 25 of 50).
+		$result = $this->data_utils->validate_line_items(
+			array(
+				array(
+					'line_item_id' => $item->get_id(),
+					'quantity'     => 1,
+					'refund_total' => 25.00,
+				),
+				array(
+					'line_item_id' => $item->get_id(),
+					'quantity'     => 1,
+					'refund_total' => 25.00,
+				),
+			),
+			$order
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'duplicate_line_item', $result->get_error_code() );
+
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
 	 * @testdox Should return error when order is not refundable.
 	 */
 	public function test_validate_preview_line_items_order_not_refundable(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The v4 refunds validators checked every `line_items` entry in isolation, so a payload repeating the same `line_item_id` passed all per-line caps while the totals were summed across entries. On the preview endpoint this returned HTTP 200 with inflated totals. On the create endpoint the same payload produced a refund amount summed across duplicates while the stored refund lines collapsed last-wins, so the amount and the lines disagreed.

This PR rejects duplicate `line_item_id` entries in both `validate_preview_line_items()` and `validate_line_items()` with a `duplicate_line_item` error (HTTP 400), and adds unit and endpoint tests for both paths.

Closes #65680.

(For Bug Fixes) Bug introduced in PR #65335.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the `rest-api-v4` experimental feature (WooCommerce > Settings > Advanced > Features, or via the `woocommerce_admin_features` filter).
2. Create an order with one product line of quantity 2 and set the order status to completed. Note the order line item ID.
3. Send `POST /wp-json/wc/v4/refunds/preview` as an admin with body `{"order_id": <order_id>, "line_items": [{"line_item_id": <item_id>, "quantity": 1}, {"line_item_id": <item_id>, "quantity": 1}]}`.
4. Verify the response is HTTP 400 with code `duplicate_line_item`. Without this fix the request returns HTTP 200 with doubled totals.
5. Send `POST /wp-json/wc/v4/refunds` with the same duplicated `line_items` (adding `"refund_total": 5` to each entry) and verify it also returns HTTP 400 with code `duplicate_line_item`, and that no refund is created on the order.
6. Verify a request with a single entry, or with entries for distinct line items, still previews and refunds successfully.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- `DataUtilsTest` (42 tests), `WC_REST_Refunds_V4_Preview_Tests` (29 tests), and `WC_REST_Refunds_V4_Controller_Tests` (16 tests) pass in wp-env, including 4 new tests covering duplicate rejection on both endpoints.
- `lint:php:changes`, `lint:changes:branch`, and PHPStan on the modified file are clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>