### PR TITLE
Explore DataForm internals for Settings UI

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -366,7 +366,8 @@
 				"@wordpress/icons"
 			],
 			"packages": [
-				"@woocommerce/admin-library"
+				"@woocommerce/admin-library",
+				"@woocommerce/settings-ui-sdk"
 			],
 			"isIgnored": true
 		},

--- a/packages/js/settings-ui-sdk/changelog/tweak-settings-ui-dataform-internals
+++ b/packages/js/settings-ui-sdk/changelog/tweak-settings-ui-dataform-internals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Render Settings UI fields through DataForm while preserving the existing settings page design.

--- a/packages/js/settings-ui-sdk/package.json
+++ b/packages/js/settings-ui-sdk/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/a11y": "catalog:wp-min",
 		"@wordpress/admin-ui": "catalog:wp-min",
 		"@wordpress/components": "catalog:wp-min",
+		"@wordpress/dataviews": "^4.17.0",
 		"@wordpress/element": "catalog:wp-min",
 		"@wordpress/i18n": "catalog:wp-min"
 	},

--- a/packages/js/settings-ui-sdk/src/dataform.tsx
+++ b/packages/js/settings-ui-sdk/src/dataform.tsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { DataForm } from '@wordpress/dataviews';
+import { createElement, useMemo } from '@wordpress/element';
+import type {
+	DataFormControlProps,
+	Field as DataFormField,
+	Form as DataFormSchema,
+} from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { NativeSettingsField } from './native-fields';
+import { resolveFieldComponent } from './registry';
+import type {
+	SettingsFieldComponent,
+	SettingsFieldContext,
+	SettingsUIField,
+	SettingsValue,
+	SettingsValues,
+} from './types';
+
+type SettingsDataFormProps = {
+	fields: SettingsUIField[];
+	values: SettingsValues;
+	initialValues: SettingsValues;
+	context: SettingsFieldContext;
+	setValue: ( fieldId: string, value: SettingsValue ) => void;
+	setValues: ( values: Partial< SettingsValues > ) => void;
+};
+
+type SettingsDataFormControlProps = DataFormControlProps< SettingsValues > & {
+	FieldComponent: SettingsFieldComponent;
+	fieldSchema: SettingsUIField;
+	initialValues: SettingsValues;
+	context: SettingsFieldContext;
+	setValue: ( fieldId: string, value: SettingsValue ) => void;
+	setValues: ( values: Partial< SettingsValues > ) => void;
+};
+
+const getFieldTypeClassName = ( type: string ) =>
+	`wc-settings-ui__field--${ type.replace( /[^a-z0-9_-]/gi, '-' ) }`;
+
+const SettingsDataFormControl = ( {
+	FieldComponent,
+	fieldSchema,
+	data,
+	onChange,
+	initialValues,
+	context,
+	setValue,
+	setValues,
+}: SettingsDataFormControlProps ) => {
+	const value = data[ fieldSchema.id ];
+
+	return (
+		<div
+			className={ [
+				'wc-settings-ui__field',
+				getFieldTypeClassName( fieldSchema.type ),
+			].join( ' ' ) }
+		>
+			<FieldComponent
+				field={ fieldSchema }
+				value={ value }
+				context={ context }
+				values={ data }
+				initialValues={ initialValues }
+				setValue={ setValue }
+				setValues={ setValues }
+				onChange={ ( nextValue ) =>
+					onChange( { [ fieldSchema.id ]: nextValue } )
+				}
+			/>
+		</div>
+	);
+};
+
+export const SettingsDataForm = ( {
+	fields,
+	values,
+	initialValues,
+	context,
+	setValue,
+	setValues,
+}: SettingsDataFormProps ) => {
+	const dataFormFields = useMemo(
+		() =>
+			fields.map( ( fieldSchema ): DataFormField< SettingsValues > => {
+				const FieldComponent =
+					resolveFieldComponent( fieldSchema, context ) ||
+					NativeSettingsField;
+
+				const Edit = (
+					props: DataFormControlProps< SettingsValues >
+				) => (
+					<SettingsDataFormControl
+						{ ...props }
+						FieldComponent={ FieldComponent }
+						fieldSchema={ fieldSchema }
+						initialValues={ initialValues }
+						context={ context }
+						setValue={ setValue }
+						setValues={ setValues }
+					/>
+				);
+
+				return {
+					id: fieldSchema.id,
+					label: fieldSchema.label,
+					description: fieldSchema.description,
+					placeholder: fieldSchema.placeholder,
+					Edit,
+					enableHiding: false,
+					enableSorting: false,
+					getValue: ( { item } ) => item[ fieldSchema.id ],
+				};
+			} ),
+		[ context, fields, initialValues, setValue, setValues ]
+	);
+
+	const form = useMemo< DataFormSchema >(
+		() => ( {
+			type: 'regular',
+			fields: fields.map( ( field ) => field.id ),
+		} ),
+		[ fields ]
+	);
+
+	return (
+		<DataForm
+			data={ values }
+			fields={ dataFormFields }
+			form={ form }
+			onChange={ setValues }
+		/>
+	);
+};

--- a/packages/js/settings-ui-sdk/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui-sdk/src/settings-ui-page.tsx
@@ -22,9 +22,8 @@ import type { ErrorInfo, ReactNode } from 'react';
 import { HiddenInputs } from './hidden-inputs';
 import { error, warn } from './diagnostics';
 import { sanitizeSettingsHtml } from './html';
-import { NativeSettingsField } from './native-fields';
+import { SettingsDataForm } from './dataform';
 import {
-	resolveFieldComponent,
 	resolveFieldVisibilityPredicate,
 	resolveGroupVisibilityPredicate,
 	resolveRegionComponent,
@@ -89,9 +88,6 @@ const getChangedValues = (
 
 	return changedValues;
 };
-
-const getFieldTypeClassName = ( type: string ) =>
-	`wc-settings-ui__field--${ type.replace( /[^a-z0-9_-]/gi, '-' ) }`;
 
 const getActionVariant = ( variant?: string ) =>
 	( [ 'primary', 'secondary', 'tertiary', 'link' ].includes( variant || '' )
@@ -805,42 +801,14 @@ export const SettingsUIPage = ( {
 						<div className="wc-settings-ui__section-card">
 							<GroupHeader group={ group } />
 							<div className="wc-settings-ui__section-fields">
-								{ group.fields.map( ( field ) => {
-									const FieldComponent =
-										resolveFieldComponent(
-											field,
-											context
-										) || NativeSettingsField;
-									const value = values[ field.id ];
-
-									return (
-										<div
-											className={ [
-												'wc-settings-ui__field',
-												getFieldTypeClassName(
-													field.type
-												),
-											].join( ' ' ) }
-											key={ field.id }
-										>
-											<FieldComponent
-												field={ field }
-												value={ value }
-												context={ context }
-												values={ values }
-												initialValues={ initialValues }
-												setValue={ setValue }
-												setValues={ setValues }
-												onChange={ ( nextValue ) =>
-													setValue(
-														field.id,
-														nextValue
-													)
-												}
-											/>
-										</div>
-									);
-								} ) }
+								<SettingsDataForm
+									fields={ group.fields }
+									values={ values }
+									initialValues={ initialValues }
+									context={ context }
+									setValue={ setValue }
+									setValues={ setValues }
+								/>
 							</div>
 						</div>
 					</section>

--- a/packages/js/settings-ui-sdk/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui-sdk/src/test/html-rendering.test.tsx
@@ -21,7 +21,7 @@ jest.mock( '@wordpress/admin-ui', () => ( {
  */
 import { SettingsUIPage } from '../settings-ui-page';
 import { __resetRegistry, registerSettingsExtension } from '../registry';
-import type { SettingsUISchema } from '../types';
+import type { SettingsFieldComponentProps, SettingsUISchema } from '../types';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -102,6 +102,65 @@ describe( 'settings HTML rendering', () => {
 		expect( container.textContent ).toContain( 'Test field' );
 		expect( container.textContent ).toContain(
 			'Shown as field description.'
+		);
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
+	it( 'renders registered field components through the settings data form', () => {
+		const CustomField = ( {
+			value,
+			onChange,
+		}: SettingsFieldComponentProps ) => (
+			<button type="button" onClick={ () => onChange( 'changed' ) }>
+				{ value }
+			</button>
+		);
+
+		registerSettingsExtension( {
+			scope: { page: 'test-page', section: 'default' },
+			components: {
+				customField: CustomField,
+			},
+		} );
+
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			section: 'default',
+			save: { adapter: 'none' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'test_field',
+							label: 'Test field',
+							type: 'text',
+							component: 'customField',
+							value: 'initial',
+						},
+					],
+				},
+			},
+		};
+
+		const { container, root } = renderElement(
+			<SettingsUIPage schema={ schema } />
+		);
+		const button = container.querySelector( 'button' );
+
+		expect( button?.textContent ).toBe( 'initial' );
+
+		act( () => {
+			button?.dispatchEvent(
+				new MouseEvent( 'click', { bubbles: true } )
+			);
+		} );
+
+		expect( container.querySelector( 'button' )?.textContent ).toBe(
+			'changed'
 		);
 
 		act( () => root.unmount() );
@@ -322,6 +381,8 @@ describe( 'settings HTML rendering', () => {
 				);
 			}
 		} );
+
+		await act( async () => {} );
 
 		act( () => {
 			link?.dispatchEvent(

--- a/plugins/woocommerce/changelog/tweak-settings-ui-dataform-internals
+++ b/plugins/woocommerce/changelog/tweak-settings-ui-dataform-internals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Render Settings UI fields through DataForm while preserving the existing settings page design.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -262,6 +262,15 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		gap: 16px;
 	}
 
+	.wc-settings-ui__section-fields > .components-v-stack,
+	.wc-settings-ui__section-fields .dataforms-layouts-regular__field {
+		width: 100%;
+	}
+
+	.wc-settings-ui__section-fields .dataforms-layouts-regular__field {
+		margin: 0;
+	}
+
 	.wc-settings-ui__field {
 		margin: 0;
 		width: 100%;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2381,6 +2381,9 @@ importers:
       '@wordpress/components':
         specifier: catalog:wp-min
         version: 29.5.4(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dataviews':
+        specifier: ^4.17.0
+        version: 4.22.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element':
         specifier: catalog:wp-min
         version: 6.19.1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This is a draft/exploration PR to evaluate whether `@wordpress/dataviews` / `DataForm` is a good internal implementation detail for the new WooCommerce Settings UI SDK without changing the page design or extension API.

- Adds a `SettingsDataForm` adapter that maps existing `SettingsUIField` schema entries into `DataForm` fields.
- Keeps the existing native field components and registered field component API intact.
- Preserves existing `wc-settings-ui__field` / field-type class names so current Settings UI styling and tests continue to apply.
- Updates `SettingsUIPage` to render each group through the DataForm adapter.
- Adds minimal CSS to neutralize DataForm wrapper spacing/width so the current Settings UI card layout remains unchanged.
- Adds `@wordpress/dataviews` as a Settings UI SDK dependency and extends the existing syncpack exception used by admin-library for DataViews.
- Adds test coverage for registered field components rendering and updating through the DataForm layer.

Evaluation note: this looks viable as an internal detail as long as we continue wrapping our existing field components and treat DataForm layout/styling as implementation plumbing rather than design source-of-truth. The main tradeoff is adding DataViews as an SDK runtime dependency/bundle surface.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

No user-facing design change is intended. A local Chrome smoke-test screenshot was captured at `/tmp/pi-settings-ui-dataform-products.png`.

### How to test the changes in this Pull Request:

1. Build/install dependencies and admin assets:
   - `pnpm install --frozen-lockfile`
   - `pnpm build`
2. Open `WooCommerce > Settings > Products` on a local site using the new Settings UI.
3. Confirm the Products settings page still uses the same card/field layout and fields render normally.
4. Edit a field, such as `Placeholder image`, and confirm the Save button enables.
5. Confirm custom/registered Settings UI fields still render and update through the Settings UI SDK API.

### Testing that has already taken place:

- `pnpm install --frozen-lockfile`
- `pnpm --filter='@woocommerce/settings-ui-sdk' test:js`
- `pnpm --filter='@woocommerce/settings-ui-sdk' lint:lang:js`
- `pnpm --filter='@woocommerce/settings-ui-sdk' lint:lang:types`
- `pnpm --filter='@woocommerce/settings-ui-sdk' build`
- `pnpm --filter='@woocommerce/plugin-woocommerce' changelog validate`
- `pnpm --filter='@woocommerce/plugin-woocommerce' lint:changes:branch`
- `pnpm --filter='@woocommerce/admin-library' lint:lang:css`
- `pnpm build`
- `git diff --check`
- Chrome smoke test on `http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=products`:
  - Confirmed Settings UI rendered.
  - Confirmed DataForm wrappers matched the rendered Settings UI fields.
  - Confirmed editing `Placeholder image` enabled the Save button.
  - No Settings UI-specific console errors observed; only existing local-site warnings/resources were present.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

Manual changelog entries are included for:

- `packages/js/settings-ui-sdk`
- `plugins/woocommerce`

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Render Settings UI fields through DataForm while preserving the existing settings page design.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
