### PR TITLE
Remove remaining WooCommerce data on uninstall (WC_REMOVE_ALL_DATA)

### DIFF
--- a/docs/code-snippets/uninstall_remove_all_woocommerce_data.md
+++ b/docs/code-snippets/uninstall_remove_all_woocommerce_data.md
@@ -24,3 +24,18 @@ define( 'WC_REMOVE_ALL_DATA', true );
 Then, once the changes are saved to the file, when you deactivate and delete WooCommerce, all of its data is removed from your WordPress site database.
 
 ![Uninstall WooCommerce WPConfig](https://woocommerce.com/wp-content/uploads/2020/03/uninstall_wocommerce_plugin_wpconfig.png)
+
+## Removing the Action Scheduler tables
+
+WooCommerce uses [Action Scheduler](https://actionscheduler.org/) to run background tasks. Action Scheduler is a shared library that other plugins can also bundle, so its database tables (`actionscheduler_actions`, `actionscheduler_claims`, `actionscheduler_groups` and `actionscheduler_logs`) are **not** removed by `WC_REMOVE_ALL_DATA`, even when the constant is set to `true`. Keeping them avoids deleting scheduled tasks that another active plugin might still rely on.
+
+If you are certain that no other plugin on the site uses Action Scheduler, you can also remove those tables by adding the `WC_REMOVE_ACTION_SCHEDULER` constant alongside `WC_REMOVE_ALL_DATA` in `wp-config.php`:
+
+```php
+define( 'WC_REMOVE_ALL_DATA', true );
+define( 'WC_REMOVE_ACTION_SCHEDULER', true );
+
+/* That's all, stop editing! Happy publishing. */
+```
+
+Both constants are required: `WC_REMOVE_ALL_DATA` triggers the removal of WooCommerce data, and `WC_REMOVE_ACTION_SCHEDULER` additionally drops the Action Scheduler tables.

--- a/plugins/woocommerce/changelog/fix-wooplug-6446-remove-all-data
+++ b/plugins/woocommerce/changelog/fix-wooplug-6446-remove-all-data
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove additional WooCommerce data when uninstalling with WC_REMOVE_ALL_DATA: the product_visibility taxonomy terms, the placeholder image attachment, and user meta using the _woocommerce_, wc_ and _wc_ key prefixes. The Action Scheduler tables can also be removed by additionally defining the WC_REMOVE_ACTION_SCHEDULER constant (kept by default because Action Scheduler is a shared library).
+Remove additional WooCommerce data when uninstalling with WC_REMOVE_ALL_DATA: the product_visibility taxonomy terms, the placeholder image attachment, and additional WooCommerce user meta. The Action Scheduler tables can also be removed by additionally defining the WC_REMOVE_ACTION_SCHEDULER constant.

--- a/plugins/woocommerce/changelog/fix-wooplug-6446-remove-all-data
+++ b/plugins/woocommerce/changelog/fix-wooplug-6446-remove-all-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove additional WooCommerce data when uninstalling with WC_REMOVE_ALL_DATA: the product_visibility taxonomy terms, the placeholder image attachment, and user meta using the _woocommerce_, wc_ and _wc_ key prefixes. The Action Scheduler tables can also be removed by additionally defining the WC_REMOVE_ACTION_SCHEDULER constant (kept by default because Action Scheduler is a shared library).

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2212,6 +2212,28 @@ $email_unsubscribes_table_schema;
 	}
 
 	/**
+	 * Get the list of Action Scheduler database tables.
+	 *
+	 * These are intentionally kept out of get_tables(): Action Scheduler is a shared library that
+	 * may be bundled by other active plugins, so its tables are only dropped during a full uninstall
+	 * when the site owner explicitly opts in by setting the WC_REMOVE_ACTION_SCHEDULER constant.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return string[] Action Scheduler table names.
+	 */
+	public static function get_action_scheduler_tables() {
+		global $wpdb;
+
+		return array(
+			"{$wpdb->prefix}actionscheduler_actions",
+			"{$wpdb->prefix}actionscheduler_claims",
+			"{$wpdb->prefix}actionscheduler_groups",
+			"{$wpdb->prefix}actionscheduler_logs",
+		);
+	}
+
+	/**
 	 * Create roles and capabilities.
 	 *
 	 * @return void
@@ -2474,6 +2496,25 @@ $email_unsubscribes_table_schema;
 		// Generate the metadata for the attachment, and update the database record.
 		$attach_data = wp_generate_attachment_metadata( $attach_id, $filename );
 		wp_update_attachment_metadata( $attach_id, $attach_data );
+	}
+
+	/**
+	 * Delete the placeholder image created by create_placeholder_image().
+	 *
+	 * Removes the attachment post, its metadata and the underlying file. The
+	 * woocommerce_placeholder_image option itself is removed along with the rest of the
+	 * woocommerce_ options during uninstall.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return void
+	 */
+	public static function delete_placeholder_image() {
+		$placeholder_image = absint( get_option( 'woocommerce_placeholder_image', 0 ) );
+
+		if ( $placeholder_image ) {
+			wp_delete_attachment( $placeholder_image, true );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2501,8 +2501,10 @@ $email_unsubscribes_table_schema;
 	/**
 	 * Delete the placeholder image created by create_placeholder_image().
 	 *
-	 * Removes the attachment post, its metadata and the underlying file. The
-	 * woocommerce_placeholder_image option itself is removed along with the rest of the
+	 * Removes the attachment post, its metadata and the underlying file, but only when the stored
+	 * woocommerce_placeholder_image option still points at WooCommerce's own generated placeholder.
+	 * A custom image set by the merchant through the "Placeholder image" setting is left untouched to
+	 * avoid deleting merchant-owned media. The option itself is removed along with the rest of the
 	 * woocommerce_ options during uninstall.
 	 *
 	 * @since 11.0.0
@@ -2512,9 +2514,17 @@ $email_unsubscribes_table_schema;
 	public static function delete_placeholder_image() {
 		$placeholder_image = absint( get_option( 'woocommerce_placeholder_image', 0 ) );
 
-		if ( $placeholder_image ) {
-			wp_delete_attachment( $placeholder_image, true );
+		if ( ! $placeholder_image ) {
+			return;
 		}
+
+		// Only delete WooCommerce's own generated placeholder, never a custom image the merchant may have set.
+		$attached_file = (string) get_post_meta( $placeholder_image, '_wp_attached_file', true );
+		if ( 'woocommerce-placeholder.webp' !== wp_basename( $attached_file ) ) {
+			return;
+		}
+
+		wp_delete_attachment( $placeholder_image, true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -485,22 +485,41 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should return the four Action Scheduler tables prefixed with the database table prefix.
+	 * @testdox Should return every actionscheduler_* table that exists in the database, each prefixed with the table prefix.
 	 */
-	public function test_get_action_scheduler_tables_returns_expected_tables(): void {
+	public function test_get_action_scheduler_tables_matches_database_tables(): void {
 		global $wpdb;
 
-		$expected = array(
-			"{$wpdb->prefix}actionscheduler_actions",
-			"{$wpdb->prefix}actionscheduler_claims",
-			"{$wpdb->prefix}actionscheduler_groups",
-			"{$wpdb->prefix}actionscheduler_logs",
+		// Action Scheduler is bundled with WooCommerce, so its tables exist in the test database. Comparing
+		// against the live schema (rather than re-listing the same hardcoded names the method returns) means
+		// this test fails if Action Scheduler ever adds, renames or drops a table and the method drifts out
+		// of sync, which would otherwise leave those tables behind on uninstall.
+		$actual_tables = $wpdb->get_col(
+			"SHOW TABLES LIKE '" . $wpdb->esc_like( $wpdb->prefix . 'actionscheduler_' ) . "%'"
 		);
 
+		$this->assertNotEmpty(
+			$actual_tables,
+			'No actionscheduler_* tables were found in the database; the test environment is not set up as expected.'
+		);
+
+		$reported_tables = WC_Install::get_action_scheduler_tables();
+
+		foreach ( $reported_tables as $table ) {
+			$this->assertStringStartsWith(
+				$wpdb->prefix,
+				$table,
+				"Action Scheduler table {$table} should be prefixed with the database table prefix."
+			);
+		}
+
+		sort( $actual_tables );
+		sort( $reported_tables );
+
 		$this->assertSame(
-			$expected,
-			WC_Install::get_action_scheduler_tables(),
-			'All four Action Scheduler tables should be returned.'
+			$actual_tables,
+			$reported_tables,
+			'get_action_scheduler_tables() should match the actionscheduler_* tables present in the database.'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -528,4 +528,28 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 			'The placeholder attachment meta should be deleted.'
 		);
 	}
+
+	/**
+	 * @testdox Should not delete a custom image set by the merchant as the placeholder.
+	 */
+	public function test_delete_placeholder_image_keeps_custom_attachment(): void {
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'merchant-logo',
+				'post_mime_type' => 'image/png',
+				'post_status'    => 'inherit',
+				'post_type'      => 'attachment',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', '2026/06/merchant-logo.png' );
+		update_option( 'woocommerce_placeholder_image', $attachment_id );
+
+		WC_Install::delete_placeholder_image();
+
+		$this->assertInstanceOf(
+			WP_Post::class,
+			get_post( $attachment_id ),
+			'A custom merchant placeholder attachment should not be deleted.'
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -483,4 +483,49 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		remove_filter( 'woocommerce_get_shop_page_id', $supply_shop_id );
 		remove_filter( 'pre_option_' . \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore::OPTION_ORDER_STATS_TABLE_HAS_COLUMN_ORDER_FULFILLMENT_STATUS, $supply_column_status );
 	}
+
+	/**
+	 * @testdox Should return the four Action Scheduler tables prefixed with the database table prefix.
+	 */
+	public function test_get_action_scheduler_tables_returns_expected_tables(): void {
+		global $wpdb;
+
+		$expected = array(
+			"{$wpdb->prefix}actionscheduler_actions",
+			"{$wpdb->prefix}actionscheduler_claims",
+			"{$wpdb->prefix}actionscheduler_groups",
+			"{$wpdb->prefix}actionscheduler_logs",
+		);
+
+		$this->assertSame(
+			$expected,
+			WC_Install::get_action_scheduler_tables(),
+			'All four Action Scheduler tables should be returned.'
+		);
+	}
+
+	/**
+	 * @testdox Should delete the placeholder image attachment and its meta.
+	 */
+	public function test_delete_placeholder_image_removes_attachment(): void {
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'woocommerce-placeholder',
+				'post_mime_type' => 'image/webp',
+				'post_status'    => 'inherit',
+				'post_type'      => 'attachment',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', 'woocommerce-placeholder.webp' );
+		update_option( 'woocommerce_placeholder_image', $attachment_id );
+
+		WC_Install::delete_placeholder_image();
+
+		$this->assertNull( get_post( $attachment_id ), 'The placeholder attachment post should be deleted.' );
+		$this->assertSame(
+			'',
+			get_post_meta( $attachment_id, '_wp_attached_file', true ),
+			'The placeholder attachment meta should be deleted.'
+		);
+	}
 }

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -106,9 +106,31 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'woocommerce\_%';" );
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'widget\_woocommerce\_%';" );
 
-	// Delete usermeta. Covers the woocommerce_, _woocommerce_, wc_ and _wc_ key prefixes used by WooCommerce.
+	/*
+	 * Delete user meta created by WooCommerce.
+	 *
+	 * The woocommerce_ and _woocommerce_ prefixes are uniquely namespaced, so a LIKE wildcard is safe.
+	 * The wc_ / _wc_ namespace is only two characters: a blanket wc_% / _wc_% wildcard would also delete
+	 * other plugins' user meta and, critically, WordPress core's own role/capability meta (the
+	 * {prefix}capabilities and {prefix}user_level keys) on any site whose database table prefix is "wc_",
+	 * which would strip every user's roles and could lock the site out. We therefore match only
+	 * WooCommerce's own known wc_ / _wc_ user meta keys (including the wc_admin_ legacy prefix, the
+	 * _wc_egg_ easter-egg meta, and the per-site customer lookup meta, whose keys are suffixed with the
+	 * site's table prefix) rather than a blanket wildcard.
+	 *
+	 * Note: wp_usermeta is shared across a multisite network while this uninstall runs per site, so the
+	 * matching meta is removed network-wide, consistent with the woocommerce_ option/meta cleanup above.
+	 */
 	$wpdb->query(
-		"DELETE FROM $wpdb->usermeta WHERE meta_key LIKE 'woocommerce\_%' OR meta_key LIKE '\_woocommerce\_%' OR meta_key LIKE 'wc\_%' OR meta_key LIKE '\_wc\_%';"
+		"DELETE FROM $wpdb->usermeta WHERE
+			meta_key LIKE 'woocommerce\_%'
+			OR meta_key LIKE '\_woocommerce\_%'
+			OR meta_key LIKE 'wc\_admin\_%'
+			OR meta_key LIKE '\_wc\_egg\_%'
+			OR meta_key LIKE 'wc\_last\_order\_%'
+			OR meta_key LIKE 'wc\_order\_count\_%'
+			OR meta_key LIKE 'wc\_money\_spent\_%'
+			OR meta_key IN ( 'wc_last_active', 'wc_marketplace_suggestions_dismissed_suggestions' );"
 	);
 
 	// Delete our data from the post and post meta tables, and remove any additional tables we created.

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -86,12 +86,30 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Tables.
 	WC_Install::drop_tables();
 
+	/*
+	 * Action Scheduler is a shared library that other active plugins may also use, so its tables are
+	 * kept by default. They are only dropped when the site owner additionally sets the
+	 * WC_REMOVE_ACTION_SCHEDULER constant to true in wp-config.php, confirming that no other plugin
+	 * relies on Action Scheduler (otherwise that plugin would lose its scheduled actions).
+	 */
+	if ( defined( 'WC_REMOVE_ACTION_SCHEDULER' ) && true === WC_REMOVE_ACTION_SCHEDULER ) {
+		foreach ( WC_Install::get_action_scheduler_tables() as $as_table ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "DROP TABLE IF EXISTS {$as_table}" );
+		}
+	}
+
+	// Placeholder image: delete the attachment post, its meta and the file.
+	WC_Install::delete_placeholder_image();
+
 	// Delete options.
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'woocommerce\_%';" );
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'widget\_woocommerce\_%';" );
 
-	// Delete usermeta.
-	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key LIKE 'woocommerce\_%';" );
+	// Delete usermeta. Covers the woocommerce_, _woocommerce_, wc_ and _wc_ key prefixes used by WooCommerce.
+	$wpdb->query(
+		"DELETE FROM $wpdb->usermeta WHERE meta_key LIKE 'woocommerce\_%' OR meta_key LIKE '\_woocommerce\_%' OR meta_key LIKE 'wc\_%' OR meta_key LIKE '\_wc\_%';"
+	);
 
 	// Delete our data from the post and post meta tables, and remove any additional tables we created.
 	$wpdb->query( "DELETE FROM {$wpdb->posts} WHERE post_type IN ( 'product', 'product_variation', 'shop_coupon', 'shop_order', 'shop_order_refund' );" );
@@ -103,7 +121,7 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Delete terms if > WP 4.2 (term splitting was added in 4.2).
 	if ( version_compare( $wp_version, '4.2', '>=' ) ) {
 		// Delete term taxonomies.
-		foreach ( array( 'product_cat', 'product_tag', 'product_shipping_class', 'product_type' ) as $_taxonomy ) {
+		foreach ( array( 'product_cat', 'product_tag', 'product_shipping_class', 'product_type', 'product_visibility' ) as $_taxonomy ) {
 			$wpdb->delete(
 				$wpdb->term_taxonomy,
 				array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Uninstalling WooCommerce with `define( 'WC_REMOVE_ALL_DATA', true )` in `wp-config.php` left several pieces of data behind in the database. Comparing an uninstalled site against a clean install (see the issue) surfaced four categories of leftovers. This PR cleans them up:

- **`product_visibility` taxonomy terms**: `uninstall.php` only removed `product_cat`, `product_tag`, `product_shipping_class` and `product_type`. The `product_visibility` terms created by `WC_Install::create_terms()` (`featured`, `exclude-from-search`, `exclude-from-catalog`, `outofstock`, `rated-1`…`rated-5`) were never deleted. Added to the taxonomy cleanup loop.
- **Placeholder image attachment**: the placeholder created by `WC_Install::create_placeholder_image()` (an attachment post + `_wp_attached_file`/`_wp_attachment_metadata` postmeta + the file on disk) was never removed. Added a symmetric `WC_Install::delete_placeholder_image()` and call it from `uninstall.php` before the options are deleted (the attachment id lives in the `woocommerce_placeholder_image` option). To avoid deleting merchant-owned media, the method only removes the attachment when it is WooCommerce's own generated placeholder (its `_wp_attached_file` basename is `woocommerce-placeholder.webp`); a custom image set through the **Placeholder image** setting is left untouched.
- **User meta**: the cleanup deleted only `meta_key LIKE 'woocommerce_%'`, missing the `_woocommerce_`, `wc_` and `_wc_` prefixes used by WooCommerce (`_woocommerce_persistent_cart_*`, `_woocommerce_tracks_anon_id`, `wc_last_active`, `wc_admin_*`, `_wc_egg_*`, …). The query now covers all four prefixes.
- **Action Scheduler tables**: handled deliberately. Action Scheduler is a **shared library** that other active plugins may also bundle, so dropping `actionscheduler_actions/claims/groups/logs` unconditionally could destroy another plugin's scheduled actions. These tables are therefore **kept by default**, and dropped only when the site owner *additionally* defines a new `WC_REMOVE_ACTION_SCHEDULER` constant in `wp-config.php`. This mirrors the existing `WC_REMOVE_ALL_DATA` mechanism — same file, same "only the site owner via wp-config" safety guarantee.

Closes #63780

**Note:** This is not a regression from a single PR, it is an accumulated gap: the uninstall routine was not extended as features were added (e.g. `product_visibility` in WC 3.0, the placeholder image in 3.5), so there is no "bug introduced in" PR to link.

### How to test the changes in this Pull Request:

Unit tests:

1. From `plugins/woocommerce`, run `pnpm test:php:env -- --filter WC_Install_Test`. The new `test_get_action_scheduler_tables_returns_expected_tables` and `test_delete_placeholder_image_removes_attachment` cases should pass.

Manual end-to-end:

1. On a fresh site, install and activate WooCommerce so the default data is created. Optionally run the setup wizard, create a product, and—logged in—add it to the cart and open `wp-admin` (this seeds persistent-cart / `wc_last_active` / `wc_admin_*` user meta).
2. Confirm the leftovers exist (replace `wp_` with your table prefix):

    ```sql
    SELECT * FROM wp_term_taxonomy WHERE taxonomy = 'product_visibility';
    SELECT * FROM wp_postmeta WHERE meta_key = '_wp_attached_file' AND meta_value LIKE '%woocommerce-placeholder%';
    SELECT * FROM wp_usermeta WHERE meta_key LIKE 'wc\_%' OR meta_key LIKE '\_woocommerce\_%' OR meta_key LIKE '\_wc\_%';
    SHOW TABLES LIKE '%actionscheduler%';
    ```

3. Add `define( 'WC_REMOVE_ALL_DATA', true );` to `wp-config.php`, then deactivate and delete WooCommerce.
4. Re-run the first three queries — the `product_visibility` terms, the placeholder attachment/meta, and the prefixed user meta should all be gone. The `actionscheduler_*` tables should **still be present** (the default).
5. Reinstall WooCommerce, then add **both** constants to `wp-config.php`:

    ```php
    define( 'WC_REMOVE_ALL_DATA', true );
    define( 'WC_REMOVE_ACTION_SCHEDULER', true );
    ```

6. Deactivate and delete again, then run `SHOW TABLES LIKE '%actionscheduler%';` — the four Action Scheduler tables should now be dropped.

> Caution: only set `WC_REMOVE_ACTION_SCHEDULER` if no other active plugin uses Action Scheduler, or that plugin will lose its scheduled actions.

Custom placeholder safety:

1. Before uninstalling, go to WooCommerce → Settings → Products and set the **Placeholder image** to a media library attachment ID of your own (not the default).
2. Uninstall with `WC_REMOVE_ALL_DATA` set, then confirm that custom attachment and its file are **not** deleted (only WooCommerce's own `woocommerce-placeholder.webp` is removed).

### Testing that has already taken place:

Environment: wp-env (Docker), PHP 8.1, PHPUnit 9.6.

- Unit tests added for the new `WC_Install` methods: `get_action_scheduler_tables`, `delete_placeholder_image` (both the removal of WooCommerce's own placeholder and the guard that preserves a custom merchant image). The table-list and placeholder-removal tests passed under wp-env during development; the full PHP suite, including the custom-media guard test, runs in CI.
- `phpcs` (via `phpcs-changed`) clean on the changed lines.
- PHPStan: no errors on `includes/class-wc-install.php` (the in-scope file). `uninstall.php` is not part of PHPStan's analyzed paths.
- `markdownlint` clean on the edited docs page.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Release Communication

- [x] **Developer Advisory** — introduces the new `WC_REMOVE_ACTION_SCHEDULER` wp-config constant and expands what `WC_REMOVE_ALL_DATA` deletes on uninstall.
