### PR TITLE
Fix Mini Cart loading placeholder styles for quantity and sale badge

### DIFF
--- a/plugins/woocommerce/changelog/fix-46179-mini-cart-placeholder-styles
+++ b/plugins/woocommerce/changelog/fix-46179-mini-cart-placeholder-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Mini Cart: fix loading placeholder styles so the quantity selector and sale badge render as clean, aligned placeholders.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -50,9 +50,17 @@
 		min-width: 33%;
 	}
 	.wc-block-components-product-price,
-	.wc-block-components-product-metadata,
+	.wc-block-components-product-metadata {
+		@include skeleton-animation();
+	}
 	.wc-block-components-quantity-selector {
 		@include skeleton-animation();
+
+		// The quantity controls (input and +/- buttons) are always rendered,
+		// so hide them to show a clean, aligned placeholder box.
+		> * {
+			visibility: hidden;
+		}
 	}
 	.wc-block-components-product-name {
 		@include skeleton-animation();
@@ -66,6 +74,15 @@
 	}
 	.wc-block-cart-item__remove-link {
 		visibility: hidden;
+	}
+	.wc-block-components-sale-badge {
+		@include skeleton-animation();
+		@include force-content();
+
+		// Clip the badge label so only the placeholder pill is shown.
+		min-width: 3em;
+		text-indent: 100%;
+		white-space: nowrap;
 	}
 	.wc-block-cart-item__image > a {
 		@include skeleton-animation();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Mini Cart / Cart loading placeholder (`.is-loading`) applied a shimmer to the product name, price and image, but two elements that are always rendered leaked their live UI through the placeholder: the quantity selector showed its `−/[n]/+` controls (looking broken and misaligned), and the sale badge had no placeholder rule at all, so the live "Save $X" badge stayed visible during loading.

This hides the quantity controls behind the shimmer box so it renders as a clean, aligned placeholder, and clips the sale badge label so only its placeholder pill shows. The fix lives in the shared `.is-loading` SCSS block, so it applies to both the Mini Cart drawer and the Cart block.

Closes #46179

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

| Before | After |
| ------ | ----- |
|        |       |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. With a block theme (e.g. Twenty Twenty-Five), make sure a Mini Cart block is present (or use the Cart block page).
2. Create a product that is **on sale** (set both a regular and a sale price) and add it to the cart.
3. Open the Cart page (or Mini Cart drawer). The loading placeholder is briefly shown while the cart hydrates — to inspect it reliably, open DevTools and add the class `wc-block-cart--is-loading` to the `.wc-block-cart` element (or `is-loading` to `.wc-block-mini-cart__drawer`).
4. Verify the **quantity selector** renders as a clean shimmer box with no visible `−/[n]/+` controls, and the **sale badge** renders as a shimmer pill with no "Save $X" text bleeding through.
5. Confirm placeholders are aligned and nothing overlaps.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified locally on wp-env (WordPress + WooCommerce, Twenty Twenty-Five block theme) by creating an on-sale product, adding it to the cart, forcing the `.is-loading` state, and confirming via screenshots and computed styles that the quantity selector renders as a clean shimmer box (inner controls hidden) and the sale badge renders as a clipped shimmer pill (`text-indent: 100%`, `overflow: hidden`). SCSS lint (`lint:css`) passes and the production blocks build succeeds.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
