### PR TITLE
Improve classic product editor publish date field

### DIFF
--- a/plugins/woocommerce/changelog/poligilad-auto-publish-field-component
+++ b/plugins/woocommerce/changelog/poligilad-auto-publish-field-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve the classic product editor published date and time field.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8630,6 +8630,31 @@ table.bar_chart {
 		margin-right: 4px;
 	}
 
+	&.post-type-product #submitdiv {
+		#wc-product-publish-datetime {
+			box-sizing: border-box;
+			display: block;
+			font-size: 13px;
+			height: 32px;
+			margin: 0 0 4px;
+			padding: 0 8px;
+			text-align: left;
+			width: 100%;
+		}
+
+		#wc-product-publish-datetime::-webkit-datetime-edit {
+			text-align: left;
+		}
+
+		#timestampdiv.wc-product-publish-has-datetime-input .timestamp-wrap {
+			display: none;
+		}
+
+		#wc-product-publish-datetime.form-invalid {
+			border-color: #d63638;
+		}
+	}
+
 	// Shipping zone name input: ID selector in the base rule outranks the form-table override above.
 	.wc-shipping-zone-settings #zone_name {
 		padding: 0 12px;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -126,6 +126,200 @@ jQuery( function ( $ ) {
 			return false;
 		} );
 
+	const wc_product_publish_timestamp = {
+		init: function () {
+			this.$timestampdiv = $( '#timestampdiv' );
+			this.$timestamp_wrap =
+				this.$timestampdiv.find( '.timestamp-wrap' );
+			this.$fields = $( '#aa, #mm, #jj, #hh, #mn' );
+
+			if (
+				! this.$timestampdiv.length ||
+				! this.$timestamp_wrap.length ||
+				5 !== this.$fields.length ||
+				$( '#wc-product-publish-datetime' ).length
+			) {
+				return;
+			}
+
+			this.render_field();
+			this.bind_events();
+			this.sync_from_core_fields();
+		},
+
+		pad: function ( value ) {
+			return ( '00' + value ).slice( -2 );
+		},
+
+		get_accessible_label: function () {
+			const timestamp = document.getElementById( 'timestamp' );
+
+			if ( ! timestamp ) {
+				return '';
+			}
+
+			const label_node = Array.prototype.find.call(
+				timestamp.childNodes,
+				function ( node ) {
+					return 3 === node.nodeType;
+				}
+			);
+
+			return label_node
+				? label_node.nodeValue.replace( /:$/, '' ).trim()
+				: '';
+		},
+
+		render_field: function () {
+			this.$datetime_input = $( '<input />', {
+				type: 'datetime-local',
+				id: 'wc-product-publish-datetime',
+				class: 'wc-product-publish-datetime-input',
+				step: '60',
+			} );
+
+			const label = this.get_accessible_label();
+
+			if ( label ) {
+				this.$datetime_input.attr( 'aria-label', label );
+			}
+
+			this.$timestamp_wrap.before( this.$datetime_input );
+			this.$timestampdiv.addClass(
+				'wc-product-publish-has-datetime-input'
+			);
+		},
+
+		bind_events: function () {
+			const self = this;
+			const save_button = this.$timestampdiv
+				.find( '.save-timestamp' )
+				.get( 0 );
+			const post_form = document.getElementById( 'post' );
+
+			this.$datetime_input.on( 'input change', function () {
+				self.sync_to_core_fields();
+			} );
+
+			this.$timestampdiv
+				.siblings( 'a.edit-timestamp' )
+				.on( 'click', function () {
+					window.setTimeout( function () {
+						self.sync_from_core_fields();
+						self.clear_invalid_state();
+						self.$datetime_input.trigger( 'focus' );
+					}, 0 );
+				} );
+
+			this.$timestampdiv
+				.find( '.cancel-timestamp' )
+				.on( 'click', function () {
+					window.setTimeout( function () {
+						self.sync_from_core_fields();
+						self.clear_invalid_state();
+					}, 0 );
+				} );
+
+			if ( save_button ) {
+				save_button.addEventListener(
+					'click',
+					function ( event ) {
+						if ( ! self.sync_to_core_fields() ) {
+							event.preventDefault();
+							event.stopImmediatePropagation();
+							self.focus_invalid_field();
+						}
+					},
+					true
+				);
+			}
+
+			if ( post_form ) {
+				post_form.addEventListener(
+					'submit',
+					function ( event ) {
+						if (
+							self.$timestampdiv.is( ':visible' ) &&
+							! self.sync_to_core_fields()
+						) {
+							event.preventDefault();
+							event.stopImmediatePropagation();
+							self.focus_invalid_field();
+						}
+					},
+					true
+				);
+			}
+		},
+
+		sync_from_core_fields: function () {
+			this.$datetime_input.val(
+				$( '#aa' ).val() +
+					'-' +
+					this.pad( $( '#mm' ).val() ) +
+					'-' +
+					this.pad( $( '#jj' ).val() ) +
+					'T' +
+					this.pad( $( '#hh' ).val() ) +
+					':' +
+					this.pad( $( '#mn' ).val() )
+			);
+		},
+
+		sync_to_core_fields: function () {
+			const value = this.$datetime_input.val();
+			const parts = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(
+				value
+			);
+
+			if ( ! parts || ! this.is_valid_datetime( parts ) ) {
+				this.set_invalid_state();
+				return false;
+			}
+
+			$( '#aa' ).val( parts[ 1 ] );
+			$( '#mm' ).val( parts[ 2 ] );
+			$( '#jj' ).val( parts[ 3 ] );
+			$( '#hh' ).val( parts[ 4 ] );
+			$( '#mn' ).val( parts[ 5 ] );
+
+			this.clear_invalid_state();
+			return true;
+		},
+
+		is_valid_datetime: function ( parts ) {
+			const attempted_date = new Date(
+				Number( parts[ 1 ] ),
+				Number( parts[ 2 ] ) - 1,
+				Number( parts[ 3 ] ),
+				Number( parts[ 4 ] ),
+				Number( parts[ 5 ] )
+			);
+
+			return (
+				attempted_date.getFullYear() === Number( parts[ 1 ] ) &&
+				attempted_date.getMonth() + 1 === Number( parts[ 2 ] ) &&
+				attempted_date.getDate() === Number( parts[ 3 ] ) &&
+				attempted_date.getHours() === Number( parts[ 4 ] ) &&
+				attempted_date.getMinutes() === Number( parts[ 5 ] )
+			);
+		},
+
+		set_invalid_state: function () {
+			this.$datetime_input.addClass( 'form-invalid' );
+		},
+
+		clear_invalid_state: function () {
+			this.$datetime_input.removeClass( 'form-invalid' );
+		},
+
+		focus_invalid_field: function () {
+			this.$datetime_input.trigger( 'focus' );
+		},
+	};
+
+	wc_product_publish_timestamp.init();
+
 	// Product type specific options.
 	$( 'select#product-type' )
 		.on( 'change', function () {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -161,13 +161,23 @@ jQuery( function ( $ ) {
 			const label_node = Array.prototype.find.call(
 				timestamp.childNodes,
 				function ( node ) {
-					return 3 === node.nodeType;
+					return (
+						3 === node.nodeType &&
+						node.nodeValue &&
+						node.nodeValue.trim()
+					);
 				}
 			);
 
-			return label_node
-				? label_node.nodeValue.replace( /:$/, '' ).trim()
-				: '';
+			if ( ! label_node ) {
+				return '';
+			}
+
+			const label_text = label_node.nodeValue.trim();
+
+			return label_text.endsWith( ':' )
+				? label_text.slice( 0, -1 ).trim()
+				: label_text;
 		},
 
 		render_field: function () {
@@ -267,9 +277,8 @@ jQuery( function ( $ ) {
 		},
 
 		sync_to_core_fields: function () {
-			const value = this.$datetime_input.val();
-			const parts = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(
-				value
+			const parts = this.parse_datetime_value(
+				this.$datetime_input.val()
 			);
 
 			if ( ! parts || ! this.is_valid_datetime( parts ) ) {
@@ -284,6 +293,66 @@ jQuery( function ( $ ) {
 			$( '#mn' ).val( parts[ 5 ] );
 
 			this.clear_invalid_state();
+			return true;
+		},
+
+		parse_datetime_value: function ( value ) {
+			const date_time_parts = ( value || '' ).split( 'T' );
+
+			if ( 2 !== date_time_parts.length ) {
+				return false;
+			}
+
+			const date_parts = date_time_parts[ 0 ].split( '-' );
+			const time_parts = date_time_parts[ 1 ].split( ':' );
+
+			if ( 3 !== date_parts.length || 2 !== time_parts.length ) {
+				return false;
+			}
+
+			const parts = [
+				null,
+				date_parts[ 0 ],
+				date_parts[ 1 ],
+				date_parts[ 2 ],
+				time_parts[ 0 ],
+				time_parts[ 1 ],
+			];
+
+			if (
+				4 !== parts[ 1 ].length ||
+				2 !== parts[ 2 ].length ||
+				2 !== parts[ 3 ].length ||
+				2 !== parts[ 4 ].length ||
+				2 !== parts[ 5 ].length ||
+				! this.is_numeric_string( parts[ 1 ] ) ||
+				! this.is_numeric_string( parts[ 2 ] ) ||
+				! this.is_numeric_string( parts[ 3 ] ) ||
+				! this.is_numeric_string( parts[ 4 ] ) ||
+				! this.is_numeric_string( parts[ 5 ] )
+			) {
+				return false;
+			}
+
+			return parts;
+		},
+
+		is_numeric_string: function ( value ) {
+			let index = 0;
+
+			if ( ! value ) {
+				return false;
+			}
+
+			for ( ; index < value.length; index++ ) {
+				if (
+					value.charAt( index ) < '0' ||
+					value.charAt( index ) > '9'
+				) {
+					return false;
+				}
+			}
+
 			return true;
 		},
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The classic product editor publish metabox currently exposes separate month, day, year, hour, and minute inputs when editing the Published/Scheduled timestamp. This updates the WooCommerce product editor experience to use a single native date/time field while continuing to sync back to WordPress Core's existing timestamp fields.

This is a UX improvement because the date and time can now be entered from one keyboard-friendly field instead of moving through several small inputs. The native date/time picker also gives users a more intuitive calendar and time selection experience, including affordances such as choosing today's date and making more granular date/time adjustments from the browser control.

The change is scoped to products, keeps the existing publish/status/save behavior intact, and preserves the visible summary text such as Published, Scheduled, and Publish immediately while editing. The newer React date/time component is not used here because this surface is still the classic editor, but the native input gives us the same underlying input type used by the newer editor experience and is styled to match the current WordPress/WooCommerce admin inputs.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<img width="808" height="1667" alt="Publish box - date   time" src="https://github.com/user-attachments/assets/677340c3-de53-4c36-951b-7b3378671902" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start a local WooCommerce development environment and build classic assets.
2. Go to **Products > Add new product** in wp-admin.
3. Add a product name, since publishing/scheduling a product requires a title in the current classic product editor flow.
4. In the **Publish** metabox, select **Edit** next to the publish date.
5. Confirm the date and time are shown in a single native date/time field, and the summary text in the row remains visible.
6. Choose a future date and time, select **OK**, publish or update the product, and confirm the product is scheduled for the selected date/time.
7. Edit the scheduled product again, change the date/time, save it, and confirm the updated date/time persists after reload.
8. Repeat with an already published product and confirm changing the published date/time persists after saving.
9. Open the date/time editor, change the value, select **Cancel**, and confirm the previous value is restored.
10. Confirm the field spacing, left alignment, and input height visually match the surrounding publish metabox controls.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Verified the JavaScript syntax with `node --check plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js`.
- Verified whitespace with `git diff --check`.
- Built classic assets with `pnpm wc:build:classic-assets`.
- Manually tested scheduling a new product with a future date/time.
- Manually tested editing an existing scheduled product's date/time.
- Manually tested editing an already published product's published date/time.
- Manually tested canceling a date/time edit restores the previous value.
- Manually verified the summary text remains visible while editing.
- Manually verified the spacing, left alignment, and input height in the publish metabox.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
