### PR TITLE
Fix incorrect "orders out of sync" warning on always-HPOS sites

### DIFF
--- a/plugins/woocommerce/changelog/fix-65735-hpos-false-out-of-sync-warning
+++ b/plugins/woocommerce/changelog/fix-65735-hpos-false-out-of-sync-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect "orders are out of sync" warning shown on WooCommerce > Settings > Advanced > Features for sites that have always used HPOS and never enabled compatibility mode.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -745,7 +745,7 @@ class CustomOrdersTableController {
 						__( 'Stop sync', 'woocommerce' )
 					);
 				}
-			} elseif ( $sync_is_pending ) {
+			} elseif ( ( $sync_enabled || ! $this->data_synchronizer->custom_orders_table_is_authoritative() ) && $sync_is_pending ) {
 				$sync_now_url = wp_nonce_url(
 					add_query_arg(
 						array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Fixes the "There are currently orders out of sync" warning incorrectly showing in **WooCommerce > Settings > Advanced > Features** on sites that have always used HPOS as the authoritative order storage and have never enabled compatibility mode (order data sync).


### Root cause

`DataSynchronizer::query_orders_pending_sync_count()` counts these placeholder posts as "missing orders" via its `RIGHT JOIN` check, so `has_orders_pending_sync()` permanently returns `true` on such sites.

In `CustomOrdersTableController::get_hpos_setting_for_sync()`, the `$get_sync_message` showed the "out of sync" / "Sync orders now" message whenever `$sync_is_pending` was `true`, with no check on whether sync was actually enabled or relevant. Since `$sync_is_pending` is always `true` on these sites, the warning always appeared.

Closes #65735  .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:
Before and After:
<img width="879" height="116" alt="Screenshot 2026-06-15 at 4 13 59 PM" src="https://github.com/user-attachments/assets/72ecec44-d272-49aa-886b-552b998634db" />
<img width="964" height="99" alt="Screenshot 2026-06-15 at 4 15 28 PM" src="https://github.com/user-attachments/assets/08fbc7cb-7eed-49dd-a4b9-117b484723ba" />

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a fresh WooCommerce install.
2. Enable HPOS from the start (`Order data storage` = High-performance,`Enable compatibility mode` = unchecked).
3. Create a couple of orders.
4. Go to **WooCommerce > Settings > Advanced > Features**.
5. Observe **"There are currently orders out of sync"** under the "Enable compatibility mode" checkbox, despite the site never having used legacy storage.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
