### PR TITLE
Fix: remove lateral padding from cart line items table and align header labels

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart-line-items-table-spacing
+++ b/plugins/woocommerce/changelog/fix-cart-line-items-table-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: remove lateral padding from cart line items table and align header labels

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
@@ -92,11 +92,8 @@ const CartLineItemsTable = ( {
 			</caption>
 			<thead>
 				<tr className="wc-block-cart-items__header">
-					<th className="wc-block-cart-items__header-image">
+					<th className="wc-block-cart-items__header-image" colSpan={ 2 }>
 						<span>{ __( 'Product', 'woocommerce' ) }</span>
-					</th>
-					<th className="wc-block-cart-items__header-product">
-						<span>{ __( 'Details', 'woocommerce' ) }</span>
 					</th>
 					<th className="wc-block-cart-items__header-total">
 						<span>{ __( 'Total', 'woocommerce' ) }</span>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -16,12 +16,6 @@ table.wc-block-cart-items {
 		@include font-small-locked;
 		text-transform: uppercase;
 
-		.wc-block-cart-items__header-image {
-			width: 80px;
-		}
-		.wc-block-cart-items__header-product {
-			visibility: hidden;
-		}
 		.wc-block-cart-items__header-total {
 			width: 100px;
 			text-align: right;
@@ -36,6 +30,9 @@ table.wc-block-cart-items {
 			flex-direction: column;
 			align-items: flex-start;
 			gap: $gap-smallest;
+		}
+		.wc-block-cart-item__image {
+			width: 80px;
 		}
 		.wc-block-cart-item__image img {
 			width: 100%;
@@ -160,12 +157,12 @@ table.wc-block-cart-items {
 		.wc-block-cart-items__row {
 			display: grid;
 			grid-template-columns: 80px 132px;
+			column-gap: $gap;
 			padding: $gap 0;
 
 			.wc-block-cart-item__image {
 				grid-column-start: 1;
 				grid-row-start: 1;
-				padding-right: $gap;
 			}
 			.wc-block-cart-item__product {
 				grid-column-start: 2;
@@ -216,16 +213,23 @@ table.wc-block-cart-items {
 			th {
 				padding: $gap-smaller $gap $gap-small 0;
 				white-space: nowrap;
+				text-align: left;
+			}
+			th:first-child {
+				padding-left: 0;
+			}
+			th:last-child {
+				padding-right: 0;
+			}
+			.wc-block-cart-items__header-image {
+				padding-left: 0;
 			}
 			td {
 				border-top: 1px solid $universal-border-light;
-				padding: $gap * 1.25 0 $gap * 1.25 $gap;
+				padding: $gap * 1.25 0;
 				vertical-align: top;
 			}
-			th:last-child {
-				padding-right: $gap;
-			}
-			td:last-child {
+			.wc-block-cart-item__image {
 				padding-right: $gap;
 			}
 		}


### PR DESCRIPTION
## Changes proposed in this Pull Request

The block cart line items table had unnecessary left and right padding on the table edges, and the "PRODUCT" header label was misaligned with the table's left edge.

This PR removes the lateral padding so content sits flush with the table boundaries, preserving only the gap between the product thumbnail and product info. The "PRODUCT" header is now aligned with the left edge of the table — this required consolidating the header from three cells to two (removing the hidden "Details" cell) and adding `text-align: left` to override the browser's default centering on `<th>` elements.

## Backward compatibility

The `.wc-block-cart-items__header-product` element has been removed from the markup. Stores targeting that class in custom CSS will be affected.

## Screenshots

Before:
<img width="1378" height="868" alt="image" src="https://github.com/user-attachments/assets/d7ede537-9549-46b1-b3da-322ddd0f4491" />


After: 
<img width="1395" height="868" alt="image" src="https://github.com/user-attachments/assets/d168359d-4c85-41cd-8bed-c0a6ab920394" />
