### PR TITLE
[e2e tests]: Replace dead demo.woothemes.com image URLs with local media

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-replace-dead-demo-image-urls
+++ b/plugins/woocommerce/changelog/fix-e2e-replace-dead-demo-image-urls
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: E2E test-only change. Replace dead demo.woothemes.com image URLs with local media library lookups. No user-facing change.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.ts
@@ -8,6 +8,7 @@ import { faker } from '@faker-js/faker';
  */
 import { test, expect } from '../../../fixtures/api-tests-fixtures';
 import { order } from '../../../data';
+import { getMediaBySlug } from '../../../utils/media';
 
 const RAND_STRING = faker.string.alphanumeric( 8 ).toLowerCase();
 const COUPON_CODE = `coupon-${ faker.string.alphanumeric( 4 ).toLowerCase() }`;
@@ -234,6 +235,13 @@ test.describe.serial( 'Orders API tests', () => {
 				'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. ' +
 				'Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n';
 
+			const { source_url: downloadFile } = await getMediaBySlug(
+				'image-01'
+			);
+			const { source_url: downloadFile2 } = await getMediaBySlug(
+				'image-02'
+			);
+
 			const simpleProducts = await request.post(
 				'./wp-json/wc/v3/products/batch',
 				{
@@ -407,7 +415,7 @@ test.describe.serial( 'Orders API tests', () => {
 									{
 										id: '2579cf07-8b08-4c25-888a-b6258dd1f035',
 										name: 'Single',
-										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+										file: downloadFile,
 									},
 								],
 								download_limit: 1,
@@ -477,12 +485,12 @@ test.describe.serial( 'Orders API tests', () => {
 									{
 										id: 'cc10249f-1de2-44d4-93d3-9f88ae629f76',
 										name: 'Single 1',
-										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+										file: downloadFile,
 									},
 									{
 										id: 'aea8ef69-ccdc-4d83-8e21-3c395ebb9411',
 										name: 'Single 2',
-										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/album.jpg',
+										file: downloadFile2,
 									},
 								],
 								download_limit: 1,

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.ts
@@ -7,6 +7,7 @@ import { faker } from '@faker-js/faker';
  * Internal dependencies
  */
 import { test, expect } from '../../../fixtures/api-tests-fixtures';
+import { getMediaBySlug } from '../../../utils/media';
 
 test.describe( 'Products API tests: List All Products', () => {
 	const PRODUCTS_COUNT = 20;
@@ -214,6 +215,13 @@ test.describe( 'Products API tests: List All Products', () => {
 				'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. ' +
 				'Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n';
 
+			const { source_url: downloadFile } = await getMediaBySlug(
+				'image-01'
+			);
+			const { source_url: downloadFile2 } = await getMediaBySlug(
+				'image-02'
+			);
+
 			//const { body: simpleProducts } = await createProducts( [
 			const simpleProducts = await request.post(
 				'./wp-json/wc/v3/products/batch',
@@ -391,7 +399,7 @@ test.describe( 'Products API tests: List All Products', () => {
 									{
 										id: '2579cf07-8b08-4c25-888a-b6258dd1f035',
 										name: 'Single',
-										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+										file: downloadFile,
 									},
 								],
 								download_limit: 1,
@@ -462,12 +470,12 @@ test.describe( 'Products API tests: List All Products', () => {
 									{
 										id: 'cc10249f-1de2-44d4-93d3-9f88ae629f76',
 										name: 'Single 1',
-										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+										file: downloadFile,
 									},
 									{
 										id: 'aea8ef69-ccdc-4d83-8e21-3c395ebb9411',
 										name: 'Single 2',
-										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/album.jpg',
+										file: downloadFile2,
 									},
 								],
 								download_limit: 1,

--- a/plugins/woocommerce/tests/e2e-pw/tests/order/order-edit.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/order/order-edit.spec.ts
@@ -9,6 +9,7 @@ import { ApiClient, WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
 import { tags, expect, test } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { random } from '../../utils/helpers';
+import { getMediaBySlug } from '../../utils/media';
 
 test.use( { storageState: ADMIN_STATE_PATH } );
 
@@ -394,7 +395,8 @@ test.describe(
 			productId: number,
 			product2Id: number,
 			noProductOrderId: number,
-			initialGrantAccessAfterPaymentSetting: string;
+			initialGrantAccessAfterPaymentSetting: string,
+			downloadFile: string;
 
 		/**
 		 * Enable the "Grant access to downloadable products after payment" setting in WooCommerce > Settings > Products > Downloadable products.
@@ -426,6 +428,10 @@ test.describe(
 			} );
 		};
 
+		test.beforeAll( async () => {
+			( { source_url: downloadFile } = await getMediaBySlug( 'image-01' ) );
+		} );
+
 		test.beforeEach( async ( { restApi } ) => {
 			await restApi
 				.post( `${ WC_API_PATH }/products`, {
@@ -436,7 +442,7 @@ test.describe(
 						{
 							id: random(),
 							name: 'Single',
-							file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+							file: downloadFile,
 						},
 					],
 				} )
@@ -455,7 +461,7 @@ test.describe(
 						{
 							id: random(),
 							name: 'Single',
-							file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+							file: downloadFile,
 						},
 					],
 				} )

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-images.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-images.spec.ts
@@ -9,6 +9,7 @@ import type { Page } from '@playwright/test';
  */
 import { test as baseTest, expect } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
+import { getMediaBySlug } from '../../utils/media';
 
 async function addImageFromLibrary(
 	page: Page,
@@ -50,14 +51,11 @@ const test = baseTest.extend( {
 		} );
 	},
 	productWithImage: async ( { restApi, product }, use ) => {
+		const { id: imageId } = await getMediaBySlug( 'image-01' );
 		let productWithImage;
 		await restApi
 			.put( `${ WC_API_PATH }/products/${ product.id }`, {
-				images: [
-					{
-						src: 'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_front.jpg',
-					},
-				],
+				images: [ { id: imageId } ],
 			} )
 			.then( ( response ) => {
 				productWithImage = response.data;
@@ -66,20 +64,15 @@ const test = baseTest.extend( {
 		await use( productWithImage );
 	},
 	productWithGallery: async ( { restApi, product }, use ) => {
+		const imageIds = await Promise.all(
+			[ 'image-01', 'image-02', 'image-03' ].map(
+				async ( slug ) => ( await getMediaBySlug( slug ) ).id
+			)
+		);
 		let productWithGallery;
 		await restApi
 			.put( `${ WC_API_PATH }/products/${ product.id }`, {
-				images: [
-					{
-						src: 'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_front.jpg',
-					},
-					{
-						src: 'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_2_back.jpg',
-					},
-					{
-						src: 'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_3_front.jpg',
-					},
-				],
+				images: imageIds.map( ( id ) => ( { id } ) ),
 			} )
 			.then( ( response ) => {
 				productWithGallery = response.data;

--- a/plugins/woocommerce/tests/e2e-pw/utils/media.ts
+++ b/plugins/woocommerce/tests/e2e-pw/utils/media.ts
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { createClient } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { admin } from '../test-data/data';
+import playwrightConfig from '../playwright.config';
+
+let api: ReturnType< typeof createClient > | null = null;
+
+function getApi() {
+	if ( ! api ) {
+		api = createClient( playwrightConfig.use.baseURL, {
+			type: 'basic',
+			username: admin.username,
+			password: admin.password,
+		} );
+	}
+	return api;
+}
+
+const cache = new Map< string, { id: number; source_url: string } >();
+
+/**
+ * Resolve a media library item by its slug.
+ *
+ * The `image-01/02/03` images are imported into the media library during site
+ * setup (see `bin/test-env-setup.sh`). Returns the attachment so callers can use
+ * its `id` (e.g. product images) or `source_url` (e.g. downloadable files, which
+ * must live within the approved uploads directory) instead of relying on an
+ * external URL.
+ *
+ * @param {string} slug The attachment slug, e.g. `image-01`.
+ * @return The resolved attachment with `id` and `source_url`.
+ */
+export const getMediaBySlug = async (
+	slug: string
+): Promise< { id: number; source_url: string } > => {
+	if ( cache.has( slug ) ) {
+		return cache.get( slug )!;
+	}
+	const response = await getApi().get<
+		Array< { id: number; source_url: string } >
+	>( 'wp/v2/media', { slug, per_page: 1 } );
+	const media = response.data?.[ 0 ];
+	if ( ! media ) {
+		throw new Error( `Media library image not found: ${ slug }` );
+	}
+	cache.set( slug, media );
+	return media;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Several E2E tests referenced product/download images hosted on `demo.woothemes.com`. Those URLs now return 400/500 from inside the test container, making the affected specs fail or flake when WooCommerce tries to sideload them.

This PR replaces every hard-coded `demo.woothemes.com` image URL with a lookup against the local media library, which is seeded with `image-01`, `image-02`, and `image-03` during site setup.

- New helper `tests/e2e-pw/utils/media.ts` — `getMediaBySlug( slug )` resolves a media library attachment by slug and returns its `id` and `source_url`. The REST client is lazily initialized and results are cached per process.
- `orders.test.ts` / `product-list.test.ts` — downloadable file URLs now use the seeded media `source_url`. The two distinct download files ("Single 1" / "Single 2") use `image-01` and `image-02` respectively, preserving the original test intent.
- `order-edit.spec.ts` — resolves the download file once in `beforeAll` instead of per-test.
- `product-images.spec.ts` — product image and gallery fixtures now attach seeded media by `id` instead of an external `src`.

### How to test the changes in this Pull Request:

1. Check out this branch and start the E2E environment.
2. Run the affected specs:
   - `tests/e2e-pw/tests/api-tests/orders/orders.test.ts`
   - `tests/e2e-pw/tests/api-tests/products/product-list.test.ts`
   - `tests/e2e-pw/tests/order/order-edit.spec.ts`
   - `tests/e2e-pw/tests/product/product-images.spec.ts`
3. Confirm they pass and no requests are made to `demo.woothemes.com`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
