### PR TITLE
Add admin user-profile control for email confirmation

### DIFF
--- a/plugins/woocommerce/changelog/add-admin-email-verified-field
+++ b/plugins/woocommerce/changelog/add-admin-email-verified-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a user profile control so admins can view and set a customer's email-confirmation status.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/Admin/UserProfileField.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/Admin/UserProfileField.php
@@ -1,0 +1,107 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\CustomerEmailVerification\Admin;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\EmailVerificationService;
+use WP_User;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds an "Email address verified" control to the wp-admin user profile screen.
+ *
+ * The verification meta is the source of truth; this checkbox simply reflects and edits it.
+ * Ticking it marks the user's current email verified (which also links any matching past guest
+ * orders); unticking it clears the status.
+ *
+ * @since 11.0.0
+ */
+class UserProfileField {
+
+	private const NONCE_ACTION = 'wc_email_verified';
+	private const FIELD        = 'wc_email_verified';
+
+	/**
+	 * Verification service.
+	 *
+	 * @var EmailVerificationService
+	 */
+	private $service;
+
+	/**
+	 * Constructor. Registers hooks.
+	 */
+	public function __construct() {
+		add_action( 'show_user_profile', array( $this, 'render' ) );
+		add_action( 'edit_user_profile', array( $this, 'render' ) );
+		add_action( 'personal_options_update', array( $this, 'save' ) );
+		add_action( 'edit_user_profile_update', array( $this, 'save' ) );
+	}
+
+	/**
+	 * Inject dependencies.
+	 *
+	 * @internal
+	 *
+	 * @param EmailVerificationService $service Verification service.
+	 */
+	final public function init( EmailVerificationService $service ): void {
+		$this->service = $service;
+	}
+
+	/**
+	 * Render the "Email address verified" checkbox.
+	 *
+	 * @param WP_User|mixed $user The user being edited.
+	 */
+	public function render( $user ): void {
+		if ( ! $user instanceof WP_User || ! current_user_can( 'edit_user', $user->ID ) ) {
+			return;
+		}
+
+		wp_nonce_field( self::NONCE_ACTION . '_' . $user->ID, self::NONCE_ACTION . '_nonce' );
+		?>
+		<h2><?php esc_html_e( 'Email confirmation', 'woocommerce' ); ?></h2>
+		<table class="form-table" role="presentation">
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Email address confirmed', 'woocommerce' ); ?></th>
+				<td>
+					<label for="<?php echo esc_attr( self::FIELD ); ?>">
+						<input type="checkbox" name="<?php echo esc_attr( self::FIELD ); ?>" id="<?php echo esc_attr( self::FIELD ); ?>" value="1" <?php checked( $this->service->is_verified( $user->ID ) ); ?> />
+						<?php esc_html_e( 'The customer has confirmed they own this email address.', 'woocommerce' ); ?>
+					</label>
+				</td>
+			</tr>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Persist the "Email address verified" checkbox when a profile is saved.
+	 *
+	 * @param int|mixed $user_id The user being saved.
+	 */
+	public function save( $user_id ): void {
+		$user_id = (int) $user_id;
+
+		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+			return;
+		}
+
+		$nonce = isset( $_POST[ self::NONCE_ACTION . '_nonce' ] ) ? sanitize_text_field( wp_unslash( $_POST[ self::NONCE_ACTION . '_nonce' ] ) ) : '';
+
+		// The nonce also guards against acting when our field was not rendered (which would
+		// otherwise clear verification on every profile save).
+		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION . '_' . $user_id ) ) {
+			return;
+		}
+
+		if ( isset( $_POST[ self::FIELD ] ) ) {
+			$this->service->mark_verified( $user_id );
+		} else {
+			$this->service->clear_verification( $user_id );
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/Admin/UserProfileField.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/Admin/UserProfileField.php
@@ -36,8 +36,9 @@ class UserProfileField {
 	public function __construct() {
 		add_action( 'show_user_profile', array( $this, 'render' ) );
 		add_action( 'edit_user_profile', array( $this, 'render' ) );
-		add_action( 'personal_options_update', array( $this, 'save' ) );
-		add_action( 'edit_user_profile_update', array( $this, 'save' ) );
+		// Saved on profile_update (not the *_profile_update hooks) because that fires after the user
+		// record is written, so an email changed in the same save is already current when we verify it.
+		add_action( 'profile_update', array( $this, 'save' ) );
 	}
 
 	/**
@@ -57,7 +58,7 @@ class UserProfileField {
 	 * @param WP_User|mixed $user The user being edited.
 	 */
 	public function render( $user ): void {
-		if ( ! $user instanceof WP_User || ! current_user_can( 'edit_user', $user->ID ) ) {
+		if ( ! $user instanceof WP_User || ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}
 
@@ -72,6 +73,7 @@ class UserProfileField {
 						<input type="checkbox" name="<?php echo esc_attr( self::FIELD ); ?>" id="<?php echo esc_attr( self::FIELD ); ?>" value="1" <?php checked( $this->service->is_verified( $user->ID ) ); ?> />
 						<?php esc_html_e( 'The customer has confirmed they own this email address.', 'woocommerce' ); ?>
 					</label>
+					<p class="description"><?php esc_html_e( 'Confirming the email address also links any past guest orders placed with it to this account.', 'woocommerce' ); ?></p>
 				</td>
 			</tr>
 		</table>
@@ -86,14 +88,15 @@ class UserProfileField {
 	public function save( $user_id ): void {
 		$user_id = (int) $user_id;
 
-		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}
 
 		$nonce = isset( $_POST[ self::NONCE_ACTION . '_nonce' ] ) ? sanitize_text_field( wp_unslash( $_POST[ self::NONCE_ACTION . '_nonce' ] ) ) : '';
 
-		// The nonce also guards against acting when our field was not rendered (which would
-		// otherwise clear verification on every profile save).
+		// profile_update fires on every wp_update_user() call, so the nonce is what scopes us to a
+		// profile-screen submission where our field was actually rendered; without it we would clear
+		// verification on every unrelated user update.
 		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION . '_' . $user_id ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/CustomerEmailVerification.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/CustomerEmailVerification.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\CustomerEmailVerification;
 
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\Admin\UserProfileField;
 use Automattic\WooCommerce\Internal\CustomerEmailVerification\Emails\CustomerVerifyEmail;
 
 /**
@@ -42,6 +43,10 @@ class CustomerEmailVerification {
 		$container = wc_get_container();
 		$container->get( VerificationController::class );
 		$container->get( VerificationEventListener::class );
+
+		if ( is_admin() ) {
+			$container->get( UserProfileField::class );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
@@ -112,11 +112,16 @@ class UserProfileFieldTest extends WC_Unit_Test_Case {
 	public function test_save_verifies_new_email_when_changed_and_checked_together(): void {
 		$user_id = wc_create_new_customer( 'before-change@example.com', 'emailchange', 'pw' );
 
+		// A fresh instance so its constructor registers the profile_update hook within this test:
+		// the container caches a shared instance, so resolving it again would not re-add the hook.
+		$field = new UserProfileField();
+		$field->init( $this->service );
+
 		$_POST['wc_email_verified_nonce'] = wp_create_nonce( 'wc_email_verified_' . $user_id );
 		$_POST['wc_email_verified']       = '1';
 
-		// The field saves on profile_update, which fires after wp_update_user has written the new
-		// email, so verification must land on 'after-change@example.com', not the old address.
+		// Changing the email runs through wp_update_user, whose profile_update hook fires after the
+		// new address is written, so verification must land on the new address, not the old one.
 		wp_update_user(
 			array(
 				'ID'         => $user_id,

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
@@ -1,0 +1,93 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\CustomerEmailVerification\Admin;
+
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\Admin\UserProfileField;
+use Automattic\WooCommerce\Internal\CustomerEmailVerification\EmailVerificationService;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the admin user-profile "Email address verified" checkbox.
+ */
+class UserProfileFieldTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var UserProfileField
+	 */
+	private $sut;
+
+	/**
+	 * The verification service.
+	 *
+	 * @var EmailVerificationService
+	 */
+	private $service;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut     = wc_get_container()->get( UserProfileField::class );
+		$this->service = wc_get_container()->get( EmailVerificationService::class );
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		unset( $_POST['wc_email_verified'], $_POST['wc_email_verified_nonce'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Saving the profile with the box checked (and a valid nonce) marks the user verified.
+	 */
+	public function test_save_marks_verified_when_checked(): void {
+		$user_id = wc_create_new_customer( 'profile-check@example.com', 'profilecheck', 'pw' );
+
+		$_POST['wc_email_verified_nonce'] = wp_create_nonce( 'wc_email_verified_' . $user_id );
+		$_POST['wc_email_verified']       = '1';
+
+		$this->sut->save( $user_id );
+
+		$this->assertTrue( $this->service->is_verified( $user_id ) );
+	}
+
+	/**
+	 * @testdox Saving the profile with the box unchecked (and a valid nonce) clears verification.
+	 */
+	public function test_save_clears_when_unchecked(): void {
+		$user_id = wc_create_new_customer( 'profile-uncheck@example.com', 'profileuncheck', 'pw' );
+		$this->service->mark_verified( $user_id );
+		$this->assertTrue( $this->service->is_verified( $user_id ) );
+
+		$_POST['wc_email_verified_nonce'] = wp_create_nonce( 'wc_email_verified_' . $user_id );
+		// No 'wc_email_verified' key in POST means the checkbox was unticked.
+
+		$this->sut->save( $user_id );
+
+		$this->assertFalse( $this->service->is_verified( $user_id ) );
+	}
+
+	/**
+	 * @testdox Saving without a valid nonce leaves verification untouched.
+	 */
+	public function test_save_does_nothing_without_valid_nonce(): void {
+		$user_id = wc_create_new_customer( 'profile-nononce@example.com', 'profilenononce', 'pw' );
+
+		$_POST['wc_email_verified'] = '1';
+		// No nonce provided.
+
+		$this->sut->save( $user_id );
+
+		$this->assertFalse( $this->service->is_verified( $user_id ), 'Without a valid nonce the checkbox must not take effect.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/Admin/UserProfileFieldTest.php
@@ -90,4 +90,40 @@ class UserProfileFieldTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $this->service->is_verified( $user_id ), 'Without a valid nonce the checkbox must not take effect.' );
 	}
+
+	/**
+	 * @testdox A non-privileged user cannot self-verify their own email via a profile save.
+	 */
+	public function test_save_does_not_allow_non_privileged_self_verify(): void {
+		$user_id = wc_create_new_customer( 'self-verify@example.com', 'selfverify', 'pw' );
+		wp_set_current_user( $user_id );
+
+		$_POST['wc_email_verified_nonce'] = wp_create_nonce( 'wc_email_verified_' . $user_id );
+		$_POST['wc_email_verified']       = '1';
+
+		$this->sut->save( $user_id );
+
+		$this->assertFalse( $this->service->is_verified( $user_id ), 'A customer without manage_woocommerce must not be able to verify their own email.' );
+	}
+
+	/**
+	 * @testdox Changing the email and ticking verify in the same save verifies the new address.
+	 */
+	public function test_save_verifies_new_email_when_changed_and_checked_together(): void {
+		$user_id = wc_create_new_customer( 'before-change@example.com', 'emailchange', 'pw' );
+
+		$_POST['wc_email_verified_nonce'] = wp_create_nonce( 'wc_email_verified_' . $user_id );
+		$_POST['wc_email_verified']       = '1';
+
+		// The field saves on profile_update, which fires after wp_update_user has written the new
+		// email, so verification must land on 'after-change@example.com', not the old address.
+		wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => 'after-change@example.com',
+			)
+		);
+
+		$this->assertTrue( $this->service->is_verified( $user_id ), 'The newly saved email address should be verified.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

> 📚 **Stacked on #65822** — review/merge that first. The base branch for this PR is `mikejolley/customer-email-verification`, so the diff here is only the admin profile field.

Adds an admin-facing control to the user profile screen for the email-verification status introduced in #65822. Simply checkbox visible to users with edit_user capability.

### Screenshot

<img width="650" height="115" alt="image" src="https://github.com/user-attachments/assets/7605d494-ac09-4001-b41f-bcf8a29a242f" />

### How to test the changes in this Pull Request:

1. Edit a customer in **wp-admin → Users**.
2. Confirm the **Email address confirmed** checkbox reflects the customer's current status (unticked for a fresh/unconfirmed account).
3. Tick it and save — the customer is now treated as confirmed (e.g. the My Account verify prompt from #65822 no longer shows).
4. Untick and save — confirmation is cleared and the prompt returns.

### Testing that has already taken place:

- PHPUnit coverage for the profile field (render + save paths) passing.
- PHPStan and PHPCS clean on the changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added to the branch manually.

</details>
