### PR TITLE
ci: skip changelog validation when no composer packages are touched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,11 @@ jobs:
             done
             echo "Populated filter: $filter"
 
+            if [ -z "$filter" ]; then
+                echo "No touched packages use changelogger; nothing to validate."
+                exit 0
+            fi
+
             pnpm --parallel --workspace-concurrency=10 --stream $filter changelog validate
 
   validate-markdown:


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The `Validate changelog` job's **"Validate - existing entries"** step builds a `pnpm --filter` list from the packages `check-changelogger-use.php` reports as touched. That script only counts packages with a `composer.json`, so a PR touching **only composer-less JS packages** (e.g. `settings-ui-sdk`, `settings-editor`, `block-templates`) yields an **empty** list. With an empty filter, `pnpm --parallel … $filter changelog validate` ran with no `--filter` — validating the **entire monorepo** at once. The parallel `composer install`s then race on shared path-repo vendor dirs and fail with `Unable to guess file type` / `failed to open dir`.

This adds a guard so the step exits early when the filter is empty (nothing to validate) instead of falling through to an unfiltered, monorepo-wide run.

### How to test / testing done:

Reproduced on #65577 (touches only `packages/js/settings-ui-sdk`): the changelog job failed three times, always inside `composer install` in the unfiltered run and never in `changelogger validate`, with an empty `Passed validation:` list. The `needs-changelog-validation` paths filter excludes `.github/**`, so this PR's own changelog job is skipped (confirmed: `Validate changelog` → _skipping_); `ci.yml` validated as well-formed YAML.

To confirm the fix end to end: after merge, update #65577 onto trunk and check that its **"Validate - existing entries"** step logs `No touched packages use changelogger; nothing to validate.` and passes, while a PR touching a composer package still validates as before.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR only modifies `.github/workflows/ci.yml`. CI workflow configuration is not part of any shipped package, and the `needs-changelog-validation` paths filter excludes `.github/**`, so no changelog entry is required (the changelog job is skipped for this PR).

</details>
