### PR TITLE
Fix Blocks e2e sample product import failing in nightly runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ on:
         description: 'The release artifact name to download and run tests for.'
         required: false
         type: string
+      releaseTag:
+        description: 'Release tag to download the artifact from. Defaults to refName, then the current ref. Lets a branch run pull a published artifact (e.g. nightly) while keeping its own checkout.'
+        required: false
+        type: string
 
 concurrency:
   # Cancel concurrent jobs but not for push event. For push use the run_id to have a unique group.
@@ -179,7 +183,7 @@ jobs:
       - name: 'Update wp-env config'
         if: ${{ inputs.artifactName != '' }}
         env:
-          RELEASE_TAG: ${{ inputs.refName != '' && inputs.refName || github.ref_name }}
+          RELEASE_TAG: ${{ inputs.releaseTag != '' && inputs.releaseTag || ( inputs.refName != '' && inputs.refName || github.ref_name ) }}
           ARTIFACT_NAME: ${{ inputs.artifactName }}
           WP_ENV_CONFIG_PATH: ${{ github.workspace }}/${{ matrix.projectPath }}
         run: node .github/workflows/scripts/override-wp-env-plugins.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }} # required by Metrics tests
           LAST_FAILED_RUN: ${{ vars.LAST_FAILED_RUN }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PLUGIN_SLUG: ${{ inputs.refName == 'nightly' && 'woocommerce-trunk-nightly' || '' }} # required by test:plugincheck
+          PLUGIN_SLUG: '' # required by test:plugincheck; nightly installs under the canonical 'woocommerce' folder
           PLAYWRIGHT_JUNIT_SUITE_NAME: 'WooCommerce Core'
           PLAYWRIGHT_JUNIT_SUITE_ID: 'woocommerce-core'
         run: |

--- a/.github/workflows/scripts/override-wp-env-plugins.js
+++ b/.github/workflows/scripts/override-wp-env-plugins.js
@@ -34,10 +34,18 @@ const wpEnvConfig = JSON.parse( fs.readFileSync( configPath, 'utf8' ) );
 // the source entry from the plugin lists. Mapped plugins are not auto-activated,
 // so `tests/e2e-pw/bin/test-env-setup.sh` activates WooCommerce explicitly.
 const wooCommerceEntries = [ '.', '../woocommerce' ];
-const withoutWooCommerce = ( plugins ) =>
-	Array.isArray( plugins )
-		? plugins.filter( ( entry ) => ! wooCommerceEntries.includes( entry ) )
-		: plugins;
+
+let removed = 0;
+const withoutWooCommerce = ( plugins ) => {
+	if ( ! Array.isArray( plugins ) ) {
+		return plugins;
+	}
+	const filtered = plugins.filter(
+		( entry ) => ! wooCommerceEntries.includes( entry )
+	);
+	removed += plugins.length - filtered.length;
+	return filtered;
+};
 
 const wooCommerceMapping = {
 	'wp-content/plugins/woocommerce': artifactUrl,
@@ -50,6 +58,11 @@ if ( wpEnvConfig.plugins ) {
 }
 
 if ( wpEnvConfig.env?.tests?.plugins ) {
+	// Scope the mapping to env.tests: `wp-env start` provisions both the
+	// development and tests instances, but the Blocks e2e suite only runs
+	// against tests. Mapping here avoids extracting the artifact into the dev
+	// instance that is never exercised. Move this to a root-level `mappings` if
+	// WooCommerce is ever needed in the dev environment too.
 	overrideConfig.env = {
 		tests: {
 			plugins: withoutWooCommerce( wpEnvConfig.env.tests.plugins ),
@@ -60,8 +73,20 @@ if ( wpEnvConfig.env?.tests?.plugins ) {
 	overrideConfig.mappings = wooCommerceMapping;
 }
 
+if ( removed === 0 ) {
+	console.error(
+		`No WooCommerce source entry (${ wooCommerceEntries.join(
+			' or '
+		) }) found in ${ configPath }. The artifact would not land at ` +
+			`wp-content/plugins/woocommerce - the plugin layout likely changed. Aborting.`
+	);
+	process.exit( 1 );
+}
+
 console.log(
-	`Mapping ${ artifactUrl } to wp-content/plugins/woocommerce`
+	`Removed ${ removed } WooCommerce source entr${
+		removed === 1 ? 'y' : 'ies'
+	}; mapping ${ artifactUrl } -> wp-content/plugins/woocommerce`
 );
 
 const overrideConfigPath = `${ WP_ENV_CONFIG_PATH }/.wp-env.override.json`;

--- a/.github/workflows/scripts/override-wp-env-plugins.js
+++ b/.github/workflows/scripts/override-wp-env-plugins.js
@@ -22,44 +22,47 @@ const artifactUrl = `https://github.com/woocommerce/woocommerce/releases/downloa
 
 const configPath = `${ WP_ENV_CONFIG_PATH }/.wp-env.json`;
 console.log( `Reading ${ configPath }` );
-const data = fs.readFileSync( configPath, 'utf8' );
-const wpEnvConfig = JSON.parse( data );
+const wpEnvConfig = JSON.parse( fs.readFileSync( configPath, 'utf8' ) );
+
+// wp-env names an installed plugin's folder after the source basename, so
+// installing WooCommerce straight from the release URL would create a
+// `woocommerce-trunk-nightly` folder - a name no real install produces and which
+// breaks the test setup's `wp-content/plugins/woocommerce/...` assumptions.
+// Instead, mount the release artifact at the canonical `woocommerce` folder via a
+// mapping (wp-env downloads and extracts it for us; the zip's top-level dir is
+// `woocommerce/`, the same one WordPress core unzips for a real user) and drop
+// the source entry from the plugin lists. Mapped plugins are not auto-activated,
+// so `tests/e2e-pw/bin/test-env-setup.sh` activates WooCommerce explicitly.
+const wooCommerceEntries = [ '.', '../woocommerce' ];
+const withoutWooCommerce = ( plugins ) =>
+	Array.isArray( plugins )
+		? plugins.filter( ( entry ) => ! wooCommerceEntries.includes( entry ) )
+		: plugins;
+
+const wooCommerceMapping = {
+	'wp-content/plugins/woocommerce': artifactUrl,
+};
 
 const overrideConfig = {};
 
 if ( wpEnvConfig.plugins ) {
-	overrideConfig.plugins = wpEnvConfig.plugins;
+	overrideConfig.plugins = withoutWooCommerce( wpEnvConfig.plugins );
 }
 
 if ( wpEnvConfig.env?.tests?.plugins ) {
 	overrideConfig.env = {
 		tests: {
-			plugins: wpEnvConfig.env.tests.plugins,
+			plugins: withoutWooCommerce( wpEnvConfig.env.tests.plugins ),
+			mappings: wooCommerceMapping,
 		},
 	};
+} else {
+	overrideConfig.mappings = wooCommerceMapping;
 }
 
-const entriesToReplace = [ '.', '../woocommerce' ];
-
-for ( const entry of entriesToReplace ) {
-	// Search and replace in root plugins
-	let found = overrideConfig.plugins.indexOf( entry );
-	if ( found >= 0 ) {
-		console.log(
-			`Replacing ${ entry } with ${ artifactUrl } in root plugins`
-		);
-		overrideConfig.plugins[ found ] = artifactUrl;
-	}
-
-	// Search and replace in test env plugins
-	found = overrideConfig.env?.tests?.plugins?.indexOf( entry );
-	if ( found >= 0 ) {
-		console.log(
-			`Replacing ${ entry } with ${ artifactUrl } in env.tests.plugins`
-		);
-		overrideConfig.env.tests.plugins[ found ] = artifactUrl;
-	}
-}
+console.log(
+	`Mapping ${ artifactUrl } to wp-content/plugins/woocommerce`
+);
 
 const overrideConfigPath = `${ WP_ENV_CONFIG_PATH }/.wp-env.override.json`;
 console.log( `Saving ${ overrideConfigPath }` );

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -32,13 +32,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Validate input'
+        env:
+          INPUT_TRIGGER: ${{ inputs.trigger }}
+          INPUT_CUSTOM_TRIGGER: ${{ inputs.custom-trigger }}
+          INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          INPUT_RELEASE_TAG: ${{ inputs.release-tag }}
         run: |
-          if [ "${{ inputs.trigger }}" == "custom" ] && [ -z "${{ inputs.custom-trigger }}" ]; then
-            echo "Custom event name is required when event name choice `custom`."
+          if [ "$INPUT_TRIGGER" = "custom" ] && [ -z "$INPUT_CUSTOM_TRIGGER" ]; then
+            echo "Custom event name is required when event name choice \`custom\`."
             exit 1
           fi
 
-          if [ -n "${{ inputs.artifact-name }}" ] && [ -z "${{ inputs.release-tag }}" ]; then
+          if [ -n "$INPUT_ARTIFACT_NAME" ] && [ -z "$INPUT_RELEASE_TAG" ]; then
             echo "Input \`release-tag\` is required when \`artifact-name\` is provided."
             exit 1
           fi

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -16,6 +16,16 @@ on:
         type: string
         description: 'Custom event name: In case the `Event name` choice is `custom`, this field is required.'
         required: false
+      artifact-name:
+        type: string
+        description: 'Release artifact to install instead of building from the branch (e.g. woocommerce-trunk-nightly.zip). Leave empty to build from the checked-out branch.'
+        required: false
+        default: ''
+      release-tag:
+        type: string
+        description: 'Release tag to download the artifact from (e.g. nightly). Required when artifact-name is set; the checkout still uses the dispatched branch.'
+        required: false
+        default: ''
 
 jobs:
   validate-input:
@@ -28,9 +38,16 @@ jobs:
             exit 1
           fi
 
+          if [ -n "${{ inputs.artifact-name }}" ] && [ -z "${{ inputs.release-tag }}" ]; then
+            echo "Input \`release-tag\` is required when \`artifact-name\` is provided."
+            exit 1
+          fi
+
   run-tests:
     name: 'Run tests'
     uses: ./.github/workflows/ci.yml
     with:
       trigger: ${{ inputs.trigger == 'custom' && inputs.custom-trigger || inputs.trigger }}
+      artifactName: ${{ inputs.artifact-name }}
+      releaseTag: ${{ inputs.release-tag }}
     secrets: inherit

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -44,7 +44,8 @@
 				"wp-content/themes/twentytwentyfour": "https://downloads.wordpress.org/theme/twentytwentyfour.latest-stable.zip",
 				"wp-content/plugins/woocommerce/blocks-bin": "./client/blocks/bin",
 				"wp-content/plugins/woocommerce/blocks-bin/playwright": "./tests/e2e-pw/bin/blocks",
-				"wp-content/plugins/woocommerce-blocks-test-plugins": "./tests/e2e-pw/test-plugins/blocks"
+				"wp-content/plugins/woocommerce-blocks-test-plugins": "./tests/e2e-pw/test-plugins/blocks",
+				"wp-content/plugins/woocommerce/i18n/languages": "./i18n/languages"
 			}
 		}
 	}

--- a/plugins/woocommerce/changelog/disable-nightly-blocks-e2e-wp-latest-1
+++ b/plugins/woocommerce/changelog/disable-nightly-blocks-e2e-wp-latest-1
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Disable the Blocks e2e WP latest-1 job in nightly checks to avoid noise while that build is fixed. CI job config only; nothing shipped to merchants.
-
-

--- a/plugins/woocommerce/changelog/fix-blocks-e2e-nightly-sample-data-path
+++ b/plugins/woocommerce/changelog/fix-blocks-e2e-nightly-sample-data-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix the Blocks e2e nightly suite: mount the released plugin at the canonical `woocommerce` folder via a wp-env mapping, instead of letting wp-env name the plugin folder after the release zip (e.g. `woocommerce-trunk-nightly`), which broke the test setup's plugin-path assumptions. The generated test translations are mapped into the plugin's languages directory the same way. Also resolve the active plugin path (WC_ABSPATH) for the sample product import.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -894,6 +894,7 @@
 					},
 					"events": [
 						"pull_request",
+						"nightly-checks",
 						"release-checks",
 						"blocks-e2e-wp-latest-1"
 					],

--- a/plugins/woocommerce/tests/e2e-pw/bin/blocks/scripts/products.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/blocks/scripts/products.sh
@@ -3,7 +3,13 @@
 ###################################################################################################
 # Import sample products and regenerate product lookup tables
 ###################################################################################################
-wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=skip
+# Resolve the active WooCommerce plugin directory instead of assuming a fixed
+# folder name. Locally and on PR CI the plugin is source-mapped as
+# `woocommerce`, but in nightly it is installed from the release zip as
+# `woocommerce-trunk-nightly`, so a hardcoded path would not exist there.
+wc_abspath=$(wp eval 'echo defined("WC_ABSPATH") ? WC_ABSPATH : "";')
+[ -n "$wc_abspath" ] || { echo "Could not resolve WC_ABSPATH; is WooCommerce active?" >&2; exit 1; }
+wp import "${wc_abspath}sample-data/sample_products.xml" --authors=skip
 wp wc tool run regenerate_product_lookup_tables --user=1
 
 # This is a hacky work around to fix product categories not having their parent category correctly assigned.

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -12,6 +12,13 @@ if [ ! -z ${CI+y} ]; then
     exit $?
 fi
 
+# In nightly runs WooCommerce is mounted via a wp-env mapping so it installs
+# under the canonical `woocommerce` folder; mapped plugins are not
+# auto-activated, so activate it before any WC-dependent setup below (e.g. the
+# `customer` role user). Harmless when WC is already active (PR/source-mapped).
+echo -e 'Activate WooCommerce \n'
+wp-env run tests-cli wp plugin activate woocommerce
+
 echo -e 'Install twentytwenty, twentytwentytwo and storefront themes \n'
 wp-env run tests-cli wp theme install storefront twentytwenty twentytwentytwo &
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Blocks e2e suite started failing on every shard in the nightly `Release checks run` immediately after #65755 moved blocks provisioning onto the Core wp-env. In a number of places in setup files and tests, the plugin is assumed to be installed in the `woocommerce` directory (always true in the CI runs for PRs); that would not be true when running the nightly build, where the plugin would be installed in the `woocommerce-trunk-nightly` directory, creating a cascading effect of errors.
Since the breakage would only show up in the nightly runs, the PR includes modifications to the build files to support more flexible control over the `tests-on-demand` workflow.

Changed files:
- Restores the assumption that the plugin will be installed in the `woocommerce` directory by properly mapping it using a `wp-env` override file modification; files `override-wp-env-plugins.js` and `plugins/woocommerce/.wp-env.json`.
- In the `products.sh`, strengthen the resolution of the plugin path using `WC_ABSPATH` to deal with similar situations. This will create a strong signal in builds that violate the assumption.
- In the file `test-env-setup.sh`, ensure the plugin is active (mapping will not automatically activate the plugin in wp-env) before running any operation assuming the plugin is active.
- In the `plugins/woocommerce/package.json` file, restore the `nightly-checks` (previously removed in #65809).
- In the `.github/workflows/tests-on-demand.yml` file, support `artifact-name` and `release-tag` parameters.
- In the `.github/workflows/ci.yml`, use the `release-tag` parameter to download the correct version of the plugin (e.g. `nightly`).

[Nightly build running with the fixes](https://github.com/woocommerce/woocommerce/actions/runs/27758798695).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. PR CI runs the full Blocks e2e suite against the source-mapped layout (plugin at `.../woocommerce/`) and must stay green.
2. Exercise the nightly (zip-artifact) layout on demand, using the parameters added in this PR:

    ```sh
    gh workflow run tests-on-demand.yml --ref fix/blocks-e2e-nightly-sample-data-path \
      -f trigger=custom -f custom-trigger=nightly-checks \
      -f artifact-name=woocommerce-trunk-nightly.zip -f release-tag=nightly
    ```

    Confirm the `Blocks e2e tests - WP latest-1 [WP 6.9.4]` shards (1–10) pass and the active plugin folder is `woocommerce` (not `woocommerce-trunk-nightly`).
3. Optional local replica: point a throwaway `wp-env` at the nightly zip via a `wp-content/plugins/woocommerce` mapping, `wp-env start`, and confirm the plugin is active as `woocommerce`, `nl_NL` installs, sample products import, and the blocks specs pass.

<!-- End testing instructions -->

### Testing that has already taken place:

-   **Nightly-layout on-demand run [27758798695](https://github.com/woocommerce/woocommerce/actions/runs/27758798695):** all 10 `Blocks e2e tests - WP latest-1 [WP 6.9.4]` shards green against the `woocommerce`-folder artifact, and Core e2e (WP 6.9.4, PHP 8.5, Gutenberg, HPOS) all green. For contrast, the pre-fix nightly [27665943890](https://github.com/woocommerce/woocommerce/actions/runs/27665943890) had all 10 shards red.
-   **PR CI:** Blocks e2e (source-mapped) all green.
-   **Local faithful replica** (throwaway `wp-env` installing `woocommerce-trunk-nightly.zip` mounted at `woocommerce`): folder = `woocommerce`, `nl_NL` installed, 18 sample products imported, and the register-block / price-filter / cart+checkout-translation specs pass.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry.

> Changelog added manually: `changelog/fix-blocks-e2e-nightly-sample-data-path` (dev / patch).
