### PR TITLE
Singularize pickup options title for one location

### DIFF
--- a/plugins/woocommerce/changelog/65806-65779-pickup-locations
+++ b/plugins/woocommerce/changelog/65806-65779-pickup-locations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Singularize pickup options title for one location

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
@@ -8,12 +8,31 @@ import { useSelect } from '@wordpress/data';
 import { checkoutStore as checkoutStoreDescriptor } from '@woocommerce/block-data';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
+import { useShippingData } from '@woocommerce/base-context/hooks';
+import { isPackageRateCollectable } from '@woocommerce/base-utils';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import Block from './block';
 import attributes from './attributes';
+
+const DEFAULT_PICKUP_OPTIONS_TITLE = __( 'Pickup locations', 'woocommerce' );
+
+export const getPickupOptionsTitle = (
+	title: string,
+	pickupLocationsCount: number
+) => {
+	if (
+		title === DEFAULT_PICKUP_OPTIONS_TITLE &&
+		pickupLocationsCount === 1
+	) {
+		return __( 'Pickup location', 'woocommerce' );
+	}
+
+	return title;
+};
 
 const FrontendBlock = ( {
 	title,
@@ -38,6 +57,10 @@ const FrontendBlock = ( {
 	);
 
 	const { showFormStepNumbers } = useCheckoutBlockContext();
+	const { shippingRates } = useShippingData();
+	const pickupLocationsCount = (
+		shippingRates[ 0 ]?.shipping_rates || []
+	).filter( isPackageRateCollectable ).length;
 
 	if ( ! prefersCollection || ! LOCAL_PICKUP_ENABLED ) {
 		return null;
@@ -48,7 +71,7 @@ const FrontendBlock = ( {
 			id="pickup-options"
 			disabled={ checkoutIsProcessing }
 			className={ clsx( 'wc-block-checkout__pickup-options', className ) }
-			title={ title }
+			title={ getPickupOptionsTitle( title, pickupLocationsCount ) }
 			description={ description }
 			showStepNumber={ showFormStepNumbers }
 		>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
@@ -9,6 +9,7 @@ import { useShippingData, useStoreCart } from '@woocommerce/base-context/hooks';
  * Internal dependencies
  */
 import CheckoutPickupOptionsBlock from '../block';
+import { getPickupOptionsTitle } from '../frontend';
 import {
 	generateShippingPackage,
 	generateShippingRate,
@@ -52,6 +53,26 @@ jest.mock( '@woocommerce/settings', () => {
 ( useStoreCart as jest.Mock ).mockImplementation( () =>
 	jest.requireActual( '@woocommerce/base-context/hooks' ).useStoreCart()
 );
+
+describe( 'getPickupOptionsTitle', () => {
+	it( 'uses the singular default title when there is one pickup location', () => {
+		expect( getPickupOptionsTitle( 'Pickup locations', 1 ) ).toBe(
+			'Pickup location'
+		);
+	} );
+
+	it( 'keeps the plural default title when there are multiple pickup locations', () => {
+		expect( getPickupOptionsTitle( 'Pickup locations', 2 ) ).toBe(
+			'Pickup locations'
+		);
+	} );
+
+	it( 'keeps custom titles unchanged', () => {
+		expect( getPickupOptionsTitle( 'Collect from store', 1 ) ).toBe(
+			'Collect from store'
+		);
+	} );
+} );
 
 const testPackageData = generateShippingPackage( {
 	packageId: 0,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updated the string in the checkout pickup options block to show the string with the correct plural/singular form (when it is the default string)

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #65779

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1520" height="607" alt="image" src="https://github.com/user-attachments/assets/5fdc893f-d69c-428d-991f-d5c0b10cc423" /> |  <img width="1554" height="608" alt="image" src="https://github.com/user-attachments/assets/f207d8d0-57e6-4c2d-a62f-47313a04d46b" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

```bash
pnpm --filter=@woocommerce/block-library test:js -- assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
```

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Singularize pickup options title for one location

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
