### PR TITLE
Don't show color swatches in the editor if they are disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-swatches-in-editor-only-if-enabled
+++ b/plugins/woocommerce/changelog/fix-swatches-in-editor-only-if-enabled
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Don't show color swatches in the editor if they are disabled
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -35,6 +35,7 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -102,6 +103,10 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 			__experimental_visual: true,
 		},
 	} );
+	const visualAttributesEnabled = getSetting(
+		'experimentalVisualAttributes',
+		false
+	);
 	const visualByTermId = useMemo( () => {
 		return attributeTerms.reduce< Record< number, VisualAttributeTerm > >(
 			( accumulator, term ) => {
@@ -128,7 +133,10 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 		) {
 			items = attribute.terms.map( ( term ) => {
 				const visual =
-					visualByTermId[ term.id ] || EMPTY_TERM_VISUALS[ term.id ];
+					visualByTermId[ term.id ] ||
+					( visualAttributesEnabled
+						? EMPTY_TERM_VISUALS[ term.id ]
+						: undefined );
 
 				return {
 					id: `${ attribute.taxonomy }-${ term.slug }`,
@@ -150,7 +158,7 @@ function AttributeItem( { blocks, isSelected, onSelect }: AttributeItemProps ) {
 			ariaLabel: string;
 			visual?: VisualAttributeTerm;
 		} >;
-	}, [ attribute, visualByTermId ] );
+	}, [ attribute, visualAttributesEnabled, visualByTermId ] );
 
 	const blockPreviewProps = useBlockPreview( {
 		blocks,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -67,6 +67,10 @@
 	&:hover {
 		background: transparent;
 	}
+
+	:where(.wc-block-product-filter-chips__label) {
+		text-decoration: line-through;
+	}
 }
 
 :where(.wc-block-product-filter-chips__label) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -23,6 +23,25 @@ class VariationSelectorAttribute extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options-variation-selector-attribute';
 
 	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 * @return void
+	 */
+	protected function enqueue_data( array $attributes = array() ): void {
+		parent::enqueue_data( $attributes );
+
+		if ( is_admin() ) {
+			$this->asset_data_registry->add(
+				'experimentalVisualAttributes',
+				array_key_exists( 'wc-visual', wc_get_attribute_types() )
+			);
+		}
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a couple of regressions related to the color swatches feature:

- Made it so color swatches only show up if the feature is actually enabled.
- Added back line-through to disabled chips.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Patterns > Add to Cart + Options > Variable...
2. Verify the color swatches only show up if you have the feature enabled in WooCommerce > Features (you must also be in a block theme). (Update: you will also need to remove all `wc-visual` attributes in your store to actually disable the attribute type)

Feature disabled | Feature enabled
--- | ---
<img width="1015" height="725" alt="imatge" src="https://github.com/user-attachments/assets/9035be5d-d6db-4b5a-bbd5-ac0f6b42bcdb" /> | <img width="1015" height="725" alt="imatge" src="https://github.com/user-attachments/assets/3c2a5947-e01e-4395-847b-a4081ead6f63" />

3. Go to the frontend and select some options so at least one of them is disabled.
4. Verify the disabled options have a line-through.

Before | After
--- | ---
<img width="935" height="547" alt="imatge" src="https://github.com/user-attachments/assets/3d79f4a7-347b-4211-af60-10acbbd809dc" /> | <img width="935" height="547" alt="imatge" src="https://github.com/user-attachments/assets/8a866f6d-3107-4c69-9e99-b8277684018e" />