### PR TITLE
StoreApi: apply woocommerce_checkout_customer_id filter in Checkout::process_customer()

### DIFF
--- a/plugins/woocommerce/changelog/44530-checkout-customer-id-filter-store-api
+++ b/plugins/woocommerce/changelog/44530-checkout-customer-id-filter-store-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add `woocommerce_checkout_customer_id` filter to block-based checkout (Store API) for parity with classic checkout. Allows third-party plugins to override the customer ID assigned to an order during block checkout — enabling concierge/B2B ordering flows that run on the classic checkout today.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -997,6 +997,7 @@ class Checkout extends AbstractCartRoute {
 		 * @since 11.0.0
 		 *
 		 * @param int $customer_id The current user's ID (0 for guests).
+		 * @return int The customer ID to assign to the order.
 		 */
 		$order->set_customer_id( absint( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) ) );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -982,6 +982,24 @@ class Checkout extends AbstractCartRoute {
 	private function process_customer( \WP_REST_Request $request ) {
 		$order = $this->get_order_or_throw();
 
+		/**
+		 * Filters the customer ID at block-based checkout processing time.
+		 *
+		 * Provides parity with the `woocommerce_checkout_customer_id` filter used in
+		 * WC_Checkout::process_customer() for the classic checkout. Fires once, at
+		 * checkout submission, after the cart has been committed to a draft order.
+		 *
+		 * Common use cases: concierge/operator ordering (a logged-in shop manager
+		 * assigns the order to a different customer account) and multi-customer B2B
+		 * flows. Note — if a new customer account is created during this request, the
+		 * newly-created account ID takes precedence over this filter's return value.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param int $customer_id The current user's ID (0 for guests).
+		 */
+		$order->set_customer_id( absint( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) ) );
+
 		if ( $this->should_create_customer_account( $request ) ) {
 			$customer_id = wc_create_new_customer(
 				$request['billing_address']['email'],

--- a/plugins/woocommerce/tests/php/src/StoreApi/Utilities/OrderControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Utilities/OrderControllerTest.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\StoreApi\Utilities;
 
 use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+use Automattic\WooCommerce\StoreApi\StoreApi;
+use Automattic\WooCommerce\StoreApi\RoutesController;
 
 /**
  * Tests for OrderController class.
@@ -22,20 +24,34 @@ class OrderControllerTest extends \WC_Unit_Test_Case {
 	private OrderController $controller;
 
 	/**
+	 * Callback stored so tearDown can call remove_filter() with the exact
+	 * callable, rather than remove_all_filters() which would clear every
+	 * callback on the hook and could break other tests running in the same
+	 * PHP process.
+	 *
+	 * @var callable|null
+	 */
+	private $customer_id_filter_cb = null;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
 		parent::setUp();
 		wc_empty_cart();
-		$this->controller = new OrderController();
+		$this->controller          = new OrderController();
+		$this->customer_id_filter_cb = null;
 	}
 
 	/**
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
+		if ( null !== $this->customer_id_filter_cb ) {
+			remove_filter( 'woocommerce_checkout_customer_id', $this->customer_id_filter_cb );
+			$this->customer_id_filter_cb = null;
+		}
 		parent::tearDown();
-		remove_all_filters( 'woocommerce_checkout_customer_id' );
 	}
 
 	/**
@@ -53,14 +69,12 @@ class OrderControllerTest extends \WC_Unit_Test_Case {
 		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
 		wp_set_current_user( $user_id );
 
-		$filter_called = false;
-		add_filter(
-			'woocommerce_checkout_customer_id',
-			function ( $id ) use ( &$filter_called ) {
-				$filter_called = true;
-				return $id;
-			}
-		);
+		$filter_called             = false;
+		$this->customer_id_filter_cb = function ( $id ) use ( &$filter_called ) {
+			$filter_called = true;
+			return $id;
+		};
+		add_filter( 'woocommerce_checkout_customer_id', $this->customer_id_filter_cb );
 
 		$order = new \WC_Order();
 		$this->controller->update_order_from_cart( $order );
@@ -72,5 +86,44 @@ class OrderControllerTest extends \WC_Unit_Test_Case {
 
 		// Logged-in user ID still lands on the order (the raw current-user call).
 		$this->assertSame( $user_id, $order->get_customer_id() );
+	}
+
+	/**
+	 * Regression guard: Checkout::process_customer() MUST apply
+	 * woocommerce_checkout_customer_id and write the filtered customer ID to
+	 * the order. Removing the apply_filters() call from production code must
+	 * flip this assertion from green to red.
+	 *
+	 * @see \Automattic\WooCommerce\StoreApi\Routes\V1\Checkout::process_customer()
+	 */
+	public function test_process_customer_applies_checkout_customer_id_filter() {
+		// $user_a is the logged-in user; $user_b_id is what the filter overrides to.
+		$user_a_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		$user_b_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_a_id );
+
+		$this->customer_id_filter_cb = static function () use ( $user_b_id ) {
+			return $user_b_id;
+		};
+		add_filter( 'woocommerce_checkout_customer_id', $this->customer_id_filter_cb );
+
+		// Create a draft order and inject it directly into the Checkout route so
+		// get_order_or_throw() can return it without a full REST request.
+		$order          = \WC_Helper_Order::create_order( $user_a_id );
+		$checkout_route = StoreApi::container()->get( RoutesController::class )->get( 'checkout' );
+
+		$order_prop = new \ReflectionProperty( $checkout_route, 'order' );
+		$order_prop->setAccessible( true );
+		$order_prop->setValue( $checkout_route, $order );
+
+		$method = new \ReflectionMethod( $checkout_route, 'process_customer' );
+		$method->setAccessible( true );
+		$method->invoke( $checkout_route, new \WP_REST_Request() );
+
+		$this->assertSame(
+			$user_b_id,
+			$order->get_customer_id(),
+			'woocommerce_checkout_customer_id filter must be applied in Checkout::process_customer(), setting the order customer to the filtered value.'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/StoreApi/Utilities/OrderControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Utilities/OrderControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi\Utilities;
+
+use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+
+/**
+ * Tests for OrderController class.
+ *
+ * Note: `woocommerce_checkout_customer_id` filter tests live at the integration
+ * level in Checkout::process_customer(). The tests below cover the OrderController
+ * methods that back the draft-order sync path.
+ */
+class OrderControllerTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * The OrderController instance under test.
+	 *
+	 * @var OrderController
+	 */
+	private OrderController $controller;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		wc_empty_cart();
+		$this->controller = new OrderController();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'woocommerce_checkout_customer_id' );
+	}
+
+	/**
+	 * Regression guard: update_order_from_cart() must NOT apply
+	 * woocommerce_checkout_customer_id so the filter fires exactly once — at
+	 * Checkout::process_customer() time — rather than on every cart mutation.
+	 *
+	 * @see \Automattic\WooCommerce\StoreApi\Routes\V1\Checkout::process_customer()
+	 * @see WC_Checkout::process_customer()
+	 */
+	public function test_update_order_from_cart_does_not_apply_checkout_customer_id_filter() {
+		$product = \WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+
+		$filter_called = false;
+		add_filter(
+			'woocommerce_checkout_customer_id',
+			function ( $id ) use ( &$filter_called ) {
+				$filter_called = true;
+				return $id;
+			}
+		);
+
+		$order = new \WC_Order();
+		$this->controller->update_order_from_cart( $order );
+
+		$this->assertFalse(
+			$filter_called,
+			'woocommerce_checkout_customer_id must not fire during cart-sync (update_order_from_cart); it must only fire once in Checkout::process_customer() at submission time.'
+		);
+
+		// Logged-in user ID still lands on the order (the raw current-user call).
+		$this->assertSame( $user_id, $order->get_customer_id() );
+	}
+}


### PR DESCRIPTION
## What

Fires the `woocommerce_checkout_customer_id` filter inside `Checkout::process_customer()` (Store API / block checkout), providing parity with `WC_Checkout::process_customer()` (line 1201) for the classic checkout.

## Why

Closes #44530.

Third-party plugins — particularly concierge/B2B order tools where a logged-in shop manager places an order on behalf of a customer — rely on `woocommerce_checkout_customer_id` to reassign the order to the correct customer account. This works on the classic shortcode checkout but was silently ignored on the block-based checkout because the Store API never called the filter.

## How

**Filter placement:** `Checkout::process_customer()` in `src/StoreApi/Routes/V1/Checkout.php`.

This is the direct block-checkout equivalent of `WC_Checkout::process_customer()` at line 1201. The filter fires **once, at checkout submission time**, not during draft-order cart-sync iterations — matching the lifecycle plugin authors depend on in the classic checkout.

When `should_create_customer_account()` is true, the newly-created account ID takes precedence (same as classic checkout, which also lets `wc_create_new_customer()` override the filtered value).

`absint()` is applied to the filter's return value to match the type expected by `set_customer_id()`.

**Security note (re: maintainer concern in the issue about MIT transactions):** This filter does not modify payment method selection or authorise charges — it only sets the customer account the order is associated with, which is the same behaviour the filter has always had in classic checkout. Any payment-method or card-on-file concerns would need to be addressed at the payment-gateway layer, not here.

## Testing

- `plugins/woocommerce/tests/php/src/StoreApi/Utilities/OrderControllerTest.php` — regression guard verifying the filter is **not** applied during `update_order_from_cart()` (cart-sync), only at submit time.

Full integration testing through the Store API checkout endpoint would cover the positive case end-to-end. I'd welcome guidance on the preferred test helper for the `/wc/store/v1/checkout` route — I did not find an existing integration test scaffold for it in the sparse checkout I was working from.

## Changelog

`plugins/woocommerce/changelog/44530-checkout-customer-id-filter-store-api`

---

> AI assistance was used in development and testing of this contribution.