### PR TITLE
fix: skip analytics events from clients without a stable visitor id

### DIFF
--- a/packages/php/woocommerce-analytics/changelog/fix-cookieless-event-session-inflation
+++ b/packages/php/woocommerce-analytics/changelog/fix-cookieless-event-session-inflation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop minting throwaway anonymous IDs for events from clients without a persisted visitor cookie (e.g. UA-spoofing crawlers hitting add-to-cart), which inflated session counts. Such events are now skipped instead.

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -458,21 +458,14 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
-	 * Resolve the visitor id for the current request.
+	 * Get the existing stable visitor id: the `tk_ai` cookie, or an IP-based hash when
+	 * proxy tracking is enabled. Returns null otherwise so the caller skips the event.
 	 *
-	 * Returns a *pre-existing* stable identifier only: the `tk_ai` cookie (set
-	 * client-side by the analytics client on first page view), or — when proxy
-	 * tracking is enabled — a deterministic IP-based hash. When neither is available
-	 * we return null so callers skip the event.
+	 * We never mint a new id here: attributing an event to a brand-new id creates a
+	 * throwaway one-event "visitor" (mostly cookie-less crawlers) that inflates session
+	 * counts. Real browsers already have a `tk_ai` cookie by the time an event fires.
 	 *
-	 * We deliberately do NOT mint a fresh id here. Attributing an event to a brand-new
-	 * id produces a throwaway one-event "visitor"; in practice that traffic is
-	 * overwhelmingly UA-spoofing crawlers that never persist a cookie, and counting them
-	 * inflates Nosara/Tracks session counts. Real browsers already carry a `tk_ai`
-	 * cookie by the time any server-side action event fires, so only non-persisting
-	 * clients reach the null path.
-	 *
-	 * @return string|null The stable visitor id, or null when none can be confirmed.
+	 * @return string|null Stable visitor id, or null when none is available.
 	 */
 	private static function get_visitor_id() {
 		// Return cached result if available.

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -87,7 +87,7 @@ class WC_Analytics_Tracking {
 			return true;
 		}
 
-		// Skip cookie-less contexts that cannot persist a stable visitor id; fresh random ids fragment sessions.
+		// Skip events that arrive without a stable visitor id (e.g. no tk_ai cookie); see get_visitor_id().
 		if ( empty( self::get_visitor_id() ) ) {
 			return true;
 		}
@@ -458,9 +458,21 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
-	 * Get the visitor id from the cookie or IP address (if proxy tracking is enabled).
+	 * Resolve the visitor id for the current request.
 	 *
-	 * @return string|null
+	 * Returns a *pre-existing* stable identifier only: the `tk_ai` cookie (set
+	 * client-side by the analytics client on first page view), or — when proxy
+	 * tracking is enabled — a deterministic IP-based hash. When neither is available
+	 * we return null so callers skip the event.
+	 *
+	 * We deliberately do NOT mint a fresh id here. Attributing an event to a brand-new
+	 * id produces a throwaway one-event "visitor"; in practice that traffic is
+	 * overwhelmingly UA-spoofing crawlers that never persist a cookie, and counting them
+	 * inflates Nosara/Tracks session counts. Real browsers already carry a `tk_ai`
+	 * cookie by the time any server-side action event fires, so only non-persisting
+	 * clients reach the null path.
+	 *
+	 * @return string|null The stable visitor id, or null when none can be confirmed.
 	 */
 	private static function get_visitor_id() {
 		// Return cached result if available.
@@ -468,57 +480,27 @@ class WC_Analytics_Tracking {
 			return self::$cached_visitor_id;
 		}
 
-		// Prefer tk_ai cookie if present.
+		// Prefer the tk_ai cookie if present.
 		if ( ! empty( $_COOKIE['tk_ai'] ) ) {
 			self::$cached_visitor_id = sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) );
 			return self::$cached_visitor_id;
 		}
 
-		// Cron and WP-CLI have no client IP or UA, so even proxy-tracking would collapse all background activity into one phantom user.
+		// Cron and WP-CLI have no real visitor; never attribute background activity to one.
 		if ( ( defined( 'DOING_CRON' ) && DOING_CRON )
 			|| ( defined( 'WP_CLI' ) && WP_CLI )
 		) {
 			return null;
 		}
 
-		// Proxy tracking provides a stable id from daily_salt + domain + ip + user_agent, even in REST/XMLRPC contexts.
+		// Proxy tracking provides a stable id from daily_salt + domain + ip + user_agent.
 		if ( Features::is_proxy_tracking_enabled() ) {
 			self::$cached_visitor_id = self::get_ip_based_visitor_id();
 			return self::$cached_visitor_id;
 		}
 
-		// Only mint a new id when we can persist it in a cookie; otherwise it would be a single-use throwaway that fragments sessions.
-		if ( headers_sent()
-			|| ( defined( 'REST_REQUEST' ) && REST_REQUEST )
-			|| ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
-		) {
-			return null;
-		}
-
-		// Base64-encoding 18 random bytes produces a 24-character anon id.
-		$binary = '';
-		for ( $i = 0; $i < 18; ++$i ) {
-			$binary .= chr( wp_rand( 0, 255 ) );
-		}
-
-		$new_visitor_id = base64_encode( $binary ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-
-		// httponly=false is intentional: _wca and client-side analytics need to read the same value the server wrote.
-		setcookie(
-			'tk_ai',
-			$new_visitor_id,
-			array(
-				'expires'  => time() + ( 365 * 24 * 60 * 60 ), // 1 year
-				'path'     => '/',
-				'domain'   => COOKIE_DOMAIN,
-				'secure'   => is_ssl(),
-				'httponly' => false,
-				'samesite' => 'Strict',
-			)
-		);
-
-		self::$cached_visitor_id = $new_visitor_id;
-		return self::$cached_visitor_id;
+		// No stable id arrived with the request. Do not mint one (see method doc).
+		return null;
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Test.php
@@ -102,13 +102,13 @@ class WC_Analytics_Tracking_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Must run BEFORE any test defines REST_REQUEST. In a plain front-end context
-	 * (not REST/XMLRPC/cron/CLI) with no `tk_ai` cookie, get_visitor_id() must NOT
-	 * return a freshly-minted id. Minting-and-attributing here is the Nov 2025
-	 * regression that produced one-event "visitors" — overwhelmingly UA-spoofing
-	 * crawler traffic that never persists the cookie — inflating Tracks session counts.
-	 * The id is still persisted in a cookie for the next request, but the current
-	 * call returns null so the event is skipped.
+	 * With no `tk_ai` cookie and proxy tracking off, get_visitor_id() must return null
+	 * instead of minting a fresh id. Minting-and-attributing here was the Nov 2025
+	 * regression that produced one-event "visitors" — overwhelmingly UA-spoofing crawler
+	 * traffic that never persists a cookie — inflating Tracks session counts.
+	 *
+	 * Order-independent: the cookie-less path no longer branches on REST_REQUEST, and the
+	 * method no longer sets a cookie server-side (real browsers get `tk_ai` client-side).
 	 */
 	public function test_get_visitor_id_returns_null_for_non_rest_request_without_cookie(): void {
 		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
@@ -123,8 +123,8 @@ class WC_Analytics_Tracking_Test extends BaseTestCase {
 
 	/**
 	 * Companion behavioral assertion: record_event() emits/queues no pixel for a
-	 * cookie-less, non-REST request — the crawler path that inflated session counts.
-	 * Must run before REST_REQUEST leaks so the non-REST branch is actually exercised.
+	 * cookie-less request — the crawler path that inflated session counts. Order-independent
+	 * (the skip no longer depends on REST_REQUEST).
 	 */
 	public function test_record_event_skips_non_rest_request_without_cookie(): void {
 		$captured = array();

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Test.php
@@ -102,6 +102,53 @@ class WC_Analytics_Tracking_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Must run BEFORE any test defines REST_REQUEST. In a plain front-end context
+	 * (not REST/XMLRPC/cron/CLI) with no `tk_ai` cookie, get_visitor_id() must NOT
+	 * return a freshly-minted id. Minting-and-attributing here is the Nov 2025
+	 * regression that produced one-event "visitors" — overwhelmingly UA-spoofing
+	 * crawler traffic that never persists the cookie — inflating Tracks session counts.
+	 * The id is still persisted in a cookie for the next request, but the current
+	 * call returns null so the event is skipped.
+	 */
+	public function test_get_visitor_id_returns_null_for_non_rest_request_without_cookie(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$method     = $reflection->getMethod( 'get_visitor_id' );
+		$method->setAccessible( true );
+
+		$this->assertNull(
+			$method->invoke( null ),
+			'A freshly-minted id must not be returned for cookie-less non-REST requests.'
+		);
+	}
+
+	/**
+	 * Companion behavioral assertion: record_event() emits/queues no pixel for a
+	 * cookie-less, non-REST request — the crawler path that inflated session counts.
+	 * Must run before REST_REQUEST leaks so the non-REST branch is actually exercised.
+	 */
+	public function test_record_event_skips_non_rest_request_without_cookie(): void {
+		$captured = array();
+		$filter   = function ( $pre, $args, $url ) use ( &$captured ) {
+			if ( false !== strpos( $url, 'pixel.wp.com' ) ) {
+				$captured[] = $url;
+			}
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '',
+			);
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$result = WC_Analytics_Tracking::record_event( 'add_to_cart' );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertTrue( $result, 'record_event should return true (skipped) for cookie-less non-REST contexts.' );
+		$this->assertCount( 0, $captured, 'No pixel.wp.com request should fire when no tk_ai cookie is present in a non-REST context.' );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel should be queued when no tk_ai cookie is present in a non-REST context.' );
+	}
+
+	/**
 	 * record_event() should short-circuit (no pixel emitted) when called from
 	 * a REST request that has no `tk_ai` cookie. Generating a one-shot id
 	 * here would fragment Nosara/Tracks sessions across cookie-less


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to WOOA7S-929.

`WC_Analytics_Tracking::get_visitor_id()` now returns a **pre-existing** stable identifier only — the `tk_ai` cookie, or (when proxy tracking is enabled) a deterministic IP-based hash — and returns `null` otherwise, so `record_event()` skips the event. The method no longer mints a fresh random `tk_ai` for cookie-less requests.

**Why:** minting-and-recording under a brand-new id produces a throwaway one-event "visitor". In production that traffic is overwhelmingly UA-spoofing crawlers (real-looking Chrome/Firefox UAs that `is_bot()` doesn't catch, hitting `?add-to-cart=` links) that never persist a cookie. Each hit inflated `woocommerceanalytics_*` session/unique counts in Nosara/Tracks, breaking the checkout-conversion denominator.

Investigation on Tracks table showed **~94% of `add_to_cart` visitor ids had exactly one event** — the throwaway signature — confirming the path was still open.

This is safe for real shoppers: the client-side analytics already sets `tk_ai` on first page view (independent of ClickHouse), so a genuine visitor carries the cookie by the time any server-side action event fires and is tracked normally. Only non-persisting clients reach the skip path.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR Automattic/jetpack#45547 (added the cookie-less mint); the May fix #64686 only closed the REST/XMLRPC/cron/CLI subset, this completes it for the front-end path.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A — no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

**Automated**

1. From `packages/php/woocommerce-analytics`, run `composer phpunit`. All tests pass (78), including the new cookie-less skip tests in `WC_Analytics_Tracking_Test.php`.

**Manual** (mirrors #64686 setup — sync this package over Jetpack's vendored copy, enable `WP_DEBUG`/`WP_DEBUG_LOG`, add a temporary `error_log()` before the pixel fires in `record_pixel_url()`):

2. Open `/shop/` in a fresh browser profile; confirm a `tk_ai` cookie is set (DevTools → Application → Cookies). Click add-to-cart → `debug.log` shows the `woocommerceanalytics_add_to_cart` pixel firing with `_ui` matching `tk_ai`.
3. In a context with **no** `tk_ai` cookie and no prior page view, trigger an add-to-cart (e.g. `curl` a `?add-to-cart=<id>` URL with no cookies, or clear cookies and hit an add-to-cart link directly). Confirm **no** pixel fires for that event and the request still succeeds. Before this change, that request emitted a pixel with a freshly-minted `_ui`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `composer phpunit` for the package: **78 tests pass**. Added two tests covering the cookie-less, non-REST skip path. Verified they have teeth: temporarily re-introducing a mint in the fallback turns the cookie-less tests red.
- `composer phpcs` on the changed files: clean.
- Root cause confirmed against `tracks.prod_events` (Spark SQL): the residual inflation is ~94% one-event throwaway visitor ids from real-UA crawler traffic, on a store already running the prior fix.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Stop minting throwaway anonymous IDs for events from clients without a persisted visitor cookie (e.g. UA-spoofing crawlers hitting add-to-cart), which inflated session counts. Such events are now skipped instead.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entry added manually at `packages/php/woocommerce-analytics/changelog/fix-cookieless-event-session-inflation`. The change ships through the `woocommerce-analytics` Composer package, not `plugins/woocommerce`, so no plugin-level changelog is required.

</details>

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>