### PR TITLE
Update "Lost your password?" copy to "Forgot your password?"

### DIFF
--- a/plugins/woocommerce/changelog/update-forgot-your-password-copy
+++ b/plugins/woocommerce/changelog/update-forgot-your-password-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update the password-recovery link and intro copy from "Lost your password?" to "Forgot your password?" across the account login, global login, and lost-password screens for consistency with common conventions.

--- a/plugins/woocommerce/templates/global/form-login.php
+++ b/plugins/woocommerce/templates/global/form-login.php
@@ -51,7 +51,7 @@ if ( is_user_logged_in() ) {
 		<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 	</p>
 	<p class="lost_password">
-		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>
+		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Forgot your password?', 'woocommerce' ); ?></a>
 	</p>
 
 	<div class="clear"></div>

--- a/plugins/woocommerce/templates/myaccount/form-login.php
+++ b/plugins/woocommerce/templates/myaccount/form-login.php
@@ -54,7 +54,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
 			</p>
 			<p class="woocommerce-LostPassword lost_password">
-				<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>
+				<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Forgot your password?', 'woocommerce' ); ?></a>
 			</p>
 
 			<?php do_action( 'woocommerce_login_form_end' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-lost-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-lost-password.php
@@ -22,7 +22,7 @@ do_action( 'woocommerce_before_lost_password_form' );
 
 <form method="post" class="woocommerce-ResetPassword lost_reset_password">
 
-	<p><?php echo apply_filters( 'woocommerce_lost_password_message', esc_html__( 'Lost your password? Please enter your username or email address. You will receive a link to create a new password via email.', 'woocommerce' ) ); ?></p><?php // @codingStandardsIgnoreLine ?>
+	<p><?php echo apply_filters( 'woocommerce_lost_password_message', esc_html__( 'Forgot your password? Please enter your username or email address. You will receive a link to create a new password via email.', 'woocommerce' ) ); ?></p><?php // @codingStandardsIgnoreLine ?>
 
 	<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">
 		<label for="user_login"><?php esc_html_e( 'Username or email', 'woocommerce' ); ?>&nbsp;<span class="required" aria-hidden="true">*</span><span class="screen-reader-text"><?php esc_html_e( 'Required', 'woocommerce' ); ?></span></label>


### PR DESCRIPTION
### Submission Review Guidelines
- [x] I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
- [x] I have checked to ensure there aren't other open Pull Requests for the same change.
- [x] I have reviewed my code for security best practices (display-string copy change only — no logic, input handling, or markup changes).

### Changes proposed in this Pull Request
Standardizes the password-recovery copy to the more common **"Forgot your password?"** phrasing in place of WordPress's older **"Lost your password?"** wording, in all three customer-facing locations so the login and reset screens stay consistent:

- `templates/myaccount/form-login.php` — recovery link on the My Account login form
- `templates/global/form-login.php` — recovery link on the shared/global login form (e.g. login during checkout)
- `templates/myaccount/form-lost-password.php` — intro sentence on the password-reset screen

Copy/UX tweak only — no logic or markup changes.

### Screenshots or screen recordings
| Before | After |
| ------ | ----- |
| Lost your password? | Forgot your password? |

### How to test the changes in this Pull Request
1. Log out (or open a private window) and visit **My Account** (`/my-account/`).
2. Under the login form, confirm the link reads **"Forgot your password?"**.
3. Click it; on the reset screen, confirm the intro reads **"Forgot your password? Please enter your username or email address…"**.
4. Where the global login form appears (e.g. login during checkout), confirm its link also reads **"Forgot your password?"**.

### Testing that has already taken place
Verified on a local WordPress 7.0 + WooCommerce 10.8.1 site (SQLite, PHP 8.4): the My Account login page renders "Forgot your password?" after the change; all three templates pass `php -l`. Change is limited to translatable display strings.

### Milestone
- [ ] Automatically assign milestone for the next WooCommerce version

### Changelog entry
Added manually — `tweak` / `patch`: "Update the password-recovery link and intro copy from 'Lost your password?' to 'Forgot your password?' across the account login, global login, and lost-password screens."

---
🤖 Prepared with [Claude Code](https://claude.com/claude-code) during an Automattic PM workshop on using AI.
