### PR TITLE
Fix REST variable product status cascade

### DIFF
--- a/plugins/woocommerce/changelog/62833-fix-rest-variable-product-status-cascade
+++ b/plugins/woocommerce/changelog/62833-fix-rest-variable-product-status-cascade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sync variable product variation trash state when product status changes through the REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -1694,8 +1694,8 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 * Save an object data.
 	 *
 	 * @since 3.0.0
-	 * @param WP_REST_Request $request  Full details about the request.
-	 * @param bool            $creating If is creating a new object.
+	 * @param WP_REST_Request<array<string, mixed>> $request  Full details about the request.
+	 * @param bool                                  $creating If is creating a new object.
 	 * @return WC_Data|WP_Error
 	 */
 	protected function save_object( $request, $creating = false ) {
@@ -1704,7 +1704,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 		if ( ! $creating && isset( $request['status'] ) ) {
 			$existing_product = $this->get_object( (int) $request['id'] );
 
-			if ( $existing_product && 0 !== $existing_product->get_id() && $existing_product->is_type( ProductType::VARIABLE ) ) {
+			if ( $existing_product instanceof WC_Product && 0 !== $existing_product->get_id() && $existing_product->is_type( ProductType::VARIABLE ) ) {
 				$previous_status = $existing_product->get_status( 'edit' );
 			}
 		}
@@ -1740,6 +1740,11 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 			return false;
 		}
 
+		/**
+		 * Variable product data store.
+		 *
+		 * @var WC_Product_Variable_Data_Store_Interface $data_store
+		 */
 		$data_store = WC_Data_Store::load( 'product-variable' );
 
 		if ( ProductStatus::TRASH === $current_status ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -1691,6 +1691,71 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	}
 
 	/**
+	 * Save an object data.
+	 *
+	 * @since 3.0.0
+	 * @param WP_REST_Request $request  Full details about the request.
+	 * @param bool            $creating If is creating a new object.
+	 * @return WC_Data|WP_Error
+	 */
+	protected function save_object( $request, $creating = false ) {
+		$previous_status = null;
+
+		if ( ! $creating && isset( $request['status'] ) ) {
+			$existing_product = $this->get_object( (int) $request['id'] );
+
+			if ( $existing_product && 0 !== $existing_product->get_id() && $existing_product->is_type( ProductType::VARIABLE ) ) {
+				$previous_status = $existing_product->get_status( 'edit' );
+			}
+		}
+
+		$object = parent::save_object( $request, $creating );
+
+		if ( is_wp_error( $object ) ) {
+			return $object;
+		}
+
+		if ( $this->maybe_sync_variable_product_status_to_variations( $object, $previous_status ) ) {
+			$object = $this->get_object( $object->get_id() );
+		}
+
+		return $object;
+	}
+
+	/**
+	 * Sync variation trash state when a variable product REST status update enters or leaves trash.
+	 *
+	 * @param WC_Data     $product         Product object.
+	 * @param string|null $previous_status Product status before the REST update.
+	 * @return bool True when variation status was synced.
+	 */
+	protected function maybe_sync_variable_product_status_to_variations( $product, $previous_status ) {
+		if ( null === $previous_status || ! $product instanceof WC_Product || ! $product->is_type( ProductType::VARIABLE ) ) {
+			return false;
+		}
+
+		$current_status = $product->get_status( 'edit' );
+
+		if ( $previous_status === $current_status ) {
+			return false;
+		}
+
+		$data_store = WC_Data_Store::load( 'product-variable' );
+
+		if ( ProductStatus::TRASH === $current_status ) {
+			$data_store->delete_variations( $product->get_id(), false );
+			return true;
+		}
+
+		if ( ProductStatus::TRASH === $previous_status ) {
+			$data_store->untrash_variations( $product->get_id() );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Clear caches here so in sync with any new variations/children.
 	 *
 	 * @param WC_Data $object Object data.

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -1877,10 +1877,89 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that updating a variable product status to trash via REST also trashes variations.
+	 */
+	public function test_update_variable_product_status_to_trash_trashes_variations() {
+		$product       = WC_Helper_Product::create_variation_product();
+		$variation_ids = $product->get_children();
+
+		try {
+			$this->assertNotEmpty( $variation_ids );
+
+			$this->update_product_via_post_request(
+				$product,
+				array(
+					'status' => ProductStatus::TRASH,
+				)
+			);
+
+			foreach ( $variation_ids as $variation_id ) {
+				$this->assertSame( ProductStatus::TRASH, get_post_status( $variation_id ) );
+			}
+		} finally {
+			$this->delete_variable_product_posts( $product->get_id(), $variation_ids );
+		}
+	}
+
+	/**
+	 * Test that restoring a trashed variable product via REST also restores variations.
+	 */
+	public function test_update_variable_product_status_from_trash_restores_variations() {
+		$product       = WC_Helper_Product::create_variation_product();
+		$variation_ids = $product->get_children();
+
+		try {
+			$this->assertNotEmpty( $variation_ids );
+
+			$delete_request = new WP_REST_Request( 'DELETE', '/wc/v3/products/' . $product->get_id() );
+			$delete_request->set_param( 'force', false );
+
+			$delete_response = $this->server->dispatch( $delete_request );
+			$this->assertEquals( 200, $delete_response->get_status() );
+
+			foreach ( $variation_ids as $variation_id ) {
+				$this->assertSame( ProductStatus::TRASH, get_post_status( $variation_id ) );
+			}
+
+			$update_response = $this->update_product_via_post_request(
+				$product,
+				array(
+					'status' => ProductStatus::DRAFT,
+				)
+			);
+
+			$updated_product_data = $update_response->get_data();
+
+			foreach ( $variation_ids as $variation_id ) {
+				$this->assertSame( ProductStatus::PUBLISH, get_post_status( $variation_id ) );
+			}
+
+			$this->assertEqualsCanonicalizing( $variation_ids, $updated_product_data['variations'] );
+		} finally {
+			$this->delete_variable_product_posts( $product->get_id(), $variation_ids );
+		}
+	}
+
+	/**
+	 * Delete a variable product and its variations by post ID.
+	 *
+	 * @param int   $product_id    Product ID.
+	 * @param int[] $variation_ids Variation IDs.
+	 */
+	private function delete_variable_product_posts( $product_id, array $variation_ids ) {
+		foreach ( $variation_ids as $variation_id ) {
+			wp_delete_post( $variation_id, true );
+		}
+
+		wp_delete_post( $product_id, true );
+	}
+
+	/**
 	 * Perform a REST POST request to update a product.
 	 *
 	 * @param WC_Product $product The product to update.
 	 * @param array      $request_body Data to be sent (JSON-encoded) as the body of the request.
+	 * @return WP_REST_Response Response object.
 	 */
 	private function update_product_via_post_request( WC_Product $product, array $request_body ) {
 		$request = new WP_REST_Request( 'POST', '/wc/v3/products/' . $product->get_id() );
@@ -1889,6 +1968,8 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
- Sync variable product variation trash state when REST product status updates enter or leave trash.
- Add regression coverage for REST status updates that trash and restore variable products.
- Add a changelog entry for the fix.

### Testing
- php -l plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
- php -l plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
- ./vendor/bin/phpunit -c phpunit.xml --filter 'WC_REST_Products_Controller_Tests::test_update_variable_product_status_(to_trash_trashes_variations|from_trash_restores_variations)'

Fixes #62833
