### PR TITLE
Fix POS catalog feed generation getting stuck in_progress when killed

### DIFF
--- a/plugins/woocommerce/changelog/fix-pos-catalog-stuck-in-progress
+++ b/plugins/woocommerce/changelog/fix-pos-catalog-stuck-in-progress
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Recover POS catalog feed generation jobs that were killed (server timeout or out of memory) and left stuck in the in_progress state, and extend the per-batch PHP time limit during generation.

--- a/plugins/woocommerce/changelog/fix-pos-catalog-stuck-in-progress
+++ b/plugins/woocommerce/changelog/fix-pos-catalog-stuck-in-progress
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fix
-Comment: Recover POS catalog feed generation jobs that were killed (server timeout or out of memory) and left stuck in the in_progress state, and extend the per-batch PHP time limit during generation.
+Comment: Recover POS catalog feed generation jobs that were killed (server timeout or out of memory) and left stuck in the in_progress state, and raise the execution time and memory limits during generation.

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
@@ -169,6 +169,25 @@ class AsyncGenerator {
 			$feed   = $this->integration->create_feed();
 			$walker = ProductWalker::from_integration( $this->integration, $feed );
 
+			/**
+			 * Filters the per-batch PHP execution time limit (in seconds) for product feed generation.
+			 *
+			 * The execution time limit is reset to this value after each processed batch, so that a low
+			 * `max_execution_time` does not abort generation part-way through a large catalog. Return 0
+			 * to leave the time limit untouched.
+			 *
+			 * This only affects PHP's own execution timeout. It does not extend Action Scheduler's
+			 * failure period (`action_scheduler_failure_period`, 300 seconds by default) nor any hard
+			 * server/host request timeout, so it is a mitigation rather than a guarantee for very large
+			 * catalogs.
+			 *
+			 * @param int $batch_time_limit The per-batch time limit in seconds.
+			 *
+			 * @since 11.0.0
+			 */
+			$batch_time_limit = (int) apply_filters( 'woocommerce_product_feed_batch_time_limit', 5 * MINUTE_IN_SECONDS );
+			$walker->add_time_limit( $batch_time_limit );
+
 			// Add dynamic args to the mapper.
 			$args = $status['args'] ?? array();
 			if (

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
@@ -166,15 +166,17 @@ class AsyncGenerator {
 		update_option( $option_key, $status );
 
 		try {
-			$feed   = $this->integration->create_feed();
-			$walker = ProductWalker::from_integration( $this->integration, $feed );
+			// Large catalogs are memory heavy, so give the process as much headroom as the
+			// host allows before the heavy lifting begins. This only raises the limit for the
+			// current process and never lowers an already higher limit.
+			wp_raise_memory_limit( 'admin' );
 
 			/**
 			 * Filters the per-batch PHP execution time limit (in seconds) for product feed generation.
 			 *
-			 * The execution time limit is reset to this value after each processed batch, so that a low
-			 * `max_execution_time` does not abort generation part-way through a large catalog. Return 0
-			 * to leave the time limit untouched.
+			 * The execution time limit is set to this value up front and reset to it after each processed
+			 * batch, so that a low `max_execution_time` does not abort generation part-way through a large
+			 * catalog. Return 0 to leave the time limit untouched.
 			 *
 			 * This only affects PHP's own execution timeout. It does not extend Action Scheduler's
 			 * failure period (`action_scheduler_failure_period`, 300 seconds by default) nor any hard
@@ -186,6 +188,16 @@ class AsyncGenerator {
 			 * @since 11.0.0
 			 */
 			$batch_time_limit = (int) apply_filters( 'woocommerce_product_feed_batch_time_limit', 5 * MINUTE_IN_SECONDS );
+
+			// Raise the time limit up front too: the walker only resets it after each batch, so the
+			// initial product query and the first batch would otherwise run under whatever (possibly
+			// very low) limit the Action Scheduler request started with.
+			if ( $batch_time_limit > 0 ) {
+				wc_set_time_limit( $batch_time_limit );
+			}
+
+			$feed   = $this->integration->create_feed();
+			$walker = ProductWalker::from_integration( $this->integration, $feed );
 			$walker->add_time_limit( $batch_time_limit );
 
 			// Add dynamic args to the mapper.

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
@@ -112,6 +112,7 @@ class AsyncGenerator {
 
 		$status = array(
 			'scheduled_at' => time(),
+			'updated_at'   => time(),
 			'completed_at' => null,
 			'state'        => self::STATE_SCHEDULED,
 			'progress'     => 0,
@@ -160,7 +161,8 @@ class AsyncGenerator {
 			return;
 		}
 
-		$status['state'] = self::STATE_IN_PROGRESS;
+		$status['state']      = self::STATE_IN_PROGRESS;
+		$status['updated_at'] = time();
 		update_option( $option_key, $status );
 
 		try {
@@ -250,6 +252,8 @@ class AsyncGenerator {
 				return $status;
 
 			case self::STATE_IN_PROGRESS:
+				// A genuinely running job (its heartbeat is still fresh, otherwise validate_status()
+				// above would have restarted it) cannot be interrupted mid-flight.
 				throw new \Exception( 'Feed generation is already in progress and cannot be stopped.' );
 
 			case self::STATE_COMPLETED:
@@ -314,11 +318,12 @@ class AsyncGenerator {
 	 * @return array                   Updated status of the feed generation.
 	 */
 	private function update_feed_progress( array $status, WalkerProgress $progress ): array {
-		$status['progress']  = $progress->total_count > 0
+		$status['progress']   = $progress->total_count > 0
 			? round( ( $progress->processed_items / $progress->total_count ) * 100, 2 )
 			: 0;
-		$status['processed'] = $progress->processed_items;
-		$status['total']     = $progress->total_count;
+		$status['processed']  = $progress->processed_items;
+		$status['total']      = $progress->total_count;
+		$status['updated_at'] = time();
 		return $status;
 	}
 
@@ -375,6 +380,32 @@ class AsyncGenerator {
 			)
 		) {
 			return false;
+		}
+
+		/**
+		 * If the job is in progress but has not updated its heartbeat within the timeout, the
+		 * process was most likely killed (server/host timeout or out of memory) before it could
+		 * mark itself as failed. Without this check, such a job would stay `in_progress` forever
+		 * and no new feed could ever be generated.
+		 *
+		 * The heartbeat (`updated_at`) is refreshed when the job starts and after every processed
+		 * batch, so an active job keeps it fresh while a killed one does not.
+		 */
+		if ( self::STATE_IN_PROGRESS === $status['state'] ) {
+			$last_activity = $status['updated_at'] ?? $status['scheduled_at'] ?? 0;
+
+			/**
+			 * Allows the timeout for a feed to remain in `in_progress` state without a heartbeat
+			 * update to be changed. Past this point the job is treated as stuck and regenerated.
+			 *
+			 * @param int $stuck_time The stuck time in seconds.
+			 * @return int The stuck time in seconds.
+			 * @since 11.0.0
+			 */
+			$in_progress_timeout = apply_filters( 'woocommerce_product_feed_in_progress_timeout', 5 * MINUTE_IN_SECONDS );
+			if ( time() - $last_activity > $in_progress_timeout ) {
+				return false;
+			}
 		}
 
 		// All good.

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
@@ -136,4 +136,95 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 
 		$this->assertTrue( $method->invoke( $this->sut, $status ) );
 	}
+
+	/**
+	 * Test that validate_status treats an in-progress job with a stale heartbeat as invalid.
+	 *
+	 * This is the recovery path for jobs whose process was killed (server timeout or out of
+	 * memory) before they could mark themselves as failed.
+	 */
+	public function test_validate_status_returns_false_for_stale_in_progress_feed() {
+		$status = array(
+			'state'        => AsyncGenerator::STATE_IN_PROGRESS,
+			'scheduled_at' => time() - HOUR_IN_SECONDS,
+			'updated_at'   => time() - HOUR_IN_SECONDS,
+		);
+
+		$method = ( new ReflectionClass( $this->sut ) )->getMethod( 'validate_status' );
+		$method->setAccessible( true );
+
+		$this->assertFalse( $method->invoke( $this->sut, $status ) );
+	}
+
+	/**
+	 * Test that validate_status keeps an in-progress job with a fresh heartbeat valid.
+	 */
+	public function test_validate_status_returns_true_for_active_in_progress_feed() {
+		$status = array(
+			'state'        => AsyncGenerator::STATE_IN_PROGRESS,
+			'scheduled_at' => time() - HOUR_IN_SECONDS,
+			'updated_at'   => time(),
+		);
+
+		$method = ( new ReflectionClass( $this->sut ) )->getMethod( 'validate_status' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( $this->sut, $status ) );
+	}
+
+	/**
+	 * Test that validate_status treats an in-progress job missing a heartbeat as invalid
+	 * when it was scheduled long ago (e.g. a job stuck before the heartbeat was introduced).
+	 */
+	public function test_validate_status_returns_false_for_in_progress_feed_without_heartbeat() {
+		$status = array(
+			'state'        => AsyncGenerator::STATE_IN_PROGRESS,
+			'scheduled_at' => time() - HOUR_IN_SECONDS,
+		);
+
+		$method = ( new ReflectionClass( $this->sut ) )->getMethod( 'validate_status' );
+		$method->setAccessible( true );
+
+		$this->assertFalse( $method->invoke( $this->sut, $status ) );
+	}
+
+	/**
+	 * Test that the heartbeat timeout for in-progress jobs is filterable.
+	 */
+	public function test_validate_status_in_progress_timeout_is_filterable() {
+		$status = array(
+			'state'        => AsyncGenerator::STATE_IN_PROGRESS,
+			'scheduled_at' => time() - 30,
+			'updated_at'   => time() - 30,
+		);
+
+		$method = ( new ReflectionClass( $this->sut ) )->getMethod( 'validate_status' );
+		$method->setAccessible( true );
+
+		// With a 10 second timeout, a 30 second old heartbeat is considered stale.
+		$callback = fn() => 10;
+		add_filter( 'woocommerce_product_feed_in_progress_timeout', $callback );
+		$this->assertFalse( $method->invoke( $this->sut, $status ) );
+		remove_filter( 'woocommerce_product_feed_in_progress_timeout', $callback );
+	}
+
+	/**
+	 * Test that feed generation records a heartbeat in the resulting status.
+	 */
+	public function test_feed_generation_action_records_heartbeat() {
+		// Make sure at least one product is present so a batch is processed.
+		WC_Helper_Product::create_simple_product();
+
+		update_option( self::OPTION_KEY, array( 'state' => AsyncGenerator::STATE_SCHEDULED ) );
+
+		$mock_mapper = $this->createMock( ProductMapper::class );
+		$mock_mapper->method( 'map_product' )->willReturn( array() );
+		$this->mock_integration->method( 'get_product_mapper' )->willReturn( $mock_mapper );
+
+		$this->sut->feed_generation_action( self::OPTION_KEY );
+
+		$updated_status = get_option( self::OPTION_KEY );
+		$this->assertSame( AsyncGenerator::STATE_COMPLETED, $updated_status['state'] );
+		$this->assertArrayHasKey( 'updated_at', $updated_status );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

A large POS catalog feed is generated inside a single Action Scheduler action. If the host kills that process (request timeout or out of memory) before it finishes, the catch block never runs, so the status option stays pinned at `in_progress` forever — and nothing reconciles it, so the catalog can never be regenerated.

This PR:

- Adds a heartbeat (`updated_at`) to in-progress jobs, refreshed when the job starts and after every batch. `validate_status()` now treats an in-progress job with a stale heartbeat as invalid, so status polling and `force_regeneration()` automatically reschedule a killed job instead of wedging.
- Raises the PHP execution time limit (up front and after each batch) and the memory limit during generation, scoped to the generating process, to reduce the chance of a kill in the first place.

Action Scheduler's 300s failure period and any hard host request timeout remain the ceiling for very large catalogs; chunked processing (each action does a few batches and re-schedules) is the follow-up that removes that ceiling entirely. The heartbeat recovery guarantees a killed job is never permanently stuck in the meantime.

### How to test the changes in this Pull Request:

1. Generate a feed via `POST /wp-json/wc/pos/v1/catalog/create` and confirm it completes (`state: completed`).
2. Simulate a killed job: while a feed is `in_progress`, set its `feed_status_*` option's `updated_at` to an old timestamp (e.g. `time() - 600`). Then poll status / call the endpoint again and confirm it reschedules a fresh job instead of staying `in_progress` forever.
3. Confirm a normally-running job (fresh heartbeat) is left untouched and still throws "already in progress" on `force_regeneration()`.

### Testing that has already taken place:

- `AsyncGeneratorTest` passes (8 tests) covering stale/active/missing-heartbeat detection, the `woocommerce_product_feed_in_progress_timeout` filter, and heartbeat recording.
- Root cause confirmed from Action Scheduler logs on an affected store ("action marked as failed after 300 seconds"); the heartbeat-based recovery was confirmed to resolve the permanently-stuck state.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually (changelog/fix-pos-catalog-stuck-in-progress).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)