### PR TITLE
Add the POS staff PIN service (POSPinService)

### DIFF
--- a/plugins/woocommerce/changelog/add-pos-staff-pin-service
+++ b/plugins/woocommerce/changelog/add-pos-staff-pin-service
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the POS PIN service (`POSPinService`): PBKDF2-HMAC-SHA-256 storage and verification of 4-digit staff PINs in `woocommerce_pos_pin` user meta (no leading underscore, so core's existing uninstall sweep cleans it up), with per-staff PIN uniqueness and a public hash record for client-side validation. No runtime surface yet; the staff endpoint and admin UI use it in follow-up changes. Part of the off-by-default `point_of_sale_staff` feature.

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -149,10 +149,7 @@ class POSPinService {
 
 		foreach ( $user_query->get_results() as $other_id ) {
 			$record = Users::get_site_user_meta( (int) $other_id, self::PIN_META_KEY, true );
-			if ( ! is_array( $record ) || empty( $record['hash'] ) ) {
-				continue;
-			}
-			if ( $this->verify_pin( $pin, $record ) ) {
+			if ( is_array( $record ) && $this->verify_pin( $pin, $record ) ) {
 				return true;
 			}
 		}
@@ -174,6 +171,10 @@ class POSPinService {
 	/**
 	 * Check whether a user has a PIN set.
 	 *
+	 * A record that verify_pin() would reject (wrong algo, out-of-range iterations,
+	 * malformed salt/hash) reads as no PIN, so "has a PIN" always means "has a PIN
+	 * that can actually verify".
+	 *
 	 * @param int $user_id The target user ID.
 	 * @return bool
 	 *
@@ -181,7 +182,7 @@ class POSPinService {
 	 */
 	public function has_pin( int $user_id ): bool {
 		$record = Users::get_site_user_meta( $user_id, self::PIN_META_KEY, true );
-		return is_array( $record ) && ! empty( $record['hash'] );
+		return null !== $this->decode_pin_record( $record );
 	}
 
 	/**
@@ -192,22 +193,28 @@ class POSPinService {
 	 * needed for the client to validate an entered PIN locally. The plaintext PIN
 	 * never leaves the device that set it.
 	 *
+	 * Only well-formed records are exposed: a record that verify_pin() would reject
+	 * returns null instead of shipping to clients, so a corrupted or hostile meta value
+	 * (e.g. a huge iteration count that would make the client's PBKDF2 hang) never
+	 * reaches a device.
+	 *
 	 * @param int $user_id The target user ID.
 	 * @return array{algo:string,iterations:int,salt:string,hash:string}|null
 	 *
 	 * @since 11.0.0
 	 */
 	public function get_public_pin_record( int $user_id ): ?array {
-		$record = Users::get_site_user_meta( $user_id, self::PIN_META_KEY, true );
-		if ( ! is_array( $record ) || empty( $record['hash'] ) ) {
+		$record  = Users::get_site_user_meta( $user_id, self::PIN_META_KEY, true );
+		$decoded = $this->decode_pin_record( $record );
+		if ( null === $decoded ) {
 			return null;
 		}
 
 		return array(
-			'algo'       => (string) ( $record['algo'] ?? self::ALGO ),
-			'iterations' => (int) ( $record['iterations'] ?? self::ITERATIONS ),
-			'salt'       => (string) ( $record['salt'] ?? '' ),
-			'hash'       => (string) ( $record['hash'] ?? '' ),
+			'algo'       => self::ALGO,
+			'iterations' => $decoded['iterations'],
+			'salt'       => base64_encode( $decoded['salt'] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			'hash'       => base64_encode( $decoded['hash'] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		);
 	}
 
@@ -226,36 +233,14 @@ class POSPinService {
 			return false;
 		}
 
-		$algo       = (string) ( $record['algo'] ?? '' );
-		$iterations = (int) ( $record['iterations'] ?? 0 );
-		$salt_b64   = (string) ( $record['salt'] ?? '' );
-		$hash_b64   = (string) ( $record['hash'] ?? '' );
-
-		// The iteration count drives PBKDF2's cost. The record comes from user meta, so a corrupted
-		// or hostile value (e.g. a billion iterations) would make every uniqueness scan hang — bound
-		// it and treat anything out of range as malformed. MAX_ITERATIONS leaves headroom to raise
-		// the cost over time while still verifying historical records.
-		if ( self::ALGO !== $algo || $iterations <= 0 || $iterations > self::MAX_ITERATIONS || '' === $salt_b64 || '' === $hash_b64 ) {
+		$decoded = $this->decode_pin_record( $record );
+		if ( null === $decoded ) {
 			return false;
 		}
 
-		// Decode the stored binary salt/hash back from their base64 envelope (see set_pin).
-		$salt          = base64_decode( $salt_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-		$expected_hash = base64_decode( $hash_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-		if ( false === $salt || false === $expected_hash ) {
-			return false;
-		}
+		$actual_hash = hash_pbkdf2( 'sha256', $pin, $decoded['salt'], $decoded['iterations'], self::HASH_BYTES, true );
 
-		// A well-formed record always carries a SALT_BYTES salt and a HASH_BYTES hash (the fixed
-		// PBKDF2-SHA256 format set_pin writes). Reject any other size as malformed before spending
-		// PBKDF2 cycles, and keep the method consistent with the format it declares.
-		if ( self::SALT_BYTES !== strlen( $salt ) || self::HASH_BYTES !== strlen( $expected_hash ) ) {
-			return false;
-		}
-
-		$actual_hash = hash_pbkdf2( 'sha256', $pin, $salt, $iterations, self::HASH_BYTES, true );
-
-		return hash_equals( $expected_hash, $actual_hash );
+		return hash_equals( $decoded['hash'], $actual_hash );
 	}
 
 	/**
@@ -268,5 +253,57 @@ class POSPinService {
 	 */
 	public function validate_pin_format( string $pin ): bool {
 		return 1 === preg_match( '/^\d{' . self::PIN_LENGTH . '}$/', $pin );
+	}
+
+	/**
+	 * Validate and decode a stored PIN record, or null if it is malformed.
+	 *
+	 * Single source of truth for what a well-formed record is, shared by has_pin(),
+	 * get_public_pin_record(), and verify_pin() so a record is only ever reported,
+	 * exposed to clients, or verified if it matches the format set_pin() writes.
+	 *
+	 * The iteration count drives PBKDF2's cost. The record comes from user meta, so a corrupted
+	 * or hostile value (e.g. a billion iterations) would make every uniqueness scan — or a mobile
+	 * client validating locally — hang; bound it and treat anything out of range as malformed.
+	 * MAX_ITERATIONS leaves headroom to raise the cost over time while still verifying
+	 * historical records.
+	 *
+	 * @param mixed $record The raw meta value (array with algo, iterations, salt, hash).
+	 * @return array{iterations:int,salt:string,hash:string}|null Decoded binary salt/hash and
+	 *                                                            iterations, or null when malformed.
+	 */
+	private function decode_pin_record( $record ): ?array {
+		if ( ! is_array( $record ) ) {
+			return null;
+		}
+
+		$algo       = (string) ( $record['algo'] ?? '' );
+		$iterations = (int) ( $record['iterations'] ?? 0 );
+		$salt_b64   = (string) ( $record['salt'] ?? '' );
+		$hash_b64   = (string) ( $record['hash'] ?? '' );
+
+		if ( self::ALGO !== $algo || $iterations <= 0 || $iterations > self::MAX_ITERATIONS || '' === $salt_b64 || '' === $hash_b64 ) {
+			return null;
+		}
+
+		// Decode the stored binary salt/hash back from their base64 envelope (see set_pin).
+		$salt = base64_decode( $salt_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$hash = base64_decode( $hash_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		if ( false === $salt || false === $hash ) {
+			return null;
+		}
+
+		// A well-formed record always carries a SALT_BYTES salt and a HASH_BYTES hash (the fixed
+		// PBKDF2-SHA256 format set_pin writes). Reject any other size as malformed before anything
+		// spends PBKDF2 cycles on it.
+		if ( self::SALT_BYTES !== strlen( $salt ) || self::HASH_BYTES !== strlen( $hash ) ) {
+			return null;
+		}
+
+		return array(
+			'iterations' => $iterations,
+			'salt'       => $salt,
+			'hash'       => $hash,
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -1,0 +1,229 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\POS\Service;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\POS\Capabilities;
+use WP_Error;
+use WP_User_Query;
+
+/**
+ * Stores and verifies POS PINs.
+ *
+ * PINs are stored as a self-describing record in user meta and shipped to the mobile
+ * client (via the staff list endpoint) so the client can validate PIN entry locally.
+ *
+ * Hash format: PBKDF2-HMAC-SHA-256, 10k iterations, 16-byte random salt, 32-byte hash.
+ * This is native on iOS (CommonCrypto / CryptoKit) and Android (SecretKeyFactory with
+ * PBKDF2WithHmacSHA256, API 26+). Brute-forcing the 4-digit PIN space against a stolen
+ * hash takes ~100 seconds with the chosen cost factor.
+ *
+ * @since 11.0.0
+ * @internal
+ */
+class POSPinService {
+
+	public const PIN_META_KEY = 'woocommerce_pos_pin';
+	public const ALGO         = 'pbkdf2-sha256';
+	public const ITERATIONS   = 10000;
+	public const SALT_BYTES   = 16;
+	public const HASH_BYTES   = 32;
+	public const PIN_LENGTH   = 4;
+
+	/**
+	 * Set or replace a user's POS PIN.
+	 *
+	 * PINs are the sole operator identifier on the POS device (the merchant taps a
+	 * 4-digit code to identify themselves at the till), so a collision between two
+	 * staff members is unresolvable — the device would have no way to tell who is
+	 * keying in 1234. To prevent that, this method PBKDF2-verifies the candidate
+	 * against every other stored PIN record and rejects on first match.
+	 *
+	 * @param int    $user_id The target user ID.
+	 * @param string $pin     The plaintext 4-digit PIN. Must match the PIN_LENGTH constant.
+	 * @return true|WP_Error  True on success, WP_Error on invalid PIN format or
+	 *                        when the PIN is already in use by another user.
+	 *
+	 * @since 11.0.0
+	 */
+	public function set_pin( int $user_id, string $pin ) {
+		if ( ! $this->validate_pin_format( $pin ) ) {
+			return new WP_Error(
+				'woocommerce_pos_invalid_pin_format',
+				__( 'PIN must be exactly 4 digits.', 'woocommerce' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		if ( $this->is_pin_used_by_other_user( $pin, $user_id ) ) {
+			return new WP_Error(
+				'woocommerce_pos_pin_in_use',
+				__( 'This PIN is already in use by another staff member. Choose a different PIN.', 'woocommerce' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$salt = random_bytes( self::SALT_BYTES );
+		$hash = hash_pbkdf2( 'sha256', $pin, $salt, self::ITERATIONS, self::HASH_BYTES, true );
+
+		// base64 encoding here is used purely to make the binary salt/hash storable in
+		// user meta and JSON-serializable on the wire; it is not used to obscure code.
+		$record = array(
+			'algo'       => self::ALGO,
+			'iterations' => self::ITERATIONS,
+			'salt'       => base64_encode( $salt ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			'hash'       => base64_encode( $hash ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		);
+
+		update_user_meta( $user_id, self::PIN_META_KEY, $record );
+
+		return true;
+	}
+
+	/**
+	 * Whether the given plaintext PIN collides with one already stored on another POS-access user.
+	 *
+	 * The PIN is the sole operator identifier at the till, so two staff sharing one would be
+	 * unresolvable on the device. set_pin() calls this internally; it is also public for the
+	 * wp-admin add-staff flow, which must check uniqueness *before* the user exists (so it can't go
+	 * through set_pin) — that caller passes 0 to scan every existing record.
+	 *
+	 * Scoping the scan to POS-access users — `Capabilities::pos_staff_user_query_args()` selects
+	 * holders of any `woocommerce_pos_*` capability — keeps stale PIN meta on non-POS users from
+	 * causing phantom collisions. Cost is bounded by the number of active staff (a handful), one
+	 * PBKDF2 evaluation per row. The candidate user is excluded so an idempotent re-set ("save the
+	 * same PIN again") is allowed.
+	 *
+	 * @param string $pin             Plaintext PIN candidate. Assumed format-validated.
+	 * @param int    $exclude_user_id User being assigned the PIN; excluded from the scan. Pass 0 at
+	 *                                create time, when the user does not exist yet.
+	 * @return bool
+	 */
+	public function is_pin_used_by_other_user( string $pin, int $exclude_user_id = 0 ): bool {
+		// Select every POS-access user except the candidate, so the new PIN can be PBKDF2-compared
+		// against each stored hash and rejected on the first match.
+		$user_query = new WP_User_Query(
+			array_merge(
+				Capabilities::pos_staff_user_query_args(),
+				array(
+					'fields'  => 'ID',
+					'number'  => -1,
+					'exclude' => array( $exclude_user_id ),
+				)
+			)
+		);
+
+		foreach ( $user_query->get_results() as $other_id ) {
+			$record = get_user_meta( (int) $other_id, self::PIN_META_KEY, true );
+			if ( ! is_array( $record ) || empty( $record['hash'] ) ) {
+				continue;
+			}
+			if ( $this->verify_pin( $pin, $record ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Remove a user's PIN.
+	 *
+	 * @param int $user_id The target user ID.
+	 *
+	 * @since 11.0.0
+	 */
+	public function delete_pin( int $user_id ): void {
+		delete_user_meta( $user_id, self::PIN_META_KEY );
+	}
+
+	/**
+	 * Check whether a user has a PIN set.
+	 *
+	 * @param int $user_id The target user ID.
+	 * @return bool
+	 *
+	 * @since 11.0.0
+	 */
+	public function has_pin( int $user_id ): bool {
+		$record = get_user_meta( $user_id, self::PIN_META_KEY, true );
+		return is_array( $record ) && ! empty( $record['hash'] );
+	}
+
+	/**
+	 * Return the public PIN record for a user, suitable for embedding in the staff
+	 * list payload sent to mobile clients. Returns null if no PIN is set.
+	 *
+	 * The record contains the algorithm, iteration count, salt, and hash — everything
+	 * needed for the client to validate an entered PIN locally. The plaintext PIN
+	 * never leaves the device that set it.
+	 *
+	 * @param int $user_id The target user ID.
+	 * @return array{algo:string,iterations:int,salt:string,hash:string}|null
+	 *
+	 * @since 11.0.0
+	 */
+	public function get_public_pin_record( int $user_id ): ?array {
+		$record = get_user_meta( $user_id, self::PIN_META_KEY, true );
+		if ( ! is_array( $record ) || empty( $record['hash'] ) ) {
+			return null;
+		}
+
+		return array(
+			'algo'       => (string) ( $record['algo'] ?? self::ALGO ),
+			'iterations' => (int) ( $record['iterations'] ?? self::ITERATIONS ),
+			'salt'       => (string) ( $record['salt'] ?? '' ),
+			'hash'       => (string) ( $record['hash'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Verify a plaintext PIN against a stored record. Used server-side by the wp-admin
+	 * staff page to confirm the current PIN before allowing changes.
+	 *
+	 * @param string $pin    The plaintext PIN to verify.
+	 * @param array  $record The stored PIN record (algo, iterations, salt, hash).
+	 * @return bool          True if the PIN matches, false otherwise.
+	 *
+	 * @since 11.0.0
+	 */
+	public function verify_pin( string $pin, array $record ): bool {
+		if ( ! $this->validate_pin_format( $pin ) ) {
+			return false;
+		}
+
+		$algo       = (string) ( $record['algo'] ?? '' );
+		$iterations = (int) ( $record['iterations'] ?? 0 );
+		$salt_b64   = (string) ( $record['salt'] ?? '' );
+		$hash_b64   = (string) ( $record['hash'] ?? '' );
+
+		if ( self::ALGO !== $algo || $iterations <= 0 || '' === $salt_b64 || '' === $hash_b64 ) {
+			return false;
+		}
+
+		// Decode the stored binary salt/hash back from their base64 envelope (see set_pin).
+		$salt          = base64_decode( $salt_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$expected_hash = base64_decode( $hash_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		if ( false === $salt || false === $expected_hash ) {
+			return false;
+		}
+
+		$actual_hash = hash_pbkdf2( 'sha256', $pin, $salt, $iterations, self::HASH_BYTES, true );
+
+		return hash_equals( $expected_hash, $actual_hash );
+	}
+
+	/**
+	 * Validate the PIN string against the expected wire format.
+	 *
+	 * @param string $pin The PIN to validate.
+	 * @return bool
+	 *
+	 * @since 11.0.0
+	 */
+	public function validate_pin_format( string $pin ): bool {
+		return 1 === preg_match( '/^\d{' . self::PIN_LENGTH . '}$/', $pin );
+	}
+}

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -6,14 +6,17 @@ namespace Automattic\WooCommerce\Internal\POS\Service;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\POS\Capabilities;
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use WP_Error;
 use WP_User_Query;
 
 /**
  * Stores and verifies POS PINs.
  *
- * PINs are stored as a self-describing record in user meta and shipped to the mobile
- * client (via the staff list endpoint) so the client can validate PIN entry locally.
+ * PINs are stored as a self-describing record in per-site user meta (via
+ * Users::*_site_user_meta(), aligning with the blog-scoped POS capabilities on multisite)
+ * and shipped to the mobile client (via the staff list endpoint) so the client can
+ * validate PIN entry locally.
  *
  * Hash format: PBKDF2-HMAC-SHA-256, 10k iterations, 16-byte random salt, 32-byte hash.
  * This is native on iOS (CommonCrypto / CryptoKit) and Android (SecretKeyFactory with
@@ -100,7 +103,12 @@ class POSPinService {
 			'hash'       => base64_encode( $hash ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		);
 
-		update_user_meta( $user_id, self::PIN_META_KEY, $record );
+		// Store the PIN per-site so it stays aligned with the blog-scoped POS capabilities on
+		// multisite (Users::update_site_user_meta suffixes the blog prefix, so the key still
+		// matches the woocommerce_% uninstall sweep). A user's PIN is only meaningful on sites
+		// where they hold POS access, and the uniqueness scan below is itself blog-scoped, so
+		// PIN storage must share that scope.
+		Users::update_site_user_meta( $user_id, self::PIN_META_KEY, $record );
 
 		return true;
 	}
@@ -140,7 +148,7 @@ class POSPinService {
 		);
 
 		foreach ( $user_query->get_results() as $other_id ) {
-			$record = get_user_meta( (int) $other_id, self::PIN_META_KEY, true );
+			$record = Users::get_site_user_meta( (int) $other_id, self::PIN_META_KEY, true );
 			if ( ! is_array( $record ) || empty( $record['hash'] ) ) {
 				continue;
 			}
@@ -160,7 +168,7 @@ class POSPinService {
 	 * @since 11.0.0
 	 */
 	public function delete_pin( int $user_id ): void {
-		delete_user_meta( $user_id, self::PIN_META_KEY );
+		Users::delete_site_user_meta( $user_id, self::PIN_META_KEY );
 	}
 
 	/**
@@ -172,7 +180,7 @@ class POSPinService {
 	 * @since 11.0.0
 	 */
 	public function has_pin( int $user_id ): bool {
-		$record = get_user_meta( $user_id, self::PIN_META_KEY, true );
+		$record = Users::get_site_user_meta( $user_id, self::PIN_META_KEY, true );
 		return is_array( $record ) && ! empty( $record['hash'] );
 	}
 
@@ -190,7 +198,7 @@ class POSPinService {
 	 * @since 11.0.0
 	 */
 	public function get_public_pin_record( int $user_id ): ?array {
-		$record = get_user_meta( $user_id, self::PIN_META_KEY, true );
+		$record = Users::get_site_user_meta( $user_id, self::PIN_META_KEY, true );
 		if ( ! is_array( $record ) || empty( $record['hash'] ) ) {
 			return null;
 		}

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -263,7 +263,7 @@ class POSPinService {
 	 * @since 11.0.0
 	 */
 	public function validate_pin_format( string $pin ): bool {
-		return 1 === preg_match( '/^\d{' . self::PIN_LENGTH . '}$/', $pin );
+		return self::PIN_LENGTH === strlen( $pin ) && ctype_digit( $pin );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -25,12 +25,13 @@ use WP_User_Query;
  */
 class POSPinService {
 
-	public const PIN_META_KEY = 'woocommerce_pos_pin';
-	public const ALGO         = 'pbkdf2-sha256';
-	public const ITERATIONS   = 10000;
-	public const SALT_BYTES   = 16;
-	public const HASH_BYTES   = 32;
-	public const PIN_LENGTH   = 4;
+	public const PIN_META_KEY   = 'woocommerce_pos_pin';
+	public const ALGO           = 'pbkdf2-sha256';
+	public const ITERATIONS     = 10000;
+	public const MAX_ITERATIONS = 100000;
+	public const SALT_BYTES     = 16;
+	public const HASH_BYTES     = 32;
+	public const PIN_LENGTH     = 4;
 
 	/**
 	 * Set or replace a user's POS PIN.
@@ -109,7 +110,8 @@ class POSPinService {
 				Capabilities::pos_staff_user_query_args(),
 				array(
 					'fields'  => 'ID',
-					'number'  => -1,
+					// WP_User_Query treats 0 as "no limit" (core WC convention): scan every staff record.
+					'number'  => 0,
 					'exclude' => array( $exclude_user_id ),
 				)
 			)
@@ -199,7 +201,11 @@ class POSPinService {
 		$salt_b64   = (string) ( $record['salt'] ?? '' );
 		$hash_b64   = (string) ( $record['hash'] ?? '' );
 
-		if ( self::ALGO !== $algo || $iterations <= 0 || '' === $salt_b64 || '' === $hash_b64 ) {
+		// The iteration count drives PBKDF2's cost. The record comes from user meta, so a corrupted
+		// or hostile value (e.g. a billion iterations) would make every uniqueness scan hang — bound
+		// it and treat anything out of range as malformed. MAX_ITERATIONS leaves headroom to raise
+		// the cost over time while still verifying historical records.
+		if ( self::ALGO !== $algo || $iterations <= 0 || $iterations > self::MAX_ITERATIONS || '' === $salt_b64 || '' === $hash_b64 ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -19,7 +19,7 @@ use WP_User_Query;
  *
  * Hash format: PBKDF2-HMAC-SHA-256, 10k iterations, 16-byte salt, 32-byte hash — native
  * on both iOS and Android. Brute-forcing the 4-digit space against a stolen hash takes
- * ~100 seconds; the PIN identifies the operator at the till and is not a credential.
+ * ~100 seconds; the PIN identifies the operator on the POS device and is not a credential.
  *
  * @since 11.0.0
  * @internal
@@ -36,9 +36,9 @@ class POSPinService {
 	/**
 	 * Set or replace a user's POS PIN.
 	 *
-	 * The PIN is the sole operator identifier at the till, so a collision between two staff
-	 * members is unresolvable on the device; the candidate is PBKDF2-verified against every
-	 * other stored record and rejected on first match. The target must already hold POS
+	 * The PIN is the sole operator identifier on the POS device, so a collision between two
+	 * staff members is unresolvable; the candidate is PBKDF2-verified against every other
+	 * stored record and rejected on first match. The target must already hold POS
 	 * access: the uniqueness scan only covers POS staff, so a PIN on a non-POS user would
 	 * become a latent collision the moment they later gain access.
 	 *

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -28,13 +28,12 @@ use WP_User_Query;
  */
 class POSPinService {
 
-	public const PIN_META_KEY   = 'woocommerce_pos_pin';
-	public const ALGO           = 'pbkdf2-sha256';
-	public const ITERATIONS     = 10000;
-	public const MAX_ITERATIONS = 100000;
-	public const SALT_BYTES     = 16;
-	public const HASH_BYTES     = 32;
-	public const PIN_LENGTH     = 4;
+	public const PIN_META_KEY = 'woocommerce_pos_pin';
+	public const ALGO         = 'pbkdf2-sha256';
+	public const ITERATIONS   = 10000;
+	public const SALT_BYTES   = 16;
+	public const HASH_BYTES   = 32;
+	public const PIN_LENGTH   = 4;
 
 	/**
 	 * Set or replace a user's POS PIN.
@@ -273,11 +272,12 @@ class POSPinService {
 	 * get_public_pin_record(), and verify_pin() so a record is only ever reported,
 	 * exposed to clients, or verified if it matches the format set_pin() writes.
 	 *
-	 * The iteration count drives PBKDF2's cost. The record comes from user meta, so a corrupted
-	 * or hostile value (e.g. a billion iterations) would make every uniqueness scan — or a mobile
-	 * client validating locally — hang; bound it and treat anything out of range as malformed.
-	 * MAX_ITERATIONS leaves headroom to raise the cost over time while still verifying
-	 * historical records.
+	 * The iteration count drives PBKDF2's cost, and set_pin() only ever writes ITERATIONS —
+	 * anything else was not written by this service and reads as malformed. The exact match
+	 * rejects both a hostile inflation (a huge count would make the uniqueness scan — or a
+	 * mobile client validating locally — hang) and a downgrade below the intended cost.
+	 * If the cost is ever raised, this check must learn to accept the previously shipped
+	 * values so historical records keep verifying.
 	 *
 	 * @param mixed $record The raw meta value (array with algo, iterations, salt, hash).
 	 * @return array{iterations:int,salt:string,hash:string}|null Decoded binary salt/hash and
@@ -293,7 +293,7 @@ class POSPinService {
 		$salt_b64   = (string) ( $record['salt'] ?? '' );
 		$hash_b64   = (string) ( $record['hash'] ?? '' );
 
-		if ( self::ALGO !== $algo || $iterations <= 0 || $iterations > self::MAX_ITERATIONS || '' === $salt_b64 || '' === $hash_b64 ) {
+		if ( self::ALGO !== $algo || self::ITERATIONS !== $iterations || '' === $salt_b64 || '' === $hash_b64 ) {
 			return null;
 		}
 

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -131,11 +131,12 @@ class POSPinService {
 	 * wp-admin add-staff flow, which must check uniqueness *before* the user exists (so it can't go
 	 * through set_pin) — that caller passes 0 to scan every existing record.
 	 *
-	 * Scoping the scan to POS-access users — `Capabilities::pos_staff_user_query_args()` selects
-	 * holders of any `woocommerce_pos_*` capability — keeps stale PIN meta on non-POS users from
-	 * causing phantom collisions. Cost is bounded by the number of active staff (a handful), one
-	 * PBKDF2 evaluation per row. The candidate user is excluded so an idempotent re-set ("save the
-	 * same PIN again") is allowed.
+	 * Scoping the scan to POS-access users keeps stale PIN meta on non-POS users from causing
+	 * phantom collisions. `Capabilities::pos_staff_user_query_args()` selects *candidates* (it
+	 * also matches explicitly denied caps), so each row is refined with the resolved-capability
+	 * check `Capabilities::has_pos_access()` before its PIN is compared. Cost is bounded by the
+	 * number of active staff (a handful), one PBKDF2 evaluation per row. The candidate user is
+	 * excluded so an idempotent re-set ("save the same PIN again") is allowed.
 	 *
 	 * @param string $pin             Plaintext PIN candidate. Assumed format-validated.
 	 * @param int    $exclude_user_id User being assigned the PIN; excluded from the scan. Pass 0 at
@@ -158,6 +159,13 @@ class POSPinService {
 		);
 
 		foreach ( $user_query->get_results() as $other_id ) {
+			// The query matches capability *names*, so it also selects users whose POS caps are
+			// explicitly denied (stored as false). Skip anyone without resolved POS access before
+			// spending PBKDF2 cycles, so their stale PIN cannot phantom-block the candidate PIN.
+			if ( ! Capabilities::has_pos_access( (int) $other_id ) ) {
+				continue;
+			}
+
 			$record = Users::get_site_user_meta( (int) $other_id, self::PIN_META_KEY, true );
 			if ( is_array( $record ) && $this->verify_pin( $pin, $record ) ) {
 				return true;

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -62,7 +62,8 @@ class POSPinService {
 	 * @param int    $user_id The target user ID.
 	 * @param string $pin     The plaintext 4-digit PIN. Must match the PIN_LENGTH constant.
 	 * @return true|WP_Error  True on success, WP_Error when the user lacks POS access, the
-	 *                        PIN format is invalid, or the PIN is already in use by another user.
+	 *                        PIN format is invalid, the PIN is already in use by another user,
+	 *                        or the record could not be written.
 	 *
 	 * @since 11.0.0
 	 */
@@ -108,7 +109,17 @@ class POSPinService {
 		// matches the woocommerce_% uninstall sweep). A user's PIN is only meaningful on sites
 		// where they hold POS access, and the uniqueness scan below is itself blog-scoped, so
 		// PIN storage must share that scope.
-		Users::update_site_user_meta( $user_id, self::PIN_META_KEY, $record );
+		//
+		// update_user_meta() also returns false for a same-value write, but the fresh random
+		// salt above means the record always differs from what is stored — false here is
+		// unambiguously a failed write, and returning success would leave the old PIN live.
+		if ( false === Users::update_site_user_meta( $user_id, self::PIN_META_KEY, $record ) ) {
+			return new WP_Error(
+				'woocommerce_pos_pin_save_failed',
+				__( 'The PIN could not be saved. Please try again.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
 
 		return true;
 	}

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -138,12 +138,16 @@ class POSPinService {
 	 * number of active staff (a handful), one PBKDF2 evaluation per row. The candidate user is
 	 * excluded so an idempotent re-set ("save the same PIN again") is allowed.
 	 *
-	 * @param string $pin             Plaintext PIN candidate. Assumed format-validated.
+	 * @param string $pin             Plaintext PIN candidate; a malformed PIN is never "in use".
 	 * @param int    $exclude_user_id User being assigned the PIN; excluded from the scan. Pass 0 at
 	 *                                create time, when the user does not exist yet.
 	 * @return bool
 	 */
 	public function is_pin_used_by_other_user( string $pin, int $exclude_user_id = 0 ): bool {
+		if ( ! $this->validate_pin_format( $pin ) ) {
+			return false;
+		}
+
 		// Select every POS-access user except the candidate, so the new PIN can be PBKDF2-compared
 		// against each stored hash and rejected on the first match.
 		$user_query = new WP_User_Query(

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -34,6 +34,11 @@ class POSPinService {
 	public const PIN_LENGTH     = 4;
 
 	/**
+	 * Seconds to wait for the PIN-write lock before proceeding without it (best-effort).
+	 */
+	private const PIN_LOCK_TIMEOUT = 5;
+
+	/**
 	 * Set or replace a user's POS PIN.
 	 *
 	 * PINs are the sole operator identifier on the POS device (the merchant taps a
@@ -46,6 +51,10 @@ class POSPinService {
 	 * The uniqueness scan only covers POS staff, so a PIN stored on a non-POS user would
 	 * be invisible to it and become a latent collision the moment that user is later
 	 * granted POS caps — this method rejects that case rather than create the record.
+	 *
+	 * The uniqueness scan and the write are serialized under a MySQL named lock so two
+	 * concurrent calls can't both pass the collision check and persist the same PIN
+	 * (see {@see set_pin_locked()}).
 	 *
 	 * @param int    $user_id The target user ID.
 	 * @param string $pin     The plaintext 4-digit PIN. Must match the PIN_LENGTH constant.
@@ -71,6 +80,37 @@ class POSPinService {
 			);
 		}
 
+		global $wpdb;
+
+		// Serialize the uniqueness scan + write. Without this, two concurrent set_pin() calls for
+		// different users could both pass is_pin_used_by_other_user() before either writes, persisting
+		// the same PIN twice — the exact collision the scan exists to prevent. A PIN is a salted hash,
+		// so it can't be guarded with a unique DB index the way core does for SKUs
+		// (WC_Product_Data_Store_CPT::obtain_lock_on_sku_for_concurrent_requests); a MySQL named lock is
+		// the cross-process primitive available without a persistent object cache. The lock name is
+		// prefixed per-site so installs sharing a MySQL server don't contend. Acquisition is
+		// best-effort: if the lock can't be taken (timeout/unsupported), we proceed rather than block a
+		// legitimate change, accepting the same narrow race we would have had without it.
+		$lock_name = $wpdb->prefix . 'wc_pos_pin_write';
+		$got_lock  = 1 === (int) $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, self::PIN_LOCK_TIMEOUT ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		try {
+			return $this->set_pin_locked( $user_id, $pin );
+		} finally {
+			if ( $got_lock ) {
+				$wpdb->query( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			}
+		}
+	}
+
+	/**
+	 * The uniqueness scan and write half of set_pin(), run inside the named lock.
+	 *
+	 * @param int    $user_id The target user ID. Assumed POS-access and format checks already passed.
+	 * @param string $pin     The plaintext 4-digit PIN.
+	 * @return true|WP_Error  True on success, WP_Error when the PIN is already in use.
+	 */
+	private function set_pin_locked( int $user_id, string $pin ) {
 		if ( $this->is_pin_used_by_other_user( $pin, $user_id ) ) {
 			return new WP_Error(
 				'woocommerce_pos_pin_in_use',
@@ -226,6 +266,13 @@ class POSPinService {
 		$salt          = base64_decode( $salt_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$expected_hash = base64_decode( $hash_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		if ( false === $salt || false === $expected_hash ) {
+			return false;
+		}
+
+		// A well-formed record always carries a SALT_BYTES salt and a HASH_BYTES hash (the fixed
+		// PBKDF2-SHA256 format set_pin writes). Reject any other size as malformed before spending
+		// PBKDF2 cycles, and keep the method consistent with the format it declares.
+		if ( self::SALT_BYTES !== strlen( $salt ) || self::HASH_BYTES !== strlen( $expected_hash ) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -111,7 +111,7 @@ class POSPinService {
 	/**
 	 * Whether the given plaintext PIN collides with one already stored on another POS-access user.
 	 *
-	 * set_pin() calls this internally; it is also public for the wp-admin add-staff flow, which
+	 * Called internally by set_pin(); also public for the wp-admin add-staff flow, which
 	 * checks uniqueness before the user exists — that caller passes 0 to scan every record.
 	 *
 	 * The query selects *candidates* (capability__in also matches explicitly denied caps), so

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -34,11 +34,6 @@ class POSPinService {
 	public const PIN_LENGTH     = 4;
 
 	/**
-	 * Seconds to wait for the PIN-write lock before proceeding without it (best-effort).
-	 */
-	private const PIN_LOCK_TIMEOUT = 5;
-
-	/**
 	 * Set or replace a user's POS PIN.
 	 *
 	 * PINs are the sole operator identifier on the POS device (the merchant taps a
@@ -52,9 +47,14 @@ class POSPinService {
 	 * be invisible to it and become a latent collision the moment that user is later
 	 * granted POS caps — this method rejects that case rather than create the record.
 	 *
-	 * The uniqueness scan and the write are serialized under a MySQL named lock so two
-	 * concurrent calls can't both pass the collision check and persist the same PIN
-	 * (see {@see set_pin_locked()}).
+	 * The uniqueness check is best-effort: it is a read-then-write, so two near-simultaneous
+	 * calls for different users could both pass before either writes and end up sharing a PIN.
+	 * A PIN is stored as a per-record salted hash, so it cannot be guarded by a unique DB index
+	 * the way core enforces SKUs ({@see WC_Product_Data_Store_CPT::obtain_lock_on_sku_for_concurrent_requests()}),
+	 * and WordPress offers no portable atomic "reserve value" primitive — mirroring the same
+	 * documented trade-off in {@see \Automattic\WooCommerce\Api\Mutations\Products\CreateProduct}.
+	 * If strict uniqueness is ever required, the caller should enforce it at a higher layer
+	 * (e.g. a mutex around the REST handler) rather than assume this service guarantees it.
 	 *
 	 * @param int    $user_id The target user ID.
 	 * @param string $pin     The plaintext 4-digit PIN. Must match the PIN_LENGTH constant.
@@ -80,37 +80,6 @@ class POSPinService {
 			);
 		}
 
-		global $wpdb;
-
-		// Serialize the uniqueness scan + write. Without this, two concurrent set_pin() calls for
-		// different users could both pass is_pin_used_by_other_user() before either writes, persisting
-		// the same PIN twice — the exact collision the scan exists to prevent. A PIN is a salted hash,
-		// so it can't be guarded with a unique DB index the way core does for SKUs
-		// (WC_Product_Data_Store_CPT::obtain_lock_on_sku_for_concurrent_requests); a MySQL named lock is
-		// the cross-process primitive available without a persistent object cache. The lock name is
-		// prefixed per-site so installs sharing a MySQL server don't contend. Acquisition is
-		// best-effort: if the lock can't be taken (timeout/unsupported), we proceed rather than block a
-		// legitimate change, accepting the same narrow race we would have had without it.
-		$lock_name = $wpdb->prefix . 'wc_pos_pin_write';
-		$got_lock  = 1 === (int) $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, self::PIN_LOCK_TIMEOUT ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-
-		try {
-			return $this->set_pin_locked( $user_id, $pin );
-		} finally {
-			if ( $got_lock ) {
-				$wpdb->query( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			}
-		}
-	}
-
-	/**
-	 * The uniqueness scan and write half of set_pin(), run inside the named lock.
-	 *
-	 * @param int    $user_id The target user ID. Assumed POS-access and format checks already passed.
-	 * @param string $pin     The plaintext 4-digit PIN.
-	 * @return true|WP_Error  True on success, WP_Error when the PIN is already in use.
-	 */
-	private function set_pin_locked( int $user_id, string $pin ) {
 		if ( $this->is_pin_used_by_other_user( $pin, $user_id ) ) {
 			return new WP_Error(
 				'woocommerce_pos_pin_in_use',

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -42,10 +42,15 @@ class POSPinService {
 	 * keying in 1234. To prevent that, this method PBKDF2-verifies the candidate
 	 * against every other stored PIN record and rejects on first match.
 	 *
+	 * The target must already have POS access (hold a `woocommerce_pos_*` capability).
+	 * The uniqueness scan only covers POS staff, so a PIN stored on a non-POS user would
+	 * be invisible to it and become a latent collision the moment that user is later
+	 * granted POS caps — this method rejects that case rather than create the record.
+	 *
 	 * @param int    $user_id The target user ID.
 	 * @param string $pin     The plaintext 4-digit PIN. Must match the PIN_LENGTH constant.
-	 * @return true|WP_Error  True on success, WP_Error on invalid PIN format or
-	 *                        when the PIN is already in use by another user.
+	 * @return true|WP_Error  True on success, WP_Error when the user lacks POS access, the
+	 *                        PIN format is invalid, or the PIN is already in use by another user.
 	 *
 	 * @since 11.0.0
 	 */
@@ -55,6 +60,14 @@ class POSPinService {
 				'woocommerce_pos_invalid_pin_format',
 				__( 'PIN must be exactly 4 digits.', 'woocommerce' ),
 				array( 'status' => 422 )
+			);
+		}
+
+		if ( ! Capabilities::has_pos_access( $user_id ) ) {
+			return new WP_Error(
+				'woocommerce_pos_no_pos_access',
+				__( 'A POS PIN can only be set for a staff member with POS access.', 'woocommerce' ),
+				array( 'status' => 400 )
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
+++ b/plugins/woocommerce/src/Internal/POS/Service/POSPinService.php
@@ -13,15 +13,13 @@ use WP_User_Query;
 /**
  * Stores and verifies POS PINs.
  *
- * PINs are stored as a self-describing record in per-site user meta (via
- * Users::*_site_user_meta(), aligning with the blog-scoped POS capabilities on multisite)
- * and shipped to the mobile client (via the staff list endpoint) so the client can
- * validate PIN entry locally.
+ * PINs are stored as a self-describing record in per-site user meta (aligning with the
+ * blog-scoped POS capabilities on multisite) and shipped to the mobile client via the
+ * staff list endpoint for local PIN-entry validation.
  *
- * Hash format: PBKDF2-HMAC-SHA-256, 10k iterations, 16-byte random salt, 32-byte hash.
- * This is native on iOS (CommonCrypto / CryptoKit) and Android (SecretKeyFactory with
- * PBKDF2WithHmacSHA256, API 26+). Brute-forcing the 4-digit PIN space against a stolen
- * hash takes ~100 seconds with the chosen cost factor.
+ * Hash format: PBKDF2-HMAC-SHA-256, 10k iterations, 16-byte salt, 32-byte hash — native
+ * on both iOS and Android. Brute-forcing the 4-digit space against a stolen hash takes
+ * ~100 seconds; the PIN identifies the operator at the till and is not a credential.
  *
  * @since 11.0.0
  * @internal
@@ -38,25 +36,17 @@ class POSPinService {
 	/**
 	 * Set or replace a user's POS PIN.
 	 *
-	 * PINs are the sole operator identifier on the POS device (the merchant taps a
-	 * 4-digit code to identify themselves at the till), so a collision between two
-	 * staff members is unresolvable — the device would have no way to tell who is
-	 * keying in 1234. To prevent that, this method PBKDF2-verifies the candidate
-	 * against every other stored PIN record and rejects on first match.
+	 * The PIN is the sole operator identifier at the till, so a collision between two staff
+	 * members is unresolvable on the device; the candidate is PBKDF2-verified against every
+	 * other stored record and rejected on first match. The target must already hold POS
+	 * access: the uniqueness scan only covers POS staff, so a PIN on a non-POS user would
+	 * become a latent collision the moment they later gain access.
 	 *
-	 * The target must already have POS access (hold a `woocommerce_pos_*` capability).
-	 * The uniqueness scan only covers POS staff, so a PIN stored on a non-POS user would
-	 * be invisible to it and become a latent collision the moment that user is later
-	 * granted POS caps — this method rejects that case rather than create the record.
-	 *
-	 * The uniqueness check is best-effort: it is a read-then-write, so two near-simultaneous
-	 * calls for different users could both pass before either writes and end up sharing a PIN.
-	 * A PIN is stored as a per-record salted hash, so it cannot be guarded by a unique DB index
-	 * the way core enforces SKUs ({@see WC_Product_Data_Store_CPT::obtain_lock_on_sku_for_concurrent_requests()}),
-	 * and WordPress offers no portable atomic "reserve value" primitive — mirroring the same
-	 * documented trade-off in {@see \Automattic\WooCommerce\Api\Mutations\Products\CreateProduct}.
-	 * If strict uniqueness is ever required, the caller should enforce it at a higher layer
-	 * (e.g. a mutex around the REST handler) rather than assume this service guarantees it.
+	 * The uniqueness check is best-effort read-then-write: near-simultaneous calls can end
+	 * up sharing a PIN. A per-record salted hash cannot be guarded by a unique DB index, and
+	 * WordPress has no portable atomic "reserve value" primitive — the same documented
+	 * trade-off as {@see \Automattic\WooCommerce\Api\Mutations\Products\CreateProduct}.
+	 * Callers needing strict uniqueness must serialize at a higher layer.
 	 *
 	 * @param int    $user_id The target user ID.
 	 * @param string $pin     The plaintext 4-digit PIN. Must match the PIN_LENGTH constant.
@@ -103,15 +93,10 @@ class POSPinService {
 			'hash'       => base64_encode( $hash ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		);
 
-		// Store the PIN per-site so it stays aligned with the blog-scoped POS capabilities on
-		// multisite (Users::update_site_user_meta suffixes the blog prefix, so the key still
-		// matches the woocommerce_% uninstall sweep). A user's PIN is only meaningful on sites
-		// where they hold POS access, and the uniqueness scan below is itself blog-scoped, so
-		// PIN storage must share that scope.
-		//
-		// update_user_meta() also returns false for a same-value write, but the fresh random
-		// salt above means the record always differs from what is stored — false here is
-		// unambiguously a failed write, and returning success would leave the old PIN live.
+		// Stored per-site to stay aligned with the blog-scoped POS capabilities on multisite
+		// (the suffixed key still matches the woocommerce_% uninstall sweep). The fresh random
+		// salt means the record always differs from what is stored, so false from
+		// update_user_meta() is unambiguously a failed write, never a same-value no-op.
 		if ( false === Users::update_site_user_meta( $user_id, self::PIN_META_KEY, $record ) ) {
 			return new WP_Error(
 				'woocommerce_pos_pin_save_failed',
@@ -126,17 +111,14 @@ class POSPinService {
 	/**
 	 * Whether the given plaintext PIN collides with one already stored on another POS-access user.
 	 *
-	 * The PIN is the sole operator identifier at the till, so two staff sharing one would be
-	 * unresolvable on the device. set_pin() calls this internally; it is also public for the
-	 * wp-admin add-staff flow, which must check uniqueness *before* the user exists (so it can't go
-	 * through set_pin) — that caller passes 0 to scan every existing record.
+	 * set_pin() calls this internally; it is also public for the wp-admin add-staff flow, which
+	 * checks uniqueness before the user exists — that caller passes 0 to scan every record.
 	 *
-	 * Scoping the scan to POS-access users keeps stale PIN meta on non-POS users from causing
-	 * phantom collisions. `Capabilities::pos_staff_user_query_args()` selects *candidates* (it
-	 * also matches explicitly denied caps), so each row is refined with the resolved-capability
-	 * check `Capabilities::has_pos_access()` before its PIN is compared. Cost is bounded by the
-	 * number of active staff (a handful), one PBKDF2 evaluation per row. The candidate user is
-	 * excluded so an idempotent re-set ("save the same PIN again") is allowed.
+	 * The query selects *candidates* (capability__in also matches explicitly denied caps), so
+	 * each row is refined with the resolved-capability check Capabilities::has_pos_access()
+	 * before its PIN is compared — stale PIN meta on users without actual POS access cannot
+	 * cause phantom collisions. Cost is bounded by the number of active staff, one PBKDF2
+	 * evaluation per row. The candidate user is excluded so an idempotent re-set is allowed.
 	 *
 	 * @param string $pin             Plaintext PIN candidate; a malformed PIN is never "in use".
 	 * @param int    $exclude_user_id User being assigned the PIN; excluded from the scan. Pass 0 at
@@ -163,9 +145,7 @@ class POSPinService {
 		);
 
 		foreach ( $user_query->get_results() as $other_id ) {
-			// The query matches capability *names*, so it also selects users whose POS caps are
-			// explicitly denied (stored as false). Skip anyone without resolved POS access before
-			// spending PBKDF2 cycles, so their stale PIN cannot phantom-block the candidate PIN.
+			// Candidates can include explicitly denied caps (see docblock); skip before hashing.
 			if ( ! Capabilities::has_pos_access( (int) $other_id ) ) {
 				continue;
 			}
@@ -191,11 +171,8 @@ class POSPinService {
 	}
 
 	/**
-	 * Check whether a user has a PIN set.
-	 *
-	 * A record that verify_pin() would reject (wrong algo, out-of-range iterations,
-	 * malformed salt/hash) reads as no PIN, so "has a PIN" always means "has a PIN
-	 * that can actually verify".
+	 * Check whether a user has a PIN set. A record that verify_pin() would reject reads
+	 * as no PIN, so "has a PIN" always means "has a PIN that can actually verify".
 	 *
 	 * @param int $user_id The target user ID.
 	 * @return bool
@@ -208,17 +185,11 @@ class POSPinService {
 	}
 
 	/**
-	 * Return the public PIN record for a user, suitable for embedding in the staff
-	 * list payload sent to mobile clients. Returns null if no PIN is set.
-	 *
-	 * The record contains the algorithm, iteration count, salt, and hash — everything
-	 * needed for the client to validate an entered PIN locally. The plaintext PIN
-	 * never leaves the device that set it.
-	 *
-	 * Only well-formed records are exposed: a record that verify_pin() would reject
-	 * returns null instead of shipping to clients, so a corrupted or hostile meta value
-	 * (e.g. a huge iteration count that would make the client's PBKDF2 hang) never
-	 * reaches a device.
+	 * Return the public PIN record for a user — algorithm, iterations, salt, hash:
+	 * everything a mobile client needs to validate an entered PIN locally (the plaintext
+	 * PIN never leaves the device that set it). Returns null when no PIN is set or the
+	 * stored record is malformed, so a corrupted or hostile meta value (e.g. a huge
+	 * iteration count that would hang the client's PBKDF2) never ships to a device.
 	 *
 	 * @param int $user_id The target user ID.
 	 * @return array{algo:string,iterations:int,salt:string,hash:string}|null
@@ -280,16 +251,12 @@ class POSPinService {
 	/**
 	 * Validate and decode a stored PIN record, or null if it is malformed.
 	 *
-	 * Single source of truth for what a well-formed record is, shared by has_pin(),
-	 * get_public_pin_record(), and verify_pin() so a record is only ever reported,
-	 * exposed to clients, or verified if it matches the format set_pin() writes.
-	 *
-	 * The iteration count drives PBKDF2's cost, and set_pin() only ever writes ITERATIONS —
-	 * anything else was not written by this service and reads as malformed. The exact match
-	 * rejects both a hostile inflation (a huge count would make the uniqueness scan — or a
-	 * mobile client validating locally — hang) and a downgrade below the intended cost.
-	 * If the cost is ever raised, this check must learn to accept the previously shipped
-	 * values so historical records keep verifying.
+	 * Single source of truth for what a well-formed record is — shared by has_pin(),
+	 * get_public_pin_record(), and verify_pin(), so a record is only ever reported,
+	 * exposed, or verified if it matches the format set_pin() writes. That includes the
+	 * exact ITERATIONS count, rejecting both hostile inflation (a huge count would hang
+	 * the uniqueness scan or a client) and a cost downgrade. If the cost is ever raised,
+	 * this check must accept previously shipped values so historical records keep verifying.
 	 *
 	 * @param mixed $record The raw meta value (array with algo, iterations, salt, hash).
 	 * @return array{iterations:int,salt:string,hash:string}|null Decoded binary salt/hash and
@@ -316,9 +283,7 @@ class POSPinService {
 			return null;
 		}
 
-		// A well-formed record always carries a SALT_BYTES salt and a HASH_BYTES hash (the fixed
-		// PBKDF2-SHA256 format set_pin writes). Reject any other size as malformed before anything
-		// spends PBKDF2 cycles on it.
+		// Reject any size other than the fixed SALT_BYTES/HASH_BYTES format before hashing.
 		if ( self::SALT_BYTES !== strlen( $salt ) || self::HASH_BYTES !== strlen( $hash ) ) {
 			return null;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -403,7 +403,10 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 		$user_id                = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		$this->extra_user_ids[] = $user_id;
 		Capabilities::set_pos_preset( $user_id, POSPreset::CASHIER );
-		$this->sut->set_pin( $user_id, $pin );
+		$this->assertTrue(
+			$this->sut->set_pin( $user_id, $pin ),
+			'Fixture: set_pin() must succeed for the collision scenarios to be meaningful.'
+		);
 		return $user_id;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -415,6 +415,26 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox is_pin_used_by_other_user ignores PINs on users whose POS caps are explicitly denied.
+	 *
+	 * WP_User_Query's capability__in matches the capability *name* in the stored map, so a user
+	 * whose caps were explicitly denied (add_cap with false) is still selected as a candidate
+	 * even though has_pos_access() resolves to no access. Their stale PIN must not block the
+	 * candidate PIN as "in use".
+	 */
+	public function test_is_pin_used_by_other_user_ignores_users_with_denied_pos_caps(): void {
+		$denied_id = $this->make_pos_user_with_pin( '1234' );
+
+		$denied_user = get_userdata( $denied_id );
+		foreach ( Capabilities::all_pos_capabilities() as $cap ) {
+			$denied_user->add_cap( $cap, false );
+		}
+		$this->assertFalse( Capabilities::has_pos_access( $denied_id ), 'Fixture: denied caps must resolve to no POS access.' );
+
+		$this->assertFalse( $this->sut->is_pin_used_by_other_user( '1234' ) );
+	}
+
+	/**
 	 * Create a POS-access user (Cashier preset) with the given PIN, tracked for cleanup.
 	 *
 	 * @param string $pin Plaintext PIN to assign.

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -234,6 +234,27 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should keep verifying the exact record format shipped in v1 (frozen golden record).
+	 */
+	public function test_verify_pin_accepts_frozen_v1_record(): void {
+		// A golden record frozen in the exact wire format this service first shipped:
+		// PBKDF2-SHA256, 10k iterations, 16-byte salt, 32-byte hash, base64 envelope —
+		// deliberately built from literals, NOT the class constants. Records like this
+		// live in merchant databases; if a change to the constants or validation stops
+		// this one from verifying, it breaks every stored PIN the same way. Such a change
+		// must handle historical records explicitly (and update this test deliberately).
+		$record = array(
+			'algo'       => 'pbkdf2-sha256',
+			'iterations' => 10000,
+			'salt'       => 'AAAAAAAAAAAAAAAAAAAAAA==',
+			'hash'       => '4LKid0czxzbVTCqt3HuQw9Fe3FdcasIOAR5YlAhmuhU=',
+		);
+
+		$this->assertTrue( $this->sut->verify_pin( '1234', $record ), 'The shipped v1 record format must keep verifying.' );
+		$this->assertFalse( $this->sut->verify_pin( '9999', $record ), 'A wrong PIN must still fail against the golden record.' );
+	}
+
+	/**
 	 * @testdox Should return null from get_public_pin_record when no PIN is set.
 	 */
 	public function test_get_public_pin_record_returns_null_when_unset(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -1,0 +1,325 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\POS\Service;
+
+use Automattic\WooCommerce\Internal\POS\Capabilities;
+use Automattic\WooCommerce\Internal\POS\POSPreset;
+use Automattic\WooCommerce\Internal\POS\Service\POSPinService;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the POSPinService class.
+ */
+class POSPinServiceTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var POSPinService
+	 */
+	private $sut;
+
+	/**
+	 * Test user id.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut     = new POSPinService();
+		$this->user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		Capabilities::set_pos_preset( $this->user_id, POSPreset::CASHIER );
+	}
+
+	/**
+	 * Extra users created mid-test that should be cleaned up.
+	 *
+	 * @var int[]
+	 */
+	private array $extra_user_ids = array();
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->extra_user_ids as $extra_id ) {
+			wp_delete_user( $extra_id );
+		}
+		$this->extra_user_ids = array();
+		wp_delete_user( $this->user_id );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should accept exactly four numeric digits as valid PIN format.
+	 */
+	public function test_validate_pin_format_accepts_four_digits(): void {
+		$this->assertTrue( $this->sut->validate_pin_format( '0000' ) );
+		$this->assertTrue( $this->sut->validate_pin_format( '1234' ) );
+		$this->assertTrue( $this->sut->validate_pin_format( '9999' ) );
+	}
+
+	/**
+	 * @testdox Should reject non-numeric, wrong-length, or empty PIN formats.
+	 */
+	public function test_validate_pin_format_rejects_invalid(): void {
+		$this->assertFalse( $this->sut->validate_pin_format( '' ) );
+		$this->assertFalse( $this->sut->validate_pin_format( '123' ) );
+		$this->assertFalse( $this->sut->validate_pin_format( '12345' ) );
+		$this->assertFalse( $this->sut->validate_pin_format( 'abcd' ) );
+		$this->assertFalse( $this->sut->validate_pin_format( '12 4' ) );
+		$this->assertFalse( $this->sut->validate_pin_format( ' 1234 ' ) );
+	}
+
+	/**
+	 * @testdox Should store a PIN record and report has_pin as true.
+	 */
+	public function test_set_pin_persists_record(): void {
+		$this->assertFalse( $this->sut->has_pin( $this->user_id ), 'No PIN should be set initially.' );
+
+		$result = $this->sut->set_pin( $this->user_id, '4242' );
+
+		$this->assertTrue( $result, 'set_pin should return true on success.' );
+		$this->assertTrue( $this->sut->has_pin( $this->user_id ) );
+
+		$record = $this->sut->get_public_pin_record( $this->user_id );
+		$this->assertIsArray( $record );
+		$this->assertSame( POSPinService::ALGO, $record['algo'] );
+		$this->assertSame( POSPinService::ITERATIONS, $record['iterations'] );
+		$this->assertNotEmpty( $record['salt'] );
+		$this->assertNotEmpty( $record['hash'] );
+	}
+
+	/**
+	 * @testdox Should reject set_pin when the PIN format is invalid.
+	 */
+	public function test_set_pin_rejects_bad_format(): void {
+		$result = $this->sut->set_pin( $this->user_id, '12' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'woocommerce_pos_invalid_pin_format', $result->get_error_code() );
+		$this->assertFalse( $this->sut->has_pin( $this->user_id ) );
+	}
+
+	/**
+	 * @testdox Should produce a unique salt per set_pin call.
+	 */
+	public function test_set_pin_generates_unique_salt_each_call(): void {
+		$this->sut->set_pin( $this->user_id, '1234' );
+		$first = $this->sut->get_public_pin_record( $this->user_id );
+
+		$this->sut->set_pin( $this->user_id, '1234' );
+		$second = $this->sut->get_public_pin_record( $this->user_id );
+
+		$this->assertNotSame( $first['salt'], $second['salt'], 'Salts must differ across set_pin calls.' );
+		$this->assertNotSame( $first['hash'], $second['hash'], 'Hashes must differ because of the new salt.' );
+	}
+
+	/**
+	 * @testdox Should clear the PIN record on delete_pin.
+	 */
+	public function test_delete_pin_removes_record(): void {
+		$this->sut->set_pin( $this->user_id, '5678' );
+		$this->assertTrue( $this->sut->has_pin( $this->user_id ) );
+
+		$this->sut->delete_pin( $this->user_id );
+
+		$this->assertFalse( $this->sut->has_pin( $this->user_id ) );
+		$this->assertNull( $this->sut->get_public_pin_record( $this->user_id ) );
+	}
+
+	/**
+	 * @testdox Should verify a matching PIN against a stored record.
+	 */
+	public function test_verify_pin_accepts_matching_pin(): void {
+		$this->sut->set_pin( $this->user_id, '4321' );
+		$record = $this->sut->get_public_pin_record( $this->user_id );
+
+		$this->assertTrue( $this->sut->verify_pin( '4321', $record ) );
+	}
+
+	/**
+	 * @testdox Should reject a non-matching PIN against a stored record.
+	 */
+	public function test_verify_pin_rejects_mismatch(): void {
+		$this->sut->set_pin( $this->user_id, '4321' );
+		$record = $this->sut->get_public_pin_record( $this->user_id );
+
+		$this->assertFalse( $this->sut->verify_pin( '4322', $record ) );
+		$this->assertFalse( $this->sut->verify_pin( '0000', $record ) );
+	}
+
+	/**
+	 * @testdox Should reject verify_pin when the input format is bad or the record is malformed.
+	 */
+	public function test_verify_pin_rejects_invalid_input(): void {
+		$this->sut->set_pin( $this->user_id, '4321' );
+		$record = $this->sut->get_public_pin_record( $this->user_id );
+
+		$this->assertFalse( $this->sut->verify_pin( '12', $record ), 'Bad format input must be rejected.' );
+		$this->assertFalse( $this->sut->verify_pin( '4321', array() ), 'Empty record must be rejected.' );
+		$this->assertFalse(
+			$this->sut->verify_pin(
+				'4321',
+				array(
+					'algo'       => 'unknown',
+					'iterations' => 10000,
+					'salt'       => 'x',
+					'hash'       => 'y',
+				)
+			),
+			'Unknown algo must be rejected.'
+		);
+	}
+
+	/**
+	 * @testdox Should return null from get_public_pin_record when no PIN is set.
+	 */
+	public function test_get_public_pin_record_returns_null_when_unset(): void {
+		$this->assertNull( $this->sut->get_public_pin_record( $this->user_id ) );
+	}
+
+	/**
+	 * @testdox Should reject set_pin when the PIN is already used by another staff member.
+	 */
+	public function test_set_pin_rejects_pin_in_use_by_another_user(): void {
+		$other_id               = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->extra_user_ids[] = $other_id;
+		Capabilities::set_pos_preset( $other_id, POSPreset::CASHIER );
+
+		$this->assertTrue( $this->sut->set_pin( $other_id, '1234' ) );
+
+		$result = $this->sut->set_pin( $this->user_id, '1234' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'woocommerce_pos_pin_in_use', $result->get_error_code() );
+		$this->assertFalse(
+			$this->sut->has_pin( $this->user_id ),
+			'No PIN should have been persisted when the candidate is taken.'
+		);
+	}
+
+	/**
+	 * @testdox Should ignore PINs on users who do not have POS access.
+	 *
+	 * A non-POS user with a stale `woocommerce_pos_pin` meta entry (e.g. left over
+	 * from v1 or a manual edit) must not block a real POS staff member from using
+	 * the same plaintext PIN. Uniqueness is scoped to users with the POS preset
+	 * meta set — non-POS users are invisible to the uniqueness scan.
+	 */
+	public function test_set_pin_ignores_non_pos_staff_users_with_stale_pin_meta(): void {
+		$non_pos_user           = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->extra_user_ids[] = $non_pos_user;
+
+		// Plant a stale PIN record directly so we don't depend on set_pin's
+		// preset check accepting a non-POS user.
+		update_user_meta(
+			$non_pos_user,
+			POSPinService::PIN_META_KEY,
+			array(
+				'algo'       => POSPinService::ALGO,
+				'iterations' => POSPinService::ITERATIONS,
+				'salt'       => base64_encode( random_bytes( POSPinService::SALT_BYTES ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'hash'       => base64_encode( hash_pbkdf2( 'sha256', '1234', random_bytes( POSPinService::SALT_BYTES ), POSPinService::ITERATIONS, POSPinService::HASH_BYTES, true ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			)
+		);
+
+		$this->assertTrue( $this->sut->set_pin( $this->user_id, '1234' ) );
+	}
+
+	/**
+	 * @testdox Should allow set_pin to re-save the same PIN for the same user (idempotent update).
+	 */
+	public function test_set_pin_allows_same_user_to_resave_same_pin(): void {
+		$this->assertTrue( $this->sut->set_pin( $this->user_id, '1234' ) );
+
+		// Re-saving the same PIN for the same user must succeed — the user is excluded
+		// from the uniqueness scan so their own existing hash does not falsely collide.
+		$this->assertTrue( $this->sut->set_pin( $this->user_id, '1234' ) );
+	}
+
+	/**
+	 * @testdox is_pin_used_by_other_user is true when another POS user already holds the PIN.
+	 */
+	public function test_is_pin_used_by_other_user_true_for_collision(): void {
+		$this->make_pos_user_with_pin( '1234' );
+
+		$this->assertTrue( $this->sut->is_pin_used_by_other_user( '1234' ) );
+	}
+
+	/**
+	 * @testdox is_pin_used_by_other_user is false when no POS user holds the PIN.
+	 */
+	public function test_is_pin_used_by_other_user_false_when_unique(): void {
+		$this->make_pos_user_with_pin( '1234' );
+
+		$this->assertFalse( $this->sut->is_pin_used_by_other_user( '5678' ) );
+	}
+
+	/**
+	 * @testdox is_pin_used_by_other_user excludes the candidate, but a create-time (exclude 0) scan sees every record.
+	 */
+	public function test_is_pin_used_by_other_user_excludes_candidate(): void {
+		$this->sut->set_pin( $this->user_id, '1234' );
+
+		$this->assertFalse(
+			$this->sut->is_pin_used_by_other_user( '1234', $this->user_id ),
+			'Excluding the candidate allows an idempotent re-set.'
+		);
+		$this->assertTrue(
+			$this->sut->is_pin_used_by_other_user( '1234', 0 ),
+			'A create-time scan (exclude 0) sees the existing PIN.'
+		);
+	}
+
+	/**
+	 * @testdox is_pin_used_by_other_user ignores stale PINs on users without POS access.
+	 */
+	public function test_is_pin_used_by_other_user_ignores_non_pos_users(): void {
+		$non_pos                = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->extra_user_ids[] = $non_pos;
+		$this->plant_pin_meta( $non_pos, '1234' );
+
+		$this->assertFalse( $this->sut->is_pin_used_by_other_user( '1234' ) );
+	}
+
+	/**
+	 * Create a POS-access user (Cashier preset) with the given PIN, tracked for cleanup.
+	 *
+	 * @param string $pin Plaintext PIN to assign.
+	 * @return int The created user id.
+	 */
+	private function make_pos_user_with_pin( string $pin ): int {
+		$user_id                = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->extra_user_ids[] = $user_id;
+		Capabilities::set_pos_preset( $user_id, POSPreset::CASHIER );
+		$this->sut->set_pin( $user_id, $pin );
+		return $user_id;
+	}
+
+	/**
+	 * Plant a well-formed PIN record directly in user meta (bypassing set_pin's POS-access check).
+	 *
+	 * @param int    $user_id Target user.
+	 * @param string $pin     Plaintext PIN to store.
+	 */
+	private function plant_pin_meta( int $user_id, string $pin ): void {
+		$salt = random_bytes( POSPinService::SALT_BYTES );
+		update_user_meta(
+			$user_id,
+			POSPinService::PIN_META_KEY,
+			array(
+				'algo'       => POSPinService::ALGO,
+				'iterations' => POSPinService::ITERATIONS,
+				'salt'       => base64_encode( $salt ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'hash'       => base64_encode( hash_pbkdf2( 'sha256', $pin, $salt, POSPinService::ITERATIONS, POSPinService::HASH_BYTES, true ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -108,6 +108,23 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should reject set_pin for a user without POS access.
+	 *
+	 * Uniqueness is scoped to POS-access users, so a PIN stored on a non-POS user would be a
+	 * latent collision once they gain POS caps. set_pin must refuse to create that record.
+	 */
+	public function test_set_pin_rejects_user_without_pos_access(): void {
+		$non_pos_user           = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->extra_user_ids[] = $non_pos_user;
+
+		$result = $this->sut->set_pin( $non_pos_user, '1234' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'woocommerce_pos_no_pos_access', $result->get_error_code() );
+		$this->assertFalse( $this->sut->has_pin( $non_pos_user ) );
+	}
+
+	/**
 	 * @testdox Should produce a unique salt per set_pin call.
 	 */
 	public function test_set_pin_generates_unique_salt_each_call(): void {
@@ -226,8 +243,8 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	 *
 	 * A non-POS user with a stale `woocommerce_pos_pin` meta entry (e.g. left over
 	 * from v1 or a manual edit) must not block a real POS staff member from using
-	 * the same plaintext PIN. Uniqueness is scoped to users with the POS preset
-	 * meta set — non-POS users are invisible to the uniqueness scan.
+	 * the same plaintext PIN. Uniqueness is scoped to users with POS access — holders
+	 * of any `woocommerce_pos_*` capability — so non-POS users are invisible to the scan.
 	 */
 	public function test_set_pin_ignores_non_pos_staff_users_with_stale_pin_meta(): void {
 		$non_pos_user           = self::factory()->user->create( array( 'role' => 'subscriber' ) );

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Internal\POS\Service;
 use Automattic\WooCommerce\Internal\POS\Capabilities;
 use Automattic\WooCommerce\Internal\POS\POSPreset;
 use Automattic\WooCommerce\Internal\POS\Service\POSPinService;
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use WC_Unit_Test_Case;
 
 /**
@@ -346,14 +347,15 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Plant a well-formed PIN record directly in user meta (bypassing set_pin's POS-access check).
+	 * Plant a well-formed PIN record directly in per-site user meta (bypassing set_pin's
+	 * POS-access check), matching how POSPinService stores it via Users::*_site_user_meta().
 	 *
 	 * @param int    $user_id Target user.
 	 * @param string $pin     Plaintext PIN to store.
 	 */
 	private function plant_pin_meta( int $user_id, string $pin ): void {
 		$salt = random_bytes( POSPinService::SALT_BYTES );
-		update_user_meta(
+		Users::update_site_user_meta(
 			$user_id,
 			POSPinService::PIN_META_KEY,
 			array(

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -276,6 +276,24 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should return WP_Error from set_pin when the meta write fails.
+	 *
+	 * A silently failed write would leave the previous PIN live while the caller
+	 * believes it changed, so the failure must be propagated.
+	 */
+	public function test_set_pin_returns_error_when_meta_write_fails(): void {
+		add_filter( 'update_user_metadata', '__return_false' );
+
+		$result = $this->sut->set_pin( $this->user_id, '4242' );
+
+		remove_filter( 'update_user_metadata', '__return_false' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'woocommerce_pos_pin_save_failed', $result->get_error_code() );
+		$this->assertFalse( $this->sut->has_pin( $this->user_id ), 'No PIN should be reported after a failed write.' );
+	}
+
+	/**
 	 * @testdox Should reject set_pin when the PIN is already used by another staff member.
 	 */
 	public function test_set_pin_rejects_pin_in_use_by_another_user(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -197,16 +197,20 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should reject a record whose iteration count is out of the safe range (DoS guard).
+	 * @testdox Should reject a record whose iteration count is not the canonical PBKDF2 cost.
 	 */
-	public function test_verify_pin_rejects_out_of_range_iterations(): void {
+	public function test_verify_pin_rejects_non_canonical_iterations(): void {
 		$this->sut->set_pin( $this->user_id, '4321' );
 		$record = $this->sut->get_public_pin_record( $this->user_id );
 
-		// A corrupted or hostile record could carry a huge iteration count to make PBKDF2 hang.
-		// It must be treated as malformed and rejected before any hashing work is done.
-		$record['iterations'] = POSPinService::MAX_ITERATIONS + 1;
-		$this->assertFalse( $this->sut->verify_pin( '4321', $record ), 'Over-the-cap iterations must be rejected.' );
+		// set_pin() only ever writes ITERATIONS. A corrupted or hostile count could inflate the
+		// PBKDF2 cost (hanging the scan or a client) or downgrade it below the intended cost —
+		// both must be treated as malformed and rejected before any hashing work is done.
+		$record['iterations'] = POSPinService::ITERATIONS + 1;
+		$this->assertFalse( $this->sut->verify_pin( '4321', $record ), 'Inflated iterations must be rejected.' );
+
+		$record['iterations'] = 1;
+		$this->assertFalse( $this->sut->verify_pin( '4321', $record ), 'Downgraded iterations must be rejected.' );
 
 		$record['iterations'] = 0;
 		$this->assertFalse( $this->sut->verify_pin( '4321', $record ), 'Non-positive iterations must be rejected.' );
@@ -266,12 +270,12 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 		);
 
 		return array(
-			'not an array'        => array( 'garbage' ),
-			'missing salt'        => array( array_diff_key( $valid, array( 'salt' => true ) ) ),
-			'unknown algo'        => array( array_merge( $valid, array( 'algo' => 'md5' ) ) ),
-			'over-cap iterations' => array( array_merge( $valid, array( 'iterations' => POSPinService::MAX_ITERATIONS + 1 ) ) ),
-			'invalid base64 salt' => array( array_merge( $valid, array( 'salt' => '!!!not-base64!!!' ) ) ),
-			'wrong hash length'   => array( array_merge( $valid, array( 'hash' => base64_encode( random_bytes( POSPinService::HASH_BYTES - 1 ) ) ) ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			'not an array'          => array( 'garbage' ),
+			'missing salt'          => array( array_diff_key( $valid, array( 'salt' => true ) ) ),
+			'unknown algo'          => array( array_merge( $valid, array( 'algo' => 'md5' ) ) ),
+			'downgraded iterations' => array( array_merge( $valid, array( 'iterations' => 1 ) ) ),
+			'invalid base64 salt'   => array( array_merge( $valid, array( 'salt' => '!!!not-base64!!!' ) ) ),
+			'wrong hash length'     => array( array_merge( $valid, array( 'hash' => base64_encode( random_bytes( POSPinService::HASH_BYTES - 1 ) ) ) ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -179,6 +179,22 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should reject a record whose iteration count is out of the safe range (DoS guard).
+	 */
+	public function test_verify_pin_rejects_out_of_range_iterations(): void {
+		$this->sut->set_pin( $this->user_id, '4321' );
+		$record = $this->sut->get_public_pin_record( $this->user_id );
+
+		// A corrupted or hostile record could carry a huge iteration count to make PBKDF2 hang.
+		// It must be treated as malformed and rejected before any hashing work is done.
+		$record['iterations'] = POSPinService::MAX_ITERATIONS + 1;
+		$this->assertFalse( $this->sut->verify_pin( '4321', $record ), 'Over-the-cap iterations must be rejected.' );
+
+		$record['iterations'] = 0;
+		$this->assertFalse( $this->sut->verify_pin( '4321', $record ), 'Non-positive iterations must be rejected.' );
+	}
+
+	/**
 	 * @testdox Should return null from get_public_pin_record when no PIN is set.
 	 */
 	public function test_get_public_pin_record_returns_null_when_unset(): void {
@@ -217,18 +233,10 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 		$non_pos_user           = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		$this->extra_user_ids[] = $non_pos_user;
 
-		// Plant a stale PIN record directly so we don't depend on set_pin's
-		// preset check accepting a non-POS user.
-		update_user_meta(
-			$non_pos_user,
-			POSPinService::PIN_META_KEY,
-			array(
-				'algo'       => POSPinService::ALGO,
-				'iterations' => POSPinService::ITERATIONS,
-				'salt'       => base64_encode( random_bytes( POSPinService::SALT_BYTES ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-				'hash'       => base64_encode( hash_pbkdf2( 'sha256', '1234', random_bytes( POSPinService::SALT_BYTES ), POSPinService::ITERATIONS, POSPinService::HASH_BYTES, true ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-			)
-		);
+		// Plant a *verifiable* stale PIN record (consistent salt/hash) directly, bypassing set_pin's
+		// POS-access check. The record genuinely matches '1234', so this test only passes because the
+		// uniqueness scan is scoped to POS-access users — a non-POS user is invisible to it.
+		$this->plant_pin_meta( $non_pos_user, '1234' );
 
 		$this->assertTrue( $this->sut->set_pin( $this->user_id, '1234' ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -110,9 +110,6 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @testdox Should reject set_pin for a user without POS access.
-	 *
-	 * Uniqueness is scoped to POS-access users, so a PIN stored on a non-POS user would be a
-	 * latent collision once they gain POS caps. set_pin must refuse to create that record.
 	 */
 	public function test_set_pin_rejects_user_without_pos_access(): void {
 		$non_pos_user           = self::factory()->user->create( array( 'role' => 'subscriber' ) );
@@ -203,9 +200,7 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 		$this->sut->set_pin( $this->user_id, '4321' );
 		$record = $this->sut->get_public_pin_record( $this->user_id );
 
-		// set_pin() only ever writes ITERATIONS. A corrupted or hostile count could inflate the
-		// PBKDF2 cost (hanging the scan or a client) or downgrade it below the intended cost —
-		// both must be treated as malformed and rejected before any hashing work is done.
+		// Any count other than ITERATIONS — inflated (DoS) or downgraded — reads as malformed.
 		$record['iterations'] = POSPinService::ITERATIONS + 1;
 		$this->assertFalse( $this->sut->verify_pin( '4321', $record ), 'Inflated iterations must be rejected.' );
 
@@ -237,12 +232,10 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	 * @testdox Should keep verifying the exact record format shipped in v1 (frozen golden record).
 	 */
 	public function test_verify_pin_accepts_frozen_v1_record(): void {
-		// A golden record frozen in the exact wire format this service first shipped:
-		// PBKDF2-SHA256, 10k iterations, 16-byte salt, 32-byte hash, base64 envelope —
-		// deliberately built from literals, NOT the class constants. Records like this
-		// live in merchant databases; if a change to the constants or validation stops
-		// this one from verifying, it breaks every stored PIN the same way. Such a change
-		// must handle historical records explicitly (and update this test deliberately).
+		// A golden record frozen in the exact wire format first shipped, deliberately built
+		// from literals, NOT the class constants. Records like this live in merchant
+		// databases: a change that stops this one verifying breaks every stored PIN the
+		// same way, and must handle historical records explicitly.
 		$record = array(
 			'algo'       => 'pbkdf2-sha256',
 			'iterations' => 10000,
@@ -264,9 +257,6 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Should treat a malformed stored record as no PIN: has_pin false, public record null.
 	 * @dataProvider provider_malformed_pin_records
-	 *
-	 * A record verify_pin() would reject must never be reported as a set PIN nor shipped
-	 * to mobile clients (e.g. a hostile iteration count would hang the client's PBKDF2).
 	 *
 	 * @param mixed $record The malformed meta value to plant.
 	 */
@@ -302,9 +292,6 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @testdox Should return WP_Error from set_pin when the meta write fails.
-	 *
-	 * A silently failed write would leave the previous PIN live while the caller
-	 * believes it changed, so the failure must be propagated.
 	 */
 	public function test_set_pin_returns_error_when_meta_write_fails(): void {
 		add_filter( 'update_user_metadata', '__return_false' );
@@ -340,19 +327,13 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @testdox Should ignore PINs on users who do not have POS access.
-	 *
-	 * A non-POS user with a stale `woocommerce_pos_pin` meta entry (e.g. left over
-	 * from v1 or a manual edit) must not block a real POS staff member from using
-	 * the same plaintext PIN. Uniqueness is scoped to users with POS access — holders
-	 * of any `woocommerce_pos_*` capability — so non-POS users are invisible to the scan.
 	 */
 	public function test_set_pin_ignores_non_pos_staff_users_with_stale_pin_meta(): void {
 		$non_pos_user           = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		$this->extra_user_ids[] = $non_pos_user;
 
-		// Plant a *verifiable* stale PIN record (consistent salt/hash) directly, bypassing set_pin's
-		// POS-access check. The record genuinely matches '1234', so this test only passes because the
-		// uniqueness scan is scoped to POS-access users — a non-POS user is invisible to it.
+		// A *verifiable* stale record genuinely matching '1234', planted bypassing set_pin's
+		// POS-access check: it must stay invisible to the POS-scoped uniqueness scan.
 		$this->plant_pin_meta( $non_pos_user, '1234' );
 
 		$this->assertTrue( $this->sut->set_pin( $this->user_id, '1234' ) );
@@ -364,9 +345,7 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	public function test_set_pin_allows_same_user_to_resave_same_pin(): void {
 		$this->assertTrue( $this->sut->set_pin( $this->user_id, '1234' ) );
 
-		// Re-saving the same PIN for the same user must succeed — the user is excluded
-		// from the uniqueness scan so their own existing hash does not falsely collide.
-		$this->assertTrue( $this->sut->set_pin( $this->user_id, '1234' ) );
+		$this->assertTrue( $this->sut->set_pin( $this->user_id, '1234' ), 'The own existing hash must not falsely collide.' );
 	}
 
 	/**
@@ -418,10 +397,8 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox is_pin_used_by_other_user ignores PINs on users whose POS caps are explicitly denied.
 	 *
-	 * WP_User_Query's capability__in matches the capability *name* in the stored map, so a user
-	 * whose caps were explicitly denied (add_cap with false) is still selected as a candidate
-	 * even though has_pos_access() resolves to no access. Their stale PIN must not block the
-	 * candidate PIN as "in use".
+	 * capability__in still selects a user whose caps are denied (add_cap with false), but
+	 * has_pos_access() resolves to no access — their stale PIN must not block the candidate.
 	 */
 	public function test_is_pin_used_by_other_user_ignores_users_with_denied_pos_caps(): void {
 		$denied_id = $this->make_pos_user_with_pin( '1234' );

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -212,6 +212,23 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should reject a record whose decoded salt or hash length is wrong.
+	 */
+	public function test_verify_pin_rejects_wrong_length_salt_or_hash(): void {
+		$this->sut->set_pin( $this->user_id, '4321' );
+		$record = $this->sut->get_public_pin_record( $this->user_id );
+
+		// Valid base64, but the decoded salt/hash are the wrong size for the declared format.
+		$short_salt         = $record;
+		$short_salt['salt'] = base64_encode( random_bytes( POSPinService::SALT_BYTES - 1 ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$this->assertFalse( $this->sut->verify_pin( '4321', $short_salt ), 'Wrong salt length must be rejected.' );
+
+		$short_hash         = $record;
+		$short_hash['hash'] = base64_encode( random_bytes( POSPinService::HASH_BYTES - 1 ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$this->assertFalse( $this->sut->verify_pin( '4321', $short_hash ), 'Wrong hash length must be rejected.' );
+	}
+
+	/**
 	 * @testdox Should return null from get_public_pin_record when no PIN is set.
 	 */
 	public function test_get_public_pin_record_returns_null_when_unset(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -237,6 +237,45 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should treat a malformed stored record as no PIN: has_pin false, public record null.
+	 * @dataProvider provider_malformed_pin_records
+	 *
+	 * A record verify_pin() would reject must never be reported as a set PIN nor shipped
+	 * to mobile clients (e.g. a hostile iteration count would hang the client's PBKDF2).
+	 *
+	 * @param mixed $record The malformed meta value to plant.
+	 */
+	public function test_malformed_record_reads_as_no_pin( $record ): void {
+		Users::update_site_user_meta( $this->user_id, POSPinService::PIN_META_KEY, $record );
+
+		$this->assertFalse( $this->sut->has_pin( $this->user_id ), 'Malformed record must read as no PIN.' );
+		$this->assertNull( $this->sut->get_public_pin_record( $this->user_id ), 'Malformed record must not be exposed to clients.' );
+	}
+
+	/**
+	 * Malformed stored PIN records that must read as "no PIN".
+	 *
+	 * @return array<string, array{mixed}>
+	 */
+	public function provider_malformed_pin_records(): array {
+		$valid = array(
+			'algo'       => POSPinService::ALGO,
+			'iterations' => POSPinService::ITERATIONS,
+			'salt'       => base64_encode( random_bytes( POSPinService::SALT_BYTES ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			'hash'       => base64_encode( random_bytes( POSPinService::HASH_BYTES ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		);
+
+		return array(
+			'not an array'        => array( 'garbage' ),
+			'missing salt'        => array( array_diff_key( $valid, array( 'salt' => true ) ) ),
+			'unknown algo'        => array( array_merge( $valid, array( 'algo' => 'md5' ) ) ),
+			'over-cap iterations' => array( array_merge( $valid, array( 'iterations' => POSPinService::MAX_ITERATIONS + 1 ) ) ),
+			'invalid base64 salt' => array( array_merge( $valid, array( 'salt' => '!!!not-base64!!!' ) ) ),
+			'wrong hash length'   => array( array_merge( $valid, array( 'hash' => base64_encode( random_bytes( POSPinService::HASH_BYTES - 1 ) ) ) ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		);
+	}
+
+	/**
 	 * @testdox Should reject set_pin when the PIN is already used by another staff member.
 	 */
 	public function test_set_pin_rejects_pin_in_use_by_another_user(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/POS/Service/POSPinServiceTest.php
@@ -385,6 +385,7 @@ class POSPinServiceTest extends WC_Unit_Test_Case {
 		$this->make_pos_user_with_pin( '1234' );
 
 		$this->assertFalse( $this->sut->is_pin_used_by_other_user( '5678' ) );
+		$this->assertFalse( $this->sut->is_pin_used_by_other_user( 'abcd' ), 'A malformed PIN is never "in use".' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Part of **WOOMOB-3179** (POS Staff — Roles & Attribution, Core/server-side M1) — **PR 3** of the stack, stacked on #65661 (presets). Behind the off-by-default `point_of_sale_staff` feature flag.

> [!NOTE]
> **Everything in this PR is currently unused.** `POSPinService` has no runtime consumers yet — nothing instantiates or calls it on any code path. It is additive scaffolding that later PRs in the stack consume: the staff REST endpoint (PR 7) and the wp-admin staff fields (PR 8+). Merging it has no observable effect; it's reviewed and landed early to keep the stack's PRs small.

Adds `POSPinService`, the server-side store for POS staff PINs:

- **PBKDF2-HMAC-SHA-256** (10k iterations, 16-byte salt, 32-byte hash) storage + verification of 4-digit PINs in `woocommerce_pos_pin` user meta. The no-leading-underscore key means core's existing `WC_REMOVE_ALL_DATA` uninstall sweep (`meta_key LIKE 'woocommerce_%'`) cleans it up — no custom uninstall code (per the WOOMOB-3179 naming convention).
- **Per-staff PIN uniqueness** — the PIN is the sole operator identifier at the till, so a collision is unresolvable on the device. The scan is scoped to POS-access users via `Capabilities::pos_staff_user_query_args()` (holders of any `woocommerce_pos_*` cap), so stale PIN meta on non-POS users can't cause phantom collisions.
- **Public hash record** (`get_public_pin_record()`) the staff endpoint ships to mobile clients so they can validate PIN entry locally; the plaintext PIN never leaves the device that set it. The hash format is native on iOS (CommonCrypto/CryptoKit) and Android (PBKDF2WithHmacSHA256).

~178 non-comment source lines.

### How to test the changes in this Pull Request:

This PR has no runtime surface; it is covered by unit tests.

1. Run the unit tests: `pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter POSPinServiceTest`. The 17 tests cover PIN-format validation, store/has/delete, per-call salt uniqueness, verification (match / mismatch / bad format / malformed record), the public hash record, and per-staff uniqueness (collision, create-time `exclude=0` scan, candidate exclusion for an idempotent re-set, and ignoring stale PINs on non-POS users).
2. Lint: `pnpm --filter='@woocommerce/plugin-woocommerce' lint:php:changes`. PHPStan: `cd plugins/woocommerce && composer exec -- phpstan analyse src/Internal/POS/Service/POSPinService.php --memory-limit=2G`.

### Testing that has already taken place:

- 17/17 PHPUnit tests pass (wp-env, PHP 8.1).
- phpcs + PHPStan clean on the changed files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually in the branch: `plugins/woocommerce/changelog/add-pos-staff-pin-service` (Significance: minor, Type: add).
