### PR TITLE
Update product status filter availability labels

### DIFF
--- a/plugins/woocommerce/changelog/update-product-filter-status-availability
+++ b/plugins/woocommerce/changelog/update-product-filter-status-availability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Product Filter Status block labels to use availability wording.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/constants.ts
@@ -28,10 +28,4 @@ export const filtersPreview = [
 		value: 'instock',
 		label: __( 'In stock', 'woocommerce' ),
 	},
-	{
-		id: 'status_onsale',
-		type: __( 'Availability', 'woocommerce' ),
-		value: 'onsale',
-		label: __( 'On sale', 'woocommerce' ),
-	},
 ];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/constants.ts
@@ -24,13 +24,13 @@ export const filtersPreview = [
 	},
 	{
 		id: 'status_instock',
-		type: __( 'Status', 'woocommerce' ),
+		type: __( 'Availability', 'woocommerce' ),
 		value: 'instock',
 		label: __( 'In stock', 'woocommerce' ),
 	},
 	{
 		id: 'status_onsale',
-		type: __( 'Status', 'woocommerce' ),
+		type: __( 'Availability', 'woocommerce' ),
 		value: 'onsale',
 		label: __( 'On sale', 'woocommerce' ),
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/product-filter-status",
-	"title": "Status Filter",
-	"description": "Let shoppers filter products by choosing stock status.",
+	"title": "Availability filter",
+	"description": "Let shoppers filter products by availability.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
@@ -30,7 +30,7 @@ const Edit = ( props: EditProps ) => {
 					'core/heading',
 					{
 						level: 3,
-						content: __( 'Status', 'woocommerce' ),
+						content: __( 'Availability', 'woocommerce' ),
 						style: {
 							spacing: {
 								margin: {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -68,7 +68,7 @@ final class ProductFilterStatus extends AbstractBlock {
 				'type'        => 'status',
 				'value'       => $status,
 				// translators: %s: status.
-				'activeLabel' => sprintf( __( 'Status: %s', 'woocommerce' ), $status_options[ $status ] ),
+				'activeLabel' => sprintf( __( 'Availability: %s', 'woocommerce' ), $status_options[ $status ] ),
 			);
 		}
 
@@ -134,7 +134,7 @@ final class ProductFilterStatus extends AbstractBlock {
 			'items'          => array_values( $filter_options ),
 			'selectionMode'  => 'multiple',
 			'storeNamespace' => 'woocommerce/product-filters',
-			'groupLabel'     => __( 'Status', 'woocommerce' ),
+			'groupLabel'     => __( 'Availability', 'woocommerce' ),
 		);
 
 		$wrapper_attributes = array(
@@ -143,7 +143,7 @@ final class ProductFilterStatus extends AbstractBlock {
 			'data-wp-context'     => wp_json_encode(
 				array(
 					/* translators: {{label}} is the status filter item label. */
-					'activeLabelTemplate' => __( 'Status: {{label}}', 'woocommerce' ),
+					'activeLabelTemplate' => __( 'Availability: {{label}}', 'woocommerce' ),
 					'filterType'          => 'status',
 					'items'               => $filter_context['items'],
 				),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -67,7 +67,7 @@ final class ProductFilterStatus extends AbstractBlock {
 			$items[] = array(
 				'type'        => 'status',
 				'value'       => $status,
-				// translators: %s: status.
+				// translators: %s: availability.
 				'activeLabel' => sprintf( __( 'Availability: %s', 'woocommerce' ), $status_options[ $status ] ),
 			);
 		}
@@ -142,7 +142,7 @@ final class ProductFilterStatus extends AbstractBlock {
 			'data-wp-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),
 			'data-wp-context'     => wp_json_encode(
 				array(
-					/* translators: {{label}} is the status filter item label. */
+					/* translators: {{label}} is the availability filter item label. */
 					'activeLabelTemplate' => __( 'Availability: {{label}}', 'woocommerce' ),
 					'filterType'          => 'status',
 					'items'               => $filter_context['items'],

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-filters/active-filter-frontend.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-filters/active-filter-frontend.block_theme.spec.ts
@@ -66,10 +66,10 @@ test.describe( 'woocommerce/product-filter-active - Frontend', () => {
 		);
 
 		await expect(
-			page.getByText( 'Status: In stock' ).first()
+			page.getByText( 'Availability: In stock' ).first()
 		).toBeVisible();
 		await expect(
-			page.getByText( 'Status: On backorder' ).first()
+			page.getByText( 'Availability: On backorder' ).first()
 		).toBeVisible();
 	} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The Status filter uses a generic label compared with the shopper-facing language used elsewhere in product filtering. This updates that label to use availability wording across the block title, default heading, preview copy, and active filter labels.

### Screenshots or screen recordings:
<img width="1445" height="2497" alt="Better block labeling" src="https://github.com/user-attachments/assets/fd37698b-873e-45d1-8106-6093602b6794" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open the Site Editor and edit a template containing the Product Filters block, or add a Product Filters block to a product archive template.
2. Open the block inserter and confirm the stock status filter appears as `Availability filter`.
3. Add the filter and confirm its default heading reads `Availability`.
4. View the template on the frontend, apply an availability filter such as `In stock`, and confirm the active filter label reads `Availability: In stock`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Built block assets with `pnpm wc:build:blocks`.
- Built WooCommerce Admin assets locally after running the admin postinstall symlink step.
- Ran `pnpm --filter='@woocommerce/block-library' lint:js`; it completed with existing package-wide warnings and no errors.
- Ran PHP syntax check for `ProductFilterStatus.php` in wp-env.
- Tested locally with wp-env on `localhost:8891`, WooCommerce 11.0.0-dev, sample products, and a block theme environment.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>