### PR TITLE
Update AGENTS.md to avoid agents adding more jQuery code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,10 @@ plugins/woocommerce/
 - `plugins/woocommerce/src/` - Modern PHP with dependency injection, PSR-4 autoloading
 - `plugins/woocommerce/includes/` - Legacy WordPress patterns, modify only when necessary
 
+**JavaScript:**
+
+- When possible, prefer vanilla JavaScript/TypeScript over jQuery for new or modified frontend code. Keep existing jQuery when a rewrite is out of scope.
+
 **Namespace:**
 
 - Root namespace: `Automattic\WooCommerce`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,10 +58,6 @@ plugins/woocommerce/
 - `plugins/woocommerce/src/` - Modern PHP with dependency injection, PSR-4 autoloading
 - `plugins/woocommerce/includes/` - Legacy WordPress patterns, modify only when necessary
 
-**JavaScript:**
-
-- When possible, prefer vanilla JavaScript/TypeScript over jQuery for new or modified frontend code. Keep existing jQuery when a rewrite is out of scope.
-
 **Namespace:**
 
 - Root namespace: `Automattic\WooCommerce`
@@ -77,6 +73,10 @@ plugins/woocommerce/
 - Current version in `plugins/woocommerce/includes/class-woocommerce.php` → `$version` property
 - Used for `@since` annotations (remove `-dev` suffix)
 - When changing template files (PHP files used to display UI on the front-end) the version in their header should be updated to the current version, without the `-dev` suffix.
+
+**JavaScript:**
+
+- Prefer vanilla JavaScript/TypeScript over jQuery for new or modified code. Keep existing jQuery when a rewrite is out of scope.
 
 ## Development Workflow
 

--- a/plugins/woocommerce/changelog/update-tell-agents-not-to-write-jquery
+++ b/plugins/woocommerce/changelog/update-tell-agents-not-to-write-jquery
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update AGENTS.md to avoid agents adding more jQuery code
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Agents seem to be writing jQuery code when modifying or adding code to a file where most of the existing code is jQuery.

Per pcShBQ-1S4-p2, we want all new code to be vanilla JS/TS. So this PR adds an specific instruction in `AGENTS.md` about this.

### How to test the changes in this Pull Request:

There is nothing user-facing to test.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->