### PR TITLE
Add resend action to the temporary-password My Account notice

### DIFF
--- a/plugins/woocommerce/changelog/add-resend-set-password-link
+++ b/plugins/woocommerce/changelog/add-resend-set-password-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a resend action to the temporary-password notice on My Account so customers can request a fresh change-password email.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -21,6 +21,7 @@ class WC_Form_Handler {
 	 */
 	public static function init() {
 		add_action( 'template_redirect', array( __CLASS__, 'redirect_reset_password_link' ) );
+		add_action( 'template_redirect', array( __CLASS__, 'resend_set_password' ) );
 		add_action( 'template_redirect', array( __CLASS__, 'save_address' ) );
 		add_action( 'template_redirect', array( __CLASS__, 'save_account_details' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'checkout_action' ), 20 );
@@ -74,6 +75,46 @@ class WC_Form_Handler {
 			);
 			exit;
 		}
+	}
+
+	/**
+	 * Resend the change-password link to a logged-in customer who still has a temporary password.
+	 *
+	 * Triggered by the temporary-password notice on the My Account pages. Generates a fresh
+	 * password-reset key for the current user and dispatches the reset-password email, mirroring
+	 * the lost-password flow but for the already-authenticated user.
+	 *
+	 * @since 11.0.0
+	 */
+	public static function resend_set_password(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['wc-resend-set-password'] ) || ! is_user_logged_in() ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$nonce_value = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $nonce_value, 'wc-resend-set-password' ) ) {
+			return;
+		}
+
+		$user     = wp_get_current_user();
+		$key      = get_password_reset_key( $user );
+		$redirect = wc_get_page_permalink( 'myaccount' );
+
+		if ( is_wp_error( $key ) ) {
+			wc_add_notice( __( 'Sorry, we were unable to resend the link. Please try again.', 'woocommerce' ), 'error' );
+		} else {
+			// phpcs:ignore WooCommerce.Commenting.CommentHooks -- Re-fires woocommerce_reset_password_notification, documented in WC_Shortcode_My_Account::retrieve_password().
+			do_action( 'woocommerce_reset_password_notification', $user->user_login, $key );
+			wc_add_notice( __( 'We have emailed you a new link to change your password.', 'woocommerce' ) );
+			// Flag so the temporary-password notice is hidden on the redirect target — the confirmation above covers it.
+			$redirect = add_query_arg( 'password-link-sent', 'true', $redirect );
+		}
+
+		wp_safe_redirect( $redirect );
+		exit;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -106,7 +106,8 @@ class WC_Form_Handler {
 		if ( is_wp_error( $key ) ) {
 			wc_add_notice( __( 'Sorry, we were unable to resend the link. Please try again.', 'woocommerce' ), 'error' );
 		} else {
-			WC()->mailer(); // Load email classes so the reset-password notification has a listener.
+			// Load email classes so the reset-password notification has a listener.
+			WC()->mailer();
 			// phpcs:ignore WooCommerce.Commenting.CommentHooks -- Re-fires woocommerce_reset_password_notification, documented in WC_Shortcode_My_Account::retrieve_password().
 			do_action( 'woocommerce_reset_password_notification', $user->user_login, $key );
 			wc_add_notice( __( 'We have emailed you a new link to change your password.', 'woocommerce' ) );

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -106,6 +106,7 @@ class WC_Form_Handler {
 		if ( is_wp_error( $key ) ) {
 			wc_add_notice( __( 'Sorry, we were unable to resend the link. Please try again.', 'woocommerce' ), 'error' );
 		} else {
+			WC()->mailer(); // Load email classes so the reset-password notification has a listener.
 			// phpcs:ignore WooCommerce.Commenting.CommentHooks -- Re-fires woocommerce_reset_password_notification, documented in WC_Shortcode_My_Account::retrieve_password().
 			do_action( 'woocommerce_reset_password_notification', $user->user_login, $key );
 			wc_add_notice( __( 'We have emailed you a new link to change your password.', 'woocommerce' ) );

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -17,6 +17,16 @@ defined( 'ABSPATH' ) || exit;
 class WC_Form_Handler {
 
 	/**
+	 * User meta key tracking the last time the set-password link was resent. Used to rate-limit resends.
+	 */
+	const SET_PASSWORD_RESEND_META = '_wc_set_password_resend_at';
+
+	/**
+	 * Minimum seconds between back-to-back set-password resend requests.
+	 */
+	const SET_PASSWORD_RESEND_RATE_LIMIT_SECONDS = 60;
+
+	/**
 	 * Hook in methods.
 	 */
 	public static function init() {
@@ -100,19 +110,30 @@ class WC_Form_Handler {
 		}
 
 		$user     = wp_get_current_user();
-		$key      = get_password_reset_key( $user );
 		$redirect = wc_get_page_permalink( 'myaccount' );
+
+		// Rate-limit resends so the button can't be used to spam the customer's inbox.
+		$last_sent_at = (int) get_user_meta( $user->ID, self::SET_PASSWORD_RESEND_META, true );
+		if ( $last_sent_at > 0 && ( time() - $last_sent_at ) < self::SET_PASSWORD_RESEND_RATE_LIMIT_SECONDS ) {
+			wc_add_notice( __( 'Please wait a moment before requesting another link to change your password.', 'woocommerce' ), 'notice' );
+			wp_safe_redirect( $redirect );
+			exit;
+		}
+
+		$key = get_password_reset_key( $user );
 
 		if ( is_wp_error( $key ) ) {
 			wc_add_notice( __( 'Sorry, we were unable to resend the link. Please try again.', 'woocommerce' ), 'error' );
 		} else {
+			// Persist the rate-limit timestamp before dispatching so two near-simultaneous requests can't both pass.
+			// This timestamp also suppresses the temporary-password notice during the cooldown — see
+			// WC_Shortcode_My_Account::my_account_add_notices() — so the confirmation below isn't contradicted.
+			update_user_meta( $user->ID, self::SET_PASSWORD_RESEND_META, (string) time() );
 			// Load email classes so the reset-password notification has a listener.
 			WC()->mailer();
 			// phpcs:ignore WooCommerce.Commenting.CommentHooks -- Re-fires woocommerce_reset_password_notification, documented in WC_Shortcode_My_Account::retrieve_password().
 			do_action( 'woocommerce_reset_password_notification', $user->user_login, $key );
 			wc_add_notice( __( 'We have emailed you a new link to change your password.', 'woocommerce' ) );
-			// Flag so the temporary-password notice is hidden on the redirect target — the confirmation above covers it.
-			$redirect = add_query_arg( 'password-link-sent', 'true', $redirect );
 		}
 
 		wp_safe_redirect( $redirect );

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -90,10 +90,13 @@ class WC_Shortcode_My_Account {
 			wc_add_notice( sprintf( __( 'Are you sure you want to log out? <a href="%s">Confirm and log out</a>', 'woocommerce' ), wc_logout_url() ) );
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$password_link_just_sent = ! empty( $_GET['password-link-sent'] );
+		// Suppress the nag during the resend cooldown so it doesn't contradict the "we emailed you" confirmation.
+		// Driven off the same timestamp WC_Form_Handler::resend_set_password() writes, so the notice reappears
+		// once the cooldown lapses and the link can be requested again.
+		$last_resend_at  = (int) get_user_meta( get_current_user_id(), WC_Form_Handler::SET_PASSWORD_RESEND_META, true );
+		$within_cooldown = $last_resend_at > 0 && ( time() - $last_resend_at ) < WC_Form_Handler::SET_PASSWORD_RESEND_RATE_LIMIT_SECONDS;
 
-		if ( ! $password_link_just_sent && get_user_option( 'default_password_nag' ) && ( wc_is_current_account_menu_item( 'dashboard' ) || wc_is_current_account_menu_item( 'edit-account' ) || wc_is_current_account_menu_item( 'orders' ) ) ) {
+		if ( ! $within_cooldown && get_user_option( 'default_password_nag' ) && ( wc_is_current_account_menu_item( 'dashboard' ) || wc_is_current_account_menu_item( 'edit-account' ) ) ) {
 			$resend_url = wp_nonce_url( add_query_arg( 'wc-resend-set-password', '1', wc_get_page_permalink( 'myaccount' ) ), 'wc-resend-set-password' );
 			wc_add_notice(
 				sprintf(

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -384,6 +384,8 @@ class WC_Shortcode_My_Account {
 
 		wp_set_password( $new_pass, $user->ID );
 		update_user_meta( $user->ID, 'default_password_nag', false );
+		// The temporary-password notice is gone for good now, so drop its resend rate-limit timestamp.
+		delete_user_meta( $user->ID, WC_Form_Handler::SET_PASSWORD_RESEND_META );
 
 		/**
 		 * Fires after the user's password has been reset via WooCommerce.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -90,16 +90,19 @@ class WC_Shortcode_My_Account {
 			wc_add_notice( sprintf( __( 'Are you sure you want to log out? <a href="%s">Confirm and log out</a>', 'woocommerce' ), wc_logout_url() ) );
 		}
 
-		if ( get_user_option( 'default_password_nag' ) && ( wc_is_current_account_menu_item( 'dashboard' ) || wc_is_current_account_menu_item( 'edit-account' ) ) ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$password_link_just_sent = ! empty( $_GET['password-link-sent'] );
+
+		if ( ! $password_link_just_sent && get_user_option( 'default_password_nag' ) && ( wc_is_current_account_menu_item( 'dashboard' ) || wc_is_current_account_menu_item( 'edit-account' ) || wc_is_current_account_menu_item( 'orders' ) ) ) {
+			$resend_url = wp_nonce_url( add_query_arg( 'wc-resend-set-password', '1', wc_get_page_permalink( 'myaccount' ) ), 'wc-resend-set-password' );
 			wc_add_notice(
 				sprintf(
-					// translators: %s: site name.
-					__( 'Your account with %s is using a temporary password. We emailed you a link to change your password.', 'woocommerce' ),
-					esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
-				),
-				'notice',
-				array(),
-				true
+					/* translators: %1$s and %2$s are opening and closing anchor tags for the resend-link button. */
+					__( '%1$sResend%2$s', 'woocommerce' ),
+					'<a href="' . esc_url( $resend_url ) . '" class="button wc-forward">',
+					'</a>'
+				) . ' ' . __( 'Your account is using a temporary password. We emailed you a link to change your password.', 'woocommerce' ),
+				'notice'
 			);
 		}
 	}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -31666,12 +31666,6 @@ parameters:
 			path: includes/shortcodes/class-wc-shortcode-my-account.php
 
 		-
-			message: '#^Function wc_add_notice invoked with 4 parameters, 1\-3 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: includes/shortcodes/class-wc-shortcode-my-account.php
-
-		-
 			message: '#^Method WC_Shortcode_My_Account\:\:add_payment_method\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a customer account is created with an auto-generated password, My Account shows a notice telling them a link to set their own password was emailed. If that email is lost or the link expires, there's currently no way to get a fresh one without logging out and using "lost password".

This adds a **Resend** action to that temporary-password notice:

- The notice now renders a right-aligned **Resend** button alongside the existing copy, on the Dashboard, Edit Account and Orders pages.
- Clicking it generates a fresh password-reset key for the logged-in customer and re-sends the change-password email (mirroring the lost-password flow, nonce-protected).
- Right after a successful resend the notice is suppressed for that page load so the confirmation message isn't contradicted.

This is split out of #65789 as a standalone improvement; it does not depend on the email-verification work.

### How to test the changes in this Pull Request:

1. Create a customer account that uses an auto-generated password (e.g. place an order at checkout with "create an account" and no password field, or create the user in wp-admin without setting a password).
2. Log in as that customer and go to **My Account** — you should see the temporary-password notice with a **Resend** button.
3. Click **Resend** — you're returned to My Account with a "We have emailed you a new link to change your password" confirmation and the temporary-password notice is gone for that view.
4. Check Mailpit (or your mail catcher) — a fresh change-password email has arrived; the link sets a new password successfully.

### Testing that has already taken place:

- PHPStan and PHPCS clean on the changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added to the branch manually.

</details>
