### PR TITLE
Remove stale variation attribute meta on updates

### DIFF
--- a/plugins/woocommerce/changelog/65766-56335-stale-attribute-meta
+++ b/plugins/woocommerce/changelog/65766-56335-stale-attribute-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove stale variation attribute meta on updates

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -80,7 +80,7 @@ class WC_Post_Data {
 		add_action( 'edited_term', array( __CLASS__, 'handle_attribute_term_updated' ), 10, 3 );
 		add_action( 'delete_term', array( __CLASS__, 'handle_attribute_term_deleted' ), 10, 4 );
 		// Product Variations - Parent Product Updates Attributes.
-		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 1 );
+		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
 		// Product Variations - Action Scheduler.
 		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
 		add_action( 'wc_regenerate_attribute_variation_summaries', array( __CLASS__, 'regenerate_attribute_variation_summaries' ), 10, 1 );
@@ -964,12 +964,18 @@ class WC_Post_Data {
 	 *
 	 * @since 10.2.0
 	 * @param WC_Product $product The variable product whose attributes were updated.
+	 * @param bool       $force   Whether the update was forced. Forced updates originate from the read-time
+	 *                            backwards-compatibility migration in the data store, where the product's
+	 *                            in-memory attributes can be an incomplete view of what's stored, so stale
+	 *                            attribute meta cleanup must be skipped to avoid deleting valid meta.
 	 *
 	 * @return void
 	 */
-	public static function on_product_attributes_updated( $product ) {
+	public static function on_product_attributes_updated( $product, $force = false ) {
 		if ( $product->is_type( 'variable' ) ) {
-			self::delete_stale_variation_attribute_meta( $product );
+			if ( ! $force ) {
+				self::delete_stale_variation_attribute_meta( $product );
+			}
 
 			global $wpdb;
 			$threshold     = self::get_variation_summaries_sync_threshold();

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -1067,8 +1067,8 @@ class WC_Post_Data {
 				...$query_args
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$invalidator = wc_get_container()->get( ProductVersionStringInvalidator::class );
 		foreach ( $variation_ids as $variation_id ) {
 			wp_cache_delete( $variation_id, 'post_meta' );

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -1008,7 +1008,6 @@ class WC_Post_Data {
 	/**
 	 * Deletes child variation attribute meta that no longer maps to a parent variation attribute.
 	 *
-	 * @since 11.0.0
 	 * @param WC_Product $product The variable product whose attributes were updated.
 	 *
 	 * @return void
@@ -1038,12 +1037,12 @@ class WC_Post_Data {
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-		$variation_ids = $wpdb->get_col(
+		$stale_rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT DISTINCT pm.post_id
-				FROM {$wpdb->postmeta} pm
-				INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
-				WHERE p.post_parent = %d
+				"SELECT pm.post_id, pm.meta_key
+					FROM {$wpdb->postmeta} pm
+					INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
+					WHERE p.post_parent = %d
 				AND p.post_type = %s
 				AND pm.meta_key LIKE %s
 				{$not_in_sql}",
@@ -1051,27 +1050,20 @@ class WC_Post_Data {
 			)
 		);
 
-		if ( empty( $variation_ids ) ) {
+		if ( empty( $stale_rows ) ) {
 			return;
 		}
 
-		$wpdb->query(
-			$wpdb->prepare(
-				"DELETE pm
-				FROM {$wpdb->postmeta} pm
-				INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
-				WHERE p.post_parent = %d
-				AND p.post_type = %s
-				AND pm.meta_key LIKE %s
-				{$not_in_sql}",
-				...$query_args
-			)
-		);
-
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$variation_ids = array();
+		foreach ( $stale_rows as $row ) {
+			$variation_id                   = (int) $row->post_id;
+			$variation_ids[ $variation_id ] = $variation_id;
+			delete_post_meta( $variation_id, $row->meta_key );
+		}
+
 		$invalidator = wc_get_container()->get( ProductVersionStringInvalidator::class );
 		foreach ( $variation_ids as $variation_id ) {
-			wp_cache_delete( $variation_id, 'post_meta' );
 			clean_post_cache( $variation_id );
 			$invalidator->invalidate( $variation_id );
 		}

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\Caches\ProductVersionStringInvalidator;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore as ProductAttributesLookupDataStore;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
@@ -968,6 +969,8 @@ class WC_Post_Data {
 	 */
 	public static function on_product_attributes_updated( $product ) {
 		if ( $product->is_type( 'variable' ) ) {
+			self::delete_stale_variation_attribute_meta( $product );
+
 			global $wpdb;
 			$threshold     = self::get_variation_summaries_sync_threshold();
 			$variation_ids = $wpdb->get_col(
@@ -1000,6 +1003,79 @@ class WC_Post_Data {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Deletes child variation attribute meta that no longer maps to a parent variation attribute.
+	 *
+	 * @since 11.0.0
+	 * @param WC_Product $product The variable product whose attributes were updated.
+	 *
+	 * @return void
+	 */
+	private static function delete_stale_variation_attribute_meta( $product ) {
+		global $wpdb;
+
+		$valid_attribute_meta_keys = array();
+		foreach ( $product->get_attributes() as $attribute ) {
+			if ( ! $attribute instanceof WC_Product_Attribute || ! $attribute->get_variation() ) {
+				continue;
+			}
+
+			$valid_attribute_meta_keys[] = wc_variation_attribute_name( $attribute->get_name() );
+		}
+		$valid_attribute_meta_keys = array_values( array_unique( $valid_attribute_meta_keys ) );
+
+		$query_args = array(
+			$product->get_id(),
+			'product_variation',
+			$wpdb->esc_like( 'attribute_' ) . '%',
+		);
+		$not_in_sql = '';
+		if ( ! empty( $valid_attribute_meta_keys ) ) {
+			$not_in_sql = ' AND pm.meta_key NOT IN ( ' . implode( ', ', array_fill( 0, count( $valid_attribute_meta_keys ), '%s' ) ) . ' )';
+			$query_args = array_merge( $query_args, $valid_attribute_meta_keys );
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$variation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT pm.post_id
+				FROM {$wpdb->postmeta} pm
+				INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
+				WHERE p.post_parent = %d
+				AND p.post_type = %s
+				AND pm.meta_key LIKE %s
+				{$not_in_sql}",
+				...$query_args
+			)
+		);
+
+		if ( empty( $variation_ids ) ) {
+			return;
+		}
+
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE pm
+				FROM {$wpdb->postmeta} pm
+				INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
+				WHERE p.post_parent = %d
+				AND p.post_type = %s
+				AND pm.meta_key LIKE %s
+				{$not_in_sql}",
+				...$query_args
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		$invalidator = wc_get_container()->get( ProductVersionStringInvalidator::class );
+		foreach ( $variation_ids as $variation_id ) {
+			wp_cache_delete( $variation_id, 'post_meta' );
+			clean_post_cache( $variation_id );
+			$invalidator->invalidate( $variation_id );
+		}
+		$invalidator->invalidate( $product->get_id() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
@@ -257,18 +257,40 @@ class WC_Post_Data_Test extends \WC_Unit_Test_Case {
 	 * @testdox Should delete variation attribute meta when the parent variation attribute is removed.
 	 */
 	public function test_product_attributes_updated_deletes_stale_variation_attribute_meta(): void {
-		$product      = WC_Helper_Product::create_variation_product();
-		$variation_id = $product->get_children()[2];
+		$product       = WC_Helper_Product::create_variation_product();
+		$variation_ids = $product->get_children();
 
-		$this->assertSame( 'red', get_post_meta( $variation_id, 'attribute_pa_colour', true ), 'Variation should start with colour attribute meta' );
-		$this->assertSame( 'huge', get_post_meta( $variation_id, 'attribute_pa_size', true ), 'Variation should start with size attribute meta' );
+		foreach ( $variation_ids as $variation_id ) {
+			update_post_meta( $variation_id, 'attribute_pa_colour', 'red' );
+			$this->assertSame( 'red', get_post_meta( $variation_id, 'attribute_pa_colour', true ), 'Variation should start with colour attribute meta' );
+		}
 
 		$attributes = $product->get_attributes();
 		unset( $attributes['pa_colour'] );
 		$product->set_attributes( $attributes );
 		$product->save();
 
-		$this->assertFalse( metadata_exists( 'post', $variation_id, 'attribute_pa_colour' ), 'Removed parent variation attribute meta should be deleted from child variations' );
-		$this->assertSame( 'huge', get_post_meta( $variation_id, 'attribute_pa_size', true ), 'Remaining parent variation attribute meta should be preserved' );
+		foreach ( $variation_ids as $variation_id ) {
+			$this->assertFalse( metadata_exists( 'post', $variation_id, 'attribute_pa_colour' ), 'Removed parent variation attribute meta should be deleted from each child variation' );
+		}
+		$this->assertSame( 'huge', get_post_meta( $variation_ids[2], 'attribute_pa_size', true ), 'Remaining parent variation attribute meta should be preserved' );
+
+		$product       = WC_Helper_Product::create_variation_product();
+		$variation_ids = $product->get_children();
+
+		foreach ( $variation_ids as $variation_id ) {
+			update_post_meta( $variation_id, 'attribute_pa_size', 'huge' );
+			update_post_meta( $variation_id, 'attribute_pa_colour', 'red' );
+			update_post_meta( $variation_id, 'attribute_pa_number', '2' );
+		}
+
+		$product->set_attributes( array() );
+		$product->save();
+
+		foreach ( $variation_ids as $variation_id ) {
+			$this->assertFalse( metadata_exists( 'post', $variation_id, 'attribute_pa_size' ), 'Removed size attribute meta should be deleted from each child variation' );
+			$this->assertFalse( metadata_exists( 'post', $variation_id, 'attribute_pa_colour' ), 'Removed colour attribute meta should be deleted from each child variation' );
+			$this->assertFalse( metadata_exists( 'post', $variation_id, 'attribute_pa_number' ), 'Removed number attribute meta should be deleted from each child variation' );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-post-data-test.php
@@ -252,4 +252,23 @@ class WC_Post_Data_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( array( $product_1->get_id(), $product_2->get_id() ), $synced_ids, 'Each product should be synced at most once per request' );
 		$this->assertEmpty( $wc_deferred_product_sync, 'The queue should be empty after the sync' );
 	}
+
+	/**
+	 * @testdox Should delete variation attribute meta when the parent variation attribute is removed.
+	 */
+	public function test_product_attributes_updated_deletes_stale_variation_attribute_meta(): void {
+		$product      = WC_Helper_Product::create_variation_product();
+		$variation_id = $product->get_children()[2];
+
+		$this->assertSame( 'red', get_post_meta( $variation_id, 'attribute_pa_colour', true ), 'Variation should start with colour attribute meta' );
+		$this->assertSame( 'huge', get_post_meta( $variation_id, 'attribute_pa_size', true ), 'Variation should start with size attribute meta' );
+
+		$attributes = $product->get_attributes();
+		unset( $attributes['pa_colour'] );
+		$product->set_attributes( $attributes );
+		$product->save();
+
+		$this->assertFalse( metadata_exists( 'post', $variation_id, 'attribute_pa_colour' ), 'Removed parent variation attribute meta should be deleted from child variations' );
+		$this->assertSame( 'huge', get_post_meta( $variation_id, 'attribute_pa_size', true ), 'Remaining parent variation attribute meta should be preserved' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When a parent products attributes are updated, the child variations attribute meta is updated accordingly to delete any stale attribute metadata

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56335 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

#### Before:
Both size and color attributes present
<img width="1399" height="547" alt="image" src="https://github.com/user-attachments/assets/5aafa837-9c4e-4837-927b-96630a1e36c6" />
<img width="527" height="586" alt="image" src="https://github.com/user-attachments/assets/e71ad1a3-3c50-47c0-8a9c-49687866f8be" />

After removing the size attribute
<img width="1396" height="555" alt="image" src="https://github.com/user-attachments/assets/35542958-a03c-41fd-914e-3cbfc5f0c34b" />
<img width="446" height="470" alt="image" src="https://github.com/user-attachments/assets/23db1c5d-2620-495a-a6d3-78468c0a06dc" />

#### After:
Both size and color attribute
<img width="1416" height="568" alt="image" src="https://github.com/user-attachments/assets/97427027-48b4-4f19-99d5-d5e0e8d447ad" />
<img width="486" height="537" alt="image" src="https://github.com/user-attachments/assets/4febaffa-54aa-435f-919c-0d27647004fd" />

After removing the size attribute
<img width="1396" height="548" alt="image" src="https://github.com/user-attachments/assets/97212d49-f0bc-4d38-935c-b14f489375e6" />
<img width="494" height="499" alt="image" src="https://github.com/user-attachments/assets/b1f6e69a-b888-4776-a410-9cf5b42c67df" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

```bash
pnpm --dir plugins/woocommerce run test:php:env -- --filter WC_Post_Data_Test::test_product_attributes_updated_deletes_stale_variation_attribute_meta
```

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove stale variation attribute meta on updates

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
