### PR TITLE
Fix total_refunds JSON example in v3 sales report docs

### DIFF
--- a/docs/apis/rest-api/v3/reports.mdx
+++ b/docs/apis/rest-api/v3/reports.mdx
@@ -309,7 +309,7 @@ woocommerce.get("reports/sales", query).parsed_response
 		"total_items": 6,
 		"total_tax": "0.00",
 		"total_shipping": "10.00",
-		"total_refunds": "10.00",
+		"total_refunds": 10,
 		"total_discount": "0.00",
 		"totals_grouped_by": "day",
 		"totals": {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes a documentation inaccuracy in the `GET /wc/v3/reports/sales` example response.

The JSON example showed the top-level `total_refunds` as a quoted string (`"10.00"`). However, unlike the other monetary fields (`total_sales`, `total_tax`, `total_shipping`, `total_discount`), the top-level `total_refunds` is a raw PHP float that is never passed through `wc_format_decimal()` (see `class-wc-rest-report-sales-v1-controller.php:209`). It is accumulated as a float starting from `0`, so `json_encode` renders it as a **JSON number**, not a quoted string.

This restores the example to an unquoted number (`10`), which matches both the actual API response and the schema, where `total_refunds` is typed as `integer`.

Note: the per-period `refunds` field added in #65467 is correctly formatted as a decimal string and is unaffected by this change — only the top-level `total_refunds` example was wrong.

Bug introduced in PR #65467.

### How to test the changes in this Pull Request:

1. Open `docs/apis/rest-api/v3/reports.mdx`.
2. Confirm the example response shows `"total_refunds": 10` (unquoted number) rather than `"total_refunds": "10.00"`.
3. Confirm it now matches the "Sales report properties" table, which lists `total_refunds` as type `integer`.

### Testing that has already taken place:

- Verified against the source (`class-wc-rest-report-sales-v1-controller.php:209` and `class-wc-report-sales-by-date.php:406-412`) that the top-level `total_refunds` is an unformatted float emitted as a JSON number.
- Confirmed the per-period `refunds` field (string) is correct and untouched.

### Screenshots or screen recordings:

_N/A — documentation-only change._

### Changelog entry

- [x] This Pull Request does not require a changelog entry. _(Documentation-only change outside the `plugins/woocommerce` package.)_

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
