### PR TITLE
Add recommended tax solutions to tax settings

### DIFF
--- a/plugins/woocommerce/changelog/65785-codex-tax-settings-recommendations
+++ b/plugins/woocommerce/changelog/65785-codex-tax-settings-recommendations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Added Tax extensions recommendations.

--- a/plugins/woocommerce/changelog/wooplug-65783-tax-settings-recommendations
+++ b/plugins/woocommerce/changelog/wooplug-65783-tax-settings-recommendations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add recommended tax solutions to WooCommerce > Settings > Tax.

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/embedded-body-layout.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/embedded-body-layout.tsx
@@ -15,6 +15,7 @@ import QueryString, { parse } from 'qs';
  */
 import { PaymentRecommendations } from '../payments';
 import { ShippingRecommendations } from '../shipping';
+import { TaxRecommendations } from '../tax';
 import { AbandonedCartRecoveryRecommendations } from '../abandoned-cart-recovery';
 import { EmbeddedBodyProps } from './embedded-body-props';
 import './style.scss';
@@ -30,6 +31,7 @@ function isWPPage(
 const EMBEDDED_BODY_COMPONENT_LIST: React.ElementType[] = [
 	PaymentRecommendations,
 	ShippingRecommendations,
+	TaxRecommendations,
 	AbandonedCartRecoveryRecommendations,
 ];
 

--- a/plugins/woocommerce/client/admin/client/tax/index.ts
+++ b/plugins/woocommerce/client/admin/client/tax/index.ts
@@ -1,0 +1,1 @@
+export * from './tax-recommendations-wrapper';

--- a/plugins/woocommerce/client/admin/client/tax/tax-recommendations-wrapper.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/tax-recommendations-wrapper.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { lazy, Suspense } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { EmbeddedBodyProps } from '../embedded-body-layout/embedded-body-props';
+import RecommendationsEligibilityWrapper from '../settings-recommendations/recommendations-eligibility-wrapper';
+
+const TaxRecommendationsLoader = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "tax-recommendations" */ './tax-recommendations'
+		)
+);
+
+export const TaxRecommendations = ( {
+	page,
+	tab,
+	section,
+}: EmbeddedBodyProps ) => {
+	if ( page !== 'wc-settings' ) {
+		return null;
+	}
+
+	if ( tab !== 'tax' ) {
+		return null;
+	}
+
+	if ( Boolean( section ) ) {
+		return null;
+	}
+
+	return (
+		<RecommendationsEligibilityWrapper>
+			<Suspense fallback={ null }>
+				<TaxRecommendationsLoader />
+			</Suspense>
+		</RecommendationsEligibilityWrapper>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/tax/tax-recommendations.scss
+++ b/plugins/woocommerce/client/admin/client/tax/tax-recommendations.scss
@@ -1,0 +1,69 @@
+.woocommerce-recommended-tax-extensions-wrapper {
+	padding-bottom: 60px;
+}
+
+.woocommerce-recommended-tax-extensions {
+	.woocommerce-list__item {
+		> .woocommerce-list__item-inner {
+			align-items: flex-start;
+		}
+
+		&:hover {
+			background-color: $white;
+
+			.woocommerce-list__item-title {
+				color: $gray-900;
+			}
+		}
+	}
+
+	.woocommerce-list__item-title {
+		font-size: 14px;
+		color: $gray-900;
+		font-weight: 600;
+	}
+
+	.woocommerce-pill {
+		margin-left: $gap-smallest;
+		margin-top: $gap-smallest;
+		margin-bottom: $gap-smallest;
+		padding: 2px 8px;
+
+		@media (min-width: #{ ($break-mobile) }) {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+	}
+
+	.woocommerce-list__item-after .components-button {
+		margin-left: $gap-small;
+	}
+
+	.woocommerce-list__item-text,
+	.woocommerce-recommended-tax__header-heading {
+		max-width: 749px;
+	}
+}
+
+.woocommerce-tax-recommendation-item {
+	&__logo {
+		display: block;
+		width: 36px;
+		height: 36px;
+		object-fit: contain;
+	}
+
+	&__monogram {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 36px;
+		height: 36px;
+		border-radius: 4px;
+		background: $gray-900;
+		color: $white;
+		font-size: 16px;
+		font-weight: 600;
+		line-height: 1;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
@@ -1,0 +1,342 @@
+/**
+ * External dependencies
+ */
+import { Button, CardFooter, ExternalLink } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Children, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Pill } from '@woocommerce/components';
+import { Text } from '@woocommerce/experimental';
+import { PluginNames, pluginsStore } from '@woocommerce/data';
+import { getAdminLink } from '@woocommerce/settings';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import taxLogo from '../task-lists/fills/tax/woocommerce-tax/logo.png';
+import { createNoticesFromResponse } from '../lib/notices';
+import {
+	DismissableList,
+	DismissableListHeading,
+} from '../settings-recommendations/dismissable-list';
+import { TrackedLink } from '~/components/tracked-link/tracked-link';
+import './tax-recommendations.scss';
+
+type TaxRecommendation = {
+	id: 'anrok-tax' | 'woocommerce-tax';
+	title: string;
+	description: string;
+	productUrl: string;
+	logo: React.ReactNode;
+	pluginSlugs: string[];
+	isRecommended?: boolean;
+};
+
+const useInstallPlugin = () => {
+	const [ pluginsBeingSetup, setPluginsBeingSetup ] = useState<
+		Array< string >
+	>( [] );
+
+	const { installPlugins, activatePlugins } = useDispatch( pluginsStore );
+
+	const handleInstall = ( slugs: string[] ): PromiseLike< void > => {
+		if ( pluginsBeingSetup.length > 0 ) {
+			return Promise.resolve();
+		}
+
+		setPluginsBeingSetup( slugs );
+
+		return installPlugins( slugs as Partial< PluginNames >[] )
+			.then( () => {
+				setPluginsBeingSetup( [] );
+			} )
+			.catch( ( response: { errors: Record< string, string > } ) => {
+				createNoticesFromResponse( response );
+				setPluginsBeingSetup( [] );
+
+				return Promise.reject();
+			} );
+	};
+
+	const handleActivate = ( slugs: string[] ): PromiseLike< void > => {
+		if ( pluginsBeingSetup.length > 0 ) {
+			return Promise.resolve();
+		}
+
+		setPluginsBeingSetup( slugs );
+
+		return activatePlugins( slugs as Partial< PluginNames >[] )
+			.then( () => {
+				setPluginsBeingSetup( [] );
+			} )
+			.catch( ( response: { errors: Record< string, string > } ) => {
+				createNoticesFromResponse( response );
+				setPluginsBeingSetup( [] );
+
+				return Promise.reject();
+			} );
+	};
+
+	return [ pluginsBeingSetup, handleInstall, handleActivate ] as const;
+};
+
+const TaxRecommendationItem = ( {
+	pluginSlug,
+	isPluginInstalled,
+	isPluginActive,
+	pluginsBeingSetup,
+	onInstallClick,
+	onActivateClick,
+	isRecommended = false,
+	title,
+	description,
+	productUrl,
+	logo,
+}: TaxRecommendation & {
+	pluginSlug: string;
+	isPluginInstalled: boolean;
+	isPluginActive: boolean;
+	pluginsBeingSetup: Array< string >;
+	onInstallClick: ( slugs: string[] ) => PromiseLike< void >;
+	onActivateClick: ( slugs: string[] ) => PromiseLike< void >;
+} ) => {
+	const { createSuccessNotice } = useDispatch( 'core/notices' );
+
+	const handleLearnMoreClick = () => {
+		recordEvent( 'settings_tax_recommendation_click', {
+			extension: title,
+		} );
+	};
+
+	const handleClick = () => {
+		recordEvent( 'settings_tax_recommendation_setup_click', {
+			plugin: pluginSlug,
+			action: isPluginInstalled ? 'activate' : 'install',
+		} );
+
+		const action = isPluginInstalled ? onActivateClick : onInstallClick;
+
+		action( [ pluginSlug ] ).then( () => {
+			createSuccessNotice(
+				isPluginInstalled
+					? sprintf(
+							/* translators: %s: extension name. */
+							__( '%s activated!', 'woocommerce' ),
+							title
+					  )
+					: sprintf(
+							/* translators: %s: extension name. */
+							__( '%s is installed!', 'woocommerce' ),
+							title
+					  ),
+				{}
+			);
+		} );
+	};
+
+	return (
+		<div className="woocommerce-list__item-inner woocommerce-tax-recommendation-item">
+			<div className="woocommerce-list__item-before">{ logo }</div>
+			<div className="woocommerce-list__item-text">
+				<span className="woocommerce-list__item-title">
+					{ title }
+					{ isRecommended && (
+						<Pill>{ __( 'Recommended', 'woocommerce' ) }</Pill>
+					) }
+				</span>
+				<span className="woocommerce-list__item-content">
+					{ description }
+					<br />
+					<ExternalLink
+						href={ productUrl }
+						onClick={ handleLearnMoreClick }
+					>
+						{ __( 'Learn more', 'woocommerce' ) }
+					</ExternalLink>
+				</span>
+			</div>
+			<div className="woocommerce-list__item-after">
+				{ isPluginActive ? (
+					<Button
+						variant="secondary"
+						aria-disabled="true"
+						aria-label={ sprintf(
+							/* translators: %s: extension name. */
+							__( '%s is already active', 'woocommerce' ),
+							title
+						) }
+					>
+						{ __( 'Active', 'woocommerce' ) }
+					</Button>
+				) : (
+					<Button
+						variant={ isPluginInstalled ? 'primary' : 'secondary' }
+						onClick={ handleClick }
+						isBusy={ pluginsBeingSetup.includes( pluginSlug ) }
+						disabled={ pluginsBeingSetup.length > 0 }
+					>
+						{ isPluginInstalled
+							? __( 'Activate', 'woocommerce' )
+							: __( 'Install', 'woocommerce' ) }
+					</Button>
+				) }
+			</div>
+		</div>
+	);
+};
+
+const TaxRecommendationsList = ( {
+	children,
+}: {
+	children: React.ReactNode;
+} ) => (
+	<DismissableList
+		className="woocommerce-recommended-tax-extensions"
+		dismissOptionName="woocommerce_settings_tax_recommendations_hidden"
+	>
+		<DismissableListHeading>
+			<Text variant="title.small" as="p" size="20" lineHeight="28px">
+				{ __( 'Recommended tax solutions', 'woocommerce' ) }
+			</Text>
+			<Text
+				className="woocommerce-recommended-tax__header-heading"
+				variant="caption"
+				as="p"
+				size="12"
+				lineHeight="16px"
+			>
+				{ __(
+					'Explore tax extensions that can help automate calculations and compliance for your store.',
+					'woocommerce'
+				) }
+			</Text>
+		</DismissableListHeading>
+		<ul className="woocommerce-list">
+			{ Children.map( children, ( item ) => (
+				<li className="woocommerce-list__item">{ item }</li>
+			) ) }
+		</ul>
+		<CardFooter>
+			<TrackedLink
+				message={ __(
+					// translators: {{Link}} is a placeholder for a html element.
+					'Visit {{Link}}the WooCommerce Marketplace{{/Link}} to find more tax solutions.',
+					'woocommerce'
+				) }
+				targetUrl={ getAdminLink(
+					'admin.php?page=wc-admin&tab=extensions&path=/extensions&category=operations'
+				) }
+				linkType="wc-admin"
+				eventName="settings_tax_recommendation_visit_marketplace_click"
+			/>
+		</CardFooter>
+	</DismissableList>
+);
+
+const getPluginSlugForAction = (
+	pluginSlugs: string[],
+	installedPlugins: string[],
+	activePlugins: string[]
+) =>
+	pluginSlugs.find(
+		( pluginSlug ) =>
+			activePlugins.includes( pluginSlug ) ||
+			installedPlugins.includes( pluginSlug )
+	) ?? pluginSlugs[ 0 ];
+
+const TaxRecommendations = () => {
+	const [ pluginsBeingSetup, handleInstall, handleActivate ] =
+		useInstallPlugin();
+	const { activePlugins, installedPlugins } = useSelect( ( select ) => {
+		const { getActivePlugins, getInstalledPlugins } =
+			select( pluginsStore );
+
+		return {
+			activePlugins: getActivePlugins() ?? [],
+			installedPlugins: getInstalledPlugins() ?? [],
+		};
+	}, [] ) ?? {
+		activePlugins: [],
+		installedPlugins: [],
+	};
+
+	const recommendations: TaxRecommendation[] = [
+		{
+			id: 'woocommerce-tax',
+			title: __( 'WooCommerce Tax', 'woocommerce' ),
+			description: __(
+				'Automate sales tax calculations right from your WooCommerce dashboard.',
+				'woocommerce'
+			),
+			productUrl: 'https://woocommerce.com/products/tax/',
+			pluginSlugs: [
+				'woocommerce-services',
+				'woocommerce-tax',
+				'woocommerce-shipping',
+			],
+			logo: (
+				<img
+					className="woocommerce-tax-recommendation-item__logo"
+					src={ taxLogo }
+					alt=""
+				/>
+			),
+			isRecommended: true,
+		},
+		{
+			id: 'anrok-tax',
+			title: __( 'Anrok', 'woocommerce' ),
+			description: __(
+				'Support sales tax, VAT, and GST compliance with automated workflows from Anrok.',
+				'woocommerce'
+			),
+			productUrl: 'https://woocommerce.com/products/anrok-tax/',
+			pluginSlugs: [ 'anrok-tax' ],
+			logo: (
+				<span
+					className="woocommerce-tax-recommendation-item__monogram"
+					aria-hidden="true"
+				>
+					A
+				</span>
+			),
+		},
+	];
+
+	return (
+		<div className="woocommerce-recommended-tax-extensions-wrapper">
+			<TaxRecommendationsList>
+				{ recommendations.map( ( recommendation ) => {
+					const isPluginActive = recommendation.pluginSlugs.some(
+						( pluginSlug ) => activePlugins.includes( pluginSlug )
+					);
+					const isPluginInstalled =
+						isPluginActive ||
+						recommendation.pluginSlugs.some( ( pluginSlug ) =>
+							installedPlugins.includes( pluginSlug )
+						);
+
+					return (
+						<TaxRecommendationItem
+							key={ recommendation.id }
+							pluginSlug={ getPluginSlugForAction(
+								recommendation.pluginSlugs,
+								installedPlugins,
+								activePlugins
+							) }
+							isPluginInstalled={ isPluginInstalled }
+							isPluginActive={ isPluginActive }
+							pluginsBeingSetup={ pluginsBeingSetup }
+							onInstallClick={ handleInstall }
+							onActivateClick={ handleActivate }
+							{ ...recommendation }
+						/>
+					);
+				} ) }
+			</TaxRecommendationsList>
+		</div>
+	);
+};
+
+export default TaxRecommendations;

--- a/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
@@ -110,29 +110,50 @@ const TaxRecommendationItem = ( {
 	};
 
 	const handleClick = () => {
+		const trackingBase = {
+			context: 'settings',
+			selected_plugin: pluginSlug,
+		};
+
+		recordEvent( 'tax_partner_click', trackingBase );
 		recordEvent( 'settings_tax_recommendation_setup_click', {
 			plugin: pluginSlug,
 			action: isPluginInstalled ? 'activate' : 'install',
 		} );
 
 		const action = isPluginInstalled ? onActivateClick : onInstallClick;
+		const eventName = isPluginInstalled
+			? 'tax_partner_activate'
+			: 'tax_partner_install';
 
-		action( [ pluginSlug ] ).then( () => {
-			createSuccessNotice(
-				isPluginInstalled
-					? sprintf(
-							/* translators: %s: extension name. */
-							__( '%s activated!', 'woocommerce' ),
-							title
-					  )
-					: sprintf(
-							/* translators: %s: extension name. */
-							__( '%s is installed!', 'woocommerce' ),
-							title
-					  ),
-				{}
-			);
-		} );
+		action( [ pluginSlug ] ).then(
+			() => {
+				recordEvent( eventName, {
+					...trackingBase,
+					success: true,
+				} );
+				createSuccessNotice(
+					isPluginInstalled
+						? sprintf(
+								/* translators: %s: extension name. */
+								__( '%s activated!', 'woocommerce' ),
+								title
+						  )
+						: sprintf(
+								/* translators: %s: extension name. */
+								__( '%s is installed!', 'woocommerce' ),
+								title
+						  ),
+					{}
+				);
+			},
+			() => {
+				recordEvent( eventName, {
+					...trackingBase,
+					success: false,
+				} );
+			}
+		);
 	};
 
 	return (

--- a/plugins/woocommerce/client/admin/client/tax/test/tax-recommendations-wrapper.test.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/test/tax-recommendations-wrapper.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import { useUser } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { TaxRecommendations } from '../tax-recommendations-wrapper';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/data', () => ( {
+	...jest.requireActual( '@woocommerce/data' ),
+	useUser: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+	Suspense: () => <div>Recommended tax solutions</div>,
+} ) );
+
+describe( 'TaxRecommendations', () => {
+	beforeEach( () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getOption: () => 'yes',
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+
+		( useUser as jest.Mock ).mockReturnValue( {
+			currentUserCan: () => true,
+		} );
+	} );
+
+	it( 'should not render when page is not wc-settings', () => {
+		const { queryByText } = render(
+			<TaxRecommendations
+				page="wc-admin"
+				tab="tax"
+				section={ undefined }
+			/>
+		);
+
+		expect(
+			queryByText( 'Recommended tax solutions' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when tab is not tax', () => {
+		const { queryByText } = render(
+			<TaxRecommendations
+				page="wc-settings"
+				tab="shipping"
+				section={ undefined }
+			/>
+		);
+
+		expect(
+			queryByText( 'Recommended tax solutions' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when section is not empty', () => {
+		const { queryByText } = render(
+			<TaxRecommendations
+				page="wc-settings"
+				tab="tax"
+				section="standard"
+			/>
+		);
+
+		expect(
+			queryByText( 'Recommended tax solutions' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when marketplace suggestions are disabled', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getOption: () => 'no',
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+
+		const { queryByText } = render(
+			<TaxRecommendations
+				page="wc-settings"
+				tab="tax"
+				section={ undefined }
+			/>
+		);
+
+		expect(
+			queryByText( 'Recommended tax solutions' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when the current user cannot install plugins', () => {
+		( useUser as jest.Mock ).mockReturnValue( {
+			currentUserCan: () => false,
+		} );
+
+		const { queryByText } = render(
+			<TaxRecommendations
+				page="wc-settings"
+				tab="tax"
+				section={ undefined }
+			/>
+		);
+
+		expect(
+			queryByText( 'Recommended tax solutions' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render on the default tax settings section', () => {
+		const { getByText } = render(
+			<TaxRecommendations
+				page="wc-settings"
+				tab="tax"
+				section={ undefined }
+			/>
+		);
+
+		expect( getByText( 'Recommended tax solutions' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/tax/test/tax-recommendations.test.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/test/tax-recommendations.test.tsx
@@ -4,6 +4,7 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -42,6 +43,7 @@ describe( 'TaxRecommendations', () => {
 		installPluginsMock.mockClear();
 		activatePluginsMock.mockClear();
 		createSuccessNoticeMock.mockClear();
+		( recordEvent as jest.Mock ).mockClear();
 
 		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
 			fn( () => ( {
@@ -125,11 +127,31 @@ describe( 'TaxRecommendations', () => {
 			] );
 		} );
 
+		expect( recordEvent ).toHaveBeenCalledWith( 'tax_partner_click', {
+			context: 'settings',
+			selected_plugin: 'woocommerce-services',
+		} );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_tax_recommendation_setup_click',
+			{
+				plugin: 'woocommerce-services',
+				action: 'install',
+			}
+		);
+
 		await waitFor( () => {
 			expect( createSuccessNoticeMock ).toHaveBeenCalledWith(
 				'WooCommerce Tax is installed!',
 				expect.anything()
 			);
+		} );
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith( 'tax_partner_install', {
+				context: 'settings',
+				selected_plugin: 'woocommerce-services',
+				success: true,
+			} );
 		} );
 	} );
 
@@ -161,10 +183,94 @@ describe( 'TaxRecommendations', () => {
 			] );
 		} );
 
+		expect( recordEvent ).toHaveBeenCalledWith( 'tax_partner_click', {
+			context: 'settings',
+			selected_plugin: 'woocommerce-tax',
+		} );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_tax_recommendation_setup_click',
+			{
+				plugin: 'woocommerce-tax',
+				action: 'activate',
+			}
+		);
+
 		await waitFor( () => {
 			expect( createSuccessNoticeMock ).toHaveBeenCalledWith(
 				'WooCommerce Tax activated!',
 				expect.anything()
+			);
+		} );
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'tax_partner_activate',
+				{
+					context: 'settings',
+					selected_plugin: 'woocommerce-tax',
+					success: true,
+				}
+			);
+		} );
+	} );
+
+	it( 'records a failed tax_partner_install event when install fails', async () => {
+		installPluginsMock.mockRejectedValueOnce( undefined );
+
+		render( <TaxRecommendations /> );
+
+		const wooCommerceTaxItem = screen
+			.getByText( 'WooCommerce Tax' )
+			.closest( '.woocommerce-list__item' );
+
+		expect( wooCommerceTaxItem ).not.toBeNull();
+
+		userEvent.click(
+			within( wooCommerceTaxItem as HTMLElement ).getByRole( 'button', {
+				name: 'Install',
+			} )
+		);
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith( 'tax_partner_install', {
+				context: 'settings',
+				selected_plugin: 'woocommerce-services',
+				success: false,
+			} );
+		} );
+	} );
+
+	it( 'records a failed tax_partner_activate event when activation fails', async () => {
+		activatePluginsMock.mockRejectedValueOnce( undefined );
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getInstalledPlugins: () => [ 'anrok-tax' ],
+				getActivePlugins: () => [],
+			} ) )
+		);
+
+		render( <TaxRecommendations /> );
+
+		const anrokItem = screen
+			.getByText( 'Anrok' )
+			.closest( '.woocommerce-list__item' );
+
+		expect( anrokItem ).not.toBeNull();
+
+		userEvent.click(
+			within( anrokItem as HTMLElement ).getByRole( 'button', {
+				name: 'Activate',
+			} )
+		);
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'tax_partner_activate',
+				{
+					context: 'settings',
+					selected_plugin: 'anrok-tax',
+					success: false,
+				}
 			);
 		} );
 	} );

--- a/plugins/woocommerce/client/admin/client/tax/test/tax-recommendations.test.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/test/tax-recommendations.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import TaxRecommendations from '../tax-recommendations';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+jest.mock( '~/components/tracked-link/tracked-link', () => ( {
+	TrackedLink: ( { message } ) => <div>{ message }</div>,
+} ) );
+
+jest.mock( '../../settings-recommendations/dismissable-list', () => ( {
+	DismissableList: ( { children } ) => children,
+	DismissableListHeading: ( { children } ) => children,
+} ) );
+
+jest.mock( '../../lib/notices', () => ( {
+	createNoticesFromResponse: () => null,
+} ) );
+
+describe( 'TaxRecommendations', () => {
+	const installPluginsMock = jest.fn().mockResolvedValue( undefined );
+	const activatePluginsMock = jest.fn().mockResolvedValue( undefined );
+	const createSuccessNoticeMock = jest.fn();
+
+	beforeEach( () => {
+		installPluginsMock.mockClear();
+		activatePluginsMock.mockClear();
+		createSuccessNoticeMock.mockClear();
+
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getInstalledPlugins: () => [],
+				getActivePlugins: () => [],
+			} ) )
+		);
+
+		( useDispatch as jest.Mock ).mockImplementation( ( store ) => {
+			if ( store === 'core/notices' ) {
+				return {
+					createSuccessNotice: createSuccessNoticeMock,
+				};
+			}
+
+			return {
+				installPlugins: installPluginsMock,
+				activatePlugins: activatePluginsMock,
+			};
+		} );
+	} );
+
+	it( 'renders WooCommerce Tax and Anrok with install buttons when no related plugins are present', () => {
+		render( <TaxRecommendations /> );
+
+		expect( screen.getByText( 'WooCommerce Tax' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Anrok' ) ).toBeInTheDocument();
+		expect( screen.getAllByText( 'Install' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'shows WooCommerce Tax as active when a shipping-related Woo plugin is active', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getInstalledPlugins: () => [],
+				getActivePlugins: () => [ 'woocommerce-shipping' ],
+			} ) )
+		);
+
+		render( <TaxRecommendations /> );
+
+		expect( screen.getByText( 'WooCommerce Tax' ) ).toBeInTheDocument();
+		expect(
+			screen.getByLabelText( 'WooCommerce Tax is already active' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Anrok' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows Activate when Anrok is installed but inactive', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getInstalledPlugins: () => [ 'anrok-tax' ],
+				getActivePlugins: () => [],
+			} ) )
+		);
+
+		render( <TaxRecommendations /> );
+
+		expect( screen.getByText( 'WooCommerce Tax' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Anrok' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Activate' ) ).toBeInTheDocument();
+	} );
+
+	it( 'installs WooCommerce Tax using the WooCommerce Services slug', async () => {
+		render( <TaxRecommendations /> );
+
+		const wooCommerceTaxItem = screen
+			.getByText( 'WooCommerce Tax' )
+			.closest( '.woocommerce-list__item' );
+
+		expect( wooCommerceTaxItem ).not.toBeNull();
+
+		userEvent.click(
+			within( wooCommerceTaxItem as HTMLElement ).getByRole( 'button', {
+				name: 'Install',
+			} )
+		);
+
+		await waitFor( () => {
+			expect( installPluginsMock ).toHaveBeenCalledWith( [
+				'woocommerce-services',
+			] );
+		} );
+
+		await waitFor( () => {
+			expect( createSuccessNoticeMock ).toHaveBeenCalledWith(
+				'WooCommerce Tax is installed!',
+				expect.anything()
+			);
+		} );
+	} );
+
+	it( 'activates the installed WooCommerce Tax alias when one is already present', async () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getInstalledPlugins: () => [ 'woocommerce-tax' ],
+				getActivePlugins: () => [],
+			} ) )
+		);
+
+		render( <TaxRecommendations /> );
+
+		const wooCommerceTaxItem = screen
+			.getByText( 'WooCommerce Tax' )
+			.closest( '.woocommerce-list__item' );
+
+		expect( wooCommerceTaxItem ).not.toBeNull();
+
+		userEvent.click(
+			within( wooCommerceTaxItem as HTMLElement ).getByRole( 'button', {
+				name: 'Activate',
+			} )
+		);
+
+		await waitFor( () => {
+			expect( activatePluginsMock ).toHaveBeenCalledWith( [
+				'woocommerce-tax',
+			] );
+		} );
+
+		await waitFor( () => {
+			expect( createSuccessNoticeMock ).toHaveBeenCalledWith(
+				'WooCommerce Tax activated!',
+				expect.anything()
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The Tax settings screen did not surface marketplace recommendations the way the Shipping settings screen already does, which made the experience inconsistent for merchants configuring store taxes. This adds a Shipping-style recommendations card to the default `WooCommerce > Settings > Tax` tab for WooCommerce Tax and Anrok, including the same dismissable layout, install and activate button states, and bottom spacing behavior.

Closes #65783.

<img width="4326" height="2006" alt="Markup on 2026-06-16 at 16:33:04" src="https://github.com/user-attachments/assets/36d24279-6288-47a4-9b66-6a128a81318d" />

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Screenshots will be added in GitHub before this draft PR is marked ready for review.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start a local WooCommerce site and log in to wp-admin.
2. Go to `WooCommerce > Settings > Tax` and confirm the default Tax tab shows a `Recommended tax solutions` card with WooCommerce Tax and Anrok.
3. Confirm the card matches the Shipping recommendations pattern by showing the dismiss menu, marketplace footer link, and `Install`, `Activate`, or `Active` button states based on plugin state.
4. Click into a Tax subsection such as `Standard rates` and confirm the recommendations card does not render there.
5. Go to `WooCommerce > Settings > Shipping` and confirm the Tax card spacing and button behavior now matches the Shipping recommendations card.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm test:js -- client/tax/test/tax-recommendations.test.tsx client/tax/test/tax-recommendations-wrapper.test.tsx --runInBand`
- `pnpm exec eslint client/tax client/embedded-body-layout/embedded-body-layout.tsx --ext=js,ts,tsx`
- `pnpm exec stylelint client/tax/tax-recommendations.scss`
- `pnpm ts:check`
- `pnpm build:project:bundle`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- Manual verification on a local site in wp-admin confirmed the card appears on the default Tax tab, does not appear on Tax subsections, and matches the Shipping recommendations layout and button behavior.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Added Tax extensions recommendations.
</details>

<details>

<summary>Changelog Entry Comment</summary>

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
