### PR TITLE
Fix: restore stock before remove_order_items() on order resumption

### DIFF
--- a/plugins/woocommerce/changelog/order-resume-item-loss-WOOPLUG-6382
+++ b/plugins/woocommerce/changelog/order-resume-item-loss-WOOPLUG-6382
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent order items from being lost when order resume fails between removing items and saving the order.
+Fix double stock reduction when a failed order is resumed at checkout, by preserving the per-item reduced-stock accounting across the order-item rebuild.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -421,23 +421,25 @@ class WC_Checkout {
 				 */
 				do_action( 'woocommerce_resume_order', $order_id );
 
-				// If stock was already reduced for this order, restore it before removing
-				// the items. The item-level `_reduced_stock` metadata lives on the order
-				// item rows and is deleted along with them; losing it breaks both the
-				// cancel-restore path (wc_increase_stock_levels reads it to know how much
-				// to restore) and the admin-update path (wc_adjust_line_item_product_stock
-				// uses it to avoid a double-reduction). Restoring now means the resumed
-				// order's stock lifecycle starts clean.
+				// When stock was already reduced for this order, the per-item
+				// `_reduced_stock` metadata lives on the order item rows and is destroyed
+				// by remove_order_items() below. set_data_from_cart() then rebuilds fresh
+				// line items with no `_reduced_stock`, which breaks stock accounting:
+				// wc_reduce_stock_levels() would reduce a second time on the next payment
+				// attempt (double reduction), and wc_maybe_adjust_line_item_product_stock()
+				// would mis-calculate the admin-update delta.
 				//
-				// Pass $order (object) not $order_id (int) so set_stock_reduced updates
-				// both post-meta and the in-memory WC_Order property; the order is saved
-				// later in this method and would otherwise overwrite the flag back to true.
+				// Rather than restore stock and reset the order flag (which desyncs when
+				// `woocommerce_can_restore_order_stock` blocks the restore while the flag is
+				// cleared anyway), we keep the order in its reduced state and carry the
+				// per-item `_reduced_stock` accounting across the rebuild. The flag stays
+				// true; the captured values are re-applied after the cart rebuild and before
+				// save(). See $reduced_stock_by_product reconciliation below.
 				//
 				// @since 11.0.0
+				$reduced_stock_by_product = array();
 				if ( $order->get_data_store()->get_stock_reduced( $order_id ) ) {
-					wc_increase_stock_levels( $order );
-					// Object form (not int) intentional — see block comment above.
-					$order->get_data_store()->set_stock_reduced( $order, false );
+					$reduced_stock_by_product = $this->get_preserved_reduced_stock( $order );
 				}
 
 				// Remove all items - we will re-add them later.
@@ -482,6 +484,15 @@ class WC_Checkout {
 			$order->set_customer_note( isset( $data['order_comments'] ) ? $data['order_comments'] : '' );
 			$order->set_payment_method( isset( $available_gateways[ $data['payment_method'] ] ) ? $available_gateways[ $data['payment_method'] ] : $data['payment_method'] );
 			$this->set_data_from_cart( $order );
+
+			// Re-apply the `_reduced_stock` accounting captured before the items were
+			// rebuilt, so the resumed order keeps an accurate record of how much stock
+			// has already been deducted. Runs after set_data_from_cart() has added the
+			// fresh line items and before save() persists them. Empty unless the order
+			// was resumed in a stock-reduced state.
+			if ( $reduced_stock_by_product ) {
+				$this->restore_reduced_stock_meta( $order, $reduced_stock_by_product );
+			}
 
 			if ( $order->has_cogs() && $this->cogs_is_enabled() ) {
 				$order->calculate_cogs_total_value();
@@ -618,6 +629,102 @@ class WC_Checkout {
 
 			// Add item to order and save.
 			$order->add_item( $item );
+		}
+	}
+
+	/**
+	 * Capture the per-item `_reduced_stock` accounting from an order that is about to
+	 * have its line items rebuilt during a resume.
+	 *
+	 * The returned map is keyed by product identity (`product_id|variation_id`) using the
+	 * same identity computation create_order_line_items() applies, so the rebuilt items can
+	 * be matched back to their preserved values. Only line items that carry a positive
+	 * `_reduced_stock` are included.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param WC_Order $order Order whose current line items hold the reduced-stock meta.
+	 * @return array Map of `product_id|variation_id` => array( 'reduced_stock' => float, 'quantity' => float ).
+	 */
+	protected function get_preserved_reduced_stock( $order ) {
+		$preserved = array();
+
+		foreach ( $order->get_items() as $item ) {
+			if ( ! $item->is_type( 'line_item' ) ) {
+				continue;
+			}
+
+			$reduced_stock = wc_stock_amount( $item->get_meta( '_reduced_stock', true ) );
+
+			if ( $reduced_stock <= 0 ) {
+				continue;
+			}
+
+			$key = $item->get_product_id() . '|' . $item->get_variation_id();
+
+			// If multiple lines resolve to the same product identity, aggregate them so the
+			// total reduced stock is preserved rather than overwritten by the last line.
+			if ( isset( $preserved[ $key ] ) ) {
+				$preserved[ $key ]['reduced_stock'] += $reduced_stock;
+				$preserved[ $key ]['quantity']      += wc_stock_amount( $item->get_quantity() );
+			} else {
+				$preserved[ $key ] = array(
+					'reduced_stock' => $reduced_stock,
+					'quantity'      => wc_stock_amount( $item->get_quantity() ),
+				);
+			}
+		}
+
+		return $preserved;
+	}
+
+	/**
+	 * Re-apply preserved `_reduced_stock` accounting to the rebuilt line items of a resumed
+	 * order, before the order is saved.
+	 *
+	 * Matching is by product identity (`product_id|variation_id`). When the rebuilt quantity
+	 * equals the preserved quantity the preserved value is reused verbatim. When it differs,
+	 * the value is reconciled by clamping it to the new quantity: `_reduced_stock` records how
+	 * many units of this line have already been deducted from product stock, and that figure
+	 * must never exceed the line quantity. Otherwise wc_maybe_adjust_line_item_product_stock()
+	 * would compute a negative delta and spuriously restore stock on a later admin update.
+	 * Clamping down is safe because the surplus reduction has no line to belong to after the
+	 * cart shrank; clamping never invents reductions, so the next wc_reduce_stock_levels() run
+	 * still tops up any shortfall.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param WC_Order $order     Order with freshly rebuilt line items.
+	 * @param array    $preserved Preserved values from get_preserved_reduced_stock().
+	 */
+	protected function restore_reduced_stock_meta( $order, $preserved ) {
+		foreach ( $order->get_items() as $item ) {
+			if ( ! $item->is_type( 'line_item' ) ) {
+				continue;
+			}
+
+			$key = $item->get_product_id() . '|' . $item->get_variation_id();
+
+			if ( ! isset( $preserved[ $key ] ) ) {
+				continue;
+			}
+
+			$new_quantity  = wc_stock_amount( $item->get_quantity() );
+			$reduced_stock = $preserved[ $key ]['reduced_stock'];
+
+			// Reconcile when the cart quantity changed: a line's reduced stock can never
+			// exceed its own quantity.
+			if ( $new_quantity !== $preserved[ $key ]['quantity'] ) {
+				$reduced_stock = min( $reduced_stock, $new_quantity );
+			}
+
+			if ( $reduced_stock <= 0 ) {
+				continue;
+			}
+
+			// Operate on the in-memory item; the order is saved later in create_order(), which
+			// persists this meta along with the rebuilt line items.
+			$item->update_meta_data( '_reduced_stock', $reduced_stock );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -436,6 +436,7 @@ class WC_Checkout {
 				// @since 11.0.0
 				if ( $order->get_data_store()->get_stock_reduced( $order_id ) ) {
 					wc_increase_stock_levels( $order );
+					// Object form (not int) intentional — see block comment above.
 					$order->get_data_store()->set_stock_reduced( $order, false );
 				}
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -421,6 +421,24 @@ class WC_Checkout {
 				 */
 				do_action( 'woocommerce_resume_order', $order_id );
 
+				// If stock was already reduced for this order, restore it before removing
+				// the items. The item-level `_reduced_stock` metadata lives on the order
+				// item rows and is deleted along with them; losing it breaks both the
+				// cancel-restore path (wc_increase_stock_levels reads it to know how much
+				// to restore) and the admin-update path (wc_adjust_line_item_product_stock
+				// uses it to avoid a double-reduction). Restoring now means the resumed
+				// order's stock lifecycle starts clean.
+				//
+				// Pass $order (object) not $order_id (int) so set_stock_reduced updates
+				// both post-meta and the in-memory WC_Order property; the order is saved
+				// later in this method and would otherwise overwrite the flag back to true.
+				//
+				// @since 11.0.0
+				if ( $order->get_data_store()->get_stock_reduced( $order_id ) ) {
+					wc_increase_stock_levels( $order );
+					$order->get_data_store()->set_stock_reduced( $order, false );
+				}
+
 				// Remove all items - we will re-add them later.
 				$order->remove_order_items();
 			} else {

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -368,20 +368,22 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Resuming a failed order restores stock and resets _order_stock_reduced.
+	 * @testdox Resuming a failed order preserves _reduced_stock across the item rebuild.
 	 *
-	 * Regression for #36702: when remove_order_items() is called during order resumption,
-	 * the item-level _reduced_stock metadata is destroyed along with the items. Without
-	 * an explicit restore-then-reset, the order-level _order_stock_reduced flag stays 'yes'.
-	 * On cancellation, wc_increase_stock_levels() skips items with no _reduced_stock meta
-	 * so stock is never restored. On admin order update, wc_adjust_line_item_product_stock()
-	 * reads _reduced_stock=0 on the fresh items and double-reduces stock.
+	 * Regression for #36702: when remove_order_items() runs during order resumption, the
+	 * item-level _reduced_stock metadata is destroyed along with the items, and
+	 * set_data_from_cart() rebuilds fresh line items with no _reduced_stock. The order stays
+	 * flagged _order_stock_reduced=true, so on the next payment attempt wc_reduce_stock_levels()
+	 * sees no _reduced_stock on the new items and reduces a SECOND time (double reduction).
 	 *
-	 * This test drives the full lifecycle: real stock reduction via an on-hold transition,
-	 * then a failed transition (no stock change), then a cart-hash-matched resume that must
-	 * restore stock before removing items and reset the flag to false.
+	 * The fix keeps the order in its reduced state and carries the per-item _reduced_stock
+	 * accounting across the rebuild rather than restoring stock and clearing the flag (which
+	 * desyncs when woocommerce_can_restore_order_stock blocks the restore). This test drives
+	 * real stock reduction via an on-hold transition, resumes the order through create_order(),
+	 * and asserts the resumed line item still carries _reduced_stock so a subsequent reduce is
+	 * a no-op instead of double-counting.
 	 */
-	public function test_resuming_failed_order_restores_stock_and_resets_flag() {
+	public function test_resuming_failed_order_preserves_reduced_stock() {
 		update_option( 'woocommerce_manage_stock', 'yes' );
 
 		$product = WC_Helper_Product::create_simple_product(
@@ -391,7 +393,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			)
 		);
 
-		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
 		$data = array(
 			'ship_to_different_address' => false,
@@ -406,11 +408,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$order = wc_get_order( $order_id );
 
 		// Transition to on-hold: fires wc_maybe_reduce_stock_levels, which calls
-		// wc_reduce_stock_levels() (sets _reduced_stock on items) and sets the
-		// _order_stock_reduced flag to true.
+		// wc_reduce_stock_levels() to set _reduced_stock on the items and the
+		// _order_stock_reduced flag to true. This is the real reduction path; the meta is
+		// never injected manually.
 		$order->update_status( 'on-hold' );
 
-		// Confirm stock was actually reduced and the flag is set.
 		$this->assertSame(
 			9,
 			wc_get_product( $product->get_id() )->get_stock_quantity(),
@@ -421,35 +423,121 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			'_order_stock_reduced must be true after stock is reduced.'
 		);
 
-		// Simulate payment failure: on-hold → failed. No stock hook fires for 'failed'.
+		// Simulate payment failure: on-hold -> failed. No stock hook fires for 'failed'.
 		$order->update_status( 'failed' );
 
-		$this->assertSame(
-			9,
-			wc_get_product( $product->get_id() )->get_stock_quantity(),
-			'Stock must still be 9 after the failed transition.'
-		);
-
-		// Second checkout attempt: same cart, same cart hash → create_order() resumes
-		// the existing failed order instead of creating a new one.
+		// Second checkout attempt: same cart, same cart hash, so create_order() resumes the
+		// existing failed order instead of creating a new one.
 		WC()->session->set( 'order_awaiting_payment', $order_id );
 
 		$order_id_2 = $this->sut->create_order( $data );
 		$this->assertIsInt( $order_id_2 );
 		$this->assertSame( $order_id, $order_id_2, 'create_order() should resume the existing failed order.' );
 
-		// The fix must have restored stock before wiping items.
+		// Stock is intentionally NOT restored on resume; the order stays reduced.
 		$this->assertSame(
-			10,
+			9,
 			wc_get_product( $product->get_id() )->get_stock_quantity(),
-			'Stock must be restored to 10 after resume.'
+			'Stock must remain at 9 after resume; the resumed order keeps its reduced state.'
 		);
 
-		// The flag must be reset so the next reduction cycle (e.g. payment success)
-		// is not blocked by wc_maybe_reduce_stock_levels's early-return guard.
-		$this->assertFalse(
+		// The order-level flag stays true because the reduction was preserved, not undone.
+		$this->assertTrue(
 			wc_get_order( $order_id )->get_data_store()->get_stock_reduced( $order_id ),
-			'_order_stock_reduced must be reset to false after resume.'
+			'_order_stock_reduced must remain true after resume.'
+		);
+
+		// The core guard: the rebuilt line item must carry the preserved _reduced_stock.
+		// This is what fails if restore_reduced_stock_meta() is removed; without it the
+		// fresh items have no _reduced_stock and this assertion sees an empty value.
+		$resumed_order = wc_get_order( $order_id_2 );
+		$resumed_items = $resumed_order->get_items();
+		$this->assertCount( 1, $resumed_items, 'Resumed order should have exactly one line item.' );
+
+		$resumed_item = current( $resumed_items );
+		$this->assertSame(
+			1.0,
+			wc_stock_amount( $resumed_item->get_meta( '_reduced_stock', true ) ),
+			'Resumed line item must carry the preserved _reduced_stock of 1.'
+		);
+
+		// Delete-the-fix consequence, asserted directly: a further reduce must be a no-op
+		// because _reduced_stock is present. Without the fix, _reduced_stock would be 0/empty
+		// and this call would drop stock from 9 to 8 (the double reduction this PR prevents).
+		wc_reduce_stock_levels( $order_id_2 );
+
+		$this->assertSame(
+			9,
+			wc_get_product( $product->get_id() )->get_stock_quantity(),
+			'A subsequent reduce must not double-count; stock stays at 9.'
+		);
+
+		WC()->cart->empty_cart();
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Resuming a failed order reconciles _reduced_stock when the cart quantity shrinks.
+	 *
+	 * Companion to test_resuming_failed_order_preserves_reduced_stock covering the reconcile
+	 * branch: when the resumed cart asks for fewer units than were originally reduced, the
+	 * preserved _reduced_stock is clamped to the new quantity so a line never records more
+	 * reduced stock than its own quantity (which would make wc_maybe_adjust_line_item_product_stock()
+	 * compute a negative delta and spuriously restore stock on a later admin update).
+	 */
+	public function test_resuming_failed_order_clamps_reduced_stock_on_quantity_decrease() {
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		$product = WC_Helper_Product::create_simple_product(
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 10,
+			)
+		);
+
+		// Reduce 3 units on the first pass.
+		WC()->cart->add_to_cart( $product->get_id(), 3 );
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'customer@example.com',
+		);
+
+		$order_id = $this->sut->create_order( $data );
+		$order    = wc_get_order( $order_id );
+		$order->update_status( 'on-hold' );
+
+		$this->assertSame(
+			7,
+			wc_get_product( $product->get_id() )->get_stock_quantity(),
+			'Stock must be reduced to 7 after reducing 3 units.'
+		);
+
+		$order->update_status( 'failed' );
+
+		// Resume with a smaller cart: 1 unit. The cart hash will differ, so to exercise the
+		// resume path we rebuild the cart to the new quantity and force the awaiting-payment
+		// session key; create_order() recomputes the hash from the current cart.
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		$order->set_cart_hash( WC()->cart->get_cart_hash() );
+		$order->save();
+		WC()->session->set( 'order_awaiting_payment', $order_id );
+
+		$order_id_2 = $this->sut->create_order( $data );
+		$this->assertSame( $order_id, $order_id_2, 'create_order() should resume the existing failed order.' );
+
+		$resumed_item = current( wc_get_order( $order_id_2 )->get_items() );
+		$this->assertSame(
+			1.0,
+			wc_stock_amount( $resumed_item->get_quantity() ),
+			'Resumed line item quantity should reflect the smaller cart (1).'
+		);
+		$this->assertSame(
+			1.0,
+			wc_stock_amount( $resumed_item->get_meta( '_reduced_stock', true ) ),
+			'_reduced_stock must be clamped to the new quantity (1), not the original 3.'
 		);
 
 		WC()->cart->empty_cart();

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -18,6 +18,15 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	private $sut;
 
 	/**
+	 * Value of woocommerce_manage_stock captured in setUp so tearDown can
+	 * restore it instead of deleting (delete_option resolves to WC defaults
+	 * rather than the actual pre-test state, which leaks into other tests).
+	 *
+	 * @var string|false
+	 */
+	private $prev_manage_stock;
+
+	/**
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
@@ -33,6 +42,8 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		};
 		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
 
+		$this->prev_manage_stock = get_option( 'woocommerce_manage_stock', false );
+
 		WC()->cart->empty_cart();
 
 		add_filter( 'woocommerce_checkout_registration_enabled', '__return_true' );
@@ -44,7 +55,16 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	public function tearDown(): void {
 		remove_filter( 'woocommerce_checkout_registration_enabled', '__return_true' );
 		delete_option( 'woocommerce_calc_taxes' );
-		delete_option( 'woocommerce_manage_stock' );
+		// Restore rather than delete so we don't leave the option absent when
+		// it had a real value before this test ran.
+		if ( false === $this->prev_manage_stock ) {
+			delete_option( 'woocommerce_manage_stock' );
+		} else {
+			update_option( 'woocommerce_manage_stock', $this->prev_manage_stock );
+		}
+		// Clear the session key set during resume-order tests so it doesn't
+		// bleed into tests that follow in the same PHP process.
+		WC()->session->set( 'order_awaiting_payment', null );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -44,6 +44,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	public function tearDown(): void {
 		remove_filter( 'woocommerce_checkout_registration_enabled', '__return_true' );
 		delete_option( 'woocommerce_calc_taxes' );
+		delete_option( 'woocommerce_manage_stock' );
 	}
 
 	/**
@@ -344,5 +345,94 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->assertInstanceOf( WP_Error::class, $result, 'create_order() should return a WP_Error when line items were not persisted.' );
 		$this->assertSame( 'checkout-error', $result->get_error_code(), 'Error code should come from the checkout try/catch path.' );
 		$this->assertStringContainsString( 'Order items could not be saved', $result->get_error_message(), 'Error message should surface the defense-in-depth guard message.' );
+	}
+
+	/**
+	 * @testdox Resuming a failed order restores stock and resets _order_stock_reduced.
+	 *
+	 * Regression for #36702: when remove_order_items() is called during order resumption,
+	 * the item-level _reduced_stock metadata is destroyed along with the items. Without
+	 * an explicit restore-then-reset, the order-level _order_stock_reduced flag stays 'yes'.
+	 * On cancellation, wc_increase_stock_levels() skips items with no _reduced_stock meta
+	 * so stock is never restored. On admin order update, wc_adjust_line_item_product_stock()
+	 * reads _reduced_stock=0 on the fresh items and double-reduces stock.
+	 *
+	 * This test drives the full lifecycle: real stock reduction via an on-hold transition,
+	 * then a failed transition (no stock change), then a cart-hash-matched resume that must
+	 * restore stock before removing items and reset the flag to false.
+	 */
+	public function test_resuming_failed_order_restores_stock_and_resets_flag() {
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		$product = WC_Helper_Product::create_simple_product(
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 10,
+			)
+		);
+
+		WC()->cart->add_to_cart( $product->get_id() );
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'payment_method'            => WC_Gateway_BACS::ID,
+			'billing_email'             => 'customer@example.com',
+		);
+
+		// First checkout creates the order (pending via BACS).
+		$order_id = $this->sut->create_order( $data );
+		$this->assertIsInt( $order_id );
+
+		$order = wc_get_order( $order_id );
+
+		// Transition to on-hold: fires wc_maybe_reduce_stock_levels, which calls
+		// wc_reduce_stock_levels() (sets _reduced_stock on items) and sets the
+		// _order_stock_reduced flag to true.
+		$order->update_status( 'on-hold' );
+
+		// Confirm stock was actually reduced and the flag is set.
+		$this->assertSame(
+			9,
+			wc_get_product( $product->get_id() )->get_stock_quantity(),
+			'Stock must be reduced to 9 after the on-hold transition.'
+		);
+		$this->assertTrue(
+			wc_get_order( $order_id )->get_data_store()->get_stock_reduced( $order_id ),
+			'_order_stock_reduced must be true after stock is reduced.'
+		);
+
+		// Simulate payment failure: on-hold → failed. No stock hook fires for 'failed'.
+		$order->update_status( 'failed' );
+
+		$this->assertSame(
+			9,
+			wc_get_product( $product->get_id() )->get_stock_quantity(),
+			'Stock must still be 9 after the failed transition.'
+		);
+
+		// Second checkout attempt: same cart, same cart hash → create_order() resumes
+		// the existing failed order instead of creating a new one.
+		WC()->session->set( 'order_awaiting_payment', $order_id );
+
+		$order_id_2 = $this->sut->create_order( $data );
+		$this->assertIsInt( $order_id_2 );
+		$this->assertSame( $order_id, $order_id_2, 'create_order() should resume the existing failed order.' );
+
+		// The fix must have restored stock before wiping items.
+		$this->assertSame(
+			10,
+			wc_get_product( $product->get_id() )->get_stock_quantity(),
+			'Stock must be restored to 10 after resume.'
+		);
+
+		// The flag must be reset so the next reduction cycle (e.g. payment success)
+		// is not blocked by wc_maybe_reduce_stock_levels's early-return guard.
+		$this->assertFalse(
+			wc_get_order( $order_id )->get_data_store()->get_stock_reduced( $order_id ),
+			'_order_stock_reduced must be reset to false after resume.'
+		);
+
+		WC()->cart->empty_cart();
+		$product->delete( true );
 	}
 }


### PR DESCRIPTION
## What

When `create_order()` resumes an existing `pending` or `failed` order (same cart hash), it calls `$order->remove_order_items()` to wipe old line items before re-populating them from the current cart. Item-level `_reduced_stock` metadata lives on those rows and is deleted along with them.

After `remove_order_items()`, the order-level `_order_stock_reduced` flag remains `yes` with no per-item record of how much was reduced. Two downstream paths break silently:

1. **Cancellation** — `wc_increase_stock_levels()` reads `_reduced_stock` per item to know how much to restore. With empty meta it skips every item. Stock is never returned.
2. **Admin order update** — `wc_adjust_line_item_product_stock()` reads `_reduced_stock = 0` on the fresh items and subtracts again. Stock is reduced a second time.

## Fix

Check `_order_stock_reduced` before calling `remove_order_items()`. If the flag is set, call `wc_increase_stock_levels($order)` while `_reduced_stock` is still present on the items, then reset the flag.

`set_stock_reduced($order, false)` is called with the **order object** (not the int ID) so both post-meta and the in-memory `WC_Order::$order_stock_reduced` property are updated. The order is saved later in `create_order()` and would overwrite the flag back to `true` if only the post-meta were written.

## Test

The regression test drives the full lifecycle:

- Create product (stock = 10), add to cart, create order
- Transition to `on-hold` → `wc_maybe_reduce_stock_levels` fires → stock = 9, `_reduced_stock` set on items, `_order_stock_reduced = true`
- Transition to `failed` (no stock hook fires)
- Second checkout with same cart → `create_order()` detects the matching cart hash and resumes the failed order
- Assert stock restored to 10 and `_order_stock_reduced` reset to `false`

Intermediate assertions confirm stock actually changed (10→9) before the resume, so the final assertion is meaningful and not a trivially-true pass against an unchanged baseline.

## How to test

1. Create a product with managed stock (qty 10).
2. Add to cart, proceed to checkout, submit with a payment gateway that sets the order to `on-hold` (or manually transition the order to `on-hold` in WP Admin after checkout).
3. Copy the order ID. In WP Admin, set the order to `failed`.
4. Return to checkout (same cart/session). The order should resume and stock should be back at 10, not 9.
5. Without the fix: stock stays at 9, `_order_stock_reduced` stays `yes`, and a subsequent cancellation will not restore it.

Closes #36702

---

*Developed with AI assistance (code generation + test writing). Manually reviewed and verified against WooCommerce data-store internals (`class-wc-order-data-store-cpt.php::set_stock_reduced`, `wc-stock-functions.php::wc_increase_stock_levels`).*