### PR TITLE
[Issue -#59464] Migrate PanelBody to ToolsPanel

### DIFF
--- a/plugins/woocommerce/changelog/fix-59464-migrate-reviews-panelbody-to-toolspanel
+++ b/plugins/woocommerce/changelog/fix-59464-migrate-reviews-panelbody-to-toolspanel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace PanelBody with ToolsPanel in All Reviews, Reviews by Category, and Reviews by Product inspector controls.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/all-reviews/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/all-reviews/block.tsx
@@ -71,33 +71,10 @@ const AllReviewsEditor = ( {
 							}
 						/>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						hasValue={ () =>
-							! attributes.showReviewRating ||
-							! attributes.showReviewerName ||
-							! attributes.showReviewImage ||
-							! attributes.showReviewDate ||
-							! attributes.showReviewContent ||
-							attributes.imageType !== 'reviewer'
-						}
-						label={ __( 'Review options', 'woocommerce' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								showReviewRating: true,
-								showReviewerName: true,
-								showReviewImage: true,
-								showReviewDate: true,
-								showReviewContent: true,
-								imageType: 'reviewer',
-							} )
-						}
-						isShownByDefault
-					>
-						{ getSharedReviewContentControls(
-							attributes,
-							setAttributes
-						) }
-					</ToolsPanelItem>
+					{ getSharedReviewContentControls(
+						attributes,
+						setAttributes
+					) }
 				</ToolsPanel>
 				<ToolsPanel
 					label={ __( 'List Settings', 'woocommerce' ) }
@@ -111,31 +88,10 @@ const AllReviewsEditor = ( {
 						} )
 					}
 				>
-					<ToolsPanelItem
-						hasValue={ () =>
-							! attributes.showOrderby ||
-							attributes.orderby !== 'most-recent' ||
-							attributes.reviewsOnPageLoad !== 10 ||
-							! attributes.showLoadMore ||
-							attributes.reviewsOnLoadMore !== 10
-						}
-						label={ __( 'List settings', 'woocommerce' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								showOrderby: true,
-								orderby: 'most-recent',
-								reviewsOnPageLoad: 10,
-								showLoadMore: true,
-								reviewsOnLoadMore: 10,
-							} )
-						}
-						isShownByDefault
-					>
-						{ getSharedReviewListControls(
-							attributes,
-							setAttributes
-						) }
-					</ToolsPanelItem>
+					{ getSharedReviewListControls(
+						attributes,
+						setAttributes
+					) }
 				</ToolsPanel>
 			</InspectorControls>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/all-reviews/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/all-reviews/block.tsx
@@ -88,10 +88,7 @@ const AllReviewsEditor = ( {
 						} )
 					}
 				>
-					{ getSharedReviewListControls(
-						attributes,
-						setAttributes
-					) }
+					{ getSharedReviewListControls( attributes, setAttributes ) }
 				</ToolsPanel>
 			</InspectorControls>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/all-reviews/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/all-reviews/block.tsx
@@ -3,8 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
 import { Icon, postComments } from '@wordpress/icons';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	ToggleControl,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -31,24 +37,106 @@ const AllReviewsEditor = ( {
 	const getInspectorControls = () => {
 		return (
 			<InspectorControls key="inspector">
-				<PanelBody title={ __( 'Content', 'woocommerce' ) }>
-					<ToggleControl
+				<ToolsPanel
+					label={ __( 'Content', 'woocommerce' ) }
+					resetAll={ () =>
+						setAttributes( {
+							showProductName: true,
+							showReviewRating: true,
+							showReviewerName: true,
+							showReviewImage: true,
+							showReviewDate: true,
+							showReviewContent: true,
+							imageType: 'reviewer',
+						} )
+					}
+				>
+					<ToolsPanelItem
+						hasValue={ () => ! attributes.showProductName }
 						label={ __( 'Product name', 'woocommerce' ) }
-						checked={ attributes.showProductName }
-						onChange={ () =>
+						onDeselect={ () =>
+							setAttributes( { showProductName: true } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Product name', 'woocommerce' ) }
+							checked={ attributes.showProductName }
+							onChange={ () =>
+								setAttributes( {
+									showProductName:
+										! attributes.showProductName,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () =>
+							! attributes.showReviewRating ||
+							! attributes.showReviewerName ||
+							! attributes.showReviewImage ||
+							! attributes.showReviewDate ||
+							! attributes.showReviewContent ||
+							attributes.imageType !== 'reviewer'
+						}
+						label={ __( 'Review options', 'woocommerce' ) }
+						onDeselect={ () =>
 							setAttributes( {
-								showProductName: ! attributes.showProductName,
+								showReviewRating: true,
+								showReviewerName: true,
+								showReviewImage: true,
+								showReviewDate: true,
+								showReviewContent: true,
+								imageType: 'reviewer',
 							} )
 						}
-					/>
-					{ getSharedReviewContentControls(
-						attributes,
-						setAttributes
-					) }
-				</PanelBody>
-				<PanelBody title={ __( 'List Settings', 'woocommerce' ) }>
-					{ getSharedReviewListControls( attributes, setAttributes ) }
-				</PanelBody>
+						isShownByDefault
+					>
+						{ getSharedReviewContentControls(
+							attributes,
+							setAttributes
+						) }
+					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'List Settings', 'woocommerce' ) }
+					resetAll={ () =>
+						setAttributes( {
+							showOrderby: true,
+							orderby: 'most-recent',
+							reviewsOnPageLoad: 10,
+							showLoadMore: true,
+							reviewsOnLoadMore: 10,
+						} )
+					}
+				>
+					<ToolsPanelItem
+						hasValue={ () =>
+							! attributes.showOrderby ||
+							attributes.orderby !== 'most-recent' ||
+							attributes.reviewsOnPageLoad !== 10 ||
+							! attributes.showLoadMore ||
+							attributes.reviewsOnLoadMore !== 10
+						}
+						label={ __( 'List settings', 'woocommerce' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								showOrderby: true,
+								orderby: 'most-recent',
+								reviewsOnPageLoad: 10,
+								showLoadMore: true,
+								reviewsOnLoadMore: 10,
+							} )
+						}
+						isShownByDefault
+					>
+						{ getSharedReviewListControls(
+							attributes,
+							setAttributes
+						) }
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 		);
 	};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/edit-utils.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/edit-utils.js
@@ -45,7 +45,7 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 				onDeselect={ () => setAttributes( { showReviewRating: true } ) }
 				isShownByDefault
 			>
-				<div style={ { display: 'flex', flexDirection: 'column', gap: '24px' } }>
+				<div className="wc-block-reviews__tools-panel-item-container">
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Product rating', 'woocommerce' ) }
@@ -114,7 +114,7 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 				}
 				isShownByDefault
 			>
-				<div style={ { display: 'flex', flexDirection: 'column', gap: '24px' } }>
+				<div className="wc-block-reviews__tools-panel-item-container">
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Image', 'woocommerce' ) }
@@ -137,38 +137,42 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 							>
 								<ToggleGroupControlOption
 									value="reviewer"
-									label={ __( 'Reviewer photo', 'woocommerce' ) }
+									label={ __(
+										'Reviewer photo',
+										'woocommerce'
+									) }
 								/>
 								<ToggleGroupControlOption
 									value="product"
 									label={ __( 'Product', 'woocommerce' ) }
 								/>
 							</ToggleGroupControl>
-							{ attributes.imageType === 'reviewer' && ! showAvatars && (
-								<Notice
-									className="wc-block-base-control-notice"
-									isDismissible={ false }
-								>
-									{ createInterpolateElement(
-										__(
-											'Reviewer photo is disabled in your <a>site settings</a>.',
-											'woocommerce'
-										),
-										{
-											a: (
-												// eslint-disable-next-line jsx-a11y/anchor-has-content
-												<a
-													href={ getAdminLink(
-														'options-discussion.php'
-													) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
+							{ attributes.imageType === 'reviewer' &&
+								! showAvatars && (
+									<Notice
+										className="wc-block-base-control-notice"
+										isDismissible={ false }
+									>
+										{ createInterpolateElement(
+											__(
+												'Reviewer photo is disabled in your <a>site settings</a>.',
+												'woocommerce'
 											),
-										}
-									) }
-								</Notice>
-							) }
+											{
+												a: (
+													// eslint-disable-next-line jsx-a11y/anchor-has-content
+													<a
+														href={ getAdminLink(
+															'options-discussion.php'
+														) }
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
+											}
+										) }
+									</Notice>
+								) }
 						</>
 					) }
 				</div>
@@ -193,7 +197,9 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 			<ToolsPanelItem
 				hasValue={ () => ! attributes.showReviewContent }
 				label={ __( 'Review content', 'woocommerce' ) }
-				onDeselect={ () => setAttributes( { showReviewContent: true } ) }
+				onDeselect={ () =>
+					setAttributes( { showReviewContent: true } )
+				}
 				isShownByDefault
 			>
 				<ToggleControl
@@ -228,7 +234,9 @@ export const getSharedReviewListControls = ( attributes, setAttributes ) => {
 					label={ __( 'Order by', 'woocommerce' ) }
 					checked={ attributes.showOrderby }
 					onChange={ () =>
-						setAttributes( { showOrderby: ! attributes.showOrderby } )
+						setAttributes( {
+							showOrderby: ! attributes.showOrderby,
+						} )
 					}
 				/>
 			</ToolsPanelItem>
@@ -242,9 +250,18 @@ export const getSharedReviewListControls = ( attributes, setAttributes ) => {
 					label={ __( 'Order Product Reviews by', 'woocommerce' ) }
 					value={ attributes.orderby }
 					options={ [
-						{ label: __( 'Most recent', 'woocommerce' ), value: 'most-recent' },
-						{ label: __( 'Highest Rating', 'woocommerce' ), value: 'highest-rating' },
-						{ label: __( 'Lowest Rating', 'woocommerce' ), value: 'lowest-rating' },
+						{
+							label: __( 'Most recent', 'woocommerce' ),
+							value: 'most-recent',
+						},
+						{
+							label: __( 'Highest Rating', 'woocommerce' ),
+							value: 'highest-rating',
+						},
+						{
+							label: __( 'Lowest Rating', 'woocommerce' ),
+							value: 'lowest-rating',
+						},
 					] }
 					onChange={ ( orderby ) => setAttributes( { orderby } ) }
 				/>
@@ -272,17 +289,22 @@ export const getSharedReviewListControls = ( attributes, setAttributes ) => {
 				}
 				label={ __( 'Load more', 'woocommerce' ) }
 				onDeselect={ () =>
-					setAttributes( { showLoadMore: true, reviewsOnLoadMore: 10 } )
+					setAttributes( {
+						showLoadMore: true,
+						reviewsOnLoadMore: 10,
+					} )
 				}
 				isShownByDefault
 			>
-				<div style={ { display: 'flex', flexDirection: 'column', gap: '24px' } }>
+				<div className="wc-block-reviews__tools-panel-item-container">
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Load more', 'woocommerce' ) }
 						checked={ attributes.showLoadMore }
 						onChange={ () =>
-							setAttributes( { showLoadMore: ! attributes.showLoadMore } )
+							setAttributes( {
+								showLoadMore: ! attributes.showLoadMore,
+							} )
 						}
 					/>
 					{ attributes.showLoadMore && (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/edit-utils.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/edit-utils.js
@@ -242,9 +242,9 @@ export const getSharedReviewListControls = ( attributes, setAttributes ) => {
 					label={ __( 'Order Product Reviews by', 'woocommerce' ) }
 					value={ attributes.orderby }
 					options={ [
-						{ label: 'Most recent', value: 'most-recent' },
-						{ label: 'Highest Rating', value: 'highest-rating' },
-						{ label: 'Lowest Rating', value: 'lowest-rating' },
+						{ label: __( 'Most recent', 'woocommerce' ), value: 'most-recent' },
+						{ label: __( 'Highest Rating', 'woocommerce' ), value: 'highest-rating' },
+						{ label: __( 'Lowest Rating', 'woocommerce' ), value: 'lowest-rating' },
 					] }
 					onChange={ ( orderby ) => setAttributes( { orderby } ) }
 				/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/edit-utils.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/edit-utils.js
@@ -255,11 +255,11 @@ export const getSharedReviewListControls = ( attributes, setAttributes ) => {
 							value: 'most-recent',
 						},
 						{
-							label: __( 'Highest Rating', 'woocommerce' ),
+							label: __( 'Highest rating', 'woocommerce' ),
 							value: 'highest-rating',
 						},
 						{
-							label: __( 'Lowest Rating', 'woocommerce' ),
+							label: __( 'Lowest rating', 'woocommerce' ),
 							value: 'lowest-rating',
 						},
 					] }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/edit-utils.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/edit-utils.js
@@ -15,6 +15,8 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
 export const getBlockControls = ( editMode, setAttributes, buttonTitle ) => (
@@ -37,103 +39,31 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 	const reviewRatingsEnabled = getSetting( 'reviewRatingsEnabled', true );
 	return (
 		<>
-			<ToggleControl
+			<ToolsPanelItem
+				hasValue={ () => ! attributes.showReviewRating }
 				label={ __( 'Product rating', 'woocommerce' ) }
-				checked={ attributes.showReviewRating }
-				onChange={ () =>
-					setAttributes( {
-						showReviewRating: ! attributes.showReviewRating,
-					} )
-				}
-			/>
-			{ attributes.showReviewRating && ! reviewRatingsEnabled && (
-				<Notice
-					className="wc-block-base-control-notice"
-					isDismissible={ false }
-				>
-					{ createInterpolateElement(
-						__(
-							'Product rating is disabled in your <a>store settings</a>.',
-							'woocommerce'
-						),
-						{
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-has-content
-								<a
-									href={ getAdminLink(
-										'admin.php?page=wc-settings&tab=products'
-									) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
+				onDeselect={ () => setAttributes( { showReviewRating: true } ) }
+				isShownByDefault
+			>
+				<div style={ { display: 'flex', flexDirection: 'column', gap: '24px' } }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Product rating', 'woocommerce' ) }
+						checked={ attributes.showReviewRating }
+						onChange={ () =>
+							setAttributes( {
+								showReviewRating: ! attributes.showReviewRating,
+							} )
 						}
-					) }
-				</Notice>
-			) }
-			<ToggleControl
-				label={ __( 'Reviewer name', 'woocommerce' ) }
-				checked={ attributes.showReviewerName }
-				onChange={ () =>
-					setAttributes( {
-						showReviewerName: ! attributes.showReviewerName,
-					} )
-				}
-			/>
-			<ToggleControl
-				label={ __( 'Image', 'woocommerce' ) }
-				checked={ attributes.showReviewImage }
-				onChange={ () =>
-					setAttributes( {
-						showReviewImage: ! attributes.showReviewImage,
-					} )
-				}
-			/>
-			<ToggleControl
-				label={ __( 'Review date', 'woocommerce' ) }
-				checked={ attributes.showReviewDate }
-				onChange={ () =>
-					setAttributes( {
-						showReviewDate: ! attributes.showReviewDate,
-					} )
-				}
-			/>
-			<ToggleControl
-				label={ __( 'Review content', 'woocommerce' ) }
-				checked={ attributes.showReviewContent }
-				onChange={ () =>
-					setAttributes( {
-						showReviewContent: ! attributes.showReviewContent,
-					} )
-				}
-			/>
-			{ attributes.showReviewImage && (
-				<>
-					<ToggleGroupControl
-						label={ __( 'Review image', 'woocommerce' ) }
-						isBlock
-						value={ attributes.imageType }
-						onChange={ ( value ) =>
-							setAttributes( { imageType: value } )
-						}
-					>
-						<ToggleGroupControlOption
-							value="reviewer"
-							label={ __( 'Reviewer photo', 'woocommerce' ) }
-						/>
-						<ToggleGroupControlOption
-							value="product"
-							label={ __( 'Product', 'woocommerce' ) }
-						/>
-					</ToggleGroupControl>
-					{ attributes.imageType === 'reviewer' && ! showAvatars && (
+					/>
+					{ attributes.showReviewRating && ! reviewRatingsEnabled && (
 						<Notice
 							className="wc-block-base-control-notice"
 							isDismissible={ false }
 						>
 							{ createInterpolateElement(
 								__(
-									'Reviewer photo is disabled in your <a>site settings</a>.',
+									'Product rating is disabled in your <a>store settings</a>.',
 									'woocommerce'
 								),
 								{
@@ -141,7 +71,7 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 										// eslint-disable-next-line jsx-a11y/anchor-has-content
 										<a
 											href={ getAdminLink(
-												'options-discussion.php'
+												'admin.php?page=wc-settings&tab=products'
 											) }
 											target="_blank"
 											rel="noopener noreferrer"
@@ -151,8 +81,132 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 							) }
 						</Notice>
 					) }
-				</>
-			) }
+				</div>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () => ! attributes.showReviewerName }
+				label={ __( 'Reviewer name', 'woocommerce' ) }
+				onDeselect={ () => setAttributes( { showReviewerName: true } ) }
+				isShownByDefault
+			>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Reviewer name', 'woocommerce' ) }
+					checked={ attributes.showReviewerName }
+					onChange={ () =>
+						setAttributes( {
+							showReviewerName: ! attributes.showReviewerName,
+						} )
+					}
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () =>
+					! attributes.showReviewImage ||
+					attributes.imageType !== 'reviewer'
+				}
+				label={ __( 'Image', 'woocommerce' ) }
+				onDeselect={ () =>
+					setAttributes( {
+						showReviewImage: true,
+						imageType: 'reviewer',
+					} )
+				}
+				isShownByDefault
+			>
+				<div style={ { display: 'flex', flexDirection: 'column', gap: '24px' } }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Image', 'woocommerce' ) }
+						checked={ attributes.showReviewImage }
+						onChange={ () =>
+							setAttributes( {
+								showReviewImage: ! attributes.showReviewImage,
+							} )
+						}
+					/>
+					{ attributes.showReviewImage && (
+						<>
+							<ToggleGroupControl
+								label={ __( 'Review image', 'woocommerce' ) }
+								isBlock
+								value={ attributes.imageType }
+								onChange={ ( value ) =>
+									setAttributes( { imageType: value } )
+								}
+							>
+								<ToggleGroupControlOption
+									value="reviewer"
+									label={ __( 'Reviewer photo', 'woocommerce' ) }
+								/>
+								<ToggleGroupControlOption
+									value="product"
+									label={ __( 'Product', 'woocommerce' ) }
+								/>
+							</ToggleGroupControl>
+							{ attributes.imageType === 'reviewer' && ! showAvatars && (
+								<Notice
+									className="wc-block-base-control-notice"
+									isDismissible={ false }
+								>
+									{ createInterpolateElement(
+										__(
+											'Reviewer photo is disabled in your <a>site settings</a>.',
+											'woocommerce'
+										),
+										{
+											a: (
+												// eslint-disable-next-line jsx-a11y/anchor-has-content
+												<a
+													href={ getAdminLink(
+														'options-discussion.php'
+													) }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										}
+									) }
+								</Notice>
+							) }
+						</>
+					) }
+				</div>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () => ! attributes.showReviewDate }
+				label={ __( 'Review date', 'woocommerce' ) }
+				onDeselect={ () => setAttributes( { showReviewDate: true } ) }
+				isShownByDefault
+			>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Review date', 'woocommerce' ) }
+					checked={ attributes.showReviewDate }
+					onChange={ () =>
+						setAttributes( {
+							showReviewDate: ! attributes.showReviewDate,
+						} )
+					}
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () => ! attributes.showReviewContent }
+				label={ __( 'Review content', 'woocommerce' ) }
+				onDeselect={ () => setAttributes( { showReviewContent: true } ) }
+				isShownByDefault
+			>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Review content', 'woocommerce' ) }
+					checked={ attributes.showReviewContent }
+					onChange={ () =>
+						setAttributes( {
+							showReviewContent: ! attributes.showReviewContent,
+						} )
+					}
+				/>
+			</ToolsPanelItem>
 		</>
 	);
 };
@@ -163,50 +217,87 @@ export const getSharedReviewListControls = ( attributes, setAttributes ) => {
 
 	return (
 		<>
-			<ToggleControl
+			<ToolsPanelItem
+				hasValue={ () => ! attributes.showOrderby }
 				label={ __( 'Order by', 'woocommerce' ) }
-				checked={ attributes.showOrderby }
-				onChange={ () =>
-					setAttributes( { showOrderby: ! attributes.showOrderby } )
-				}
-			/>
-			<SelectControl
+				onDeselect={ () => setAttributes( { showOrderby: true } ) }
+				isShownByDefault
+			>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Order by', 'woocommerce' ) }
+					checked={ attributes.showOrderby }
+					onChange={ () =>
+						setAttributes( { showOrderby: ! attributes.showOrderby } )
+					}
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () => attributes.orderby !== 'most-recent' }
 				label={ __( 'Order Product Reviews by', 'woocommerce' ) }
-				value={ attributes.orderby }
-				options={ [
-					{ label: 'Most recent', value: 'most-recent' },
-					{ label: 'Highest Rating', value: 'highest-rating' },
-					{ label: 'Lowest Rating', value: 'lowest-rating' },
-				] }
-				onChange={ ( orderby ) => setAttributes( { orderby } ) }
-			/>
-			<RangeControl
+				onDeselect={ () => setAttributes( { orderby: 'most-recent' } ) }
+				isShownByDefault
+			>
+				<SelectControl
+					label={ __( 'Order Product Reviews by', 'woocommerce' ) }
+					value={ attributes.orderby }
+					options={ [
+						{ label: 'Most recent', value: 'most-recent' },
+						{ label: 'Highest Rating', value: 'highest-rating' },
+						{ label: 'Lowest Rating', value: 'lowest-rating' },
+					] }
+					onChange={ ( orderby ) => setAttributes( { orderby } ) }
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () => attributes.reviewsOnPageLoad !== 10 }
 				label={ __( 'Starting Number of Reviews', 'woocommerce' ) }
-				value={ attributes.reviewsOnPageLoad }
-				onChange={ ( reviewsOnPageLoad ) =>
-					setAttributes( { reviewsOnPageLoad } )
-				}
-				max={ maxPerPage }
-				min={ minPerPage }
-			/>
-			<ToggleControl
-				label={ __( 'Load more', 'woocommerce' ) }
-				checked={ attributes.showLoadMore }
-				onChange={ () =>
-					setAttributes( { showLoadMore: ! attributes.showLoadMore } )
-				}
-			/>
-			{ attributes.showLoadMore && (
+				onDeselect={ () => setAttributes( { reviewsOnPageLoad: 10 } ) }
+				isShownByDefault
+			>
 				<RangeControl
-					label={ __( 'Load More Reviews', 'woocommerce' ) }
-					value={ attributes.reviewsOnLoadMore }
-					onChange={ ( reviewsOnLoadMore ) =>
-						setAttributes( { reviewsOnLoadMore } )
+					label={ __( 'Starting Number of Reviews', 'woocommerce' ) }
+					value={ attributes.reviewsOnPageLoad }
+					onChange={ ( reviewsOnPageLoad ) =>
+						setAttributes( { reviewsOnPageLoad } )
 					}
 					max={ maxPerPage }
 					min={ minPerPage }
 				/>
-			) }
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () =>
+					! attributes.showLoadMore ||
+					attributes.reviewsOnLoadMore !== 10
+				}
+				label={ __( 'Load more', 'woocommerce' ) }
+				onDeselect={ () =>
+					setAttributes( { showLoadMore: true, reviewsOnLoadMore: 10 } )
+				}
+				isShownByDefault
+			>
+				<div style={ { display: 'flex', flexDirection: 'column', gap: '24px' } }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Load more', 'woocommerce' ) }
+						checked={ attributes.showLoadMore }
+						onChange={ () =>
+							setAttributes( { showLoadMore: ! attributes.showLoadMore } )
+						}
+					/>
+					{ attributes.showLoadMore && (
+						<RangeControl
+							label={ __( 'Load More Reviews', 'woocommerce' ) }
+							value={ attributes.reviewsOnLoadMore }
+							onChange={ ( reviewsOnLoadMore ) =>
+								setAttributes( { reviewsOnLoadMore } )
+							}
+							max={ maxPerPage }
+							min={ minPerPage }
+						/>
+					) }
+				</div>
+			</ToolsPanelItem>
 		</>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/editor.scss
@@ -1,3 +1,9 @@
 .wc-block-reviews__selection {
 	width: 100%;
 }
+
+.wc-block-reviews__tools-panel-item-container {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
@@ -105,33 +105,10 @@ const ReviewsByCategoryEditor = ( {
 							}
 						/>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						hasValue={ () =>
-							! attributes.showReviewRating ||
-							! attributes.showReviewerName ||
-							! attributes.showReviewImage ||
-							! attributes.showReviewDate ||
-							! attributes.showReviewContent ||
-							attributes.imageType !== 'reviewer'
-						}
-						label={ __( 'Review options', 'woocommerce' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								showReviewRating: true,
-								showReviewerName: true,
-								showReviewImage: true,
-								showReviewDate: true,
-								showReviewContent: true,
-								imageType: 'reviewer',
-							} )
-						}
-						isShownByDefault
-					>
 						{ getSharedReviewContentControls(
 							attributes,
 							setAttributes
 						) }
-					</ToolsPanelItem>
 				</ToolsPanel>
 				<ToolsPanel
 					label={ __( 'List Settings', 'woocommerce' ) }
@@ -145,31 +122,10 @@ const ReviewsByCategoryEditor = ( {
 						} )
 					}
 				>
-					<ToolsPanelItem
-						hasValue={ () =>
-							! attributes.showOrderby ||
-							attributes.orderby !== 'most-recent' ||
-							attributes.reviewsOnPageLoad !== 10 ||
-							! attributes.showLoadMore ||
-							attributes.reviewsOnLoadMore !== 10
-						}
-						label={ __( 'List settings', 'woocommerce' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								showOrderby: true,
-								orderby: 'most-recent',
-								reviewsOnPageLoad: 10,
-								showLoadMore: true,
-								reviewsOnLoadMore: 10,
-							} )
-						}
-						isShownByDefault
-					>
 						{ getSharedReviewListControls(
 							attributes,
 							setAttributes
 						) }
-					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
@@ -105,10 +105,10 @@ const ReviewsByCategoryEditor = ( {
 							}
 						/>
 					</ToolsPanelItem>
-						{ getSharedReviewContentControls(
-							attributes,
-							setAttributes
-						) }
+					{ getSharedReviewContentControls(
+						attributes,
+						setAttributes
+					) }
 				</ToolsPanel>
 				<ToolsPanel
 					label={ __( 'List Settings', 'woocommerce' ) }
@@ -122,10 +122,7 @@ const ReviewsByCategoryEditor = ( {
 						} )
 					}
 				>
-						{ getSharedReviewListControls(
-							attributes,
-							setAttributes
-						) }
+					{ getSharedReviewListControls( attributes, setAttributes ) }
 				</ToolsPanel>
 			</InspectorControls>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
@@ -3,15 +3,18 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
+import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
+import { Icon, commentContent } from '@wordpress/icons';
 import {
 	Button,
-	PanelBody,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 	Placeholder,
 	ToggleControl,
 	withSpokenMessages,
 } from '@wordpress/components';
-import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
-import { Icon, commentContent } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -43,38 +46,131 @@ const ReviewsByCategoryEditor = ( {
 	const getInspectorControls = () => {
 		return (
 			<InspectorControls key="inspector">
-				<PanelBody
-					title={ __( 'Category', 'woocommerce' ) }
-					initialOpen={ false }
+				<ToolsPanel
+					label={ __( 'Category', 'woocommerce' ) }
+					resetAll={ () => setAttributes( { categoryIds: [] } ) }
 				>
-					<ProductCategoryControl
-						selected={ attributes.categoryIds }
-						onChange={ ( value = [] ) => {
-							const ids = value.map( ( { id } ) => id );
-							setAttributes( { categoryIds: ids } );
-						} }
-						isCompact={ true }
-						showReviewCount={ true }
-					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Content', 'woocommerce' ) }>
-					<ToggleControl
+					<ToolsPanelItem
+						hasValue={ () =>
+							( attributes.categoryIds || [] ).length > 0
+						}
+						label={ __( 'Category', 'woocommerce' ) }
+						onDeselect={ () =>
+							setAttributes( { categoryIds: [] } )
+						}
+						isShownByDefault
+					>
+						<ProductCategoryControl
+							selected={ attributes.categoryIds }
+							onChange={ ( value = [] ) => {
+								const ids = value.map( ( { id } ) => id );
+								setAttributes( { categoryIds: ids } );
+							} }
+							isCompact={ true }
+							showReviewCount={ true }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Content', 'woocommerce' ) }
+					resetAll={ () =>
+						setAttributes( {
+							showProductName: true,
+							showReviewRating: true,
+							showReviewerName: true,
+							showReviewImage: true,
+							showReviewDate: true,
+							showReviewContent: true,
+							imageType: 'reviewer',
+						} )
+					}
+				>
+					<ToolsPanelItem
+						hasValue={ () => ! attributes.showProductName }
 						label={ __( 'Product name', 'woocommerce' ) }
-						checked={ attributes.showProductName }
-						onChange={ () =>
+						onDeselect={ () =>
+							setAttributes( { showProductName: true } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Product name', 'woocommerce' ) }
+							checked={ attributes.showProductName }
+							onChange={ () =>
+								setAttributes( {
+									showProductName:
+										! attributes.showProductName,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () =>
+							! attributes.showReviewRating ||
+							! attributes.showReviewerName ||
+							! attributes.showReviewImage ||
+							! attributes.showReviewDate ||
+							! attributes.showReviewContent ||
+							attributes.imageType !== 'reviewer'
+						}
+						label={ __( 'Review options', 'woocommerce' ) }
+						onDeselect={ () =>
 							setAttributes( {
-								showProductName: ! attributes.showProductName,
+								showReviewRating: true,
+								showReviewerName: true,
+								showReviewImage: true,
+								showReviewDate: true,
+								showReviewContent: true,
+								imageType: 'reviewer',
 							} )
 						}
-					/>
-					{ getSharedReviewContentControls(
-						attributes,
-						setAttributes
-					) }
-				</PanelBody>
-				<PanelBody title={ __( 'List Settings', 'woocommerce' ) }>
-					{ getSharedReviewListControls( attributes, setAttributes ) }
-				</PanelBody>
+						isShownByDefault
+					>
+						{ getSharedReviewContentControls(
+							attributes,
+							setAttributes
+						) }
+					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'List Settings', 'woocommerce' ) }
+					resetAll={ () =>
+						setAttributes( {
+							showOrderby: true,
+							orderby: 'most-recent',
+							reviewsOnPageLoad: 10,
+							showLoadMore: true,
+							reviewsOnLoadMore: 10,
+						} )
+					}
+				>
+					<ToolsPanelItem
+						hasValue={ () =>
+							! attributes.showOrderby ||
+							attributes.orderby !== 'most-recent' ||
+							attributes.reviewsOnPageLoad !== 10 ||
+							! attributes.showLoadMore ||
+							attributes.reviewsOnLoadMore !== 10
+						}
+						label={ __( 'List settings', 'woocommerce' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								showOrderby: true,
+								orderby: 'most-recent',
+								reviewsOnPageLoad: 10,
+								showLoadMore: true,
+								reviewsOnLoadMore: 10,
+							} )
+						}
+						isShownByDefault
+					>
+						{ getSharedReviewListControls(
+							attributes,
+							setAttributes
+						) }
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 		);
 	};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -110,33 +110,10 @@ const ReviewsByProductEditor = ( {
 						} )
 					}
 				>
-					<ToolsPanelItem
-						hasValue={ () =>
-							! attributes.showReviewRating ||
-							! attributes.showReviewerName ||
-							! attributes.showReviewImage ||
-							! attributes.showReviewDate ||
-							! attributes.showReviewContent ||
-							attributes.imageType !== 'reviewer'
-						}
-						label={ __( 'Review options', 'woocommerce' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								showReviewRating: true,
-								showReviewerName: true,
-								showReviewImage: true,
-								showReviewDate: true,
-								showReviewContent: true,
-								imageType: 'reviewer',
-							} )
-						}
-						isShownByDefault
-					>
 						{ getSharedReviewContentControls(
 							attributes,
 							setAttributes
 						) }
-					</ToolsPanelItem>
 				</ToolsPanel>
 				<ToolsPanel
 					label={ __( 'List Settings', 'woocommerce' ) }
@@ -150,31 +127,10 @@ const ReviewsByProductEditor = ( {
 						} )
 					}
 				>
-					<ToolsPanelItem
-						hasValue={ () =>
-							! attributes.showOrderby ||
-							attributes.orderby !== 'most-recent' ||
-							attributes.reviewsOnPageLoad !== 10 ||
-							! attributes.showLoadMore ||
-							attributes.reviewsOnLoadMore !== 10
-						}
-						label={ __( 'List settings', 'woocommerce' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								showOrderby: true,
-								orderby: 'most-recent',
-								reviewsOnPageLoad: 10,
-								showLoadMore: true,
-								reviewsOnLoadMore: 10,
-							} )
-						}
-						isShownByDefault
-					>
 						{ getSharedReviewListControls(
 							attributes,
 							setAttributes
 						) }
-					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -87,7 +87,11 @@ const ReviewsByProductEditor = ( {
 						isShownByDefault
 					>
 						<ProductControl
-							selected={ attributes.productId ? [ attributes.productId ] : [] }
+							selected={
+								attributes.productId
+									? [ attributes.productId ]
+									: []
+							}
 							onChange={ ( value = [] ) => {
 								const id = value[ 0 ] ? value[ 0 ].id : 0;
 								setAttributes( { productId: id } );
@@ -110,10 +114,10 @@ const ReviewsByProductEditor = ( {
 						} )
 					}
 				>
-						{ getSharedReviewContentControls(
-							attributes,
-							setAttributes
-						) }
+					{ getSharedReviewContentControls(
+						attributes,
+						setAttributes
+					) }
 				</ToolsPanel>
 				<ToolsPanel
 					label={ __( 'List Settings', 'woocommerce' ) }
@@ -127,10 +131,7 @@ const ReviewsByProductEditor = ( {
 						} )
 					}
 				>
-						{ getSharedReviewListControls(
-							attributes,
-							setAttributes
-						) }
+					{ getSharedReviewListControls( attributes, setAttributes ) }
 				</ToolsPanel>
 			</InspectorControls>
 		);
@@ -161,7 +162,9 @@ const ReviewsByProductEditor = ( {
 				) }
 				<div className="wc-block-reviews__selection">
 					<ProductControl
-						selected={ attributes.productId ? [ attributes.productId ] : [] }
+						selected={
+							attributes.productId ? [ attributes.productId ] : []
+						}
 						onChange={ ( value = [] ) => {
 							const id = value[ 0 ] ? value[ 0 ].id : 0;
 							setAttributes( { productId: id } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -87,7 +87,7 @@ const ReviewsByProductEditor = ( {
 						isShownByDefault
 					>
 						<ProductControl
-							selected={ attributes.productId || 0 }
+							selected={ attributes.productId ? [ attributes.productId ] : [] }
 							onChange={ ( value = [] ) => {
 								const id = value[ 0 ] ? value[ 0 ].id : 0;
 								setAttributes( { productId: id } );
@@ -161,7 +161,7 @@ const ReviewsByProductEditor = ( {
 				) }
 				<div className="wc-block-reviews__selection">
 					<ProductControl
-						selected={ attributes.productId || 0 }
+						selected={ attributes.productId ? [ attributes.productId ] : [] }
 						onChange={ ( value = [] ) => {
 							const id = value[ 0 ] ? value[ 0 ].id : 0;
 							setAttributes( { productId: id } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -3,16 +3,19 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import {
-	Button,
-	PanelBody,
-	Placeholder,
-	withSpokenMessages,
-} from '@wordpress/components';
 import { SearchListItem } from '@woocommerce/editor-components/search-list-control';
 import ProductControl from '@woocommerce/editor-components/product-control';
 import { commentContent, Icon } from '@wordpress/icons';
 import { decodeEntities } from '@wordpress/html-entities';
+import {
+	Button,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	Placeholder,
+	withSpokenMessages,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -73,29 +76,106 @@ const ReviewsByProductEditor = ( {
 	const getInspectorControls = () => {
 		return (
 			<InspectorControls key="inspector">
-				<PanelBody
-					title={ __( 'Product', 'woocommerce' ) }
-					initialOpen={ false }
+				<ToolsPanel
+					label={ __( 'Product', 'woocommerce' ) }
+					resetAll={ () => setAttributes( { productId: 0 } ) }
 				>
-					<ProductControl
-						selected={ attributes.productId || 0 }
-						onChange={ ( value = [] ) => {
-							const id = value[ 0 ] ? value[ 0 ].id : 0;
-							setAttributes( { productId: id } );
-						} }
-						renderItem={ renderProductControlItem }
-						isCompact={ true }
-					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Content', 'woocommerce' ) }>
-					{ getSharedReviewContentControls(
-						attributes,
-						setAttributes
-					) }
-				</PanelBody>
-				<PanelBody title={ __( 'List Settings', 'woocommerce' ) }>
-					{ getSharedReviewListControls( attributes, setAttributes ) }
-				</PanelBody>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.productId }
+						label={ __( 'Product', 'woocommerce' ) }
+						onDeselect={ () => setAttributes( { productId: 0 } ) }
+						isShownByDefault
+					>
+						<ProductControl
+							selected={ attributes.productId || 0 }
+							onChange={ ( value = [] ) => {
+								const id = value[ 0 ] ? value[ 0 ].id : 0;
+								setAttributes( { productId: id } );
+							} }
+							renderItem={ renderProductControlItem }
+							isCompact={ true }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Content', 'woocommerce' ) }
+					resetAll={ () =>
+						setAttributes( {
+							showReviewRating: true,
+							showReviewerName: true,
+							showReviewImage: true,
+							showReviewDate: true,
+							showReviewContent: true,
+							imageType: 'reviewer',
+						} )
+					}
+				>
+					<ToolsPanelItem
+						hasValue={ () =>
+							! attributes.showReviewRating ||
+							! attributes.showReviewerName ||
+							! attributes.showReviewImage ||
+							! attributes.showReviewDate ||
+							! attributes.showReviewContent ||
+							attributes.imageType !== 'reviewer'
+						}
+						label={ __( 'Review options', 'woocommerce' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								showReviewRating: true,
+								showReviewerName: true,
+								showReviewImage: true,
+								showReviewDate: true,
+								showReviewContent: true,
+								imageType: 'reviewer',
+							} )
+						}
+						isShownByDefault
+					>
+						{ getSharedReviewContentControls(
+							attributes,
+							setAttributes
+						) }
+					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'List Settings', 'woocommerce' ) }
+					resetAll={ () =>
+						setAttributes( {
+							showOrderby: true,
+							orderby: 'most-recent',
+							reviewsOnPageLoad: 10,
+							showLoadMore: true,
+							reviewsOnLoadMore: 10,
+						} )
+					}
+				>
+					<ToolsPanelItem
+						hasValue={ () =>
+							! attributes.showOrderby ||
+							attributes.orderby !== 'most-recent' ||
+							attributes.reviewsOnPageLoad !== 10 ||
+							! attributes.showLoadMore ||
+							attributes.reviewsOnLoadMore !== 10
+						}
+						label={ __( 'List settings', 'woocommerce' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								showOrderby: true,
+								orderby: 'most-recent',
+								reviewsOnPageLoad: 10,
+								showLoadMore: true,
+								reviewsOnLoadMore: 10,
+							} )
+						}
+						isShownByDefault
+					>
+						{ getSharedReviewListControls(
+							attributes,
+							setAttributes
+						) }
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 		);
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59464 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="266" height="756" alt="review-all-before" src="https://github.com/user-attachments/assets/756c9870-373b-40ec-85ae-833584b8e2aa" /> | <img width="271" height="691" alt="all-review-after" src="https://github.com/user-attachments/assets/75b2772c-4e08-486e-bf49-e8700c8bc1c1" /> |
| <img width="271" height="769" alt="review-by-product-before" src="https://github.com/user-attachments/assets/93318392-d669-4446-8194-174fb93619a8" /> | <img width="269" height="696" alt="review-by-product-after" src="https://github.com/user-attachments/assets/873fb198-cc65-42d8-aff7-13d7a9a5c2af" /> |
| <img width="271" height="770" alt="review-by-category-before" src="https://github.com/user-attachments/assets/58ff4714-350a-4680-866b-a38032c13ba1" /> | <img width="267" height="696" alt="review-by-category-after" src="https://github.com/user-attachments/assets/fd0cc6ec-8e86-46f6-99e3-ef698e9b1795" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open the Gutenberg block editor by creating a new Post/Page or navigating to Appearance > Editor.
2. Insert an **All Reviews** block onto the canvas. (You can also test this with the **Reviews by Category** or **Reviews by Product** blocks).
3. Ensure the block is selected and open the right-hand Block Settings sidebar.
4. Observe the controls under the "Review options" and "List settings" panels. Verify that there is now proper vertical spacing between each setting (e.g., "Product rating", "Reviewer name", "Image", "Review date", "Review content", "Load more").
5. Toggle the **Image** setting on. Verify that there is proper spacing between the "Image" toggle and the "Review image" toggle group that appears below it.
6. Toggle the **Load more** setting on. Verify that there is proper spacing between the "Load more" toggle and the "Load More Reviews" range slider that appears below it.
7. Click the **3-dots menu** on the ToolsPanel (e.g., next to the "Review options" heading) and verify that you can individually check/uncheck the visibility of each setting without any issues.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>