### PR TITLE
Validate address on the Store API checkout-order endpoint before persisting changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-checkout-order-address-validation
+++ b/plugins/woocommerce/changelog/fix-store-api-checkout-order-address-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store API: validate address data on the checkout-order endpoint before it is persisted, so a rejected request can no longer modify an existing order's address or totals.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -70628,12 +70628,6 @@ parameters:
 			path: src/StoreApi/Routes/V1/Checkout.php
 
 		-
-			message: '#^@param WC_Order \$order does not accept actual type of parameter\: WC_Order\|WC_Order_Refund\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: src/StoreApi/Routes/V1/CheckoutOrder.php
-
-		-
 			message: '#^Access to an undefined property WooCommerce\:\:\$payment_gateways\.$#'
 			identifier: property.notFound
 			count: 1
@@ -70649,12 +70643,6 @@ parameters:
 			message: '#^Call to an undefined method WC_Order\|WC_Order_Refund\:\:get_billing_email\(\)\.$#'
 			identifier: method.notFound
 			count: 1
-			path: src/StoreApi/Routes/V1/CheckoutOrder.php
-
-		-
-			message: '#^Call to an undefined method WC_Order\|WC_Order_Refund\:\:needs_payment\(\)\.$#'
-			identifier: method.notFound
-			count: 2
 			path: src/StoreApi/Routes/V1/CheckoutOrder.php
 
 		-
@@ -70828,12 +70816,6 @@ parameters:
 		-
 			message: '#^PHPDoc tag @param has invalid value \(bool The WP_DEBUG mode\.\)\: Unexpected token "The", expected variable at offset 115 on line 4$#'
 			identifier: phpDoc.parseError
-			count: 1
-			path: src/StoreApi/Routes/V1/CheckoutOrder.php
-
-		-
-			message: '#^Parameter \#1 \$order of method Automattic\\WooCommerce\\StoreApi\\Utilities\\OrderController\:\:validate_existing_order_before_payment\(\) expects WC_Order, WC_Order\|WC_Order_Refund given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/StoreApi/Routes/V1/CheckoutOrder.php
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -198,28 +198,27 @@ class CheckoutOrder extends AbstractCartRoute {
 	 */
 	private function update_billing_address( \WP_REST_Request $request ) {
 		$customer = wc()->customer;
+
+		// Billing address is a required field.
 		$billing  = $request['billing_address'];
-		$shipping = $request['shipping_address'];
+
+		// If shipping address (optional field) was not provided, set it to the given billing address (required field).
+		$shipping = $request['shipping_address'] ?? $billing;
 
 		$this->order->set_billing_address( $billing );
 		$this->order->set_shipping_address( $shipping );
 		$this->order_controller->validate_existing_order_before_update( $this->order );
 
-		// Billing address is a required field.
+		// Update customer object with validated order addresses.
 		foreach ( $billing as $key => $value ) {
 			if ( is_callable( [ $customer, "set_billing_$key" ] ) ) {
 				$customer->{"set_billing_$key"}( $value );
 			}
 		}
 
-		// If shipping address (optional field) was not provided, set it to the given billing address (required field).
-		$shipping_address_values = $shipping ?? $billing;
-
-		foreach ( $shipping_address_values as $key => $value ) {
+		foreach ( $shipping as $key => $value ) {
 			if ( is_callable( [ $customer, "set_shipping_$key" ] ) ) {
 				$customer->{"set_shipping_$key"}( $value );
-			} elseif ( 'phone' === $key ) {
-				$customer->update_meta_data( 'shipping_phone', $value );
 			}
 		}
 
@@ -234,7 +233,6 @@ class CheckoutOrder extends AbstractCartRoute {
 		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', $customer, $request );
 
 		$customer->save();
-
 		$this->order->save();
 		$this->order->calculate_totals();
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -109,7 +109,7 @@ class CheckoutOrder extends AbstractCartRoute {
 		$order_id    = absint( $request['id'] );
 		$this->order = wc_get_order( $order_id );
 
-		if ( ! $this->order || ! $this->order->needs_payment() ) {
+		if ( ! $this->order instanceof \WC_Order || ! $this->order->needs_payment() ) {
 			return new \WP_Error(
 				'invalid_order_update_status',
 				__( 'This order cannot be paid for.', 'woocommerce' )
@@ -119,8 +119,8 @@ class CheckoutOrder extends AbstractCartRoute {
 		/**
 		 * Process request data.
 		 *
-		 * Note: Customer data is persisted from the request first so that OrderController::update_addresses_from_cart
-		 * uses the up to date customer address.
+		 * The order address is validated before anything is persisted, so a rejected request
+		 * cannot mutate the existing order or the customer record.
 		 */
 		$this->update_billing_address( $request );
 		$this->update_order_from_request( $request );
@@ -186,9 +186,13 @@ class CheckoutOrder extends AbstractCartRoute {
 	protected function cart_updated( \WP_REST_Request $request ) {}
 
 	/**
-	 * Updates the current customer session using data from the request (e.g. address data).
+	 * Applies the billing and shipping address from the request to the order and customer.
 	 *
-	 * Address session data is synced to the order itself later on by OrderController::update_order_from_cart()
+	 * The address is set on the order and validated before anything is persisted, so a rejected
+	 * request cannot mutate the order or the customer. wc()->customer is saved on shutdown (see
+	 * WooCommerce::initialize_cart()), so its address fields are only set once validation passes.
+	 *
+	 * @throws RouteException When the order address fails validation.
 	 *
 	 * @param \WP_REST_Request $request Full details about the request.
 	 */
@@ -196,6 +200,10 @@ class CheckoutOrder extends AbstractCartRoute {
 		$customer = wc()->customer;
 		$billing  = $request['billing_address'];
 		$shipping = $request['shipping_address'];
+
+		$this->order->set_billing_address( $billing );
+		$this->order->set_shipping_address( $shipping );
+		$this->order_controller->validate_existing_order_before_update( $this->order );
 
 		// Billing address is a required field.
 		foreach ( $billing as $key => $value ) {
@@ -227,8 +235,6 @@ class CheckoutOrder extends AbstractCartRoute {
 
 		$customer->save();
 
-		$this->order->set_billing_address( $billing );
-		$this->order->set_shipping_address( $shipping );
 		$this->order->save();
 		$this->order->calculate_totals();
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -200,7 +200,7 @@ class CheckoutOrder extends AbstractCartRoute {
 		$customer = wc()->customer;
 
 		// Billing address is a required field.
-		$billing  = $request['billing_address'];
+		$billing = $request['billing_address'];
 
 		// If shipping address (optional field) was not provided, set it to the given billing address (required field).
 		$shipping = $request['shipping_address'] ?? $billing;

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -175,6 +175,18 @@ class OrderController {
 	}
 
 	/**
+	 * Validate an existing order's address data before the order is updated from the request.
+	 *
+	 * Runs before any request data is persisted so a rejected address cannot mutate the order.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
+	 * @param \WC_Order $order Order object.
+	 */
+	public function validate_existing_order_before_update( \WC_Order $order ): void {
+		$this->validate_addresses( $order, $order->needs_shipping() );
+	}
+
+	/**
 	 * Perform custom order validation via WooCommerce hooks.
 	 *
 	 * Allows plugins to perform custom validation before payment.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -74,16 +74,8 @@ class Checkout extends MockeryTestCase {
 		$schema_controller = new SchemaController( $this->mock_extend );
 		$route             = new CheckoutRoute( $schema_controller, $schema_controller->get( 'checkout' ) );
 		register_rest_route( $route->get_namespace(), $route->get_path(), $route->get_args(), true );
-		$checkout_order_route = new CheckoutOrderRoute(
-			$schema_controller,
-			$schema_controller->get( 'checkout-order' )
-		);
-		register_rest_route(
-			$checkout_order_route->get_namespace(),
-			$checkout_order_route->get_path(),
-			$checkout_order_route->get_args(),
-			true
-		);
+		$order_route = new CheckoutOrderRoute( $schema_controller, $schema_controller->get( 'checkout-order' ) );
+		register_rest_route( $order_route->get_namespace(), $order_route->get_path(), $order_route->get_args(), true );
 
 		$fixtures = new FixtureData();
 		$fixtures->payments_enable_bacs();
@@ -1578,26 +1570,10 @@ class Checkout extends MockeryTestCase {
 		update_option( 'woocommerce_specific_ship_to_countries', array( 'US' ) );
 
 		$order = \WC_Helper_Order::create_order( 0 );
-		$order->set_shipping_address(
-			array(
-				'first_name' => 'Jeroen',
-				'last_name'  => 'Sormani',
-				'company'    => 'WooCompany',
-				'address_1'  => 'WooAddress',
-				'address_2'  => '',
-				'city'       => 'WooCity',
-				'state'      => 'NY',
-				'postcode'   => '12345',
-				'country'    => 'US',
-				'phone'      => '555-32123',
-			)
-		);
-		$order->save();
 
 		$original_billing_country  = $order->get_billing_country();
 		$original_shipping_country = $order->get_shipping_country();
 		$original_total            = $order->get_total();
-		$original_total_tax        = $order->get_total_tax();
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout/' . $order->get_id() );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1636,7 +1612,6 @@ class Checkout extends MockeryTestCase {
 		$this->assertEquals( $original_billing_country, $stored_order->get_billing_country() );
 		$this->assertEquals( $original_shipping_country, $stored_order->get_shipping_country() );
 		$this->assertEquals( $original_total, $stored_order->get_total() );
-		$this->assertEquals( $original_total_tax, $stored_order->get_total_tax() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Automattic\WooCommerce\StoreApi\Routes\V1\Checkout as CheckoutRoute;
+use Automattic\WooCommerce\StoreApi\Routes\V1\CheckoutOrder as CheckoutOrderRoute;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
@@ -73,6 +74,16 @@ class Checkout extends MockeryTestCase {
 		$schema_controller = new SchemaController( $this->mock_extend );
 		$route             = new CheckoutRoute( $schema_controller, $schema_controller->get( 'checkout' ) );
 		register_rest_route( $route->get_namespace(), $route->get_path(), $route->get_args(), true );
+		$checkout_order_route = new CheckoutOrderRoute(
+			$schema_controller,
+			$schema_controller->get( 'checkout-order' )
+		);
+		register_rest_route(
+			$checkout_order_route->get_namespace(),
+			$checkout_order_route->get_path(),
+			$checkout_order_route->get_args(),
+			true
+		);
 
 		$fixtures = new FixtureData();
 		$fixtures->payments_enable_bacs();
@@ -1555,6 +1566,77 @@ class Checkout extends MockeryTestCase {
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'woocommerce_rest_invalid_address_country', $response->get_data()['code'] );
 		$this->assertStringContainsString( 'Sorry, we do not allow orders from the provided country (France)', $response->get_data()['message'] );
+	}
+
+	/**
+	 * @testdox Existing order payment should not persist address data when country validation fails.
+	 */
+	public function test_checkout_order_does_not_persist_invalid_country_address() {
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'US' ) );
+		update_option( 'woocommerce_ship_to_countries', 'specific' );
+		update_option( 'woocommerce_specific_ship_to_countries', array( 'US' ) );
+
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_shipping_address(
+			array(
+				'first_name' => 'Jeroen',
+				'last_name'  => 'Sormani',
+				'company'    => 'WooCompany',
+				'address_1'  => 'WooAddress',
+				'address_2'  => '',
+				'city'       => 'WooCity',
+				'state'      => 'NY',
+				'postcode'   => '12345',
+				'country'    => 'US',
+				'phone'      => '555-32123',
+			)
+		);
+		$order->save();
+
+		$original_billing_country  = $order->get_billing_country();
+		$original_shipping_country = $order->get_shipping_country();
+		$original_total            = $order->get_total();
+		$original_total_tax        = $order->get_total_tax();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout/' . $order->get_id() );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_query_params(
+			array(
+				'key'           => $order->get_order_key(),
+				'billing_email' => $order->get_billing_email(),
+			)
+		);
+		// Forbidden country (IN) on both addresses is what should trigger the rejection.
+		$invalid_address = array(
+			'first_name' => 'Test',
+			'last_name'  => 'Kumar',
+			'company'    => '',
+			'address_1'  => '1 MG Road',
+			'address_2'  => '',
+			'city'       => 'Mumbai',
+			'state'      => 'MH',
+			'postcode'   => '400001',
+			'country'    => 'IN',
+			'phone'      => '',
+		);
+		$request->set_body_params(
+			array(
+				'billing_address'  => array_merge( $invalid_address, array( 'email' => $order->get_billing_email() ) ),
+				'shipping_address' => $invalid_address,
+				'payment_method'   => WC_Gateway_BACS::ID,
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_invalid_address_country', $response->get_data()['code'] );
+
+		$stored_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( $original_billing_country, $stored_order->get_billing_country() );
+		$this->assertEquals( $original_shipping_country, $stored_order->get_shipping_country() );
+		$this->assertEquals( $original_total, $stored_order->get_total() );
+		$this->assertEquals( $original_total_tax, $stored_order->get_total_tax() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Store API checkout-order endpoint (`POST /wc/store/v1/checkout/{order_id}`) persisted the request's address and recalculated order totals before validating the address, whereas the other checkout routes validate first. As a result, a request that failed address validation still returned a `400` but left the order (and customer) updated with the rejected data.

This moves the address validation ahead of persistence: the address is set on the order in memory, validated via the new `OrderController::validate_existing_order_before_update()`, and only saved if validation passes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Place an order. UK address.
2. Edit the order. Set status to "pending payment"
3. Go to Settings > WooCommerce and exclude India from "Selling location(s)".
4. Using API client, get a noncetoken: GET `wp-json/wc/store/v1/cart`, look at headers
5. Using API client, set noncetoken in headers, and POST `wp-json/wc/store/v1/checkout/<orderid>`. I use basic auth to avoid needing cart tokens as well.

POST body:

```
{
  "billing_address": {
    "first_name": "Test",
    "last_name": "Kumar",
    "address_1": "1 MG Road",
    "city": "Mumbai",
    "state": "MH",
    "postcode": "400001",
    "country": "IN",
    "email": "test@example.com"
  }
}
```

This should be rejected with `error 400`. Now view the order in admin and confirm the addresses did not change. 

<!-- End testing instructions -->

### Testing that has already taken place:

- New regression test passes; full `Checkout` class shows no new failures vs. `trunk`.
- PHPStan clean on the modified source files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- Changelog entry already added to the branch manually, so the auto-create box is intentionally left unchecked. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Store API: validate address data on the checkout-order endpoint before it is persisted, so a rejected request can no longer modify an existing order's address or totals.

</details>
