### PR TITLE
Fix uploads directory Site Health loopback failures

### DIFF
--- a/plugins/woocommerce/changelog/65723-fix-site-health-upload-loopback
+++ b/plugins/woocommerce/changelog/65723-fix-site-health-upload-loopback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid a critical Site Health warning when WooCommerce cannot verify uploads directory protection.

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -97,6 +97,13 @@ class SiteHealth {
 		}
 
 		$data        = $is_good ? $test['good'] : $test['fail'];
+		$label       = is_callable( $data['label'] )
+			? ( $data['label'] )( $context )
+			: $data['label'];
+		$status      = $is_good ? 'good' : ( $data['status'] ?? 'recommended' );
+		$status      = is_callable( $status )
+			? $status( $context )
+			: $status;
 		$description = is_callable( $data['description'] )
 			? ( $data['description'] )( $context )
 			: $data['description'];
@@ -110,8 +117,8 @@ class SiteHealth {
 		}
 
 		return array(
-			'label'       => $data['label'],
-			'status'      => $is_good ? 'good' : ( $data['status'] ?? 'recommended' ),
+			'label'       => $label,
+			'status'      => $status,
 			'badge'       => array(
 				'label' => 'security' === $test['badge'] ? __( 'Security', 'woocommerce' ) : __( 'Performance', 'woocommerce' ),
 				'color' => 'blue',
@@ -131,6 +138,7 @@ class SiteHealth {
 	 *   - check: callable returning bool (true = good) or array (empty = good, otherwise context for description/actions).
 	 *   - good: result data when the check passes (label, description).
 	 *   - fail: result data when the check fails (status defaults to 'recommended', label, description, optional actions).
+	 *     Label, status, and description may be callables that receive the check context.
 	 *
 	 * @return array<string, array>
 	 */
@@ -166,9 +174,13 @@ class SiteHealth {
 					'description' => __( 'The directory used for downloadable product files is not browsable from the web.', 'woocommerce' ),
 				),
 				'fail'  => array(
-					'status'      => 'critical',
-					'label'       => __( 'WooCommerce uploads directory is browsable from the web', 'woocommerce' ),
-					'description' => __( 'Directory browsing can expose downloadable product files. Configure your web server to prevent directory indexing for the WooCommerce uploads directory.', 'woocommerce' ),
+					'status'      => fn( ?array $context ) => ! empty( $context['unverified'] ) ? 'recommended' : 'critical',
+					'label'       => fn( ?array $context ) => ! empty( $context['unverified'] )
+						? __( 'WooCommerce could not verify uploads directory protection', 'woocommerce' )
+						: __( 'WooCommerce uploads directory is browsable from the web', 'woocommerce' ),
+					'description' => fn( ?array $context ) => ! empty( $context['unverified'] )
+						? __( 'A loopback request to the WooCommerce uploads directory failed, so WooCommerce could not confirm whether directory browsing is disabled. Check your server configuration or try again later.', 'woocommerce' )
+						: __( 'Directory browsing can expose downloadable product files. Configure your web server to prevent directory indexing for the WooCommerce uploads directory.', 'woocommerce' ),
 					'actions'     => array(
 						array(
 							'url'     => 'https://woocommerce.com/document/digital-downloadable-product-handling/#protecting-your-uploads-directory',
@@ -501,13 +513,17 @@ class SiteHealth {
 	/**
 	 * Check if the WooCommerce uploads directory is protected from directory browsing.
 	 *
-	 * @return bool
+	 * @return bool|array{unverified: true}
 	 */
 	private function is_uploads_directory_protected() {
 		$cache_key = '_woocommerce_upload_directory_status';
 		$status    = get_transient( $cache_key );
 
 		if ( false !== $status ) {
+			if ( 'unverified' === $status ) {
+				return array( 'unverified' => true );
+			}
+
 			return 'protected' === $status;
 		}
 
@@ -520,13 +536,15 @@ class SiteHealth {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return false;
+			set_transient( $cache_key, 'unverified', DAY_IN_SECONDS );
+			return array( 'unverified' => true );
 		}
 
 		$response_code = intval( wp_remote_retrieve_response_code( $response ) );
 
 		if ( 0 === $response_code ) {
-			return false;
+			set_transient( $cache_key, 'unverified', DAY_IN_SECONDS );
+			return array( 'unverified' => true );
 		}
 
 		$response_content = wp_remote_retrieve_body( $response );

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -174,13 +174,19 @@ class SiteHealth {
 					'description' => __( 'The directory used for downloadable product files is not browsable from the web.', 'woocommerce' ),
 				),
 				'fail'  => array(
-					'status'      => fn( ?array $context ) => ! empty( $context['unverified'] ) ? 'recommended' : 'critical',
-					'label'       => fn( ?array $context ) => ! empty( $context['unverified'] )
-						? __( 'WooCommerce could not verify uploads directory protection', 'woocommerce' )
-						: __( 'WooCommerce uploads directory is browsable from the web', 'woocommerce' ),
-					'description' => fn( ?array $context ) => ! empty( $context['unverified'] )
-						? __( 'A loopback request to the WooCommerce uploads directory failed, so WooCommerce could not confirm whether directory browsing is disabled. Check your server configuration or try again later.', 'woocommerce' )
-						: __( 'Directory browsing can expose downloadable product files. Configure your web server to prevent directory indexing for the WooCommerce uploads directory.', 'woocommerce' ),
+					'status'      => function ( ?array $context ) {
+						return ! empty( $context['unverified'] ) ? 'recommended' : 'critical';
+					},
+					'label'       => function ( ?array $context ) {
+						return ! empty( $context['unverified'] )
+							? __( 'WooCommerce could not verify uploads directory protection', 'woocommerce' )
+							: __( 'WooCommerce uploads directory is browsable from the web', 'woocommerce' );
+					},
+					'description' => function ( ?array $context ) {
+						return ! empty( $context['unverified'] )
+							? __( 'A loopback request to the WooCommerce uploads directory failed, so WooCommerce could not confirm whether directory browsing is disabled. Check your server configuration or try again later.', 'woocommerce' )
+							: __( 'Directory browsing can expose downloadable product files. Configure your web server to prevent directory indexing for the WooCommerce uploads directory.', 'woocommerce' );
+					},
 					'actions'     => array(
 						array(
 							'url'     => 'https://woocommerce.com/document/digital-downloadable-product-handling/#protecting-your-uploads-directory',

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -542,14 +542,14 @@ class SiteHealth {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			set_transient( $cache_key, 'unverified', DAY_IN_SECONDS );
+			set_transient( $cache_key, 'unverified', HOUR_IN_SECONDS );
 			return array( 'unverified' => true );
 		}
 
 		$response_code = intval( wp_remote_retrieve_response_code( $response ) );
 
 		if ( 0 === $response_code ) {
-			set_transient( $cache_key, 'unverified', DAY_IN_SECONDS );
+			set_transient( $cache_key, 'unverified', HOUR_IN_SECONDS );
 			return array( 'unverified' => true );
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
@@ -36,11 +36,14 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Upload directory protection check fails when the HTTP request fails.
+	 * @testdox Upload directory protection check is inconclusive when the HTTP request fails.
 	 */
-	public function test_uploads_directory_protection_fails_for_http_request_error(): void {
-		$filter_callback = static function ( $_preempt, $_parsed_args, $_url ) {
+	public function test_uploads_directory_protection_is_inconclusive_for_http_request_error(): void {
+		$request_count   = 0;
+		$filter_callback = static function ( $_preempt, $_parsed_args, $_url ) use ( &$request_count ) {
 			unset( $_preempt, $_parsed_args, $_url );
+
+			++$request_count;
 
 			return new WP_Error( 'http_request_failed', 'Request failed.' );
 		};
@@ -50,19 +53,27 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 		try {
 			$result = $this->sut->run_test( 'woocommerce_uploads_directory_protection' );
 
-			$this->assertSame( 'critical', $result['status'], 'Request failures should not be reported as protected.' );
-			$this->assertFalse( get_transient( '_woocommerce_upload_directory_status' ), 'Request failures should not be cached.' );
+			$this->assertSame( 'recommended', $result['status'], 'Request failures should not be reported as a confirmed security failure.' );
+			$this->assertSame( 'WooCommerce could not verify uploads directory protection', $result['label'], 'Request failures should report that the result could not be verified.' );
+			$this->assertSame( 'unverified', get_transient( '_woocommerce_upload_directory_status' ), 'Request failures should be cached.' );
+
+			$this->sut->run_test( 'woocommerce_uploads_directory_protection' );
+
+			$this->assertSame( 1, $request_count, 'Cached request failures should not trigger another loopback request.' );
 		} finally {
 			remove_filter( 'pre_http_request', $filter_callback, 10 );
 		}
 	}
 
 	/**
-	 * @testdox Upload directory protection check fails when the HTTP response code is zero.
+	 * @testdox Upload directory protection check is inconclusive when the HTTP response code is zero.
 	 */
-	public function test_uploads_directory_protection_fails_for_zero_response_code(): void {
-		$filter_callback = static function ( $_preempt, $_parsed_args, $_url ) {
+	public function test_uploads_directory_protection_is_inconclusive_for_zero_response_code(): void {
+		$request_count   = 0;
+		$filter_callback = static function ( $_preempt, $_parsed_args, $_url ) use ( &$request_count ) {
 			unset( $_preempt, $_parsed_args, $_url );
+
+			++$request_count;
 
 			return array(
 				'headers'  => array(),
@@ -81,8 +92,45 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 		try {
 			$result = $this->sut->run_test( 'woocommerce_uploads_directory_protection' );
 
-			$this->assertSame( 'critical', $result['status'], 'Missing response codes should not be reported as protected.' );
-			$this->assertFalse( get_transient( '_woocommerce_upload_directory_status' ), 'Missing response codes should not be cached.' );
+			$this->assertSame( 'recommended', $result['status'], 'Missing response codes should not be reported as a confirmed security failure.' );
+			$this->assertSame( 'WooCommerce could not verify uploads directory protection', $result['label'], 'Missing response codes should report that the result could not be verified.' );
+			$this->assertSame( 'unverified', get_transient( '_woocommerce_upload_directory_status' ), 'Missing response codes should be cached.' );
+
+			$this->sut->run_test( 'woocommerce_uploads_directory_protection' );
+
+			$this->assertSame( 1, $request_count, 'Cached missing response codes should not trigger another loopback request.' );
+		} finally {
+			remove_filter( 'pre_http_request', $filter_callback, 10 );
+		}
+	}
+
+	/**
+	 * @testdox Upload directory protection check is critical when directory browsing is exposed.
+	 */
+	public function test_uploads_directory_protection_is_critical_when_directory_browsing_is_exposed(): void {
+		$filter_callback = static function ( $_preempt, $_parsed_args, $_url ) {
+			unset( $_preempt, $_parsed_args, $_url );
+
+			return array(
+				'headers'  => array(),
+				'body'     => '<html><body>Index of /woocommerce_uploads/</body></html>',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+
+		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
+
+		try {
+			$result = $this->sut->run_test( 'woocommerce_uploads_directory_protection' );
+
+			$this->assertSame( 'critical', $result['status'], 'Browsable uploads directories should remain critical.' );
+			$this->assertSame( 'WooCommerce uploads directory is browsable from the web', $result['label'], 'Browsable uploads directories should keep the confirmed security failure label.' );
+			$this->assertSame( 'unprotected', get_transient( '_woocommerce_upload_directory_status' ), 'Browsable uploads directory results should be cached as unprotected.' );
 		} finally {
 			remove_filter( 'pre_http_request', $filter_callback, 10 );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When the WooCommerce uploads directory Site Health check can't complete its loopback request, we don't actually know whether the directory is browsable from the web. Previously that path was reported as a critical confirmed failure, using the same copy as a genuinely exposed directory. It also returned before setting the transient, so the failed loopback request could be repeated on every Site Health page load.

I've split that indeterminate state out from the confirmed failure state. Failed requests and response code `0` now cache an `unverified` result for a day and show a recommended warning saying WooCommerce couldn't verify the uploads directory protection. Confirmed exposed directory listings still show the critical "browsable from the web" result.

Closes #65723.

(For Bug Fixes) Bug introduced in PR #64758.

### Screenshots or screen recordings:

<img width="824" height="199" alt="Screenshot 2026-06-15 at 15 51 33" src="https://github.com/user-attachments/assets/125031b5-6fb1-4a84-ac14-ecf20453cfae" />

### How to test the changes in this Pull Request:

1. From `plugins/woocommerce`, run:

    ```bash
    pnpm test:php:env -- --filter SiteHealthTest
    ```

    Confirm the `SiteHealthTest` tests pass.

2. In a local WooCommerce environment, temporarily force the uploads directory loopback request to fail, for example with a temporary snippet/mu-plugin:

    ```php
    add_filter(
        'pre_http_request',
        function ( $preempt, $parsed_args, $url ) {
            if ( str_contains( $url, '/woocommerce_uploads/' ) ) {
                return new WP_Error( 'http_request_failed', 'Request failed.' );
            }

            return $preempt;
        },
        10,
        3
    );
    ```

3. Delete the `_woocommerce_upload_directory_status` transient, then visit **Tools > Site Health**. Confirm the WooCommerce uploads directory check is shown as recommended with the "WooCommerce could not verify uploads directory protection" label, not as a critical "browsable from the web" failure.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

Manual changelog entry added in `plugins/woocommerce/changelog/65723-fix-site-health-upload-loopback`.

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Avoid a critical Site Health warning when WooCommerce cannot verify uploads directory protection.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
