### PR TITLE
Rework new-account and password-reset email content

### DIFF
--- a/plugins/woocommerce/changelog/add-customer-email-verification-order-linking
+++ b/plugins/woocommerce/changelog/add-customer-email-verification-order-linking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add customer email verification, letting shoppers securely link past guest orders to their account once they confirm ownership of their email address.

--- a/plugins/woocommerce/changelog/update-account-email-content
+++ b/plugins/woocommerce/changelog/update-account-email-content
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Refresh the new-account and password-reset email content, replacing the password with an email-confirmation call to action.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -41,6 +41,7 @@ use Automattic\WooCommerce\Caches\OrderCountCacheService;
 use Automattic\WooCommerce\Internal\Caches\ProductVersionStringInvalidator;
 use Automattic\WooCommerce\Internal\Caches\OrdersVersionStringInvalidator;
 use Automattic\WooCommerce\Internal\Caches\TaxRateVersionStringInvalidator;
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\CustomerEmailVerification;
 use Automattic\WooCommerce\Internal\StockNotifications\StockNotifications;
 use Automattic\Jetpack\Constants;
 
@@ -383,6 +384,7 @@ final class WooCommerce {
 		$container->get( OrdersVersionStringInvalidator::class );
 		$container->get( TaxRateVersionStringInvalidator::class );
 		$container->get( OrderMilestoneEasterEgg::class );
+		$container->get( CustomerEmailVerification::class );
 
 		// Feature flags.
 		if ( Constants::is_true( 'WOOCOMMERCE_BIS_ALPHA_ENABLED' ) ) {

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
@@ -5,9 +5,9 @@
  * @package WooCommerce\Emails
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\EmailVerificationService;
 
 if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 
@@ -64,6 +64,13 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 		 * @var string
 		 */
 		public $user_display_name;
+
+		/**
+		 * Email verification URL.
+		 *
+		 * @var string
+		 */
+		public $verify_url;
 
 		/**
 		 * Constructor.
@@ -126,6 +133,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 				$this->recipient          = $this->user_email;
 				$this->user_pass          = $user_pass;
 				$this->password_generated = $password_generated;
+				$this->verify_url         = wc_get_container()->get( EmailVerificationService::class )->build_verification_url( $user_id );
 			}
 
 			$this->send_notification();
@@ -136,6 +144,8 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 		/**
 		 * Get content html.
 		 *
+		 * Note: Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+		 *
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -145,6 +155,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'email_heading'      => $this->get_heading(),
 					'additional_content' => $this->get_additional_content(),
 					'user_login'         => $this->user_login,
+					'user_email'         => $this->user_email,
 					'user_display_name'  => $this->user_display_name,
 					'blogname'           => $this->get_blogname(),
 					'set_password_url'   => $this->set_password_url,
@@ -152,7 +163,8 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'plain_text'         => false,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					'user_pass'          => $this->user_pass,
+					'verify_url'         => $this->verify_url,
 				)
 			);
 		}
@@ -169,6 +181,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'email_heading'      => $this->get_heading(),
 					'additional_content' => $this->get_additional_content(),
 					'user_login'         => $this->user_login,
+					'user_email'         => $this->user_email,
 					'user_display_name'  => $this->user_display_name,
 					'blogname'           => $this->get_blogname(),
 					'set_password_url'   => $this->set_password_url,
@@ -176,7 +189,8 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'plain_text'         => true,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					'user_pass'          => $this->user_pass,
+					'verify_url'         => $this->verify_url,
 				)
 			);
 		}
@@ -192,12 +206,14 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 				array(
 					'user_login'         => $this->user_login,
 					'user_display_name'  => $this->user_display_name,
+					'user_email'         => $this->user_email,
 					'set_password_url'   => $this->set_password_url,
 					'sent_to_admin'      => false,
 					'plain_text'         => false,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					'user_pass'          => $this->user_pass,
+					'verify_url'         => $this->verify_url,
 				)
 			);
 		}

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
@@ -161,7 +161,8 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'plain_text'         => false,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					// Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					'user_pass'          => $this->user_pass,
 					'verify_url'         => $this->verify_url,
 				)
 			);
@@ -187,7 +188,8 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'plain_text'         => true,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					// Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					'user_pass'          => $this->user_pass,
 					'verify_url'         => $this->verify_url,
 				)
 			);
@@ -210,7 +212,8 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'plain_text'         => false,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					// Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
+					'user_pass'          => $this->user_pass,
 					'verify_url'         => $this->verify_url,
 				)
 			);

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
@@ -144,8 +144,6 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 		/**
 		 * Get content html.
 		 *
-		 * Note: Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
-		 *
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -163,7 +161,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'plain_text'         => false,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass,
+					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
 					'verify_url'         => $this->verify_url,
 				)
 			);
@@ -189,7 +187,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'plain_text'         => true,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass,
+					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
 					'verify_url'         => $this->verify_url,
 				)
 			);
@@ -212,7 +210,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) {
 					'plain_text'         => false,
 					'email'              => $this,
 					'password_generated' => $this->password_generated,
-					'user_pass'          => $this->user_pass,
+					'user_pass'          => $this->user_pass, // Password is no longer used in the template, but we're keeping it here for backwards compatibility with custom templates.
 					'verify_url'         => $this->verify_url,
 				)
 			);

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-reset-password.php
@@ -6,7 +6,8 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	// Exit if accessed directly.
+	exit;
 }
 
 if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
@@ -57,6 +58,13 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @var string
 		 */
 		public $user_display_name;
+
+		/**
+		 * Reset password URL.
+		 *
+		 * @var string
+		 */
+		public $reset_url;
 
 		/**
 		 * Constructor.
@@ -131,6 +139,14 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 				$this->reset_key         = $reset_key;
 				$this->user_email        = stripslashes( $this->object->user_email );
 				$this->recipient         = $this->user_email;
+				$this->reset_url         = add_query_arg(
+					array(
+						'key'   => $this->reset_key,
+						'id'    => $this->user_id,
+						'login' => rawurlencode( $this->user_login ),
+					),
+					wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) )
+				);
 				$customer                = new WC_Customer( $this->object->ID );
 				$first_name              = ! empty( $customer->get_billing_first_name() ) ? $customer->get_billing_first_name() : $this->object->first_name;
 				$this->user_display_name = ! empty( $first_name ) ? $first_name : $this->user_login;
@@ -155,6 +171,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 					'user_login'         => $this->user_login,
 					'user_display_name'  => $this->user_display_name,
 					'reset_key'          => $this->reset_key,
+					'reset_url'          => $this->reset_url,
 					'blogname'           => $this->get_blogname(),
 					'additional_content' => $this->get_additional_content(),
 					'sent_to_admin'      => false,
@@ -178,6 +195,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 					'user_login'         => $this->user_login,
 					'user_display_name'  => $this->user_display_name,
 					'reset_key'          => $this->reset_key,
+					'reset_url'          => $this->reset_url,
 					'blogname'           => $this->get_blogname(),
 					'additional_content' => $this->get_additional_content(),
 					'sent_to_admin'      => false,
@@ -201,6 +219,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 					'user_login'        => $this->user_login,
 					'user_display_name' => $this->user_display_name,
 					'reset_key'         => $this->reset_key,
+					'reset_url'         => $this->reset_url,
 					'sent_to_admin'     => false,
 					'plain_text'        => false,
 					'email'             => $this,

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -326,9 +326,14 @@ function wc_set_customer_auth_cookie( $customer_id ) {
  * @return int
  */
 function wc_update_new_customer_past_orders( $customer_id ) {
+	$customer = get_user_by( 'id', absint( $customer_id ) );
+
+	if ( ! $customer ) {
+		return 0;
+	}
+
 	$linked          = 0;
 	$complete        = 0;
-	$customer        = get_user_by( 'id', absint( $customer_id ) );
 	$customer_orders = wc_get_orders(
 		array(
 			'limit'    => -1,

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -36370,18 +36370,6 @@ parameters:
 			path: includes/wc-user-functions.php
 
 		-
-			message: '#^Cannot access property \$ID on WP_User\|false\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: includes/wc-user-functions.php
-
-		-
-			message: '#^Cannot access property \$user_email on WP_User\|false\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: includes/wc-user-functions.php
-
-		-
 			message: '#^Cannot call method get_customer_id\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
 			identifier: method.nonObject
 			count: 1

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -31,6 +31,7 @@ class EmailPreview {
 	const USER_OBJECT_EMAILS = array(
 		'WC_Email_Customer_New_Account',
 		'WC_Email_Customer_Reset_Password',
+		'Automattic\WooCommerce\Internal\CustomerEmailVerification\Emails\CustomerVerifyEmail',
 	);
 
 	const TRANSIENT_PREVIEW_EMAIL_IMPROVEMENTS = 'woocommerce_preview_email_improvements';
@@ -201,6 +202,10 @@ class EmailPreview {
 			$this->email->user_email = $object->user_email;
 			$this->email->user_login = $object->user_login;
 
+			if ( property_exists( $this->email, 'user_display_name' ) ) {
+				$this->email->user_display_name = $object->first_name;
+			}
+
 			if ( property_exists( $this->email, 'reset_key' ) ) {
 				$this->email->reset_key = 'reset_key';
 			}
@@ -211,6 +216,10 @@ class EmailPreview {
 
 			if ( property_exists( $this->email, 'user_id' ) ) {
 				$this->email->user_id = 0;
+			}
+
+			if ( property_exists( $this->email, 'verify_url' ) ) {
+				$this->email->verify_url = 'https://example.com/verify-email';
 			}
 
 			$this->email->set_object( $object );

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -210,6 +210,10 @@ class EmailPreview {
 				$this->email->reset_key = 'reset_key';
 			}
 
+			if ( property_exists( $this->email, 'reset_url' ) ) {
+				$this->email->reset_url = 'https://example.com/reset-password';
+			}
+
 			if ( property_exists( $this->email, 'set_password_url' ) ) {
 				$this->email->set_password_url = 'https://example.com/set-password';
 			}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/CustomerEmailVerification.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/CustomerEmailVerification.php
@@ -1,0 +1,54 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\CustomerEmailVerification;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\Emails\CustomerVerifyEmail;
+
+/**
+ * Boot class for the customer email verification subsystem.
+ *
+ * Resolves each controller so that their constructors register hooks during the
+ * plugins_loaded action.
+ *
+ * @since 11.0.0
+ */
+class CustomerEmailVerification {
+
+	/**
+	 * Initialize the subsystem.
+	 *
+	 * @since 11.0.0
+	 */
+	public function __construct() {
+		add_action( 'plugins_loaded', array( $this, 'init_hooks' ) );
+	}
+
+	/**
+	 * Resolve all subsystem controllers so their constructors register hooks.
+	 *
+	 * @internal
+	 * @since 11.0.0
+	 */
+	public function init_hooks(): void {
+		add_filter( 'woocommerce_email_classes', array( $this, 'register_email_classes' ) );
+
+		$container = wc_get_container();
+		$container->get( VerificationController::class );
+		$container->get( OrderLinker::class );
+		$container->get( VerificationEventListener::class );
+	}
+
+	/**
+	 * Register the customer email verification email with WooCommerce.
+	 *
+	 * @internal
+	 *
+	 * @param array $emails Registered email classes.
+	 * @return array
+	 */
+	public function register_email_classes( array $emails ): array {
+		$emails['WC_Email_Customer_Verify_Email'] = new CustomerVerifyEmail();
+		return $emails;
+	}
+}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
@@ -1,0 +1,214 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\CustomerEmailVerification;
+
+use Automattic\WooCommerce\Internal\Utilities\Users;
+
+/**
+ * Service class providing the foundational primitives for customer email verification.
+ *
+ * This class is the single source of truth for whether a customer has proven they
+ * control their account email address. It manages the verified status meta, the
+ * expiring verification token used in emailed verify-links, and provides helper
+ * methods consumed by the rest of the email-verification feature.
+ *
+ * @since 11.0.0
+ */
+class EmailVerificationService {
+
+	/**
+	 * User meta key that stores the verified email address (lower-cased).
+	 * The customer is considered verified only while this matches their current account email.
+	 */
+	private const VERIFIED_META = '_wc_email_verified';
+
+	/**
+	 * User meta key that stores the verification token as "{timestamp}:{wp_fast_hash}".
+	 */
+	private const KEY_META = '_wc_email_verification_key';
+
+	/**
+	 * Return whether the given user has verified their current account email address.
+	 *
+	 * A user is verified only while the stored verified email matches their current
+	 * account email, so changing the account email automatically invalidates the
+	 * status — no change event needs to be observed.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return bool True when the stored verified email matches the user's current email.
+	 */
+	public function is_verified( int $user_id ): bool {
+		$verified_email = (string) Users::get_site_user_meta( $user_id, self::VERIFIED_META );
+
+		if ( '' === $verified_email ) {
+			return false;
+		}
+
+		$user = get_user_by( 'id', $user_id );
+
+		return $user instanceof \WP_User && 0 === strcasecmp( $verified_email, $user->user_email );
+	}
+
+	/**
+	 * Mark the given user as having verified their current account email address.
+	 *
+	 * Stores the verified email address, clears the pending verification key, and
+	 * fires the {@see 'woocommerce_customer_email_verified'} action. No-ops if the
+	 * user is already verified for their current email.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return void
+	 */
+	public function mark_verified( int $user_id ): void {
+		if ( $this->is_verified( $user_id ) ) {
+			return;
+		}
+
+		$user = get_user_by( 'id', $user_id );
+
+		if ( ! $user instanceof \WP_User ) {
+			return;
+		}
+
+		// Store the verified email (lower-cased) so the status self-invalidates if the account email later changes.
+		Users::update_site_user_meta( $user_id, self::VERIFIED_META, strtolower( $user->user_email ) );
+		Users::delete_site_user_meta( $user_id, self::KEY_META );
+
+		/**
+		 * Fires after a customer has verified their email address.
+		 *
+		 * @param int $user_id The WordPress user ID of the verified customer.
+		 *
+		 * @since 11.0.0
+		 */
+		do_action( 'woocommerce_customer_email_verified', $user_id );
+	}
+
+	/**
+	 * Clear the email-verification status for the given user.
+	 *
+	 * Removes both the verified-timestamp meta and any pending verification key,
+	 * effectively resetting the user to an unverified state.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return void
+	 */
+	public function clear_verification( int $user_id ): void {
+		Users::delete_site_user_meta( $user_id, self::VERIFIED_META );
+		Users::delete_site_user_meta( $user_id, self::KEY_META );
+	}
+
+	/**
+	 * Generate and store a one-time email-verification key for the given user.
+	 *
+	 * The plaintext key is returned for inclusion in the verification email link.
+	 * The stored value is a "{timestamp}:{wp_fast_hash}" pair so the plaintext is
+	 * never persisted and the token expires after DAY_IN_SECONDS.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return string The plaintext verification key.
+	 */
+	public function create_verification_key( int $user_id ): string {
+		$key = wp_generate_password( 20, false );
+		Users::update_site_user_meta( $user_id, self::KEY_META, time() . ':' . wp_fast_hash( $key ) );
+		return $key;
+	}
+
+	/**
+	 * Build a one-time email-verification URL for the given user.
+	 *
+	 * Mints a fresh verification key and returns the My Account URL carrying that key and the
+	 * user ID as query args, ready to drop into an email. The matching reader is
+	 * {@see VerificationController::maybe_process_request()}.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return string The verification URL.
+	 */
+	public function build_verification_url( int $user_id ): string {
+		return add_query_arg(
+			array(
+				'wc_verify_email_key'  => $this->create_verification_key( $user_id ),
+				'wc_verify_email_user' => $user_id,
+			),
+			wc_get_page_permalink( 'myaccount' )
+		);
+	}
+
+	/**
+	 * Validate a plaintext verification key against the stored hash for the given user.
+	 *
+	 * Returns false if no token is stored, if the token has expired, or if the key
+	 * does not match the stored hash.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int    $user_id WordPress user ID.
+	 * @param string $key     The plaintext verification key to check.
+	 * @return bool True when the key is valid and has not expired.
+	 */
+	public function check_verification_key( int $user_id, string $key ): bool {
+		$parsed = $this->parse_stored_key( $user_id );
+
+		if ( null === $parsed ) {
+			return false;
+		}
+
+		list( $timestamp, $hash ) = $parsed;
+
+		if ( time() - $timestamp > DAY_IN_SECONDS ) {
+			return false;
+		}
+
+		return wp_verify_fast_hash( $key, $hash );
+	}
+
+	/**
+	 * Parse the stored verification token into its timestamp and hash parts.
+	 *
+	 * The token is persisted as "{timestamp}:{wp_fast_hash}"; this is the single place
+	 * that knows that format.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return array{0: int, 1: string}|null The [timestamp, hash] pair, or null when no token is stored.
+	 */
+	private function parse_stored_key( int $user_id ): ?array {
+		$stored = (string) Users::get_site_user_meta( $user_id, self::KEY_META );
+
+		if ( ! str_contains( $stored, ':' ) ) {
+			return null;
+		}
+
+		list( $timestamp, $hash ) = explode( ':', $stored, 2 );
+
+		return array( (int) $timestamp, $hash );
+	}
+
+	/**
+	 * Return the number of seconds elapsed since the last verification key was issued, or null if no key exists.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return int|null Seconds since the last key was created, or null when no key is stored.
+	 */
+	public function seconds_since_last_key( int $user_id ): ?int {
+		$parsed = $this->parse_stored_key( $user_id );
+
+		if ( null === $parsed ) {
+			return null;
+		}
+
+		return time() - $parsed[0];
+	}
+}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
@@ -24,7 +24,7 @@ class EmailVerificationService {
 	private const VERIFIED_META = '_wc_email_verified';
 
 	/**
-	 * User meta key that stores the verification token as "{timestamp}:{wp_fast_hash}".
+	 * User meta key that stores the verification token as "{timestamp}:{key_hash}:{email_hash}".
 	 */
 	private const KEY_META = '_wc_email_verification_key';
 
@@ -109,8 +109,10 @@ class EmailVerificationService {
 	 * Generate and store a one-time email-verification key for the given user.
 	 *
 	 * The plaintext key is returned for inclusion in the verification email link.
-	 * The stored value is a "{timestamp}:{wp_fast_hash}" pair so the plaintext is
-	 * never persisted and the token expires after DAY_IN_SECONDS.
+	 * The stored value is a "{timestamp}:{key_hash}:{email_hash}" triplet so the plaintext
+	 * is never persisted and the token expires after DAY_IN_SECONDS. The email hash binds
+	 * the token to the account email in effect at issuance, so a key emailed to one address
+	 * can never verify a different address the account is later switched to.
 	 *
 	 * @since 11.0.0
 	 *
@@ -118,8 +120,11 @@ class EmailVerificationService {
 	 * @return string The plaintext verification key.
 	 */
 	public function create_verification_key( int $user_id ): string {
-		$key = wp_generate_password( 20, false );
-		Users::update_site_user_meta( $user_id, self::KEY_META, time() . ':' . wp_fast_hash( $key ) );
+		$key        = wp_generate_password( 20, false );
+		$user       = get_user_by( 'id', $user_id );
+		$email_hash = $user instanceof \WP_User ? wp_fast_hash( strtolower( $user->user_email ) ) : '';
+
+		Users::update_site_user_meta( $user_id, self::KEY_META, time() . ':' . wp_fast_hash( $key ) . ':' . $email_hash );
 		return $key;
 	}
 
@@ -148,8 +153,8 @@ class EmailVerificationService {
 	/**
 	 * Validate a plaintext verification key against the stored hash for the given user.
 	 *
-	 * Returns false if no token is stored, if the token has expired, or if the key
-	 * does not match the stored hash.
+	 * Returns false if no token is stored, if the token has expired, if the account email
+	 * has changed since the token was issued, or if the key does not match the stored hash.
 	 *
 	 * @since 11.0.0
 	 *
@@ -164,10 +169,21 @@ class EmailVerificationService {
 			return false;
 		}
 
-		list( $timestamp, $hash ) = $parsed;
+		list( $timestamp, $hash, $email_hash ) = $parsed;
 
 		if ( time() - $timestamp > DAY_IN_SECONDS ) {
 			return false;
+		}
+
+		// Tokens issued after email-binding was added carry the email they were minted for. Reject
+		// the token if the account email has since changed, so a key emailed to one address can't be
+		// used to verify a different address. Legacy tokens (empty hash) skip this check.
+		if ( '' !== $email_hash ) {
+			$user = get_user_by( 'id', $user_id );
+
+			if ( ! $user instanceof \WP_User || ! wp_verify_fast_hash( strtolower( $user->user_email ), $email_hash ) ) {
+				return false;
+			}
 		}
 
 		return wp_verify_fast_hash( $key, $hash );
@@ -176,11 +192,12 @@ class EmailVerificationService {
 	/**
 	 * Parse the stored verification token into its timestamp and hash parts.
 	 *
-	 * The token is persisted as "{timestamp}:{wp_fast_hash}"; this is the single place
-	 * that knows that format.
+	 * The token is persisted as "{timestamp}:{key_hash}:{email_hash}"; this is the single place
+	 * that knows that format. The email hash is absent on legacy tokens minted before email
+	 * binding was added, in which case it is returned as an empty string.
 	 *
 	 * @param int $user_id WordPress user ID.
-	 * @return array{0: int, 1: string}|null The [timestamp, hash] pair, or null when no token is stored.
+	 * @return array{0: int, 1: string, 2: string}|null The [timestamp, key_hash, email_hash] triplet, or null when no valid token is stored.
 	 */
 	private function parse_stored_key( int $user_id ): ?array {
 		$stored = (string) Users::get_site_user_meta( $user_id, self::KEY_META );
@@ -189,9 +206,16 @@ class EmailVerificationService {
 			return null;
 		}
 
-		list( $timestamp, $hash ) = explode( ':', $stored, 2 );
+		$parts      = explode( ':', $stored, 3 );
+		$timestamp  = (int) ( $parts[0] ?? 0 );
+		$hash       = (string) ( $parts[1] ?? '' );
+		$email_hash = (string) ( $parts[2] ?? '' );
 
-		return array( (int) $timestamp, $hash );
+		if ( '' === $hash ) {
+			return null;
+		}
+
+		return array( $timestamp, $hash, $email_hash );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
@@ -209,6 +209,8 @@ class EmailVerificationService {
 			return null;
 		}
 
-		return time() - $parsed[0];
+		// Clamp to zero so a future timestamp (clock skew, migrations) can't report negative
+		// elapsed time and wedge the resend rate-limit / "recently sent" notice logic.
+		return max( 0, time() - $parsed[0] );
 	}
 }

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
@@ -92,7 +92,7 @@ class EmailVerificationService {
 	/**
 	 * Clear the email-verification status for the given user.
 	 *
-	 * Removes both the verified-timestamp meta and any pending verification key,
+	 * Removes both the verified-email meta and any pending verification key,
 	 * effectively resetting the user to an unverified state.
 	 *
 	 * @since 11.0.0

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
@@ -37,14 +37,13 @@ class CustomerVerifyEmail extends WC_Email {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->id                     = 'customer_verify_email';
-		$this->customer_email         = true;
-		$this->title                  = __( 'Confirm email address', 'woocommerce' );
-		$this->description            = __( 'Sent to customers with a link to confirm they own their account email address.', 'woocommerce' );
-		$this->template_html          = 'emails/customer-verify-email.php';
-		$this->template_plain         = 'emails/plain/customer-verify-email.php';
-		$this->template_block_content = 'emails/block/customer-verify-email.php';
-		$this->email_group            = 'accounts';
+		$this->id             = 'customer_verify_email';
+		$this->customer_email = true;
+		$this->title          = __( 'Confirm email address', 'woocommerce' );
+		$this->description    = __( 'Sent to customers with a link to confirm they own their account email address.', 'woocommerce' );
+		$this->template_html  = 'emails/customer-verify-email.php';
+		$this->template_plain = 'emails/plain/customer-verify-email.php';
+		$this->email_group    = 'accounts';
 
 		// Trigger.
 		add_action( 'woocommerce_customer_verify_email_notification', array( $this, 'trigger' ), 10, 2 );

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
@@ -37,13 +37,14 @@ class CustomerVerifyEmail extends WC_Email {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->id             = 'customer_verify_email';
-		$this->customer_email = true;
-		$this->title          = __( 'Confirm email address', 'woocommerce' );
-		$this->description    = __( 'Sent to customers with a link to confirm they own their account email address.', 'woocommerce' );
-		$this->template_html  = 'emails/customer-verify-email.php';
-		$this->template_plain = 'emails/plain/customer-verify-email.php';
-		$this->email_group    = 'accounts';
+		$this->id                     = 'customer_verify_email';
+		$this->customer_email         = true;
+		$this->title                  = __( 'Confirm email address', 'woocommerce' );
+		$this->description            = __( 'Sent to customers with a link to confirm they own their account email address.', 'woocommerce' );
+		$this->template_html          = 'emails/customer-verify-email.php';
+		$this->template_plain         = 'emails/plain/customer-verify-email.php';
+		$this->template_block_content = 'emails/block/customer-verify-email.php';
+		$this->email_group            = 'accounts';
 
 		// Trigger.
 		add_action( 'woocommerce_customer_verify_email_notification', array( $this, 'trigger' ), 10, 2 );

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
@@ -96,9 +96,9 @@ class CustomerVerifyEmail extends WC_Email {
 			$customer                = new WC_Customer( $user_id );
 			$first_name              = ! empty( $customer->get_billing_first_name() ) ? $customer->get_billing_first_name() : $this->object->first_name;
 			$this->user_display_name = ! empty( $first_name ) ? $first_name : $this->object->user_login;
-		}
 
-		$this->send_notification();
+			$this->send_notification();
+		}
 
 		$this->restore_locale();
 	}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
@@ -1,0 +1,168 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\CustomerEmailVerification\Emails;
+
+use WC_Customer;
+use WC_Email;
+use WP_User;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Customer email verification email.
+ *
+ * Sent to a customer with a link to confirm they own their account email address.
+ *
+ * @since 11.0.0
+ */
+class CustomerVerifyEmail extends WC_Email {
+
+	/**
+	 * Verification link included in the email.
+	 *
+	 * @var string
+	 */
+	public $verify_url;
+
+	/**
+	 * Display name used to greet the customer.
+	 *
+	 * @var string
+	 */
+	public $user_display_name;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->id             = 'customer_verify_email';
+		$this->customer_email = true;
+		$this->title          = __( 'Confirm email address', 'woocommerce' );
+		$this->description    = __( 'Sent to customers with a link to confirm they own their account email address.', 'woocommerce' );
+		$this->template_html  = 'emails/customer-verify-email.php';
+		$this->template_plain = 'emails/plain/customer-verify-email.php';
+		$this->email_group    = 'accounts';
+
+		// Trigger.
+		add_action( 'woocommerce_customer_verify_email_notification', array( $this, 'trigger' ), 10, 2 );
+
+		// Call parent constructor.
+		parent::__construct();
+	}
+
+	/**
+	 * Get email subject.
+	 *
+	 * @return string
+	 */
+	public function get_default_subject() {
+		return __( 'Confirm your email address for {site_title}', 'woocommerce' );
+	}
+
+	/**
+	 * Get email heading.
+	 *
+	 * @return string
+	 */
+	public function get_default_heading() {
+		return __( 'Confirm your email address', 'woocommerce' );
+	}
+
+	/**
+	 * Default content to show below the main email content.
+	 *
+	 * @return string
+	 */
+	public function get_default_additional_content() {
+		return __( 'Thanks for reading.', 'woocommerce' );
+	}
+
+	/**
+	 * Trigger the sending of this email.
+	 *
+	 * @param int    $user_id    The user ID to send the email to.
+	 * @param string $verify_url The verification link.
+	 * @return void
+	 */
+	public function trigger( $user_id, $verify_url = '' ) {
+		$this->setup_locale();
+
+		if ( $user_id && $verify_url ) {
+			$this->object            = new WP_User( $user_id );
+			$this->verify_url        = $verify_url;
+			$this->recipient         = wp_unslash( $this->object->user_email );
+			$customer                = new WC_Customer( $user_id );
+			$first_name              = ! empty( $customer->get_billing_first_name() ) ? $customer->get_billing_first_name() : $this->object->first_name;
+			$this->user_display_name = ! empty( $first_name ) ? $first_name : $this->object->user_login;
+		}
+
+		$this->send_notification();
+
+		$this->restore_locale();
+	}
+
+	/**
+	 * Get content html.
+	 *
+	 * @return string
+	 */
+	public function get_content_html() {
+		return wc_get_template_html(
+			$this->template_html,
+			array(
+				'email_heading'      => $this->get_heading(),
+				'additional_content' => $this->get_additional_content(),
+				'user_display_name'  => $this->user_display_name,
+				'user_email'         => $this->object instanceof WP_User ? $this->object->user_email : '',
+				'verify_url'         => $this->verify_url,
+				'blogname'           => $this->get_blogname(),
+				'sent_to_admin'      => false,
+				'plain_text'         => false,
+				'email'              => $this,
+			)
+		);
+	}
+
+	/**
+	 * Get content plain.
+	 *
+	 * @return string
+	 */
+	public function get_content_plain() {
+		return wc_get_template_html(
+			$this->template_plain,
+			array(
+				'email_heading'      => $this->get_heading(),
+				'additional_content' => $this->get_additional_content(),
+				'user_display_name'  => $this->user_display_name,
+				'user_email'         => $this->object instanceof WP_User ? $this->object->user_email : '',
+				'verify_url'         => $this->verify_url,
+				'blogname'           => $this->get_blogname(),
+				'sent_to_admin'      => false,
+				'plain_text'         => true,
+				'email'              => $this,
+			)
+		);
+	}
+
+	/**
+	 * Get the content rendered into the block email editor's WooCommerce content placeholder.
+	 *
+	 * @return string
+	 */
+	public function get_block_editor_email_template_content() {
+		return wc_get_template_html(
+			$this->template_block_content,
+			array(
+				'user_display_name' => $this->user_display_name,
+				'user_email'        => $this->object instanceof WP_User ? $this->object->user_email : '',
+				'verify_url'        => $this->verify_url,
+				'sent_to_admin'     => false,
+				'plain_text'        => false,
+				'email'             => $this,
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmail.php
@@ -34,6 +34,20 @@ class CustomerVerifyEmail extends WC_Email {
 	public $user_display_name;
 
 	/**
+	 * Customer email address. Populated by the email preview ({@see EmailPreview}) for the editor.
+	 *
+	 * @var string
+	 */
+	public $user_email;
+
+	/**
+	 * Customer login. Populated by the email preview ({@see EmailPreview}) for the editor.
+	 *
+	 * @var string
+	 */
+	public $user_login;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/OrderLinker.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/OrderLinker.php
@@ -17,7 +17,13 @@ class OrderLinker {
 	 */
 	public function __construct() {
 		// wc_update_new_customer_past_orders() already no-ops on an invalid/guest user ID.
-		add_action( 'woocommerce_customer_email_verified', 'wc_update_new_customer_past_orders' );
+		// Wrapped in a void closure because the function returns a count that an action callback must not return.
+		add_action(
+			'woocommerce_customer_email_verified',
+			static function ( int $user_id ): void {
+				wc_update_new_customer_past_orders( $user_id );
+			}
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/OrderLinker.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/OrderLinker.php
@@ -16,21 +16,8 @@ class OrderLinker {
 	 * Constructor. Registers hooks.
 	 */
 	public function __construct() {
-		add_action( 'woocommerce_customer_email_verified', array( $this, 'link_past_orders' ) );
-	}
-
-	/**
-	 * Link the verified customer's matching guest orders to their account.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param int $user_id The verified user's ID.
-	 */
-	public function link_past_orders( int $user_id ): void {
-		// ponytail: link inline; re-add an Action Scheduler job if a store with thousands of guest orders times out here.
-		if ( get_user_by( 'id', $user_id ) ) {
-			wc_update_new_customer_past_orders( $user_id );
-		}
+		// wc_update_new_customer_past_orders() already no-ops on an invalid/guest user ID.
+		add_action( 'woocommerce_customer_email_verified', 'wc_update_new_customer_past_orders' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/OrderLinker.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/OrderLinker.php
@@ -17,11 +17,13 @@ class OrderLinker {
 	 */
 	public function __construct() {
 		// wc_update_new_customer_past_orders() already no-ops on an invalid/guest user ID.
-		// Wrapped in a void closure because the function returns a count that an action callback must not return.
+		// Wrapped in a void closure because the function returns a count that an action callback must not
+		// return. The argument is left untyped and cast here: under strict_types a third party firing this
+		// hook with a numeric string would otherwise throw a TypeError.
 		add_action(
 			'woocommerce_customer_email_verified',
-			static function ( int $user_id ): void {
-				wc_update_new_customer_past_orders( $user_id );
+			static function ( $user_id ): void {
+				wc_update_new_customer_past_orders( absint( $user_id ) );
 			}
 		);
 	}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/OrderLinker.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/OrderLinker.php
@@ -1,0 +1,60 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\CustomerEmailVerification;
+
+/**
+ * Links a verified customer's matching guest orders to their account.
+ *
+ * Listens for the email-verified event and reuses wc_update_new_customer_past_orders().
+ *
+ * @since 11.0.0
+ */
+class OrderLinker {
+
+	/**
+	 * Constructor. Registers hooks.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_customer_email_verified', array( $this, 'link_past_orders' ) );
+	}
+
+	/**
+	 * Link the verified customer's matching guest orders to their account.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id The verified user's ID.
+	 */
+	public function link_past_orders( int $user_id ): void {
+		// ponytail: link inline; re-add an Action Scheduler job if a store with thousands of guest orders times out here.
+		if ( get_user_by( 'id', $user_id ) ) {
+			wc_update_new_customer_past_orders( $user_id );
+		}
+	}
+
+	/**
+	 * Whether the user has at least one guest order that could be linked on verification.
+	 *
+	 * Deliberately checks existence only (a single row, no details) so it is cheap to call
+	 * on page load and discloses nothing beyond "there is something to link".
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id The user ID to check.
+	 * @return bool
+	 */
+	public function has_linkable_orders( int $user_id ): bool {
+		$user = get_user_by( 'id', $user_id );
+
+		return $user && ! empty(
+			wc_get_orders(
+				array(
+					'limit'    => 1,
+					'customer' => array( array( 0, $user->user_email ) ),
+					'return'   => 'ids',
+				)
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -1,0 +1,244 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\CustomerEmailVerification;
+
+/**
+ * Processes email-verification links and sends/resends verification emails.
+ *
+ * @since 11.0.0
+ */
+class VerificationController {
+
+	/**
+	 * Nonce action used to protect the send-verification request.
+	 */
+	private const SEND_NONCE_ACTION = 'woocommerce-send-verification-email';
+
+	/**
+	 * Query param used to trigger the send-verification request.
+	 */
+	private const SEND_PARAM = 'wc_send_verification';
+
+	/**
+	 * Minimum seconds between resend attempts (rate limit).
+	 */
+	private const SEND_RATE_LIMIT = 60;
+
+	/**
+	 * Verification service.
+	 *
+	 * @var EmailVerificationService
+	 */
+	private $service;
+
+	/**
+	 * Order linker, used to detect whether there are guest orders worth verifying for.
+	 *
+	 * @var OrderLinker
+	 */
+	private $order_linker;
+
+	/**
+	 * Constructor. Registers hooks.
+	 */
+	public function __construct() {
+		add_action( 'template_redirect', array( $this, 'maybe_process_request' ) );
+		// Priority 1 so the notice is queued before woocommerce_output_all_notices() prints it (priority 5).
+		add_action( 'woocommerce_account_content', array( $this, 'maybe_add_orders_notice' ), 1 );
+	}
+
+	/**
+	 * Inject dependencies.
+	 *
+	 * @internal
+	 * @param EmailVerificationService $service      Verification service.
+	 * @param OrderLinker              $order_linker Order linker.
+	 */
+	final public function init( EmailVerificationService $service, OrderLinker $order_linker ): void {
+		$this->service      = $service;
+		$this->order_linker = $order_linker;
+	}
+
+	/**
+	 * Read the verify-link query args from the current request and process them.
+	 */
+	public function maybe_process_request(): void {
+		if ( isset( $_GET[ self::SEND_PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$this->handle_send_request();
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['wc_verify_email_key'], $_GET['wc_verify_email_user'] ) ) {
+			return;
+		}
+		$key     = sanitize_text_field( wp_unslash( $_GET['wc_verify_email_key'] ) );
+		$user_id = absint( wp_unslash( $_GET['wc_verify_email_user'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( $this->process_verification( $user_id, $key ) ) {
+			if ( get_current_user_id() !== $user_id ) {
+				wc_set_customer_auth_cookie( $user_id );
+			}
+			wc_add_notice( __( 'Your email address has been confirmed.', 'woocommerce' ) );
+		} else {
+			wc_add_notice( __( 'This confirmation link is invalid or has expired. Please request a new one.', 'woocommerce' ), 'error' );
+		}
+
+		wp_safe_redirect( wc_get_page_permalink( 'myaccount' ) );
+		exit;
+	}
+
+	/**
+	 * Handle a request to send (or resend) the verification email, triggered by the My Account prompt.
+	 *
+	 * Verifies the nonce, applies a rate-limit (does not re-send within the window), dispatches the
+	 * email, and redirects to the orders section. The orders notice points the customer to their
+	 * inbox, so no extra confirmation notice is added here.
+	 *
+	 * @since 11.0.0
+	 */
+	public function handle_send_request(): void {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id ) {
+			return;
+		}
+
+		$nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $nonce, self::SEND_NONCE_ACTION ) ) {
+			wc_add_notice( __( 'Invalid request. Please try again.', 'woocommerce' ), 'error' );
+			wp_safe_redirect( wc_get_account_endpoint_url( 'orders' ) );
+			exit;
+		}
+
+		// Only send a fresh link if the last one is outside the rate-limit window; otherwise the
+		// existing link still stands. Either way the orders notice points the customer to their inbox.
+		$seconds_since = $this->service->seconds_since_last_key( $user_id );
+		if ( null === $seconds_since || $seconds_since >= self::SEND_RATE_LIMIT ) {
+			$this->send_verification_email( $user_id );
+		}
+
+		wp_safe_redirect( wc_get_account_endpoint_url( 'orders' ) );
+		exit;
+	}
+
+	/**
+	 * Return whether the email-confirmation notice should be shown on the current page.
+	 *
+	 * True only for a logged-in customer who is not yet confirmed, does not have a temporary
+	 * password (those confirm via their set-password link), and has at least one guest order that
+	 * could be linked (existence only; no details exposed). Whether the notice carries a call to
+	 * action or a "check your inbox" message is decided in {@see self::maybe_add_orders_notice()}.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return bool
+	 */
+	public function should_show_prompt(): bool {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		if ( $this->service->is_verified( $user_id ) ) {
+			return false;
+		}
+
+		// A temporary-password account already has a set-password link (which also verifies on use),
+		// surfaced by the temporary-password notice — don't show a second prompt alongside it.
+		if ( get_user_option( 'default_password_nag', $user_id ) ) {
+			return false;
+		}
+
+		return $this->order_linker->has_linkable_orders( $user_id );
+	}
+
+	/**
+	 * Add the email-verification prompt as a standard notice on the My Account "Orders" section.
+	 *
+	 * Hooked to {@see 'woocommerce_account_content'} at priority 1, so the notice is queued before
+	 * woocommerce_output_all_notices() prints it (priority 5). Only shown on the orders endpoint,
+	 * and only when there are guest orders worth verifying for.
+	 *
+	 * @internal
+	 * @since 11.0.0
+	 */
+	public function maybe_add_orders_notice(): void {
+		if ( ! is_wc_endpoint_url( 'orders' ) || ! $this->should_show_prompt() ) {
+			return;
+		}
+
+		// Within the rate-limit window a confirmation link was sent recently: point the customer to
+		// their inbox without a resend call to action.
+		$seconds_since = $this->service->seconds_since_last_key( get_current_user_id() );
+		if ( null !== $seconds_since && $seconds_since < self::SEND_RATE_LIMIT ) {
+			wc_add_notice( __( 'Confirm your email address to view past orders. We emailed you a link to confirm your email.', 'woocommerce' ), 'notice' );
+			return;
+		}
+
+		$send_url = wp_nonce_url(
+			add_query_arg( self::SEND_PARAM, '1', wc_get_account_endpoint_url( 'orders' ) ),
+			self::SEND_NONCE_ACTION
+		);
+
+		$notice = sprintf(
+			'%1$s <a href="%2$s" class="button wc-forward">%3$s</a>',
+			esc_html__( 'Confirm your email address to view past orders.', 'woocommerce' ),
+			esc_url( $send_url ),
+			esc_html__( 'Confirm your email address', 'woocommerce' )
+		);
+
+		wc_add_notice( $notice, 'notice' );
+	}
+
+	/**
+	 * Validate a key and verify the user.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $key     Plaintext verification key.
+	 * @return bool True when verification succeeded.
+	 */
+	public function process_verification( int $user_id, string $key ): bool {
+		if ( ! $user_id || '' === $key ) {
+			return false;
+		}
+		if ( ! $this->service->check_verification_key( $user_id, $key ) ) {
+			return false;
+		}
+		$this->service->mark_verified( $user_id );
+		return true;
+	}
+
+	/**
+	 * Send (or resend) a verification email to a user.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public function send_verification_email( int $user_id ): void {
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return;
+		}
+		$verify_url = $this->service->build_verification_url( $user_id );
+
+		WC()->mailer();
+
+		/**
+		 * Triggers sending of the customer email-verification email.
+		 *
+		 * @param int    $user_id    The WordPress user ID of the customer.
+		 * @param string $verify_url The one-time verification URL to include in the email.
+		 *
+		 * @since 11.0.0
+		 */
+		do_action( 'woocommerce_customer_verify_email_notification', $user_id, $verify_url );
+	}
+}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -16,6 +16,11 @@ class VerificationController {
 	private const SEND_NONCE_ACTION = 'woocommerce-send-verification-email';
 
 	/**
+	 * Nonce action used to protect the confirm-email form submission.
+	 */
+	private const VERIFY_NONCE_ACTION = 'woocommerce-verify-email';
+
+	/**
 	 * Query param used to trigger the send-verification request.
 	 */
 	private const SEND_PARAM = 'wc_send_verification';
@@ -61,7 +66,12 @@ class VerificationController {
 	}
 
 	/**
-	 * Read the verify-link query args from the current request and process them.
+	 * Route an incoming request.
+	 *
+	 * The emailed verification link is a GET, which email clients and security scanners routinely
+	 * prefetch. To stop an automated prefetch from consuming the one-time key, a GET on the link only
+	 * renders an interstitial that auto-submits a POST (with a no-JS fallback button); verification
+	 * happens solely on that POST, in {@see self::handle_confirm_submission()}.
 	 */
 	public function maybe_process_request(): void {
 		if ( isset( $_GET[ self::SEND_PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -69,31 +79,143 @@ class VerificationController {
 			return;
 		}
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_GET['wc_verify_email_key'], $_GET['wc_verify_email_user'] ) ) {
+		if ( $this->is_confirm_submission() ) {
+			$this->handle_confirm_submission();
 			return;
 		}
-		$key     = sanitize_text_field( wp_unslash( $_GET['wc_verify_email_key'] ) );
-		$user_id = absint( wp_unslash( $_GET['wc_verify_email_user'] ) );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['wc_verify_email_key'], $_GET['wc_verify_email_user'] ) ) {
+			$this->render_confirm_page(
+				absint( wp_unslash( $_GET['wc_verify_email_user'] ) ),
+				sanitize_text_field( wp_unslash( $_GET['wc_verify_email_key'] ) )
+			);
+		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Whether the current request is a submission of the confirm form (JS auto-submit or no-JS button).
+	 *
+	 * @return bool
+	 */
+	private function is_confirm_submission(): bool {
+		$method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) : 'GET';
+
+		// Nonce is verified in handle_confirm_submission(); this only routes the request.
+		return 'POST' === $method && isset( $_POST['wc_verify_email_submit'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * Verify the address after the customer submits the confirm form.
+	 *
+	 * This is the only path that consumes the one-time key, so a GET prefetch of the emailed link by
+	 * an email client or security scanner cannot complete verification.
+	 *
+	 * @since 11.0.0
+	 */
+	private function handle_confirm_submission(): void {
+		$nonce = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $nonce, self::VERIFY_NONCE_ACTION ) ) {
+			wc_add_notice( __( 'Invalid request. Please try again.', 'woocommerce' ), 'error' );
+			wp_safe_redirect( wc_get_account_endpoint_url( 'orders' ) );
+			exit;
+		}
+
+		$user_id = isset( $_POST['wc_verify_email_user'] ) ? absint( wp_unslash( $_POST['wc_verify_email_user'] ) ) : 0;
+		$key     = isset( $_POST['wc_verify_email_key'] ) ? sanitize_text_field( wp_unslash( $_POST['wc_verify_email_key'] ) ) : '';
 
 		$current_user_id = get_current_user_id();
 
-		// Refuse verification if the email key was for a different user than the one logged in.
+		// Refuse verification if the key was for a different user than the one logged in.
 		if ( $current_user_id && $current_user_id !== $user_id ) {
 			wc_add_notice( __( 'Unable to confirm this email while you are logged in to a different account. Please log out and open the link again.', 'woocommerce' ), 'error' );
 		} elseif ( $this->process_verification( $user_id, $key ) ) {
-			if ( 0 === $current_user_id ) {
-				wc_set_customer_auth_cookie( $user_id );
-			}
+			// Deliberately no auto-login: a logged-out visitor verifies, then logs in. Setting an auth
+			// cookie here would be exploitable as login CSRF (the logged-out nonce isn't browser-bound).
 			wc_add_notice( __( 'Your email address has been confirmed.', 'woocommerce' ) );
+		} elseif ( $current_user_id === $user_id && $this->service->is_verified( $user_id ) ) {
+			// The form was submitted twice (e.g. the JS auto-submit plus a manual click) and the key is
+			// already consumed. The address is verified, so reassure rather than show a misleading
+			// error. Guard against a duplicate when the first submission already queued the notice.
+			$confirmed_notice = __( 'Your email address has been confirmed.', 'woocommerce' );
+			if ( ! wc_has_notice( $confirmed_notice, 'success' ) ) {
+				wc_add_notice( $confirmed_notice );
+			}
 		} else {
 			wc_add_notice( __( 'This confirmation link is invalid or has expired. Please request a new one.', 'woocommerce' ), 'error' );
 		}
 
-		// Land on the Orders endpoint where the linked orders and the verification prompt live.
 		wp_safe_redirect( wc_get_account_endpoint_url( 'orders' ) );
 		exit;
+	}
+
+	/**
+	 * Output the lightweight confirm page for an emailed verification link and stop.
+	 *
+	 * Performs no verification — a prefetch of the emailed link only renders this. The page
+	 * auto-submits its POST form via JavaScript and shows a manual button when JS is unavailable.
+	 *
+	 * @param int    $user_id User ID from the link.
+	 * @param string $key     Plaintext verification key from the link.
+	 * @return void
+	 */
+	private function render_confirm_page( int $user_id, string $key ): void {
+		nocache_headers();
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_confirm_page_html() escapes every interpolated value.
+		echo $this->get_confirm_page_html( $user_id, $key );
+		exit;
+	}
+
+	/**
+	 * Build the confirm-page HTML. Kept separate from output/exit so it is unit-testable.
+	 *
+	 * @param int    $user_id User ID from the link.
+	 * @param string $key     Plaintext verification key from the link.
+	 * @return string Fully escaped, self-contained HTML document.
+	 */
+	private function get_confirm_page_html( int $user_id, string $key ): string {
+		$heading = __( 'Confirm your email address', 'woocommerce' );
+		$intro   = __( 'Confirm your email address to link your past orders to your account.', 'woocommerce' );
+		$button  = __( 'Confirm email address', 'woocommerce' );
+
+		$template = '<!DOCTYPE html>
+<html %1$s>
+<head>
+<meta charset="%2$s" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex, nofollow" />
+<title>%3$s</title>
+</head>
+<body>
+<main class="wc-verify-email" style="max-width:32em;margin:4em auto;text-align:center;font-family:sans-serif;">
+<h1>%3$s</h1>
+<p>%4$s</p>
+<form id="wc-verify-email-form" method="post" action="%5$s">
+%6$s
+<input type="hidden" name="wc_verify_email_submit" value="1" />
+<input type="hidden" name="wc_verify_email_user" value="%7$s" />
+<input type="hidden" name="wc_verify_email_key" value="%8$s" />
+<button type="submit" style="font-size:1em;padding:0.75em 1.5em;cursor:pointer;">%9$s</button>
+</form>
+<script>document.getElementById( "wc-verify-email-form" ).submit();</script>
+</main>
+</body>
+</html>';
+
+		return sprintf(
+			$template,
+			get_language_attributes(),
+			esc_attr( get_bloginfo( 'charset' ) ),
+			esc_html( $heading ),
+			esc_html( $intro ),
+			esc_url( wc_get_page_permalink( 'myaccount' ) ),
+			wp_nonce_field( self::VERIFY_NONCE_ACTION, '_wpnonce', true, false ),
+			esc_attr( (string) $user_id ),
+			esc_attr( $key ),
+			esc_html( $button )
+		);
 	}
 
 	/**
@@ -182,7 +304,7 @@ class VerificationController {
 		// their inbox without a resend call to action.
 		$seconds_since = $this->service->seconds_since_last_key( get_current_user_id() );
 		if ( null !== $seconds_since && $seconds_since < self::SEND_RATE_LIMIT ) {
-			wc_add_notice( __( 'Confirm your email address to view past orders. We emailed you a link to confirm your email.', 'woocommerce' ), 'notice' );
+			wc_add_notice( __( 'We emailed you a link to confirm your email address.', 'woocommerce' ), 'notice' );
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -77,8 +77,15 @@ class VerificationController {
 		$user_id = absint( wp_unslash( $_GET['wc_verify_email_user'] ) );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		if ( $this->process_verification( $user_id, $key ) ) {
-			if ( get_current_user_id() !== $user_id ) {
+		$current_user_id = get_current_user_id();
+
+		// Refuse to verify (and silently switch accounts) when signed in as someone else. The link
+		// authenticates as its owner, so honouring it here would log the current user out of their
+		// own account. Only the link's owner, or a logged-out visitor, may complete verification.
+		if ( $current_user_id && $current_user_id !== $user_id ) {
+			wc_add_notice( __( 'Unable to confirm this email while you are logged in to a different account. Please log out and open the link again.', 'woocommerce' ), 'error' );
+		} elseif ( $this->process_verification( $user_id, $key ) ) {
+			if ( 0 === $current_user_id ) {
 				wc_set_customer_auth_cookie( $user_id );
 			}
 			wc_add_notice( __( 'Your email address has been confirmed.', 'woocommerce' ) );

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -79,7 +79,7 @@ class VerificationController {
 
 		$current_user_id = get_current_user_id();
 
-		// Refuse verification is the email key was for a different user than the one logged in.
+		// Refuse verification if the email key was for a different user than the one logged in.
 		if ( $current_user_id && $current_user_id !== $user_id ) {
 			wc_add_notice( __( 'Unable to confirm this email while you are logged in to a different account. Please log out and open the link again.', 'woocommerce' ), 'error' );
 		} elseif ( $this->process_verification( $user_id, $key ) ) {

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -79,9 +79,7 @@ class VerificationController {
 
 		$current_user_id = get_current_user_id();
 
-		// Refuse to verify (and silently switch accounts) when signed in as someone else. The link
-		// authenticates as its owner, so honouring it here would log the current user out of their
-		// own account. Only the link's owner, or a logged-out visitor, may complete verification.
+		// Refuse verification is the email key was for a different user than the one logged in.
 		if ( $current_user_id && $current_user_id !== $user_id ) {
 			wc_add_notice( __( 'Unable to confirm this email while you are logged in to a different account. Please log out and open the link again.', 'woocommerce' ), 'error' );
 		} elseif ( $this->process_verification( $user_id, $key ) ) {
@@ -93,8 +91,7 @@ class VerificationController {
 			wc_add_notice( __( 'This confirmation link is invalid or has expired. Please request a new one.', 'woocommerce' ), 'error' );
 		}
 
-		// Land on the Orders endpoint where the linked orders and the verification prompt live,
-		// matching the send/resend flow. The notice added above renders there.
+		// Land on the Orders endpoint where the linked orders and the verification prompt live.
 		wp_safe_redirect( wc_get_account_endpoint_url( 'orders' ) );
 		exit;
 	}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -93,7 +93,9 @@ class VerificationController {
 			wc_add_notice( __( 'This confirmation link is invalid or has expired. Please request a new one.', 'woocommerce' ), 'error' );
 		}
 
-		wp_safe_redirect( wc_get_page_permalink( 'myaccount' ) );
+		// Land on the Orders endpoint where the linked orders and the verification prompt live,
+		// matching the send/resend flow. The notice added above renders there.
+		wp_safe_redirect( wc_get_account_endpoint_url( 'orders' ) );
 		exit;
 	}
 

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -189,7 +189,7 @@ class VerificationController {
 			'%1$s <a href="%2$s" class="button wc-forward">%3$s</a>',
 			esc_html__( 'Confirm your email address to view past orders.', 'woocommerce' ),
 			esc_url( $send_url ),
-			esc_html__( 'Confirm your email address', 'woocommerce' )
+			esc_html__( 'Confirm email address', 'woocommerce' )
 		);
 
 		wc_add_notice( $notice, 'notice' );

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationEventListener.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationEventListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\CustomerEmailVerification;
+
+use WP_User;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Listens for account events that should change a customer's email-verification status.
+ *
+ * Completing a password reset proves the customer controls their inbox, so it marks the
+ * email verified. This fires for both WordPress core resets (wp-login.php) and WooCommerce
+ * resets (lost-password and the new-account set-password link), all of which are email-based
+ * and dispatch the core `after_password_reset` action.
+ *
+ * @since 11.0.0
+ */
+class VerificationEventListener {
+
+	/**
+	 * Verification service.
+	 *
+	 * @var EmailVerificationService
+	 */
+	private $service;
+
+	/**
+	 * Constructor. Registers hooks.
+	 */
+	public function __construct() {
+		add_action( 'after_password_reset', array( $this, 'on_password_reset' ) );
+	}
+
+	/**
+	 * Inject dependencies.
+	 *
+	 * @internal
+	 *
+	 * @param EmailVerificationService $service Verification service.
+	 */
+	final public function init( EmailVerificationService $service ): void {
+		$this->service = $service;
+	}
+
+	/**
+	 * Mark the user's email verified after a completed password reset.
+	 *
+	 * @param WP_User|mixed $user The user whose password was reset.
+	 */
+	public function on_password_reset( $user ): void {
+		if ( $user instanceof WP_User ) {
+			$this->service->mark_verified( $user->ID );
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
@@ -36,6 +36,7 @@ class WCTransactionalEmails {
 		'customer_partially_refunded_order',
 		'customer_reset_password',
 		'customer_review_request',
+		'customer_verify_email',
 		'failed_order',
 		'new_order',
 	);

--- a/plugins/woocommerce/templates/emails/block/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/block/customer-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 11.0.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -36,21 +36,7 @@ defined( 'ABSPATH' ) || exit;
 
 <!-- wp:paragraph -->
 <p><?php
-	/* translators: %s: Store name */
-	printf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), '<!--[woocommerce/site-title]-->' );
-?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><?php
-/* translators: %s: Username */
-echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocommerce/customer-username]-->' ), array( 'b' => array() ) );
-?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><?php
-	echo esc_html__( 'If you didn’t make this request, just ignore this email. If you’d like to proceed, reset your password via the link below:', 'woocommerce' );
+	echo esc_html__( 'We received a request to update your password. To reset your password, click the link below:', 'woocommerce' );
 ?></p>
 <!-- /wp:paragraph -->
 
@@ -59,6 +45,6 @@ echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocomm
 <!-- /wp:woocommerce/email-content -->
 
 <!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center"> <?php echo esc_html__( 'Thanks for reading.', 'woocommerce' ); ?> </p>
+<p class="has-text-align-center"> <?php echo esc_html__( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?> </p>
 <!-- /wp:paragraph -->
 

--- a/plugins/woocommerce/templates/emails/block/customer-verify-email.php
+++ b/plugins/woocommerce/templates/emails/block/customer-verify-email.php
@@ -29,14 +29,15 @@ defined( 'ABSPATH' ) || exit;
 
 <!-- wp:paragraph -->
 <p><?php
-	/* translators: %s: Customer username */
-	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-username]-->' );
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
 ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p><?php
-	echo esc_html__( 'Confirm your email address to link your past orders to your account. Click the link below:', 'woocommerce' );
+	/* translators: %s: Customer email */
+	printf( esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ), '<!--[woocommerce/customer-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->
 
@@ -44,6 +45,6 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center"> <?php echo esc_html__( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?> </p>
+<!-- wp:paragraph -->
+<p> <?php echo esc_html__( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?> </p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-verify-email.php
+++ b/plugins/woocommerce/templates/emails/block/customer-verify-email.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Customer verify email address email (initial block version)
+ *
+ * This template can be overridden by editing it in the WooCommerce email editor.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Block
+ * @version 11.0.0
+ */
+
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
+?>
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"> <?php echo esc_html__( 'Confirm your email address', 'woocommerce' ); ?> </h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php
+	/* translators: %s: Customer username */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-username]-->' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php
+	echo esc_html__( 'Confirm your email address to link your past orders to your account. Click the link below:', 'woocommerce' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woocommerce/email-content {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
+<!-- /wp:woocommerce/email-content -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"> <?php echo esc_html__( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?> </p>
+<!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -93,7 +93,7 @@ if ( 'customer_verify_email' === $email->id ) :
 	// Customer verify email address email.
 	?>
 <p>
-	<a class="link" href="<?php echo esc_url( $verify_url ?? wc_get_page_permalink( 'myaccount' ) ); ?>">
+	<a class="link" href="<?php echo esc_url( ! empty( $verify_url ) ? $verify_url : wc_get_page_permalink( 'myaccount' ) ); ?>">
 		<?php esc_html_e( 'Confirm email address', 'woocommerce' ); ?>
 	</a>
 </p>

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -13,7 +13,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.5.0
+ * @version 11.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -89,6 +89,17 @@ if ( 'customer_reset_password' === $email->id && isset( $reset_key, $user_id ) )
 	<?php
 endif;
 
+if ( 'customer_verify_email' === $email->id ) :
+	// Customer verify email address email.
+	?>
+<p>
+	<a class="link" href="<?php echo esc_url( $verify_url ?? wc_get_page_permalink( 'myaccount' ) ); ?>">
+		<?php esc_html_e( 'Confirm email address', 'woocommerce' ); ?>
+	</a>
+</p>
+	<?php
+endif;
+
 /**
  * Action hook for email classes to hook into the general block email template.
  *
@@ -110,6 +121,7 @@ $emails_without_order_details = apply_filters( 'woocommerce_emails_general_block
 $accounts_related_emails = array(
 	'customer_reset_password',
 	'customer_new_account',
+	'customer_verify_email',
 );
 
 $emails_without_order_details = array_merge( $emails_without_order_details ?? array(), $accounts_related_emails );

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -14,6 +14,8 @@
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
  * @version 11.0.0
+ *
+ * @var \WC_Order    $order      Order object.
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -89,14 +91,13 @@ if ( 'customer_reset_password' === $email->id && isset( $reset_key, $user_id ) )
 	<?php
 endif;
 
-if ( 'customer_verify_email' === $email->id ) :
-	// Customer verify email address email.
+if ( 'customer_verify_email' === $email->id && $verify_url ) :
 	?>
-<p>
-	<a class="link" href="<?php echo esc_url( ! empty( $verify_url ) ? $verify_url : wc_get_page_permalink( 'myaccount' ) ); ?>">
-		<?php esc_html_e( 'Confirm email address', 'woocommerce' ); ?>
-	</a>
-</p>
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button" style="display:inline-block"><a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( $verify_url ); ?>"><?php esc_html_e( 'Confirm email address', 'woocommerce' ); ?></a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
 	<?php
 endif;
 

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -73,11 +73,19 @@ if ( 'customer_invoice' === $email->id ) :
 endif;
 
 if ( 'customer_new_account' === $email->id ) :
-	?>
-	<?php if ( $set_password_url ) : ?>
-		<p><a href="<?php echo esc_attr( $set_password_url ); ?>"><?php printf( esc_html__( 'Set your new password.', 'woocommerce' ) ); ?></a></p>
+	if ( $password_generated && $set_password_url ) :
+		?>
+		<p><a href="<?php echo esc_url( $set_password_url ); ?>"><?php esc_html_e( 'Confirm email address and set password', 'woocommerce' ); ?></a></p>
+		<?php
+	else :
+		?>
+		<p><a href="<?php echo esc_url( $verify_url ?? wc_get_page_permalink( 'myaccount' ) ); ?>"><?php esc_html_e( 'Confirm email address', 'woocommerce' ); ?></a></p>
 		<?php
 	endif;
+	?>
+	<?php /* translators: %s: the customer's email address. */ ?>
+	<p><?php echo wp_kses_post( sprintf( __( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ), '<strong>' . esc_html( $user_email ) . '</strong>' ) ); ?></p>
+	<?php
 endif;
 
 if ( 'customer_reset_password' === $email->id && isset( $reset_key, $user_id ) ) :

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -80,7 +80,7 @@ if ( 'customer_new_account' === $email->id ) :
 		<?php
 	else :
 		?>
-		<p><a href="<?php echo esc_url( $verify_url ?? wc_get_page_permalink( 'myaccount' ) ); ?>"><?php esc_html_e( 'Confirm email address', 'woocommerce' ); ?></a></p>
+		<p><a href="<?php echo esc_url( $verify_url ); ?>"><?php esc_html_e( 'Confirm email address', 'woocommerce' ); ?></a></p>
 		<?php /* translators: %s: the customer's email address. */ ?>
 		<p><?php echo wp_kses_post( sprintf( __( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ), '<strong>' . esc_html( $user_email ) . '</strong>' ) ); ?></p>
 		<?php

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -75,16 +75,17 @@ endif;
 if ( 'customer_new_account' === $email->id ) :
 	if ( $password_generated && $set_password_url ) :
 		?>
-		<p><a href="<?php echo esc_url( $set_password_url ); ?>"><?php esc_html_e( 'Confirm email address and set password', 'woocommerce' ); ?></a></p>
+		<p><a href="<?php echo esc_url( $set_password_url ); ?>"><?php esc_html_e( 'Set your new password', 'woocommerce' ); ?></a></p>
+		<p><?php esc_html_e( "Once you've clicked the link and set your new password, we'll link any past orders to your account.", 'woocommerce' ); ?></p>
 		<?php
 	else :
 		?>
 		<p><a href="<?php echo esc_url( $verify_url ?? wc_get_page_permalink( 'myaccount' ) ); ?>"><?php esc_html_e( 'Confirm email address', 'woocommerce' ); ?></a></p>
+		<?php /* translators: %s: the customer's email address. */ ?>
+		<p><?php echo wp_kses_post( sprintf( __( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ), '<strong>' . esc_html( $user_email ) . '</strong>' ) ); ?></p>
 		<?php
 	endif;
 	?>
-	<?php /* translators: %s: the customer's email address. */ ?>
-	<p><?php echo wp_kses_post( sprintf( __( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ), '<strong>' . esc_html( $user_email ) . '</strong>' ) ); ?></p>
 	<?php
 endif;
 

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -58,11 +58,17 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 	<?php
 	if ( $password_generated && $set_password_url ) {
-		$button_url   = $set_password_url;
-		$button_label = __( 'Confirm email address and set password', 'woocommerce' );
+		$button_url    = $set_password_url;
+		$button_label  = __( 'Set your new password', 'woocommerce' );
+		$link_message  = esc_html__( "Once you've clicked the link and set your new password, we'll link any past orders to your account.", 'woocommerce' );
 	} else {
 		$button_url   = $verify_url ?? wc_get_page_permalink( 'myaccount' );
 		$button_label = __( 'Confirm email address', 'woocommerce' );
+		$link_message = sprintf(
+			/* translators: %s: the customer's email address. */
+			esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
+			'<strong>' . esc_html( $user_email ) . '</strong>'
+		);
 	}
 	wc_get_template(
 		'emails/email-button.php',
@@ -73,17 +79,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 	);
 	?>
 
-	<p>
-	<?php
-	echo wp_kses_post(
-		sprintf(
-		/* translators: %s: the customer's email address. */
-			__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
-			'<strong>' . esc_html( $user_email ) . '</strong>'
-		)
-	);
-	?>
-	</p>
+	<p><?php echo wp_kses_post( $link_message ); ?></p>
 
 	<div class="hr hr-bottom"></div>
 

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -44,69 +44,53 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-
 <?php /* translators: %s: Customer first name, or username if name is not available */ ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ); ?></p>
-
 <?php if ( $email_improvements_enabled ) : ?>
 	<?php /* translators: %s: Site title */ ?>
 	<p><?php printf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), esc_html( $blogname ) ); ?></p>
 	<div class="hr hr-top"></div>
-
 	<?php /* translators: %s: Username */ ?>
 	<p><?php echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), esc_html( $user_login ) ), array( 'b' => array() ) ); ?></p>
-
-	<?php
-	if ( $password_generated && $set_password_url ) {
-		$button_url    = $set_password_url;
-		$button_label  = __( 'Set your new password', 'woocommerce' );
-		$link_message  = esc_html__( "Once you've clicked the link and set your new password, we'll link any past orders to your account.", 'woocommerce' );
-	} else {
-		$button_url   = $verify_url ?? wc_get_page_permalink( 'myaccount' );
-		$button_label = __( 'Confirm email address', 'woocommerce' );
-		$link_message = sprintf(
-			/* translators: %s: the customer's email address. */
-			esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
-			'<strong>' . esc_html( $user_email ) . '</strong>'
-		);
-	}
-	wc_get_template(
-		'emails/email-button.php',
-		array(
-			'url'   => $button_url,
-			'label' => $button_label,
-		)
-	);
-	?>
-
-	<p><?php echo wp_kses_post( $link_message ); ?></p>
-
-	<div class="hr hr-bottom"></div>
-
 	<p>
-	<?php
-	echo wp_kses_post(
-		sprintf(
-			/* translators: %1$s: account link open, %2$s account link close */
-			__( 'You can access your %1$saccount area%2$s to view orders, change your password, and more.', 'woocommerce' ),
-			'<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '">',
-			'</a>'
-		)
-	);
-	?>
+		<?php
+		if ( $password_generated && $set_password_url ) {
+			wc_get_template(
+				'emails/email-button.php',
+				array(
+					'url'   => $set_password_url,
+					'label' => __( 'Set your new password', 'woocommerce' ),
+				)
+			);
+		} else {
+			echo wp_kses(
+				sprintf(
+				/* translators: %s: the customer's email address. */
+					__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
+					'<b>' . esc_html( $user_email ) . '</b>'
+				),
+				array( 'b' => array() )
+			);
+			wc_get_template(
+				'emails/email-button.php',
+				array(
+					'url'   => $verify_url,
+					'label' => __( 'Confirm email address', 'woocommerce' ),
+				)
+			);
+		}
+		?>
 	</p>
-
+	<div class="hr hr-bottom"></div>
+	<p><?php echo esc_html__( 'You can access your account area to view orders, change your password, and more via the link below:', 'woocommerce' ); ?></p>
+	<p><a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>"><?php printf( esc_html__( 'My account', 'woocommerce' ) ); ?></a></p>
 <?php else : ?>
 	<?php /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */ ?>
 	<p><?php printf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
 	<?php if ( $password_generated && $set_password_url ) : ?>
-		<?php
-		// If the password has not been set by the user during the sign up process, send them a link to set a new password.
-		?>
-		<p><a href="<?php echo esc_attr( $set_password_url ); ?>"><?php printf( esc_html__( 'Click here to set your new password.', 'woocommerce' ) ); ?></a></p>
+		<p><a href="<?php echo esc_url( $set_password_url ); ?>"><?php printf( esc_html__( 'Click here to set your new password.', 'woocommerce' ) ); ?></a></p>
 	<?php endif; ?>
 <?php endif; ?>
-
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 
 <?php

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -12,7 +12,20 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.9.0
+ * @version 11.0.0
+ *
+ * @var string    $email_heading      Email heading.
+ * @var string    $additional_content Additional content below the body.
+ * @var string    $user_display_name  Customer's display name.
+ * @var string    $user_login         Customer's username.
+ * @var string    $user_email         Customer's email address.
+ * @var string    $blogname           Site name.
+ * @var bool      $sent_to_admin      Whether sent to admin.
+ * @var bool      $plain_text         Whether plain-text variant.
+ * @var \WC_Email $email              Email object.
+ * @var bool      $password_generated Whether password was generated.
+ * @var string    $set_password_url   Set password URL.
+ * @var string    $verify_url         Email verify URL.
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -31,29 +44,73 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
+
 <?php /* translators: %s: Customer first name, or username if name is not available */ ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ); ?></p>
+
 <?php if ( $email_improvements_enabled ) : ?>
 	<?php /* translators: %s: Site title */ ?>
 	<p><?php printf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), esc_html( $blogname ) ); ?></p>
 	<div class="hr hr-top"></div>
+
 	<?php /* translators: %s: Username */ ?>
 	<p><?php echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), esc_html( $user_login ) ), array( 'b' => array() ) ); ?></p>
-	<?php if ( $password_generated && $set_password_url ) : ?>
-		<?php // If the password has not been set by the user during the sign up process, send them a link to set a new password. ?>
-		<p><a href="<?php echo esc_attr( $set_password_url ); ?>"><?php printf( esc_html__( 'Set your new password.', 'woocommerce' ) ); ?></a></p>
-	<?php endif; ?>
+
+	<?php
+	if ( $password_generated && $set_password_url ) {
+		$button_url   = $set_password_url;
+		$button_label = __( 'Confirm email address and set password', 'woocommerce' );
+	} else {
+		$button_url   = $verify_url ?? wc_get_page_permalink( 'myaccount' );
+		$button_label = __( 'Confirm email address', 'woocommerce' );
+	}
+	wc_get_template(
+		'emails/email-button.php',
+		array(
+			'url'   => $button_url,
+			'label' => $button_label,
+		)
+	);
+	?>
+
+	<p>
+	<?php
+	echo wp_kses_post(
+		sprintf(
+		/* translators: %s: the customer's email address. */
+			__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
+			'<strong>' . esc_html( $user_email ) . '</strong>'
+		)
+	);
+	?>
+	</p>
+
 	<div class="hr hr-bottom"></div>
-	<p><?php echo esc_html__( 'You can access your account area to view orders, change your password, and more via the link below:', 'woocommerce' ); ?></p>
-	<p><a href="<?php echo esc_attr( wc_get_page_permalink( 'myaccount' ) ); ?>"><?php printf( esc_html__( 'My account', 'woocommerce' ) ); ?></a></p>
+
+	<p>
+	<?php
+	echo wp_kses_post(
+		sprintf(
+			/* translators: %1$s: account link open, %2$s account link close */
+			__( 'You can access your %1$saccount area%2$s to view orders, change your password, and more.', 'woocommerce' ),
+			'<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '">',
+			'</a>'
+		)
+	);
+	?>
+	</p>
+
 <?php else : ?>
 	<?php /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */ ?>
 	<p><?php printf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
 	<?php if ( $password_generated && $set_password_url ) : ?>
-		<?php // If the password has not been set by the user during the sign up process, send them a link to set a new password. ?>
+		<?php
+		// If the password has not been set by the user during the sign up process, send them a link to set a new password.
+		?>
 		<p><a href="<?php echo esc_attr( $set_password_url ); ?>"><?php printf( esc_html__( 'Click here to set your new password.', 'woocommerce' ) ); ?></a></p>
 	<?php endif; ?>
 <?php endif; ?>
+
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 
 <?php

--- a/plugins/woocommerce/templates/emails/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/customer-reset-password.php
@@ -24,6 +24,7 @@
  * @var string    $reset_key          Reset key.
  * @var string    $user_id            User ID.
  * @var string    $user_login         User login.
+ * @var string    $reset_url          Reset password URL.
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -45,28 +46,29 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name, or username if name is not available. */ ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ); ?></p>
-<p><?php esc_html_e( 'We received a request to update your password. To reset your password, click the link below:', 'woocommerce' ); ?></p>
-
-<?php
-$reset_url = add_query_arg(
-	array(
-		'key'   => $reset_key,
-		'id'    => $user_id,
-		'login' => rawurlencode( $user_login ),
-	),
-	wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) )
-);
-wc_get_template(
-	'emails/email-button.php',
-	array(
-		'url'   => $reset_url,
-		'label' => __( 'Reset password', 'woocommerce' ),
-	)
-);
-?>
-<p>
-	<?php esc_html_e( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?>
-</p>
+<?php if ( $email_improvements_enabled ) : ?>
+	<p><?php esc_html_e( 'We received a request to update your password. To reset your password, click the link below:', 'woocommerce' ); ?></p>
+	<?php
+	wc_get_template(
+		'emails/email-button.php',
+		array(
+			'url'   => $reset_url,
+			'label' => __( 'Reset password', 'woocommerce' ),
+		)
+	);
+	?>
+	<p><?php esc_html_e( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?></p>
+<?php else : ?>
+	<?php /* translators: %s: Store name */ ?>
+	<p><?php printf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), esc_html( $blogname ) ); ?></p>
+	<?php /* translators: %s: Customer username */ ?>
+	<p><?php printf( esc_html__( 'Username: %s', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
+	<p><?php esc_html_e( 'If you didn\'t make this request, just ignore this email. If you\'d like to proceed:', 'woocommerce' ); ?></p>
+	<p>
+		<a class="link" href="<?php echo esc_url( $reset_url ); ?>"><?php esc_html_e( 'Click here to reset your password', 'woocommerce' ); ?></a>
+		<?php esc_html_e( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?>
+	</p>
+<?php endif; ?>
 
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 

--- a/plugins/woocommerce/templates/emails/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/customer-reset-password.php
@@ -12,48 +12,62 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.9.0
+ * @version 11.0.0
+ *
+ * @var string    $email_heading      Email heading.
+ * @var string    $additional_content Additional content below the body.
+ * @var string    $user_display_name  Customer's display name.
+ * @var string    $blogname           Site name.
+ * @var bool      $sent_to_admin      Whether sent to admin.
+ * @var bool      $plain_text         Whether plain-text variant.
+ * @var \WC_Email $email              Email object.
+ * @var string    $reset_key          Reset key.
+ * @var string    $user_id            User ID.
+ * @var string    $user_login         User login.
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
+defined( 'ABSPATH' ) || exit;
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
-?>
-
-<?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+/**
+ * Fires to output the email header.
+ *
+ * @hooked WC_Emails::email_header()
+ *
+ * @since 3.7.0
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer first name, or username if name is not available */ ?>
+
+<?php /* translators: %s: Customer first name, or username if name is not available. */ ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ); ?></p>
-<?php /* translators: %s: Store name */ ?>
-<p><?php printf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), esc_html( $blogname ) ); ?></p>
-<?php if ( $email_improvements_enabled ) : ?>
-	<div class="hr hr-top"></div>
-	<?php /* translators: %s: Username */ ?>
-	<p><?php echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), esc_html( $user_login ) ), array( 'b' => array() ) ); ?></p>
-	<div class="hr hr-bottom"></div>
-	<p><?php esc_html_e( 'If you didn’t make this request, just ignore this email. If you’d like to proceed, reset your password via the link below:', 'woocommerce' ); ?></p>
-<?php else : ?>
-	<?php /* translators: %s: Customer username */ ?>
-	<p><?php printf( esc_html__( 'Username: %s', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
-	<p><?php esc_html_e( 'If you didn\'t make this request, just ignore this email. If you\'d like to proceed:', 'woocommerce' ); ?></p>
-<?php endif; ?>
+<p><?php esc_html_e( 'We received a request to update your password. To reset your password, click the link below:', 'woocommerce' ); ?></p>
+
+<?php
+$reset_url = add_query_arg(
+	array(
+		'key'   => $reset_key,
+		'id'    => $user_id,
+		'login' => rawurlencode( $user_login ),
+	),
+	wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) )
+);
+wc_get_template(
+	'emails/email-button.php',
+	array(
+		'url'   => $reset_url,
+		'label' => __( 'Reset password', 'woocommerce' ),
+	)
+);
+?>
 <p>
-	<a class="link" href="<?php echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id, 'login' => rawurlencode( $user_login ) ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); ?>"><?php // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound ?>
-		<?php
-		if ( $email_improvements_enabled ) {
-			esc_html_e( 'Reset your password', 'woocommerce' );
-		} else {
-			esc_html_e( 'Click here to reset your password', 'woocommerce' );
-		}
-		?>
-	</a>
+	<?php esc_html_e( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?>
 </p>
+
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 
 <?php
@@ -66,4 +80,11 @@ if ( $additional_content ) {
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
+/**
+ * Fires to output the email footer.
+ *
+ * @hooked WC_Emails::email_footer()
+ *
+ * @since 3.7.0
+ */
 do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/customer-verify-email.php
+++ b/plugins/woocommerce/templates/emails/customer-verify-email.php
@@ -44,29 +44,18 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name, or username if name is not available. */ ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ); ?></p>
-<p>
-<?php
-echo wp_kses_post(
-	sprintf(
-		/* translators: %s: the customer's email address. */
-		__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
-		'<strong>' . esc_html( $user_email ) . '</strong>'
-	)
-);
-?>
-</p>
+<?php /* translators: %s: the customer's email address. */ ?>
+<p><?php printf( esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ), '<b>' . esc_html( $user_email ) . '</b>' ); ?></p>
 <?php
 wc_get_template(
 	'emails/email-button.php',
 	array(
-		'url'   => ! empty( $verify_url ) ? $verify_url : wc_get_page_permalink( 'myaccount' ),
+		'url'   => $verify_url,
 		'label' => __( 'Confirm email address', 'woocommerce' ),
 	)
 );
 ?>
-<p>
-	<?php esc_html_e( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?>
-</p>
+<p><?php esc_html_e( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?></p>
 
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 

--- a/plugins/woocommerce/templates/emails/customer-verify-email.php
+++ b/plugins/woocommerce/templates/emails/customer-verify-email.php
@@ -59,7 +59,7 @@ echo wp_kses_post(
 wc_get_template(
 	'emails/email-button.php',
 	array(
-		'url'   => $verify_url ?? wc_get_page_permalink( 'myaccount' ),
+		'url'   => ! empty( $verify_url ) ? $verify_url : wc_get_page_permalink( 'myaccount' ),
 		'label' => __( 'Confirm email address', 'woocommerce' ),
 	)
 );

--- a/plugins/woocommerce/templates/emails/customer-verify-email.php
+++ b/plugins/woocommerce/templates/emails/customer-verify-email.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Customer verify email address email
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-verify-email.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails
+ * @version 11.0.0
+ *
+ * @var string    $email_heading      Email heading.
+ * @var string    $additional_content Additional content below the body.
+ * @var string    $user_display_name  Customer's display name.
+ * @var string    $user_email         Email address being confirmed.
+ * @var string    $verify_url         One-time verification URL.
+ * @var string    $blogname           Site name.
+ * @var bool      $sent_to_admin      Whether sent to admin.
+ * @var bool      $plain_text         Whether plain-text variant.
+ * @var \WC_Email $email              Email object.
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+/**
+ * Fires to output the email header.
+ *
+ * @hooked WC_Emails::email_header()
+ *
+ * @since 3.7.0
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+
+<?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
+
+<?php /* translators: %s: Customer first name, or username if name is not available. */ ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ); ?></p>
+<p>
+<?php
+echo wp_kses_post(
+	sprintf(
+		/* translators: %s: the customer's email address. */
+		__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
+		'<strong>' . esc_html( $user_email ) . '</strong>'
+	)
+);
+?>
+</p>
+<?php
+wc_get_template(
+	'emails/email-button.php',
+	array(
+		'url'   => $verify_url ?? wc_get_page_permalink( 'myaccount' ),
+		'label' => __( 'Confirm email address', 'woocommerce' ),
+	)
+);
+?>
+<p>
+	<?php esc_html_e( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ); ?>
+</p>
+
+<?php echo $email_improvements_enabled ? '</div>' : ''; ?>
+
+<?php
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content email-additional-content-aligned">' : '';
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
+}
+
+/**
+ * Fires to output the email footer.
+ *
+ * @hooked WC_Emails::email_footer()
+ *
+ * @since 3.7.0
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/email-button.php
+++ b/plugins/woocommerce/templates/emails/email-button.php
@@ -14,7 +14,9 @@
 
 defined( 'ABSPATH' ) || exit;
 
+// Fall back to the default when the option is set but empty (get_option's default only covers a missing option).
 $wc_button_bg   = get_option( 'woocommerce_email_base_color', '#7f54b3' );
+$wc_button_bg   = $wc_button_bg ? $wc_button_bg : '#7f54b3';
 $wc_button_text = wc_hex_is_light( $wc_button_bg ) ? '#000000' : '#ffffff';
 ?>
 <p style="margin: 24px 0;">

--- a/plugins/woocommerce/templates/emails/email-button.php
+++ b/plugins/woocommerce/templates/emails/email-button.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Email call-to-action button.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-button.php.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails
+ * @version 11.0.0
+ *
+ * @var string $url   Button destination URL.
+ * @var string $label Button text.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$wc_button_bg   = get_option( 'woocommerce_email_base_color', '#7f54b3' );
+$wc_button_text = wc_hex_is_light( $wc_button_bg ) ? '#000000' : '#ffffff';
+?>
+<p style="margin: 24px 0;">
+	<a href="<?php echo esc_url( $url ); ?>" style="display:inline-block;padding:16px 32px;background-color:<?php echo esc_attr( $wc_button_bg ); ?>;color:<?php echo esc_attr( $wc_button_text ); ?>;border-radius:4px;font-weight:bold;font-size:15px;text-decoration:none;">
+		<?php echo esc_html( $label ); ?>
+	</a>
+</p>

--- a/plugins/woocommerce/templates/emails/plain/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-new-account.php
@@ -47,18 +47,18 @@ echo sprintf( esc_html__( 'Username: %s.', 'woocommerce' ), esc_html( $user_logi
 // Only send the set new password link if the user hasn't set their password during sign-up.
 if ( $password_generated && $set_password_url ) {
 	/* translators: URL follows */
-	echo esc_html__( 'To confirm your email address and set your password, visit the following address: ', 'woocommerce' ) . "\n\n";
+	echo esc_html__( 'To set your new password, visit the following address: ', 'woocommerce' ) . "\n\n";
 	echo esc_html( $set_password_url ) . "\n\n";
+	echo esc_html__( "Once you've clicked the link and set your new password, we'll link any past orders to your account.", 'woocommerce' );
 } else {
 	echo esc_html__( 'To confirm your email address, visit the following address: ', 'woocommerce' ) . "\n\n";
 	echo esc_html( $verify_url ?? wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
+	printf(
+		/* translators: %s: the customer's email address. */
+		esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
+		esc_html( $user_email )
+	);
 }
-
-printf(
-	/* translators: %s: the customer's email address. */
-	esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
-	esc_html( $user_email )
-);
 
 echo "\n\n----------------------------------------\n\n";
 

--- a/plugins/woocommerce/templates/emails/plain/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-new-account.php
@@ -12,14 +12,23 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 10.9.0
+ * @version 11.0.0
+ *
+ * @var string    $email_heading      Email heading.
+ * @var string    $additional_content Additional content below the body.
+ * @var string    $user_display_name  Customer's display name.
+ * @var string    $user_login         Customer's username.
+ * @var string    $user_email         Customer's email address.
+ * @var string    $blogname           Site name.
+ * @var bool      $sent_to_admin      Whether sent to admin.
+ * @var bool      $plain_text         Whether plain-text variant.
+ * @var \WC_Email $email              Email object.
+ * @var bool      $password_generated Whether password was generated.
+ * @var string    $set_password_url   Set password URL.
+ * @var string    $verify_url         Email verify URL.
  */
 
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
-
 defined( 'ABSPATH' ) || exit;
-
-$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
@@ -27,28 +36,34 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %s: Customer first name, or username if name is not available */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ) . "\n\n";
-if ( $email_improvements_enabled ) {
-	/* translators: %s: Site title */
-	echo sprintf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), esc_html( $blogname ) ) . "\n\n";
-	echo "----------------------------------------\n\n";
-	/* translators: %s: Username */
-	echo sprintf( esc_html__( 'Username: %s.', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
-	echo "----------------------------------------\n\n";
-	echo esc_html__( 'You can access your account area to view orders, change your password, and more via the link below:', 'woocommerce' ) . "\n\n";
-	echo esc_html( wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
-} else {
-	/* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */
-	echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), esc_html( $user_login ), esc_html( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
-}
+
+/* translators: %s: Site title */
+echo sprintf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), esc_html( $blogname ) ) . "\n\n";
+
+echo "----------------------------------------\n\n";
+/* translators: %s: Username */
+echo sprintf( esc_html__( 'Username: %s.', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
 
 // Only send the set new password link if the user hasn't set their password during sign-up.
 if ( $password_generated && $set_password_url ) {
 	/* translators: URL follows */
-	echo esc_html__( 'To set your password, visit the following address: ', 'woocommerce' ) . "\n\n";
+	echo esc_html__( 'To confirm your email address and set your password, visit the following address: ', 'woocommerce' ) . "\n\n";
 	echo esc_html( $set_password_url ) . "\n\n";
+} else {
+	echo esc_html__( 'To confirm your email address, visit the following address: ', 'woocommerce' ) . "\n\n";
+	echo esc_html( $verify_url ?? wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
 }
 
+printf(
+	/* translators: %s: the customer's email address. */
+	esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
+	esc_html( $user_email )
+);
+
 echo "\n\n----------------------------------------\n\n";
+
+echo esc_html__( 'You can access your account area to view orders, change your password, and more via the link below:', 'woocommerce' ) . "\n\n";
+echo esc_html( wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
 
 /**
  * Show user-defined additional content - this is set in each email's settings.
@@ -58,4 +73,10 @@ if ( $additional_content ) {
 	echo "\n\n----------------------------------------\n\n";
 }
 
+/**
+ * Filter the email footer text.
+ *
+ * @param string $footer_text The footer text.
+ * @since 2.3.0
+ */
 echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/plugins/woocommerce/templates/emails/plain/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-new-account.php
@@ -28,7 +28,11 @@
  * @var string    $verify_url         Email verify URL.
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 defined( 'ABSPATH' ) || exit;
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
@@ -36,23 +40,28 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %s: Customer first name, or username if name is not available */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ) . "\n\n";
-
-/* translators: %s: Site title */
-echo sprintf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), esc_html( $blogname ) ) . "\n\n";
-
-echo "----------------------------------------\n\n";
-/* translators: %s: Username */
-echo sprintf( esc_html__( 'Username: %s.', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
+if ( $email_improvements_enabled ) {
+	/* translators: %s: Site title */
+	echo sprintf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), esc_html( $blogname ) ) . "\n\n";
+	echo "----------------------------------------\n\n";
+	/* translators: %s: Username */
+	echo sprintf( esc_html__( 'Username: %s.', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
+	echo "----------------------------------------\n\n";
+	echo esc_html__( 'You can access your account area to view orders, change your password, and more via the link below:', 'woocommerce' ) . "\n\n";
+	echo esc_html( wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
+} else {
+	/* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */
+	echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), esc_html( $user_login ), esc_html( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
+}
 
 // Only send the set new password link if the user hasn't set their password during sign-up.
 if ( $password_generated && $set_password_url ) {
 	/* translators: URL follows */
-	echo esc_html__( 'To set your new password, visit the following address: ', 'woocommerce' ) . "\n\n";
+	echo esc_html__( 'To set your password, visit the following address: ', 'woocommerce' ) . "\n\n";
 	echo esc_html( $set_password_url ) . "\n\n";
-	echo esc_html__( "Once you've clicked the link and set your new password, we'll link any past orders to your account.", 'woocommerce' );
 } else {
 	echo esc_html__( 'To confirm your email address, visit the following address: ', 'woocommerce' ) . "\n\n";
-	echo esc_html( $verify_url ?? wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
+	echo esc_html( $verify_url ) . "\n\n";
 	printf(
 		/* translators: %s: the customer's email address. */
 		esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
@@ -61,9 +70,6 @@ if ( $password_generated && $set_password_url ) {
 }
 
 echo "\n\n----------------------------------------\n\n";
-
-echo esc_html__( 'You can access your account area to view orders, change your password, and more via the link below:', 'woocommerce' ) . "\n\n";
-echo esc_html( wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
 
 /**
  * Show user-defined additional content - this is set in each email's settings.

--- a/plugins/woocommerce/templates/emails/plain/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-reset-password.php
@@ -24,9 +24,14 @@
  * @var string    $reset_key          Reset key.
  * @var string    $user_id            User ID.
  * @var string    $user_login         User login.
+ * @var string    $reset_url          Reset password URL.
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 defined( 'ABSPATH' ) || exit;
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
@@ -34,15 +39,22 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %s: Customer first name, or username if name is not available */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ) . "\n\n";
-echo esc_html__( 'We received a request to update your password. To reset your password, click the link below:', 'woocommerce' );
+if ( $email_improvements_enabled ) {
+	esc_html_e( 'We received a request to update your password. To reset your password, click the link below:', 'woocommerce' );
+	echo "\n\n----------------------------------------\n\n";
+	echo esc_url( $reset_url );
+	echo "\n\n----------------------------------------\n\n";
+	esc_html_e( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' );
+} else {
+	/* translators: %s: Store name */
+	echo sprintf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), esc_html( $blogname ) ) . "\n\n";
+	/* translators: %s: Customer username */
+	echo sprintf( esc_html__( 'Username: %s', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
+	echo esc_html__( 'If you didn\'t make this request, just ignore this email. If you\'d like to proceed:', 'woocommerce' ) . "\n\n";
+	echo esc_url( $reset_url ) . "\n\n";
+}
 
 echo "\n\n----------------------------------------\n\n";
-
-echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id, 'login' => rawurlencode( $user_login ) ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
-
-echo "\n\n----------------------------------------\n\n";
-
-echo esc_html__( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ) . "\n\n";
 
 /**
  * Show user-defined additional content - this is set in each email's settings.

--- a/plugins/woocommerce/templates/emails/plain/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-reset-password.php
@@ -12,14 +12,21 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 10.9.0
+ * @version 11.0.0
+ *
+ * @var string    $email_heading      Email heading.
+ * @var string    $additional_content Additional content below the body.
+ * @var string    $user_display_name  Customer's display name.
+ * @var string    $blogname           Site name.
+ * @var bool      $sent_to_admin      Whether sent to admin.
+ * @var bool      $plain_text         Whether plain-text variant.
+ * @var \WC_Email $email              Email object.
+ * @var string    $reset_key          Reset key.
+ * @var string    $user_id            User ID.
+ * @var string    $user_login         User login.
  */
 
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
-
 defined( 'ABSPATH' ) || exit;
-
-$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
@@ -27,22 +34,15 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %s: Customer first name, or username if name is not available */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ) . "\n\n";
-/* translators: %s: Store name */
-echo sprintf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), esc_html( $blogname ) ) . "\n\n";
-if ( $email_improvements_enabled ) {
-	echo "----------------------------------------\n\n";
-}
-/* translators: %s: Customer username */
-echo sprintf( esc_html__( 'Username: %s', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
-if ( $email_improvements_enabled ) {
-	echo "----------------------------------------\n\n";
-	echo esc_html__( 'If you didn’t make this request, just ignore this email. If you’d like to proceed, reset your password via the link below:', 'woocommerce' ) . "\n\n";
-} else {
-	echo esc_html__( 'If you didn\'t make this request, just ignore this email. If you\'d like to proceed:', 'woocommerce' ) . "\n\n";
-}
-echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id, 'login' => rawurlencode( $user_login ) ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ) . "\n\n"; // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
+echo esc_html__( 'We received a request to update your password. To reset your password, click the link below:', 'woocommerce' );
 
 echo "\n\n----------------------------------------\n\n";
+
+echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id, 'login' => rawurlencode( $user_login ) ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
+
+echo "\n\n----------------------------------------\n\n";
+
+echo esc_html__( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ) . "\n\n";
 
 /**
  * Show user-defined additional content - this is set in each email's settings.
@@ -52,4 +52,10 @@ if ( $additional_content ) {
 	echo "\n\n----------------------------------------\n\n";
 }
 
+/**
+ * Filter the email footer text.
+ *
+ * @param string $footer_text The footer text.
+ * @since 2.3.0
+ */
 echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/plugins/woocommerce/templates/emails/plain/customer-verify-email.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-verify-email.php
@@ -33,15 +33,12 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %s: Customer first name, or username if name is not available */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ) . "\n\n";
-echo sprintf(
-	/* translators: %s: the customer's email address. */
-	esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
-	esc_html( $user_email )
-) . "\n\n";
+/* translators: %s: the customer's email address. */
+echo sprintf( esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ), esc_html( $user_email ) ) . "\n\n";
 
-echo esc_url( ! empty( $verify_url ) ? $verify_url : wc_get_page_permalink( 'myaccount' ) );
-
-echo "\n\n----------------------------------------\n\n";
+echo "----------------------------------------\n\n";
+echo esc_url( $verify_url ) . "\n\n";
+echo "----------------------------------------\n\n";
 
 echo esc_html__( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ) . "\n\n";
 

--- a/plugins/woocommerce/templates/emails/plain/customer-verify-email.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-verify-email.php
@@ -39,7 +39,7 @@ echo sprintf(
 	esc_html( $user_email )
 ) . "\n\n";
 
-echo esc_url( $verify_url ?? wc_get_page_permalink( 'myaccount' ) );
+echo esc_url( ! empty( $verify_url ) ? $verify_url : wc_get_page_permalink( 'myaccount' ) );
 
 echo "\n\n----------------------------------------\n\n";
 

--- a/plugins/woocommerce/templates/emails/plain/customer-verify-email.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-verify-email.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Customer verify email address email (plain text)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-verify-email.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Plain
+ * @version 11.0.0
+ *
+ * @var string    $email_heading      Email heading.
+ * @var string    $additional_content Additional content below the body.
+ * @var string    $user_display_name  Customer's display name.
+ * @var string    $user_email         Email address being confirmed.
+ * @var string    $verify_url         One-time verification URL.
+ * @var string    $blogname           Site name.
+ * @var bool      $sent_to_admin      Whether sent to admin.
+ * @var bool      $plain_text         Whether plain-text variant.
+ * @var \WC_Email $email              Email object.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/* translators: %s: Customer first name, or username if name is not available */
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_display_name ) ) . "\n\n";
+echo sprintf(
+	/* translators: %s: the customer's email address. */
+	esc_html__( "Once you've confirmed that %s is your email address, we'll link any past orders to your account.", 'woocommerce' ),
+	esc_html( $user_email )
+) . "\n\n";
+
+echo esc_url( $verify_url ?? wc_get_page_permalink( 'myaccount' ) );
+
+echo "\n\n----------------------------------------\n\n";
+
+echo esc_html__( "If you didn't request this email, there's nothing to worry about, and you can safely ignore it.", 'woocommerce' ) . "\n\n";
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+	echo "\n\n----------------------------------------\n\n";
+}
+
+/**
+ * Filter the email footer text.
+ *
+ * @param string $footer_text The footer text.
+ * @since 2.3.0
+ */
+echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
@@ -72,6 +72,67 @@ class EmailVerificationServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A token is rejected after the account email changes, so it can't verify a different address.
+	 */
+	public function test_token_rejected_after_email_change(): void {
+		$user_id = wc_create_new_customer( 'issued-for@example.com', 'tokenuser', 'pw' );
+
+		$key = $this->sut->create_verification_key( $user_id );
+		$this->assertTrue( $this->sut->check_verification_key( $user_id, $key ), 'Token should be valid for the email it was issued for' );
+
+		wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => 'changed-to@example.com',
+			)
+		);
+		clean_user_cache( $user_id );
+
+		$this->assertFalse(
+			$this->sut->check_verification_key( $user_id, $key ),
+			'A token minted for the old email must not verify the new email'
+		);
+	}
+
+	/**
+	 * @testdox A token still verifies after a non-email profile change (case-insensitive email match).
+	 */
+	public function test_token_accepted_after_non_email_change(): void {
+		$user_id = wc_create_new_customer( 'stable@example.com', 'stableuser', 'pw' );
+
+		$key = $this->sut->create_verification_key( $user_id );
+
+		wp_update_user(
+			array(
+				'ID'           => $user_id,
+				'display_name' => 'Renamed Customer',
+			)
+		);
+		clean_user_cache( $user_id );
+
+		$this->assertTrue(
+			$this->sut->check_verification_key( $user_id, $key ),
+			'A token must remain valid when the account email is unchanged'
+		);
+	}
+
+	/**
+	 * @testdox A legacy token stored without an email binding is still accepted.
+	 */
+	public function test_legacy_token_without_email_binding_is_accepted(): void {
+		$user_id = wc_create_new_customer( 'legacy@example.com', 'legacyuser', 'pw' );
+
+		$key = wp_generate_password( 20, false );
+		// Simulate a token stored before email binding was added (timestamp:key_hash, no email hash).
+		Users::update_site_user_meta( $user_id, '_wc_email_verification_key', time() . ':' . wp_fast_hash( $key ) );
+
+		$this->assertTrue(
+			$this->sut->check_verification_key( $user_id, $key ),
+			'Pre-existing two-part tokens must remain valid for backward compatibility'
+		);
+	}
+
+	/**
 	 * @testdox An expired token should be rejected.
 	 */
 	public function test_expired_token_is_rejected(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
@@ -44,13 +44,11 @@ class EmailVerificationServiceTest extends WC_Unit_Test_Case {
 		$hook_calls = 0;
 		$hook_arg   = null;
 
-		add_action(
-			'woocommerce_customer_email_verified',
-			function ( $id ) use ( &$hook_calls, &$hook_arg ) {
-				$hook_calls++;
-				$hook_arg = $id;
-			}
-		);
+		$listener = static function ( $id ) use ( &$hook_calls, &$hook_arg ) {
+			$hook_calls++;
+			$hook_arg = $id;
+		};
+		add_action( 'woocommerce_customer_email_verified', $listener );
 
 		$this->sut->mark_verified( $user_id );
 
@@ -58,7 +56,7 @@ class EmailVerificationServiceTest extends WC_Unit_Test_Case {
 		$this->assertSame( 1, $hook_calls, 'Hook should fire exactly once' );
 		$this->assertSame( $user_id, $hook_arg, 'Hook should receive the correct user ID' );
 
-		remove_all_actions( 'woocommerce_customer_email_verified' );
+		remove_action( 'woocommerce_customer_email_verified', $listener );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
@@ -1,0 +1,142 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\CustomerEmailVerification;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\EmailVerificationService;
+use Automattic\WooCommerce\Internal\Utilities\Users;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the EmailVerificationService class.
+ */
+class EmailVerificationServiceTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var EmailVerificationService
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = wc_get_container()->get( EmailVerificationService::class );
+	}
+
+	/**
+	 * @testdox A freshly created customer should not be verified by default.
+	 */
+	public function test_user_is_unverified_by_default(): void {
+		$user_id = wc_create_new_customer( 'a@example.com', 'usera', 'pw' );
+
+		$this->assertFalse( $this->sut->is_verified( $user_id ), 'New customers should not be verified by default' );
+	}
+
+	/**
+	 * @testdox Marking a user as verified should set the meta and fire the hook exactly once.
+	 */
+	public function test_mark_verified_sets_meta_and_fires_hook(): void {
+		$user_id    = wc_create_new_customer( 'b@example.com', 'userb', 'pw' );
+		$hook_calls = 0;
+		$hook_arg   = null;
+
+		add_action(
+			'woocommerce_customer_email_verified',
+			function ( $id ) use ( &$hook_calls, &$hook_arg ) {
+				$hook_calls++;
+				$hook_arg = $id;
+			}
+		);
+
+		$this->sut->mark_verified( $user_id );
+
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'User should be verified after mark_verified()' );
+		$this->assertSame( 1, $hook_calls, 'Hook should fire exactly once' );
+		$this->assertSame( $user_id, $hook_arg, 'Hook should receive the correct user ID' );
+
+		remove_all_actions( 'woocommerce_customer_email_verified' );
+	}
+
+	/**
+	 * @testdox A valid key should be accepted and an invalid key should be rejected.
+	 */
+	public function test_token_round_trip(): void {
+		$user_id = wc_create_new_customer( 'c@example.com', 'userc', 'pw' );
+
+		$key = $this->sut->create_verification_key( $user_id );
+
+		$this->assertTrue( $this->sut->check_verification_key( $user_id, $key ), 'Valid key should be accepted' );
+		$this->assertFalse( $this->sut->check_verification_key( $user_id, 'wrong-key' ), 'Wrong key should be rejected' );
+	}
+
+	/**
+	 * @testdox An expired token should be rejected.
+	 */
+	public function test_expired_token_is_rejected(): void {
+		$user_id = wc_create_new_customer( 'd@example.com', 'userd', 'pw' );
+		$key     = $this->sut->create_verification_key( $user_id );
+		// Rewrite the stored value's timestamp to be older than the expiry window, keeping the same hash.
+		$stored = (string) Users::get_site_user_meta( $user_id, '_wc_email_verification_key' );
+		$parts  = explode( ':', $stored, 2 );
+		$hash   = $parts[1];
+		Users::update_site_user_meta( $user_id, '_wc_email_verification_key', ( time() - DAY_IN_SECONDS - 10 ) . ':' . $hash );
+		$this->assertFalse( $this->sut->check_verification_key( $user_id, $key ) );
+	}
+
+	/**
+	 * @testdox Clearing verification should reset the user's verified status.
+	 */
+	public function test_clear_verification_resets_status(): void {
+		$user_id = wc_create_new_customer( 'e@example.com', 'usere', 'pw' );
+
+		$this->sut->mark_verified( $user_id );
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'User should be verified before clearing' );
+
+		$this->sut->clear_verification( $user_id );
+
+		$this->assertFalse( $this->sut->is_verified( $user_id ), 'User should not be verified after clearing' );
+	}
+
+	/**
+	 * @testdox A verified status self-invalidates when the account email changes.
+	 */
+	public function test_is_verified_false_after_email_change(): void {
+		$user_id = wc_create_new_customer( 'before-change@example.com', 'changeuser', 'pw' );
+
+		$this->sut->mark_verified( $user_id );
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'User should be verified for their current email' );
+
+		wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => 'after-change@example.com',
+			)
+		);
+		clean_user_cache( $user_id );
+
+		$this->assertFalse( $this->sut->is_verified( $user_id ), 'Changing the account email must invalidate verification' );
+	}
+
+	/**
+	 * @testdox A verified status is preserved across non-email profile changes.
+	 */
+	public function test_is_verified_preserved_after_non_email_change(): void {
+		$user_id = wc_create_new_customer( 'keep-verified@example.com', 'keepuser', 'pw' );
+
+		$this->sut->mark_verified( $user_id );
+
+		wp_update_user(
+			array(
+				'ID'           => $user_id,
+				'display_name' => 'Renamed Customer',
+			)
+		);
+		clean_user_cache( $user_id );
+
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'Non-email profile changes must not invalidate verification' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
@@ -45,7 +45,7 @@ class EmailVerificationServiceTest extends WC_Unit_Test_Case {
 		$hook_arg   = null;
 
 		$listener = static function ( $id ) use ( &$hook_calls, &$hook_arg ) {
-			$hook_calls++;
+			++$hook_calls;
 			$hook_arg = $id;
 		};
 		add_action( 'woocommerce_customer_email_verified', $listener );

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmailTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Emails/CustomerVerifyEmailTest.php
@@ -1,0 +1,85 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\CustomerEmailVerification\Emails;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\Emails\CustomerVerifyEmail;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for CustomerVerifyEmail.
+ *
+ * @covers \Automattic\WooCommerce\Internal\CustomerEmailVerification\Emails\CustomerVerifyEmail
+ */
+class CustomerVerifyEmailTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var CustomerVerifyEmail
+	 */
+	private $sut;
+
+	/**
+	 * Initialise the mailer (loads the WC_Email base class) before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		WC()->mailer()->init();
+
+		$this->sut = new CustomerVerifyEmail();
+	}
+
+	/**
+	 * @testdox Class is registered with the WC mailer so the Settings > Emails page renders it.
+	 */
+	public function test_is_registered_with_wc_emails(): void {
+		$emails = WC()->mailer()->get_emails();
+
+		$this->assertArrayHasKey( 'WC_Email_Customer_Verify_Email', $emails );
+		$this->assertInstanceOf( CustomerVerifyEmail::class, $emails['WC_Email_Customer_Verify_Email'] );
+	}
+
+	/**
+	 * @testdox trigger() sends an email to the customer containing the verification link.
+	 */
+	public function test_trigger_sends_email_with_verify_url(): void {
+		$user_id = wc_create_new_customer( 'verify@example.com', 'verifytestuser', 'password' );
+		$this->assertIsInt( $user_id );
+
+		$verify_url = add_query_arg(
+			array(
+				'wc_verify_email_key'  => 'TESTKEY',
+				'wc_verify_email_user' => $user_id,
+			),
+			wc_get_page_permalink( 'myaccount' )
+		);
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$before = count( $mailer->mock_sent );
+
+		$this->sut->trigger( $user_id, $verify_url );
+
+		$after = count( $mailer->mock_sent );
+
+		$this->assertSame( $before + 1, $after, 'trigger() must dispatch exactly one email.' );
+
+		$sent = $mailer->mock_sent[ $before ];
+		$this->assertSame( 'verify@example.com', $sent['to'][0][0], 'Email must be addressed to the customer.' );
+		$this->assertStringContainsString( 'wc_verify_email_key=TESTKEY', $sent['body'], 'Email body must contain the verification link.' );
+	}
+
+	/**
+	 * @testdox trigger() is a no-op when user_id or verify_url is missing.
+	 */
+	public function test_trigger_noop_without_args(): void {
+		$mailer = tests_retrieve_phpmailer_instance();
+		$before = count( $mailer->mock_sent );
+
+		$this->sut->trigger( 0, '' );
+
+		$after = count( $mailer->mock_sent );
+		$this->assertSame( $before, $after, 'trigger() with no args must not send any email.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/ImplicitVerificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/ImplicitVerificationTest.php
@@ -1,0 +1,50 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\CustomerEmailVerification;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\EmailVerificationService;
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\VerificationEventListener;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for implicit email verification triggered by completed password resets.
+ */
+class ImplicitVerificationTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var EmailVerificationService
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = wc_get_container()->get( EmailVerificationService::class );
+
+		// Resolve the listener so its after_password_reset hook is registered.
+		wc_get_container()->get( VerificationEventListener::class );
+	}
+
+	/**
+	 * Completing a password reset fires the core after_password_reset action, which both
+	 * WordPress core and WooCommerce dispatch. The listener should mark the email verified.
+	 *
+	 * @testdox A completed password reset marks the customer's email as verified.
+	 */
+	public function test_after_password_reset_marks_email_verified(): void {
+		$user_id = wc_create_new_customer( 'reset@example.com', 'resetuser', 'pw' );
+		$user    = get_user_by( 'id', $user_id );
+
+		$this->assertFalse( $this->sut->is_verified( $user_id ), 'New customers should not be verified by default' );
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing a core WordPress hook to exercise the listener, not defining a new hook.
+		do_action( 'after_password_reset', $user, 'newpassword123' );
+
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'Customer should be verified after a password reset' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -67,13 +67,14 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 	 */
 	private function dispatch_send_request(): void {
 		$abort = static function ( $location ): void {
-			throw new \RuntimeException( (string) $location );
+			throw new \RuntimeException( esc_html( (string) $location ) );
 		};
 		add_filter( 'wp_redirect', $abort );
 		try {
 			$this->sut->handle_send_request();
 		} catch ( \RuntimeException $e ) {
-			unset( $e ); // Expected: handle_send_request() redirects and exits.
+			// Expected: handle_send_request() redirects and exits.
+			unset( $e );
 		} finally {
 			remove_filter( 'wp_redirect', $abort );
 		}
@@ -251,7 +252,7 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 
 		$notification_count = 0;
 		$listener           = static function () use ( &$notification_count ) {
-			$notification_count++;
+			++$notification_count;
 		};
 		add_action( 'woocommerce_customer_verify_email_notification', $listener );
 
@@ -292,6 +293,8 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$elapsed = $this->service->seconds_since_last_key( $user_id );
 
 		$this->assertNotNull( $elapsed, 'Should return an integer after key creation' );
-		$this->assertLessThan( 5, $elapsed, 'Elapsed time should be under 5 seconds immediately after key creation' );
+		$this->assertGreaterThanOrEqual( 0, $elapsed, 'Elapsed time should never be negative' );
+		// Generous upper bound: proves a real, recent elapsed value without being flaky on a slow runner.
+		$this->assertLessThan( 60, $elapsed, 'Elapsed time should be well within the rate-limit window after key creation' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -1,0 +1,305 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\CustomerEmailVerification;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\EmailVerificationService;
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\VerificationController;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the My Account email-verification prompt and send-trigger.
+ */
+class MyAccountPromptTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var VerificationController
+	 */
+	private $sut;
+
+	/**
+	 * The verification service.
+	 *
+	 * @var EmailVerificationService
+	 */
+	private $service;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->service = wc_get_container()->get( EmailVerificationService::class );
+		$this->sut     = wc_get_container()->get( VerificationController::class );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		wc_clear_notices();
+		unset( $GLOBALS['wp']->query_vars['orders'] );
+		parent::tearDown();
+	}
+
+	// -------------------------------------------------------------------------
+	// should_show_prompt()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @testdox should_show_prompt returns false when no user is logged in.
+	 */
+	public function test_should_show_prompt_returns_false_for_logged_out_visitor(): void {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->sut->should_show_prompt(), 'Logged-out visitors should not see the prompt' );
+	}
+
+	/**
+	 * @testdox should_show_prompt returns true for an unverified customer with linkable guest orders.
+	 */
+	public function test_should_show_prompt_returns_true_for_logged_in_unverified_customer(): void {
+		$email   = 'prompt-unverified@example.com';
+		$user_id = wc_create_new_customer( $email, 'promptunverified', 'pw' );
+		wp_set_current_user( $user_id );
+
+		// A linkable guest order must exist for the prompt to appear.
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		$this->assertTrue( $this->sut->should_show_prompt(), 'Unverified customers with linkable guest orders should see the prompt' );
+	}
+
+	/**
+	 * @testdox should_show_prompt returns false for an unverified customer with no linkable guest orders.
+	 */
+	public function test_should_show_prompt_returns_false_without_linkable_orders(): void {
+		$user_id = wc_create_new_customer( 'prompt-no-orders@example.com', 'promptnoorders', 'pw' );
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( $this->sut->should_show_prompt(), 'Unverified customers with nothing to link should not see the prompt' );
+	}
+
+	// -------------------------------------------------------------------------
+	// maybe_add_orders_notice()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @testdox The orders notice carries a resend call-to-action button when no link was sent recently.
+	 */
+	public function test_orders_notice_shows_cta_when_not_recently_sent(): void {
+		global $wp;
+		$email   = 'cta-prompt@example.com';
+		$user_id = wc_create_new_customer( $email, 'ctapromptuser', 'pw' );
+		wp_set_current_user( $user_id );
+
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		$wp->query_vars['orders'] = '';
+		wc_clear_notices();
+
+		$this->sut->maybe_add_orders_notice();
+
+		$notices = wc_get_notices( 'notice' );
+		$this->assertNotEmpty( $notices );
+		$this->assertStringContainsString( 'button wc-forward', $notices[0]['notice'], 'A prompt with no recent send should carry the resend button.' );
+	}
+
+	/**
+	 * @testdox Right after a send, the orders notice drops the resend call-to-action button.
+	 */
+	public function test_orders_notice_shows_check_inbox_without_cta_when_recently_sent(): void {
+		global $wp;
+		$email   = 'inbox-prompt@example.com';
+		$user_id = wc_create_new_customer( $email, 'inboxpromptuser', 'pw' );
+		wp_set_current_user( $user_id );
+
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		// A confirmation link was just sent.
+		$this->service->create_verification_key( $user_id );
+
+		$wp->query_vars['orders'] = '';
+		wc_clear_notices();
+
+		$this->sut->maybe_add_orders_notice();
+
+		$notices = wc_get_notices( 'notice' );
+		$this->assertNotEmpty( $notices );
+		$this->assertStringNotContainsString( 'button wc-forward', $notices[0]['notice'], 'The recently-sent notice must not carry a resend button.' );
+	}
+
+	/**
+	 * @testdox should_show_prompt returns false for an account using a temporary password.
+	 */
+	public function test_should_show_prompt_returns_false_with_temporary_password(): void {
+		$email   = 'temp-pass@example.com';
+		$user_id = wc_create_new_customer( $email, 'temppassuser', 'pw' );
+		wp_set_current_user( $user_id );
+
+		// A linkable guest order exists, so only the temporary-password suppression should hide the prompt.
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		update_user_option( $user_id, 'default_password_nag', true, true );
+
+		$this->assertFalse( $this->sut->should_show_prompt(), 'Prompt should be hidden when the temporary-password notice covers verification' );
+	}
+
+	/**
+	 * @testdox should_show_prompt returns false for a logged-in customer whose email is verified.
+	 */
+	public function test_should_show_prompt_returns_false_for_verified_customer(): void {
+		$user_id = wc_create_new_customer( 'prompt-verified@example.com', 'promptverified', 'pw' );
+		wp_set_current_user( $user_id );
+		$this->service->mark_verified( $user_id );
+
+		$this->assertFalse( $this->sut->should_show_prompt(), 'Verified customers should not see the prompt' );
+	}
+
+	// -------------------------------------------------------------------------
+	// handle_send_request()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @testdox handle_send_request dispatches the verify-email notification when called with a valid nonce.
+	 */
+	public function test_handle_send_request_dispatches_notification_for_valid_nonce(): void {
+		$user_id = wc_create_new_customer( 'send-trigger@example.com', 'sendtrigger', 'pw' );
+		wp_set_current_user( $user_id );
+
+		$_GET['_wpnonce'] = wp_create_nonce( 'woocommerce-send-verification-email' );
+
+		$notification_fired = false;
+		add_action(
+			'woocommerce_customer_verify_email_notification',
+			function ( $uid ) use ( &$notification_fired ) {
+				unset( $uid );
+				$notification_fired = true;
+			}
+		);
+
+		// handle_send_request() calls wp_safe_redirect() and exit; catch the redirect with a filter.
+		add_filter( 'wp_redirect', '__return_false' );
+
+		try {
+			$this->sut->handle_send_request();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Swallow exit() equivalents if any slip through.
+		}
+
+		remove_all_filters( 'wp_redirect' );
+		remove_all_actions( 'woocommerce_customer_verify_email_notification' );
+		unset( $_GET['_wpnonce'] );
+
+		$this->assertTrue( $notification_fired, 'Notification hook should fire for a valid send request' );
+	}
+
+	/**
+	 * @testdox handle_send_request does not dispatch the notification when the nonce is invalid.
+	 */
+	public function test_handle_send_request_rejects_invalid_nonce(): void {
+		$user_id = wc_create_new_customer( 'bad-nonce@example.com', 'badnonceuser', 'pw' );
+		wp_set_current_user( $user_id );
+
+		$_GET['_wpnonce'] = 'not-a-valid-nonce';
+
+		$notification_fired = false;
+		add_action(
+			'woocommerce_customer_verify_email_notification',
+			function () use ( &$notification_fired ) {
+				$notification_fired = true;
+			}
+		);
+
+		add_filter( 'wp_redirect', '__return_false' );
+
+		try {
+			$this->sut->handle_send_request();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		}
+
+		remove_all_filters( 'wp_redirect' );
+		remove_all_actions( 'woocommerce_customer_verify_email_notification' );
+		unset( $_GET['_wpnonce'] );
+
+		$this->assertFalse( $notification_fired, 'Notification hook should not fire when the nonce is invalid' );
+	}
+
+	/**
+	 * @testdox handle_send_request suppresses a second send when issued within the rate-limit window.
+	 */
+	public function test_handle_send_request_suppresses_immediate_resend(): void {
+		$user_id = wc_create_new_customer( 'rate-limit@example.com', 'ratelimituser', 'pw' );
+		wp_set_current_user( $user_id );
+
+		$notification_count = 0;
+		add_action(
+			'woocommerce_customer_verify_email_notification',
+			function () use ( &$notification_count ) {
+				$notification_count++;
+			}
+		);
+
+		add_filter( 'wp_redirect', '__return_false' );
+
+		// First send (no existing key).
+		$_GET['_wpnonce'] = wp_create_nonce( 'woocommerce-send-verification-email' );
+		try {
+			$this->sut->handle_send_request();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		}
+
+		// Second send — key was just created (seconds_since_last_key < 60).
+		$_GET['_wpnonce'] = wp_create_nonce( 'woocommerce-send-verification-email' );
+		try {
+			$this->sut->handle_send_request();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		}
+
+		remove_all_filters( 'wp_redirect' );
+		remove_all_actions( 'woocommerce_customer_verify_email_notification' );
+		unset( $_GET['_wpnonce'] );
+
+		$this->assertSame( 1, $notification_count, 'Notification should fire exactly once despite two send attempts within the rate-limit window' );
+	}
+
+	// -------------------------------------------------------------------------
+	// EmailVerificationService::seconds_since_last_key()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @testdox seconds_since_last_key returns null when no key has been issued.
+	 */
+	public function test_seconds_since_last_key_returns_null_with_no_key(): void {
+		$user_id = wc_create_new_customer( 'nokey@example.com', 'nokeyuser', 'pw' );
+
+		$this->assertNull( $this->service->seconds_since_last_key( $user_id ), 'Should return null when no key has been issued' );
+	}
+
+	/**
+	 * @testdox seconds_since_last_key returns a small non-negative integer immediately after key creation.
+	 */
+	public function test_seconds_since_last_key_returns_small_value_after_key_creation(): void {
+		$user_id = wc_create_new_customer( 'freshkey@example.com', 'freshkeyuser', 'pw' );
+		$this->service->create_verification_key( $user_id );
+
+		$elapsed = $this->service->seconds_since_last_key( $user_id );
+
+		$this->assertNotNull( $elapsed, 'Should return an integer after key creation' );
+		$this->assertLessThan( 5, $elapsed, 'Elapsed time should be under 5 seconds immediately after key creation' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -45,6 +45,18 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		parent::tearDown();
 	}
 
+	/**
+	 * Create a linkable guest order for the given email.
+	 *
+	 * @param string $email Billing email to attach the guest order to.
+	 */
+	private function create_guest_order( string $email ): void {
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_customer_id( 0 );
+		$order->save();
+	}
+
 	// -------------------------------------------------------------------------
 	// should_show_prompt()
 	// -------------------------------------------------------------------------
@@ -67,10 +79,7 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		wp_set_current_user( $user_id );
 
 		// A linkable guest order must exist for the prompt to appear.
-		$order = \WC_Helper_Order::create_order( 0 );
-		$order->set_billing_email( $email );
-		$order->set_customer_id( 0 );
-		$order->save();
+		$this->create_guest_order( $email );
 
 		$this->assertTrue( $this->sut->should_show_prompt(), 'Unverified customers with linkable guest orders should see the prompt' );
 	}
@@ -98,10 +107,7 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$user_id = wc_create_new_customer( $email, 'ctapromptuser', 'pw' );
 		wp_set_current_user( $user_id );
 
-		$order = \WC_Helper_Order::create_order( 0 );
-		$order->set_billing_email( $email );
-		$order->set_customer_id( 0 );
-		$order->save();
+		$this->create_guest_order( $email );
 
 		$wp->query_vars['orders'] = '';
 		wc_clear_notices();
@@ -122,10 +128,7 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$user_id = wc_create_new_customer( $email, 'inboxpromptuser', 'pw' );
 		wp_set_current_user( $user_id );
 
-		$order = \WC_Helper_Order::create_order( 0 );
-		$order->set_billing_email( $email );
-		$order->set_customer_id( 0 );
-		$order->save();
+		$this->create_guest_order( $email );
 
 		// A confirmation link was just sent.
 		$this->service->create_verification_key( $user_id );
@@ -149,10 +152,7 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		wp_set_current_user( $user_id );
 
 		// A linkable guest order exists, so only the temporary-password suppression should hide the prompt.
-		$order = \WC_Helper_Order::create_order( 0 );
-		$order->set_billing_email( $email );
-		$order->set_customer_id( 0 );
-		$order->save();
+		$this->create_guest_order( $email );
 
 		update_user_option( $user_id, 'default_password_nag', true, true );
 

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -66,8 +66,8 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 	 * filter aborts control flow before exit so the test survives to assert.
 	 */
 	private function dispatch_send_request(): void {
-		$abort = static function (): void {
-			throw new \RuntimeException( 'wp_redirect' );
+		$abort = static function ( $location ): void {
+			throw new \RuntimeException( (string) $location );
 		};
 		add_filter( 'wp_redirect', $abort );
 		try {

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -57,6 +57,28 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$order->save();
 	}
 
+	/**
+	 * Invoke handle_send_request(), trapping the wp_safe_redirect() + exit it ends with.
+	 *
+	 * handle_send_request() always finishes with wp_safe_redirect() then exit;. A
+	 * '__return_false' filter does NOT prevent that exit — it would terminate the whole
+	 * PHPUnit run, silently skipping every later test. Throwing from the wp_redirect
+	 * filter aborts control flow before exit so the test survives to assert.
+	 */
+	private function dispatch_send_request(): void {
+		$abort = static function (): void {
+			throw new \RuntimeException( 'wp_redirect' );
+		};
+		add_filter( 'wp_redirect', $abort );
+		try {
+			$this->sut->handle_send_request();
+		} catch ( \RuntimeException $e ) {
+			unset( $e ); // Expected: handle_send_request() redirects and exits.
+		} finally {
+			remove_filter( 'wp_redirect', $abort );
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// should_show_prompt()
 	// -------------------------------------------------------------------------
@@ -184,25 +206,14 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$_GET['_wpnonce'] = wp_create_nonce( 'woocommerce-send-verification-email' );
 
 		$notification_fired = false;
-		add_action(
-			'woocommerce_customer_verify_email_notification',
-			function ( $uid ) use ( &$notification_fired ) {
-				unset( $uid );
-				$notification_fired = true;
-			}
-		);
+		$listener           = static function () use ( &$notification_fired ) {
+			$notification_fired = true;
+		};
+		add_action( 'woocommerce_customer_verify_email_notification', $listener );
 
-		// handle_send_request() calls wp_safe_redirect() and exit; catch the redirect with a filter.
-		add_filter( 'wp_redirect', '__return_false' );
+		$this->dispatch_send_request();
 
-		try {
-			$this->sut->handle_send_request();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Swallow exit() equivalents if any slip through.
-		}
-
-		remove_all_filters( 'wp_redirect' );
-		remove_all_actions( 'woocommerce_customer_verify_email_notification' );
+		remove_action( 'woocommerce_customer_verify_email_notification', $listener );
 		unset( $_GET['_wpnonce'] );
 
 		$this->assertTrue( $notification_fired, 'Notification hook should fire for a valid send request' );
@@ -218,22 +229,14 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$_GET['_wpnonce'] = 'not-a-valid-nonce';
 
 		$notification_fired = false;
-		add_action(
-			'woocommerce_customer_verify_email_notification',
-			function () use ( &$notification_fired ) {
-				$notification_fired = true;
-			}
-		);
+		$listener           = static function () use ( &$notification_fired ) {
+			$notification_fired = true;
+		};
+		add_action( 'woocommerce_customer_verify_email_notification', $listener );
 
-		add_filter( 'wp_redirect', '__return_false' );
+		$this->dispatch_send_request();
 
-		try {
-			$this->sut->handle_send_request();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-		}
-
-		remove_all_filters( 'wp_redirect' );
-		remove_all_actions( 'woocommerce_customer_verify_email_notification' );
+		remove_action( 'woocommerce_customer_verify_email_notification', $listener );
 		unset( $_GET['_wpnonce'] );
 
 		$this->assertFalse( $notification_fired, 'Notification hook should not fire when the nonce is invalid' );
@@ -247,31 +250,20 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		wp_set_current_user( $user_id );
 
 		$notification_count = 0;
-		add_action(
-			'woocommerce_customer_verify_email_notification',
-			function () use ( &$notification_count ) {
-				$notification_count++;
-			}
-		);
-
-		add_filter( 'wp_redirect', '__return_false' );
+		$listener           = static function () use ( &$notification_count ) {
+			$notification_count++;
+		};
+		add_action( 'woocommerce_customer_verify_email_notification', $listener );
 
 		// First send (no existing key).
 		$_GET['_wpnonce'] = wp_create_nonce( 'woocommerce-send-verification-email' );
-		try {
-			$this->sut->handle_send_request();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-		}
+		$this->dispatch_send_request();
 
 		// Second send — key was just created (seconds_since_last_key < 60).
 		$_GET['_wpnonce'] = wp_create_nonce( 'woocommerce-send-verification-email' );
-		try {
-			$this->sut->handle_send_request();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-		}
+		$this->dispatch_send_request();
 
-		remove_all_filters( 'wp_redirect' );
-		remove_all_actions( 'woocommerce_customer_verify_email_notification' );
+		remove_action( 'woocommerce_customer_verify_email_notification', $listener );
 		unset( $_GET['_wpnonce'] );
 
 		$this->assertSame( 1, $notification_count, 'Notification should fire exactly once despite two send attempts within the rate-limit window' );

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/OrderLinkerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/OrderLinkerTest.php
@@ -1,0 +1,98 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\CustomerEmailVerification;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\EmailVerificationService;
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\OrderLinker;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the OrderLinker class.
+ */
+class OrderLinkerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var OrderLinker
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// Resolve from the container to guarantee the constructor ran and hooks are registered.
+		$this->sut = wc_get_container()->get( OrderLinker::class );
+	}
+
+	/**
+	 * @testdox Verifying a customer should link their matching guest orders to their account.
+	 */
+	public function test_verifying_links_matching_guest_orders(): void {
+		$user_id = wc_create_new_customer( 'order-link-test@example.com', 'orderlinkuser', 'pw' );
+		$user    = get_user_by( 'id', $user_id );
+
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $user->user_email );
+		$order->set_customer_id( 0 );
+		$order->save();
+		$order_id = $order->get_id();
+
+		wc_get_container()->get( EmailVerificationService::class )->mark_verified( $user_id );
+
+		$linked_order = wc_get_order( $order_id );
+		$this->assertSame( $user_id, $linked_order->get_customer_id(), 'Matching guest order should be linked to the verified customer' );
+	}
+
+	/**
+	 * @testdox Guest orders with a different email should not be linked when a customer verifies.
+	 */
+	public function test_guest_orders_for_other_emails_are_not_linked(): void {
+		$user_id = wc_create_new_customer( 'other-link-test@example.com', 'otherlinkuser', 'pw' );
+
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( 'completely-different@example.com' );
+		$order->set_customer_id( 0 );
+		$order->save();
+		$order_id = $order->get_id();
+
+		wc_get_container()->get( EmailVerificationService::class )->mark_verified( $user_id );
+
+		$unlinked_order = wc_get_order( $order_id );
+		$this->assertSame( 0, $unlinked_order->get_customer_id(), 'Orders with a different billing email should remain unlinked' );
+	}
+
+	/**
+	 * @testdox has_linkable_orders is true when a matching guest order exists, false otherwise.
+	 */
+	public function test_has_linkable_orders_detects_matching_guest_orders(): void {
+		$email   = 'has-linkable@example.com';
+		$user_id = wc_create_new_customer( $email, 'haslinkableuser', 'pw' );
+
+		$this->assertFalse( $this->sut->has_linkable_orders( $user_id ), 'No guest orders yet — should be false' );
+
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		$this->assertTrue( $this->sut->has_linkable_orders( $user_id ), 'A matching guest order exists — should be true' );
+	}
+
+	/**
+	 * @testdox has_linkable_orders is false when guest orders exist only for a different email.
+	 */
+	public function test_has_linkable_orders_ignores_other_emails(): void {
+		$user_id = wc_create_new_customer( 'no-linkable@example.com', 'nolinkableuser', 'pw' );
+
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( 'someone-else@example.com' );
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		$this->assertFalse( $this->sut->has_linkable_orders( $user_id ), 'Guest orders for a different email should not count' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\CustomerEmailVerification;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\EmailVerificationService;
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\OrderLinker;
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\VerificationController;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the VerificationController class.
+ */
+class VerificationControllerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var VerificationController
+	 */
+	private $ctrl;
+
+	/**
+	 * The verification service.
+	 *
+	 * @var EmailVerificationService
+	 */
+	private $service;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->service = wc_get_container()->get( EmailVerificationService::class );
+		// Resolving the controller also triggers its constructor (hooks) and init() (deps).
+		$this->ctrl = wc_get_container()->get( VerificationController::class );
+		// Resolve OrderLinker so its woocommerce_customer_email_verified hook is registered.
+		wc_get_container()->get( OrderLinker::class );
+	}
+
+	/**
+	 * @testdox A valid key should mark the user as verified.
+	 */
+	public function test_valid_key_marks_verified(): void {
+		$user_id = wc_create_new_customer( 'verify-valid@example.com', 'verifyvaliduser', 'pw' );
+		$key     = $this->service->create_verification_key( $user_id );
+
+		$result = $this->ctrl->process_verification( $user_id, $key );
+
+		$this->assertTrue( $result, 'process_verification() should return true for a valid key' );
+		$this->assertTrue( $this->service->is_verified( $user_id ), 'User should be marked verified after a valid key' );
+	}
+
+	/**
+	 * @testdox An invalid key should not mark the user as verified.
+	 */
+	public function test_invalid_key_does_not_verify(): void {
+		$user_id = wc_create_new_customer( 'verify-invalid@example.com', 'verifyinvaliduser', 'pw' );
+		$this->service->create_verification_key( $user_id );
+
+		$result = $this->ctrl->process_verification( $user_id, 'bogus' );
+
+		$this->assertFalse( $result, 'process_verification() should return false for a bogus key' );
+		$this->assertFalse( $this->service->is_verified( $user_id ), 'User should not be verified after a bad key' );
+	}
+
+	/**
+	 * @testdox Sending a verification email then verifying the link should mark the user verified and link their guest orders.
+	 */
+	public function test_send_then_verify_round_trip_links_orders(): void {
+		$email   = 'roundtrip@example.com';
+		$user_id = wc_create_new_customer( $email, 'roundtripuser', 'pw' );
+
+		// Create a matching guest order.
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_customer_id( 0 );
+		$order->save();
+		$order_id = $order->get_id();
+
+		// Capture the verify URL emitted by send_verification_email().
+		$captured_url = '';
+		add_action(
+			'woocommerce_customer_verify_email_notification',
+			function ( $uid, $url ) use ( &$captured_url ) {
+				// The $uid arg is unused but required by the two-argument hook signature.
+				unset( $uid );
+				$captured_url = $url;
+			},
+			10,
+			2
+		);
+
+		$this->ctrl->send_verification_email( $user_id );
+
+		remove_all_actions( 'woocommerce_customer_verify_email_notification' );
+
+		$this->assertNotEmpty( $captured_url, 'send_verification_email() should fire the notification action with a URL' );
+
+		// Extract key and user from the URL and process the verification.
+		parse_str( (string) wp_parse_url( $captured_url, PHP_URL_QUERY ), $args );
+
+		$this->assertArrayHasKey( 'wc_verify_email_key', $args, 'URL should contain wc_verify_email_key' );
+		$this->assertArrayHasKey( 'wc_verify_email_user', $args, 'URL should contain wc_verify_email_user' );
+
+		$verified = $this->ctrl->process_verification( (int) $args['wc_verify_email_user'], $args['wc_verify_email_key'] );
+
+		$this->assertTrue( $verified, 'process_verification() should return true for the emailed key' );
+		$this->assertTrue( $this->service->is_verified( $user_id ), 'User should be verified after the round-trip' );
+
+		// Confirm OrderLinker linked the guest order.
+		$linked_order = wc_get_order( $order_id );
+		$this->assertSame( $user_id, $linked_order->get_customer_id(), 'Guest order should be linked to the verified customer' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
@@ -125,13 +125,14 @@ class VerificationControllerTest extends WC_Unit_Test_Case {
 		$_GET['wc_verify_email_key']  = $key;
 		$_GET['wc_verify_email_user'] = (string) $link_owner;
 		$abort                        = static function ( $location ): void {
-			throw new \RuntimeException( (string) $location );
+			throw new \RuntimeException( esc_html( (string) $location ) );
 		};
 		add_filter( 'wp_redirect', $abort );
 		try {
 			$this->ctrl->maybe_process_request();
 		} catch ( \RuntimeException $e ) {
-			unset( $e ); // Expected: the controller redirects and exits.
+			// Expected: the controller redirects and exits.
+			unset( $e );
 		} finally {
 			remove_filter( 'wp_redirect', $abort );
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
@@ -121,18 +121,18 @@ class VerificationControllerTest extends WC_Unit_Test_Case {
 		wp_set_current_user( $other_user );
 
 		// maybe_process_request() reads the verify args from the URL and ends in wp_safe_redirect()/exit;
-		// throw from the redirect filter so the exit is never reached and the test can assert.
+		// throw the redirect target from the filter so the exit is never reached and we can assert on it.
 		$_GET['wc_verify_email_key']  = $key;
 		$_GET['wc_verify_email_user'] = (string) $link_owner;
-		$abort                        = static function ( $location ): void {
+		$redirect_to                  = '';
+		$abort                        = static function ( $location ) {
 			throw new \RuntimeException( esc_html( (string) $location ) );
 		};
 		add_filter( 'wp_redirect', $abort );
 		try {
 			$this->ctrl->maybe_process_request();
 		} catch ( \RuntimeException $e ) {
-			// Expected: the controller redirects and exits.
-			unset( $e );
+			$redirect_to = $e->getMessage();
 		} finally {
 			remove_filter( 'wp_redirect', $abort );
 		}
@@ -145,5 +145,6 @@ class VerificationControllerTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $this->service->is_verified( $link_owner ), 'A link opened while logged in as a different user must not verify the link owner' );
 		$this->assertNotEmpty( $error_notices, 'An error notice should explain that verification is blocked while logged in elsewhere' );
+		$this->assertStringContainsString( 'orders', $redirect_to, 'Should redirect back to the Orders endpoint' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
@@ -111,40 +111,154 @@ class VerificationControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox A valid link is rejected without verifying or switching accounts when another user is logged in.
+	 * @testdox A GET on the emailed link renders an auto-submitting confirm form without consuming the key.
 	 */
-	public function test_verification_rejected_when_logged_in_as_other_user(): void {
+	public function test_get_link_renders_form_without_consuming_key(): void {
+		$user_id = wc_create_new_customer( 'get-landing@example.com', 'getlanding', 'pw' );
+		$key     = $this->service->create_verification_key( $user_id );
+
+		// get_confirm_page_html() is the pure builder behind the render-and-exit path.
+		$build = new \ReflectionMethod( $this->ctrl, 'get_confirm_page_html' );
+		$build->setAccessible( true );
+		$html = (string) $build->invoke( $this->ctrl, $user_id, $key );
+
+		$this->assertFalse( $this->service->is_verified( $user_id ), 'Rendering the landing page must not verify the user' );
+		$this->assertTrue( $this->service->check_verification_key( $user_id, $key ), 'Rendering the landing page must not consume the one-time key' );
+		// Must be a hidden field, not the button's value: HTMLFormElement.submit() (the JS auto-submit)
+		// omits submit-button name/value, so a button-only marker silently breaks verification when JS is on.
+		$this->assertStringContainsString( '<input type="hidden" name="wc_verify_email_submit"', $html, 'The submit marker that gates verification must be a hidden field so the JS auto-submit sends it' );
+		$this->assertStringContainsString( '_wpnonce', $html, 'The form must include a nonce field' );
+		$this->assertStringContainsString( '.submit()', $html, 'The page must auto-submit via JavaScript' );
+		$this->assertStringContainsString( 'type="submit"', $html, 'A manual fallback button must be present for when JS is unavailable' );
+	}
+
+	/**
+	 * @testdox Submitting the confirm form with a valid key verifies the address and links guest orders.
+	 */
+	public function test_confirm_submission_verifies_and_links_orders(): void {
+		$email   = 'confirm-post@example.com';
+		$user_id = wc_create_new_customer( $email, 'confirmpost', 'pw' );
+
+		$order = \WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_customer_id( 0 );
+		$order->save();
+
+		$key = $this->service->create_verification_key( $user_id );
+		wp_set_current_user( $user_id );
+
+		$redirect = $this->submit_confirmation( $user_id, $key, wp_create_nonce( 'woocommerce-verify-email' ) );
+
+		$success_notices = wc_get_notices( 'success' );
+		wc_clear_notices();
+		wp_set_current_user( 0 );
+
+		$this->assertTrue( $this->service->is_verified( $user_id ), 'A valid confirm submission should verify the address' );
+		$this->assertSame( $user_id, wc_get_order( $order->get_id() )->get_customer_id(), 'Guest order should link to the verified customer' );
+		$this->assertNotEmpty( $success_notices, 'A confirmation notice should be shown' );
+		$this->assertStringContainsString( 'orders', $redirect, 'Should redirect to the Orders endpoint' );
+	}
+
+	/**
+	 * @testdox A confirm submission with an invalid nonce does not verify or consume the key.
+	 */
+	public function test_confirm_submission_requires_valid_nonce(): void {
+		$user_id = wc_create_new_customer( 'bad-nonce@example.com', 'badnonce', 'pw' );
+		$key     = $this->service->create_verification_key( $user_id );
+		wp_set_current_user( $user_id );
+
+		$this->submit_confirmation( $user_id, $key, 'not-a-valid-nonce' );
+
+		$error_notices = wc_get_notices( 'error' );
+		wc_clear_notices();
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->service->is_verified( $user_id ), 'An invalid nonce must not verify the address' );
+		$this->assertTrue( $this->service->check_verification_key( $user_id, $key ), 'An invalid nonce must not consume the key' );
+		$this->assertNotEmpty( $error_notices, 'An invalid request should produce an error notice' );
+	}
+
+	/**
+	 * @testdox A confirm submission while logged in as a different user is rejected without verifying.
+	 */
+	public function test_confirm_submission_rejected_when_logged_in_as_other_user(): void {
 		$link_owner = wc_create_new_customer( 'link-owner@example.com', 'linkowner', 'pw' );
 		$other_user = wc_create_new_customer( 'other-user@example.com', 'otheruser', 'pw' );
 		$key        = $this->service->create_verification_key( $link_owner );
 
 		wp_set_current_user( $other_user );
 
-		// maybe_process_request() reads the verify args from the URL and ends in wp_safe_redirect()/exit;
-		// throw the redirect target from the filter so the exit is never reached and we can assert on it.
-		$_GET['wc_verify_email_key']  = $key;
-		$_GET['wc_verify_email_user'] = (string) $link_owner;
-		$redirect_to                  = '';
-		$abort                        = static function ( $location ) {
+		$redirect = $this->submit_confirmation( $link_owner, $key, wp_create_nonce( 'woocommerce-verify-email' ) );
+
+		$error_notices = wc_get_notices( 'error' );
+		wc_clear_notices();
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->service->is_verified( $link_owner ), 'A submission while logged in as a different user must not verify the link owner' );
+		$this->assertNotEmpty( $error_notices, 'An error notice should explain that verification is blocked while logged in elsewhere' );
+		$this->assertStringContainsString( 'orders', $redirect, 'Should redirect back to the Orders endpoint' );
+	}
+
+	/**
+	 * @testdox Submitting the confirm form twice shows success, not a contradictory error.
+	 */
+	public function test_double_confirm_submission_does_not_error(): void {
+		$user_id = wc_create_new_customer( 'double-confirm@example.com', 'doubleconfirm', 'pw' );
+		$key     = $this->service->create_verification_key( $user_id );
+		wp_set_current_user( $user_id );
+
+		$nonce = wp_create_nonce( 'woocommerce-verify-email' );
+		$this->submit_confirmation( $user_id, $key, $nonce );
+		$this->submit_confirmation( $user_id, $key, $nonce );
+
+		$error_notices   = wc_get_notices( 'error' );
+		$success_notices = wc_get_notices( 'success' );
+		wc_clear_notices();
+		wp_set_current_user( 0 );
+
+		$this->assertTrue( $this->service->is_verified( $user_id ), 'The first submission should verify the address' );
+		$this->assertEmpty( $error_notices, 'A repeat submission of a consumed key must not produce an error once verified' );
+		$this->assertCount( 1, $success_notices, 'The customer should see exactly one confirmation notice, not a duplicate' );
+	}
+
+	/**
+	 * Drive a confirm-form POST through the controller, returning the captured redirect target.
+	 *
+	 * handle_confirm_submission() ends in wp_safe_redirect()/exit; a filter throws the redirect target
+	 * so the exit is never reached and the test can assert on the outcome.
+	 *
+	 * @param int    $user_id User ID to submit.
+	 * @param string $key     Verification key to submit.
+	 * @param string $nonce   Nonce value to submit.
+	 * @return string The redirect location the handler attempted.
+	 */
+	private function submit_confirmation( int $user_id, string $key, string $nonce ): string {
+		$_SERVER['REQUEST_METHOD']       = 'POST';
+		$_POST['wc_verify_email_submit'] = '1';
+		$_POST['_wpnonce']               = $nonce;
+		$_POST['wc_verify_email_user']   = (string) $user_id;
+		$_POST['wc_verify_email_key']    = $key;
+
+		$redirect = '';
+		$abort    = static function ( $location ) {
 			throw new \RuntimeException( esc_html( (string) $location ) );
 		};
 		add_filter( 'wp_redirect', $abort );
 		try {
 			$this->ctrl->maybe_process_request();
 		} catch ( \RuntimeException $e ) {
-			$redirect_to = $e->getMessage();
+			$redirect = $e->getMessage();
 		} finally {
 			remove_filter( 'wp_redirect', $abort );
+			$_SERVER['REQUEST_METHOD'] = 'GET';
+			unset(
+				$_POST['wc_verify_email_submit'],
+				$_POST['_wpnonce'],
+				$_POST['wc_verify_email_user'],
+				$_POST['wc_verify_email_key']
+			);
 		}
 
-		$error_notices = wc_get_notices( 'error' );
-
-		unset( $_GET['wc_verify_email_key'], $_GET['wc_verify_email_user'] );
-		wc_clear_notices();
-		wp_set_current_user( 0 );
-
-		$this->assertFalse( $this->service->is_verified( $link_owner ), 'A link opened while logged in as a different user must not verify the link owner' );
-		$this->assertNotEmpty( $error_notices, 'An error notice should explain that verification is blocked while logged in elsewhere' );
-		$this->assertStringContainsString( 'orders', $redirect_to, 'Should redirect back to the Orders endpoint' );
+		return $redirect;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/VerificationControllerTest.php
@@ -81,20 +81,16 @@ class VerificationControllerTest extends WC_Unit_Test_Case {
 
 		// Capture the verify URL emitted by send_verification_email().
 		$captured_url = '';
-		add_action(
-			'woocommerce_customer_verify_email_notification',
-			function ( $uid, $url ) use ( &$captured_url ) {
-				// The $uid arg is unused but required by the two-argument hook signature.
-				unset( $uid );
-				$captured_url = $url;
-			},
-			10,
-			2
-		);
+		$listener     = static function ( $uid, $url ) use ( &$captured_url ) {
+			// The $uid arg is unused but required by the two-argument hook signature.
+			unset( $uid );
+			$captured_url = $url;
+		};
+		add_action( 'woocommerce_customer_verify_email_notification', $listener, 10, 2 );
 
 		$this->ctrl->send_verification_email( $user_id );
 
-		remove_all_actions( 'woocommerce_customer_verify_email_notification' );
+		remove_action( 'woocommerce_customer_verify_email_notification', $listener, 10 );
 
 		$this->assertNotEmpty( $captured_url, 'send_verification_email() should fire the notification action with a URL' );
 
@@ -112,5 +108,41 @@ class VerificationControllerTest extends WC_Unit_Test_Case {
 		// Confirm OrderLinker linked the guest order.
 		$linked_order = wc_get_order( $order_id );
 		$this->assertSame( $user_id, $linked_order->get_customer_id(), 'Guest order should be linked to the verified customer' );
+	}
+
+	/**
+	 * @testdox A valid link is rejected without verifying or switching accounts when another user is logged in.
+	 */
+	public function test_verification_rejected_when_logged_in_as_other_user(): void {
+		$link_owner = wc_create_new_customer( 'link-owner@example.com', 'linkowner', 'pw' );
+		$other_user = wc_create_new_customer( 'other-user@example.com', 'otheruser', 'pw' );
+		$key        = $this->service->create_verification_key( $link_owner );
+
+		wp_set_current_user( $other_user );
+
+		// maybe_process_request() reads the verify args from the URL and ends in wp_safe_redirect()/exit;
+		// throw from the redirect filter so the exit is never reached and the test can assert.
+		$_GET['wc_verify_email_key']  = $key;
+		$_GET['wc_verify_email_user'] = (string) $link_owner;
+		$abort                        = static function ( $location ): void {
+			throw new \RuntimeException( (string) $location );
+		};
+		add_filter( 'wp_redirect', $abort );
+		try {
+			$this->ctrl->maybe_process_request();
+		} catch ( \RuntimeException $e ) {
+			unset( $e ); // Expected: the controller redirects and exits.
+		} finally {
+			remove_filter( 'wp_redirect', $abort );
+		}
+
+		$error_notices = wc_get_notices( 'error' );
+
+		unset( $_GET['wc_verify_email_key'], $_GET['wc_verify_email_user'] );
+		wc_clear_notices();
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->service->is_verified( $link_owner ), 'A link opened while logged in as a different user must not verify the link owner' );
+		$this->assertNotEmpty( $error_notices, 'An error notice should explain that verification is blocked while logged in elsewhere' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailsTest.php
@@ -52,6 +52,7 @@ class WCTransactionalEmailsTest extends \WC_Unit_Test_Case {
 
 		$this->assertIsArray( $emails );
 		$this->assertContains( 'customer_new_account', $emails );
+		$this->assertContains( 'customer_verify_email', $emails );
 		$this->assertContains( 'customer_completed_order', $emails );
 		$this->assertContains( 'customer_processing_order', $emails );
 		$this->assertContains( 'customer_pos_completed_order', $emails );

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
@@ -88,7 +88,7 @@ class WooContentProcessorTest extends \WC_Unit_Test_Case {
 		$content = $this->woo_content_processor->get_woo_content( $wc_email );
 
 		$this->assertNotEmpty( $content );
-		$this->assertStringContainsString( 'Confirm email address and set password', $content );
+		$this->assertStringContainsString( 'Set your new password', $content );
 		$this->assertStringNotContainsString( 'Test email header', $content );
 		$this->assertStringNotContainsString( 'Test email footer', $content );
 		$this->assertStringNotContainsString( '<body>', $content );

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
@@ -78,16 +78,17 @@ class WooContentProcessorTest extends \WC_Unit_Test_Case {
 			}
 		);
 
-		$wc_email                   = new \WC_Email_Customer_New_Account();
-		$wc_email->user_login       = 'testuser';
-		$wc_email->user_email       = 'test@example.com';
-		$wc_email->user_pass        = 'testpass';
-		$wc_email->set_password_url = 'https://example.com/set-password';
+		$wc_email                     = new \WC_Email_Customer_New_Account();
+		$wc_email->user_login         = 'testuser';
+		$wc_email->user_email         = 'test@example.com';
+		$wc_email->user_pass          = 'testpass';
+		$wc_email->password_generated = true;
+		$wc_email->set_password_url   = 'https://example.com/set-password';
 
 		$content = $this->woo_content_processor->get_woo_content( $wc_email );
 
 		$this->assertNotEmpty( $content );
-		$this->assertStringContainsString( 'Set your new password', $content );
+		$this->assertStringContainsString( 'Confirm email address and set password', $content );
 		$this->assertStringNotContainsString( 'Test email header', $content );
 		$this->assertStringNotContainsString( 'Test email footer', $content );
 		$this->assertStringNotContainsString( '<body>', $content );

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
@@ -89,6 +89,7 @@ class WooContentProcessorTest extends \WC_Unit_Test_Case {
 
 		$this->assertNotEmpty( $content );
 		$this->assertStringContainsString( 'Set your new password', $content );
+		$this->assertStringContainsString( "Once you've clicked the link and set your new password, we'll link any past orders to your account.", $content );
 		$this->assertStringNotContainsString( 'Test email header', $content );
 		$this->assertStringNotContainsString( 'Test email footer', $content );
 		$this->assertStringNotContainsString( '<body>', $content );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

> 📚 **Stacked on #65822** — review/merge that first. The base branch for this PR is `mikejolley/customer-email-verification`, so the diff here is only the email-content changes.

Reworks the account email content so it leans on the new email-verification flow instead of leaking a password:

- **New-account email** — drops the temporary password from the body and instead presents a single "Confirm email address" (or "Confirm email address and set password") call to action backed by the verification link, with copy explaining that confirming links past orders. The `$user_pass` template variable is retained for backwards compatibility with custom templates.
- **Password-reset email** — refreshed content and button copy.
- Shared `email-button.php` partial and the block-editor (`general-block-email.php`) variants updated to match.

### How to test the changes in this Pull Request:

1. With #65822 in the stack, create a new customer account (e.g. via checkout) using an email that has matching guest orders.
2. Open the new-account email in Mailpit — it should show a **Confirm email address and set password** button and the "we'll link any past orders" copy, with no plaintext password.
3. Click through and confirm the email; past guest orders link as in #65822.
4. Trigger a password-reset email and confirm the refreshed content/button render correctly in HTML, plain-text and the block editor preview.

### Testing that has already taken place:

- PHPStan and PHPCS clean on the changed files.
- `WooContentProcessorTest` updated and passing for the new block-editor new-account content.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added to the branch manually.

</details>
