### PR TITLE
[Issue - #64842] productInContext support for grouped and bundle products

### DIFF
--- a/plugins/woocommerce/changelog/fix-64842-product-in-context-grouped-product-child-rows
+++ b/plugins/woocommerce/changelog/fix-64842-product-in-context-grouped-product-child-rows
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Wrap each grouped product child row in a woocommerce/products interactivity context so that state.productInContext resolves to the child product in all rendering contexts, not just the Single Product Template.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/README.md
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/README.md
@@ -157,6 +157,21 @@ printf(
 
 The second argument to `wp_interactivity_data_wp_context` (`'woocommerce/products'`) namespaces the context to the `woocommerce/products` store; the JS store's `getContext< ProductContext >( 'woocommerce/products' )` calls read from it.
 
+#### Composite and custom product templates
+
+Grouped products are not special because of their product type alone. They work because the template does two things for each rendered child item:
+
+1. Load the child product into the store before descendants bind to `state.productInContext.*`.
+2. Wrap the child item's markup in a local `woocommerce/products` context so descendants resolve the child product instead of the parent product.
+
+That same pattern applies to custom composite product types, such as bundle-like extensions that register their own Add to Cart + Options block template part. Core does not automatically infer or hydrate child items for custom product types. If an extension renders child-product UI and wants descendants to use `state.productInContext`, it should:
+
+-   Load the parent product with `wc_interactivity_api_load_product()`.
+-   Load each rendered child product before outputting bindings that read from `state.productInContext`.
+-   Wrap each child item's subtree with `wp_interactivity_data_wp_context( [ 'productId' => $child_id, 'variationId' => null ], 'woocommerce/products' )`.
+
+For grouped products in core, see `GroupedProductItem::get_product_row()` for the server-side wrapper pattern.
+
 ### Reading product data in a block
 
 Once state is populated and a current product is set, blocks read from it either through directives (SSR + client) or through a JS store reference.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItem.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItem.php
@@ -58,6 +58,13 @@ class GroupedProductItem extends AbstractBlock {
 		$post    = get_post( $product_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$product = wc_get_product( $product_id );
 
+		if ( ! $product instanceof \WC_Product || ! $post instanceof \WP_Post ) {
+			$post    = $previous_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$product = $previous_product;
+
+			return '';
+		}
+
 		add_filter( 'render_block_context', array( $this, 'set_is_descendant_of_grouped_product_selector_context' ), 10, 2 );
 
 		// Create new block with custom context.
@@ -71,6 +78,18 @@ class GroupedProductItem extends AbstractBlock {
 
 		// Render with dynamic set to false to prevent calling render_callback.
 		$block_content = $new_block->render( array( 'dynamic' => false ) );
+
+		$block_content = sprintf(
+			'<div data-wp-interactive="woocommerce/products" %1$s>%2$s</div>',
+			wp_interactivity_data_wp_context(
+				array(
+					'productId'   => $product->get_id(),
+					'variationId' => null,
+				),
+				'woocommerce/products'
+			),
+			$block_content
+		);
 
 		remove_filter( 'render_block_context', array( $this, 'set_is_descendant_of_grouped_product_selector_context' ) );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -222,6 +222,26 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that grouped product child rows scope descendants to the child product context.
+	 */
+	public function test_grouped_product_children_are_wrapped_in_products_context(): void {
+		$simple_product = new \WC_Product_Simple();
+		$simple_product->set_regular_price( 10 );
+		$simple_product->set_sku( 'child-sku' );
+		$simple_product_id = $simple_product->save();
+
+		$grouped_product = new \WC_Product_Grouped();
+		$grouped_product->set_children( array( $simple_product_id ) );
+		$grouped_product_id = $grouped_product->save();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $grouped_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'data-wp-interactive="woocommerce/products"', $markup, 'Grouped child rows should initialize the products store for descendant bindings.' );
+		$this->assertStringContainsString( 'woocommerce/products::', $markup, 'Grouped child rows should set a products-store local context.' );
+		$this->assertStringContainsString( 'productId', $markup, 'Grouped child rows should scope descendant bindings to a concrete child product ID.' );
+	}
+
+	/**
 	 * Tests that the quantity selector block is not visible for sold individually products and manage stock products with stock quantity <= 1.
 	 */
 	public function test_stepper_not_visible_for_sold_individually_products_and_manage_stock() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- This PR addresses the follow-up for `productInContext` support for grouped products and custom composite products (like bundles). Previously, the fix in #64667 only supported the scenario where a grouped product was rendered inside a Single Product Template. 

- With these changes, each grouped product child row is now explicitly wrapped in a `woocommerce/products` interactivity context (`wp_interactivity_data_wp_context`). This ensures that `state.productInContext` cleanly resolves to the child product in *all* rendering contexts.

- Additionally, this PR updates the `README.md` for `woocommerce/products` to clarify how `productInContext` APIs should be utilized by third-party custom product types (like bundle-like extensions).


Closes #64842.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. In WP Admin, go to **Products > Add New** and create two simple products (e.g., "Child Product A" and "Child Product B") with prices.
2. Create a new **Grouped Product** and assign the two simple products as its "Linked Products" (under Grouped products).
3. Navigate to **Pages > Add New** and insert a **Single Product** block onto the canvas. Set the block to display the Grouped Product you just created.
4. Save the page and view it on the frontend.
5. Verify that the grouped product's add-to-cart table renders correctly. Specifically, verify that each child row displays its correct specific product data (name, price, stock, quantity input), confirming that the interactivity API is correctly resolving `state.productInContext` to the *child* product ID, rather than falling back to the parent grouped product context.
6. Verify that adding items to the cart from this grouped product works as expected.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
